### PR TITLE
Adding sync icon when synchronization model has changed within layer panel view

### DIFF
--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -746,10 +746,13 @@
         this._writableTableButtons();
       }
 
+      // Set title changes (as in name, sync info,...)
+      this.setLayerName(this.dataLayer);
+
       // Set sql button changes
       _.each(sql_button_changes, function(value, key) {
         self[ value === "remove" ? 'removeClassFromButton' : 'addClassToButton' ]('sql_mod', key);
-      })
+      });
     },
 
     // Enable the correct buttons depending on

--- a/lib/assets/test/spec/cartodb/table/layer_panel_view.spec.js
+++ b/lib/assets/test/spec/cartodb/table/layer_panel_view.spec.js
@@ -262,7 +262,6 @@ describe("cdb.admin.LayerPanelView", function() {
     it("should add sync-table icon if table is synced and layer is in a visualization", function() {
       view.vis.set('type', 'derived');
       view.table.synchronization.set("id","test");
-      view.setLayerName(view.dataLayer);
       expect(view.$('.layer-info a.info .name i.synced').length).toBe(1);
     });
 


### PR DESCRIPTION
Sync info wasn't loaded when table synchronization model was fetched. Now it is working, and also the proper test has been fixed, it "simulated" the behaviour, so now it is fixed as well.

Fixes #2674

cc @CartoDB/frontend 

![screen shot 2015-03-10 at 11 38 28](https://cloud.githubusercontent.com/assets/132146/6573328/fd20c816-c719-11e4-8965-a43c20e7e3ee.png)
