### PR TITLE
Improved pagination for new dashboard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@
 * Added back Twitter import for new create dialog.
 * Adds random quotes in the loading screens.
 * Improved speed in dashboard caching frontend side [#2465](https://github.com/CartoDB/cartodb/pull/2465)
+* Improve new pagination [#2529](https://github.com/CartoDB/cartodb/pull/2529)
 
 Bugfixes:
 * When being in any configuration page remove the arrow from the breadcrumb [#2312](https://github.com/CartoDB/cartodb/pull/2312)

--- a/app/assets/stylesheets/new_common/pagination.css.scss
+++ b/app/assets/stylesheets/new_common/pagination.css.scss
@@ -19,17 +19,23 @@
   border: 1px $cStructure-mainLine solid;
   border-right-width: 0;
 }
-.Pagination-listItemLink {
+.Pagination-listItemInner {
   display: inline-block;
   padding: 10px 15px;
-  color: $cTypography-link;
   border: none;
-  background: transparent;
+  background: $cStructure-mainBkg;
   outline: none;
+}
+.Pagination-listItemInner--link {
+  color: $cTypography-link;
   &:hover {
     color: $cTypography-linkHover;
     text-decoration: underline;
   }
+}
+.Pagination-listItemInner--more {
+  background-color: $cStructure-grayBkg;
+  color: $cTypography-help;
 }
 .Pagination-listItem:first-child {
   border-radius: 5px 0 0 5px;
@@ -39,8 +45,8 @@
   border-radius: 0 5px 5px 0;
 }
 .Pagination-listItem.is-current,
-.Pagination-listItem.is-current .Pagination-listItemLink,
-.Pagination-listItem.is-current .Pagination-listItemLink:hover {
+.Pagination-listItem.is-current .Pagination-listItemInner--link,
+.Pagination-listItem.is-current .Pagination-listItemInner--link:hover {
   color: $cTypography-headers;
   cursor: default;
   text-decoration: none;

--- a/app/assets/stylesheets/new_common/pagination.css.scss
+++ b/app/assets/stylesheets/new_common/pagination.css.scss
@@ -39,10 +39,16 @@
 }
 .Pagination-listItem:first-child {
   border-radius: 5px 0 0 5px;
+  .Pagination-listItemInner {
+    border-radius: 5px 0 0 5px;
+  }
 }
 .Pagination-listItem:last-child {
   border-right-width: 1px;
   border-radius: 0 5px 5px 0;
+  .Pagination-listItemInner {
+    border-radius: 0 5px 5px 0;
+  }
 }
 .Pagination-listItem.is-current,
 .Pagination-listItem.is-current .Pagination-listItemInner--link,

--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.7.12
+3.7.13

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/model.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/model.js
@@ -11,11 +11,12 @@ var urlToStub = function() {
  */
 module.exports = cdb.core.Model.extend({
   defaults: {
-    total_count:       0,
-    per_page:          10,
-    current_page:      1,
-    display_count:     5,
-    url_to:            urlToStub
+    total_count:          0,
+    per_page:             10,
+    current_page:         1,
+    display_count:        5,
+    extras_display_count: 1,
+    url_to:               urlToStub
   },
 
   pagesCount: function() {
@@ -27,6 +28,11 @@ module.exports = cdb.core.Model.extend({
 
   isCurrentPage: function(page) {
     return this.get('current_page') === page;
+  },
+
+  shouldBeVisible: function() {
+    var pagesCount = this.pagesCount();
+    return this.get('total_count') > 0 && pagesCount > 1 && this.get('current_page') <= pagesCount;
   },
 
   urlTo: function(page) {
@@ -52,7 +58,36 @@ module.exports = cdb.core.Model.extend({
     }
     rangeStart = Math.max(rangeStart, 1);
 
-    return _.range(rangeStart, this._rangeEnd(rangeStart));
+    return this._withExtraPages(
+      _.range(rangeStart, this._rangeEnd(rangeStart))
+    );
+  },
+
+  _withExtraPages: function(pagesRelativeToCurrentPage) {
+    var lastPage = this.pagesCount();
+    var extraCount = this.get('extras_display_count');
+    var extraStartPages = _.range(1, extraCount + 1);
+    var extraEndPages = _.range(lastPage - extraCount + 1, lastPage + 1);
+
+    var startPagesDiff = pagesRelativeToCurrentPage[0] - extraStartPages.slice(-1)[0];
+    if (startPagesDiff === 2) {
+      // There is only one missing page in the gap, so add it
+      extraStartPages.push(pagesRelativeToCurrentPage[0] - 1);
+    } else if (startPagesDiff > 2) {
+      // There are more hidden pages at low range, add padding at end
+      extraStartPages.push(-1);
+    }
+
+    var endPagesDiff = extraEndPages[0] - pagesRelativeToCurrentPage.slice(-1);
+    if (endPagesDiff === 2) {
+      // There is only one missing page in the gap, so add it
+      extraEndPages.unshift(extraEndPages[0] - 1);
+    } if (endPagesDiff > 2) {
+      // There are more hidden pages at high range, add padding at beginning
+      extraEndPages.unshift(-2);
+    }
+
+    return _.union(extraStartPages, pagesRelativeToCurrentPage, extraEndPages);
   },
 
   _inLowRange: function() {

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/template.jst.ejs
@@ -1,12 +1,16 @@
-<% if (1 < pagesCount && pagesCount >= currentPage) { %>
-  <span class="DefaultDescription Pagination-label">
-    Page <%= currentPage %> of <%= pagesCount %>
-  </span>
-  <ul class="Pagination-list">
-    <% m.pagesToDisplay().forEach(function(page) { %>
-    <li class="Pagination-listItem <%= m.isCurrentPage(page) ? 'is-current' : '' %>">
-      <a class="Pagination-listItemLink" href="<%= m.urlTo(page) %>"><%= page %></a>
-    </li>
-    <% }) %>
-  </ul>
-<% } %>
+<span class="DefaultDescription Pagination-label">
+  Page <%= currentPage %> of <%= pagesCount %>
+</span>
+<ul class="Pagination-list">
+  <% m.pagesToDisplay().forEach(function(page) { %>
+    <% if (page > 0) { %>
+      <li class="Pagination-listItem <%= m.isCurrentPage(page) ? 'is-current' : '' %>">
+        <a class="Pagination-listItemInner Pagination-listItemInner--link" href="<%= m.urlTo(page) %>" data-page="<%= page %>"><%= page %></a>
+      </li>
+    <% } else { %>
+      <li class="Pagination-listItem Pagination-listItem">
+        <span class="Pagination-listItemInner Pagination-listItemInner--more">&hellip;</span>
+      </li>
+    <% } %>
+  <% }) %>
+</ul>

--- a/lib/assets/javascripts/cartodb/new_common/views/pagination/view.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/pagination/view.js
@@ -1,4 +1,5 @@
 var cdb = require('cartodb.js');
+var $ = require('jquery');
 var navigateThroughRouter = require('../../view_helpers/navigate_through_router');
 
 /**
@@ -19,32 +20,40 @@ module.exports = cdb.core.View.extend({
 
   className: 'Pagination',
 
-  initialize: function(args) {
-    this.template = cdb.templates.getTemplate('new_common/views/pagination/template');
+  events: {
+    'click a': '_paginate'
+  },
 
-    if (args.router) {
-      this.router = args.router;
-      this.events = {
-        'click a': navigateThroughRouter
-      };
-    }
+  initialize: function() {
+    this.template = cdb.templates.getTemplate('new_common/views/pagination/template');
+    this.router = this.options.router;
 
     this.model.bind('change', this.render, this);
   },
 
   render: function() {
-    if (this.model.get('total_count') > 0) {
-      this.$el.html(this.template({
-        m: this.model,
-        pagesCount: this.model.pagesCount(),
-        currentPage: this.model.get('current_page')
-      }));
+    if (this.model.shouldBeVisible()) {
+      this.$el.html(
+        this.template({
+          m: this.model,
+          pagesCount: this.model.pagesCount(),
+          currentPage: this.model.get('current_page')
+        })
+      );
+      this.$el.addClass(this.className);
+      this.delegateEvents();
     } else {
       this.$el.html('');
     }
-    this.$el.addClass(this.className);
-    this.delegateEvents();
 
     return this;
+  },
+
+  _paginate: function(ev) {
+    if (this.router) {
+      navigateThroughRouter.apply(this, arguments);
+    }
+    this.model.set('current_page', $(ev.target).data('page'));
+    this.render(); // forced since the change event is not triggered here for some reason
   }
 });

--- a/lib/assets/test/spec/cartodb/new_common/views/pagination/model.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/views/pagination/model.spec.js
@@ -59,37 +59,50 @@ describe('new_common/views/pagination/model', function() {
     describe('given there are more pages than expected to be visible', function() {
       beforeEach(function() {
         this.m = new PaginationModel({
-          total_count:   110,
+          total_count:   130,
           per_page:      10,
-          display_count: 5
+          display_count: 5,
+          extras_display_count: 1
         });
       });
 
-      describe('and current page is with the first visible pages', function() {
+      describe('when current page is with the first visible pages', function() {
         it('should return a sequence of integers relative to current page', function() {
-          var expectedSequence = [1,2,3,4,5];
+          var expectedSequence = [1,2,3,4,5, -2, 13];
           expect(this.m.set('current_page', 1).pagesToDisplay()).toEqual(expectedSequence);
           expect(this.m.set('current_page', 2).pagesToDisplay()).toEqual(expectedSequence);
           expect(this.m.set('current_page', 3).pagesToDisplay()).toEqual(expectedSequence);
         });
       });
 
-      describe('and current page is in the middle range of available pages', function() {
-        it('should return a sequence of integers where the current page is always in the middle of the range', function() {
-          expect(this.m.set('current_page', 4).pagesToDisplay()).toEqual([2,3,4,5,6]);
-          expect(this.m.set('current_page', 5).pagesToDisplay()).toEqual([3,4,5,6,7]);
-          expect(this.m.set('current_page', 6).pagesToDisplay()).toEqual([4,5,6,7,8]);
-          expect(this.m.set('current_page', 7).pagesToDisplay()).toEqual([5,6,7,8,9]);
-          expect(this.m.set('current_page', 8).pagesToDisplay()).toEqual([6,7,8,9,10]);
+      describe('when current page is within lower threshold for extras', function() {
+        it('should display additional pages too since they are still within the sequence', function() {
+          expect(this.m.set('current_page', 4).pagesToDisplay()).toEqual([1,2,3,4,5,6, -2, 13]);
+          expect(this.m.set('current_page', 5).pagesToDisplay()).toEqual([1,2,3,4,5,6,7, -2, 13]);
         });
       });
 
-      describe('and current page is within the last expected visible pages', function() {
+      describe('when current page is in the middle range of available pages', function() {
+        it('should return a sequence of pages with additional pages separated by undefined', function() {
+          expect(this.m.set('current_page', 6).pagesToDisplay()).toEqual([1, -1, 4,5,6,7,8, -2, 13]);
+          expect(this.m.set('current_page', 7).pagesToDisplay()).toEqual([1, -1, 5,6,7,8,9, -2, 13]);
+          expect(this.m.set('current_page', 8).pagesToDisplay()).toEqual([1, -1, 6,7,8,9,10, -2, 13]);
+        });
+      });
+
+      describe('when current page is reach threshold', function() {
+        it('should display additional pages too since they are still within the sequence', function() {
+          expect(this.m.set('current_page', 9).pagesToDisplay()).toEqual([1, -1, 7,8,9,10,11,12,13]);
+          expect(this.m.set('current_page', 10).pagesToDisplay()).toEqual([1, -1, 8,9,10,11,12,13]);
+        });
+      });
+
+      describe('when current page is within the upper threshold for extras', function() {
         it('should return a sequence of integers of the last visible pages', function() {
-          var expectedSequence = [7,8,9,10,11];
-          expect(this.m.set('current_page', 9).pagesToDisplay()).toEqual(expectedSequence);
-          expect(this.m.set('current_page', 10).pagesToDisplay()).toEqual(expectedSequence);
+          var expectedSequence = [1, -1, 9,10,11,12,13];
           expect(this.m.set('current_page', 11).pagesToDisplay()).toEqual(expectedSequence);
+          expect(this.m.set('current_page', 12).pagesToDisplay()).toEqual(expectedSequence);
+          expect(this.m.set('current_page', 13).pagesToDisplay()).toEqual(expectedSequence);
         });
       });
     });

--- a/lib/assets/test/spec/cartodb/new_common/views/pagination/view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/views/pagination/view.spec.js
@@ -25,13 +25,15 @@ describe('new_common/views/pagination/view', function() {
     });
     spyOn(this.router, 'navigate');
 
-    this.view = new PaginationView({
-      model:  this.model,
-      router: this.router
-    });
+    this.createView = function() {
+      this.view = new PaginationView({
+        model: this.model,
+        router: this.router
+      });
+    };
 
+    this.createView();
     this.view.render();
-    this.html = this.view.el.innerHTML;
   });
 
   it('should have no leaks', function() {
@@ -39,12 +41,12 @@ describe('new_common/views/pagination/view', function() {
   });
 
   it('should render current page and the total count', function() {
-    expect(this.html).toContain('Page 42 of 180');
+    expect(this.innerHTML()).toContain('Page 42 of 180');
   });
 
   it('should render URLs by provided url_to function', function() {
-    expect(this.html).toContain('/url/to/page/40'); //first
-    expect(this.html).toContain('/url/to/page/44'); //last
+    expect(this.innerHTML()).toContain('/url/to/page/40'); //first
+    expect(this.innerHTML()).toContain('/url/to/page/44'); //last
   });
 
   it('should re-render on model change', function() {
@@ -58,13 +60,12 @@ describe('new_common/views/pagination/view', function() {
         total_count:  0,
         current_page: 1
       });
-      this.html = this.view.el.innerHTML;
     });
 
     it('should not render pagination items at all', function() {
-      expect(this.html).not.toContain('Page ');
-      expect(this.html).not.toContain('Pagination-label');
-      expect(this.html).not.toContain('Pagination-list');
+      expect(this.innerHTML()).not.toContain('Page ');
+      expect(this.innerHTML()).not.toContain('Pagination-label');
+      expect(this.innerHTML()).not.toContain('Pagination-list');
     });
   });
 
@@ -74,16 +75,14 @@ describe('new_common/views/pagination/view', function() {
         total_count:  this.model.get('per_page'),
         current_page: 1
       });
-
-      this.html = this.view.el.innerHTML;
     });
 
     it('should not render pagination label', function() {
-      expect(this.html).not.toContain('Page 1 of 1');
+      expect(this.innerHTML()).not.toContain('Page 1 of 1');
     });
 
     it('should not render pagination list', function() {
-      expect(this.html).not.toContain('Pagination-list');
+      expect(this.innerHTML()).not.toContain('Pagination-list');
     });
   });
 
@@ -93,23 +92,49 @@ describe('new_common/views/pagination/view', function() {
         total_count: this.model.get('per_page'),
         current_page: 9000
       });
-
-      this.html = this.view.el.innerHTML;
     });
 
     it('should not render pagination list', function() {
-      expect(this.html).not.toContain('Pagination-list');
+      expect(this.innerHTML()).not.toContain('Pagination-list');
     });
   });
 
 
   describe('click a link', function() {
     beforeEach(function() {
-      this.view.$('a').click();
+      this.clickLink = function() {
+        this.view.$('a').click();
+      };
+      this.model.bind('change', function() {
+        this.called = true;
+      }, this);
     });
 
-    it('should navigate through router', function() {
-      expect(this.router.navigate).toHaveBeenCalled();
+    describe('when view is created with a router', function() {
+      beforeEach(function() {
+        this.clickLink();
+      });
+
+      it('should navigate through router', function() {
+        expect(this.router.navigate).toHaveBeenCalled();
+      });
+
+      it('should update the current page', function() {
+        expect(this.called).toBeTruthy();
+      });
+    });
+
+    describe('whne view is not created with a router', function() {
+      beforeEach(function() {
+        this.router = undefined;
+        this.createView();
+        this.view.render();
+        this.clickLink();
+      });
+
+      it('should update the current page', function() {
+        expect(this.called).toBeTruthy();
+      });
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.7.12",
+  "version": "3.7.13",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #2413

- Added the "edge" (only 1 as it was defined in the issue) if there are more pages than can be visible, just like how Github's own pagination works.
- Also update the pagination model immediately on click, to avoid the re-render delay until a response returns.

![screen shot 2015-02-26 at 16 29 13](https://cloud.githubusercontent.com/assets/978461/6394905/15b08086-bdd5-11e4-9ab3-e90d1cb2a1ca.png)
![screen shot 2015-02-26 at 16 29 25](https://cloud.githubusercontent.com/assets/978461/6394906/15bc61da-bdd5-11e4-83e9-baa187ffe442.png)
![screen shot 2015-02-26 at 16 29 34](https://cloud.githubusercontent.com/assets/978461/6394907/15c640ce-bdd5-11e4-87ff-517ad8a4c1e4.png)
![screen shot 2015-02-26 at 16 29 59](https://cloud.githubusercontent.com/assets/978461/6394908/15e2e6fc-bdd5-11e4-941f-a6956227915e.png)
![screen shot 2015-02-26 at 16 30 10](https://cloud.githubusercontent.com/assets/978461/6394909/15e9c65c-bdd5-11e4-96b9-d240066e8109.png)
