### PR TITLE
Pagination for new public dashboard maps/datasets

### DIFF
--- a/app/assets/stylesheets/new_common/content-footer.css.scss
+++ b/app/assets/stylesheets/new_common/content-footer.css.scss
@@ -2,17 +2,16 @@
 @import "../new_variables/colors";
 @import "../new_variables/sizes";
 
-.ContentFooter > .u-inner {
+.ContentFooterInner {
   @include display-flex();
   @include justify-content(space-between, justify);
-  @include align-items(center, center);
-  position:relative;
+  @include align-items(center);
+  position: relative;
   height: 81px;
-  padding: 0 0 50px 0;
-  overflow:hidden;
+  padding: 0 0 $sMargin-section 0;
+  overflow: hidden;
 }
 .ContentFooter-lockedIcon {
   font-size: $sFontSize-small;
   color: $cTypography-help;
 }
-

--- a/app/assets/stylesheets/new_common/pagination.css.scss
+++ b/app/assets/stylesheets/new_common/pagination.css.scss
@@ -16,11 +16,12 @@
   @include align-items(center, center);
 }
 .Pagination-listItem {
-  display: inline-block;
   border: 1px $cStructure-mainLine solid;
   border-right-width: 0;
+}
+.Pagination-listItemLink {
+  display: inline-block;
   padding: 10px 15px;
-  margin: 0;
 }
 .Pagination-listItem:first-child {
   border-radius: 5px 0 0 5px;
@@ -29,8 +30,8 @@
   border-right-width: 1px;
   border-radius: 0 5px 5px 0;
 }
