### PR TITLE
Show delete items last in filters list

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/views/filters.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/filters.jst.ejs
@@ -106,6 +106,11 @@
                 <a class="Filters-actionsLink js-deselect_all" href="#/deselect-all">Deselect all</a>
               <% } %>
             </li>
+            <% if (selectedItemsCount === 1) { %>
+              <li class="Filters-actionsItem">
+                <a class="Filters-actionsLink js-privacy" href="#/change-privacy">Change privacy</a>
+              </li>
+            <% } %>
             <li class="Filters-actionsItem">
               <a class="Filters-actionsLink js-lock" href="#/lock">
                 <%= locked ? 'Unlock' : 'Lock' %> <%= pluralizedContentTypeSelected %>&hellip;
@@ -114,11 +119,6 @@
             <li class="Filters-actionsItem">
               <a class="Filters-actionsLink is--critical js-delete" href="#/delete">Delete <%= pluralizedContentTypeSelected %>&hellip;</a>
             </li>
-            <% if (selectedItemsCount === 1) { %>
-              <li class="Filters-actionsItem">
-                <a class="Filters-actionsLink js-privacy" href="#/change-privacy">Change privacy</a>
-              </li>
-            <% } %>
           <% } %>
         </ul>
       </div>


### PR DESCRIPTION
Fixes #2402 

1 selected item (privacy moved to the left):
![screen shot 2015-02-20 at 16 44 26](https://cloud.githubusercontent.com/assets/978461/6289432/7aba234c-b920-11e4-8d78-4348033d4e9a.png)

2 selected items (privacy not available, deselect all available):
![screen shot 2015-02-20 at 16 44 32](https://cloud.githubusercontent.com/assets/978461/6289434/7abd0468-b920-11e4-91e3-303eba050e3a.png)

All items selected (select all not available):
![screen shot 2015-02-20 at 16 44 43](https://cloud.githubusercontent.com/assets/978461/6289433/7abbe844-b920-11e4-8552-f97b3ba0f15e.png)
