### PR TITLE
Hiding 'forgot password' link if it isn't SaaS

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -91,12 +91,14 @@
       </div>
     </div>
   </div>
-
-  <footer class="Sessions-footer">
-    <div class="u-inner">
-      <div class="Sessions-notloggedin">
-        <p class="Sessions-text Sessions-text--footer u-txt-center"><%= link_to "Forgot password?", forget_password_url %> · <%= link_to 'Create an account', "https://cartodb.com/signup" %></p>
+  
+  <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+    <footer class="Sessions-footer">
+      <div class="u-inner">
+        <div class="Sessions-notloggedin">
+          <p class="Sessions-text Sessions-text--footer u-txt-center"><%= link_to "Forgot password?", forget_password_url %> · <%= link_to 'Create an account', "https://cartodb.com/signup" %></p>
+        </div>
       </div>
-    </div>
-  </footer>
+    </footer>
+  <% end %>
 </div>


### PR DESCRIPTION
Ref. [Ticket #2190: "forgot password" not working with new login in open-source edition #2190](https://github.com/CartoDB/cartodb/issues/2190)

Assuming that:  SaaS ==> `account_host: ‘cartodb.com’` in app_config.yml because of @javisantana 's comment [here](https://github.com/CartoDB/cartodb/issues/1956).

Also, I did the link not visible because of @saleiva 's comment in the same [post](https://github.com/CartoDB/cartodb/issues/1956) (*All related with the SaaS part I think that shoulnd't be visible...*)

Previews:
- `account_host:       'localhost.lan:3000'` --> (No link)
![screen shot 2015-02-24 at 17 21 04](https://cloud.githubusercontent.com/assets/3958416/6354556/740cb518-bc50-11e4-8f4b-d31355108cd4.png)

- `account_host:       'cartodb.com'` --> (With link)
![screen shot 2015-02-24 at 17 17 41](https://cloud.githubusercontent.com/assets/3958416/6354573/9a5f1f44-bc50-11e4-8291-55fbd60388c6.png)

Please, @javisantana @saleiva , could you check it? Thanks!
