### PR TITLE
Unstack key fragment if there's an error fixes #2562

### DIFF
--- a/services/importer/lib/importer/importer_stats.rb
+++ b/services/importer/lib/importer/importer_stats.rb
@@ -29,7 +29,12 @@ module CartoDB
         return_value = nil
         @timing_stack.push(key)
         Statsd.timing(timing_chain) do
-          return_value = yield
+          begin
+            return_value = yield
+          rescue => e
+            @timing_stack.pop
+            raise e
+          end
         end
         @timing_stack.pop
         return_value


### PR DESCRIPTION
@Kartones could you please CR this? I haven't been able to reproduce this, but ogr2ogr failing and retrying (or maybe a multiple import with many files) is the only scenario where this problem can happen. [Loader is the only place where 'ogr2ogr' string is sent to metrics](https://github.com/CartoDB/cartodb/blob/master/services/importer/lib/importer/loader.rb#L61) and there's no way the body of that (`run_ogr2ogr`) can make a recursive call to `Loader.run`.

This fix improves @`timing_stack` management ensuring the key is always popped, although knowing why is `Loader.run` invoked that many times in a row is something to be known yet.

I'm also adding @lbosque and @rafatower to this PR because maybe they see something I don't.