### PR TITLE
Don't including shared twice fixes #2899

### DIFF
--- a/app/models/visualization/collection.rb
+++ b/app/models/visualization/collection.rb
@@ -297,7 +297,8 @@ module CartoDB
       def add_liked_by_conditions_to_dataset(dataset, user_id)
         user_shared_vis = user_shared_vis(user_id)
         dataset = dataset.where { ( { privacy: [CartoDB::Visualization::Member::PRIVACY_PUBLIC, CartoDB::Visualization::Member::PRIVACY_LINK] } ) | ( { user_id: user_id } ) | ( { id: user_shared_vis } ) }
-        include_shared_entities(dataset, { user_id: user_id } )
+        # TODO: this probably introduces duplicates. See #2899. Should be removed when like count and list matches for organizations
+        #include_shared_entities(dataset, { user_id: user_id } )
       end
 
       def base_collection(filters)

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -480,6 +480,28 @@ describe Visualization::Collection do
       liked_count(user1).should eq 2
       liked(user2).count.should eq 2
       liked_count(user2).should eq 2
+
+      # Sharing a table won't count it as liked
+      table22 = create_table(user2)
+      v22 = table22.table_visualization
+      v22.privacy = Visualization::Member::PRIVACY_PRIVATE
+      v22.store
+      permission22 = v22.permission
+      permission22.acl = [ { type: CartoDB::Permission::TYPE_USER,
+          entity: {
+            id: user1.id,
+            username: user1.username
+          },
+          access: CartoDB::Permission::ACCESS_READONLY } ]
+      v22.stubs(:invalidate_cache_and_refresh_named_map).returns(nil)
+      permission22.stubs(:entity).returns(v22)
+      permission22.stubs(:notify_permissions_change).returns(nil)
+      permission22.save
+      liked(user1).count.should eq 2
+      liked_count(user1).should eq 2
+      liked(user2).count.should eq 2
+      liked_count(user2).should eq 2
+
     end
 
     it "checks filtering by 'liked' " do


### PR DESCRIPTION
@Kartones CR this fix for #2899, please. I haven't been able to reproduce it in local yet, but it still passes the previous tests, so probably commented line was not neccesary I think it's related to duplications and organization sharing.