### PR TITLE
Don't remove params from the WMS URL

### DIFF
--- a/lib/assets/javascripts/cartodb/table/basemap/basemap_dialog/wms_basemap_pane.js
+++ b/lib/assets/javascripts/cartodb/table/basemap/basemap_dialog/wms_basemap_pane.js
@@ -45,9 +45,11 @@
         params.push("service=WMS");
       }
 
+      params.push("type=wms");
+
       url += "?" + params.join("&");
 
-      req += '?url=' + encodeURIComponent(url) + "&type=wms";
+      req += '?url=' + encodeURIComponent(url);
 
       if (method === "create" && this.get('layer') && this.get('srs')) {
         req += "&layer=" + this.get('layer');

--- a/lib/assets/javascripts/cartodb/table/basemap/basemap_dialog/wms_basemap_pane.js
+++ b/lib/assets/javascripts/cartodb/table/basemap/basemap_dialog/wms_basemap_pane.js
@@ -26,14 +26,26 @@
       var req = this._PROXY_URL + this.methodToURL[method];
       var url = this.get('wms_url');
 
-      // If the user didn't provided the necessary params, let's add them
-      var hasCapabilities = url.toLowerCase().indexOf("request=getcapabilities") != -1;
-      var hasService = url.toLowerCase().indexOf("service=wms") != -1;
+      var parser = document.createElement('a');
 
-      if (!hasCapabilities && !hasService) {
-        url = url.replace(/\?.*/,''); // strip params
-        url += "?request=GetCapabilities&service=WMS";
+      parser.href = url;
+
+      var params = parser.search.substr(1).split("&");
+
+      var hasCapabilities = _.find(params, function(p) { return p.toLowerCase().indexOf("request=getcapabilities") !== -1; });
+      var hasService      = _.find(params, function(p) { return p.toLowerCase().indexOf("service=wms") !== -1; });
+
+      // If the user didn't provided the necessary params, let's add them
+
+      if (!hasCapabilities) {
+        params.push("request=GetCapabilities");
       }
+
+      if (!hasService) {
+        params.push("service=WMS");
+      }
+
+      url += "?" + params.join("&");
 
       req += '?url=' + encodeURIComponent(url) + "&type=wms";
 

--- a/lib/assets/test/spec/cartodb/table/basemap_wms_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/basemap_wms_dialog.spec.js
@@ -1,39 +1,72 @@
-describe("Basemap WMS dialog", function() {
+describe("Basemap WMS pane", function() {
 
-  var view;
+  describe("cdb.admin.WMSService ", function() {
 
-  beforeEach(function() {
+    it("should add necessary params", function() {
 
-    cdb.admin.WMSService.prototype._PROXY_URL = 'http://cartodb-wms.global.ssl.fastly.net/api';
-    cdb.admin.WMSService.prototype._PROXY_TILES = 'http://cartodb-wms.global.ssl.fastly.net/mapproxy';
+      var url = "http://myURL";
 
-    view = new cdb.admin.WMSBasemapChooserPane();
-  });
+      var model = new cdb.admin.WMSService({ wms_url: url });
 
-  it("should trigger a success event if the WMS is valid", function(done) {
+      var resultURL = model.url("create");
 
-    view.bind("chooseWMSLayers", function() {
-      expect(true).toEqual(true);
-      done();
+      expect(resultURL.indexOf(encodeURIComponent("request=GetCapabilities"))).toBeGreaterThan(0);
+      expect(resultURL.indexOf(encodeURIComponent("service=WMS"))).toBeGreaterThan(0);
+      expect(resultURL.indexOf(encodeURIComponent("type=wms"))).toBeGreaterThan(0);
+
     });
 
-    var url = "http://geodata.nationaalgeoregister.nl/bevolkingskernen2008/wms";
-    view.checkTileJson(url);
+    it("shouldn't remove extra params in the URL", function() {
 
-  });
+      var url = "http://myURL?request=GetCapabilities&service=WMS&type=wms&FORMAT=image/png24";
 
-  it("should trigger an error if the WMS is invalid", function(done) {
+      var model = new cdb.admin.WMSService({ wms_url: url });
 
-    view.bind("errorChooser", function() {
-      expect(true).toEqual(true);
-      done();
+      var resultURL = model.url("create");
+
+      expect(resultURL.indexOf(encodeURIComponent("FORMAT=image/png24"))).toBeGreaterThan(0);
+      expect(resultURL.indexOf(encodeURIComponent("service=WMS"))).toBeGreaterThan(0);
+
     });
 
-    var url = "I'm not an URL, you know";
-
-    view.checkTileJson(url);
-
   });
 
+  describe("cdb.admin.WMSBasemapChooserPane", function() {
+    var view;
+
+    beforeEach(function() {
+
+      cdb.admin.WMSService.prototype._PROXY_URL = 'http://cartodb-wms.global.ssl.fastly.net/api';
+      cdb.admin.WMSService.prototype._PROXY_TILES = 'http://cartodb-wms.global.ssl.fastly.net/mapproxy';
+
+      view = new cdb.admin.WMSBasemapChooserPane();
+    });
+
+    it("should trigger a success event if the WMS is valid", function(done) {
+
+      view.bind("chooseWMSLayers", function() {
+        expect(true).toEqual(true);
+        done();
+      });
+
+      var url = "http://geodata.nationaalgeoregister.nl/bevolkingskernen2008/wms";
+      view.checkTileJson(url);
+
+    });
+
+    it("should keep parms", function(done) {
+
+      view.bind("errorChooser", function() {
+        expect(true).toEqual(true);
+        done();
+      });
+
+      var url = "I'm not an URL, you know";
+
+      view.checkTileJson(url);
+
+    });
+
+  });
 });
 


### PR DESCRIPTION
When a user submitted a URL of a WMS to generate a basemap, we automatically got rid of the params in the URL and append some necessary params to get the WMS layers. This PR fixes that.