### PR TITLE
[NOMERGE] 1720 google disconnect at box organization user page

### DIFF
--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
-require_dependency '../../../lib/google_plus_api'
-require_dependency '../../../lib/google_plus_config'
+require_dependency '../../lib/google_plus_api'
+require_dependency '../../lib/google_plus_config'
 
 class Admin::OrganizationUsersController < ApplicationController
   ssl_required  :profile, :account, :oauth, :api_key, :regenerate_api_key

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
-require_relative '../../../lib/google_plus_api'
-require_relative '../../../lib/google_plus_config'
+require_dependency '../../../lib/google_plus_api'
+require_dependency '../../../lib/google_plus_config'
 
 class Admin::OrganizationUsersController < ApplicationController
   ssl_required  :profile, :account, :oauth, :api_key, :regenerate_api_key

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
-require_relative '../../../lib/google_plus_api'
-require_relative '../../../lib/google_plus_config'
+require_dependency '../../lib/google_plus_api'
+require_dependency '../../lib/google_plus_config'
 
 class Admin::UsersController < ApplicationController
   ssl_required  :account, :profile, :account_update, :profile_update

--- a/app/controllers/google_plus_controller.rb
+++ b/app/controllers/google_plus_controller.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-require_relative '../../lib/google_plus_api'
+require_dependency '../../lib/google_plus_api'
 
 class GooglePlusController < ApplicationController
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
-require_relative '../../lib/google_plus_api'
-require_relative '../../lib/google_plus_config'
+require_dependency '../../lib/google_plus_api'
+require_dependency '../../lib/google_plus_config'
 
 class SessionsController < ApplicationController
   layout 'frontend'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -407,6 +407,8 @@ class User < Sequel::Model
 
     return unless new_password_value == new_password_confirmation_value && !new_password_value.nil?
 
+    self.last_password_change_date = Time.zone.now unless new?
+
     self.password = new_password_value
   end
 

--- a/app/views/admin/organization_users/_form.html.erb
+++ b/app/views/admin/organization_users/_form.html.erb
@@ -76,10 +76,9 @@
                 </div>
               </div>
 
-              <% if @user.google_sign_in && @google_plus_config.present? %>
+              <% if @google_plus_config.present? %>
                 <div class="row" id="google_row">
                   <div class="field">
-                    <label>GOOGLE+ ACCOUNT</label>
                     <%= render partial: 'google_plus/google_plus_disconnect_button',  locals: { config: @google_plus_config } %>
                   </div>
                 </div>

--- a/app/views/admin/organization_users/edit.html.erb
+++ b/app/views/admin/organization_users/edit.html.erb
@@ -15,19 +15,6 @@
       , user_data = <%=raw current_user.data.to_json.html_safe %>
       , access_token = '';
 
-    function disconnectGoogleAccount(access_token, callback, errorCallback) {
-      var revokeUrl = 'https://accounts.google.com/o/oauth2/revoke?token=' + access_token;
-      $.ajax({
-        type: 'GET',
-        url: revokeUrl,
-        async: false,
-        contentType: "application/json",
-        dataType: 'jsonp',
-        success: callback,
-        error: errorCallback
-      });
-    }
-
   </script>
 <% end %>
 <%= content_for(:css) do %>

--- a/app/views/admin/users/account.html.erb
+++ b/app/views/admin/users/account.html.erb
@@ -96,6 +96,11 @@
         </div>
 
         <div class="Form-footer">
+          <% if @google_plus_config.present? %>
+            <%= render partial: 'google_plus/google_plus_disconnect_button',  locals: { config: @google_plus_config } %>
+          <% end %>
+
+
           <p class="Form-footerText"></p>
           <%= button_tag(type: 'submit', class: 'Button Button--main') do %>
             <% content_tag(:span, 'Save changes') %>

--- a/app/views/admin/users/account.html.erb
+++ b/app/views/admin/users/account.html.erb
@@ -45,7 +45,7 @@
             <label class="Form-label">Email</label>
           </div>
           <div class="Form-rowData">
-            <%= f.text_field :email, :class => "Form-input Form-input--long #{ 'Form-input--error' if @user.errors[:email].present? }" %>
+            <%= f.text_field :email, :class => "Form-input Form-input--long #{ 'Form-input--error' if @user.errors[:email].present? } #{ 'is-disabled' if !@user.can_change_email }", :readonly => !@user.can_change_email %>
           </div>
           <div class="Form-rowInfo">
             <% if (@user.errors[:email].present?) %>

--- a/app/views/google_plus/_google_plus_disconnect_button.html.erb
+++ b/app/views/google_plus/_google_plus_disconnect_button.html.erb
@@ -3,11 +3,16 @@
 </span>
 
 <span id="google_disconnect" style="display: none">
-  <a onclick="#" id="disconnectGoogleButton">Disconnect your Google+ account</a>
+  <% if @user.last_password_change_date.nil? %>
+    <span>You must set a password before being able to disconnect yout Google+ account</span>
+  <% else %>
+    <a style="cursor: pointer;" onclick="if(confirm('Are you sure you want to disconnect your Google+ account')) { disconnectGoogleAccount(access_token, function() { $('#google_disconnect').hide(); }, function() { alert('There was an error disconnecting your Google account'); }) } " id="disconnectGoogleButton">Disconnect your Google+ account</a>
+  <% end %>
 </span>
 
 <script>
   document.domain = '<%= config.domain %>'
+  var access_token = '';
 
   function signinCallback(authResult) {
     if (typeof authResult.access_token != 'undefined') {
@@ -25,4 +30,18 @@
       signinCallbackCalled(authResult);
     }
   }
+
+  function disconnectGoogleAccount(access_token, callback, errorCallback) {
+    var revokeUrl = 'https://accounts.google.com/o/oauth2/revoke?token=' + access_token;
+    $.ajax({
+      type: 'GET',
+      url: revokeUrl,
+      async: false,
+      contentType: "application/json",
+      dataType: 'jsonp',
+      success: callback,
+      error: errorCallback
+    });
+  }
+
 </script>


### PR DESCRIPTION
Google+ disconnect

@xavijam right now, in the new organization user page, if there's Google config present and user is logged in with Google (no matter whether he signed up with Google or not)...
  * If user has changed his password, it displays disconnect link.
  * If user has not changed his password, it displays a message.

Clicking the disconnect button will trigger a JS confirm dialog and if he confirm he will be disconnected and link hidden.

We spoke about making interaction simpler, and this is the simplest I can imagine. I guess you don't want JS confirm dialog, and maybe you'll want to make some more front changes. Would you mind applying styles and so on before I do final testing on staging? Whatever you change, do it as well in the old page. Right now the behaviour is the same, but it also opens the old modal after confirmation.

@Kartones FYI, changing `require_relative` for `require_dependency` removes reloading issues when using `/lib` files.