-.Pagination-listItem.is--current,
-.Pagination-listItem.is--current a,
-.Pagination-listItem.is--current a:hover {
+.Pagination-listItem.is-current,
+.Pagination-listItem.is-current a,
+.Pagination-listItem.is-current a:hover {
   color: $cTypography-headers;
 }

--- a/app/assets/stylesheets/new_public_dashboard/public-body.css.scss
+++ b/app/assets/stylesheets/new_public_dashboard/public-body.css.scss
@@ -14,5 +14,5 @@
 .PublicBody-content {
   @include display-flex();
   @include flex-grow(1);
-  margin: $sMargin-group 0 $sMargin-section 0;
+  margin-top: $sMargin-group;
 }

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -136,7 +136,7 @@ class Admin::PagesController < ApplicationController
     @content_type = content_type
     @maps_url = view_context.public_visualizations_home_url(user_domain: params[:user_domain])
     @datasets_url = view_context.public_datasets_home_url(user_domain: params[:user_domain])
-    @current_page = params[:page].present? ? params[:page] : 1
+    @current_page = params[:page].to_i > 0 ? params[:page] : 1
 
     # Note that these are shared for both new and current layouts, so dont change lightly
     @name               = viewed_user.name_or_username

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -150,7 +150,7 @@ class Admin::PagesController < ApplicationController
   end
 
   def new_public_datasets(viewed_user)
-    @datasets_per_page = DATASETS_PER_PAGE
+    @datasets_per_page = 20
     visualizations = Visualization::Collection.new.fetch({
       user_id:  viewed_user.id,
       type:     Visualization::Member::TYPE_CANONICAL,
@@ -203,7 +203,7 @@ class Admin::PagesController < ApplicationController
   end
 
   def new_public_dashboard(viewed_user)
-    @vis_per_page = VISUALIZATIONS_PER_PAGE
+    @vis_per_page = 9
     visualizations = Visualization::Collection.new.fetch({
       user_id:  viewed_user.id,
       type:     Visualization::Member::TYPE_DERIVED,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -229,4 +229,8 @@ module ApplicationHelper
   def vis_json_url(vis_id)
     "#{ api_v2_visualizations_vizjson_url(user_domain: params[:user_domain], id: vis_id).sub(/(http:|https:)/i, '') }.json"
   end
+
+  def maps_or_datasets_str(is_maps = true)
+    is_maps ? 'maps' : 'datasets'
+  end
 end

--- a/app/views/admin/pages/new_public_datasets.html.erb
+++ b/app/views/admin/pages/new_public_datasets.html.erb
@@ -6,60 +6,56 @@
   <%= @name %> is creating and sharing public datasets using CartoDB
 <% end %>
 
-<%= content_for(:js) do %>
-  <script>
-    var user_name = '<%= @username %>';
-  </script>
-
-  <%= javascript_include_tag 'cdb.js', 'templates.js', 'public_dashboard' %>
-<% end %>
-
-<% if @datasets.size == 0 %>
-  <div class="IntermediateInfo">
-    <div class="LayoutIcon">
-      <i class="iconFont iconFont-Map"></i>
+<div class="PublicBody-content">
+  <% if @datasets.size == 0 %>
+    <div class="IntermediateInfo">
+      <div class="LayoutIcon">
+        <i class="iconFont iconFont-Map"></i>
+      </div>
+      <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public datasets yet</h3>
+      <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to 'maps', public_visualizations_home_url(user_domain: params[:user_domain]) %></p>
     </div>
-    <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public datasets yet</h3>
-    <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to 'maps', public_visualizations_home_url(user_domain: params[:user_domain]) %></p>
-  </div>
-<% else %>
-  <ul class="DatasetsList">
-    <% @datasets.each do |ds| %>
-      <% user_domain = ds[:owner].organization ? ds[:owner].username : nil %>
-      <li class="DatasetsList-item">
-        <div class="DatasetsList-itemPrimaryInfo">
-          <div class="DatasetsList-itemCategory is--<%= ds[:geometry_type] %>Dataset"></div>
-          <div class="DatasetsList-itemInfo">
-            <h3 class="DatasetsList-itemTitle DefaultTitle">
-              <a href="<%= public_table_url(user_domain: user_domain, id: ds[:title]) %>" title="<%= ds[:title] %>" class="DefaultTitle-link u-ellipsLongText"><%= ds[:title] %></a>
-            </h3>
-            <p class="DefaultDescription u-ellipsLongText"><%= raw ds[:desc] %></p>
-          </div>
-        </div>
-        <div class="DatasetsList-itemSecondaryInfo">
-          <div class="DatasetsList-itemMeta">
-            <div class="RowsIndicator">
-              <i class="iconFont iconFont-Rows RowsIndicator-icon"></i>
-              <%= pluralize(ds[:rows_count], 'row') %>
-            </div>
-            <div class="SizeIndicator">
-              <i class="iconFont iconFont-Floppy SizeIndicator-icon"></i>
-              <%= number_to_human_size(ds[:size_in_bytes]) %>
-            </div>
-            <div class="DatasetsList-itemTimeDiff DefaultTimeDiff">
-              <i class="iconFont iconFont-Clock DefaultTimeDiff-icon"></i>
-              <%= time_ago_in_words(ds[:updated_at]) %>
+  <% else %>
+    <ul class="DatasetsList">
+      <% @datasets.each do |ds| %>
+        <% user_domain = ds[:owner].organization ? ds[:owner].username : nil %>
+        <li class="DatasetsList-item">
+          <div class="DatasetsList-itemPrimaryInfo">
+            <div class="DatasetsList-itemCategory is--<%= ds[:geometry_type] %>Dataset"></div>
+            <div class="DatasetsList-itemInfo">
+              <h3 class="DatasetsList-itemTitle DefaultTitle">
+                <a href="<%= public_table_url(user_domain: user_domain, id: ds[:title]) %>" title="<%= ds[:title] %>" class="DefaultTitle-link u-ellipsLongText"><%= ds[:title] %></a>
+              </h3>
+              <p class="DefaultDescription u-ellipsLongText"><%= raw ds[:desc] %></p>
             </div>
           </div>
-          <div class="DatasetsList-itemTags">
-            <div class="DefaultTags">
-              <% if ds[:tags].size > 0 %>
-                <% formatted_tags(ds[:tags]) do |tag| %><a class="DefaultTags-item js-tag-link" href="<%= public_datasets_tag_url(user_domain: user_domain, tag: tag) %>"><%= tag %></a><% end %>
-              <% end %>
+          <div class="DatasetsList-itemSecondaryInfo">
+            <div class="DatasetsList-itemMeta">
+              <div class="RowsIndicator">
+                <i class="iconFont iconFont-Rows RowsIndicator-icon"></i>
+                <%= pluralize(ds[:rows_count], 'row') %>
+              </div>
+              <div class="SizeIndicator">
+                <i class="iconFont iconFont-Floppy SizeIndicator-icon"></i>
+                <%= number_to_human_size(ds[:size_in_bytes]) %>
+              </div>
+              <div class="DatasetsList-itemTimeDiff DefaultTimeDiff">
+                <i class="iconFont iconFont-Clock DefaultTimeDiff-icon"></i>
+                <%= time_ago_in_words(ds[:updated_at]) %>
+              </div>
+            </div>
+            <div class="DatasetsList-itemTags">
+              <div class="DefaultTags">
+                <% if ds[:tags].size > 0 %>
+                  <% formatted_tags(ds[:tags]) do |tag| %><a class="DefaultTags-item js-tag-link" href="<%= public_datasets_tag_url(user_domain: user_domain, tag: tag) %>"><%= tag %></a><% end %>
+                <% end %>
+              </div>
             </div>
           </div>
-        </div>
-      </li>
-    <% end %>
-  </ul>
-<% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>
+
+<%= render 'admin/shared/new_pagination', total_count: @total_count, per_page: @datasets_per_page, current_page: @current_page %>

--- a/app/views/admin/pages/new_public_datasets.html.erb
+++ b/app/views/admin/pages/new_public_datasets.html.erb
@@ -8,13 +8,7 @@
 
 <div class="PublicBody-content">
   <% if @datasets.size == 0 %>
-    <div class="IntermediateInfo">
-      <div class="LayoutIcon">
-        <i class="iconFont iconFont-Map"></i>
-      </div>
-      <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public datasets yet</h3>
-      <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to 'maps', public_visualizations_home_url(user_domain: params[:user_domain]) %></p>
-    </div>
+    <%= render 'admin/shared/new_no_results', is_maps: false, alt_url: public_visualizations_home_url(user_domain: params[:user_domain]) %>
   <% else %>
     <ul class="DatasetsList">
       <% @datasets.each do |ds| %>

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -8,13 +8,7 @@
 
 <div class="PublicBody-content">
   <% if @visualizations.size == 0 %>
-    <div class="IntermediateInfo">
-      <div class="LayoutIcon">
-        <i class="iconFont iconFont-Map"></i>
-      </div>
-      <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public maps yet</h3>
-      <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to 'datasets', public_datasets_home_url(user_domain: params[:user_domain]) %></p>
-    </div>
+    <%= render 'admin/shared/new_no_results', is_maps: true, alt_url: public_datasets_home_url(user_domain: params[:user_domain]) %>
   <% else %>
     <ul class="MapsList">
       <% @visualizations.each do |vis| %>

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -6,60 +6,64 @@
   <%= @name %> is creating maps and visualizations using CartoDB
 <% end %>
 
-<% if @visualizations.size == 0 %>
-  <div class="IntermediateInfo">
-    <div class="LayoutIcon">
-      <i class="iconFont iconFont-Map"></i>
+<div class="PublicBody-content">
+  <% if @visualizations.size == 0 %>
+    <div class="IntermediateInfo">
+      <div class="LayoutIcon">
+        <i class="iconFont iconFont-Map"></i>
+      </div>
+      <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public maps yet</h3>
+      <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to 'datasets', public_datasets_home_url(user_domain: params[:user_domain]) %></p>
     </div>
-    <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public maps yet</h3>
-    <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to 'datasets', public_datasets_home_url(user_domain: params[:user_domain]) %></p>
-  </div>
-<% else %>
-  <ul class="MapsList">
-    <% @visualizations.each do |vis| %>
-      <% user_domain = vis[:owner].organization ? vis[:owner].username : nil %>
-      <li class="MapsList-item">
-        <div class="MapCard">
-          <div class="MapCard-header">
-          </div>
-          <div class="MapCard-content">
-            <div class="MapCard-contentBody">
-              <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
-                <h3 class="DefaultTitle">
-                  <a href="<%= public_visualizations_public_map_url(user_domain: user_domain, id: vis[:id]) %>" class="DefaultTitle-link u-ellipsLongText" title="<%= vis[:title] %>"><%= vis[:title] %></a>
-                </h3>
-              </div>
-
-              <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
-                <% if vis[:description] %>
-                  <p class="DefaultDescription" title="<%= vis[:description] %>"><%= raw truncate(vis[:description], :length => 85) %></p>
-                <% else %>
-                  <span class="DefaultDescription is--empty"></span>
-                <% end %>
-              </div>
-
-              <div class="DefaultTags MapCard-contentBodyRow">
-                <% if vis[:tags].size > 0 %>
-                  <% formatted_tags(vis[:tags]) do |tag| %>
-                    <a class="DefaultTags-item js-tag-link" href="<%= public_tag_url(user_domain: user_domain, tag: tag) %>"><%= tag %></a>
-                  <% end %>
-                <% end %>
-              </div>
+  <% else %>
+    <ul class="MapsList">
+      <% @visualizations.each do |vis| %>
+        <% user_domain = vis[:owner].organization ? vis[:owner].username : nil %>
+        <li class="MapsList-item">
+          <div class="MapCard">
+            <div class="MapCard-header">
             </div>
-            <div class="MapCard-contentFooter">
-              <div class="MapCard-contentFooterDetails--left">
-                <div class="MapCard-contentFooterTimeDiff DefaultTimeDiff">
-                  <i class="iconFont iconFont-Clock DefaultTimeDiff-icon"></i>
-                  <%= time_ago_in_words(vis[:updated_at]) %>
+            <div class="MapCard-content">
+              <div class="MapCard-contentBody">
+                <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
+                  <h3 class="DefaultTitle">
+                    <a href="<%= public_visualizations_public_map_url(user_domain: user_domain, id: vis[:id]) %>" class="DefaultTitle-link u-ellipsLongText" title="<%= vis[:title] %>"><%= vis[:title] %></a>
+                  </h3>
+                </div>
+
+                <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
+                  <% if vis[:description] %>
+                    <p class="DefaultDescription" title="<%= vis[:description] %>"><%= raw truncate(vis[:description], :length => 85) %></p>
+                  <% else %>
+                    <span class="DefaultDescription is--empty"></span>
+                  <% end %>
+                </div>
+
+                <div class="DefaultTags MapCard-contentBodyRow">
+                  <% if vis[:tags].size > 0 %>
+                    <% formatted_tags(vis[:tags]) do |tag| %>
+                      <a class="DefaultTags-item js-tag-link" href="<%= public_tag_url(user_domain: user_domain, tag: tag) %>"><%= tag %></a>
+                    <% end %>
+                  <% end %>
                 </div>
               </div>
-              <div class="MapCard-contentFooterDetails--right">
-                <%# likes %>
+              <div class="MapCard-contentFooter">
+                <div class="MapCard-contentFooterDetails--left">
+                  <div class="MapCard-contentFooterTimeDiff DefaultTimeDiff">
+                    <i class="iconFont iconFont-Clock DefaultTimeDiff-icon"></i>
+                    <%= time_ago_in_words(vis[:updated_at]) %>
+                  </div>
+                </div>
+                <div class="MapCard-contentFooterDetails--right">
+                  <%# likes %>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </li>
-    <% end %>
-  </ul>
-<% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>
+
+<%= render 'admin/shared/new_pagination', total_count: @total_count, per_page: @vis_per_page, current_page: @current_page %>

--- a/app/views/admin/shared/_new_no_results.html.erb
+++ b/app/views/admin/shared/_new_no_results.html.erb
@@ -1,0 +1,12 @@
+<div class="IntermediateInfo">
+  <div class="LayoutIcon">
+    <i class="iconFont iconFont-Map"></i>
+  </div>
+  <% if @total_count > 0 %>
+    <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any items on this page</h3>
+    <p class="DefaultParagraph">Try the <%= link_to 'first page', url_for(page: nil) %> instead</p>
+  <% else  %>
+    <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public <%= maps_or_datasets_str(is_maps) %> yet</h3>
+    <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to maps_or_datasets_str(!is_maps), alt_url %></p>
+  <% end %>
+</div>

--- a/app/views/admin/shared/_new_pagination.html.erb
+++ b/app/views/admin/shared/_new_pagination.html.erb
@@ -1,0 +1,23 @@
+<div class="ContentFooter">
+  <div class="u-inner ContentFooterInner">
+    <div></div>
+    <div class="js-content-footer"></div>
+  </div>
+</div>
+
+<% content_for(:js) do %>
+  <script type="text/javascript">
+    var paginationModelAttrs = {
+      current_page: <%= current_page %>,
+      total_count: <%= total_count %>,
+      per_page: <%= per_page %>,
+      url_to: function(page) {
+        if (page === 1) {
+          return '<%= url_for(page: nil) %>';
+        } else {
+          return '<%= url_for(page: 12321) %>'.replace('12321', page);
+        }
+      }
+    }
+  </script>
+<% end %>

--- a/app/views/admin/visualizations/new-dashboard.html.erb
+++ b/app/views/admin/visualizations/new-dashboard.html.erb
@@ -27,7 +27,7 @@
   <div class="NoDatasets"></div>
   <div class="ContentList" id="content-list"></div>
   <div class="ContentFooter" id="content-footer">
-    <div class="u-inner" id="content-footer-inner"></div>
+    <div class="u-inner ContentFooterInner" id="content-footer-inner"></div>
   </div>
 </div>
 

--- a/app/views/layouts/new_public_dashboard.html.erb
+++ b/app/views/layouts/new_public_dashboard.html.erb
@@ -43,7 +43,7 @@
           <% else %>
             <%= link_to 'Datasets', @datasets_url, class: "DropdownLink js-breadcrumb-dropdown-target" %>
           <% end %>
-          <% content_for(:abs_positioned) do %>
+          <% content_for(:js) do %>
             <div class="js-breadcrumb-dropdown-content dropdown BreadcrumbsDropdown BreadcrumbsDropdown" style="display: none;">
               <ul class="BreadcrumbsDropdown-list">
                 <li class="BreadcrumbsDropdown-listItem">
@@ -86,9 +86,9 @@
         <% end %>
       </ul>
     </div>
-    <div class="PublicBody-content">
-      <%= yield %>
-    </div>
+
+    <%= yield %>
+
     <%= render 'admin/shared/new_footer' %>
     <script type="text/javascript">
       var favMapViewAttrs = {
@@ -107,6 +107,5 @@
     </script>
     <%= javascript_include_tag 'cdb.js', 'templates', 'new_public_dashboard_deps', 'new_public_dashboard' %>
     <%= yield :js %>
-    <%= yield :abs_positioned %>
   </body>
 </html>

--- a/lib/assets/javascripts/cartodb/new_common/view_helpers/navigate_through_router.js
+++ b/lib/assets/javascripts/cartodb/new_common/view_helpers/navigate_through_router.js
@@ -7,7 +7,7 @@ var $ = require('jquery');
  * @returns {boolean}
  */
 function isLinuxMiddleOrRightClick(ev) {
-  return ev.which === 2 || ev.which === 3
+  return ev.which === 2 || ev.which === 3;
 }
 
 /**
@@ -25,7 +25,7 @@ function isCtrlKeyPressed(ev) {
 }
 
 /**
- * Default click handler, to be used together with a cartodb.js view, to manage default link behavior.
+ * Click handler for a cartodb.js view, to navigate event target's href URL through the view's router.navigate method.
  *
  * The default behavior is:
  * Unless cmd/ctrl keys are pressed it will cancel the default link behavior and instead navigate to the URL set in the
@@ -40,17 +40,17 @@ function isCtrlKeyPressed(ev) {
  *     <a href="/special/uri" id="#my-special-link" ...
  *
  *   - In the view file:
- *     var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+ *     var navigateThroughRouter = require('new_common/view_helpers/navigateThroughRouter');
  *     module.exports = new cdb.core.View.extend({
  *       events: {
- *         'click a#my-link': handleAHref
+ *         'click a#my-link': navigateThroughRouter
  *         'click a#my-special-link': this._myCustomRoute
  *       }
  *
  *       _myCustomRoute: function(ev) {
  *         // Here you can do you custom logic before/after the routing, e.g.:
  *         console.log('before changing route');
- *         handleAHref.apply(this, arguments);
+ *         navigateThroughRouter.apply(this, arguments);
  *         console.log('after changing route');
  *       }
  *

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/model.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/model.js
@@ -48,7 +48,7 @@ module.exports = cdb.core.Model.extend({
       rangeStart = this.get('current_page') - this._startOffset();
     } else {
       // Somewhere between the low and high boundary
-      rangeStart = this.pagesCount() - this.get('display_count') +1;
+      rangeStart = this.pagesCount() - this.get('display_count') + 1;
     }
     rangeStart = Math.max(rangeStart, 1);
 
@@ -73,6 +73,6 @@ module.exports = cdb.core.Model.extend({
 
   _rangeEnd: function(rangeStart) {
     // If we are too close to the range end then cap to the pages count.
-    return Math.min(rangeStart + this.get('display_count'), this.pagesCount() +1);
+    return Math.min(rangeStart + this.get('display_count'), this.pagesCount() + 1);
   }
 });

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/template.jst.ejs
@@ -4,8 +4,8 @@
   </span>
   <ul class="Pagination-list">
     <% m.pagesToDisplay().forEach(function(page) { %>
-    <li class="Pagination-listItem <%= m.isCurrentPage(page) ? 'is--current' : '' %>">
-      <a href="<%= m.urlTo(page) %>"><%= page %></a>
+    <li class="Pagination-listItem <%= m.isCurrentPage(page) ? 'is-current' : '' %>">
+      <a class="Pagination-listItemLink" href="<%= m.urlTo(page) %>"><%= page %></a>
     </li>
     <% }) %>
   </ul>

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/template.jst.ejs
@@ -1,6 +1,6 @@
-<% if (m.pagesCount() > 1) { %>
+<% if (1 < pagesCount && pagesCount >= currentPage) { %>
   <span class="DefaultDescription Pagination-label">
-    Page <%= m.get('current_page') %> of <%= m.pagesCount() %>
+    Page <%= currentPage %> of <%= pagesCount %>
   </span>
   <ul class="Pagination-list">
     <% m.pagesToDisplay().forEach(function(page) { %>

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/view.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/view.js
@@ -7,22 +7,27 @@ var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
  * Expected to be created with a pagination model, see the model for available params, here we create w/ the minimum:
  *   new PaginationView({
  *     model: new PaginationModel({
- *       // Minimum compulsory:
+ *       // Compulsory:
  *       urlTo:  function(page) { return '/?page='+ page },
+
+         // Optional, to router clicks on <a> tags through router.navigate by default
  *       router: new Router(...)
  *     })
  *   });
  */
 module.exports = cdb.core.View.extend({
-  className: 'Pagination',
 
-  events: {
-    'click a': handleAHref
-  },
+  className: 'Pagination',
 
   initialize: function(args) {
     this.template = cdb.templates.getTemplate('new_common/views/pagination/template');
-    this.router = args.router;
+
+    if (args.router) {
+      this.router = args.router;
+      this.events = {
+        'click a': handleAHref
+      };
+    }
 
     this.model.bind('change', this.render, this);
   },
@@ -35,6 +40,7 @@ module.exports = cdb.core.View.extend({
     } else {
       this.$el.html('');
     }
+    this.$el.addClass(this.className);
     this.delegateEvents();
 
     return this;

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/view.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/view.js
@@ -1,5 +1,5 @@
 var cdb = require('cartodb.js');
-var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+var navigateThroughRouter = require('new_common/view_helpers/navigate_through_router');
 
 /**
  * Responsible for pagination.
@@ -25,7 +25,7 @@ module.exports = cdb.core.View.extend({
     if (args.router) {
       this.router = args.router;
       this.events = {
-        'click a': handleAHref
+        'click a': navigateThroughRouter
       };
     }
 

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/view.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/view.js
@@ -35,7 +35,9 @@ module.exports = cdb.core.View.extend({
   render: function() {
     if (this.model.get('total_count') > 0) {
       this.$el.html(this.template({
-        m: this.model
+        m: this.model,
+        pagesCount: this.model.pagesCount(),
+        currentPage: this.model.get('current_page')
       }));
     } else {
       this.$el.html('');

--- a/lib/assets/javascripts/cartodb/new_dashboard/content_footer/view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/content_footer/view.js
@@ -2,11 +2,11 @@ var cdb = require('cartodb.js');
 var PaginationModel = require('new_common/views/pagination/model');
 var PaginationView = require('new_common/views/pagination/view');
 var pluralizeString = require('new_common/view_helpers/pluralize_string');
-var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+var navigateThroughRouter = require('new_common/view_helpers/navigate_through_router');
 
 var filterShortcutId = 'filter-shortcut';
 var events = {};
-events['click #'+ filterShortcutId +' a'] = handleAHref;
+events['click #' + filterShortcutId + ' a'] = navigateThroughRouter;
 
 /**
  * Responsible for the content footer of the layout.

--- a/lib/assets/javascripts/cartodb/new_dashboard/content_result_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/content_result_view.js
@@ -1,7 +1,7 @@
 var $ = require('jquery');
 var cdb = require('cartodb.js');
 cdb.admin = require('cdb.admin');
-var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+var navigateThroughRouter = require('new_common/view_helpers/navigate_through_router');
 var CreateDialog = require('new_common/dialogs/create/create_view');
 
 /*
@@ -12,7 +12,7 @@ module.exports = cdb.core.View.extend({
 
   events: {
     'click .js-mail-link': '_onMailClick',
-    'click .js-link':      handleAHref,
+    'click .js-link':      navigateThroughRouter,
     'click .js-connect':   '_onConnectClick'
   },
 
@@ -32,7 +32,7 @@ module.exports = cdb.core.View.extend({
     if (type) {
       defaultUrl = this.router.rootUrlForCurrentType().toDefault();
     }
-    
+
     this.$el.html(this.template({
       defaultUrl:     defaultUrl,
       page:           this.router.model.get('page'),
@@ -73,7 +73,7 @@ module.exports = cdb.core.View.extend({
       createDialog.bind('hide', function(d) {
         this.clean();
       });
-      
+
       createDialog.bind('done', function(d) {
         console.log("show background importer");
         // this.trigger('connectDataset', this);

--- a/lib/assets/javascripts/cartodb/new_dashboard/datasets/datasets_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/datasets/datasets_item.js
@@ -1,7 +1,7 @@
 var cdb = require('cartodb.js');
 var moment = require('moment');
 var Utils = require('cdb.Utils');
-var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+var navigateThroughRouter = require('new_common/view_helpers/navigate_through_router');
 var pluralizeString = require('new_common/view_helpers/pluralize_string');
 var LikesView = require('new_common/views/likes/view');
 
@@ -14,7 +14,7 @@ module.exports = cdb.core.View.extend({
   className: 'DatasetsList-item DatasetsList-item--selectable',
 
   events: {
-    'click .js-tag-link': handleAHref,
+    'click .js-tag-link': navigateThroughRouter,
     'click': '_selectDataset'
   },
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/datasets/remote_datasets_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/datasets/remote_datasets_item.js
@@ -1,5 +1,5 @@
 var DatasetsItem = require('new_dashboard/datasets/datasets_item');
-var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+var navigateThroughRouter = require('new_common/view_helpers/navigate_through_router');
 var Utils = require('cdb.Utils');
 var pluralizeString = require('new_common/view_helpers/pluralize_string');
 
@@ -14,7 +14,7 @@ module.exports = DatasetsItem.extend({
   className: 'DatasetsList-item',
 
   events: {
-    'click .js-tag-link': handleAHref,
+    'click .js-tag-link': navigateThroughRouter,
     'click': '_selectDataset'
   },
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -1,5 +1,5 @@
 var cdb = require('cartodb.js');
-var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+var navigateThroughRouter = require('new_common/view_helpers/navigate_through_router');
 var pluralizeString = require('new_common/view_helpers/pluralize_string');
 var CreateDialog = require('new_common/dialogs/create/create_view');
 var DeleteItemsDialog = require('new_dashboard/dialogs/delete_items_view');
@@ -31,7 +31,7 @@ module.exports = cdb.core.View.extend({
     'click .js-new_map':        '_newMap',
     'click .js-lock':           '_openChangeLockDialog',
     'click .js-privacy':        '_openChangePrivacyDialog',
-    'click .js-link':           handleAHref
+    'click .js-link':           navigateThroughRouter
   },
 
   initialize: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/header/breadcrumbs/dropdown_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/header/breadcrumbs/dropdown_view.js
@@ -1,7 +1,7 @@
 var cdb = require('cartodb.js');
 cdb.admin = require('cdb.admin');
 var $ = require('jquery');
-var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+var navigateThroughRouter = require('new_common/view_helpers/navigate_through_router');
 
 /**
  * The content of the dropdown menu opened by the link at the end of the breadcrumbs menu, e.g.
@@ -54,7 +54,7 @@ module.exports = cdb.admin.DropdownMenu.extend({
 
   _navigateToLinksHref: function() {
     this.hide(); //hide must be called before routing for proper deconstruct of dropdown
-    handleAHref.apply(this, arguments);
+    navigateThroughRouter.apply(this, arguments);
   },
 
   clean: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -1,6 +1,6 @@
 var cdb = require('cartodb.js');
 var moment = require('moment');
-var handleAHref = require('new_common/view_helpers/handle_a_href_on_click');
+var navigateThroughRouter = require('new_common/view_helpers/navigate_through_router');
 var MapviewsGraph = require('new_dashboard/mapviews_graph');
 var LikesView = require('new_common/views/likes/view');
 var Utils = require('cdb.Utils');
@@ -17,7 +17,7 @@ module.exports = cdb.core.View.extend({
   tagName: 'li',
 
   events: {
-    'click tag-link': handleAHref,
+    'click tag-link': navigateThroughRouter,
     'click':          '_onCardClick'
   },
 

--- a/lib/assets/javascripts/cartodb/new_public_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_public_dashboard/entry.js
@@ -2,6 +2,8 @@ var $ = require('jquery');
 var cdb = require('cartodb.js');
 var FavMapView = require('./fav_map_view');
 var UserInfoView = require('./user_info_view');
+var PaginationModel = require('new_common/views/pagination/model');
+var PaginationView = require('new_common/views/pagination/view');
 
 $(function() {
   cdb.init(function() {
@@ -18,5 +20,11 @@ $(function() {
       el: $('.js-user-info')
     });
     userInfoView.render();
+
+    var paginationView = new PaginationView({
+      el: '.js-content-footer',
+      model: new PaginationModel(window.paginationModelAttrs)
+    });
+    paginationView.render();
   });
 });

--- a/lib/assets/javascripts/cartodb/new_public_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_public_dashboard/entry.js
@@ -9,7 +9,7 @@ $(function() {
   cdb.init(function() {
     cdb.templates.namespace = 'cartodb/';
 
-    $(document.body).bind(function () {
+    $(document.body).bind('click', function () {
       cdb.god.trigger('closeDialogs');
     });
 

--- a/lib/assets/test/spec/cartodb/new_common/views/pagination/view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/views/pagination/view.spec.js
@@ -10,7 +10,7 @@ describe('new_common/views/pagination/view', function() {
       total_count:  9000,
       per_page:     50,
       current_page: 42,
-      url_to:       function(page) { return '/url/to/page/'+ page }
+      url_to:       function(page) { return '/url/to/page/' + page; }
     });
     spyOn(this.model, 'bind').and.callThrough();
 
@@ -85,6 +85,22 @@ describe('new_common/views/pagination/view', function() {
       expect(this.html).not.toContain('Pagination-list');
     });
   });
+
+  describe('given current page is larger than available page', function() {
+    beforeEach(function() {
+      this.model.set({
+        total_count: this.model.get('per_page'),
+        current_page: 9000
+      });
+
+      this.html = this.view.el.innerHTML;
+    });
+
+    it('should not render pagination list', function() {
+      expect(this.html).not.toContain('Pagination-list');
+    });
+  });
+
 
   describe('click a link', function() {
     beforeEach(function() {


### PR DESCRIPTION
Fixes #2157 

- as [discussed in an earlier issue related to new public dashboard](https://github.com/CartoDB/cartodb/pull/2088#discussion_r24177229), use existing client-side code to render pagination to avoid duplicating the logic. only need minimal bootstrapping to set it up
- make the whole pagination item clickable (larger click surface)
- renamed `handle_a_href_on_click` => `navigate_through_router` to make its intention clearer