### PR TITLE
Only create a new visualization when import comes from map section or dialog

### DIFF
--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create/create_model.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create/create_model.js
@@ -41,7 +41,13 @@ module.exports = cdb.core.Model.extend({
   initialize: function(val, opts) {
     this.user = opts && opts.user || {};
     this.selectedDatasets = new Backbone.Collection(opts && opts.selectedDatasets);
-    this.upload = new UploadModel({}, { user: this.user });
+    this.upload = new UploadModel({
+      // Only create a new visualization when 
+      // dialog purpose is for creating a new map
+      create_vis: val.type === "map"
+    }, {
+      user: this.user
+    });
     this.mapTemplate = new cdb.core.Model();
     this.vis = new cdb.admin.Visualization({ name: 'Untitled map' });
 
@@ -195,7 +201,8 @@ module.exports = cdb.core.Model.extend({
 
   setUpload: function(d) {
     if (d && !_.isEmpty(d)) {
-      this.upload.set(d);
+      // Set upload properties except create_vis (defined at the beginning)
+      this.upload.set(_.omit(d, 'create_vis'));
     } else {
       this.upload.clear();
     }

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
@@ -124,7 +124,19 @@ module.exports = cdb.core.View.extend({
 
   _onDroppedFile: function(files) {
     if (files) {
-      var imp = new ImportsModel({ upload: { type: 'file', value: files } }, { user: this.user })
+      var imp = new ImportsModel(
+        {
+          upload: {
+            type: 'file',
+            value: files,
+            // Only create a visualization from an import
+            // if user is in maps section
+            create_vis: this.router.model.isMaps()
+          }
+        }, {
+          user: this.user
+        }
+      );
       this.collection.add(imp);
     }
   },


### PR DESCRIPTION
This behaviour works for new create dialog (depending if user open 'connect data' or 'create map' dialog) and for new drag and drop (depending if user is in maps or datasets section).

cc @saleiva 

Fixes #2884