### PR TITLE
Limit to 50 the number of maximum layers of a kml file fixes #2044

### DIFF
--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -222,6 +222,10 @@ module CartoDB
       title: 'File is password protected',
       what_about: "File is password protected and can't be imported. Please remove password protection or create a new compressed file without password and try again."
     },
+    1019 => {
+      title: 'Too Many Layers',
+      what_about: "The file has too many layers. It can have 50 as maximum." # ./services/importer/lib/importer/kml_splitter.rb
+    },
     2001 => {
       title: 'Unable to load data',
       what_about: "We couldn't load data from your file into the database.  Please <a href='mailto:support@cartodb.com?subject=Import load error'>contact us</a> and we will help you to load your data."

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -40,6 +40,7 @@ module CartoDB
     class EmptyFileError                        < StandardError; end
     class ExtractionError                       < StandardError; end
     class PasswordNeededForExtractionError      < ExtractionError; end
+    class TooManyLayersError                    < StandardError; end
     class GeometryCollectionNotSupportedError   < StandardError; end
     class InvalidGeoJSONError                   < StandardError; end
     class InvalidShpError                       < StandardError; end
@@ -80,6 +81,7 @@ module CartoDB
       GDriveNotPublicError                  => 1010,
       InvalidNameError                      => 1014,
       PasswordNeededForExtractionError      => 1018,
+      TooManyLayersError                    => 1019,
       LoadError                             => 2001,
       EncodingDetectionError                => 2002,
       MalformedCSVException                 => 2003,

--- a/services/importer/lib/importer/kml_splitter.rb
+++ b/services/importer/lib/importer/kml_splitter.rb
@@ -2,10 +2,12 @@
 require 'open3'
 require_relative './source_file'
 require_relative './unp'
+require_relative './exceptions'
 
 module CartoDB
   module Importer2
     class KmlSplitter
+      MAX_LAYERS = 50
       def self.support?(source_file)
         source_file.extension == '.kml'
       end
@@ -16,7 +18,9 @@ module CartoDB
       end
 
       def run
-        return self unless multiple_layers?(source_file)
+        n_layers = layers_in(source_file).length
+        return self if n_layers <= 1
+        raise CartoDB::Importer2::TooManyLayersError.new("File has too many layers (#{n_layers}). Maximum number of layers: #{MAX_LAYERS}") if n_layers > MAX_LAYERS
         @source_files = source_files_for(source_file, layers_in(source_file))
         self
       end

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -34,10 +34,6 @@ module CartoDB
         crawl(temporary_directory).each { |dir_path| process(dir_path) }
         @source_files = split(source_files)
         self
-      rescue => exception
-        puts exception.to_s
-        puts exception.backtrace
-        raise exception #ExtractionError
       end
 
       def without_unpacking(path)


### PR DESCRIPTION
@Kartones CR this, please.

@javisantana , @iriberri , what do you think about this limitation? #2044 error was caused by a KML file with more than 1000 layers. It's fast in viewers like Google Earth, but since we create a table per layer (it's treated like a multiple import) it won't end in a reasonable time. We can check layer number before splitting and importing, so I've added a 50 limit.