### PR TITLE
Open create dialog object from any place

### DIFF
--- a/app/assets/stylesheets/new_dashboard/content-result.css.scss
+++ b/app/assets/stylesheets/new_dashboard/content-result.css.scss
@@ -116,6 +116,13 @@
   color: $cTypography-paragraphs;
   font-weight: $sFontWeight-lighter;
 }
+.ContentResult-textTitle {
+  color: $cTypography-link;
+  text-decoration: underline;
+  &:hover {
+    color: $cTypography-linkHover;
+  }
+}
 
 @include keyframes(pulsate) {
   0% {right:100%;}

--- a/lib/assets/javascripts/cartodb/new_dashboard/content_result_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/content_result_view.js
@@ -59,12 +59,12 @@ module.exports = cdb.core.View.extend({
     if (e) e.preventDefault();
 
     if (this.user && this.user.canCreateDatasets()) {
-      var createDialog = new CreateDialog({
-        clean_on_hide: true,
-        type: 'dataset',
-        user: this.user
-      });
-      createDialog.appendToBody();
+      cdb.god.trigger(
+        'openCreateDialog',
+        {
+          type: 'dataset'
+        }
+      );
     }
   }
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/entry.js
@@ -5,6 +5,8 @@ var MainView = require('./main_view');
 var sendUsageToMixpanel = require('./send_usage_to_mixpanel');
 var ChangePrivacyDialog = require('./dialogs/change_privacy_view');
 var ChangePrivacyViewModel = require('./dialogs/change_privacy/view_model');
+var CreateDialog = require('../new_common/dialogs/create/create_view');
+var DEFAULT_VIS_NAME = 'Untitled map';
 
 if (window.trackJs) {
   window.trackJs.configure({
@@ -32,8 +34,12 @@ $(function() {
       dashboardUrl: currentUser.viewUrl().dashboard()
     });
 
+    // Why not have only one collection?
+    var collection =  new cdb.admin.Visualizations();
+
     var dashboard = new MainView({
       el: document.body,
+      collection: collection,
       user: currentUser,
       config: window.config,
       router: router
@@ -66,6 +72,52 @@ $(function() {
         });
         dialog.appendToBody();
       }
+    });
+
+    cdb.god.bind('openCreateDialog', function(d) {
+      var createDialog = new CreateDialog({
+        type: d.type || 'map',
+        user: currentUser,
+        previewMap: d.previewMap,
+        selectedItems: d.selectedItems || [],
+        clean_on_hide: true
+      });
+
+      createDialog.bind('mapCreated', function(vis) {
+        window.location = vis.viewUrl().edit();
+      }, this);
+
+      createDialog.bind('datasetCreated', function(tableMetadata) {
+        if (router.model.isDatasets()) {
+          var vis = new cdb.admin.Visualization({ type: 'table' });
+          vis.permission.owner = currentUser;
+          vis.set('table', tableMetadata.toJSON());
+          window.location = vis.viewUrl(currentUser).edit();
+        } else {
+          var vis = new cdb.admin.Visualization({ name: DEFAULT_VIS_NAME });
+          vis.save({
+            tables: [ tableMetadata.get('id') ]
+          },{
+            success: function(m) {
+              window.location = vis.viewUrl().edit();
+            },
+            error: function(e) {
+              createDialog.close();
+              collection.trigger('error');
+            }
+          });  
+        }
+      }, this);
+      
+      createDialog.bind('datasetSelected', function(d) {
+        cdb.god.trigger('datasetSelected', d, this);
+      }, this);
+      
+      createDialog.bind('remoteSelected', function(d) {
+        cdb.god.trigger('remoteSelected', d, this);
+      }, this);
+      
+      createDialog.appendToBody();
     });
   });
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -4,7 +4,6 @@ var _ = require('underscore');
 var Utils = require('cdb.Utils');
 var navigateThroughRouter = require('../new_common/view_helpers/navigate_through_router');
 var pluralizeString = require('../new_common/view_helpers/pluralize_string');
-var CreateDialog = require('../new_common/dialogs/create/create_view');
 var DeleteItemsDialog = require('../new_dashboard/dialogs/delete_items_view');
 var ChangeLockDialog = require('../new_dashboard/dialogs/change_lock_view');
 var ChangeLockViewModel = require('./dialogs/change_lock_view_model');
@@ -21,8 +20,6 @@ var DeleteItemsViewModel = require('./dialogs/delete_items_view_model');
 module.exports = cdb.core.View.extend({
 
   _TOOLTIPS: ['js-likes', 'js-mapviews', 'js-updated_at', 'js-size'],
-
-  _DEFAULT_VIS_NAME: 'Untitled map',
 
   events: {
     'submit .js-search-form':   '_submitSearch',
@@ -277,44 +274,13 @@ module.exports = cdb.core.View.extend({
   },
 
   _openCreateDialog: function(type, selectedItems) {
-    var createDialog = new CreateDialog({
-      type: type || 'map',
-      user: this.user,
-      selectedItems: selectedItems ? this._selectedItems() : [],
-      clean_on_hide: true
-    });
-    createDialog.bind('mapCreated', function(vis) {
-      window.location = vis.viewUrl().edit();
-    }, this);
-    createDialog.bind('datasetCreated', function(tableMetadata) {
-      if (this.router.model.isDatasets()) {
-        var vis = new cdb.admin.Visualization({ type: 'table' });
-        vis.permission.owner = this.user;
-        vis.set('table', tableMetadata.toJSON());
-        window.location = vis.viewUrl(this.user).edit();
-      } else {
-        var vis = new cdb.admin.Visualization({ name: this._DEFAULT_VIS_NAME });
-        var self = this;
-        vis.save({
-          tables: [ tableMetadata.get('id') ]
-        },{
-          success: function(m) {
-            window.location = vis.viewUrl().edit();
-          },
-          error: function(e) {
-            createDialog.close();
-            self.collection.trigger('error');
-          }
-        });  
+    cdb.god.trigger(
+      'openCreateDialog',
+      {
+        type: type,
+        selectedItems: selectedItems ? this._selectedItems() : []
       }
-    }, this);
-    createDialog.bind('datasetSelected', function(d) {
-      cdb.god.trigger('datasetSelected', d, this);
-    }, this);
-    createDialog.bind('remoteSelected', function(d) {
-      cdb.god.trigger('remoteSelected', d, this);
-    }, this);
-    createDialog.appendToBody();
+    );
   },
 
   // Filter actions

--- a/lib/assets/javascripts/cartodb/new_dashboard/list_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/list_view.js
@@ -84,7 +84,6 @@ module.exports = cdb.core.View.extend({
         var m = new cdb.core.Model(d);
         var view = new PlaceholderItem({
           model: m,
-          user: this.user,
           collection: this.collection
         });
         this.$el.append(view.render().el);

--- a/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
@@ -26,9 +26,6 @@ module.exports = cdb.core.View.extend({
   },
 
   _initModels: function() {
-    // Why not have only one collection?
-    this.collection =  new cdb.admin.Visualizations();
-
     this.user = this.options.user;
     this.router = this.options.router;
     this.localStorage = new LocalStorage();

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/placeholder_item_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/placeholder_item_view.js
@@ -15,7 +15,6 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function() {
-    this.user = this.options.user;
     this.template = cdb.templates.getTemplate('new_dashboard/maps/placeholder_item');
   },
 
@@ -33,40 +32,13 @@ module.exports = cdb.core.View.extend({
   },
 
   _openCreateDialog: function() {
-    var createDialog = new CreateDialog({
-      type: 'map',
-      user: this.user,
-      previewMap: this.model.get('video').id,
-      clean_on_hide: true
-    });
-    createDialog.bind('mapCreated', function(vis) {
-      window.location = vis.viewUrl().edit();
-    }, this);
-    createDialog.bind('datasetCreated', function(tableMetadata) {
-      // Those cards are always present in maps section, so
-      // a new visualization is always required
-      var vis = new cdb.admin.Visualization({ name: 'Untitled map' });
-      var self = this;
-      vis.save({
-        tables: [ tableMetadata.get('id') ]
-      },{
-        success: function(m) {
-          window.location = vis.viewUrl().edit();
-        },
-        error: function(e) {
-          createDialog.close();
-          self.collection.trigger('error');
-        }
-      });
-    }, this);
-    createDialog.bind('datasetSelected', function(d) {
-      cdb.god.trigger('datasetSelected', d, this);
-    }, this);
-    createDialog.bind('remoteSelected', function(d) {
-      cdb.god.trigger('remoteSelected', d, this);
-    }, this);
-
-    createDialog.appendToBody();
+    cdb.god.trigger(
+      'openCreateDialog',
+      {
+        type: 'map',
+        previewMap: this.model.get('video').id
+      }
+    );
   }
 
 });

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/content_no_datasets.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/content_no_datasets.jst.ejs
@@ -1,2 +1,4 @@
 <h4 class="IntermediateInfo-title">You have not connected any dataset yet</h4>
-<p class="DefaultParagraph">Connect your data with a click or start with one of the datasets from the data library listed below.</p>
+<p class="DefaultParagraph">
+  <button class="ContentResult-textTitle js-connect">Connect your data</button> with a click or start with one of the datasets from the data library listed below.
+</p>

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/filters.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/filters.jst.ejs
@@ -105,15 +105,17 @@
                 <a class="Filters-actionsLink js-deselect_all" href="#/deselect-all">Deselect all <%= tag || q ? 'yours' : '' %></a>
               <% } %>
             </li>
-            <% if (content_type === "datasets" && !liked) { %>
-              <li class="Filters-actionsItem">
-                <% if (selectedItemsCount <= maxLayersByMap) { %>
-                  <a class="Filters-actionsLink js-create_map" href="#/create-map">Create map</a>
-                <% } else { %>
-                  <span class="Filters-actionsText">Max map layers selected (<%= maxLayersByMap %> max)</span>
-                <% } %>
-              </li>
-            <% } %>
+          <% } %>
+          <% if (content_type === "datasets" && !liked) { %>
+            <li class="Filters-actionsItem">
+              <% if (selectedItemsCount <= maxLayersByMap) { %>
+                <a class="Filters-actionsLink js-create_map" href="#/create-map">Create map</a>
+              <% } else { %>
+                <span class="Filters-actionsText">Max map layers selected (<%= maxLayersByMap %> max)</span>
+              <% } %>
+            </li>
+          <% } %>
+          <% if (shared !== "only" && shared !== "yes" && !library) { %>
             <% if (selectedItemsCount === 1 && !liked) { %>
               <li class="Filters-actionsItem">
                 <a class="Filters-actionsLink js-privacy" href="#/change-privacy">Change privacy...</a>

--- a/lib/assets/test/spec/cartodb/new_dashboard/filters_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/filters_view.spec.js
@@ -149,13 +149,13 @@ describe('new_dashboard/filters_view', function() {
         this.collection.reset([{ selected: true }]);
         this.router.model.set('content_type', 'datasets');
         console.log(this.user.get('max_layers'));
-        expect(this.innerHTML()).toContain('Create map');
+        expect(this.view.$('.js-create_map').length).toBe(1);
       });
 
       it('should not be displayed when selected items are not datasets', function() {
         this.router.model.set('content_type', 'maps');
         this.collection.reset([{ selected: true }]);
-        expect(this.innerHTML()).not.toContain('Create map');
+        expect(this.view.$('.js-create_map').length).toBe(0);
       });
 
       it('should not be displayed when user is in liked section', function() {
@@ -164,14 +164,24 @@ describe('new_dashboard/filters_view', function() {
           liked: true
         });
         this.collection.reset([{ selected: true }]);
-        expect(this.innerHTML()).not.toContain('Create map');
+        expect(this.view.$('.js-create_map').length).toBe(0);
+      });
+
+      it('should be displayed when user is in data library section', function() {
+        this.router.model.set({
+          content_type: 'datasets',
+          library: true,
+          liked: false
+        });
+        this.collection.reset([{ selected: true }]);
+        expect(this.view.$('.js-create_map').length).toBe(1);
       });
 
       it('should not be displayed when number of selected items are bigger than available layers per map', function() {
         this.user.set('max_layers', 1);
         this.router.model.set('content_type', 'datasets');
         this.collection.reset([{ selected: true }, { selected: true }]);
-        expect(this.innerHTML()).not.toContain('Create map');
+        expect(this.view.$('.js-create_map').length).toBe(0);
         expect(this.innerHTML()).toContain('Max map layers selected');
       });
 


### PR DESCRIPTION
### What does it mean?

Before those changes, create dialog was created + opened from the place where user decided to make an action. That means, for example, if the user wanted to create a map using filter options, that view created a new create-dialog.

Now it has been replaced by something more logic, god will send a signal about the decision to open a new create-dialog (with optional parameters), and in the entry point of the view we will have a listener waiting to open that dialog at any time.

![create](https://cloud.githubusercontent.com/assets/132146/6846978/03de8b56-d3c3-11e4-8244-4ff3941298be.gif)


Fixes #2913.