### PR TITLE
fixes style reset #2244

### DIFF
--- a/lib/assets/javascripts/cartodb/common/import/import_layer_pane.js
+++ b/lib/assets/javascripts/cartodb/common/import/import_layer_pane.js
@@ -105,7 +105,7 @@
       table_metadata.fetch({
         success: function(m) {
           // Check if actual table is the same requested
-          if (self.tableCombo.getSelected().name == m.get('name') && m.get('geometry_types').length == 0) {
+          if (self.tableCombo.getSelected().name == m.get('name') && m.statsGeomColumnTypes().length == 0) {
             self._toggleElements(['p.warning.geo'], true, false);
           }
         }

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -130,9 +130,11 @@
       if(resp.name) {
         resp.id = resp.name;
       }
-      // do not drop geometry_types. It's calculated from sql query
-      // but in some places the cached value from backend is enough
-      //delete resp.geometry_types;
+      // move geometry_types to stats one
+      // geometry_types from backend are not reliable anymore and it can only be used
+      // for non editing stuff (showing icons, general checks on table list)
+      resp.stats_geometry_types = resp.geometry_types;
+      delete resp.geometry_types;
       delete resp.schema;
       return resp;
     },
@@ -213,6 +215,12 @@
         return c[1] == type;
       });
       return _(t).pluck(0);
+    },
+
+    // return geometry columns calculated backend stats
+    // use geomColumnTypes if you need something reliable (but slower and async)
+    statsGeomColumnTypes: function(geometryTypes) {
+      return this.geomColumnTypes(this.get('stats_geometry_types'))
     },
 
     // return the current column types in an array

--- a/lib/assets/javascripts/cartodb/new_dashboard/datasets/datasets_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/datasets/datasets_item.js
@@ -37,7 +37,7 @@ module.exports = cdb.core.View.extend({
 
     var d = {
       isRaster:                vis.get('kind') === 'raster',
-      geometryType:            table.geomColumnTypes().length > 0 ? table.geomColumnTypes()[0] : '',
+      geometryType:            table.statsGeomColumnTypes().length > 0 ? table.statsGeomColumnTypes()[0] : '',
       title:                   vis.get('name'),
       datasetUrl:              encodeURI(this.router.currentUserUrl.datasetsUrl().toDataset(this.table)),
       isOwner:                 isOwner,

--- a/lib/assets/javascripts/cartodb/new_dashboard/datasets/remote_datasets_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/datasets/remote_datasets_item.js
@@ -37,7 +37,7 @@ module.exports = DatasetsItem.extend({
 
     var d = {
       isRaster:                vis.get('kind') === 'raster',
-      geometryType:            table.geomColumnTypes().length > 0 ? table.geomColumnTypes()[0] : '',
+      geometryType:            table.statsGeomColumnTypes().length > 0 ? table.statsGeomColumnTypes()[0] : '',
       title:                   vis.get('name'),
       source:                  source,
       description:             description,

--- a/lib/assets/test/spec/cartodb/models/table.spec.js
+++ b/lib/assets/test/spec/cartodb/models/table.spec.js
@@ -194,7 +194,7 @@ describe("admin table", function() {
 
     it("should return stats geom column types", function() {
       table.set({ stats_geometry_types: ['ST_MultiPolygon']});
-      expect(table.statsFeomColumnTypes()).toEqual(['polygon']);
+      expect(table.statsGeomColumnTypes()).toEqual(['polygon']);
     });
 
     it("hasgeomtype", function() {

--- a/lib/assets/test/spec/cartodb/models/table.spec.js
+++ b/lib/assets/test/spec/cartodb/models/table.spec.js
@@ -192,6 +192,11 @@ describe("admin table", function() {
 
     });
 
+    it("should return stats geom column types", function() {
+      table.set({ stats_geometry_types: ['ST_MultiPolygon']});
+      expect(table.statsFeomColumnTypes()).toEqual(['polygon']);
+    });
+
     it("hasgeomtype", function() {
       var r = new cdb.admin.Row({
         cartodb_id: 100,


### PR DESCRIPTION
this fixes part of the style reset. There is an important change for the frontend:

instead of using geometry_types (or geomColumnTypes which uses it) all the time we need to use:

- statsGeomColumnTypes: if the check needs to be fast and sync. For example, to decide what icon we use in the dashboard

- geomColumnTypes for realiable queries. It only can be used if geometry_types has been fetched from the sql api
