### PR TITLE
Fix bubble wizard legend not being updated on column change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ Bugfixes:
 * Fix contrast for nav buttons [#2696](https://github.com/CartoDB/cartodb/pull/2696)
 * Fix top/bottom padding for delete dialog [#2721](https://github.com/CartoDB/cartodb/pull/2721)
 * Fix filters view's search component behavior [#2708](https://github.com/CartoDB/cartodb/pull/2708)
+* Fix bubble wizard legend not being updated on column change [#2747](https://github.com/CartoDB/cartodb/pull/2747)
 
 3.8.1 (2015-02-26)
 ------------------

--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.7.26
+3.7.27

--- a/lib/assets/javascripts/cartodb/table/menu_modules/legends/bubble_legend.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/legends/bubble_legend.js
@@ -6,76 +6,62 @@ cdb.admin.mod.BubbleLegend = cdb.admin.mod.CustomLegend.extend({
   _FILTER_NAME: "bubble",
 
   _setupTemplates: function() {
-
     this.template = this.getTemplate('table/menu_modules/legends/views/bubble_legend_pane');
 
-    this.item_templates = [];
-    this.item_templates["text"]  = 'table/menu_modules/legends/views/legend_item_text';
-    this.item_templates["color"] = 'table/menu_modules/legends/views/legend_item_color';
-
+    this.itemTemplates = {
+      text: 'table/menu_modules/legends/views/legend_item_text',
+      color: 'table/menu_modules/legends/views/legend_item_color'
+    };
   },
 
   _setupSync: function(min, max) {
-
     this.leftLabel  = "< " + min;
     this.rightLabel = max + " >";
 
-    this.leftSync  = true;
-    this.rightSync = true;
+    this.leftSync  = false;
+    this.rightSync = false;
 
-    if (this.items && this.items.length > 1 && this.items.at(0).get("legend_type") == "bubble") {
+    if (this.items && this.items.length > 1 && this.items.at(0).get("legend_type") === "bubble") {
+      this.leftSync  = this.items.at(0).get('sync');
+      this.rightSync = this.items.at(1).get('sync');
 
-      this.leftSync  = this.items.at(0).get("sync");
-      this.rightSync = this.items.at(1).get("sync");
-
-      this.leftLabel  = !this.leftSync  ? this.leftLabel  : this.items.at(0).get("value");
-      this.rightLabel = !this.rightSync ? this.rightLabel : this.items.at(1).get("value");
-
+      this.leftLabel  = this.leftSync  ? this.items.at(0).get("value") : this.leftLabel;
+      this.rightLabel = this.rightSync ? this.items.at(1).get("value") : this.rightLabel;
     }
-
   },
 
+  // implements cdb.admin.mod.CustomLegend.prototype._calculateItems
   _calculateItems: function() {
-
     var items = [];
-
     var color = this.wizardProperties.get("marker-fill");
-
-    var min, max;
-
     var metadata = this.wizardProperties.get("metadata");
 
     if (metadata) {
-
       var min = metadata[0];
-      var max = metadata[metadata.length - 1];
+      var max = _.last(metadata);
 
       this._setupSync(min, max);
 
-      items.push(new cdb.geo.ui.LegendItemModel({ legend_type: "bubble", name: "Left label",  type: "text",  sync: this.leftSync, value: this.leftLabel }));
-      items.push(new cdb.geo.ui.LegendItemModel({ legend_type: "bubble", name: "Right Label", type: "text",  sync: this.rightSync, value: this.rightLabel }));
+      items.push(new cdb.geo.ui.LegendItemModel({ legend_type: "bubble", name: "Left label",  type: "text", sync: this.leftSync, value:  this.leftLabel }));
+      items.push(new cdb.geo.ui.LegendItemModel({ legend_type: "bubble", name: "Right Label", type: "text", sync: this.rightSync, value: this.rightLabel }));
       items.push(new cdb.geo.ui.LegendItemModel({ name: "Color", type: "color", value: color }));
 
       this.items.reset(items);
     }
-
   },
 
+  // implements cdb.admin.mod.CustomLegend.prototype._renderItem
   _renderItem: function(item) {
-
     var view = new cdb.admin.mod.LegendEditorItem({
       model: item,
       observe: "value",
       showSwitch: true,
-      template_name: this.item_templates[item.get("type")],
+      template_name: this.itemTemplates[item.get("type")],
       extra_colors: this.options.extra_colors
     });
 
     this.$el.find("ul").append(view.render().$el);
     this.addView(view);
     this.legendItems.push(view);
-
   }
-
 });
-

--- a/lib/assets/javascripts/cartodb/table/menu_modules/legends/legend_fields_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/legends/legend_fields_pane.js
@@ -194,7 +194,7 @@ cdb.admin.mod.LegendFieldsPane = cdb.core.View.extend({
     var previousWizardProperties = m.previousAttributes();
 
     var currentType  = m.get("type");
-    var previousType = m.previousAttributes().type;
+    var previousType = previousWizardProperties.type;
 
     var metadataDiff = _(wizardProperties.metadata).difference(previousWizardProperties.metadata)
 
@@ -211,41 +211,42 @@ cdb.admin.mod.LegendFieldsPane = cdb.core.View.extend({
 
     // Let's check what has changed and decide if we want to update the legend or not
     if (currentType === previousType) {
-
       var currentProperty  = m.get('property');
       var previousProperty = previousWizardProperties.property;
+      var equalProperty = currentProperty == previousProperty;
 
       if (this.model.get("type") === 'custom') {
         return;
-      }
-      else if (currentType === 'category') {
-
-       var difference = _.difference(m.get('categories'), previousWizardProperties.categories);
-       if ((currentProperty == previousProperty) && (!difference || (difference && difference.length == 0))) return;
-
-      }
-      else if (currentType === 'bubble') {
+      } else if (currentType === 'category') {
+        var difference = _.difference(m.get('categories'), previousWizardProperties.categories);
+        if (equalProperty && (!difference || (difference && difference.length === 0))) {
+          return;
+        }
+      } else if (currentType === 'bubble') {
 
         var equalMarkerFill = (m.get("marker-fill") == previousWizardProperties["marker-fill"]);
         var equalRadiusMin  = (m.get("radius_min")  == previousWizardProperties["radius_min"]);
         var equalRadiusMax  = (m.get("radius_max")  == previousWizardProperties["radius_max"]);
 
-        if (equalMarkerFill && equalRadiusMin && equalRadiusMax && metadataDiff.length == 0) return;
+        if (equalProperty && equalMarkerFill && equalRadiusMin && equalRadiusMax && metadataDiff.length === 0) {
+          return;
+        }
 
-      }
-      else if (currentType === 'intensity') {
-        if (m.get("marker-fill") == previousWizardProperties["marker-fill"]) return;
-      }
-      else if (currentType === 'density' || currentType === 'choropleth') {
+      } else if (currentType === 'intensity') {
+        if (m.get("marker-fill") == previousWizardProperties["marker-fill"]) {
+          return;
+        }
+      } else if (currentType === 'density' || currentType === 'choropleth') {
 
         var equalColorRamp = (m.get("color_ramp") === previousWizardProperties["color_ramp"]);
         var equalMethod    = (m.get("method") === previousWizardProperties["method"]);
 
         var condition = equalColorRamp && equalMethod;
 
-        if (condition && (currentType === "density" || currentType === 'choropleth' && metadataDiff.length == 0)) return;
+        if (condition && (currentType === "density" || currentType === 'choropleth' && metadataDiff.length === 0)) {
+          return;
+        }
       }
-
     }
 
     var type = this._getLegendType();

--- a/lib/assets/test/spec/cartodb/common/create_dialog/create_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/common/create_dialog/create_dialog.spec.js
@@ -72,6 +72,11 @@ describe("Create dialog", function() {
       quota: 100000
     });
 
+    // Without this the custom date picker throws an error, since it internally has a setTimeout to initialize the
+    // date picker, this breaks because some (unrelated to this test) prerequisities are not there (DOM elements).
+    // See line ~60-65 in custom_datepicker.js
+    spyOn(window, 'setTimeout');
+
     view.render();
 
     expect(view.$('.create-tab.twitter > a').hasClass('disabled')).toBeFalsy();

--- a/lib/assets/test/spec/cartodb/table/menu_modules/legend_editor.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/legend_editor.spec.js
@@ -263,26 +263,6 @@ describe('cdb.admin.mod.LegendEditor ', function() {
     expect(view).toHaveNoLeaks();
   })
 
-  // this can't happen
-  xit('should change the selected option to none in the combo when the wizard changes to a non-existant legend type', function() {
-
-    view.$('select').val('custom').change();
-
-    dataLayer.wizard_properties.active("polygon");
-    expect(view.templates.$el.find(".select2-choice span").text()).toEqual("none");
-
-  });
-
-  // this can't happen
-  xit('should change the selected option to none when the wizard changes to a non-existant legend type', function() {
-
-    view.$('select').val('custom').change();
-
-    dataLayer.active('polygon');
-    expect(view.templates.$el.find(".select2-choice span").text()).toEqual("none");
-
-  });
-
 });
 
 
@@ -381,6 +361,3 @@ describe('cdb.admin.mod.LegendEditor: choropleth', function() {
 
 
 });
-
-
-

--- a/lib/assets/test/spec/cartodb/table/menu_modules/legends/bubble_legend.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/legends/bubble_legend.spec.js
@@ -1,0 +1,82 @@
+describe('cdb.admin.mod.BubbleLegend', function() {
+  beforeEach(function() {
+    // Prevent API calls for related models
+    spyOn(Backbone, 'sync');
+
+    var table = TestUtil.createTable('test');
+    var layer = new cdb.admin.CartoDBLayer();
+
+    this.wizardProps = new cdb.admin.WizardProperties({
+      table: table,
+      layer: layer,
+
+      // Take from real-life data...
+      type: "bubble",
+      property: "track_seg_point_id",
+      qfunction: "Quantile",
+      radius_min: 10,
+      radius_max: 25,
+      "marker-fill": "#FF5C00",
+      "marker-opacity": 0.9,
+      "marker-line-width": 1.5,
+      "marker-line-color": "#FFF",
+      "marker-line-opacity": 1,
+      "marker-comp-op": "none",
+      zoom: 15,
+      geometry_type: "point",
+      "text-placement-type": "simple",
+      "text-label-position-tolerance": 10,
+      metadata: [51,102,154,205,256,307,358,410,461,512]
+    });
+
+    this.legend = new cdb.admin.mod.BubbleLegend({
+      model: {
+        items: new Backbone.Collection()
+      },
+      wizardProperties: this.wizardProps
+    });
+  });
+
+  describe('._calculateItems', function() {
+    beforeEach(function() {
+      this.legend._calculateItems();
+    });
+
+    it('should set bubble items with sync state set to false by default', function() {
+      expect(this.legend.items.pluck('sync')).toEqual([false, false, undefined]);
+    });
+
+    it('should set bubble items with sync value based on previous state', function() {
+      this.legend._calculateItems();
+      expect(this.legend.items.pluck('sync')).toEqual([false, false, undefined]);
+
+      // Changing individual items' sync state can be done through the form UI, through a checkbox "lock [x]"
+      this.legend.items.at(1).set('sync', true);
+      this.legend._calculateItems();
+      expect(this.legend.items.pluck('sync')).toEqual([false, true, undefined]);
+
+      this.legend.items.at(0).set('sync', true);
+      this.legend._calculateItems();
+      expect(this.legend.items.pluck('sync')).toEqual([true, true, undefined]);
+    });
+
+    it('should set label values from metadata', function() {
+      expect(this.legend.items.at(0).get('value')).toEqual('< 51');
+      expect(this.legend.items.at(1).get('value')).toEqual('512 >');
+    });
+
+    it('should update labels based only if sync state is disabled', function() {
+      this.wizardProps.set('metadata', [1,2,3]);
+      this.legend._calculateItems();
+      expect(this.legend.items.at(0).get('value')).toEqual('< 1');
+      expect(this.legend.items.at(1).get('value')).toEqual('3 >');
+
+      this.legend.items.at(1).set('sync', true);
+      this.legend.items.at(0).set('sync', true);
+      this.wizardProps.set('metadata', [4,5,6]);
+      this.legend._calculateItems();
+      expect(this.legend.items.at(0).get('value')).toEqual('< 1');
+      expect(this.legend.items.at(1).get('value')).toEqual('3 >');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.7.26",
+  "version": "3.7.27",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Solves #2594 

There are two issues:

1. Changed the default lock state to be off, so the values are updated as expected. If set manually to locked they will _not_ be updated even if changing column later on (AFAIK this is the desired behavior of this lock state).
1. Even if I fixed 1, when changing to bubble wizard from another it did not always update the legend if some other props happened to be the same.

While at it also did some cleanup on the formatting to adhere to the informal standard.

![bubble-legends](https://cloud.githubusercontent.com/assets/978461/6623672/a1d80f42-c8e4-11e4-8d9e-1b0d3e726f11.gif)

Bonus: Fixed this test case that caused the annoying JS error output (not failing test though) on stdout:
```bash
..........>> TypeError: 'undefined' is not an object (evaluating 'tbl.offsetWidth') at
>> vendor/assets/javascripts/datepicker.js:458
>> vendor/assets/javascripts/datepicker.js:770
>> vendor/assets/javascripts/cartodb.uncompressed.js:25
>> vendor/assets/javascripts/cartodb.uncompressed.js:25
>> vendor/assets/javascripts/datepicker.js:776
>> lib/assets/javascripts/cartodb/common/import/custom_datepicker.js:135
>> lib/assets/javascripts/cartodb/common/import/custom_datepicker.js:63
....
```