### PR TITLE
Organization profiles for new public dashboard

### DIFF
--- a/app/assets/stylesheets/new_common/datasets-list.css.scss
+++ b/app/assets/stylesheets/new_common/datasets-list.css.scss
@@ -130,16 +130,3 @@ $selectedItemPaddingOnSides: $sMargin-element - 1px;
   @include display-flex();
   margin-left: 4px;
 }
-.DatasetsList-item:hover,
-.DatasetsList-item.is--selected {
-  padding: $sMargin-group $selectedItemPaddingOnSides;
-  margin: -1px -#{$sMargin-element} 0 -#{$sMargin-element};
-  border-radius: 4px;
-  cursor: pointer;
-}
-.DatasetsList-item:hover {
-  background-color: $cCard-hoverFill;
-  border: 1px $cCard-hoverBorder solid;
-}
-// .DatasetsList-item:hover .DatasetsList-itemCategory,
-// .DatasetsList-item.is--selected .DatasetsList-itemCategory { border-color: #199BDB }

--- a/app/assets/stylesheets/new_common/user-avatar.css.scss
+++ b/app/assets/stylesheets/new_common/user-avatar.css.scss
@@ -34,6 +34,9 @@
 .UserAvatar-img {
   border: 1px solid transparent;
 }
+.UserAvatar-img--no-src {
+  background-image: image-url("avatars/avatar_ghost_red.png");
+}
 .UserAvatar-img.is-error {
   border-color: $cHighlight-negative;
   border-radius: $sAvatar-borderRadius;
@@ -41,21 +44,25 @@
 .UserAvatar-img--large {
   width: $sAvatar-public;
   height: $sAvatar-public;
+  background-size: $sAvatar-public;
   border-radius: $sAvatar-borderRadius;
 }
 .UserAvatar-img--medium {
   width: $sAvatar-default;
   height: $sAvatar-default;
+  background-size: $sAvatar-default;
   border-radius: $sAvatar-borderRadius;
 }
 .UserAvatar-img--small {
   width: $sAvatar-small;
   height: $sAvatar-small;
+  background-size: $sAvatar-small;
   border-radius: $sAvatar-borderRadiusSmall;
 }
 .UserAvatar-img--smaller {
   width: $sAvatar-meta;
   height: $sAvatar-meta;
+  background-size: $sAvatar-meta;
   border-radius: $sAvatar-borderRadiusSmall;
 }
 

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -91,7 +91,7 @@ class Admin::PagesController < ApplicationController
   end
 
   def new_datasets_for_organization(org)
-    set_new_layout_vars_for_organization(organization, 'datasets')
+    set_new_layout_vars_for_organization(org, 'datasets')
     render_new_datasets(org.public_datasets(current_page, NEW_DATASETS_PER_PAGE, tag_or_nil))
   end
 
@@ -231,8 +231,6 @@ class Admin::PagesController < ApplicationController
             exclude_raster: true
           }).first,
         content_type: content_type,
