### PR TITLE
Fixing search bugs within new create dialog

### DIFF
--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create/create_content.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create/create_content.js
@@ -18,6 +18,10 @@ var CreateLoading = require('new_common/dialogs/create/create_loading');
  */
 
 module.exports = cdb.core.View.extend({
+
+  events: {
+    'click': '_onClickContent'
+  },
   
   initialize: function() {
     this.user = this.options.user;
@@ -116,6 +120,10 @@ module.exports = cdb.core.View.extend({
 
   _initBinds: function() {
     this.model.bind('change:option', this._setOption, this);
+  },
+
+  _onClickContent: function() {
+    cdb.god.trigger('closeDialogs');
   }
 
 });

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create/listing/navigation_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create/listing/navigation_view.js
@@ -81,6 +81,8 @@ module.exports = cdb.core.View.extend({
     this.model.bind('change:state', this.render, this);
     this.routerModel.bind('change', this.render, this);
     this.collection.bind('reset', this.render, this);
+    cdb.god.bind('closeDialogs', this._animate, this);
+    this.add_related_model(cdb.god);
     this.add_related_model(this.collection);
     this.add_related_model(this.routerModel);
   },
@@ -162,8 +164,8 @@ module.exports = cdb.core.View.extend({
   },
 
   _submitSearch: function(e) {
-    if (e) e.preventDefault();
-    var val = this.$('.js-search-input').val().trim()
+    if (e) this.killEvent(e);
+    var val = this.$('.js-search-input').val().trim();
     var tag = val.search(':') === 0 ? val.replace(':', '') : '';
     var q = val.search(':') !== 0 ? val : '';
     var shared = this.routerModel.get('shared');

--- a/lib/assets/javascripts/cartodb/new_common/views/base_dialog/view.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/base_dialog/view.js
@@ -28,8 +28,7 @@ module.exports = BaseDialog.extend({
   className: 'Dialog is-opening',
 
   overrideDefaults: {
-    template_name: 'new_common/views/base_dialog/template',
-    enter_to_confirm: true
+    template_name: 'new_common/views/base_dialog/template'
   },
 
   initialize: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -201,7 +201,8 @@ module.exports = cdb.core.View.extend({
     var view = new DeleteItemsDialog({
       viewModel: viewModel,
       currentUserUrl: this.router.currentUserUrl,
-      user: this.user
+      user: this.user,
+      enter_to_confirm: true
     });
 
     var self = this;
@@ -224,7 +225,8 @@ module.exports = cdb.core.View.extend({
 
     var view = new ChangeLockDialog({
       contentType: this.router.model.get('content_type'),
-      viewModel: viewModel
+      viewModel: viewModel,
+      enter_to_confirm: true
     });
 
     var self = this;
@@ -245,7 +247,8 @@ module.exports = cdb.core.View.extend({
     var privacyDlg = new ChangePrivacyDialog({
       vis: this._selectedItems()[0], // only pass first item since batch operation is not supported
       user: this.user,
-      upgradeUrl: this.router.currentUserUrl.toUpgradeAccount()
+      upgradeUrl: this.router.currentUserUrl.toUpgradeAccount(),
+      enter_to_confirm: true
     });
 
     privacyDlg.bind('hide', function(){


### PR DESCRIPTION
- Fixes enter_to_confirm problem with all new dialogs.
- When user clicks outside search, it checks if it should disable search field, within new create dialog.