### PR TITLE
Make npm browserify dependencies more strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   ],
   "devDependencies": {
     "aws-sdk": "2.0.0-rc11",
-    "browserify": "^6.3.2",
-    "browserify-shim": "^3.8.2",
+    "browserify": "6.1.0",
+    "browserify-shim": "3.8.0",
     "git-rev": "~0.2.1",
     "grunt": "~0.4.4",
     "grunt-available-tasks": "^0.5.4",
     "grunt-aws": "~0.3.0",
-    "grunt-browserify": "^3.2.0",
+    "grunt-browserify": "3.2.1",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-compass": "~0.7.2",
@@ -44,14 +44,13 @@
     "moment": "^2.8.4",
     "open": "0.0.5",
     "queue-async": "^1.0.7",
-    "remapify": "^1.3.0",
+    "remapify": "1.4.2",
     "rewireify": "0.0.13",
     "shelljs": "~0.2.6",
     "source-map-support": "^0.2.8",
     "uglify-js": "1.3.3",
     "underscore": "~1.6.0",
-    "watchify": "^2.1.1",
-    "miller-rabin": "1.1.1"
+    "watchify": "^2.1.1"
   },
   "files": [
     "dist"


### PR DESCRIPTION
`grunt-browserify` v3.2.1 (latest at this point in time) requires `browserify` v6.1.0, so need to make the dependencies more strict to avoid dependency issues. Same thing goes for `remapify`.

This also fix the [miller-rabbis dependency issue](1647) from last week.

watch https://github.com/jmreidy/grunt-browserify/pull/272 to update dependencies once grunt-browserify is updated so we can update our dependencies properly