-        maps_url:     view_context.public_visualizations_home_url(user_domain: params[:user_domain]),
-        datasets_url: view_context.public_datasets_home_url(user_domain: params[:user_domain]),
       })
     set_shared_layout_vars(user, {
         name:       user.name_or_username,
@@ -245,10 +243,8 @@ class Admin::PagesController < ApplicationController
 
   def set_new_layout_vars_for_organization(org, content_type)
     set_new_layout_vars({
-        most_viewed_vis_map: nil, # TODO: how to get?
+        most_viewed_vis_map: org.public_vis_by_type(Visualization::Member::TYPE_DERIVED, 1, 1, nil, 'mapviews').first,
         content_type:        content_type,
-        maps_url:            nil, # TODO: how to get?
-        datasets_url:        nil, # TODO: how to get?
       })
     set_shared_layout_vars(org, {
         name:       org.display_name.blank? ? org.name : org.display_name,
@@ -259,8 +255,8 @@ class Admin::PagesController < ApplicationController
   def set_new_layout_vars(required)
     @most_viewed_vis_map = required.fetch(:most_viewed_vis_map)
     @content_type        = required.fetch(:content_type)
-    @maps_url            = required.fetch(:maps_url)
-    @datasets_url        = required.fetch(:datasets_url)
+    @maps_url            = view_context.public_visualizations_home_url(user_domain: params[:user_domain])
+    @datasets_url        = view_context.public_datasets_home_url(user_domain: params[:user_domain])
   end
 
   def set_new_pagination_vars(required)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -10,6 +10,8 @@ class Admin::PagesController < ApplicationController
 
   DATASETS_PER_PAGE = 10
   VISUALIZATIONS_PER_PAGE = 5
+  NEW_DATASETS_PER_PAGE = 20
+  MAPS_PER_PAGE = 9
   USER_TAGS_LIMIT = 100
 
   ssl_required :common_data, :public, :datasets
@@ -66,104 +68,95 @@ class Admin::PagesController < ApplicationController
   end #sitemap
 
   def datasets
-    username = CartoDB.extract_subdomain(request)
-    viewed_user = User.where(username: username.strip.downcase).first
-
-    if viewed_user.nil?
-      org = get_organization_if_exists(user)
-      return datasets_organization(org) unless org.nil?
-    end
-
-    return render_404 if viewed_user.nil?
-
-    # Redirect to org url if has only user
-    if viewed_user.has_organization?
-      if CartoDB.extract_real_subdomain(request) != viewed_user.organization.name
-        redirect_to CartoDB.base_url(viewed_user.organization.name) <<  \
-          public_datasets_home_path(user_domain: viewed_user.username) and return
-      end
-    end
-
-    set_vars_for_layout(viewed_user, 'datasets')
-
-    if viewed_user.has_feature_flag?('new_public_dashboard')
-      new_public_datasets(viewed_user)
-    else
-      public_datasets(viewed_user)
-    end
+    datasets = CartoDB::ControllerFlows::Public::Datasets.new(self)
+    content = CartoDB::ControllerFlows::Public::Content.new(request, datasets)
+    content.render()
   end
 
-  def public #dashboard, i.e. maps
-    username = CartoDB.extract_subdomain(request)
-    viewed_user = User.where(username: username.strip.downcase).first
+  def public
+    maps = CartoDB::ControllerFlows::Public::Maps.new(self)
+    content = CartoDB::ControllerFlows::Public::Content.new(request, maps)
+    content.render()
+  end
 
-    if viewed_user.nil?
-      org = get_organization_if_exists(username)
-      return public_organization(org) unless org.nil?
-    end
+  def new_datasets_for_user(user)
+    set_new_layout_vars_for_user(user, 'datasets')
+    render_new_datasets(
+      user_public_vis_list({
+        user:  user,
+        vis_type: Visualization::Member::TYPE_CANONICAL,
+        per_page: NEW_DATASETS_PER_PAGE,
+      })
+    )
+  end
 
-    return render_404 if viewed_user.nil?
+  def new_datasets_for_organization(org)
+    set_new_layout_vars_for_organization(organization, 'datasets')
+    render_new_datasets(org.public_datasets(current_page, NEW_DATASETS_PER_PAGE, tag_or_nil))
+  end
 
-    # Redirect to org url if has only user
-    if viewed_user.has_organization?
-      if CartoDB.extract_real_subdomain(request) != viewed_user.organization.name
-        redirect_to CartoDB.base_url(viewed_user.organization.name) << "/u/#{viewed_user.username}/" and return
-      end
-    end
+  def new_maps_for_user(user)
+    set_new_layout_vars_for_user(user, 'maps')
+    render_new_maps(
+      user_public_vis_list({
+        user:     user,
+        vis_type: Visualization::Member::TYPE_DERIVED,
+        per_page: MAPS_PER_PAGE,
+      })
+    )
+  end
 
-    set_vars_for_layout(viewed_user, 'maps')
+  def new_maps_for_organization(org)
+    set_new_layout_vars_for_organization(org, 'maps')
+    render_new_maps(org.public_visualizations(current_page, MAPS_PER_PAGE, tag_or_nil))
+  end
 
-    if viewed_user.has_feature_flag?('new_public_dashboard')
-      new_public_dashboard(viewed_user)
-    else
-      public_dashboard(viewed_user)
-    end
+  def old_datasets_for_user(user)
+    vis_type = Visualization::Member::TYPE_CANONICAL
+    set_old_layout_vars_for_user(user, vis_type)
+    render_old_datasets(
+      user_public_vis_list({
+        user:     user,
+        vis_type: vis_type,
+        per_page: DATASETS_PER_PAGE,
+      })
+    )
+  end
+
+  def old_datasets_for_organization(org)
+    set_old_layout_vars_for_organization(org, Visualization::Member::TYPE_CANONICAL)
+    render_old_datasets(org.public_datasets(current_page, DATASETS_PER_PAGE, tag_or_nil))
+  end
+
+  def old_maps_for_user(user)
+    vis_type = Visualization::Member::TYPE_DERIVED
+    set_old_layout_vars_for_user(user, vis_type)
+    render_old_datasets(
+      user_public_vis_list({
+        user:     user,
+        vis_type: vis_type,
+        per_page: VISUALIZATIONS_PER_PAGE,
+      })
+    )
+  end
+
+  def old_maps_for_organization(org)
+    set_old_layout_vars_for_organization(org, Visualization::Member::TYPE_DERIVED)
+
+    render_old_maps(org.public_visualizations(current_page, VISUALIZATIONS_PER_PAGE, tag_or_nil))
+  end
+
+  def render_not_found
+    render_404
   end
 
   private
 
-  def set_vars_for_layout(viewed_user, content_type)
-    @most_viewed_vis_map = Visualization::Collection.new.fetch({
-      user_id:  viewed_user.id,
-      type:     Visualization::Member::TYPE_DERIVED,
-      privacy:  Visualization::Member::PRIVACY_PUBLIC,
-      order:    'mapviews',
-      page:     1,
-      per_page: 1,
-      exclude_shared: true,
-      exclude_raster: true
-    }).first
-    @content_type = content_type
-    @maps_url = view_context.public_visualizations_home_url(user_domain: params[:user_domain])
-    @datasets_url = view_context.public_datasets_home_url(user_domain: params[:user_domain])
-    @current_page = params[:page].to_i > 0 ? params[:page] : 1
-
-    # Note that these are shared for both new and current layouts, so dont change lightly
-    @name               = viewed_user.name_or_username
-    @twitter_username   = viewed_user.twitter_username
-    @available_for_hire = viewed_user.available_for_hire
-    @email              = viewed_user.email
-    @description        = viewed_user.description
-    @website            = !viewed_user.website.blank? && viewed_user.website[/^https?:\/\//].nil? ? "http://#{viewed_user.website}" : viewed_user.website
-    @website_clean      = @website ? @website.gsub(/https?:\/\//, "") : ""
-    @avatar_url         = viewed_user.avatar
-  end
-
-  def new_public_datasets(viewed_user)
-    @datasets_per_page = 20
-    visualizations = Visualization::Collection.new.fetch({
-      user_id:  viewed_user.id,
-      type:     Visualization::Member::TYPE_CANONICAL,
-      privacy:  Visualization::Member::PRIVACY_PUBLIC,
-      page:     @current_page,
-      per_page: @datasets_per_page,
-      order:    'updated_at',
-      o:        {updated_at: :desc},
-      tags:     params[:tag],
-      exclude_shared: true,
-      exclude_raster: true,
-    })
-    @total_count = visualizations.total_entries
+  def render_new_datasets(vis_list)
+    set_new_pagination_vars({
+        total_count: vis_list.total_entries,
+        per_page:    NEW_DATASETS_PER_PAGE,
+      })
 
     @datasets = []
     # TODO logic as done client-side, how and where to encapsulate this better?
@@ -176,7 +169,7 @@ class Admin::PagesController < ApplicationController
       'st_point'           => 'point'
     }
 
-    visualizations.each do |vis|
+    vis_list.each do |vis|
       geometry_type = vis.kind
       if geometry_type != 'raster'
         table_geometry_types = vis.table.geometry_types
@@ -202,23 +195,14 @@ class Admin::PagesController < ApplicationController
     end
   end
 
-  def new_public_dashboard(viewed_user)
-    @vis_per_page = 9
-    visualizations = Visualization::Collection.new.fetch({
-      user_id:  viewed_user.id,
-      type:     Visualization::Member::TYPE_DERIVED,
-      privacy:  Visualization::Member::PRIVACY_PUBLIC,
-      page:     @current_page,
-      per_page: @vis_per_page,
-      order:    'updated_at',
-      o:        {updated_at: :desc},
-      exclude_shared: true,
-      exclude_raster: true
-    })
-    @total_count = visualizations.total_entries
+  def render_new_maps(vis_list)
+    set_new_pagination_vars({
+        total_count: vis_list.total_entries,
+        per_page:    MAPS_PER_PAGE,
+      })
 
     @visualizations = []
-    visualizations.each do |vis|
+    vis_list.each do |vis|
       @visualizations.push({
         title:        vis.name,
         description:  vis.description_clean,
@@ -232,178 +216,168 @@ class Admin::PagesController < ApplicationController
     respond_to do |format|
       format.html { render 'new_public_maps', layout: 'new_public_dashboard' }
     end
-  end #new_public_dashboard
-
-  def public_dashboard(viewed_user)
-    @username   = viewed_user.username
-    @tags       = viewed_user.tags(true, Visualization::Member::TYPE_DERIVED)
-    @tables_num = viewed_user.public_table_count
-    @vis_num    = viewed_user.public_visualization_count
-
-    visualizations = Visualization::Collection.new.fetch({
-      user_id:  viewed_user.id,
-      type:     Visualization::Member::TYPE_DERIVED,
-      privacy:  Visualization::Member::PRIVACY_PUBLIC,
-      page:     params[:page].nil? ? 1 : params[:page],
-      per_page: VISUALIZATIONS_PER_PAGE,
-      order:    'updated_at',
-      o:        {updated_at: :desc},
-      tags:     params[:tag],
-      exclude_shared: true,
-      exclude_raster: true
-    })
-
-    @visualizations = []
-    @pages = (visualizations.total_entries.to_f / VISUALIZATIONS_PER_PAGE).ceil
-
-    visualizations.each do |vis|
-      @visualizations.push(
-        {
-          title:        vis.name,
-          description:  vis.description_clean,
-          id:           vis.id,
-          tags:         vis.tags,
-          layers:       vis.layers(:carto_and_torque),
-          mapviews:     vis.stats.values.reduce(:+), # Sum last 30 days stats, for now only approach
-          url_options:  (vis.url_options.present? ? vis.url_options : Visualization::Member::DEFAULT_URL_OPTIONS),
-          owner:        vis.user
-        }
-      )
-    end
-
-    respond_to do |format|
-      format.html { render 'public_dashboard', layout: 'application_public_dashboard' }
-    end
-  end #public_dashboard
-
-  def public_datasets(viewed_user)
-    @tags             = viewed_user.tags(true, Visualization::Member::TYPE_CANONICAL)
-    @username         = viewed_user.username
-    @name             = viewed_user.name.present? ? viewed_user.name : viewed_user.username
-    @available_for_hire = viewed_user.available_for_hire
-    @email              = viewed_user.email
-    @twitter_username = viewed_user.twitter_username
-    @description      = viewed_user.description
-    @website          = viewed_user.website
-    @website_clean    = @website ? @website.gsub(/https?:\/\//, '') : ''
-
-    @avatar_url = viewed_user.avatar
-
-    @tables_num = viewed_user.public_table_count
-    @vis_num    = viewed_user.public_visualization_count
-
-    datasets = Visualization::Collection.new.fetch({
-      user_id:  viewed_user.id,
-      type:     Visualization::Member::TYPE_CANONICAL,
-      privacy:  Visualization::Member::PRIVACY_PUBLIC,
-      page:     params[:page].nil? ? 1 : params[:page],
-      per_page: DATASETS_PER_PAGE,
-      order:    'updated_at',
-      o:        {updated_at: :desc},
-      tags:     params[:tag],
-      exclude_shared: true,
-      exclude_raster: true
-    })
-
-    @datasets = []
-    @pages = (datasets.total_entries.to_f / DATASETS_PER_PAGE).ceil
-
-    datasets.each do |dataset|
-      @datasets.push(
-        {
-          title:        dataset.name,
-          description:  dataset.description_clean,
-          updated_at:   dataset.updated_at,
-          owner:        dataset.user,
-          tags:         dataset.tags
-        }
-      )
-    end
-
-    respond_to do |format|
-      format.html { render 'public_datasets', layout: 'application_public_dashboard' }
-    end
   end
 
-  def public_organization(organization)
-    @organization = organization
-
-    @name = ( !@organization.display_name.blank? ? @organization.display_name : @organization.name )
-    @avatar_url = @organization.avatar_url
-
-    @twitter_username = @organization.twitter_username
-    @description      = @organization.description
-    @website          = !@organization.website.blank? && @organization.website[/^https?:\/\//].nil? ? "http://#{@organization.website}" : @organization.website
-    @website_clean    = @website ? @website.gsub(/https?:\/\//, "") : ""
-
-    @tables_num = @organization.public_datasets_count
-    @vis_num = @organization.public_visualizations_count
-
-    page = params[:page].nil? ? 1 : params[:page]
-    vis_list = @organization.public_visualizations(page, VISUALIZATIONS_PER_PAGE, params[:tag])
-
-    @pages = (vis_list.total_entries / VISUALIZATIONS_PER_PAGE).ceil
-
-    @visualizations = []
-    vis_list.each do |vis|
-      @visualizations.push(
-        {
-          title:        vis.name,
-          description:  vis.description_clean,
-          id:           vis.id,
-          tags:         vis.tags,
-          layers:       vis.layers(:carto_and_torque),
-          url_options:  (vis.url_options.present? ? vis.url_options : Visualization::Member::DEFAULT_URL_OPTIONS),
-          owner:        vis.user
-        }
-      )
-    end
-
-    @tags = @organization.tags(Visualization::Member::TYPE_DERIVED)
-
-    respond_to do |format|
-      format.html { render 'public_dashboard', layout: 'application_public_dashboard' }
-    end
+  def set_new_layout_vars_for_user(user, content_type)
+    set_new_layout_vars({
+        most_viewed_vis_map: Visualization::Collection.new.fetch({
+            user_id:        user.id,
+            type:           Visualization::Member::TYPE_DERIVED,
+            privacy:        Visualization::Member::PRIVACY_PUBLIC,
+            order:          'mapviews',
+            page:           1,
+            per_page:       1,
+            exclude_shared: true,
+            exclude_raster: true
+          }).first,
+        content_type: content_type,
+        maps_url:     view_context.public_visualizations_home_url(user_domain: params[:user_domain]),
+        datasets_url: view_context.public_datasets_home_url(user_domain: params[:user_domain]),
+      })
+    set_shared_layout_vars(user, {
+        name:       user.name_or_username,
+        avatar_url: user.avatar,
+      }, {
+        available_for_hire: user.available_for_hire,
+        email:              user.email,
+      })
   end
 
-  def datasets_organization(organization)
-    @organization = organization
+  def set_new_layout_vars_for_organization(org, content_type)
+    set_new_layout_vars({
+        most_viewed_vis_map: nil, # TODO: how to get?
+        content_type:        content_type,
+        maps_url:            nil, # TODO: how to get?
+        datasets_url:        nil, # TODO: how to get?
+      })
+    set_shared_layout_vars(org, {
+        name:       org.display_name.blank? ? org.name : org.display_name,
+        avatar_url: org.avatar_url,
+      })
+  end
 
-    @twitter_username = @organization.twitter_username
-    @description      = @organization.description
-    @website          = !@organization.website.blank? && @organization.website[/^https?:\/\//].nil? ? "http://#{@organization.website}" : @organization.website
-    @website_clean    = @website ? @website.gsub(/https?:\/\//, "") : ""
+  def set_new_layout_vars(required)
+    @most_viewed_vis_map = required.fetch(:most_viewed_vis_map)
+    @content_type        = required.fetch(:content_type)
+    @maps_url            = required.fetch(:maps_url)
+    @datasets_url        = required.fetch(:datasets_url)
+  end
 
-    @tables_num = @organization.public_datasets_count
-    @vis_num = @organization.public_visualizations_count
+  def set_new_pagination_vars(required)
+    @total_count  = required.fetch(:total_count)
+    @per_page     = required.fetch(:per_page)
+    @current_page = current_page
+  end
 
-    page = params[:page].nil? ? 1 : params[:page]
-    vis_list = @organization.public_datasets(page, DATASETS_PER_PAGE, params[:tag])
+  # Shared as in shared for both new and old layout
+  def set_shared_layout_vars(model, required, optional = {})
+    @twitter_username   = model.twitter_username
+    @description        = model.description
+    @website            = !model.website.blank? && model.website[/^https?:\/\//].nil? ? "http://#{model.website}" : model.website
+    @website_clean      = @website ? @website.gsub(/https?:\/\//, "") : ""
+    @name               = required.fetch(:name)
+    @avatar_url         = required.fetch(:avatar_url)
+    @email              = optional.fetch(:email, nil)
+    @available_for_hire = optional.fetch(:available_for_hire, false)
+  end
 
-    @pages = (vis_list.total_entries.to_f / DATASETS_PER_PAGE).ceil
+  def set_old_layout_vars_for_user(user, vis_type)
+    @username   = user.username
+    @tables_num = user.public_table_count
+    @vis_num    = user.public_visualization_count
+    @tags       = user.tags(true, vis_type)
+
+    set_shared_layout_vars(user, {
+      name:       user.name_or_username,
+      avatar_url: user.avatar,
+    }, {
+      # Optional
+      available_for_hire: user.available_for_hire,
+      email:              user.email,
+    })
+  end
+
+  def set_old_layout_vars_for_organization(org, vis_type)
+    @organization = org
+    @tables_num   = org.public_datasets_count
+    @vis_num      = org.public_visualizations_count
+    @tags         = org.tags(vis_type)
+
+    set_shared_layout_vars(org, {
+      name:       org.display_name.blank? ? org.name : org.display_name,
+      avatar_url: org.avatar_url,
+    })
+  end
+
+  def render_old_datasets(vis_list)
+    set_old_pagination_vars(vis_list, DATASETS_PER_PAGE)
 
     @datasets = []
     vis_list.each do |dataset|
-      @datasets.push(
-        {
-          title:        dataset.name,
-          description:  dataset.description_clean,
-          updated_at:   dataset.updated_at,
-          tags:         dataset.tags,
-          owner:        dataset.user
-        }
-      )
+      @datasets.push({
+        title:       dataset.name,
+        description: dataset.description_clean,
+        updated_at:  dataset.updated_at,
+        owner:       dataset.user,
+        tags:        dataset.tags
+      })
     end
-
-    @tags = @organization.tags(Visualization::Member::TYPE_CANONICAL)
 
     respond_to do |format|
       format.html { render 'public_datasets', layout: 'application_public_dashboard' }
     end
+  end
+
+  def render_old_maps(vis_list)
+    set_old_pagination_vars(vis_list, VISUALIZATIONS_PER_PAGE)
+
+    @visualizations = []
+    vis_list.each do |vis|
+      @visualizations.push({
+        title:       vis.name,
+        description: vis.description_clean,
+        id:          vis.id,
+        tags:        vis.tags,
+        layers:      vis.layers(:carto_and_torque),
+        url_options: (vis.url_options.present? ? vis.url_options : Visualization::Member::DEFAULT_URL_OPTIONS),
+        owner:       vis.user
+      })
+    end
+
+    respond_to do |format|
+      format.html { render 'public_dashboard', layout: 'application_public_dashboard' }
+    end
+  end
+
+  def set_old_pagination_vars(vis_list, per_page)
+    @pages = (vis_list.total_entries.to_f / per_page).ceil
+  end
+
+  def user_public_vis_list(required)
+    Visualization::Collection.new.fetch({
+      user_id:  required.fetch(:user).id,
+      type:     required.fetch(:vis_type),
+      per_page: required.fetch(:per_page),
+      privacy:  Visualization::Member::PRIVACY_PUBLIC,
+      page:     current_page,
+      order:    'updated_at',
+      o:        {updated_at: :desc},
+      tags:     tag_or_nil,
+      exclude_shared: true,
+      exclude_raster: true,
+    })
   end
 
   def get_organization_if_exists(name)
     Organization.where(name: name).first
+  end
+
+  def current_page
+    params[:page].to_i > 0 ? params[:page] : 1
+  end
+
+  def tag_or_nil
+    params[:tag]
   end
 
   def belongs_to_organization

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -229,8 +229,4 @@ module ApplicationHelper
   def vis_json_url(vis_id)
     "#{ api_v2_visualizations_vizjson_url(user_domain: params[:user_domain], id: vis_id).sub(/(http:|https:)/i, '') }.json"
   end
-
-  def maps_or_datasets_str(is_maps = true)
-    is_maps ? 'maps' : 'datasets'
-  end
 end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -7,4 +7,7 @@ class FeatureFlag < Sequel::Model
   # @param name       String
   # @param restricted boolean
 
-end 
+  def self.allowed?(name)
+    !!where(name: name, restricted: false).first
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -163,9 +163,7 @@ class Organization < Sequel::Model
     self.auth_token
   end
 
-  private
-
-  def public_vis_by_type(type, page_num, items_per_page, tags)
+  def public_vis_by_type(type, page_num, items_per_page, tags, order = 'updated_at')
     CartoDB::Visualization::Collection.new.fetch(
         user_id:  self.users.map(&:id),
         type:     type,
@@ -173,10 +171,12 @@ class Organization < Sequel::Model
         page:     page_num,
         per_page: items_per_page,
         tags:     tags,
-        order:    'updated_at',
+        order:    order,
         o:        {updated_at: :desc}
     )
   end
+
+  private
 
   def public_vis_count_by_type(type)
     CartoDB::Visualization::Collection.new.fetch(
@@ -204,4 +204,3 @@ class Organization < Sequel::Model
   end
 
 end
-

--- a/app/views/admin/pages/new_public_datasets.html.erb
+++ b/app/views/admin/pages/new_public_datasets.html.erb
@@ -52,4 +52,4 @@
   <% end %>
 </div>
 
-<%= render 'admin/shared/new_pagination', total_count: @total_count, per_page: @datasets_per_page, current_page: @current_page %>
+<%= render 'admin/shared/new_pagination' %>

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -60,4 +60,4 @@
   <% end %>
 </div>
 
-<%= render 'admin/shared/new_pagination', total_count: @total_count, per_page: @vis_per_page, current_page: @current_page %>
+<%= render 'admin/shared/new_pagination' %>

--- a/app/views/admin/shared/_new_no_results.html.erb
+++ b/app/views/admin/shared/_new_no_results.html.erb
@@ -6,7 +6,7 @@
     <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any items on this page</h3>
     <p class="DefaultParagraph">Try the <%= link_to 'first page', url_for(page: nil) %> instead</p>
   <% else  %>
-    <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public <%= maps_or_datasets_str(is_maps) %> yet</h3>
-    <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to maps_or_datasets_str(!is_maps), alt_url %></p>
+    <h3 class="IntermediateInfo-title"><%= @name %> doesn't have any public <%= @content_type === 'maps' ? 'maps' : 'datasets' %> yet</h3>
+    <p class="DefaultParagraph">But maybe he/she has some very interesting <%= link_to @content_type === 'maps' ? 'datasets' : 'maps', alt_url %></p>
   <% end %>
 </div>

--- a/app/views/admin/shared/_new_pagination.html.erb
+++ b/app/views/admin/shared/_new_pagination.html.erb
@@ -8,9 +8,10 @@
 <% content_for(:js) do %>
   <script type="text/javascript">
     var paginationModelAttrs = {
-      current_page: <%= current_page %>,
-      total_count: <%= total_count %>,
-      per_page: <%= per_page %>,
+      current_page: <%= @current_page %>,
+      total_count: <%= @total_count %>,
+      total_count: 37,
+      per_page: <%= @per_page %>,
       url_to: function(page) {
         if (page === 1) {
           return '<%= url_for(page: nil) %>';

--- a/app/views/admin/shared/_new_pagination.html.erb
+++ b/app/views/admin/shared/_new_pagination.html.erb
@@ -10,7 +10,6 @@
     var paginationModelAttrs = {
       current_page: <%= @current_page %>,
       total_count: <%= @total_count %>,
-      total_count: 37,
       per_page: <%= @per_page %>,
       url_to: function(page) {
         if (page === 1) {

--- a/app/views/layouts/new_public_dashboard.html.erb
+++ b/app/views/layouts/new_public_dashboard.html.erb
@@ -33,7 +33,11 @@
     </div>
     <div class="UserInfo js-user-info">
       <div class="UserAvatar UserInfo-avatar">
-        <img src="<%= @avatar_url %>" class="UserAvatar-img UserAvatar-img--large" />
+        <% if @avatar_url %>
+          <img src="<%= @avatar_url %>" class="UserAvatar-img UserAvatar-img--large" />
+        <% else %>
+          <div class="UserAvatar-img UserAvatar-img--large UserAvatar-img--no-src"></div>
+        <% end %>
       </div>
       <h2 class="UserInfo-name">
         <%= @name %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -137,6 +137,9 @@ end
 
 require 'csv'
 require 'state_machine'
+require 'cartodb/controller_flows/public/content'
+require 'cartodb/controller_flows/public/datasets'
+require 'cartodb/controller_flows/public/maps'
 require 'cartodb/errors'
 require 'cartodb/logger'
 require 'cartodb/sql_parser'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,8 +209,9 @@ CartoDB::Application.routes.draw do
     get '(/u/:user_domain)/dashboard/common_data/:tag'  => 'pages#common_data',    as: :dashboard_common_data_tag
 
     # Public dashboard
-    # root goes to 'pages#public'
+    # root also goes to 'pages#public', as: public_visualizations_home
     get '(/u/:user_domain)/page/:page'               => 'pages#public', as: :public_page
+    get '(/u/:user_domain(/page/:page))'             => 'pages#public', as: :public_page_alt
     get '(/u/:user_domain)/tag/:tag'                 => 'pages#public', as: :public_tag
     get '(/u/:user_domain)/tag/:tag/:page'           => 'pages#public', as: :public_tag_page
     # Public dataset

--- a/lib/assets/javascripts/cartodb/new_dashboard/datasets/remote_datasets_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/datasets/remote_datasets_item.js
@@ -11,7 +11,7 @@ var pluralizeString = require('new_common/view_helpers/pluralize_string');
 module.exports = DatasetsItem.extend({
 
   tagName: 'li',
-  className: 'DatasetsList-item',
+  className: 'DatasetsList-item DatasetsList-item--selectable',
 
   events: {
     'click .js-tag-link': navigateThroughRouter,

--- a/lib/cartodb/controller_flows/public/content.rb
+++ b/lib/cartodb/controller_flows/public/content.rb
@@ -1,0 +1,46 @@
+module CartoDB
+  module ControllerFlows
+    module Public
+
+      class Content
+
+        def initialize(request, renderer)
+          @request  = request
+          @renderer = renderer
+        end
+
+        def render
+          username = CartoDB.extract_subdomain(@request).strip.downcase
+          viewed_user = User.where(username: username).first
+
+          if viewed_user.nil?
+            org = Organization.where(name: username).first
+            unless org.nil?
+              if FeatureFlag.allowed?('new_public_dashboard')
+                return @renderer.new_organization_content(org)
+              else
+                return @renderer.old_organization_content(org)
+              end
+            end
+          end
+
+          return @renderer.render_404 if viewed_user.nil?
+
+          if viewed_user.has_organization?
+            if CartoDB.extract_real_subdomain(@request) != viewed_user.organization.name
+              # redirect username.host.ext => org-name.host.ext/u/username
+              @ctrl.redirect_to CartoDB.base_url(viewed_user.organization.name) << @renderer.organization_path and return
+            end
+          end
+
+          if viewed_user.has_feature_flag?('new_public_dashboard')
+            return @renderer.new_user_content(viewed_user)
+          else
+            return @renderer.old_user_content(viewed_user)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/cartodb/controller_flows/public/content.rb
+++ b/lib/cartodb/controller_flows/public/content.rb
@@ -16,7 +16,7 @@ module CartoDB
           if viewed_user.nil?
             org = Organization.where(name: username).first
             unless org.nil?
-              if FeatureFlag.allowed?('new_public_dashboard')
+              if FeatureFlag.allowed?('new_public_dashboard_global')
                 return @renderer.new_organization_content(org)
               else
                 return @renderer.old_organization_content(org)

--- a/lib/cartodb/controller_flows/public/datasets.rb
+++ b/lib/cartodb/controller_flows/public/datasets.rb
@@ -1,0 +1,38 @@
+module CartoDB
+  module ControllerFlows
+    module Public
+
+      class Datasets
+
+        def initialize(ctrl)
+          @ctrl = ctrl
+        end
+
+        def new_organization_content(org)
+          @ctrl.new_datasets_for_organization(org)
+        end
+
+        def old_organization_content(org)
+          @ctrl.old_datasets_for_organization(org)
+        end
+
+        def organization_path(user)
+          @ctrl.public_datasets_home_path(user_domain: user.username)
+        end
+
+        def render_404
+          @ctrl.render_not_found
+        end
+
+        def new_user_content(user)
+          @ctrl.new_datasets_for_user(user)
+        end
+
+        def old_user_content(user)
+          @ctrl.old_datasets_for_user(user)
+        end
+      end
+
+    end
+  end
+end

--- a/lib/cartodb/controller_flows/public/maps.rb
+++ b/lib/cartodb/controller_flows/public/maps.rb
@@ -1,0 +1,38 @@
+module CartoDB
+  module ControllerFlows
+    module Public
+
+      class Maps
+
+        def initialize(ctrl)
+          @ctrl = ctrl
+        end
+
+        def new_organization_content(org)
+          @ctrl.new_maps_for_organization(org)
+        end
+
+        def old_organization_content(org)
+          @ctrl.old_maps_for_organization(org)
+        end
+
+        def organization_path(user)
+          @ctrl.public_visualizations_home_path(user_domain: user.username)
+        end
+
+        def render_404
+          @ctrl.render_not_found
+        end
+
+        def new_user_content(user)
+          @ctrl.new_maps_for_user(user)
+        end
+
+        def old_user_content(user)
+          @ctrl.old_maps_for_user(user)
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Fixed #2179 

![screen shot 2015-02-11 at 18 14 07](https://cloud.githubusercontent.com/assets/978461/6151967/cee5e1e4-b219-11e4-9e46-c6fe6bfd1e8b.png)

**Rationales for changes:**

- added new `FeatureFlag.allowed?` method, for conveniently check flag that is not tied to a user instance
- DRY'ed the controller to get rid of the duplicated logic that existed in basically all entry points:
 - flow control logic (unrelated to rendering) was extracted to POROs models (placed in `lib/cartodb/controller_flow/public/, I'm happy to rename the concept if you have any suggestions)
 - view logic was extracted to private methods in the controller, e.g.:
   - some common parameters used here and there, `current_page` (pagination), `tag_or_nil`
   - setting `@vars` used by the views
 - separated new vs. old (current) rendering, so once the current dashboard is deprecated we can simply remove all methods prefixed with (old_*) when that time comes

Notice that the actual Rails rendering is still left in the controller. Hopefully it should be easier to read & maintain the logic related to this controller from now on.