### PR TITLE
Fixes for new dashboard texts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,13 +30,13 @@
 * Add loading+error state for privacy dialog [#2484](https://github.com/CartoDB/cartodb/pull/2484)
 * Change visuals in share view of privacy dialog [#2492](https://github.com/CartoDB/cartodb/pull/2492)
 * Added back Twitter import for new create dialog.
-* improved speed in dashboard caching frontend side
-  [#2465](https://github.com/CartoDB/cartodb/pull/2465)
+* Improved speed in dashboard caching frontend side [#2465](https://github.com/CartoDB/cartodb/pull/2465)
 
 Bugfixes:
 * When being in any configuration page remove the arrow from the breadcrumb [#2312](https://github.com/CartoDB/cartodb/pull/2312)
 * Pressing enter when deleting a table opens a new modal [#2126](https://github.com/CartoDB/cartodb/pull/2126)
 * Deselect all doesn't work [#2341](https://github.com/CartoDB/cartodb/issues/2341)
+* Fixes for new dashboard texts [#2499](https://github.com/CartoDB/cartodb/pull/2499)
 
 3.8.0 (2015-01-30)
 ------------------

--- a/app/assets/stylesheets/new_common/default-description.css.scss
+++ b/app/assets/stylesheets/new_common/default-description.css.scss
@@ -3,12 +3,33 @@
 
 @import "../new_variables/colors";
 @import "../new_variables/sizes";
+@import "../new_variables/mixins";
 
 .DefaultDescription {
   font-size: $sFontSize-normal;
   font-weight: $sFontWeight-lighter;
+  line-height: $sLineHeight-normal;
   color: $cTypography-secondary;
   overflow-wrap: break-word;
+  position: relative;
+}
+.DefaultDescription--twoLines {
+  height: 2 * $sLineHeight-normal;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  &:after {
+    content: ' ';
+    display: block;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: $sLineHeight-normal;
+    width: 2 * $sLineHeight-normal;
+    @include background-horizontal(transparent, white);
+  }
 }
 .DefaultDescription.is--empty {
   color: $cTypography-help;

--- a/app/assets/stylesheets/new_common/default-description.css.scss
+++ b/app/assets/stylesheets/new_common/default-description.css.scss
@@ -13,24 +13,6 @@
   overflow-wrap: break-word;
   position: relative;
 }
-.DefaultDescription--twoLines {
-  height: 2 * $sLineHeight-normal;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  &:after {
-    content: ' ';
-    display: block;
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    height: $sLineHeight-normal;
-    width: 2 * $sLineHeight-normal;
-    @include background-horizontal(transparent, white);
-  }
-}
 .DefaultDescription.is--empty {
   color: $cTypography-help;
   font-style: italic;

--- a/app/assets/stylesheets/new_common/default-description.css.scss
+++ b/app/assets/stylesheets/new_common/default-description.css.scss
@@ -8,6 +8,7 @@
   font-size: $sFontSize-normal;
   font-weight: $sFontWeight-lighter;
   color: $cTypography-secondary;
+  overflow-wrap: break-word;
 }
 .DefaultDescription.is--empty {
   color: $cTypography-help;

--- a/app/assets/stylesheets/new_common/map-card.css.scss
+++ b/app/assets/stylesheets/new_common/map-card.css.scss
@@ -33,13 +33,39 @@ $opacityTransition: 250ms;
   border-radius: $sCard-borderRadius;
   margin: 0 auto;
 }
-.MapCard--selectable:hover {
-  background-color: $cCard-hoverFill;
-  border-color: $cCard-hoverBorder;
+.MapCard-desc {
+  height: 2 * $sLineHeight-normal;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  &:after {
+    content: ' ';
+    display: block;
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: $sLineHeight-normal;
+    width: 2 * $sLineHeight-normal;
+    @include background-horizontal(rgba(255,255,255,0), rgba(255,255,255,1));
+  }
 }
-.MapCard--selectable.is-selected {
-  background-color: $cCard-selectedFill;
-  border-color: $cCard-selectedBorder;
+.MapCard--selectable{
+  &:hover {
+    background-color: $cCard-hoverFill;
+    border-color: $cCard-hoverBorder;
+    .MapCard-desc:after {
+      @include background-horizontal(rgba(255,255,255,0), $cCard-hoverFill);
+    }
+  }
+  &.is-selected {
+    background-color: $cCard-selectedFill;
+    border-color: $cCard-selectedBorder;
+    .MapCard-desc:after {
+      @include background-horizontal(rgba(255,255,255,0), $cCard-selectedFill);
+    }
+  }
 }
 .MapCard-header {
   position: relative;

--- a/app/assets/stylesheets/new_common/map-card.css.scss
+++ b/app/assets/stylesheets/new_common/map-card.css.scss
@@ -33,6 +33,9 @@ $opacityTransition: 250ms;
   border-radius: $sCard-borderRadius;
   margin: 0 auto;
 }
+.MapCard-title {
+  width: 100%; // required for child text-overflow to work as expected in FF
+}
 .MapCard-desc {
   height: 2 * $sLineHeight-normal;
   display: -webkit-box;

--- a/app/assets/stylesheets/new_dashboard/privacy-indicator.css.scss
+++ b/app/assets/stylesheets/new_dashboard/privacy-indicator.css.scss
@@ -8,8 +8,7 @@ $cPrivacy-public:   rgba(#8EB83F, 1);
 $cPrivacy-other:    rgba(#F5A623, 1);
 
 .PrivacyIndicator {
-  @include display-flex();
-  @include align-items(center, center);
+  display: inline-block;
   position: relative;
   color: $cTypography-secondary;
   font-weight: $sFontWeight-lighter;
@@ -20,6 +19,7 @@ $cPrivacy-other:    rgba(#F5A623, 1);
 }
 .PrivacyIndicator:before {
   content: '';
+  display: inline-block;
   width: 8px;
   height: 8px;
   background-color: $cTypography-help;

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -28,7 +28,7 @@
 
                 <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
                   <% if vis[:desc] %>
-                    <p class="DefaultDescription" title="<%= vis[:desc] %>"><%= raw truncate(vis[:desc], length: 45) %></p>
+                    <p class="DefaultDescription DefaultDescription--twoLines" title="<%= vis[:desc] %>"><%= raw vis[:desc] %></p>
                   <% else %>
                     <span class="DefaultDescription is--empty"></span>
                   <% end %>

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -21,7 +21,7 @@
             <div class="MapCard-content">
               <div class="MapCard-contentBody">
                 <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
-                  <h3 class="DefaultTitle">
+                  <h3 class="MapCard-title DefaultTitle">
                     <a href="<%= public_visualizations_public_map_url(user_domain: user_domain, id: vis[:id]) %>" class="DefaultTitle-link u-ellipsLongText" title="<%= vis[:title] %>"><%= vis[:title] %></a>
                   </h3>
                 </div>

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -28,7 +28,7 @@
 
                 <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
                   <% if vis[:desc] %>
-                    <p class="DefaultDescription" title="<%= vis[:desc] %>"><%= raw truncate(vis[:desc], :length => 85) %></p>
+                    <p class="DefaultDescription" title="<%= vis[:desc] %>"><%= raw truncate(vis[:desc], length: 65) %></p>
                   <% else %>
                     <span class="DefaultDescription is--empty"></span>
                   <% end %>

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -28,7 +28,7 @@
 
                 <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
                   <% if vis[:desc] %>
-                    <p class="DefaultDescription DefaultDescription--twoLines" title="<%= vis[:desc] %>"><%= raw vis[:desc] %></p>
+                    <p class="MapCard-desc DefaultDescription DefaultDescription--twoLines" title="<%= vis[:desc] %>"><%= raw vis[:desc] %></p>
                   <% else %>
                     <span class="DefaultDescription is--empty"></span>
                   <% end %>

--- a/app/views/admin/pages/new_public_maps.html.erb
+++ b/app/views/admin/pages/new_public_maps.html.erb
@@ -28,7 +28,7 @@
 
                 <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
                   <% if vis[:desc] %>
-                    <p class="DefaultDescription" title="<%= vis[:desc] %>"><%= raw truncate(vis[:desc], length: 65) %></p>
+                    <p class="DefaultDescription" title="<%= vis[:desc] %>"><%= raw truncate(vis[:desc], length: 45) %></p>
                   <% else %>
                     <span class="DefaultDescription is--empty"></span>
                   <% end %>

--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.7.10
+3.7.11

--- a/lib/assets/javascripts/cartodb/new_common/views/create/listing/datasets_no_result.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/views/create/listing/datasets_no_result.jst.ejs
@@ -9,7 +9,7 @@
   </div>
   <h4 class="IntermediateInfo-title">
     <% if (page > 1 || totalItems === 0 && totalEntries > 0) { %>
-      There are no results in this page  
+      There are no results in this page
     <% } %>
 
     <% if (( tag || q ) && totalItems === 0 && totalEntries === 0) { %>
@@ -17,7 +17,7 @@
     <% } %>
 
     <% if (page === 1 && !tag && !q && totalItems === 0 && totalEntries === 0) { %>
-      There are not <%= shared ? 'shared' : '' %> <%= locked ? 'locked' : '' %> <%= library ? 'library' : '' %> <%= type %> 
+      There are no <%= shared ? 'shared' : '' %> <%= locked ? 'locked' : '' %> <%= library ? 'library' : '' %> <%= type %>
     <% } %>
   </h4>
   <p class="DefaultParagraph">

--- a/lib/assets/javascripts/cartodb/new_dashboard/content_controller_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/content_controller_view.js
@@ -92,7 +92,7 @@ module.exports = cdb.core.View.extend({
     var noResultsView = new ContentResult({
       router:     this.router,
       collection: this.collection,
-      template:   'new_dashboard/views/content_no_results'
+      template:   'new_dashboard/views/content_no_results',
     });
 
     this.controlledViews['no_results'] = noResultsView;

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
@@ -86,6 +86,7 @@ module.exports = BaseDialog.extend({
 
     return cdb.templates.getTemplate('new_dashboard/dialogs/delete_items_view_template')({
       selectedCount: this._viewModel.length,
+      isDatasets: this._viewModel.isDeletingDatasets(),
       pluralizedContentType: this._pluralizedContentType(),
       affectedEntitiesCount: affectedEntities.length,
       affectedEntitiesSample: affectedEntities.slice(0, AFFECTED_ENTITIES_SAMPLE_COUNT),

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view_template.jst.ejs
@@ -10,6 +10,9 @@
     <% } %>
     Deleted <%= pluralizedContentType %> cannot be recovered, be sure before proceeding.
   </p>
+  <% if (isDatasets) { %>
+    <p class="Dialog-headerText">We recommend you export your dataset before deleting.</p>
+  <% } %>
 </div>
 
 <% if (affectedVisCount > 0) { %>

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -7,7 +7,7 @@ var LikesView = require('../../new_common/views/likes/view');
 var Utils = require('cdb.Utils');
 cdb.admin = require('cdb.admin');
 
-var SHORT_DES = 65;
+var SHORT_DES = 45;
 
 /**
  * Represents a map card on dashboard.

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -7,7 +7,7 @@ var LikesView = require('../../new_common/views/likes/view');
 var Utils = require('cdb.Utils');
 cdb.admin = require('cdb.admin');
 
-var SHORT_DES = 85;
+var SHORT_DES = 65;
 
 /**
  * Represents a map card on dashboard.

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -7,8 +7,6 @@ var LikesView = require('../../new_common/views/likes/view');
 var Utils = require('cdb.Utils');
 cdb.admin = require('cdb.admin');
 
-var SHORT_DES = 45;
-
 /**
  * Represents a map card on dashboard.
  */
@@ -43,7 +41,6 @@ module.exports = cdb.core.View.extend({
         url:                     this._getMapUrl(),
         name:                    map.get('name'),
         des:                     map.get('description'),
-        short_des:               Utils.truncate(description, SHORT_DES),
         tags:                    this.model.get('tags') && this.model.get('tags').length > 0 && this.model.get('tags').slice(0,3),
         tags_count:              map.get('tags') && map.get('tags').length || 0,
         routerModel:             this.router.model,

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/content_no_results.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/content_no_results.jst.ejs
@@ -9,7 +9,7 @@
   </div>
   <h4 class="IntermediateInfo-title">
     <% if (page > 1 || totalItems === 0 && totalEntries > 0) { %>
-      There are no results in this page  
+      There are no results in this page
     <% } %>
 
     <% if (( tag || q ) && totalItems === 0 && totalEntries === 0) { %>
@@ -17,7 +17,7 @@
     <% } %>
 
     <% if (page === 1 && !tag && !q && totalItems === 0 && totalEntries === 0) { %>
-      There are not <%= shared ? 'shared' : '' %> <%= locked ? 'locked' : '' %> <%= library ? 'library' : '' %> <%= type %> 
+      There are no <%= shared ? 'shared' : '' %> <%= locked ? 'locked' : '' %> <%= library ? 'library' : '' %> <%= type %>
     <% } %>
   </h4>
   <p class="DefaultParagraph">

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/content_no_results.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/content_no_results.jst.ejs
@@ -8,15 +8,19 @@
       <% } else { %> iconFont-Lens <% } %>" />
   </div>
   <h4 class="IntermediateInfo-title">
-    <% if (page > 1 || totalItems === 0 && totalEntries > 0) { %>
+    <% if (page > 1 && totalItems === 0 && totalEntries > 0) { %>
       There are no results in this page
+    <% } %>
+
+    <% if (liked && totalEntries === 0 ) { %>
+      You haven't liked any datasets yet
     <% } %>
 
     <% if (( tag || q ) && totalItems === 0 && totalEntries === 0) { %>
       0 <%= tag || q %> <%= type %> found
     <% } %>
 
-    <% if (page === 1 && !tag && !q && totalItems === 0 && totalEntries === 0) { %>
+    <% if (page === 1 && !tag && !q && !liked && totalItems === 0 && totalEntries === 0) { %>
       There are no <%= shared ? 'shared' : '' %> <%= locked ? 'locked' : '' %> <%= library ? 'library' : '' %> <%= type %>
     <% } %>
   </h4>
@@ -29,7 +33,7 @@
       Back to your <a class="ContentResult-urlLink" href="<%= defaultUrl %>"><%= type %></a>
     <% } %>
 
-    <% if (!tag && !q && totalItems === 0 && totalEntries === 0) { %>
+    <% if (!liked && !tag && !q && totalItems === 0 && totalEntries === 0) { %>
       No <%= type %>, no fun
     <% } %>
   </p>

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
@@ -17,7 +17,7 @@
 
       <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
         <% if (des) { %>
-          <p class="DefaultDescription" title="<%= des %>"><%= short_des %></p>
+          <p class="DefaultDescription DefaultDescription--twoLines" title="<%= des %>"><%= des %></p>
         <% } else { %>
           <span class="DefaultDescription is--empty">No description</span>
         <% } %>

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
@@ -17,7 +17,7 @@
 
       <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
         <% if (des) { %>
-          <p class="DefaultDescription DefaultDescription--twoLines" title="<%= des %>"><%= des %></p>
+          <p class="MapCard-desc DefaultDescription" title="<%= des %>"><%= des %></p>
         <% } else { %>
           <span class="DefaultDescription is--empty">No description</span>
         <% } %>

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
@@ -7,7 +7,7 @@
   <div class="MapCard-content">
     <div class="MapCard-contentBody">
       <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
-        <h3 class="MapCard-contentBodyTitle DefaultTitle">
+        <h3 class="MapCard-title DefaultTitle">
           <a class="DefaultTitle-link u-ellipsLongText" title="<%= name %>" href="<%= url %>"><%= name %></a>
         </h3>
         <% if (showPermissionIndicator) { %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.7.10",
+  "version": "3.7.11",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fixes #2391 by [truncating text more:](https://github.com/CartoDB/cartodb/issues/2391#issuecomment-75962937)

description with a larger characters: ![screen shot 2015-02-25 at 16 14 38](https://cloud.githubusercontent.com/assets/978461/6373256/c52dcebe-bd09-11e4-9ecc-2c2430d9bb05.png) 
description with a smaller characters: ![screen shot 2015-02-25 at 16 15 33](https://cloud.githubusercontent.com/assets/978461/6373257/c54557dc-bd09-11e4-85bd-4230fd789b11.png)

---

- Fixes #2433 show export encouragement -text for delete datasets dialog: ![screen shot 2015-02-25 at 15 44 16](https://cloud.githubusercontent.com/assets/978461/6373075/d6287616-bd08-11e4-9ae2-98033fb4b5bb.png)

---

- Fixes #2427 replaced “_There are not datasets. No datasets no fun_” with proposed text ![screen shot 2015-02-25 at 16 07 43](https://cloud.githubusercontent.com/assets/978461/6373092/ec47fc96-bd08-11e4-91a4-a37c58176bbf.png)