### PR TITLE
Upgrade cartodb extension to 0.7.3 #990

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1853,7 +1853,7 @@ TRIGGER
   # Upgrade the cartodb postgresql extension
   def upgrade_cartodb_postgres_extension(statement_timeout=nil, cdb_extension_target_version=nil)
     if cdb_extension_target_version.nil?
-      cdb_extension_target_version = '0.7.2'
+      cdb_extension_target_version = '0.7.3'
     end
 
     in_database({


### PR DESCRIPTION
@Kartones mini review, https://github.com/CartoDB/cartodb-postgresql/releases/tag/0.7.3

shall not merge until the new version is deployed in production