### PR TITLE
Upgrade cartodb postgres extension to 0.5.2 #1990

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1743,7 +1743,7 @@ TRIGGER
   # Cartodb functions
   def load_cartodb_functions(statement_timeout = nil, cdb_extension_target_version = nil)
     if cdb_extension_target_version.nil?
-      cdb_extension_target_version = '0.5.1'
+      cdb_extension_target_version = '0.5.2'
     end
 
     add_python


### PR DESCRIPTION
@juanignaciosl one-liner, just upgrade version of the plugin

check https://github.com/CartoDB/cartodb-postgresql/pull/67/files for the diff of the changes in the extension