### PR TITLE
Sort table view columns alphabetically

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Bugfixes:
 * Fix Changing email requires new password [#2764](https://github.com/CartoDB/cartodb/pull/2764)
 * Fix "Update in multi-user account" [#2794](https://github.com/CartoDB/cartodb/pull/2794)
 * Fix incorrect quota value in dropdown [#2804](https://github.com/CartoDB/cartodb/issues/2804)
+* Fix Columns are no longer alphabetically ordered in the table view [#2825](https://github.com/CartoDB/cartodb/pull/2825)
 
 3.9.0 (2015-02-13)
 ------------------

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -790,9 +790,16 @@
 
       return _.chain(schema)
         .clone()
-        .sort() // alphabetically first..
         .sort(function(a, b) { // ..and then re-sort by priorities defined above
-          return priority(a[0]) - priority(b[0]);
+          var prioA = priority(a[0]);
+          var prioB = priority(b[0]);
+          if (prioA < prioB) {
+            return -1;
+          } else if (prioA > prioB) {
+            return 1;
+          } else { //priority is the same (i.e. __default__), so compare alphabetically
+            return a[0] < b[0] ? -1 : 1;
+          }
         })
         .value();
     },

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -178,8 +178,8 @@
       return name && name.replace(/"/g, '');
     },
 
-    sortSchema: function(priorities) {
-      this.set('schema', cdb.admin.CartoDBTableMetadata.sortSchema(this.get('schema'), priorities));
+    sortSchema: function() {
+      this.set('schema', cdb.admin.CartoDBTableMetadata.sortSchema(this.get('schema')));
     },
 
     error: function(msg, resp) {
@@ -775,23 +775,26 @@
       });
     },
 
-    sortSchema: function(schema, priorities) {
-      priorities = priorities || {
-        'cartodb_id': 100,
-        'the_geom': 99,
-        'created_at': 1,
-        'updated_at': 0,
-        '__default__': 2
+    sortSchema: function(schema) {
+      var priorities = {
+        'cartodb_id': 1,
+        'the_geom': 2,
+        '__default__': 3,
+        'created_at': 4,
+        'updated_at': 5
       };
-      var sc = _.clone(schema);
-      sc.sort(function(a, b) {
-        function priority(v) {
-          var pa = priorities[v];
-          return pa === undefined ? priorities['__default__']: pa;
-        }
-        return priority(b[0]) - priority(a[0]);
-      });
-      return sc;
+
+      function priority(v) {
+        return priorities[v] || priorities['__default__'];
+      }
+
+      return _.chain(schema)
+        .clone()
+        .sort() // alphabetically first..
+        .sort(function(a, b) { // ..and then re-sort by priorities defined above
+          return priority(a[0]) - priority(b[0]);
+        })
+        .value();
     },
 
     /**

--- a/lib/assets/test/spec/cartodb/models/table.spec.js
+++ b/lib/assets/test/spec/cartodb/models/table.spec.js
@@ -119,14 +119,13 @@ describe("admin table", function() {
       table = new cdb.admin.CartoDBTableMetadata({
         name: 'testTable',
         schema: [
-          ['baz', 'string'],
+          ['otra_foobar', 'string'],
           ['test2', 'number'],
-          ['foo', 'string'],
-          ['foo2', 'string'],
-          ['bar', 'string'],
-          ['foo1', 'string'],
-          ['the_geom', 'number'],
-          ['updated_at', 'number'],
+          ['_desc', 'string'],
+          ['other', 'string'],
+          ['the_geom', 'geometry'],
+          ["created_at", "date"],
+          ['updated_at', 'date'],
           ['cartodb_id', 'number']
         ]
       });
@@ -136,16 +135,16 @@ describe("admin table", function() {
 
       expect(table.get('schema')).toEqual([
           ['cartodb_id', 'number'],
-          ['the_geom', 'number'],
-          ['bar', 'string'],
-          ['baz', 'string'],
-          ['foo', 'string'],
-          ['foo1', 'string'],
-          ['foo2', 'string'],
+          ['the_geom', 'geometry'],
+          ['_desc', 'string'],
+          ['other', 'string'],
+          ['otra_foobar', 'string'],
           ['test2', 'number'],
-          ['updated_at', 'number']
+          ["created_at", "date"],
+          ["updated_at", "date"]
         ]
       );
+
       expect(changeSchemaSpy).toHaveBeenCalled();
     });
 

--- a/lib/assets/test/spec/cartodb/models/table.spec.js
+++ b/lib/assets/test/spec/cartodb/models/table.spec.js
@@ -119,23 +119,34 @@ describe("admin table", function() {
       table = new cdb.admin.CartoDBTableMetadata({
         name: 'testTable',
         schema: [
+          ['baz', 'string'],
           ['test2', 'number'],
+          ['foo', 'string'],
+          ['foo2', 'string'],
+          ['bar', 'string'],
+          ['foo1', 'string'],
           ['the_geom', 'number'],
           ['updated_at', 'number'],
           ['cartodb_id', 'number']
         ]
       });
-      var s = sinon.spy();
-      table.bind('change:schema', s);
+      var changeSchemaSpy = jasmine.createSpy();
+      table.bind('change:schema', changeSchemaSpy);
       table.sortSchema();
+
       expect(table.get('schema')).toEqual([
           ['cartodb_id', 'number'],
           ['the_geom', 'number'],
+          ['bar', 'string'],
+          ['baz', 'string'],
+          ['foo', 'string'],
+          ['foo1', 'string'],
+          ['foo2', 'string'],
           ['test2', 'number'],
           ['updated_at', 'number']
         ]
       );
-      expect(s.called).toEqual(true);
+      expect(changeSchemaSpy).toHaveBeenCalled();
     });
 
     it("should copy the types of the original schema" ,function() {
@@ -680,7 +691,7 @@ describe("admin table", function() {
     });
 
     it("should allow refresh all table data", function() {
-      spyOn(tableData.table, 'fetch').and.callFake(function(obj) { 
+      spyOn(tableData.table, 'fetch').and.callFake(function(obj) {
         obj.complete();
       });
       spyOn(tableData, 'fetch');


### PR DESCRIPTION
Fixes #2638

- Changed the `sortSchema` method to sort "default" items alphabetically i.e. items that should not be on a specific position according to the predefined priorities
- Removed the optional priorities param since it was not used anywhere

![screen shot 2015-03-18 at 15 48 19](https://cloud.githubusercontent.com/assets/978461/6711310/7a069104-cd86-11e4-8414-e25868980c6c.png)
