### PR TITLE
Fix visuals in privacy share permissions view

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 * Open privacy dialog directly from items [#2442](https://github.com/CartoDB/cartodb/pull/2442)
 * Fixes error handling when adding an erroneous WMS URL.
 * Add loading+error state for privacy dialog [#2484](https://github.com/CartoDB/cartodb/pull/2484)
+* Change visuals in share view of privacy dialog [#2492](https://github.com/CartoDB/cartodb/pull/2492)
 
 Bugfixes:
 * When being in any configuration page remove the arrow from the breadcrumb [#2312](https://github.com/CartoDB/cartodb/pull/2312)

--- a/app/assets/stylesheets/new_common/dialog.css.scss
+++ b/app/assets/stylesheets/new_common/dialog.css.scss
@@ -162,7 +162,8 @@ $sStickyHeight: 97px;
   @include flex-grow(100);
   border: 1px solid $cStructure-mainLine;
   background-color: $cExpandedBkg;
-  overflow: scroll;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 .Dialog-expandedSubContentInner {
   position: relative; // necessary to position subHeader properly

--- a/app/assets/stylesheets/new_common/dialog.css.scss
+++ b/app/assets/stylesheets/new_common/dialog.css.scss
@@ -46,6 +46,11 @@ body.is-inDialog {
   top: $sMargin-section;
   right: $sMargin-section;
 }
+.Dialog-backBtn {
+  position: fixed;
+  top: $sMargin-section;
+  left: $sMargin-section;
+}
 .Dialog-content {
   width: 100%;
 }
@@ -170,8 +175,11 @@ $sStickyHeight: 97px;
   width: $sLayout-width;
   z-index: 100; // for underlying content not to be visible
 }
-.Dialog-body--expanded {
-  padding: #{$sStickyHeight+$sMargin-group} 0 $sStickyHeight 0; // compensate so content is not covered by "sticky" subheader or footer
+.Dialog-body--expanded.is-expandedWithSubHeader {
+  padding-top: $sStickyHeight + $sMargin-group;
+}
+.Dialog-body--expanded.is-expandedWithSubFooter {
+  padding-bottom: $sStickyHeight;
 }
 .Dialog-stickyFooter {
   position: fixed;
@@ -231,4 +239,3 @@ $sStickyHeight: 97px;
     @include transform(scale(2.0));
   }
 }
-

--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.7.6
+3.7.7

--- a/lib/assets/javascripts/cartodb/new_common/views/create/dialog_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/views/create/dialog_template.jst.ejs
@@ -1,5 +1,5 @@
 <div class="Dialog-header Dialog-header--expanded CreateDialog-header"></div>
-<div class="Dialog-body Dialog-body--expanded CreateDialog-body"></div>
+<div class="Dialog-body Dialog-body--expanded is-expandedWithSubHeader is-expandedWithSubFooter CreateDialog-body"></div>
 <div class="Dialog-footer Dialog-footer--expanded CreateDialog-footer">
   <div class="u-inner"></div>
 </div>

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/header_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/header_template.jst.ejs
@@ -1,11 +1,17 @@
 <div class="Dialog-header Dialog-header--expanded u-inner">
+  <% if (showBackButton) { %>
+    <button class="NavButton Dialog-backBtn js-back">
+      <i class="iconFont iconFont-ArrowPrev"></i>
+    </button>
+  <% } %>
+
   <div class="Dialog-headerIcon Dialog-headerIcon--positive">
     <i class="iconFont iconFont-Unlock"></i>
   </div>
   <p class="Dialog-headerTitle u-ellipsLongText">
-    <%= itemName %> privacy
+    <%= title %>
   </p>
   <p class="DefaultSecondary">
-    Although we believe in the power of open data, you can also protect your <%= itemType %>.
+    <%= subtitle %>
   </p>
 </div>

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view.js
@@ -11,8 +11,7 @@ module.exports = cdb.core.View.extend({
   className: 'Dialog-expandedSubContent',
 
   events: {
-    'click .js-save' : '_onClickSave',
-    'click .js-back' : '_onClickBack'
+    'click .js-save' : '_onClickSave'
   },
 
   initialize: function() {
@@ -28,12 +27,8 @@ module.exports = cdb.core.View.extend({
   render: function() {
     this.clearSubViews();
 
-    var usersCount = this._organization().users.length;
-
     this.$el.html(
       this._template({
-        usersCount: usersCount,
-        colleagueOrColleaguesStr: pluralizeString('colleage', usersCount)
       })
     );
 
@@ -80,11 +75,6 @@ module.exports = cdb.core.View.extend({
   _appendPermissionView: function(view) {
     this.$('.js-permissions').append(view.render().el);
     this.addView(view);
-  },
-
-  _onClickBack: function(ev) {
-    this.killEvent(ev);
-    this._viewModel.changeState('Start');
   },
 
   _onClickSave: function(ev) {

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy/share_view/template.jst.ejs
@@ -1,13 +1,4 @@
-<div class="u-inner Dialog-expandedSubContentInner">
-  <div class="Dialog-stickySubHeader ChangePrivacy-shareHeader">
-    <button class="js-back NavButton ChangePrivacy-shareHeaderBackIcon">
-      <i class="iconFont iconFont-ArrowPrev"></i>
-    </button>
-    <div class="DefaultSecondary">Share with your <%= usersCount %> <%= colleagueOrColleaguesStr %></div>
-  </div>
-
-  <div class="Dialog-body Dialog-body--withoutBorder Dialog-body--expanded js-permissions"></div>
-</div>
+<div class="u-inner Dialog-body Dialog-body--withoutBorder Dialog-body--expanded is-expandedWithSubFooter js-permissions"></div>
 
 <div class="Dialog-stickyFooter">
   <div class="Dialog-footer ChangePrivacy-shareFooter u-inner">
@@ -25,4 +16,3 @@
     </div>
   </div>
 </div>
-

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_privacy_view.js
@@ -1,5 +1,6 @@
 var cdb = require('cartodb.js');
 var $ = require('jquery');
+var _ = require('underscore');
 var BaseDialog = require('../../new_common/views/base_dialog/view');
 var StartView = require('./change_privacy/start_view');
 var ShareView = require('./change_privacy/share_view');
@@ -8,6 +9,12 @@ var ShareView = require('./change_privacy/share_view');
  * Change privacy datasets/maps dialog.
  */
 module.exports = BaseDialog.extend({
+
+  events: function() {
+    return _.extend({}, BaseDialog.prototype.events, {
+      'click .js-back': '_goBack'
+    });
+  },
 
   initialize: function() {
     this.elder('initialize');
@@ -67,12 +74,20 @@ module.exports = BaseDialog.extend({
   },
 
   _headerContentEl: function() {
-    return $(
-      cdb.templates.getTemplate('new_dashboard/dialogs/change_privacy/header_template')({
-        itemName: this._viewModel.get('vis').get('name'),
-        itemType: this._viewModel.get('vis').isVisualization() ? 'map' : 'dataset'
-      })
-    )[0];
+    var d = {
+      title: this._viewModel.get('vis').get('name') + ' privacy',
+      showBackButton: false
+    }
+
+    if (this._viewModel.get('state') === 'Share') {
+      d.subtitle = 'Select your colleagues you want to give access in the list below';
+      d.showBackButton = true;
+    } else {
+      var type = this._viewModel.get('vis').isVisualization() ? 'map' : 'dataset';
+      d.subtitle = 'Although we believe in the power of open data, you can also protect your ' + type;
+    }
+
+    return $( cdb.templates.getTemplate('new_dashboard/dialogs/change_privacy/header_template')(d) )[0];
   },
 
   _renderSaving: function() {
@@ -85,5 +100,10 @@ module.exports = BaseDialog.extend({
     return cdb.templates.getTemplate('new_dashboard/templates/fail')({
       msg: ''
     });
+  },
+
+  _goBack: function(ev) {
+    this.killEvent(ev);
+    this._viewModel.changeState('Start');
   }
 });

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/mamufas_import_dialog_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/mamufas_import_dialog_view.jst.ejs
@@ -5,7 +5,7 @@
   <p class="Dialog-headerTitle">Drag and drop your data to this window</p>
   <p class="Dialog-headerText">Drop your file to connect a new dataset.</p>
 </div>
-<div class="Dialog-body Dialog-body--expanded MamufasDialog-body">
+<div class="Dialog-body Dialog-body--expanded is-expandedWithSubHeader is-expandedWithSubFooter MamufasDialog-body">
   <div class="MamufasDialog-dropZone">
     <i class="iconFont iconFont-AddDocument MamufasDialog-dropZoneIcon"></i>
   </div>

--- a/lib/assets/test/spec/cartodb/new_dashboard/dialogs/change_privacy/share_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/dialogs/change_privacy/share_view.spec.js
@@ -48,20 +48,6 @@ describe('new_dashboard/dialogs/change_privacy/share_view', function() {
     expect(this.view).toHaveNoLeaks();
   });
 
-  describe('on click .js-back', function() {
-    beforeEach(function() {
-      this.view.$('.js-back').click();
-    });
-
-    it('should kill event', function() {
-      expect(this.view.killEvent).toHaveBeenCalled();
-    });
-
-    it('should change state to start', function() {
-      expect(this.viewModel.changeState).toHaveBeenCalledWith('Start');
-    });
-  });
-
   describe('given there is at least one dependant visualization', function() {
     beforeEach(function() {
       this.dependantUser = {

--- a/lib/assets/test/spec/cartodb/new_dashboard/dialogs/change_privacy_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/dialogs/change_privacy_view.spec.js
@@ -74,13 +74,25 @@ describe('new_dashboard/dialogs/change_privacy_view', function() {
       expect(this.innerHTML()).toContain('privacy');
     });
 
-    describe('when change state to something else', function() {
+    describe('when change state to share', function() {
       beforeEach(function() {
         this.viewModel.changeState('Share');
       });
 
       it('should have rendered share view', function() {
-        expect(this.innerHTML()).toContain('Share with your');
+        expect(this.innerHTML()).toContain('Select your ');
+      });
+
+      describe('when clicking back button', function() {
+        beforeEach(function() {
+          spyOn(this.viewModel, 'changeState').and.callThrough();
+          this.view.$('.js-back').click();
+        });
+
+        it('should change state to Share', function() {
+          expect(this.viewModel.changeState).toHaveBeenCalled();
+          expect(this.viewModel.changeState).toHaveBeenCalledWith('Start');
+        });
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.7.6",
+  "version": "3.7.7",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #2363 

- Moved back button to header
- Removed subheader
- Updated affected views due to class name changes

![privacy-visual-changes](https://cloud.githubusercontent.com/assets/978461/6369492/3212d4c0-bce7-11e4-9d46-54cf629b1050.gif)