### PR TITLE
Hiding "common data" link if it isn't SaaS

### DIFF
--- a/app/models/common_data.rb
+++ b/app/models/common_data.rb
@@ -19,6 +19,10 @@ class CommonData
     @datasets
   end
 
+  def is_enabled?
+    !config('username').nil? && !config('api_key').nil?
+  end
+
   private
 
   def get_datasets(json)
@@ -81,10 +85,6 @@ class CommonData
 
   def export_query(table_name)
     "select * from #{table_name}"
-  end
-
-  def is_enabled
-    !config('username').nil? && !config('api_key').nil?
   end
 
   def config(key, default=nil)

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -5,7 +5,8 @@
     <ul class="right">
       <li><%= link_to 'tables', tables_index_path(user_domain: params[:user_domain]), :class => :tables %></a></li>
       <li><%= link_to 'visualizations', visualizations_index_path(user_domain: params[:user_domain]), :class => :visualizations %></a></li>
-      <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+      <% if ( ( Cartodb.config[:common_data]['username'] && (Cartodb.config[:common_data]['username'] != "")) && ( Cartodb.config[:common_data]['host'] && (Cartodb.config[:common_data]['host'] != "") ) && ( Cartodb.config[:common_data]['api_key'] && (Cartodb.config[:common_data]['api_key'] != "") ) 
+        ) %>
         <li><%= link_to 'common data', dashboard_common_data_path(user_domain: params[:user_domain]), :class => selected_if(current_path.include? 'common_data') %></a></li>
       <% end %>
       <li><%= link_to 'documentation', Cartodb.config[:developers_host] %></a></li>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -5,7 +5,9 @@
     <ul class="right">
       <li><%= link_to 'tables', tables_index_path(user_domain: params[:user_domain]), :class => :tables %></a></li>
       <li><%= link_to 'visualizations', visualizations_index_path(user_domain: params[:user_domain]), :class => :visualizations %></a></li>
-      <li><%= link_to 'common data', dashboard_common_data_path(user_domain: params[:user_domain]), :class => selected_if(current_path.include? 'common_data') %></a></li>
+      <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+        <li><%= link_to 'common data', dashboard_common_data_path(user_domain: params[:user_domain]), :class => selected_if(current_path.include? 'common_data') %></a></li>
+      <% end %>
       <li><%= link_to 'documentation', Cartodb.config[:developers_host] %></a></li>
       <li>
         <a class="dropdown account separator" href="<%= account_url %>"><%= current_user.username %><span>|</span></a>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -5,8 +5,7 @@
     <ul class="right">
       <li><%= link_to 'tables', tables_index_path(user_domain: params[:user_domain]), :class => :tables %></a></li>
       <li><%= link_to 'visualizations', visualizations_index_path(user_domain: params[:user_domain]), :class => :visualizations %></a></li>
-      <% if ( ( Cartodb.config[:common_data]['username'] && (Cartodb.config[:common_data]['username'] != "")) && ( Cartodb.config[:common_data]['host'] && (Cartodb.config[:common_data]['host'] != "") ) && ( Cartodb.config[:common_data]['api_key'] && (Cartodb.config[:common_data]['api_key'] != "") ) 
-        ) %>
+      <% if ::CommonData.new.is_enabled? %>
         <li><%= link_to 'common data', dashboard_common_data_path(user_domain: params[:user_domain]), :class => selected_if(current_path.include? 'common_data') %></a></li>
       <% end %>
       <li><%= link_to 'documentation', Cartodb.config[:developers_host] %></a></li>


### PR DESCRIPTION
Ticket [Ref.1958](https://github.com/CartoDB/cartodb/issues/1958) : **common data" link not working in open-source edition, not sure if it
should be disabled**

Assuming that:
SaaS ==> account_host: ‘cartodb.com’ in app_config.yml

Preview:
![screen shot 2015-02-26 at 16 44 38](https://cloud.githubusercontent.com/assets/3958416/6395865/4a7c0db6-bddb-11e4-83b6-27682e09708b.png)
