### PR TITLE
Hiding signup link from header if it isn't SaaS

### DIFF
--- a/app/views/admin/pages/public_dashboard.html.erb
+++ b/app/views/admin/pages/public_dashboard.html.erb
@@ -21,6 +21,7 @@
     var visualizations = <%= raw urls.to_json %>;
     var no_cdn =  <%= !Rails.env.production? ? true : false %>;
     var user_name = '<%= @username %>';
+    var account_host = '<%= Cartodb.config[:account_host] %>';
   </script>
 
   <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false&v=3.12"></script>

--- a/app/views/admin/pages/public_datasets.html.erb
+++ b/app/views/admin/pages/public_datasets.html.erb
@@ -9,6 +9,7 @@
 <%= content_for(:js) do %>
   <script>
     var user_name = '<%= @username %>';
+    var account_host = '<%= Cartodb.config[:account_host] %>';
   </script>
 
   <%= javascript_include_tag 'cdb.js', 'templates.js', 'public_dashboard' %>

--- a/app/views/admin/shared/_new_public_header.erb
+++ b/app/views/admin/shared/_new_public_header.erb
@@ -25,11 +25,13 @@
         <li class="Header-settingsItem js-learn" style="display:none;">
           <a href="http://docs.cartodb.com/" class="Header-settingsLink">Learn</a>
         </li>
-        <li class="Header-settingsItem Header-settingsItem--avatar js-user-settings">
-          <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
-            <span>Sign up</span>
-          </a>
-        </li>
+        <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+          <li class="Header-settingsItem Header-settingsItem--avatar js-user-settings">
+            <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
+              <span>Sign up</span>
+            </a>
+          </li>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/app/views/admin/shared/_public_header.html.erb
+++ b/app/views/admin/shared/_public_header.html.erb
@@ -6,7 +6,9 @@
       <% if clone %>
         <li><a href="http://cartodb.com/login">Clone this</a><li>
       <% end %>
-      <li><a class="signup" href="http://cartodb.com/signup">Sign up</a><li>
+      <% if ( Cartodb.config[:account_host] == "cartodb.com") %>
+        <li><a class="signup" href="http://cartodb.com/signup">Sign up</a><li>
+      <% end %>
       <li><a href="http://cartodb.com/login" class="border login">Login</a></li>
     </ul>
   </div>

--- a/lib/assets/javascripts/cartodb/public/views/public_header.jst.ejs
+++ b/lib/assets/javascripts/cartodb/public/views/public_header.jst.ejs
@@ -10,7 +10,9 @@
     <% } %>
     
     <% if (!username) { %>
-      <li><a class='signup' href='http://cartodb.com/signup'>Sign up</a><li>
+      <% if (cdb.config.get('account_host') === "cartodb.com" ) { %>
+        <li><a class='signup' href='http://cartodb.com/signup'>Sign up</a><li>
+      <% } %>
       <li><a href='http://cartodb.com/login' class='border login'>Login</a></li>
     <% } else { %>
       

--- a/lib/assets/javascripts/cartodb/public_dashboard/public_dashboard.js
+++ b/lib/assets/javascripts/cartodb/public_dashboard/public_dashboard.js
@@ -125,6 +125,8 @@
       if (cdb.config.isOrganizationUrl()) cdb.config.set('url_prefix', cdb.config.organizationUrl());
       cdb.templates.namespace = 'cartodb/';
 
+      cdb.config.set('account_host', account_host);
+
       var public_dashboard = new PublicDashboard({
         no_cdn:         window.no_cdn,
         visualizations: window.visualizations,

--- a/lib/assets/test/spec/cartodb/public/public_header.spec.js
+++ b/lib/assets/test/spec/cartodb/public/public_header.spec.js
@@ -17,6 +17,10 @@ describe("Public pages header tests", function() {
       owner_username: "test",
       isMobileDevice: false
     });
+
+    cdb.config.set({
+      account_host: 'cartodb.com'
+    });
   })
 
   afterEach(function() {


### PR DESCRIPTION
Ref. [ticket #2191](https://github.com/CartoDB/cartodb/issues/2191) : **"create an account" should be removed from open-source edition **

Assuming that:
SaaS ==> account_host: ‘cartodb.com’ in app_config.yml

I had to add account_host var to javascript from Cartodb.config[:account_host]
Tests modification adding account_host to db.config.

- account_host:       'localhost.lan:3000'
![screen shot 2015-03-03 at 18 06 00](https://cloud.githubusercontent.com/assets/3958416/6468407/144fc7e8-c1d5-11e4-9873-7dcbfa3be0c6.png)

- account_host:       'cartodb.com'
![screen shot 2015-03-03 at 18 11 52](https://cloud.githubusercontent.com/assets/3958416/6468406/0f82b8ec-c1d5-11e4-99e0-6f250f1cd7f2.png)

