### PR TITLE
Fix account settings link for org admin

### DIFF
--- a/lib/assets/javascripts/cartodb/new_common/urls/organization_user_model.js
+++ b/lib/assets/javascripts/cartodb/new_common/urls/organization_user_model.js
@@ -9,11 +9,10 @@ module.exports = UserUrl.extend({
    * @override user_model.toAccountSettings
    */
   toAccountSettings: function() {
-    var username = this.get('user').get('username');
     if (this.get('user').isOrgAdmin()) {
-      return this._superadminHost() + '/account/'+ username;
+      return this._toStr('organization');
     } else {
-      return this._toStr('organization/users', username, 'edit');
+      return this._toStr('organization/users', this.get('user').get('username'), 'edit');
     }
   },
 

--- a/lib/assets/test/spec/cartodb/new_common/urls/organization_user_model.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/urls/organization_user_model.spec.js
@@ -34,8 +34,8 @@ describe("new_common/urls/organization_user_model", function() {
         });
       });
 
-      it('should return URL to manage the own user but on superadmin host', function() {
-        expect(this.url.toAccountSettings()).toMatch('(http|file)://host.ext/account/baz');
+      it('should return URL to manage organization', function() {
+        expect(this.url.toAccountSettings()).toMatch('(http|file)://bodega.host.ext/u/baz/organization');
       });
     });
 


### PR DESCRIPTION
Fixes #1948 by pointing the "organization" URL to the correct, expected place
![screen shot 2015-01-28 at 17 42 56](https://cloud.githubusercontent.com/assets/978461/5942019/212e8c2c-a715-11e4-9b6c-b71dcb4355e8.png)
