### PR TITLE
Make breadcrumb dropdown only work on dashboard

### DIFF
--- a/app/assets/stylesheets/new_common/header.css.scss
+++ b/app/assets/stylesheets/new_common/header.css.scss
@@ -50,6 +50,12 @@ $cHeader-dark:  rgba(#3A91D7, 1);
     text-decoration: underline;
     &:after { border-top-color: white }
   }
+  &.is-disabled {
+    &:hover {
+      text-decoration: none;
+      cursor: default;
+    }
+  }
 }
 .Header-settings { height: $height }
 .Header-settingsList {

--- a/lib/assets/javascripts/cartodb/new_common/views/dashboard_header/breadcrumbs/dropdown_link.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/views/dashboard_header/breadcrumbs/dropdown_link.jst.ejs
@@ -1,1 +1,1 @@
-<button class="DropdownLink DropdownLink--white Header-navigationBreadcrumbLink"><%= title %></button>
+<button class="Header-navigationBreadcrumbLink <%= dropdownEnabled ? 'DropdownLink DropdownLink--white' : 'is-disabled' %>"><%= title %></button>

--- a/lib/assets/javascripts/cartodb/new_common/views/dashboard_header_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/dashboard_header_view.js
@@ -14,24 +14,24 @@ module.exports = cdb.core.View.extend({
     'click .js-settings-dropdown': '_createSettingsDropdown'
   },
 
-  initialize: function(args) {
-    if (!args.el) {
+  initialize: function() {
+    if (!this.options.el) {
       throw new Error('el element is required');
     }
-    if (!args.viewModel) {
+    if (!this.options.viewModel) {
       throw new Error('viewModel is required');
     }
-    if (!args.currentUserUrl) {
-      if (args.router.currentUserUrl) {
-        this.options.currentUserUrl = args.router.currentUserUrl;
+    if (!this.options.currentUserUrl) {
+      if (this.options.router.currentUserUrl) {
+        this.options.currentUserUrl = this.options.router.currentUserUrl;
       } else {
-        throw new Error('currentUserUrl is required');
+        throw new Error('currentUserUrl is required (either explicitly or implicitly through a router)');
       }
     }
 
-    this.viewModel = args.viewModel;
-    this.viewModel.bind('change', this.render, this);
-    this.add_related_model(this.viewModel);
+    this._viewModel = this.options.viewModel;
+    this._viewModel.bind('change', this.render, this);
+    this.add_related_model(this._viewModel);
   },
 
   render: function() {
@@ -45,10 +45,12 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderBreadcrumbsDropdownLink: function() {
-    var template = cdb.templates.getTemplate('new_common/views/dashboard_header/breadcrumbs/dropdown_link');
-    this.$('.js-breadcrumb-dropdown').html(template({
-      title: this.viewModel.breadcrumbTitle()
-    }));
+    this.$('.js-breadcrumb-dropdown').html(
+      cdb.templates.getTemplate('new_common/views/dashboard_header/breadcrumbs/dropdown_link')({
+        title: this._viewModel.breadcrumbTitle(),
+        dropdownEnabled: this._viewModel.isBreadcrumbDropdownEnabled()
+      })
+    )
   },
 
   _renderNotifications: function() {
@@ -83,18 +85,19 @@ module.exports = cdb.core.View.extend({
   },
 
   _createBreadcrumbsDropdown: function(ev) {
-    this.killEvent(ev);
-
-    this._setupDropdown(new BreadcrumbsDropdown({
-      target: $(ev.target),
-      model: this.model,
-      viewModel: this.options.viewModel,
-      currentUserUrl: this.options.currentUserUrl,
-      router: this.options.router, // optional
-      horizontal_offset: -110,
-      tick: 'center',
-      template_base: 'new_common/views/dashboard_header/breadcrumbs/dropdown'
-    }));
+    if (this._viewModel.isBreadcrumbDropdownEnabled()) {
+      this.killEvent(ev);
+      this._setupDropdown(new BreadcrumbsDropdown({
+        target: $(ev.target),
+        model: this.model,
+        viewModel: this._viewModel,
+        currentUserUrl: this.options.currentUserUrl,
+        router: this.options.router, // optional
+        horizontal_offset: -110,
+        tick: 'center',
+        template_base: 'new_common/views/dashboard_header/breadcrumbs/dropdown'
+      }));
+    }
   },
 
   _setupDropdown: function(dropdownView) {

--- a/lib/assets/javascripts/cartodb/new_dashboard/header_view_model.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/header_view_model.js
@@ -20,6 +20,10 @@ module.exports = cdb.core.Model.extend({
     }
   },
 
+  isBreadcrumbDropdownEnabled: function() {
+    return true;
+  },
+
   isDisplayingDatasets: function() {
     return this.router.model.get('content_type') === 'datasets';
   },

--- a/lib/assets/javascripts/cartodb/new_keys/header_view_model.js
+++ b/lib/assets/javascripts/cartodb/new_keys/header_view_model.js
@@ -9,6 +9,10 @@ module.exports = cdb.core.Model.extend({
     return 'Configuration';
   },
 
+  isBreadcrumbDropdownEnabled: function() {
+    return false;
+  },
+
   isDisplayingDatasets: function() {
     return false;
   },

--- a/lib/assets/test/spec/cartodb/new_common/views/dashboard_header/shared_for_view_model.js
+++ b/lib/assets/test/spec/cartodb/new_common/views/dashboard_header/shared_for_view_model.js
@@ -12,6 +12,7 @@ module.exports = function() {
 
   [
     'breadcrumbTitle',
+    'isBreadcrumbDropdownEnabled',
     'isDisplayingDatasets',
     'isDisplayingMaps',
     'isDisplayingLockedItems'


### PR DESCRIPTION
I.e. on API keys/OAuth pages it simply renders “Configuration” without
the dropdown arrow and non-interactive

Fixes #2312