### PR TITLE
Geocoding dialog should be enabled in visualization view

### DIFF
--- a/lib/assets/javascripts/cartodb/common/header.js
+++ b/lib/assets/javascripts/cartodb/common/header.js
@@ -104,8 +104,11 @@ cdb.admin.Header = cdb.core.View.extend({
   _openOptionsMenu: function(e) {
     this.killEvent(e);
 
+    var self = this;
+    var $target = $(e.target);
+
     // Options menu
-    var options_menu = new cdb.admin.HeaderOptionsMenu({
+    this.options_menu = new cdb.admin.HeaderOptionsMenu({
       target: $(e.target),
       // use the current visualization instead the master one
       model: this.options.visualization,
@@ -116,16 +119,17 @@ cdb.admin.Header = cdb.core.View.extend({
       globalError: this.options.globalError,
       template_base: 'table/header/views/options_menu'
     }).bind("onDropdownShown",function(ev) {
-      cdb.god.unbind("closeDialogs", options_menu.hide, options_menu);
+      cdb.god.unbind("closeDialogs", self.options_menu.hide, self.options_menu);
       cdb.god.trigger("closeDialogs");
-      cdb.god.bind("closeDialogs", options_menu.hide, options_menu);
+      cdb.god.bind("closeDialogs", self.options_menu.hide, self.options_menu);
     }).bind('onDropdownHidden', function() {
-      cdb.god.unbind(null, null, options_menu);
+      this.clean();
+      $target.unbind('click');
+      cdb.god.unbind(null, null, self.options_menu);
     });
 
-    this.$body.append(options_menu.render().el);
-    options_menu.open(e);
-
+    this.$body.append(this.options_menu.render().el);
+    this.options_menu.open(e);
   },
 
   /**

--- a/lib/assets/javascripts/cartodb/table/header/options_menu.js
+++ b/lib/assets/javascripts/cartodb/table/header/options_menu.js
@@ -111,21 +111,18 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
   _exportTable: function(e){
     e.preventDefault();
 
-    if (!this.model.isVisualization()) {
+    // If a sql is applied but it is not valid, don't let user export it
+    if (this.table.isInSQLView() && this.dataLayer && !this.dataLayer.get('query')) return false;
 
-      // If a sql is applied but it is not valid, don't let user export it
-      if (this.table.isInSQLView() && this.dataLayer && !this.dataLayer.get('query')) return false;
+    var export_dialog = new cdb.admin.ExportTableDialog({
+      model: this.dataLayer.table,
+      config: config,
+      user_data: this.user.toJSON()
+    });
 
-      var export_dialog = new cdb.admin.ExportTableDialog({
-        model: this.table,
-        config: config,
-        user_data: this.user.toJSON()
-      });
-
-      export_dialog
-        .appendToBody()
-        .open();
-    }
+    export_dialog
+      .appendToBody()
+      .open();
   },
 
   /**
@@ -233,31 +230,27 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
   _georeference: function(e) {
     e.preventDefault();
 
-    if (!this.model.isVisualization()) {
-      var dlg;
-      if (!this.options.geocoder.isGeocoding() && !this.table.isSync()) {
-        
-        dlg = new cdb.admin.GeocodingDialog({
-          table:  this.table,
-          user:   this.user,
-          tabs:   ['lonlat', 'city', 'admin', 'postal', 'ip', 'address'],
-          option: 'lonlat'
-        });
+    if (!this.options.geocoder.isGeocoding() && !this.table.isSync() && !this.table.isInSQLView()) {
+      
+      dlg = new cdb.admin.GeocodingDialog({
+        table:  this.table,
+        user:   this.user,
+        tabs:   ['lonlat', 'city', 'admin', 'postal', 'ip', 'address'],
+        option: 'lonlat'
+      });
 
-        dlg.bind('geocodingChosen', this._onGeocodingChosen, this);
+      dlg.bind('geocodingChosen', this._onGeocodingChosen, this);
 
-      } else if (this.options.geocoder.isGeocoding()) {
-        dlg = new cdb.admin.GeocoderWorking();
-      } else {
-        // If table can't geocode == is synched, return!
-        return;
-      }
-
-      dlg
-        .appendToBody()
-        .open({ center: true });
-
+    } else if (this.options.geocoder.isGeocoding()) {
+      dlg = new cdb.admin.GeocoderWorking();
+    } else {
+      // If table can't geocode == is synched, return!
+      return;
     }
+
+    dlg
+      .appendToBody()
+      .open({ center: true });
   },
 
   _onGeocodingChosen: function(data) {

--- a/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
@@ -42,6 +42,19 @@
 
   <% } else { %>
 
+    <% if (dataLayer && !dataLayer.get('query')) { %>
+      <li><a class="small export_table" href="#/export">Export layer</a></li>
+
+      <li class="<% if (table.isSync()) { %>disabled<% } %>">
+        <a class="small georeference" href="#/georeference">
+          Georeference layer
+          <div class="progress-bar">
+            <div class="bar-2"></div>
+          </div>
+        </a>
+      </li>
+    <% } %>
+
     <!-- Visualization options  -->
     <li><a class="small duplicate_vis" href="#/duplicate">Duplicate visualization</a></li>
     <% if (isVisOwner) { %>

--- a/lib/assets/javascripts/cartodb/table/header_view.js
+++ b/lib/assets/javascripts/cartodb/table/header_view.js
@@ -244,27 +244,7 @@ var HeaderView = cdb.admin.HeaderView = cdb.core.View.extend({
 
   showGeoreferenceWindow: function(e) {
     this.killEvent(e);
-    if (!this.vis.isVisualization()) {
-      this.trigger('georeference', null);
-    } else {
-      this.warning_dlg && this.warning_dlg.clean();
-      this.warning_dlg = new cdb.admin.BaseDialog({
-        title: this._TEXTS.no_geo.title,
-        description: _.template(this._TEXTS.no_geo.description)({ prefix: cdb.config.prefixUrl(), table_name: this.table.get('name') }),
-        template_name: 'common/views/confirm_dialog',
-        clean_on_hide: true,
-        enter_to_confirm: true,
-        ok_button_classes: "right button grey",
-        ok_title: this._TEXTS.no_geo.ok,
-        cancel_button_classes: "hide",
-        modal_type: "confirmation",
-        width: 500
-      });
-
-      this.warning_dlg
-        .appendToBody()
-        .open();
-    }
+    this.trigger('georeference', null);
   },
 
   showColumnTypeOptions: function(e) {

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -632,7 +632,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
   },
 
   checkGeoRef: function() {
-    if(this.options && this.table && !this.vis.isVisualization()) {
+    if(this.options && this.table) {
       if(!this.table.isGeoreferenced()) {
         this.showNoGeoRefWarning();
         this.georeferenced = false;

--- a/lib/assets/javascripts/cartodb/table/noGeoRefData_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/noGeoRefData_dialog.js
@@ -12,14 +12,14 @@
 cdb.admin.NoGeoRefDataDialog = cdb.admin.BaseDialog.extend({
   
   _TEXTS: {
-    title:      _t('No georeferenced data on your table'),
-    content:    _t('Although we can see you have data on your table, it does not \
+    title:      _t('No georeferenced data on your layer'),
+    content:    _t('Although we can see you have data, it does not \
                 appear to be georeferenced. You will not see anything on the map if \
                 your records are not georeferenced. Click on Georeference if you want \
                 to use a geocoder to get location out of your data, or cancel.'),
-    no_content: _t('There seems to be no data on this table, so there is nothing \
+    no_content: _t('There seems to be no data on this layer, so there is nothing \
                 to represent on the map. You can add some data or run SQL queries \
-                to select some. Click cancel to continue.'),
+                to select some.'),
     close:      _t('Ok, close'),
     georef:     _t('Georeference'),
     cancel:     _t('Cancel')

--- a/lib/assets/test/spec/cartodb/table/header/header.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/header.spec.js
@@ -291,6 +291,13 @@ describe("Table/Visualization Header tests", function() {
     cdb.config.prefixUrl = originalPrefixUrl;
   });
 
+  it("should create a new options dropdown menu each time link is clicked", function() {
+    this.header.options.visualization = this.header.model;
+    this.header.$('.dropdown').click();
+    var optionsMenuCid = this.header.options_menu.cid;
+    this.header.$('.dropdown').click();
+    expect(optionsMenuCid).not.toEqual(this.header.options_menu);
+  });
 
   it("should check sync info when data layer changes", function() {
     spyOn(this.header, '_setSyncInfo');

--- a/lib/assets/test/spec/cartodb/table/header/options_menu.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/options_menu.spec.js
@@ -103,6 +103,19 @@ describe("Header options menu", function() {
   it("should open the menu options with visualization mode", function() {
     this.vis.set('type', 'derived');
     options_menu.render();
+    expect(options_menu.$el.find("li").size()).toEqual(5);
+    expect(options_menu.$el.find("li:contains('Duplicate visualization')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Delete visualization')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Georeference layer')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Export layer')").size()).toEqual(1);
+  });
+
+  it("shouldn't display layer options if table has a sql applied in visualization mode", function() {
+    this.vis.set('type', 'derived');
+    sqlView = new cdb.admin.SQLViewData(null, { sql: 'select * from test' })
+    cartodb_layer.set('query', 'select * from test');
+    this.vis.map.layers.last().table.useSQLView(sqlView);
+    options_menu.render();
     expect(options_menu.$el.find("li").size()).toEqual(3);
     expect(options_menu.$el.find("li:contains('Duplicate visualization')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Delete visualization')").size()).toEqual(1);


### PR DESCRIPTION

![screen shot 2015-03-09 at 16 28 08](https://cloud.githubusercontent.com/assets/132146/6557956/55cb34f2-c679-11e4-853b-adf131b22cba.png)

*PROS*
- [x] GEO button in table view enabled.
- [x] No geocoding data dialog will appear when a layer without data or geo info is added.
- [x] Georeference this layer should be a visible option within the editor in a visualization view.

*CONS*
- Each layer added without data or geo data, will make No-geo dialog appear.

*ONE MORE THING*
- [x] Export this layer available in visualization view

cc @saleiva @iriberri @javisantana @javierarce 

Fixes #2541.