### PR TITLE
Unify colors for secondary buttons

### DIFF
--- a/app/assets/stylesheets/new_common/buttons.css.scss
+++ b/app/assets/stylesheets/new_common/buttons.css.scss
@@ -54,16 +54,17 @@ $buttonBorderSize: 1px;
   &:hover { background-color: rgba(#B93F37, 1) }
 }
 .Button--secondary {
-  border: $sButton-border solid #CCCCCC;
-  color: #666666;
+  border: 1px solid $cIcons-default;
   background-color: rgba(white, 1);
-  &:hover {
-    background-color: rgba(#CCCCCC, 1);
-    color:white;
+  span {
+    color: $cIcons-default;
   }
-}
-.Button--secondary span {
-  color: #666666;
+  &:hover {
+    border-color: $cIcons-active;
+    span {
+      color: $cIcons-active;
+    }
+  }
 }
 .Button.is-disabled {
   @include opacity(0.4);


### PR DESCRIPTION
Fixes #2071 

Default styles
![screen shot 2015-02-13 at 13 43 25](https://cloud.githubusercontent.com/assets/978461/6187436/d355d7ca-b386-11e4-8a99-309057d41cd7.png)
![screen shot 2015-02-13 at 13 47 28](https://cloud.githubusercontent.com/assets/978461/6187443/e274ada8-b386-11e4-94e9-6d7798ee2367.png)

On hover:
![screen shot 2015-02-13 at 13 43 30](https://cloud.githubusercontent.com/assets/978461/6187437/d355fa8e-b386-11e4-9bfd-fc0fa10da14b.png)
![screen shot 2015-02-13 at 13 47 31](https://cloud.githubusercontent.com/assets/978461/6187446/e3df74f2-b386-11e4-97cc-f5dcaf10a9ef.png)

