### PR TITLE
Provide a meaningful error when import fails because of stament timeout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
   [documentation](https://github.com/CartoDB/cartodb/wiki/How-to-configure-basemaps-in-CartoDB)
 * Added oEmbed support for visualizations [#1965](https://github.com/CartoDB/cartodb/issues/1965)
 * [content guessing] Prioritize ip over country guessing [#2089](https://github.com/CartoDB/cartodb/issues/2089)
+* Added new import error code (6667) for detecting and reporting statement timeouts.
 
 3.8.0 (2015-01-30)
 ------------------

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -61,6 +61,15 @@ module CartoDB
         runner.log.append("Before persisting metadata '#{name}' data_import_id: #{data_import_id}")
         persist_metadata(result, name, data_import_id)
         runner.log.append("Table '#{name}' registered")
+      rescue => exception
+        if exception.message =~ /canceling statement due to statement timeout/i
+          raise CartoDB::Importer2::StatementTimeoutError.new(
+            exception.message,
+            CartoDB::Importer2::ERRORS_MAP[CartoDB::Importer2::StatementTimeoutError]
+          )
+        else
+          raise exception
+        end
       end
 
       def success?

--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -286,6 +286,10 @@ module CartoDB
       title: 'Dataset too big',
       what_about: "The dataset you tried to import is too big and cannot be processed. If the dataset allows it, you can try splitting it into smaller files and then using the 'Merge Tables' functionality."
     },
+    6667 => {
+      title: 'Import timed out',
+      what_about: "There is been a problem importing your file due to the time is been taking to process it. Please try again and contact us if the problem persist."
+    },
     99999 => {
       title: 'Unknown',
       what_about: "Sorry, something went wrong and we're not sure what. Try

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -5,6 +5,15 @@ require_relative '../../../../services/datasources/lib/datasources/exceptions'
 module CartoDB
   module Importer2
 
+    class BaseImportError < StandardError
+      def initialize(message, error_code=nil)
+        super(message)
+        self.error_code = error_code
+      end
+
+      attr_accessor :error_code
+    end
+
     # Generic/unmapped errors
     class GenericImportError                    < StandardError; end
     # Mapped errors
@@ -36,6 +45,7 @@ module CartoDB
     class MalformedCSVException                 < GenericImportError; end
     class TooManyColumnsError                   < GenericImportError; end
     class DuplicatedColumnError                 < GenericImportError; end
+    class StatementTimeoutError                 < BaseImportError; end
 
     # @see also app/models/synchronization/member.rb => run() for more error codes
     # @see config/initializers/carto_db.rb For the texts
@@ -64,6 +74,7 @@ module CartoDB
       GeometryCollectionNotSupportedError   => 3201,
       KmlNetworkLinkError                   => 3202,
       FileTooBigError                       => 6666,
+      StatementTimeoutError                 => 6667,
       StorageQuotaExceededError             => 8001,
       TableQuotaExceededError               => 8002,
       UnknownError                          => 99999,

--- a/services/importer/lib/importer/loader.rb
+++ b/services/importer/lib/importer/loader.rb
@@ -231,6 +231,9 @@ module CartoDB
         raise DuplicatedColumnError.new(job.logger) if ogr2ogr.command_output[0..200] =~ /specified more than once/
         raise InvalidGeoJSONError.new(job.logger) if ogr2ogr.command_output =~ /nrecognized GeoJSON/
         raise TooManyColumnsError.new(job.logger) if ogr2ogr.command_output =~ /tables can have at most 1600 columns/
+        if ogr2ogr.command_output =~ /canceling statement due to statement timeout/i
+          raise StatementTimeoutError.new(exception.message, ERRORS_MAP[CartoDB::Importer2::StatementTimeoutError])
+        end
 
         if ogr2ogr.exit_code != 0
           # OOM

--- a/services/importer/lib/importer/raster2pgsql.rb
+++ b/services/importer/lib/importer/raster2pgsql.rb
@@ -120,6 +120,10 @@ module CartoDB
         self.command_output << "\n#{output_message}"
         self.exit_code = status.to_i
 
+        if output =~ /canceling statement due to statement timeout/i
+          raise StatementTimeoutError.new(output_message, ERRORS_MAP[StatementTimeoutError])
+        end
+
         raise UnknownSridError.new(output_message)          if output =~ /invalid srid/i
         raise TiffToSqlConversionError.new(output_message)  if status.to_i != 0
         raise TiffToSqlConversionError.new(output_message)  if output =~ /failure/i


### PR DESCRIPTION
Fixes #1678, by checking statement timeout errors upon import (or table registering) and providing a new feedback message.