### PR TITLE
Removed marker-comp-op property within cluster CartoCSS

### DIFF
--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -311,7 +311,6 @@ function cluster_generator(table, props, changed, callback) {
   c += "  marker-line-opacity: " + props['marker-line-opacity'] + ";\n";
   c += "  marker-line-color: " + props['marker-line-color'] + ";\n";
   c += "  marker-allow-overlap: true;\n";
-  c += "  marker-comp-op: dst-atop;\n";
 
   var base = 20;
   var min = props["radius_min"];


### PR DESCRIPTION
**marker-comp-op** property set to **dst-atop** sends cluster layer at the bottom.