### PR TITLE
Add affected users feedback before revoking access

### DIFF
--- a/app/assets/stylesheets/new_common/user-avatar.css.scss
+++ b/app/assets/stylesheets/new_common/user-avatar.css.scss
@@ -10,35 +10,61 @@
 @import "../new_variables/sizes";
 
 .UserAvatar {
+  position: relative;
   @include inline-block();
   vertical-align: middle;
 }
-.UserAvatar--large {
+.UserAvatar.is-error:before {
+  content: 'x';
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  @include display-flex();
+  @include justify-content(center);
+  @include align-items(center);
+  width: 16px;
+  height: 16px;
+  border-radius: 30px;
+  background-color: $cHighlight-negative;
+  color: white;
+  font-size: $sFontSize-smallUpperCase;
+  font-weight: $sFontWeight-lighter;
+  text-align: center;
+}
+.UserAvatar-img {
+  border: 1px solid transparent;
+}
+.UserAvatar-img.is-error {
+  border-color: $cHighlight-negative;
+  border-radius: $sAvatar-borderRadius;
+}
+.UserAvatar-img--large {
   width: $sAvatar-public;
   height: $sAvatar-public;
   border-radius: $sAvatar-borderRadius;
 }
-.UserAvatar--medium {
+.UserAvatar-img--medium {
   width: $sAvatar-default;
   height: $sAvatar-default;
   border-radius: $sAvatar-borderRadius;
 }
-.UserAvatar--small {
+.UserAvatar-img--small {
   width: $sAvatar-small;
   height: $sAvatar-small;
   border-radius: $sAvatar-borderRadiusSmall;
 }
-.UserAvatar--smaller {
+.UserAvatar-img--smaller {
   width: $sAvatar-meta;
   height: $sAvatar-meta;
   border-radius: $sAvatar-borderRadiusSmall;
 }
+
 // to just show [...], used in delete items for example
 // Example usage: <div class="UserAvatar"><span class="UserAvatar--moreItems../div>
-.UserAvatar--moreItems {
+.UserAvatar-moreItems {
   @include display-flex();
-  @include justify-content(center, center);
-  @include align-items(baseline, baseline);
+  @include justify-content(center);
+  @include align-items(baseline);
   font-size: 26px;
   line-height: 26px;
   color: $cIcons-default;
@@ -46,6 +72,6 @@
   box-shadow: 0 0 0 1px $cIcons-default inset; // use box-shadow to get border inside of the box
   border-radius: $sAvatar-borderRadius;
 }
-.UserAvatar--moreItems:before {
+.UserAvatar-moreItems:before {
   content: '...'
 }

--- a/app/assets/stylesheets/new_dashboard/default-description.css.scss
+++ b/app/assets/stylesheets/new_dashboard/default-description.css.scss
@@ -13,3 +13,6 @@
   color: $cTypography-help;
   font-style: italic;
 }
+.DefaultDescription--error {
+  color: $cHighlight-negative;
+}

--- a/app/views/admin/visualizations/new-dashboard.html.erb
+++ b/app/views/admin/visualizations/new-dashboard.html.erb
@@ -54,7 +54,7 @@
         </li>
         <li class="Header-settingsItem">
           <a href="#/options" class="UserAvatar" id="header-settings-dropdown">
-            <%= image_tag current_user.avatar_url, class: "UserAvatar--medium" %>
+            <%= image_tag current_user.avatar_url, class: "UserAvatar-img UserAvatar-img--medium" %>
           </a>
         </li>
       </ul>

--- a/lib/assets/javascripts/cartodb/new_common/urls/user_model.js
+++ b/lib/assets/javascripts/cartodb/new_common/urls/user_model.js
@@ -50,7 +50,7 @@ module.exports = cdb.core.Model.extend({
       });
     } else {
       // Vis is owned by other user, so return the appropriate user URL to point to the correct location:
-      return this.get('mapUrlForVisOwnerFn')(vis);
+      return this.get('urls').mapUrl(vis);
     }
   },
   

--- a/lib/assets/javascripts/cartodb/new_common/urls_fn.js
+++ b/lib/assets/javascripts/cartodb/new_common/urls_fn.js
@@ -14,7 +14,7 @@ module.exports = function(accountHost) {
       var args = {
         user: user,
         account_host: accountHost,
-        mapUrlForVisOwnerFn: this.mapUrl
+        urls: this
       };
 
       if (user.isInsideOrg()) {

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view.js
@@ -19,6 +19,7 @@ module.exports = cdb.core.View.extend({
     this._org = args.organization;
     this._permission = args.permission;
     this._canChangeWriteAccess = args.canChangeWriteAccess;
+    this._tableMetadata = args.tableMetadata;
 
     this._template = cdb.templates.getTemplate('new_dashboard/dialogs/change_privacy/share_view/template');
   },
@@ -34,7 +35,7 @@ module.exports = cdb.core.View.extend({
         colleagueOrColleaguesStr: pluralizeString('colleage', usersCount)
       })
     );
-    
+
     this._renderOrganizationPermissionView();
     this._renderUserPermissionViews();
 
@@ -54,6 +55,8 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderUserPermissionViews: function() {
+    var usersUsingVis = this._usersUsingVis();
+    
     this._org.users.each(function(user) {
       this._appendPermissionView(
         new PermissionView({
@@ -62,12 +65,25 @@ module.exports = cdb.core.View.extend({
           canChangeWriteAccess: this._canChangeWriteAccess,
           title: user.get('username'),
           desc: user.get('name'),
-          avatarUrl: user.get('avatar_url')
+          avatarUrl: user.get('avatar_url'),
+          isUsingVis: _.any(usersUsingVis, function(u) { return u.id === user.get('id'); })
         })
       );
     }, this);
   },
-  
+
+  _usersUsingVis: function() {
+    return _.chain(_.union(
+        this._tableMetadata.get('dependent_visualizations'),
+        this._tableMetadata.get('non_dependent_visualizations')
+      ))
+      .compact()
+      .map(function(visData) {
+        return visData.permission.owner;
+      })
+      .value();
+  },
+
   _appendPermissionView: function(view) {
     this.$('.js-permissions').append(view.render().el);
     this.addView(view);

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view/permission_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view/permission_view.js
@@ -15,6 +15,11 @@ module.exports = cdb.core.View.extend({
   
   initialize: function() {
     this._permission = this.options.permission;
+    this._isUsingVis = this.options.isUsingVis;
+    this._title = this.options.title;
+    this._desc = this.options.desc;
+    this._avatarUrl = this.options.avatarUrl;
+    this._canChangeWriteAccess = this.options.canChangeWriteAccess;
 
     this._permission.acl.bind('add remove reset change', this.render, this);
     this.add_related_model(this._permission);
@@ -27,18 +32,36 @@ module.exports = cdb.core.View.extend({
         readId: 'read-'+ this.cid,
         canRead: this._canRead(),
         canWrite: this._canWrite(),
-        canChangeWriteAccess: this.options.canChangeWriteAccess,
-        title: this.options.title,
-        desc: this.options.desc,
-        avatarUrl: this.options.avatarUrl
+        canChangeWriteAccess: this._canChangeWriteAccess,
+        title: this._title,
+        desc: this._descStr(),
+        avatarUrl: this._avatarUrl,
+        willRevokeAccess: this._willRevokeAccess()
       })
     );
     
     return this;
   },
-  
+
+  _willRevokeAccess: function() {
+    return this._isUsingVis && !this._canRead();
+  },
+
+  _descStr: function() {
+    if (this._isUsingVis) {
+      var desc = this._desc || 'this user';
+      if (this._canRead()) {
+        return desc +' is using this dataset';
+      } else {
+        return desc +"'s maps will be affected";
+      }
+    } else {
+      return this._desc || '';
+    }
+  },
+
   _toggleWrite: function() {
-    if (this.options.canChangeWriteAccess) {
+    if (this._canChangeWriteAccess) {
       if (this._canWrite()) {
         this._permission.setPermission(this.model, cdb.admin.Permission.READ_ONLY);
       } else {

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view/permission_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view/permission_view_template.jst.ejs
@@ -1,7 +1,7 @@
 <div class="ChangePrivacy-shareListItemInfo">
   <% if (avatarUrl) { %>
-    <div class="UserAvatar ChangePrivacy-shareListItemIcon">
-      <img src="<%= avatarUrl %>" class="UserAvatar--medium" />
+    <div class="UserAvatar ChangePrivacy-shareListItemIcon <%= willRevokeAccess ? 'is-error' : '' %>">
+      <img src="<%= avatarUrl %>" class="UserAvatar-img UserAvatar-img--medium <%= willRevokeAccess ? 'is-error' : '' %>" />
     </div>
   <% } else { %>
     <div class="LayoutIcon ChangePrivacy-shareListItemIcon">
@@ -10,7 +10,7 @@
   <% } %>
   <div>
     <div class="DefaultTitle u-ellipsLongText"><%= title %></div>
-    <p class="DefaultDescription u-ellipsLongText"><%= desc %></p>
+    <p class="DefaultDescription u-ellipsLongText <%= willRevokeAccess ? 'DefaultDescription--error' : '' %>"><%= desc %></p>
   </div>
 </div>
 <div>

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy_view.js
@@ -6,6 +6,8 @@ var StartView = require('./change_privacy/start_view');
 var ShareView = require('./change_privacy/share_view');
 var PrivacyOptions = require('./change_privacy/options_collection');
 
+var START_VIEW = 'start_view';
+var SHARE_VIEW = 'share_view';
 
 /**
  * Change privacy datasets/maps dialog.
@@ -24,7 +26,7 @@ module.exports = BaseDialog.extend({
     }
 
     this._contentPane = this._newContentPane();
-    this._contentPane.active('start_view');
+    this._contentPane.active(START_VIEW);
     this.addView(this._contentPane);
   },
 
@@ -36,6 +38,9 @@ module.exports = BaseDialog.extend({
       this._renderHeaderTemplate(),
       this._renderActiveContentPane().el
     ];
+  },
+  cancel: function() {
+    this.clean();
   },
 
   _renderHeaderTemplate: function() {
@@ -54,30 +59,14 @@ module.exports = BaseDialog.extend({
 
   _newContentPane: function() {
     var pane = new cdb.ui.common.TabPane();
-    pane.addTab('start_view', new StartView({
-      vis: this._vis,
-      user: this._user,
-      upgradeUrl: this._upgradeUrl,
-      privacyOptions: this._privacyOptions
-    }));
+    pane.addTab(START_VIEW, this._newStartView());
 
-    // Will only have permissions if current user is part of an organization
     if (this._hasOrganization()) {
-      pane.addTab('share_view', new ShareView({
-        organization: this._user.organization,
-        permission: this._permission,
-        canChangeWriteAccess: !this._vis.isVisualization()
-      }));
-      pane.getPane('share_view').bind('click:back', function() {
-        this._contentPane.active('start_view');
-        this.render();
-        this.$('.content').removeClass('Dialog-content--expanded');
-      }, this);
-      pane.getPane('start_view').bind('click:share', function() {
-        this._contentPane.active('share_view');
-        this.render();
-        this.$('.content').addClass('Dialog-content--expanded');
-      }, this);
+      var shareView = this._newShareView();
+      pane.addTab(SHARE_VIEW, shareView);
+      
+      pane.getPane(SHARE_VIEW).bind('click:back', this._changeToStartView, this);
+      pane.getPane(START_VIEW).bind('click:share', this._changeToShareView, this);
     }
     
     pane.each(function(name, view) {
@@ -87,8 +76,48 @@ module.exports = BaseDialog.extend({
     return pane;
   },
   
-  cancel: function() {
-    this.clean();
+  _newStartView: function() {
+    return new StartView({
+      vis: this._vis,
+      user: this._user,
+      upgradeUrl: this._upgradeUrl,
+      privacyOptions: this._privacyOptions
+    });
+  },
+
+  _newShareView: function() {
+    var tableMetadata = this._vis.tableMetadata();
+    var visIsTable = !this._vis.isVisualization();
+
+    var shareView = new ShareView({
+      organization: this._user.organization,
+      permission: this._permission,
+      canChangeWriteAccess: visIsTable,
+      tableMetadata: tableMetadata
+    });
+
+    if (visIsTable) {
+      tableMetadata.fetch({
+        silent: true,
+        success: function() {
+          shareView.render();
+        }
+      });
+    }
+
+    return shareView;
+  },
+
+  _changeToStartView: function() {
+    this._contentPane.active(START_VIEW);
+    this.render();
+    this.$('.content').removeClass('Dialog-content--expanded');
+  },
+  
+  _changeToShareView: function() {
+    this._contentPane.active(SHARE_VIEW);
+    this.render();
+    this.$('.content').addClass('Dialog-content--expanded');
   },
 
   _save: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
@@ -32,7 +32,7 @@
               <%= vis.timeDiff %>
               <% if (!vis.isOwner) { %>
                 by <span class="UserAvatar">
-                  <img class="UserAvatar--smaller" src="<%= vis.owner.avatar_url %>" alt="<%= vis.owner.name || vis.owner.username  %>" title="<%= vis.owner.name || vis.owner.username  %>" />
+                  <img class="UserAvatar-img UserAvatar-img--smaller" src="<%= vis.owner.avatar_url %>" alt="<%= vis.owner.name || vis.owner.username  %>" title="<%= vis.owner.name || vis.owner.username  %>" />
                 </span>
               <% } %>
             </div>
@@ -49,12 +49,12 @@
     <div>
       <% affectedEntitiesSample.forEach(function(user) { %>
         <span class="UserAvatar DeleteItems-affectedEntitiesAvatar">
-          <img class="UserAvatar--medium" src="<%= user.get('avatar_url') %>" alt="<%= user.get('name') || user.get('username') %>" title="<%= user.get('name') || user.get('username') %>" />
+          <img class="UserAvatar-img UserAvatar-img--medium" src="<%= user.get('avatar_url') %>" alt="<%= user.get('name') || user.get('username') %>" title="<%= user.get('name') || user.get('username') %>" />
         </span>
       <% }); %>
       <% if (affectedEntitiesCount > affectedEntitiesSampleCount) { %>
         <div class="UserAvatar DeleteItems-affectedEntitiesAvatar">
-          <span class="UserAvatar--medium UserAvatar--moreItems" />
+          <span class="UserAvatar-img UserAvatar-img--medium UserAvatar--moreItems" />
         </div>
       <% } %>
     </div>

--- a/lib/assets/javascripts/cartodb/new_dashboard/header/breadcrumbs/dropdown.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/header/breadcrumbs/dropdown.jst.ejs
@@ -1,7 +1,7 @@
 <ul class="BreadcrumbsDropdown-list">
   <li class="BreadcrumbsDropdown-listItem">
     <span class="BreadcrumbsDropdown-icon UserAvatar">
-      <img class="UserAvatar--small" src="<%= avatarUrl %>" title="<%= userName %>" alt="<%= userName %>" />
+      <img class="UserAvatar-img UserAvatar-img--small" src="<%= avatarUrl %>" title="<%= userName %>" alt="<%= userName %>" />
     </span>
     <nav class="BreadcrumbsDropdown-options">
       <a href="<%= mapsUrl %>" class="BreadcrumbsDropdown-optionsItem <%= !isDatasets && !isLocked ? 'is--selected' : '' %>">Your maps</a>

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/datasets_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/datasets_item.jst.ejs
@@ -56,7 +56,7 @@
         <% if (!isOwner) { %>
           by
           <span class="UserAvatar">
-            <img class="UserAvatar--smaller" src="<%= owner.avatar_url %>" alt="<%= owner.name || owner.username  %>" title="<%= owner.name || owner.username  %>" />
+            <img class="UserAvatar-img UserAvatar-img--smaller" src="<%= owner.avatar_url %>" alt="<%= owner.name || owner.username  %>" title="<%= owner.name || owner.username  %>" />
           </span>
         <% } %>
     </label>

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
@@ -51,7 +51,7 @@
           <% if (!isOwner) { %>
             by
             <span class="UserAvatar">
-              <img class="UserAvatar--smaller" src="<%= owner.avatar_url %>" alt="<%= owner.name || owner.username  %>" title="<%= owner.name || owner.username  %>" />
+              <img class="UserAvatar-img UserAvatar-img--smaller" src="<%= owner.avatar_url %>" alt="<%= owner.name || owner.username  %>" title="<%= owner.name || owner.username  %>" />
             </span>
           <% } %>
         </div>

--- a/lib/assets/test/spec/cartodb/new_common/urls/user_model.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/urls/user_model.spec.js
@@ -1,4 +1,5 @@
 var UserUrl = require('new_common/urls/user_model');
+var urlsFn = require('new_common/urls_fn');
 var cdbAdmin = require('cdb.admin');
 
 describe("new_common/urls/user_model", function() {
@@ -25,12 +26,12 @@ describe("new_common/urls/user_model", function() {
     this.originalMapsUrl = UserUrl.__get__('MapsUrl');
     UserUrl.__set__('MapsUrl', this.MapsUrlSpy);
 
-    this.mapUrlForVisOwnerFnSpy = jasmine.createSpy('mapUrlForVisOwnerFn');
+    this.urls = urlsFn('account_host');
 
     this.url = new UserUrl({
       user: this.user,
       account_host: 'host.ext',
-      mapUrlForVisOwnerFn: this.mapUrlForVisOwnerFnSpy
+      urls: this.urls
     });
   });
 
@@ -141,22 +142,23 @@ describe("new_common/urls/user_model", function() {
               }
             }
           });
-          this.mapUrlStub = jasmine.createSpyObj('MapUrl', ['toEdit']);
-          this.mapUrlForVisOwnerFnSpy.and.returnValue(this.mapUrlStub);
-          
+          spyOn(this.urls, 'mapUrl');
+          this.otherMapUrlStub = jasmine.createSpyObj('mapUrl', ['toPublic']);
+          this.urls.mapUrl.and.returnValue(this.otherMapUrlStub);
+
           this.mapUrl = this.url.mapUrl(this.vis);
         });
 
         it('should create mapUrl model from other user', function() {
-          expect(this.mapUrlForVisOwnerFnSpy).toHaveBeenCalled();
+          expect(this.urls.mapUrl).toHaveBeenCalled();
         });
 
         it('should have created mapUrl with given visualization', function() {
-          expect(this.mapUrlForVisOwnerFnSpy.calls.argsFor(0)[0]).toBe(this.vis);
+          expect(this.urls.mapUrl.calls.argsFor(0)[0]).toBe(this.vis);
         });
         
         it('should return new mapUrl obj', function() {
-          expect(this.mapUrl).toBe(this.mapUrlStub);
+          expect(this.mapUrl).toBe(this.otherMapUrlStub);
         });
       });
     });

--- a/lib/assets/test/spec/cartodb/new_common/urls_fn.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/urls_fn.spec.js
@@ -44,8 +44,8 @@ describe("new_common/urls_fn", function() {
           expect(this.modelCreatedWith).toEqual(jasmine.objectContaining({ account_host: this.accountHost }));
         });
 
-        it('should create url w/ mapUrl fn passed as special function to create mapUrl for visualization owner', function() {
-          expect(this.modelCreatedWith).toEqual(jasmine.objectContaining({ mapUrlForVisOwnerFn: this.urls.mapUrl }));
+        it('should create url w/ this urls object', function() {
+          expect(this.modelCreatedWith).toEqual(jasmine.objectContaining({ urls: this.urls }));
         });
       });
 
@@ -78,8 +78,8 @@ describe("new_common/urls_fn", function() {
           expect(this.modelCreatedWith).toEqual(jasmine.objectContaining({ account_host: this.accountHost }));
         });
 
-        it('should create url w/ mapUrl fn passed as special function to create mapUrl for visualization owner', function() {
-          expect(this.modelCreatedWith).toEqual(jasmine.objectContaining({ mapUrlForVisOwnerFn: this.urls.mapUrl }));
+        it('should create url w/ this urls object', function() {
+          expect(this.modelCreatedWith).toEqual(jasmine.objectContaining({ urls: this.urls }));
         });
       });
     });

--- a/lib/assets/test/spec/cartodb/new_dashboard/dialogs/change_privacy/share_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/dialogs/change_privacy/share_view.spec.js
@@ -8,11 +8,18 @@ var cdbAdmin = require('cdb.admin');
 describe('new_dashboard/dialogs/change_privacy/share_view', function() {
   beforeEach(function() {
     this.permission = new cdbAdmin.Permission();
-    this.org = new cdbAdmin.Organization();
+    this.org = new cdbAdmin.Organization({
+      users: [{
+        id: 'abc-123',
+        username: 'pepe'
+      }]
+    });
+    this.tableMetadata = new cdbAdmin.CartoDBTableMetadata();
     
     this.view = new ShareView({
       organization: this.org,
-      permission: this.permission
+      permission: this.permission,
+      tableMetadata: this.tableMetadata
     });
     this.view.render(); 
   });
@@ -35,6 +42,28 @@ describe('new_dashboard/dialogs/change_privacy/share_view', function() {
 
     it('should fire a click:back event', function() {
       expect(this.view.trigger).toHaveBeenCalledWith('click:back');
+    });
+  });
+
+  describe('given there is at least one dependant visualization', function() {
+    beforeEach(function() {
+      this.visData = {
+        permission: {
+          owner: {
+            id: 'abc-123'
+          }
+        }
+      };
+      this.tableMetadata.set('dependent_visualizations', [ this.visData ]);
+    });
+
+    it('should render OK', function() {
+      expect(this.view.render()).toBe(this.view);
+    });
+
+    it('should rendered users', function() {
+      this.view.render();
+      expect(this.innerHTML()).toContain('pepe');
     });
   });
 });


### PR DESCRIPTION
Fixes #1963 

Basically, get related visualizations and compare their owners against the users list and show affected state accordingly:

![affected](https://cloud.githubusercontent.com/assets/978461/5957032/836a77c6-a7b4-11e4-8146-1d63121397be.gif)
