### PR TITLE
Enable previews and forces https

### DIFF
--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.4.7
+3.4.8

--- a/lib/assets/javascripts/cartodb/new_dashboard/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/mapcard_preview.js
@@ -23,7 +23,7 @@ module.exports = cdb.core.View.extend({
 
   load: function() {
     this._startLoader();
-    cdb.Image(this.vizjson).size(this.width, this.height).getUrl(this._onImageCallback);
+    cdb.Image(this.vizjson, { https: true }).size(this.width, this.height).getUrl(this._onImageCallback);
 
     return this;
   },

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -59,7 +59,7 @@ module.exports = cdb.core.View.extend({
 
     this._renderMapviewsGraph();
     this._renderLikesIndicator();
-    //this._renderMapThumbnail();
+    this._renderMapThumbnail();
 
     return this;
   },

--- a/lib/assets/javascripts/cartodb/new_public_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_public_dashboard/entry.js
@@ -28,12 +28,12 @@ $(function() {
     });
     paginationView.render();
 
-    //$('.MapCard').each(function() {
-      //var mapCardPreview = new MapCardPreview({
-        //el: $(this).find('.js-header'),
-        //vizjson: $(this).attr("vizjson-url")
-      //}).load();
-    //});
+    $('.MapCard').each(function() {
+      var mapCardPreview = new MapCardPreview({
+        el: $(this).find('.js-header'),
+        vizjson: $(this).attr("vizjson-url")
+      }).load();
+    });
 
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/vendor/assets/javascripts/cartodb.mod.odyssey.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.mod.odyssey.uncompressed.js
@@ -1,5 +1,5 @@
-// version: 3.12.0
-// sha: 5a20eabecdbc6575f1d2f5462f439963700f37e0
+// version: 3.12.1
+// sha: 5edef4b6b70395a521139a0467fd625a5f103a4f
 
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.O=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 

--- a/vendor/assets/javascripts/cartodb.mod.torque.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.mod.torque.uncompressed.js
@@ -2652,7 +2652,7 @@ L.TorqueLayer = L.CanvasLayer.extend({
     if (options.animationDuration) {
       this.animator.duration(options.animationDuration);
     }
-
+    this._clearCaches();
     this.redraw();
     return this;
   },
@@ -4658,7 +4658,10 @@ var filters = require('./torque_filters');
           if (typeof self._icons.itemsToLoad === 'undefined'){
             this._icons.itemsToLoad = img_names.length;
           }
-          new_img.crossOrigin = "Anonymous";
+          var filtered = self._shader.getLayers().some(function(layer){return typeof layer.shader["image-filters"] !== "undefined"});
+          if (filtered){
+            new_img.crossOrigin = 'Anonymous';
+          }
           new_img.onload = function(e){
             self._icons[this.src] = this;
             if (Object.keys(self._icons).length === img_names.length + 1){
@@ -4672,6 +4675,9 @@ var filters = require('./torque_filters');
           new_img.onerror = function(){
             self._forcePoints = true;
             self.clearSpriteCache();
+            if(filtered){
+              console.info("Only CORS-enabled, or same domain image-files can be used in combination with image-filters");
+            }
             console.error("Couldn't get marker-file " + this.src);
           };
           this.itemsToLoad++;
@@ -5076,6 +5082,7 @@ module.exports = {
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"./core":4}]},{},[10])(10)
 });
+
 (function() {
 
 if(typeof(google) == "undefined" || typeof(google.maps) == "undefined")

--- a/vendor/assets/javascripts/cartodb.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.uncompressed.js
@@ -1,6 +1,6 @@
-// cartodb.js version: 3.12.0
+// cartodb.js version: 3.12.1
 // uncompressed version: cartodb.uncompressed.js
-// sha: e24a8668d778730348fd2b8d23b34ceaa594a777
+// sha: 1b0b627c93b4b8861d118f3d65255cdf2cac3c92
 (function() {
   var root = this;
 
@@ -34255,18 +34255,13 @@ cdb.vis.Vis = Vis;
 
     _setupTilerConfiguration: function(protocol, domain, port) {
 
-      var vizjson = this.imageOptions.vizjson;
-
-      var isHTTPS = vizjson.indexOf("https") !== -1 ? true : false;
-
       this.options.tiler_domain   = domain;
+      this.options.tiler_protocol = protocol;
+      this.options.tiler_port     = port;
 
-      if (isHTTPS) {
+      if (this.userOptions.https || this.imageOptions.vizjson.indexOf("https") === 0) {
         this.options.tiler_protocol = "https";
         this.options.tiler_port     = 443;
-      } else {
-        this.options.tiler_protocol = protocol;
-        this.options.tiler_port     = port;
       }
 
     },
@@ -34334,12 +34329,12 @@ cdb.vis.Vis = Vis;
 
       var basemap = this.userOptions.basemap || this.imageOptions.basemap;
 
-      if (basemap && basemap.type) {
+      if (basemap) {
 
         var type = basemap.type.toLowerCase();
 
-        if (type === "background") return this._getPlainBasemapLayer(basemap.color);
-        else                       return this._getHTTPBasemapLayer(basemap);
+        if (type === "plain") return this._getPlainBasemapLayer(basemap.color);
+        else                  return this._getHTTPBasemapLayer(basemap);
 
       }
 
@@ -34351,11 +34346,6 @@ cdb.vis.Vis = Vis;
 
       var layerDefinition = new LayerDefinition(options.layer_definition, options);
       var ld = layerDefinition.toJSON();
-
-      // TODO: remove this
-      for (var i = 0; i<ld.layers.length; i++) {
-        delete ld.layers[i].options.interactivity
-      }
 
       ld.layers.unshift(this._getBasemapLayer());
 


### PR DESCRIPTION
Enables the map previews and forces to get the data using the `https` protocol.

@CartoDB/frontend: can you review it, please?

