### PR TITLE
Cdb 1956 - hiding "account settings" link if it isn't SaaS

### DIFF
--- a/app/views/admin/organizations/_settings_account.html.erb
+++ b/app/views/admin/organizations/_settings_account.html.erb
@@ -17,13 +17,15 @@
           <p>Configuration, logo,...</p>
         </span>
       </a>
-      <a href="<%= account_url %>">
-        <span class="icon settings"></span>
-        <span class="info">
-          <h2>Account settings</h2>
-          <p>Invoicing, access,...</p>
-        </span>
-      </a>
+      <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+        <a href="<%= account_url %>">
+          <span class="icon settings"></span>
+          <span class="info">
+            <h2>Account settings</h2>
+            <p>Invoicing, access,...</p>
+          </span>
+        </a>
+      <% end %>
     </div>
   </nav>
 <% end %>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -5,7 +5,9 @@
     <ul class="right">
       <li><%= link_to 'tables', tables_index_path(user_domain: params[:user_domain]), :class => :tables %></a></li>
       <li><%= link_to 'visualizations', visualizations_index_path(user_domain: params[:user_domain]), :class => :visualizations %></a></li>
-      <li><%= link_to 'common data', dashboard_common_data_path(user_domain: params[:user_domain]), :class => selected_if(current_path.include? 'common_data') %></a></li>
+      <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+        <li><%= link_to 'common data', dashboard_common_data_path(user_domain: params[:user_domain]), :class => selected_if(current_path.include? 'common_data') %></a></li>
+      <% end %>
       <li><%= link_to 'documentation', Cartodb.config[:developers_host] %></a></li>
       <li>
         <a class="dropdown account separator" href="<%= account_url %>"><%= current_user.username %><span>|</span></a>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -5,9 +5,7 @@
     <ul class="right">
       <li><%= link_to 'tables', tables_index_path(user_domain: params[:user_domain]), :class => :tables %></a></li>
       <li><%= link_to 'visualizations', visualizations_index_path(user_domain: params[:user_domain]), :class => :visualizations %></a></li>
-      <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
-        <li><%= link_to 'common data', dashboard_common_data_path(user_domain: params[:user_domain]), :class => selected_if(current_path.include? 'common_data') %></a></li>
-      <% end %>
+      <li><%= link_to 'common data', dashboard_common_data_path(user_domain: params[:user_domain]), :class => selected_if(current_path.include? 'common_data') %></a></li>
       <li><%= link_to 'documentation', Cartodb.config[:developers_host] %></a></li>
       <li>
         <a class="dropdown account separator" href="<%= account_url %>"><%= current_user.username %><span>|</span></a>


### PR DESCRIPTION
Ticket [Ref.1956](https://github.com/CartoDB/cartodb/issues/1956) : **CartoDB editor: "account settings" not working in open-source version**

Assuming that:
SaaS ==> account_host: ‘cartodb.com’ in app_config.yml

Previews:

**Before:**
![before](https://cloud.githubusercontent.com/assets/3958416/6412275/f2c66218-be81-11e4-9b3f-6454a52e0496.png)

**After:**
![screen shot 2015-02-27 at 12 55 47](https://cloud.githubusercontent.com/assets/3958416/6412281/fa051ee8-be81-11e4-875f-b7453719e093.png)

