### PR TITLE
Disable geocoding options (feature flags) and test

### DIFF
--- a/lib/assets/javascripts/cartodb/table/geocoding_dialog/geocoding_dialog_content.js
+++ b/lib/assets/javascripts/cartodb/table/geocoding_dialog/geocoding_dialog_content.js
@@ -41,7 +41,8 @@
         key:      _t('<%= name %> key is not specified and panel can\'t be enabled'),
         account:  _t('<%= name %> data source is not available in your plan. Please upgrade'),
         credits:  _t('You\'ve reached the available <%= name %> credits for your account this month'),
-        quota:    _t('Your geocoding quota is not defined, please contact us at support@cartodb.com')
+        quota:    _t('Your geocoding quota is not defined, please contact us at support@cartodb.com'),
+        georef_disabled:  _t('You don\'t have this option available in this version')
       }
     },
 
@@ -92,6 +93,12 @@
     },
 
     _genCityPane: function() {
+      // Check if the user has the georeferentation_disabled flag enabled
+      if (this.user.featureEnabled('georef_disabled')) {
+        this._setFailedTab('city', 'georef_disabled');
+        return false;
+      }
+
       var view = new cdb.admin.GeocodingDialog.Pane.DefaultGeocoder({
         table:          this.options.table,
         kind:           "namedplace",
@@ -105,6 +112,12 @@
     },
 
     _genAdminPane: function() {
+      // Check if the user has the georeferentation_disabled flag enabled
+      if (this.user.featureEnabled('georef_disabled')) {
+        this._setFailedTab('admin', 'georef_disabled');
+        return false;
+      }
+
       var view = new cdb.admin.GeocodingDialog.Pane.DefaultGeocoder({
         table:          this.options.table,
         kind:           "admin1",
@@ -118,6 +131,12 @@
     },
 
     _genPostalPane: function() {
+      // Check if the user has the georeferentation_disabled flag enabled
+      if (this.user.featureEnabled('georef_disabled')) {
+        this._setFailedTab('postal', 'georef_disabled');
+        return false;
+      }
+
       var view = new cdb.admin.GeocodingDialog.Pane.DefaultGeocoder({
         table:          this.options.table,
         kind:           "postalcode",
@@ -131,6 +150,12 @@
     },
 
     _genIPPane: function() {
+      // Check if the user has the georeferentation_disabled flag enabled
+      if (this.user.featureEnabled('georef_disabled')) {
+        this._setFailedTab('ip', 'georef_disabled');
+        return false;
+      }
+
       var view = new cdb.admin.GeocodingDialog.Pane.IP({
         table:    this.options.table
       })
@@ -141,6 +166,12 @@
     },
 
     _genAddressPane: function() {
+      // Check if the user has the georeferentation_disabled flag enabled
+      if (this.user.featureEnabled('georef_disabled')) {
+        this._setFailedTab('address', 'georef_disabled');
+        return false;
+      }
+
       // Check if user can use 'address geocoder' checking his/her 
       // geocoding and quota params
       if (!this.user.get('geocoding') || this.user.get('geocoding').quota === null) {

--- a/lib/assets/test/spec/cartodb/models/user.spec.js
+++ b/lib/assets/test/spec/cartodb/models/user.spec.js
@@ -32,4 +32,14 @@ describe('cdb.admin.User', function() {
     expect(user.isOrgAdmin()).toEqual(false);
   });
 
+  it("hasFeatureFlagEnabled", function () {
+    var flagOK = 'test_flag';
+    var feature_flags = [];
+    feature_flags.push(flagOK);
+    user.set('feature_flags',feature_flags);
+    
+    expect(user.featureEnabled(flagOK)).toEqual(true);
+    expect(user.featureEnabled('flagWrong')).toEqual(false);
+  });
+
 });

--- a/lib/assets/test/spec/cartodb/table/geocoding_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/geocoding_dialog.spec.js
@@ -118,7 +118,18 @@ describe("Geocoding dialog", function() {
     expect(dialog).toHaveNoLeaks();
   });
 
-
+  it("should not have tabs city, admin, postal, ip and address available if georef_disabled flag (feature flags) is enabled", function() {
+    var feature_flags = [];
+    feature_flags.push('georef_disabled');
+    user.set('feature_flags', feature_flags);
+     
+    dialog.render();
+    expect(dialog.$('.create-tab.city .city').hasClass('disabled')).toBeTruthy();
+    expect(dialog.$('.create-tab.admin .admin').hasClass('disabled')).toBeTruthy();
+    expect(dialog.$('.create-tab.postal .postal').hasClass('disabled')).toBeTruthy();
+    expect(dialog.$('.create-tab.ip .ip').hasClass('disabled')).toBeTruthy();
+    expect(dialog.$('.create-tab.address .address').hasClass('disabled')).toBeTruthy();
+  });
 
 
   // Latitude and longitude pane


### PR DESCRIPTION
This new branch and commit is related to this old [PR](https://github.com/CartoDB/cartodb/pull/1500/files?diff=split)
The reason is that there was a lot of conflicts because it was an old branch, so I decided to create a new one pulling from master.

it uses a [Feature Flag](https://github.com/Vizzuality/cartodb-management/wiki/Feature-Flags) called **georef_disabled**.