### PR TITLE
New dashboard url routes

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/router.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/router.js
@@ -17,10 +17,10 @@ module.exports = Router.extend({
   routes: {
 
     // Index
-    'dashboard':                                               '_changeRouteToDatasets',
-    'dashboard?:queries':                                      '_changeRouteToDatasets',
-    'dashboard/':                                              '_changeRouteToDatasets',
-    'dashboard/?:queries':                                     '_changeRouteToDatasets',
+    'dashboard':                                               '_changeRouteToMaps',
+    'dashboard?:queries':                                      '_changeRouteToMaps',
+    'dashboard/':                                              '_changeRouteToMaps',
+    'dashboard/?:queries':                                     '_changeRouteToMaps',
 
     // Search locked maps in shared datasets/maps
     'dashboard/:content_type/shared/locked/search/:q':         '_changeRouteToSearch',

--- a/lib/assets/javascripts/cartodb/new_dashboard/router.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/router.js
@@ -22,6 +22,12 @@ module.exports = Router.extend({
     'dashboard/':                                              '_changeRouteToMaps',
     'dashboard/?:queries':                                     '_changeRouteToMaps',
 
+    // Supporting old tables/vis urls
+    'dashboard/tables':                                        '_changeRouteToDatasets',
+    'dashboard/tables/:whatever':                              '_changeRouteToDatasets',
+    'dashboard/visualizations':                                '_changeRouteToMaps',
+    'dashboard/visualizations/:whatever':                      '_changeRouteToMaps',
+
     // Search locked maps in shared datasets/maps
     'dashboard/:content_type/shared/locked/search/:q':         '_changeRouteToSearch',
     'dashboard/:content_type/shared/locked/search/:q/:page':   '_changeRouteToSearch',


### PR DESCRIPTION
- Default dashboard url will go to maps section.
- Old tables/visualizations url still working.