### PR TITLE
CDB-1762-add zoom level tooltip

### DIFF
--- a/lib/assets/javascripts/cartodb/table/overlays/zoom.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/zoom.js
@@ -82,6 +82,7 @@ cdb.admin.overlays.Zoom = cdb.core.View.extend({
 
     this.$el.find(".info").html(zoom);
 
+    this._createTooltip(this.$el.find(".info"));
   },
 
   zoom_in: function(ev) {
@@ -189,6 +190,19 @@ cdb.admin.overlays.Zoom = cdb.core.View.extend({
 
     return this;
 
+  },
+
+  _createTooltip: function(elem) {
+    debugger
+    var tooltip = new cdb.common.TipsyTooltip({
+      el: elem,
+      gravity: 'w',
+      title: function() {
+        //return _.template(self._TEXTS.limits[type])({ name: ( self._TABS[tab].label || self._TABS[tab].title ) })
+        return ("zoom level");
+      }
+    })
+    this.addView(tooltip);
   }
 
 });

--- a/lib/assets/javascripts/cartodb/table/overlays/zoom.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/zoom.js
@@ -82,7 +82,6 @@ cdb.admin.overlays.Zoom = cdb.core.View.extend({
 
     this.$el.find(".info").html(zoom);
 
-    this._createTooltip(this.$el.find(".info"));
   },
 
   zoom_in: function(ev) {
@@ -188,20 +187,22 @@ cdb.admin.overlays.Zoom = cdb.core.View.extend({
 
     this._checkZoom();
 
+    this._createTooltip();
+
     return this;
 
   },
 
   _createTooltip: function(elem) {
-    debugger
+
     var tooltip = new cdb.common.TipsyTooltip({
-      el: elem,
+      el: this.$('.info'),
       gravity: 'w',
       title: function() {
-        //return _.template(self._TEXTS.limits[type])({ name: ( self._TABS[tab].label || self._TABS[tab].title ) })
         return ("zoom level");
       }
     })
+
     this.addView(tooltip);
   }
 


### PR DESCRIPTION
creating tooltip with feedback: zoom_level

From [ticket #1762](https://github.com/CartoDB/cartodb/issues/1762)