### PR TITLE
[grunt] change the source for gitrev

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,7 @@
       pkg: grunt.file.readJSON('package.json'),
       aws: aws,
       env: env,
-      gitrev: exec('git rev-parse HEAD', { silent:true }).output.replace('\n', ''),
+      gitrev: exec('test -d .git && git rev-parse HEAD || cat REVISION', { silent:true }).output.replace('\n', ''),
 
       assets_dir: ASSETS_DIR,
       root_assets_dir: ROOT_ASSETS_DIR,


### PR DESCRIPTION
Background: we started getting this warning since we removed `.git` directory from the deployment process:

![grunt_sha1_failing](https://cloud.githubusercontent.com/assets/223956/6391065/448ea126-bdb2-11e4-8b77-04d0749a3db8.png)

This changes the way in which `gitrev` value is obtained in Grunt.

If `.git` directory is present it will get it from Git history and otherwise `REVISION` file will be used, it's the file where Capistrano stores the latest changeset SHA1.

@viddo @xavijam @zenitraM please review, thanks!