### PR TITLE
Fix sync jobs logger #399

### DIFF
--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -132,7 +132,7 @@ module CartoDB
         importer = nil
         self.state    = STATE_SYNCING
 
-        @log = CartoDB::Log.new(type: CartoDB::Log::TYPE_SYNCHRONIZATION, user_id: user.id)
+        @log = CartoDB::Log.new(type: CartoDB::Log::TYPE_SYNCHRONIZATION, user_id: user.id).save
         self.log_id = @log.id
         store
 


### PR DESCRIPTION
Save the job logger model to DB so that it gets an ID that can be used
later on to refer to. Otherwise the sync object remains with a garbage
value for log_id.

@Kartones please review