### PR TITLE
Fix mapping of bool to string #1966

### DIFF
--- a/services/importer/lib/importer/ogr2ogr.rb
+++ b/services/importer/lib/importer/ogr2ogr.rb
@@ -73,7 +73,7 @@ module CartoDB
 
       def guessing_option
         if csv_guessing && is_csv?
-          "-oo AUTODETECT_TYPE=YES -oo QUOTED_FIELDS_AS_STRING=#{quoted_fields_guessing ? 'NO' : 'YES' }"
+          "-oo AUTODETECT_TYPE=YES -oo QUOTED_FIELDS_AS_STRING=#{quoted_fields_guessing ? 'YES' : 'NO' }"
         else
           ''
         end


### PR DESCRIPTION
This will make ogr2ogr2 honor `quoted_fields_guessing` which was wrongly
mapped to `QUOTED_FIELDS_AS_STRING` when passed.

@juanignaciosl one-liner review please