### PR TITLE
Hiding 'Buy more seats"/"Upgrade your quota" if isn't SaaS

### DIFF
--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -63,9 +63,13 @@
       <div class="foot">
         <% if current_user.organization.seats > @users.count %>
           <%= link_to "Create new user", new_organization_user_path(user_domain: params[:user_domain]), :class => 'right button grey' %>
-          <%= link_to "Buy more seats", upgrade_url, :class => 'margin10 underline left' %>
+          <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+            <%= link_to "Buy more seats", upgrade_url, :class => 'margin10 underline left' %>
+          <% end %>
         <% else %>
-          <%= link_to "Upgrade your quota", upgrade_url, :class => "button green right" %>
+          <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+            <%= link_to "Upgrade your quota", upgrade_url, :class => "button green right" %>
+          <% end %>
         <% end %>
       </div>
     </section>

--- a/lib/assets/javascripts/cartodb/new_common/views/dashboard_header/settings_dropdown_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/dashboard_header/settings_dropdown_view.js
@@ -59,7 +59,7 @@ module.exports = cdb.admin.DropdownMenu.extend({
       usedDataPct:      usedDataPct,
       progressBarClass: progressBarClass,
       availableDataStr: bytesToSize(availableDataSize).toString(),
-      showUpgradeLink:    upgradeAccountUrl && (user.isOrgAdmin() || !user.isInsideOrg()),
+      showUpgradeLink:    upgradeAccountUrl && (user.isOrgAdmin() || !user.isInsideOrg()) && (cdb.config.get('account_host') === 'cartodb.com'),
       upgradeUrl:         upgradeAccountUrl,
       publicProfileUrl:   currentUserUrl.toPublicProfile(),
       apiKeysUrl:         currentUserUrl.toApiKeys(),

--- a/lib/assets/test/spec/cartodb/new_common/views/dashboard_header/settings_dropdown_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/views/dashboard_header/settings_dropdown_view.spec.js
@@ -24,6 +24,8 @@ describe('new_common/views/dashboard_header/settings_dropdown_view', function() 
       currentUserUrl: this.currentUserUrl
     });
 
+    cdb.config.set('account_host', 'cartodb.com');
+
     spyOn(this.view, 'hide');
 
     this.view.render();


### PR DESCRIPTION
Ticket [Ref.1957](https://github.com/CartoDB/cartodb/issues/1957) : **CartoDB editor: "buy more seats" not working in open-source edition**

I'm hiding *upgrade_url*.

Assuming that:
SaaS ==> account_host: ‘cartodb.com’ in app_config.yml

Preview:
![screen shot 2015-02-25 at 19 17 08](https://cloud.githubusercontent.com/assets/3958416/6377410/2a3b1bee-bd24-11e4-8a54-ad6fd9638079.png)