### PR TITLE
Prioritize ip over country guessing #2089

### DIFF
--- a/services/importer/lib/importer/georeferencer.rb
+++ b/services/importer/lib/importer/georeferencer.rb
@@ -44,8 +44,8 @@ module CartoDB
 
         create_the_geom_from_geometry_column  ||
         create_the_geom_from_latlon           ||
-        create_the_geom_from_country_guessing ||
         create_the_geom_from_ip_guessing      ||
+        create_the_geom_from_country_guessing ||
         create_the_geom_in(table_name)
 
         enable_autovacuum


### PR DESCRIPTION
- Tables containing a significant number of IP's are far less frequent
than tables containing countries.

- IP geocoding gives better precission.

- Points are lighter than polygons.

- The user can geocode by country afterwards if feels so.

@juanignaciosl please CR