### PR TITLE
Don't encode type=wms param when submiting a URL to the WMS proxy server

### DIFF
--- a/lib/assets/javascripts/cartodb/table/basemap/basemap_dialog/wms_basemap_pane.js
+++ b/lib/assets/javascripts/cartodb/table/basemap/basemap_dialog/wms_basemap_pane.js
@@ -45,11 +45,9 @@
         params.push("service=WMS");
       }
 
-      params.push("type=wms");
-
       url += "?" + params.join("&");
 
-      req += '?url=' + encodeURIComponent(url);
+      req += '?url=' + encodeURIComponent(url) + "&type=wms";
 
       if (method === "create" && this.get('layer') && this.get('srs')) {
         req += "&layer=" + this.get('layer');

--- a/lib/assets/test/spec/cartodb/table/basemap_wms_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/basemap_wms_dialog.spec.js
@@ -12,7 +12,7 @@ describe("Basemap WMS pane", function() {
 
       expect(resultURL.indexOf(encodeURIComponent("request=GetCapabilities"))).toBeGreaterThan(0);
       expect(resultURL.indexOf(encodeURIComponent("service=WMS"))).toBeGreaterThan(0);
-      expect(resultURL.indexOf(encodeURIComponent("type=wms"))).toBeGreaterThan(0);
+      expect(resultURL.indexOf("type=wms")).toBeGreaterThan(0);
 
     });
 


### PR DESCRIPTION
Don't encode type=wms param when submitting a URL to the WMS proxy server.