### PR TITLE
Remove per-user statsd metrics

### DIFF
--- a/app/controllers/api/json/visualizations_controller.rb
+++ b/app/controllers/api/json/visualizations_controller.rb
@@ -118,7 +118,6 @@ class Api::Json::VisualizationsController < Api::ApplicationController
       next_vis.set_prev_list_item!(vis)
     end
 
-    current_user.update_visualization_metrics
     render_jsonp(vis)
   rescue CartoDB::InvalidMember
     render_jsonp({ errors: vis.full_errors }, 400)
@@ -189,7 +188,6 @@ class Api::Json::VisualizationsController < Api::ApplicationController
     vis = Visualization::Member.new(id: @table_id).fetch
     return(head 403) unless vis.is_owner?(current_user)
     vis.delete
-    current_user.update_visualization_metrics
     return head 204
   rescue KeyError
     head(404)
@@ -550,7 +548,6 @@ class Api::Json::VisualizationsController < Api::ApplicationController
       total_likes:    collection.total_liked_entries,
       total_shared:   collection.total_shared_entries
     }
-    current_user.update_visualization_metrics
     render_jsonp(response)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -946,7 +946,6 @@ class User < Sequel::Model
       # Hack to support users without the new MU functiones loaded
       user_data_size_function = self.cartodb_extension_version_pre_mu? ? "CDB_UserDataSize()" : "CDB_UserDataSize('#{self.database_schema}')"
       result = in_database(:as => :superuser).fetch("SELECT cartodb.#{user_data_size_function}").first[:cdb_userdatasize]
-      update_gauge("db_size", result)
       result
     rescue
       attempts += 1
@@ -1209,18 +1208,6 @@ class User < Sequel::Model
 
   def metric_key
     "cartodb.#{Rails.env.production? ? "user" : Rails.env + "-user"}.#{self.username}"
-  end
-
-  def update_gauge(gauge, value)
-    Statsd.gauge("#{metric_key}.#{gauge}", value)
-  rescue
-  end
-
-  def update_visualization_metrics
-    update_gauge("visualizations.total", maps.count)
-    update_gauge("visualizations.table", table_count)
-
-    update_gauge("visualizations.derived", visualization_count({ exclude_shared: true, exclude_raster: true }))
   end
 
   def rebuild_quota_trigger

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1206,10 +1206,6 @@ class User < Sequel::Model
       .to_a.fetch(0, {}).fetch(:created_at, nil)
   end
 
-  def metric_key
-    "cartodb.#{Rails.env.production? ? "user" : Rails.env + "-user"}.#{self.username}"
-  end
-
   def rebuild_quota_trigger
     puts "Setting user quota in db '#{database_name}' (#{username})"
     in_database(:as => :superuser) do |db|


### PR DESCRIPTION
Turns out we're sending *per-user* metrics to Statsd every time:

- the user viewed the dashboard / created / edited a new viz
- the database size is requested

This PR removes them.