### PR TITLE
Redirecting user to editor when an import has been completed

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_item_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_item_view.js
@@ -14,7 +14,7 @@ module.exports = cdb.core.View.extend({
   tagName: 'li',
 
   events: {
-    'click .js-abort':      '_abortUpload',
+    'click .js-abort':      '_removeItem',
     'click .js-show_error': '_showImportError',
     'click .js-show_stats': '_showImportStats',
     'click .js-close':      '_removeItem'
@@ -118,10 +118,6 @@ module.exports = cdb.core.View.extend({
       clean_on_hide: true,
       model: this.model
     })).appendToBody();
-  },
-
-  _abortUpload: function() {
-    this.model.stopUpload();
   },
 
   _showImportError: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_item_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_item_view.js
@@ -44,14 +44,18 @@ module.exports = cdb.core.View.extend({
     };
 
     // URL
-    if (imp.table_name) {
+    if (d.state === "complete") {
       if (imp.derived_visualization_id) {
-        var vis = new cdb.admin.Visualization({ id: imp.derived_visualization_id });
-        vis.permission.owner = this.user;
-        d.url = encodeURI(this.router.currentUserUrl.mapUrl(vis).toEdit());
+        var vis = this.model.getVisMetadata();
+        if (vis) {
+          d.url = encodeURI(this.router.currentUserUrl.mapUrl(vis).toEdit());
+        }
       } else {
-        var table = new cdb.admin.CartoDBTableMetadata({ name: imp.table_name });
-        d.url = encodeURI(this.router.currentUserUrl.datasetsUrl().toDataset(table));
+        var table = this.model.getTableMetadata();
+        if (table) {
+          d.url = encodeURI(this.router.currentUserUrl.datasetsUrl().toDataset(table));
+        }
+        
       }
     }
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
@@ -12,9 +12,7 @@ module.exports = cdb.core.View.extend({
 
   className: 'BackgroundImporter',
 
-  events: {
-    // 'click .js-hide': 'disable'
-  },
+  events: {},
 
   initialize: function() {
     this.user = this.options.user;
@@ -67,13 +65,21 @@ module.exports = cdb.core.View.extend({
     }
   },
 
-  _checkImports: function() {
+  _checkImports: function(mdl, c) {
     var failed = 0;
 
     this.collection.each(function(m) {
-      if (m.hasFailed()) ++failed;
+      if (m.hasFailed()) {
+        ++failed;
+      }
     });
 
+    // Redirect to dataset/map url?
+    if (( this.collection.size() - failed ) === 1 && mdl && mdl.get('state') === "complete" && c && c.changes && c.changes.state) {
+      this._goTo(mdl);
+    }
+
+    // Badge changes
     if (this.$('.BackgroundImporter-headerBadgeCount').length === 0 && failed > 0) {
       var $span = $('<span>').addClass("BackgroundImporter-headerBadgeCount Badge Badge--negative").text(failed);
       this.$('.BackgroundImporter-headerBadge')
@@ -101,11 +107,6 @@ module.exports = cdb.core.View.extend({
 
   disable: function() {
     this.collection.destroyCheck();
-    // this.hide();
-    // var self = this;
-    // setTimeout(function() {
-    //   self._cleanImports();
-    // }, 300);
   },
 
   add: function(imp) {
@@ -118,6 +119,23 @@ module.exports = cdb.core.View.extend({
 
   hide: function() {
     this.$el.removeClass('is-visible');
+  },
+
+  _goTo: function(mdl) {
+    var imp = mdl.get('import');
+    var derivedVisId = imp.derived_visualization_id;
+    var url = '';
+
+    if (derivedVisId) {
+      var vis = new cdb.admin.Visualization({ id: derivedVisId });
+      vis.permission.owner = this.user;
+      url = this.router.currentUserUrl.mapUrl(vis).toEdit();
+    } else {
+      var table = new cdb.admin.CartoDBTableMetadata({ name: imp.table_name });
+      url = this.router.currentUserUrl.datasetsUrl().toDataset(table);
+    }
+
+    window.location = url;
   },
 
   clean: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
@@ -123,16 +123,18 @@ module.exports = cdb.core.View.extend({
 
   _goTo: function(mdl) {
     var imp = mdl.get('import');
-    var derivedVisId = imp.derived_visualization_id;
     var url = '';
 
-    if (derivedVisId) {
-      var vis = new cdb.admin.Visualization({ id: derivedVisId });
-      vis.permission.owner = this.user;
-      url = this.router.currentUserUrl.mapUrl(vis).toEdit();
+    if (imp.derived_visualization_id) {
+      var vis = mdl.getVisMetadata();
+      if (vis) {
+        url = encodeURI(this.router.currentUserUrl.mapUrl(vis).toEdit());
+      }
     } else {
-      var table = new cdb.admin.CartoDBTableMetadata({ name: imp.table_name });
-      url = this.router.currentUserUrl.datasetsUrl().toDataset(table);
+      var table = mdl.getTableMetadata();
+      if (table) {
+        url = encodeURI(this.router.currentUserUrl.datasetsUrl().toDataset(table));  
+      }
     }
 
     this._redirect(url);

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
@@ -135,6 +135,10 @@ module.exports = cdb.core.View.extend({
       url = this.router.currentUserUrl.datasetsUrl().toDataset(table);
     }
 
+    this._redirect(url);
+  },
+
+  _redirect: function(url) {
     window.location = url;
   },
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/imports_model.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/imports_model.js
@@ -130,6 +130,29 @@ module.exports = cdb.core.Model.extend({
     }
   },
 
+  getVisMetadata: function() {
+    var derivedVisId = this.imp.get('derived_visualization_id');
+
+    if (!derivedVisId) {
+      return false;
+    }
+
+    var vis = new cdb.admin.Visualization({ id: derivedVisId });
+    vis.permission.owner = this.user;
+
+    return vis;
+  },
+
+  getTableMetadata: function() {
+    var tableName = this.imp.get('table_name');
+
+    if (!tableName) {
+      return false;
+    }
+
+    return new cdb.admin.CartoDBTableMetadata({ name: tableName });
+  },
+
   stopUpload: function() {
     this.upl.stopUpload();
   },

--- a/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_item_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_item_view.spec.js
@@ -1,0 +1,66 @@
+var Backbone = require('backbone');
+var cdb = require('cartodb.js');
+var Router = require('../../../../../javascripts/cartodb/new_dashboard/router');
+var UserUrl = require('../../../../../javascripts/cartodb/new_common/urls/user_model');
+var ImportsModel = require('../../../../../javascripts/cartodb/new_dashboard/background_importer/imports_model');
+var BackgroundImporterView = require('../../../../../javascripts/cartodb/new_dashboard/background_importer/background_importer_view');
+var BackgroundImporterItemView = require('../../../../../javascripts/cartodb/new_dashboard/background_importer/background_importer_item_view');
+
+describe('new_dashboard/background_importer/background_importer_item_view', function() {
+
+  beforeEach(function() {
+    var user = new cdb.admin.User({ username: 'paco' });
+
+    this.router = new Router({
+      currentUserUrl: new UserUrl({
+        account_host: 'cartodb.com',
+        user: user
+      })
+    });
+
+    this.router.model.set({
+      content_type: 'datasets'
+    });
+
+    this.model = new ImportsModel();
+
+    spyOn(this.router.model, 'bind').and.callThrough();
+    spyOn(this.model, 'bind').and.callThrough();
+
+    this.view = new BackgroundImporterItemView({
+      router: this.router,
+      model: this.model,
+      user: user
+    });
+  });
+
+  it('should render properly', function() {
+    this.view.render();
+    expect(this.view.$el.hasClass('ImportItem')).toBeTruthy();
+    expect(this.view.$('.ImportItem-text').length).toBe(1);
+  });
+
+  it('should bind model changes', function() {
+    expect(this.model.bind.calls.argsFor(0)[0]).toEqual('change:state');
+    expect(this.model.bind.calls.argsFor(1)[0]).toEqual('change');
+    expect(this.model.bind.calls.argsFor(2)[0]).toEqual('remove');
+  });
+
+  it('should stop upload and remove it when upload is aborted', function() {
+    this.view.render();
+    spyOn(this.view, 'clean');
+    this.model.set('state', 'uploading');
+    this.view.$('.js-abort').click();
+    expect(this.view.clean).toHaveBeenCalled();
+  });
+
+  it('should have no leaks', function() {
+    this.view.render();
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+
+});

--- a/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_view.spec.js
@@ -81,21 +81,23 @@ describe('new_dashboard/background_importer/background_importer_view', function(
     this.view.items.fetch = function() {};
     this.view.user.fetch = function() {};
 
-    spyOn(this.view, '_goTo');
+    spyOn(this.view, '_redirect');
+
     var mdl = new ImportsModel({ state: 'error'});
     this.view.collection.add(mdl);
-    expect(this.view._goTo).not.toHaveBeenCalled();
+    expect(this.view._redirect).not.toHaveBeenCalled();
     var mdl1 = new ImportsModel({ state: 'pending'});
     this.view.collection.add(mdl1);
-    expect(this.view._goTo).not.toHaveBeenCalled();
+    expect(this.view._redirect).not.toHaveBeenCalled();
     var mdl2 = new ImportsModel({ state: 'pending'});
     this.view.collection.add(mdl2);
-    expect(this.view._goTo).not.toHaveBeenCalled();
+    expect(this.view._redirect).not.toHaveBeenCalled();
     mdl1.set('state', 'complete');
-    expect(this.view._goTo).not.toHaveBeenCalled();
+    expect(this.view._redirect).not.toHaveBeenCalled();
     this.view.collection.remove(mdl1);
-    mdl2.set('state', 'complete');
-    expect(this.view._goTo).toHaveBeenCalled();
+    mdl2.imp.set({ table_name: 'jur' });
+    mdl2.set({ state: 'complete' });
+    expect(this.view._redirect).toHaveBeenCalledWith('http://paco.cartodb.com/tables/jur');
   });
 
   it('should have no leaks', function() {

--- a/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_view.spec.js
@@ -76,6 +76,28 @@ describe('new_dashboard/background_importer/background_importer_view', function(
     expect(this.view.$('.BackgroundImporter-headerBadgeCount').length).toBe(0);
   });
 
+  it('should check if application should redirect user to map/dataset view', function() {
+    this.view.render();
+    this.view.items.fetch = function() {};
+    this.view.user.fetch = function() {};
+
+    spyOn(this.view, '_goTo');
+    var mdl = new ImportsModel({ state: 'error'});
+    this.view.collection.add(mdl);
+    expect(this.view._goTo).not.toHaveBeenCalled();
+    var mdl1 = new ImportsModel({ state: 'pending'});
+    this.view.collection.add(mdl1);
+    expect(this.view._goTo).not.toHaveBeenCalled();
+    var mdl2 = new ImportsModel({ state: 'pending'});
+    this.view.collection.add(mdl2);
+    expect(this.view._goTo).not.toHaveBeenCalled();
+    mdl1.set('state', 'complete');
+    expect(this.view._goTo).not.toHaveBeenCalled();
+    this.view.collection.remove(mdl1);
+    mdl2.set('state', 'complete');
+    expect(this.view._goTo).toHaveBeenCalled();
+  });
+
   it('should have no leaks', function() {
     this.view.render();
     expect(this.view).toHaveNoLeaks();

--- a/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_view.spec.js
@@ -97,7 +97,7 @@ describe('new_dashboard/background_importer/background_importer_view', function(
     this.view.collection.remove(mdl1);
     mdl2.imp.set({ table_name: 'jur' });
     mdl2.set({ state: 'complete' });
-    expect(this.view._redirect).toHaveBeenCalledWith('http://paco.cartodb.com/tables/jur');
+    expect(this.view._redirect).toHaveBeenCalledWith(window.location.protocol + '//paco.cartodb.com/tables/jur');
   });
 
   it('should have no leaks', function() {


### PR DESCRIPTION
When user imports a new dataset, we should redirect to the dataset/map item when it is completed.

Cases:

- If there is only an import and it is completed.
- If there is one or several failed imports and last one is completed.
- Rest of them, no redirect.

Fixes #2358.
Fixes #2551.