### PR TITLE
Shows an error if the vis is private

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/mapcard_preview.js
@@ -46,6 +46,10 @@ module.exports = cdb.core.View.extend({
     $img.fadeIn(250);
   },
 
+  showError: function() {
+    this._onError();
+  },
+
   _onSuccess: function(url) {
     this._stopLoader();
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -110,7 +110,11 @@ module.exports = cdb.core.View.extend({
     if (this.imageURL) {
       mapCardPreview.loadURL(this.imageURL);
     } else {
-      mapCardPreview.load();
+      if (this.model.get('privacy') !== "PRIVATE") {
+        mapCardPreview.load();
+      } else {
+        mapCardPreview.showError();
+      }
     }
 
     var self = this;

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -110,10 +110,10 @@ module.exports = cdb.core.View.extend({
     if (this.imageURL) {
       mapCardPreview.loadURL(this.imageURL);
     } else {
-      if (this.model.get('privacy') !== "PRIVATE") {
-        mapCardPreview.load();
-      } else {
+      if (this.model.get('privacy') === "LINK" || this.model.get('privacy') === "PRIVATE") {
         mapCardPreview.showError();
+      } else {
+        mapCardPreview.load();
       }
     }
 


### PR DESCRIPTION
Right now we can't make a map preview of a private visualization, so instead we show the error image of the map preview.