### PR TITLE
Prevents CartoCSS from parsing incorrect symbolizers

### DIFF
--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -784,8 +784,16 @@ cdb.admin.CartoParser.prototype = {
       this.definitions = defs = ruleset.toList(parse_env);
       var mapDef;
       for(var i in defs){
-        if(defs[i].elements[0].value === "Map"){
-          mapDef = defs.splice(i, 1)[0];
+        if(defs[i].elements.length > 0){
+            if(defs[i].elements[0].value === "Map"){
+                mapDef = defs.splice(i, 1)[0];
+            }
+        }
+        else{
+            parse_env.error({
+                message: 'Unknown symbolizer',
+                index: defs[i].specificity[defs[i].specificity.length-1]
+            });
         }
       }
       var symbolizers = torque.cartocss_reference.version.latest.layer;

--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -789,12 +789,6 @@ cdb.admin.CartoParser.prototype = {
                 mapDef = defs.splice(i, 1)[0];
             }
         }
-        else{
-            parse_env.error({
-                message: 'Unknown symbolizer',
-                index: defs[i].specificity[defs[i].specificity.length-1]
-            });
-        }
       }
       var symbolizers = torque.cartocss_reference.version.latest.layer;
       if (mapDef){


### PR DESCRIPTION
Ref #2845 
@javisantana 
![screen shot 2015-03-20 at 17 59 43](https://cloud.githubusercontent.com/assets/3707222/6756542/e98966d2-cf2a-11e4-8472-73bc9c86977d.png)
