### PR TITLE
Add map previews in the remove table dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Added new import error code (6667) for detecting and reporting statement timeouts.
 * Fixes creation of a visualization from a table [#2145](https://github.com/CartoDB/cartodb/issues/2145)
 * Added PlatformLimits service. For now, only includes an importer maximum file size limit.
+* Added map previews in the delete table dialog
 
 3.8.0 (2015-01-30)
 ------------------

--- a/app/assets/stylesheets/new_common/map-card.css.scss
+++ b/app/assets/stylesheets/new_common/map-card.css.scss
@@ -38,6 +38,7 @@
   border-color: $cCard-selectedBorder;
 }
 .MapCard-header {
+  @include inline-block();
   position: relative;
   width: 100%;
   height: 170px;

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -16,7 +16,7 @@
         <li class="MapsList-item">
           <div class="MapCard" vizjson-url="<%= api_v2_visualizations_vizjson_url(user_domain: user_domain, id: vis[:id]) %>.json">
             <div class="MapCard-header js-header">
-              <div class="MapCard-loader js-header-loader"></div>
+              <div class="MapCard-loader"></div>
             </div>
             <div class="MapCard-content">
               <div class="MapCard-contentBody">

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -14,7 +14,7 @@
       <% @visualizations.each do |vis| %>
         <% user_domain = vis[:owner].organization ? vis[:owner].username : nil %>
         <li class="MapsList-item">
-          <div class="MapCard" vizjson-url="<%= api_v2_visualizations_vizjson_url(user_domain: user_domain, id: vis[:id]) %>.json">
+          <div class="MapCard" data-vizjson-url="<%= api_v2_visualizations_vizjson_url(user_domain: user_domain, id: vis[:id]) %>.json">
             <div class="MapCard-header js-header">
               <div class="MapCard-loader"></div>
             </div>

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
@@ -178,6 +178,14 @@ AsyncFetchBeforeRender.applyTo(View, {
 
   done: function() {
     this.reRenderAnimated();
+
+    $('.MapCard').each(function() {
+      var mapCardPreview = new MapCardPreview({
+        el: $(this).find('.js-header'),
+        vizjson: $(this).attr("vizjson-url")
+      }).load();
+    });
+
   }
 });
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
@@ -1,6 +1,7 @@
 var cdb = require('cartodb.js');
 var BaseDialog = require('new_common/views/base_dialog/view');
 var pluralizeString = require('new_common/view_helpers/pluralize_string');
+var MapCardPreview = require('new_dashboard/mapcard_preview');
 var queue = require('queue-async');
 var batchProcessItems = require('new_common/batch_process_items');
 var _ = require('underscore');
@@ -68,6 +69,7 @@ var View = BaseDialog.extend({
       var vis = new cdb.admin.Visualization(visData);
       var isOwner = vis.permission.isOwner(this.user);
       return {
+        vizjson: vis.vizjsonURL(),
         name: vis.get('name'),
         url: this.router.currentUserUrl.mapUrl(vis).toEdit(),
         owner: vis.permission.owner,

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
@@ -185,7 +185,7 @@ AsyncFetchBeforeRender.applyTo(View, {
 
       var mapCardPreview = new MapCardPreview({
         el: $(this).find('.js-header'),
-        vizjson: $(this).attr("vizjson-url"),
+        vizjson: $(this).data("vizjson-url"),
         width: 298,
         height: 130
       }).load();

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
@@ -179,11 +179,19 @@ AsyncFetchBeforeRender.applyTo(View, {
   done: function() {
     this.reRenderAnimated();
 
-    $('.MapCard').each(function() {
+    var self = this;
+
+    this.$el.find(".MapCard").each(function() {
+
       var mapCardPreview = new MapCardPreview({
         el: $(this).find('.js-header'),
-        vizjson: $(this).attr("vizjson-url")
+        vizjson: $(this).attr("vizjson-url"),
+        width: 298,
+        height: 130
       }).load();
+
+      self.addView(mapCardPreview);
+
     });
 
   }

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
@@ -18,7 +18,7 @@
       <li class="MapsList-item">
         <div class="MapCard" vizjson-url="<%= vis.vizjson %>">
           <div class="MapCard-header MapCard-header--compact">
-            <div class="MapCard-loader js-header-loader"></div>
+            <div class="MapCard-loader"></div>
           </div>
           <div class="MapCard-content MapCard-content--compact">
             <div class="MapCard-contentBody">

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
@@ -16,7 +16,7 @@
   <ul class="Dialog-body MapsList MapsList--centerItems is-singleRow">
     <% visibleAffectedVis.forEach(function(vis) { %>
       <li class="MapsList-item">
-        <div class="MapCard">
+        <div class="MapCard" vizjson-url="<%= vis.vizjson %>">
           <div class="MapCard-header MapCard-header--compact">
             <div class="MapCard-loader js-header-loader"></div>
           </div>

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
@@ -17,9 +17,9 @@
     <% visibleAffectedVis.forEach(function(vis) { %>
       <li class="MapsList-item">
         <div class="MapCard" vizjson-url="<%= vis.vizjson %>">
-          <div class="MapCard-header MapCard-header--compact js-header">
+          <a href="<%= vis.url %>" target="_blank" class="MapCard-header MapCard-header--compact js-header">
             <div class="MapCard-loader"></div>
-          </div>
+          </a>
           <div class="MapCard-content MapCard-content--compact">
             <div class="MapCard-contentBody">
               <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
@@ -17,7 +17,9 @@
     <% visibleAffectedVis.forEach(function(vis) { %>
       <li class="MapsList-item">
         <div class="MapCard">
-          <div class="MapCard-header MapCard-header--compact"></div>
+          <div class="MapCard-header MapCard-header--compact">
+            <div class="MapCard-loader js-header-loader"></div>
+          </div>
           <div class="MapCard-content MapCard-content--compact">
             <div class="MapCard-contentBody">
               <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
@@ -16,7 +16,7 @@
   <ul class="Dialog-body MapsList MapsList--centerItems is-singleRow">
     <% visibleAffectedVis.forEach(function(vis) { %>
       <li class="MapsList-item">
-        <div class="MapCard" vizjson-url="<%= vis.vizjson %>">
+        <div class="MapCard" data-vizjson-url="<%= vis.vizjson %>">
           <a href="<%= vis.url %>" target="_blank" class="MapCard-header MapCard-header--compact js-header">
             <div class="MapCard-loader"></div>
           </a>

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
@@ -17,7 +17,7 @@
     <% visibleAffectedVis.forEach(function(vis) { %>
       <li class="MapsList-item">
         <div class="MapCard" vizjson-url="<%= vis.vizjson %>">
-          <div class="MapCard-header MapCard-header--compact">
+          <div class="MapCard-header MapCard-header--compact js-header">
             <div class="MapCard-loader"></div>
           </div>
           <div class="MapCard-content MapCard-content--compact">

--- a/lib/assets/javascripts/cartodb/new_dashboard/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/mapcard_preview.js
@@ -23,9 +23,15 @@ module.exports = cdb.core.View.extend({
 
   load: function() {
     this._startLoader();
-    cdb.Image(this.vizjson, { https: true }).size(this.width, this.height).getUrl(this._onImageCallback);
+    cdb.Image(this.vizjson, { https: this._isHTTPS() }).size(this.width, this.height).getUrl(this._onImageCallback);
 
     return this;
+  },
+
+  _isHTTPS: function() {
+
+    return location.protocol.indexOf("https") === 0;
+ 
   },
 
   _startLoader: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
@@ -1,6 +1,6 @@
 <div class="MapCard MapCard--selectable <%= selected ? 'is-selected' : '' %>">
   <div class="MapCard-header js-header">
-    <div class="MapCard-loader js-header-loader"></div>
+    <div class="MapCard-loader"></div>
     <div class="MapCard-headerGraph js-header-graph"></div>
   </div>
   <div class="MapCard-content">

--- a/lib/assets/javascripts/cartodb/new_public_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_public_dashboard/entry.js
@@ -31,7 +31,7 @@ $(function() {
     $('.MapCard').each(function() {
       var mapCardPreview = new MapCardPreview({
         el: $(this).find('.js-header'),
-        vizjson: $(this).attr("vizjson-url")
+        vizjson: $(this).data("vizjson-url")
       }).load();
     });
 

--- a/lib/assets/test/spec/cartodb/new_dashboard/dialogs/delete_items_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/dialogs/delete_items_view.spec.js
@@ -285,7 +285,7 @@ describe('new_dashboard/dialogs/delete_items_view', function() {
       });
 
       it('should render the vizjson', function() {
-        expect(this.innerHTML()).toContain('vizjson-url="/api/v2/viz/8b44c8ba-6fcf-11e4-8581-080027880ca6/viz.json"');
+        expect(this.innerHTML()).toContain('data-vizjson-url="/api/v2/viz/8b44c8ba-6fcf-11e4-8581-080027880ca6/viz.json"');
       });
 
       it('should be linked to open map in new window', function() {

--- a/lib/assets/test/spec/cartodb/new_dashboard/dialogs/delete_items_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/dialogs/delete_items_view.spec.js
@@ -65,7 +65,7 @@ describe('new_dashboard/dialogs/delete_items_view', function() {
       it('should not have rendered the original render just yet', function() {
         expect(this.view.render_content).not.toHaveBeenCalled();
       });
-      
+
       afterEach(function() {
         // finish to void timeouts
         this.itemFetches.forEach(function(fetchOpts) {
@@ -119,7 +119,7 @@ describe('new_dashboard/dialogs/delete_items_view', function() {
       it('should log error', function() {
         expect(this.trackedError).toContain('something failed');
       });
-      
+
       afterEach(function() {
         window.trackJs = this.originalTrackJs;
       });
@@ -282,6 +282,10 @@ describe('new_dashboard/dialogs/delete_items_view', function() {
 
       it('should render affected map', function() {
         expect(this.innerHTML()).toContain('MapCard');
+      });
+
+      it('should render the vizjson', function() {
+        expect(this.innerHTML()).toContain('vizjson-url="/api/v2/viz/8b44c8ba-6fcf-11e4-8581-080027880ca6/viz.json"');
       });
 
       it('should be linked to open map in new window', function() {

--- a/lib/assets/test/spec/cartodb/new_dashboard/mapcard_preview.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/mapcard_preview.spec.js
@@ -11,7 +11,7 @@ describe('new_dashboard/mapcard_preview', function() {
 
     var card = '<div class="MapCard MapCard--selectable">'
     + '<div class="MapCard-header js-header">'
-    + '  <div class="MapCard-loader js-header-loader"></div>'
+    + '  <div class="MapCard-loader"></div>'
     + '</div>'
     + '</div>';
 


### PR DESCRIPTION
### Changes

- Adds the vizjson URL [to the template](https://github.com/CartoDB/cartodb/blob/42a2ae35cc0b68c11e3c0a1995e9e6026e97a6a8/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs#L19) of the map card items in the delete dialog
- [Uses the protocol of the current location to request the image](https://github.com/CartoDB/cartodb/blob/42a2ae35cc0b68c11e3c0a1995e9e6026e97a6a8/lib/assets/javascripts/cartodb/new_dashboard/mapcard_preview.js) (necessary for development)


![screen shot 2015-02-13 at 17 02 54](https://cloud.githubusercontent.com/assets/4933/6190437/44f0acc8-b3a2-11e4-833a-814314ac9b6d.png)
