### PR TITLE
Add healthcheck fail flag file

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,7 +7,7 @@ class HomeController < ApplicationController
   skip_before_filter :ensure_org_url_if_org_user
 
   def app_status
-    return head(500) if Cartodb.config[:disable_file] && File.exists?(File.expand_path(Cartodb.config[:disable_file]))
+    return head(503) if Cartodb.config[:disable_file] && File.exists?(File.expand_path(Cartodb.config[:disable_file]))
     db_ok    = Rails::Sequel.connection.select('OK').first.values.include?('OK')
     redis_ok = $tables_metadata.dbsize
     api_ok   = true

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,6 +7,7 @@ class HomeController < ApplicationController
   skip_before_filter :ensure_org_url_if_org_user
 
   def app_status
+    return head(500) if Cartodb.config[:disable_file] && File.exists?(File.expand_path(Cartodb.config[:disable_file]))
     db_ok    = Rails::Sequel.connection.select('OK').first.values.include?('OK')
     redis_ok = $tables_metadata.dbsize
     api_ok   = true

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -8,6 +8,7 @@ defaults: &defaults
   secret_token:       '71c2b25921b84a1cb21c71503ab8fb23'
   account_host:       'localhost.lan:3000'
   account_path:       '/account'
+  disable_file:       '~/disable'
   watcher:
     ttl:              60
   tiler:


### PR DESCRIPTION
This allows to set a config flag (disable_file on app_config) that will, on each health check, check for the existance of a given file.

If this file exists, the /status route will not perform any additional healthcheck and be forced to return 500.

cc @lbosque @Kartones 