### PR TITLE
Fix change privacy dialog issues

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view/permission_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view/permission_view_template.jst.ejs
@@ -14,15 +14,15 @@
   </div>
 </div>
 <div>
-  <span class="<%= canChangeWriteAccess ? '': 'u-disabled' %>">
-    <div class="Toggler ChangePrivacy-shareListItemToggler">
-      <input type="checkbox" id="<%= writeId %>" class="js-write"
-          <%= canWrite ? 'checked="checked"' : '' %>
-          <%= canChangeWriteAccess ? '': 'disabled="disabled"' %> />
-      <label for="<%= writeId %>" />
-    </div>
-    <span class="DefaultDescription ChangePrivacy-shareListItemTogglerText">Write</span>
-  </span>
+  <% if (canChangeWriteAccess) { %>
+    <span>
+      <div class="Toggler ChangePrivacy-shareListItemToggler">
+        <input type="checkbox" id="<%= writeId %>" class="js-write" <%= canWrite ? 'checked="checked"' : '' %> />
+        <label for="<%= writeId %>" />
+      </div>
+      <span class="DefaultDescription ChangePrivacy-shareListItemTogglerText">Write</span>
+    </span>
+  <% } %>
 
   <div class="Toggler ChangePrivacy-shareListItemToggler">
     <input type="checkbox" id="<%= readId %>" class="js-read" <%= canRead ? 'checked="checked"' : '' %> />

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/start_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/start_view.js
@@ -22,7 +22,7 @@ module.exports = cdb.core.View.extend({
     this.user = args.user;
     this.upgradeUrl = args.upgradeUrl;
     this.privacyOptions = args.privacyOptions;
-    
+
     this.template = cdb.templates.getTemplate('new_dashboard/dialogs/change_privacy/start_view_template');
 
     this.privacyOptions.bind('change', this.render, this);
@@ -43,11 +43,10 @@ module.exports = cdb.core.View.extend({
         saveBtnClassNames: selectedOption.canSave() ? '' : DISABLED_SAVE_CLASS_NAME,
         showUpgradeBanner: !!this.upgradeUrl && this.privacyOptions.any(function(option) { return !!option.get('disabled'); }),
         upgradeUrl: this.upgradeUrl,
-        showShareBanner: !!org,
-        orgUsersCount: org && org.users.length
+        showShareBanner: !!org
       })
     );
-    
+
     return this;
   },
 
@@ -71,7 +70,7 @@ module.exports = cdb.core.View.extend({
       this.trigger('click:share');
     }
   },
-  
+
   _onClickSave: function(ev) {
     this.killEvent(ev);
     this.trigger('click:save');

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/start_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/start_view_template.jst.ejs
@@ -32,7 +32,6 @@
   <div class="Dialog-body u-inner ChangePrivacy-shareBanner">
     <div class="LayoutIcon ChangePrivacy-shareBannerIcon">
       <i class="iconFont iconFont-People iconFont--super"></i>
-      <span class="Badge Dialog-headerIconBadge"><%= orgUsersCount %></span>
     </div>
     <div class="DefaultSecondary">
       Team work is always better. <a href="#" class="js-share">Share this dataset with your colleagues</a>

--- a/lib/assets/test/spec/cartodb/new_dashboard/dialogs/change_privacy/permission_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/dialogs/change_privacy/permission_view.spec.js
@@ -9,7 +9,7 @@ describe('new_dashboard/dialogs/change_privacy/share_view/permission_view', func
       name: 'Pepe paco',
       avatar_url: 'http://host.ext/path/img.jpg'
     });
-    
+
     this.permission = new cdbAdmin.Permission({});
     spyOn(this.permission, 'setPermission').and.callThrough();
     spyOn(this.permission, 'removePermission').and.callThrough();
@@ -18,7 +18,7 @@ describe('new_dashboard/dialogs/change_privacy/share_view/permission_view', func
     this.desc = this.model.get('name');
     this.avatarUrl = this.model.get('avatar_url');
     this.canChangeWriteAccess = true;
-    
+
     this.createView = function() {
       this.view = new PermissionView({
         model: this.model,
@@ -73,8 +73,10 @@ describe('new_dashboard/dialogs/change_privacy/share_view/permission_view', func
     beforeEach(function() {
       this.createView();
     });
-    
+
     it('should not disable any toggler', function() {
+      expect(this.innerHTML()).toContain('js-write');
+      expect(this.innerHTML()).toContain('js-read');
       expect(this.innerHTML()).not.toContain('disabled');
     });
 
@@ -88,7 +90,7 @@ describe('new_dashboard/dialogs/change_privacy/share_view/permission_view', func
         this.view.$('.js-write').click();
         this.view.$('.js-write').click();
         this.view.$('.js-write').click();
-        
+
         expect(this.permission.setPermission.calls.argsFor(0)).toEqual([ this.model, cdbAdmin.Permission.READ_WRITE ]);
         expect(this.permission.setPermission.calls.argsFor(1)).toEqual([ this.model, cdbAdmin.Permission.READ_ONLY ]);
         expect(this.permission.setPermission.calls.argsFor(2)).toEqual([ this.model, cdbAdmin.Permission.READ_WRITE ]);
@@ -101,9 +103,9 @@ describe('new_dashboard/dialogs/change_privacy/share_view/permission_view', func
       this.canChangeWriteAccess = false;
       this.createView();
     });
-    
-    it('should disable write toggler', function() {
-      expect(this.innerHTML()).toContain('disabled');
+
+    it('should not render write toggler', function() {
+      expect(this.innerHTML()).not.toContain('js-write');
       this.view.$('.js-write').click();
       expect(this.permission.setPermission).not.toHaveBeenCalled();
     });
@@ -113,7 +115,7 @@ describe('new_dashboard/dialogs/change_privacy/share_view/permission_view', func
     beforeEach(function() {
       this.createView();
     });
-    
+
     it('should toggle read access', function() {
       this.view.$('.js-read').click();
       this.view.$('.js-read').click();
@@ -124,9 +126,8 @@ describe('new_dashboard/dialogs/change_privacy/share_view/permission_view', func
       expect(this.permission.setPermission.calls.argsFor(1)).toEqual([ this.model, cdbAdmin.Permission.READ_ONLY ]);
     });
   });
-  
+
   afterEach(function() {
     this.view.clean();
   });
 });
-


### PR DESCRIPTION
Fixes #2365 (hide the count that can be misinterpreted)
![screen shot 2015-02-20 at 18 21 52](https://cloud.githubusercontent.com/assets/978461/6305701/5cd4f14c-b92d-11e4-945f-571b22842036.png)

---

Fixes #2027 (hide write permissions for maps), i.e.:
For maps only display read toggler:
![screen shot 2015-02-20 at 18 13 10](https://cloud.githubusercontent.com/assets/978461/6305708/6d64ed5a-b92d-11e4-88f8-3fdbcd8f0820.png)

For datasets display both:
![screen shot 2015-02-20 at 18 12 58](https://cloud.githubusercontent.com/assets/978461/6305709/6d66cb2a-b92d-11e4-9d49-d22d643eed35.png)