### PR TITLE
Adds force_https parameter to force https in iframe's URL

### DIFF
--- a/app/controllers/api/json/oembed_controller.rb
+++ b/app/controllers/api/json/oembed_controller.rb
@@ -14,6 +14,7 @@ class Api::Json::OembedController < Api::ApplicationController
     width = params[:maxwidth] || '100%'
     height = params[:maxheight] || '100%'
     format = request.query_parameters[:format]
+    force_https = true if params[:force_https].nil?
 
     if (width =~ /^[0-9]+(%|px)?$/) == nil
       raise ActionController::RoutingError.new('Incorrect width')
@@ -40,7 +41,8 @@ class Api::Json::OembedController < Api::ApplicationController
       raise ActionController::RoutingError.new('Visualization not found: ' + uuid)
     end
 
-    url = URI.join(public_visualizations_show_url(id: uuid, protocol: uri.scheme) + "/", 'embed_map')
+    protocol = force_https ? "https" : uri.scheme
+    url = URI.join(public_visualizations_show_url(id: uuid, protocol: protocol) + "/", 'embed_map')
     html = "<iframe width='#{width}' height='#{height}' frameborder='0' src='#{url}' allowfullscreen webkitallowfullscreen mozallowfullscreen oallowfullscreen msallowfullscreen></iframe>"
 
     response_data = {

--- a/app/controllers/api/json/oembed_controller.rb
+++ b/app/controllers/api/json/oembed_controller.rb
@@ -14,7 +14,7 @@ class Api::Json::OembedController < Api::ApplicationController
     width = params[:maxwidth] || '100%'
     height = params[:maxheight] || '100%'
     format = request.query_parameters[:format]
-    force_https = true if params[:force_https].nil?
+    force_https = true if params[:allow_http].nil?
 
     if (width =~ /^[0-9]+(%|px)?$/) == nil
       raise ActionController::RoutingError.new('Incorrect width')


### PR DESCRIPTION
currently, the protocol in the iframe's URL is determined by the protocol in the URL in the url parameter. we've added a force_https parameter to force iframe's URL to be https (Default: true)