### PR TITLE
Validate presence of token fixes #2186

### DIFF
--- a/app/models/synchronization/synchronization_oauth.rb
+++ b/app/models/synchronization/synchronization_oauth.rb
@@ -21,6 +21,8 @@ class SynchronizationOauth < Sequel::Model
   def validate
     super
 
+    validates_presence :token
+
     if new?
       existing_oauth = SynchronizationOauth.filter(
           user_id:  user_id,

--- a/spec/models/synchronization/synchronization_oauth_spec.rb
+++ b/spec/models/synchronization/synchronization_oauth_spec.rb
@@ -67,6 +67,22 @@ describe SynchronizationOauth do
             token: UUIDTools::UUID.timestamp_create
         )
       }.to raise_exception Sequel::ValidationFailed
+
+      expect {
+        SynchronizationOauth.create(
+          user_id: @user_id,
+          service: service_name,
+          token: nil
+        )
+      }.to raise_exception Sequel::ValidationFailed
+
+      expect {
+        SynchronizationOauth.create(
+          user_id: @user_id,
+          service: service_name,
+          token: ''
+        )
+      }.to raise_exception Sequel::ValidationFailed
     end
   end
 


### PR DESCRIPTION
@Kartones CR this, please.

@iriberri this is likely to move the GDrive sync issues from syncing to authentication, since attempts to store empty tokens will fail. Please let me know when anybody reports problems so we can analyse why are those tokens being stored empty.