### PR TITLE
Remove specs for cached vizjson that was removed

### DIFF
--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -1014,23 +1014,13 @@ describe Visualization::Member do
   end
 
   describe '#to_vizjson' do
-    it "calculates and returns the vizjson if not cached" do
+    it "calculates and returns the vizjson" do
       member = Visualization::Member.new(random_attributes_for_vis_member(user_id: @user_mock.id))
       member.store
       mocked_vizjson = {mocked: 'vizjson'}
       member.expects(:calculate_vizjson).returns(mocked_vizjson).once
 
       member.to_vizjson.should eq mocked_vizjson
-    end
-
-    it "Returns the vizjson if it was cached before" do
-      member = Visualization::Member.new(random_attributes_for_vis_member(user_id: @user_mock.id))
-      member.store
-      mocked_vizjson = {mocked: 'vizjson'}
-      member.expects(:calculate_vizjson).returns(mocked_vizjson).once
-
-      vizjson = member.to_vizjson # calculate and cache
-      member.to_vizjson.should eq vizjson
     end
   end
 
@@ -1117,21 +1107,6 @@ describe Visualization::Member do
       member.expects(:invalidate_redis_cache).once
 
       member.invalidate_cache
-    end
-  end
-
-  describe '#invalidate_redis_cache' do
-    it "Invalidates the vizjson in redis cache" do
-      member = Visualization::Member.new(random_attributes_for_vis_member(user_id: @user_mock.id))
-      member.store
-      mocked_vizjson = {mocked: 'vizjson'}
-      member.expects(:calculate_vizjson).returns(mocked_vizjson).once
-
-      vizjson = member.to_vizjson
-      member.send(:redis_cache).get(member.redis_vizjson_key).should eq vizjson.to_json
-
-      member.invalidate_cache
-      member.send(:redis_cache).get(member.redis_vizjson_key).should be_nil
     end
   end
 end


### PR DESCRIPTION
Since 2 tests fail on master atm, due to https://github.com/CartoDB/cartodb/commit/83ba1a2f2037560310fddce4265277faa0dea889 (hotfix on master) I think it makes sense to remove those the failing tests that asserts the cache. 