### PR TITLE
Fixing problems within infowindow header with image template [NOT MERGE]

### DIFF
--- a/lib/assets/javascripts/cartodb/table/infowindow.js
+++ b/lib/assets/javascripts/cartodb/table/infowindow.js
@@ -218,20 +218,18 @@
      *  Attempts to load the cover URL and show it
      */
     _loadCover: function() {
-
       if (!this._containsCover()) return;
 
-      var self = this;
+      var $cover = this.$(".cover");
+      var $imageNotFound = this.$(".image_not_found");
+      var $img = $cover.find("img");
+      var url = $img.attr('src');
 
-      var
-      $cover         = this.$el.find(".cover"),
-      $imageNotFound = this.$el.find(".image_not_found");
-
-      var url = this._getCoverURL();
-
-      if (!this._isValidURL(url)) {
+      if (!this._isValidURL(url) || $img.length === 0) {
         $imageNotFound.fadeIn(250);
         return;
+      } else {
+        $imageNotFound.hide();
       }
 
       // configure spinner
@@ -239,18 +237,6 @@
       target  = document.getElementById('spinner'),
       opts    = { lines: 9, length: 4, width: 2, radius: 4, corners: 1, rotate: 0, color: '#ccc', speed: 1, trail: 60, shadow: true, hwaccel: false, zIndex: 2e9 },
       spinner = new Spinner(opts).spin(target);
-
-      // create the image
-      var $img = $cover.find("img");
-
-      $imageNotFound.hide();
-
-      $img.hide(function() {
-        this.remove();
-      });
-
-      $img = $("<img />").attr("src", url);
-      $cover.append($img);
 
       $img.load(function(){
         spinner.stop();

--- a/lib/assets/javascripts/cartodb/table/views/infowindow/custom_templates/infowindow_header_with_image.jst.mustache
+++ b/lib/assets/javascripts/cartodb/table/views/infowindow/custom_templates/infowindow_header_with_image.jst.mustache
@@ -3,17 +3,18 @@
   <div class="cartodb-popup-header">
     <div class="cover">
       <div id="spinner"></div>
-      <div class="image_not_found"> <i></i> <a href="#/map" class="help">Non-valid picture URL</a></div>
-      {{#content.fields}}
-      {{^position}}
+      <div class="image_not_found">
+        <i></i>
+        <a href="#/map" class="help">Non-valid picture URL</a>
+      </div>
       <span class="separator"></span>
+      <div class="shadow"></div>
+      {{#content.fields.length}}
       {{#content.fields.1 }}
       <h1 class="order1">{{=<% %>=}}{{<%={{ }}=%>{{{ content.fields.1.name }}}{{=<% %>=}}}}<%={{ }}=%></h1>
       {{/content.fields.1 }}
-      <div class="shadow"></div>
-      <img src="{{=<% %>=}}{{<%={{ }}=%>{{{ name }}}{{=<% %>=}}}}<%={{ }}=%>" style="height:138px;display:inline" />
-      {{/position}}
-      {{/content.fields}}
+      <img src="{{=<% %>=}}{{<%={{ }}=%>{{{ content.fields.0.name }}}{{=<% %>=}}}}<%={{ }}=%>" />
+      {{/content.fields.length}}
     </div>
   </div>
   <div class="cartodb-popup-content-wrapper">

--- a/lib/assets/javascripts/cartodb/table/views/infowindow/templates/infowindow_header_with_image.jst.mustache
+++ b/lib/assets/javascripts/cartodb/table/views/infowindow/templates/infowindow_header_with_image.jst.mustache
@@ -1,27 +1,20 @@
 <div class="cartodb-popup header with-image v2" data-cover="true">
   <a href="#close" class="cartodb-popup-close-button close">x</a>
   <div class="cartodb-popup-header">
-  <div class="cover">
+    <div class="cover">
       <div id="spinner"></div>
-      <div class="image_not_found"> <i></i> <a href="#map" class="help">Non-valid picture URL</a></div>
-      {{#content.fields}}
-        {{#index}}
-          {{#value}}
-            <h1 class="order{{index}}">{{{ value }}}</h1>
-          {{/value}}
-          {{^value}}
-            <h1 class="order{{index}}">null</h1>
-          {{/value}}
-        {{/index}}
-        {{^index}}
-          {{^value}}
-            <h1 class="empty">null</h1>
-          {{/value}}
-          <span class="separator"></span>      
-        {{/index}}
-      {{/content.fields}}
-
+      <div class="image_not_found">
+        <i></i>
+        <a href="#/map" class="help">Non-valid picture URL</a>
+      </div>
+      <span class="separator"></span>
       <div class="shadow"></div>
+      {{#content.fields.length}}
+        {{#content.fields.1}}
+          <h1 class="order1">{{content.fields.1.value}}</h1>
+        {{/content.fields.1}}
+        <img src="{{content.fields.0.value}}" />
+      {{/content.fields.length}}
     </div>
   </div>
 
@@ -29,15 +22,15 @@
     <div class="cartodb-popup-content">
       {{#content.fields}}
         <div class="order{{index}}">
-            {{#index}}
-              {{#title}}<h4>{{title}}</h4>{{/title}}
-              {{#value}}
-                <p>{{{ value }}}</p>
-              {{/value}}
-              {{^value}}
-                <p class="empty">null</p>
-              {{/value}}
-            {{/index}}
+          {{#index}}
+            {{#title}}<h4>{{title}}</h4>{{/title}}
+            {{#value}}
+              <p>{{{ value }}}</p>
+            {{/value}}
+            {{^value}}
+              <p class="empty">null</p>
+            {{/value}}
+          {{/index}}
         </div>
       {{/content.fields}}
     </div>


### PR DESCRIPTION
- Stop adding <img> tag programmatically. It'd edit <img> element if it is present in the .cover block.
- Stop rendering all fields in cover within infowindow-header-with-image template.
- Added proper elements in infowindow-header-with-image custom template.

cc @javisantana 

Fixes #1970