### PR TITLE
Checks that layer is animated before actually adding the timeline

### DIFF
--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -1125,7 +1125,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
       layerView = this.mapView.getLayerByCid(layer.cid);
 
-      if (layerView && steps > 1) {
+      if (layerView && typeof layerView.getStep !== "undefined" && steps > 1) {
         if (!this.timeline) {
           this.timeline = new cdb.geo.ui.TimeSlider({
             layer: layerView,


### PR DESCRIPTION
Ref #2114 

The problem was that in the timeline add function, it wasn't checking whether the layer was animated or not. This fixes it.

@javisantana 
@Xatpy 