### PR TITLE
Fixed additional information sent to Rollbar so you can trace actual problem

### DIFF
--- a/services/importer/lib/importer/georeferencer.rb
+++ b/services/importer/lib/importer/georeferencer.rb
@@ -197,7 +197,7 @@ module CartoDB
             raise "Geocoding failed" if geocoding.state == 'failed'
           rescue => e
             Rollbar.report_message('Georeferencer could not register geocoding, fallback to geocoder.run',
-                                   'error', { user_id: user_id, backtrace: e.backtrace, config: config })
+                                   'error', error_info: "user_id: #{user_id}, config: #{config}, backtrace: #{e.backtrace.join('\n')}")
             geocoder.run
           end
 


### PR DESCRIPTION
@rafatower , have you got any clue about #1951 error origin? I've searched for code requesting "SELECT *" without tables with some input but I can't find any. If you have at least any guess, please let me know. If not, CR this improvement that should make actual backtrace available at Rollbar, please.