### PR TITLE
Forces the update of the rendered_text attribute when closing the overlay

### DIFF
--- a/lib/assets/javascripts/cartodb/table/overlays/image.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/image.js
@@ -206,9 +206,9 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
     this.$text.html(img);
     this.$text.attr("contenteditable", false);
 
-    var self = this;
-
     extra.url = url;
+
+    extra.rendered_text = "<img src='" + url + "' style='width: " + boxWidth + "px'/>";
 
     if (extra.url !== extra.default_image_url) extra.has_default_image = false;
 
@@ -266,6 +266,7 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
     var img       = "<img src='" + url + "' style='width: " + boxWidth + "px'/>";
 
     extra.rendered_text = img;
+
     this.model.set({ extra: extra }, { silent: true });
 
     this.$el
@@ -329,10 +330,8 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
 
     this.$text = this.$el.find(".content div.text");
 
-    var self = this;
-
-      self._setURL();
-      self._applyStyle(false);
+    this._setURL();
+    this._applyStyle(false);
 
     this.$el.addClass(this.model.get("device"));
 

--- a/lib/assets/javascripts/cartodb/table/overlays/image.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/image.js
@@ -325,6 +325,11 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
 
   },
 
+  clean: function() {
+    $(document).unbind('keydown', this._onKeyDown, this);
+    cdb.core.View.prototype.clean.call(this);
+  },
+
   render: function() {
 
     this._place();

--- a/lib/assets/javascripts/cartodb/table/overlays/image.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/image.js
@@ -25,6 +25,7 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
     $(document).bind('keydown', this._onKeyDown);
 
     this.template = this.getTemplate('table/views/overlays/image');
+    this.image_template =  _.template("<img src='<%= url %>' style='width: <%= width %>px'/>");
 
     this._setupModels();
 
@@ -208,7 +209,7 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
 
     extra.url = url;
 
-    extra.rendered_text = "<img src='" + url + "' style='width: " + boxWidth + "px'/>";
+    extra.rendered_text = this.image_template({ url: url, width: boxWidth });
 
     if (extra.url !== extra.default_image_url) extra.has_default_image = false;
 
@@ -263,7 +264,7 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
     var style     = this.model.get("style");
     var boxWidth  = style["box-width"];
     var extra     = this.model.get("extra");
-    var img       = "<img src='" + url + "' style='width: " + boxWidth + "px'/>";
+    var img       = this.image_template({ url: url, width: boxWidth });
 
     extra.rendered_text = img;
 

--- a/lib/assets/javascripts/cartodb/table/overlays/image.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/image.js
@@ -156,7 +156,7 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
     +', ' + boxOpacity + ' )';
 
     this.$el.css("background-color", rgbaCol);
-    this.$el.find("img").css("width", boxWidth);
+    this.$("img").css("width", boxWidth);
 
     if (save) this.model.save();
 
@@ -289,7 +289,7 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
 
     this.dropdown = new cdb.admin.OverlayPropertiesDropdown({
       tick: "left",
-      target: this.$el.find(".edit"),
+      target: this.$(".edit"),
       model: this.model,
       horizontal_position: "left",
       horizontal_offset: 26,
@@ -331,7 +331,7 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
 
     this.$el.append(this.template());
 
-    this.$text = this.$el.find(".content div.text");
+    this.$text = this.$(".content div.text");
 
     this._setURL();
     this._applyStyle(false);

--- a/lib/assets/javascripts/cartodb/table/overlays/image.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/image.js
@@ -211,7 +211,9 @@ cdb.admin.overlays.Image = cdb.admin.overlays.Text.extend({
 
     extra.rendered_text = this.image_template({ url: url, width: boxWidth });
 
-    if (extra.url !== extra.default_image_url) extra.has_default_image = false;
+    if (extra.url !== extra.default_image_url) {
+      extra.has_default_image = false;
+    }
 
     this.model.set({ extra: extra }, { silent: true });
 


### PR DESCRIPTION
Fixes #2120 #2020 #1979.

@CartoDB/frontend: review this, please.