### PR TITLE
Fixes the showing of map previews in the delete items dialog

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
@@ -45,6 +45,12 @@ module.exports = BaseDialog.extend({
     this.add_related_model(this._viewModel);
   },
 
+  render: function() {
+    cdb.ui.common.Dialog.prototype.render.apply(this, arguments);
+    this._loadMapPreviews();
+    return this;
+  },
+
   /**
    * @implements cdb.ui.common.Dialog.prototype.render_content
    */
@@ -73,18 +79,6 @@ module.exports = BaseDialog.extend({
     // An entity can be an User or Organization
     var affectedEntities = this._viewModel.affectedEntities();
     var affectedVisData = this._viewModel.affectedVisData();
-
-    var self = this;
-    this.$el.find('.MapCard').each(function() {
-      var mapCardPreview = new MapCardPreview({
-        el: $(this).find('.js-header'),
-        vizjson: $(this).data('vizjson-url'),
-        width: 298,
-        height: 130
-      }).load();
-
-      self.addView(mapCardPreview);
-    });
 
     return cdb.templates.getTemplate('new_dashboard/dialogs/delete_items_view_template')({
       selectedCount: this._viewModel.length,
@@ -123,6 +117,23 @@ module.exports = BaseDialog.extend({
     this.killEvent(e);
     this._viewModel.deleteItems();
     this.render();
+  },
+
+  _loadMapPreviews: function() {
+
+    var self = this;
+
+    this.$el.find('.MapCard').each(function() {
+      var mapCardPreview = new MapCardPreview({
+        el: $(this).find('.js-header'),
+        vizjson: $(this).data('vizjson-url'),
+        width: 298,
+        height: 130
+      }).load();
+
+      self.addView(mapCardPreview);
+    });
+ 
   },
 
   _renderDeletingItems: function() {

--- a/lib/assets/test/spec/cartodb/new_dashboard/dialogs/delete_items_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/dialogs/delete_items_view.spec.js
@@ -19,7 +19,8 @@ describe('new_dashboard/dialogs/delete_items_view', function() {
     this.contentType = 'datasets';
 
     this.models = [];
-    this.createView = function() {
+
+    this.createView = function(callback) {
       this.viewModel = new ViewModel(this.models, {
         contentType: this.contentType
       });
@@ -29,12 +30,28 @@ describe('new_dashboard/dialogs/delete_items_view', function() {
         viewModel: this.viewModel,
         currentUserUrl: this.currentUserUrl
       });
+
+      spyOn(this.view, '_loadMapPreviews');
+
+      if (callback) {
+        callback(this.view, this.viewModel);
+      }
+
     };
   });
 
   it('should load prerequisites when creating the view', function() {
     this.createView();
     expect(this.viewModel.loadPrerequisites).toHaveBeenCalled();
+  });
+
+  it('should attempt to load the map previews after the rendering is done', function() {
+    this.createView(function(view, model) {
+      model.setState('LoadingPrerequisites');
+      view.appendToBody();
+    });
+
+    expect(this.view._loadMapPreviews).toHaveBeenCalled();
   });
 
   describe('when loading prerequisites', function() {


### PR DESCRIPTION
We attempt to load the previews after the rendering of the dialog has been finished. This PR fixes the problem and adds new spec.