### PR TITLE
Adding olark chat within CartoDB editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   New Config entry-set: ['oauth']['mailchimp'] (see config/app_config.yml.sample for further details)
   Requires also a feature_flag enabled either globally or to a specific users: 'mailchimp_import'
 * Added icon font source ([how to make changes](http://github.com/CartoDB/cartodb/blob/master/app/assets/fonts/icon_font/README.md))
+* Integrated Olark chat within CartoDB editor
 
 
 3.7.1 (2014-12-30)

--- a/app/assets/stylesheets/table/olark_widget.css.scss
+++ b/app/assets/stylesheets/table/olark_widget.css.scss
@@ -1,0 +1,10 @@
+/*
+ *  Olark widget style hack
+ *  - It moves the widget to the middle
+ *    of the screen.
+ */
+
+#habla_window_div {
+  margin: 0 0 0 -115px!important;
+  left: 50%!important;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,8 @@
     <% if ( ( controller_name != "visualizations" && controller_name != "tables" ) || action_name != "show" ) %>
       <%= render 'admin/shared/footer' %>
     <% end %>
-
-    <%= render 'shared/olark' -%>
+    <% if ( ( controller_name == "visualizations" || controller_name == "tables" ) && action_name == "show" ) %>
+      <%= render 'shared/olark' -%>
+    <% end %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,5 +23,7 @@
     <% if ( ( controller_name != "visualizations" && controller_name != "tables" ) || action_name != "show" ) %>
       <%= render 'admin/shared/footer' %>
     <% end %>
+
+    <%= render 'shared/olark' -%>
   </body>
 </html>

--- a/app/views/shared/_olark.html.erb
+++ b/app/views/shared/_olark.html.erb
@@ -1,4 +1,4 @@
-<% if Cartodb.config[:olark].present? && Cartodb.config[:olark]["app_id"].present?  %> # && Rails.env != 'development'
+<% if Cartodb.config[:olark].present? && Cartodb.config[:olark]["app_id"].present?  %>
     <script data-cfasync="false" type='text/javascript'>/*<![CDATA[*/window.olark||(function(c){var f=window,d=document,l=f.location.protocol=="https:"?"https:":"http:",z=c.name,r="load";var nt=function(){
     f[z]=function(){
     (a.s=a.s||[]).push(arguments)};var a=f[z]._={

--- a/app/views/shared/_olark.html.erb
+++ b/app/views/shared/_olark.html.erb
@@ -1,0 +1,20 @@
+<% if Cartodb.config[:olark].present? && Cartodb.config[:olark]["app_id"].present?  %> # && Rails.env != 'development'
+    <script data-cfasync="false" type='text/javascript'>/*<![CDATA[*/window.olark||(function(c){var f=window,d=document,l=f.location.protocol=="https:"?"https:":"http:",z=c.name,r="load";var nt=function(){
+    f[z]=function(){
+    (a.s=a.s||[]).push(arguments)};var a=f[z]._={
+    },q=c.methods.length;while(q--){(function(n){f[z][n]=function(){
+      f[z]("call",n,arguments)}})(c.methods[q])}a.l=c.loader;a.i=nt;a.p={
+    0:+new Date};a.P=function(u){
+    a.p[u]=new Date-a.p[0]};function s(){
+    a.P(r);f[z](r)}f.addEventListener?f.addEventListener(r,s,false):f.attachEvent("on"+r,s);var ld=function(){function p(hd){
+    hd="head";return["<",hd,"></",hd,"><",i,' onl' + 'oad="var d=',g,";d.getElementsByTagName('head')[0].",j,"(d.",h,"('script')).",k,"='",l,"//",a.l,"'",'"',"></",i,">"].join("")}var i="body",m=d[i];if(!m){
+    return setTimeout(ld,100)}a.P(1);var j="appendChild",h="createElement",k="src",n=d[h]("div"),v=n[j](d[h](z)),b=d[h]("iframe"),g="document",e="domain",o;n.style.display="none";m.insertBefore(n,m.firstChild).id=z;b.frameBorder="0";b.id=z+"-loader";if(/MSIE[ ]+6/.test(navigator.userAgent)){
+    b.src="javascript:false"}b.allowTransparency="true";v[j](b);try{
+    b.contentWindow[g].open()}catch(w){
+    c[e]=d[e];o="javascript:var d="+g+".open();d.domain='"+d.domain+"';";b[k]=o+"void(0);"}try{
+    var t=b.contentWindow[g];t.write(p());t.close()}catch(x){
+    b[k]=o+'d.write("'+p().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}a.P(2)};ld()};nt()})({
+    loader: "static.olark.com/jsclient/loader0.js",name:"olark",methods:["configure","extend","declare","identify"]});
+    /* custom configuration goes here (www.olark.com/documentation) */
+    olark.identify('<%= Cartodb.config[:olark]["app_id"] %>');/*]]>*/</script><noscript><a href="https://www.olark.com/site/9369-171-10-7255/contact" title="Questions?" target="_blank">Questions? Feedback?</a> powered by <a href="http://www.olark.com?welcome" title="Olark live chat software">Olark live chat software</a></noscript>
+<% end %>

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -189,6 +189,8 @@ defaults: &defaults
   gdrive: 
     api_key: ""
     app_id: ""
+  olark: 
+    app_id: ''
   enforce_non_empty_layer_css: true
   users_dumps:
     service:

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -189,6 +189,8 @@ defaults: &defaults
   gdrive: 
     api_key: ""
     app_id: ""
+  # This enables a support chat within editor
+  # Use your Olark api id to enable it. If you remove this entry or don't define an app key, it won't be activated.
   olark: 
     app_id: ''
   enforce_non_empty_layer_css: true


### PR DESCRIPTION
Olark chat activated for CartoDB editor.
It is only possible to enable it through application config.