### PR TITLE
Unselecting items within new dashboard when a signal is sent

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -2,7 +2,6 @@ var cdb = require('cartodb.js');
 var $ = require('jquery');
 var _ = require('underscore');
 var navigateThroughRouter = require('../new_common/view_helpers/navigate_through_router');
-var urls = require('../new_common/urls_fn');
 var pluralizeString = require('../new_common/view_helpers/pluralize_string');
 var CreateDialog = require('../new_common/dialogs/create/create_view');
 var DeleteItemsDialog = require('../new_dashboard/dialogs/delete_items_view');
@@ -42,7 +41,6 @@ module.exports = cdb.core.View.extend({
   initialize: function() {
     this.router = this.options.router;
     this.user = this.options.user;
-    this.userUrl = urls(cdb.config.get('account_host')).userUrl(this.user);
     this.localStorage = this.options.localStorage;
     this.template = cdb.templates.getTemplate('new_dashboard/views/filters');
 
@@ -105,6 +103,7 @@ module.exports = cdb.core.View.extend({
     this.collection.bind('add remove change reset', this.render, this);
     this.user.bind('change:remaining_byte_quota', this.render, this);
     cdb.god.bind('closeDialogs', this._animate, this);
+    cdb.god.bind('closeDialogs', this._unselectAll, this);
     _.bindAll(this, '_onWindowScroll');
 
     this.add_related_model(this.collection);
@@ -260,10 +259,10 @@ module.exports = cdb.core.View.extend({
       currentUserUrl: this.router.currentUserUrl
     });
     createDialog.bind('mapCreated', function(vis) {
-      window.location.href = vis.viewUrl();
+      window.location.href = this.router.currentUserUrl.mapUrl(vis).toEdit();
     });
     createDialog.bind('datasetCreated', function(m) {
-      window.location = new DatasetsUrl({ userUrl: this.userUrl }).toDataset(m);
+      window.location = this.router.currentUserUrl.datasetsUrl().toDataset(m);
     }, this);
     createDialog.bind('datasetSelected', function(d) {
       this.trigger('datasetSelected', d, this);

--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -260,7 +260,7 @@ module.exports = cdb.core.View.extend({
     });
     createDialog.bind('mapCreated', function(vis) {
       window.location.href = this.router.currentUserUrl.mapUrl(vis).toEdit();
-    });
+    }, this);
     createDialog.bind('datasetCreated', function(m) {
       window.location = this.router.currentUserUrl.datasetsUrl().toDataset(m);
     }, this);

--- a/lib/assets/test/spec/cartodb/new_dashboard/filters_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/filters_view.spec.js
@@ -80,6 +80,12 @@ describe('new_dashboard/filters_view', function() {
     expect(args[2]).toEqual(this.view);
   });
 
+  it('should deselect items when god triggers an event', function() {
+    spyOn(this.view, '_select');
+    cdb.god.trigger('closeDialogs');
+    expect(this.view._select).toHaveBeenCalled();
+  });
+
   it("should not show total figures when content_type router attribute has changed", function() {
     this.router.model.set('content_type', 'maps');
     expect(this.view.$('.Filters-typeLink').find('strong').length).toBe(0);

--- a/lib/assets/test/spec/cartodb/new_dashboard/filters_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/filters_view.spec.js
@@ -81,9 +81,9 @@ describe('new_dashboard/filters_view', function() {
   });
 
   it('should deselect items when god triggers an event', function() {
-    spyOn(this.view, '_select');
+    this.collection.reset({ selected: true }, { selected: true });
     cdb.god.trigger('closeDialogs');
-    expect(this.view._select).toHaveBeenCalled();
+    expect(this.collection.where({ selected: true }).length).toBe(0);
   });
 
   it("should not show total figures when content_type router attribute has changed", function() {


### PR DESCRIPTION
- Deselect items within new dashboard when god triggers 'closeDialogs' signal.
- Removed unnecessary urls_fn reference, using currentUserUrls properly

Fixes https://github.com/CartoDB/cartodb/issues/2026