### PR TITLE
rows with empty the_geom should not be taken into account for rows_geocoded_after

### DIFF
--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -118,7 +118,7 @@ class Geocoding < Sequel::Model
     Statsd.gauge("geocodings.cache_hits", "+#{self.cache_hits}") rescue nil
     table_geocoder.process_results if state == 'completed'
     create_automatic_geocoding if automatic_geocoding_id.blank?
-    rows_geocoded_after = table.owner.in_database.select.from(table.sequel_qualified_table_name).where(cartodb_georef_status: true).count rescue 0
+    rows_geocoded_after = table.owner.in_database.select.from(table.sequel_qualified_table_name).where('cartodb_georef_status is true and the_geom is not null').count rescue 0
     self.update(state: 'finished', real_rows: rows_geocoded_after - rows_geocoded_before, used_credits: calculate_used_credits)
     self.report
   rescue => e


### PR DESCRIPTION
@rafatower take a look at this, do you agree on the change? This is not only a fix for #1005 but a change to the `real_rows` metric.