### PR TITLE
Fix for cdb.admin.WizardProperties test

### DIFF
--- a/lib/assets/test/spec/cartodb/models/wizards.spec.js
+++ b/lib/assets/test/spec/cartodb/models/wizards.spec.js
@@ -314,7 +314,7 @@ describe('cdb.admin.WizardProperties', function() {
     })
 
   });
-  
+
   it("should send stats", function() {
     var c = 0;
     var l = new cdb.admin.CartoDBLayer();
@@ -330,26 +330,38 @@ describe('cdb.admin.WizardProperties', function() {
     expect(c).toEqual(2);
   })
 
-  it("should active polygon when column is removed", function(done) {
-    table.set({ schema: [['test', 'number'], ['test2', 'string']] });
+  describe('when column is removed', function() {
     var called = false;
-    var t0, t1;
-    model.bind('change:type', function() {
-      t0 = +Date.now()
-    });
-    model.bind('change:form', function() {
-      t1 = +Date.now()
-    });
-    model.cartoStylesGeneration.bind('change:properties', function() { called = true })
-    model.active('bubble');
-    table.set({ schema: [['test2', 'string']] });
-    expect(model.get('type')).toEqual('polygon');
+    var type = 0;
+    var form = 1;
+    var orderedCallbacksCalled;
 
-    setTimeout(function() {
-      console.log("t1 = " + t1, "t0 = " + t0);
-      expect(t1 > t0).toEqual(true);
-      done();
-    }, 700);
+    beforeEach(function(done) {
+      orderedCallbacksCalled = [];
+      model.bind('change:type', function() {
+        orderedCallbacksCalled.push(type);
+      });
+      model.bind('change:form', function() {
+        orderedCallbacksCalled.push(form);
+        done();
+      });
+      model.cartoStylesGeneration.bind('change:properties', function() { called = true });
+      model.active('bubble');
+      table.set({ schema: [['test2', 'string']] });
+    });
+
+    it('should active polygon ', function() {
+      expect(model.get('type')).toEqual('polygon');
+    });
+
+    it('should have called change:properties', function() {
+      expect(called).toBeTruthy();
+    });
+
+    it('should have called change:type and change:form in that order', function() {
+      // TODO: change:type callback is called twice, does it matter?
+      expect(orderedCallbacksCalled).toEqual([ type, type, form ]);
+    });
   });
 
   it("should rename column", function() {
@@ -440,7 +452,7 @@ describe('cdb.admin.WizardProperties', function() {
     });
 
     layer.set({
-      tile_style_custom: false, 
+      tile_style_custom: false,
       tile_style: 'test',
     });
 


### PR DESCRIPTION
Due to [a randomly failing non-deterministic client-side test in cdb.admin.WizardProperties](http://clinker.cartodb.net/jenkins/job/CartoDB-PR-testing/1928/console) I decided to take a stab at it while waiting for the results of the next build. I figured the setTimeout was the culprit so I refactored the test case to use the async mechanism provided by Jasmine (the done callback). 

But for some reason the tests continued to fail randomly, so I changed the assertion to:

```js
expect(t1).toBeGreaterThan(t0)
```

But the test still continued to fail sometimes, but now I could see why:

```bash
$ grunt jasmine --filter="wizards.spec.js"
Running "jasmine:cartodbui" (jasmine) task
Testing jasmine specs via PhantomJS

............................X.............

Summary (1 tests failed)
X cdb.admin.WizardProperties when column is removed should active polygon
   Expected 1424887420802 to be greater than 1424887420802.
   Error: Expected 1424887420802 to be greater than 1424887420802.
       at stack (file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:1455)
       at buildExpectationResult (file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:1425)
       at file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:572
       at file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:321
       at addExpectationResult (file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:516)
       at file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:1386
       at file:///Users/viddo/src/cartodb/lib/assets/test/spec/cartodb/models/wizards.spec.js:359
       at attemptSync (file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:1741)
       at file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:1729
       at file:///Users/viddo/src/cartodb/.grunt/grunt-contrib-jasmine/jasmine.js:1753

42 specs in 1.076s.
>> 1 failures
Warning: Task "jasmine:cartodbui" failed. Use --force to continue.

Aborted due to warnings.
Task 'jasmine:cartodbui' took 3462ms
All tasks took 3462ms
```

So apparently `t0` and `t1` sometimes ends up having the same value... not very reliable. By the look of the spec it seems the intention is to verify the callbacks are called in a certain order, so I [changed the expectation to check for that](https://github.com/CartoDB/cartodb/commit/3be64a12c9a22ba22b37d6dd18008c5b41c6e35e#diff-f1d844b66e092d29fc92855ed83c3db1R363) instead, and now the spec seems to work fine.

**Conclusions:**
1. Please don't use setTimeout in test cases. They are unreliable and when accumulated they slow down the test suite significantly, use the provided async mechanism instead.
1. Don't use `+Date()` to do comparisons of order, since the value may not be unique. Use something that can be checked consistently instead.

The test case is the same, simply refactored it to have the setup in a beforeEach block, and each assertion in its own `it` block.