### PR TITLE
Table gets registered twice on the dashboard

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -987,33 +987,42 @@ class User < Sequel::Model
   end
 
   # this method search for tables with all the columns needed in a cartodb table.
-  # it does not check column types or triggers attached
+  # it does not check column types, and only the latest cartodbfication trigger attached (test_quota_per_row)
   # returns the list of tables in the database with those columns but not in metadata database
   def search_for_cartodbfied_tables
     metadata_table_names = self.tables.select(:name).map(&:name).map { |t| "'" + t + "'" }.join(',')
+
     db = self.in_database(:as => :superuser)
     reserved_columns = Table::CARTODB_COLUMNS + [Table::THE_GEOM_WEBMERCATOR]
     cartodb_columns = (reserved_columns).map { |t| "'" + t.to_s + "'" }.join(',')
     sql = %Q{
       WITH a as (
         SELECT table_name, count(column_name::text) cdb_columns_count
-        FROM information_schema.columns c, pg_tables t
+        FROM information_schema.columns c, pg_tables t, pg_trigger tg
         WHERE
-        t.tablename = c.table_name AND
-        t.schemaname = c.table_schema AND
-        t.tableowner = '#{database_username}' AND
+          t.tablename = c.table_name AND
+          t.schemaname = c.table_schema AND
+          c.table_schema = '#{database_schema}' AND
+          t.tableowner = '#{database_username}' AND
     }
 
     if metadata_table_names.length != 0
-      sql += "c.table_name not in (#{metadata_table_names}) AND"
+      sql += %Q{
+        c.table_name NOT IN (#{metadata_table_names}) AND
+      }
     end
 
     sql += %Q{
-          column_name in (#{cartodb_columns})
-          group by 1
+          column_name IN (#{cartodb_columns}) AND
+
+          tg.tgrelid = (t.schemaname || '.' || t.tablename)::regclass::oid AND
+          tg.tgname = 'test_quota_per_row'
+
+          GROUP BY 1
       )
-      select table_name from a where cdb_columns_count = #{reserved_columns.length}
+      SELECT table_name FROM a WHERE cdb_columns_count = #{reserved_columns.length}
     }
+
     db[sql].all.map { |t| t[:table_name] }
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -961,6 +961,21 @@ describe User do
 
     it "should return cartodbfied tables" do
       @user.in_database.run('create table ghost_table (cartodb_id integer, the_geom geometry, the_geom_webmercator geometry, updated_at date, created_at date)')
+
+      @user.in_database.run(%Q{
+        CREATE OR REPLACE FUNCTION test_quota_per_row()
+          RETURNS trigger
+          AS $$
+          BEGIN
+            RETURN NULL;
+          END;
+          $$
+          LANGUAGE plpgsql;
+      })
+      @user.in_database.run( %Q{
+        CREATE TRIGGER test_quota_per_row BEFORE INSERT ON ghost_table EXECUTE PROCEDURE test_quota_per_row()
+      })
+
       @user.in_database.run('create table non_ghost_table (test integer)')
       tables = @user.search_for_cartodbfied_tables
       tables.should =~ ['ghost_table']
@@ -969,6 +984,21 @@ describe User do
     it "should link a table in the database" do
       tables = @user.tables.all.map(&:name)
       @user.in_database.run('create table ghost_table (cartodb_id integer, the_geom geometry, the_geom_webmercator geometry, updated_at date, created_at date)')
+
+      @user.in_database.run(%Q{
+        CREATE OR REPLACE FUNCTION test_quota_per_row()
+          RETURNS trigger
+          AS $$
+          BEGIN
+            RETURN NULL;
+          END;
+          $$
+          LANGUAGE plpgsql;
+      })
+      @user.in_database.run( %Q{
+        CREATE TRIGGER test_quota_per_row BEFORE INSERT ON ghost_table EXECUTE PROCEDURE test_quota_per_row()
+      })
+
       @user.link_ghost_tables
       new_tables = @user.tables.all.map(&:name)
       new_tables.should include('ghost_table')
@@ -977,6 +1007,21 @@ describe User do
     it "should link a renamed table in the database" do
       tables = @user.tables.all.map(&:name)
       @user.in_database.run('create table ghost_table_2 (cartodb_id integer, the_geom geometry, the_geom_webmercator geometry, updated_at date, created_at date)')
+
+      @user.in_database.run(%Q{
+        CREATE OR REPLACE FUNCTION test_quota_per_row()
+          RETURNS trigger
+          AS $$
+          BEGIN
+            RETURN NULL;
+          END;
+          $$
+          LANGUAGE plpgsql;
+      })
+      @user.in_database.run( %Q{
+        CREATE TRIGGER test_quota_per_row BEFORE INSERT ON ghost_table_2 EXECUTE PROCEDURE test_quota_per_row()
+      })
+
       @user.link_ghost_tables
       @user.in_database.run('alter table ghost_table_2 rename to ghost_table_renamed')
       @user.link_ghost_tables


### PR DESCRIPTION
Fixes #1840

- Added checking latest cartodbfication trigger added to narrow as much as possible the timeframe that a table is not yet at metadata but present at user schema. Further improvements would require more drastic measures like "not link ghost tables if user has an ongoing import".
- Tested at staging environment, couldn't reproduce duplication so at least the issue looks mitigated.