### PR TITLE
Aborting old and unfinished visualization requests in new dashboard

### DIFF
--- a/lib/assets/javascripts/cartodb/dashboard/control/control_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/control/control_view.js
@@ -116,10 +116,14 @@
       this.hideBarLoader();
     },
 
-    _onDataError: function(e) {
-      this.hideMainLoader();
-      this.hideBarLoader();
-      this._showBlock(['subheader', 'error']);
+    _onDataError: function(col, e, opts) {
+      // Old requests can be stopped, so aborted requests are not
+      // considered as an error
+      if (!e || (e && e.statusText !== "abort")) {
+        this.hideMainLoader();
+        this.hideBarLoader();
+        this._showBlock(['subheader', 'error']);
+      }
     },
 
 

--- a/lib/assets/javascripts/cartodb/models/vis.js
+++ b/lib/assets/javascripts/cartodb/models/vis.js
@@ -476,6 +476,8 @@ cdb.admin.Visualizations = Backbone.Collection.extend({
     this.bind("update",         this._checkPage, this);
     this.bind("add",            this._fetchAgain, this);
 
+    // Overrriding default sync, preventing 
+    this.sync = Backbone.syncAbort;
   },
 
   getTotalPages: function() {

--- a/lib/assets/javascripts/cartodb/models/vis.js
+++ b/lib/assets/javascripts/cartodb/models/vis.js
@@ -477,6 +477,7 @@ cdb.admin.Visualizations = Backbone.Collection.extend({
     this.bind("add",            this._fetchAgain, this);
 
     // Overrriding default sync, preventing 
+    // run several request at the same time
     this.sync = Backbone.syncAbort;
   },
 

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create/listing/datasets_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create/listing/datasets_view.js
@@ -27,7 +27,13 @@ module.exports = cdb.core.View.extend({
     this.routerModel.bind('change', this._onRouterChange, this);
     this.collection.bind('loading', this._onDataLoading, this);
     this.collection.bind('reset', this._onDataFetched, this);
-    this.collection.bind('error', this._onDataError, this);
+    this.collection.bind('error', function() {
+      // Old requests can be stopped, so aborted requests are not
+      // considered as an error
+      if (!e || (e && e.statusText !== "abort")) {
+        this._onDataError()
+      }
+    }, this);
     this.add_related_model(this.routerModel);
     this.add_related_model(this.createModel);
     this.add_related_model(this.collection);

--- a/lib/assets/javascripts/cartodb/new_dashboard/content_controller_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/content_controller_view.js
@@ -26,7 +26,13 @@ module.exports = cdb.core.View.extend({
     this.collection.bind('reset', this._onDataFetched, this);
     this.collection.bind('loading', this._onDataLoading, this);
     this.collection.bind('add remove', this._onDataChange, this);
-    this.collection.bind('error', this._onDataError, this);
+    this.collection.bind('error', function(col, e, opts) {
+      // Old requests can be stopped, so aborted requests are not
+      // considered as an error
+      if (!e || (e && e.statusText !== "abort")) {
+        this._onDataError()
+      }
+    }, this);
 
     // Binding window scroll :(
     $(window).bind('scroll', this._onWindowScroll);

--- a/lib/assets/test/spec/cartodb/dashboard/dashboard_control_view.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/dashboard_control_view.spec.js
@@ -158,6 +158,22 @@ describe("Dashboard control view", function() {
     expect(view.hideBarLoader).toHaveBeenCalled();
   });
 
+  it("shouldn't show the error block when any collection fetch is aborted", function() {
+    router.model.set({ model: 'tables' }, { silent: true });
+    spyOn(view, 'hideBarLoader');
+    spyOn(view, 'hideMainLoader');
+    
+    tables.trigger('error', tables, { statusText: 'abort' } );
+    expect(view.$('.error').hasClass('active')).toBeFalsy();
+    expect(view.hideMainLoader).not.toHaveBeenCalled();
+    expect(view.hideBarLoader).not.toHaveBeenCalled();
+
+    visualizations.trigger('error', visualizations, { statusText: 'abort' });
+    expect(view.$('.error').hasClass('active')).toBeFalsy();
+    expect(view.hideMainLoader).not.toHaveBeenCalled();
+    expect(view.hideBarLoader).not.toHaveBeenCalled();
+  });
+
   it("should show tables or visualizations list when query search works", function() {
     router.model.set({ model: 'tables', q: 'table' });
     tables.total_entries = 1;

--- a/lib/assets/test/spec/cartodb/new_dashboard/content_controller_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/content_controller_view.spec.js
@@ -122,6 +122,15 @@ describe('new_dashboard/content_controller_view', function() {
       expect(_.size(this.view.enabledViews)).toBe(2);
     });
 
+    it('shouldn\'t show error block when collection fetch is aborted', function() {
+      this.router.model.set({ content_type: 'datasets' });
+      this.collection.trigger('loading');
+      expect(this.view._isBlockEnabled('error')).toBeFalsy();
+      this.collection.trigger('error', this.collection, { statusText: 'abort' }, {});
+      expect(this.view._isBlockEnabled('error')).toBeFalsy();
+      expect(_.size(this.view.enabledViews)).toBe(2);
+    });
+
     it('should redirect to library route when collection is empty and none of the filters are applied, being in datasets', function() {
       var url = '';
       var options;


### PR DESCRIPTION
When a user clicks over new dashboard tabs, several times, it makes several requests. Sometimes new ones finish before old ones, and UI could show wrong info. Aborting old requests avoid this problem.

#### PROS:
- User will see what he/she wants, related with the current selected section (or filter).
- It will work for **new** and **old dashboard**.

#### CONS:
- Unfortunately we need to check if the error comes from an 'abort' action before showing the error state.

REVIEWER: @javisantana 

Fixes #2737