### PR TITLE
Fix image infowindows

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
@@ -17,6 +17,13 @@
     initialize: function() {
       this._setupModel();
       this._setupTemplate();
+
+      // An internal collection to keep track of the fields and their order
+      this.sortedFields = new Backbone.Collection;
+      this.sortedFields.comparator = function(model) {
+        return model.get('position');
+      }
+
       this.render();
     },
 
@@ -30,6 +37,8 @@
       this.renderFields();
       this.$selectAll = this.$el.find(".selectall");
       this.renderSelectAll();
+
+      this._storeSortedFields();
 
       return this;
     },
@@ -86,7 +95,7 @@
     _selectAll: function() {
       var self = this;
 
-      var names = this._getColumnNamesFromView();
+      var names = this.sortedFields.map(function(w){return w.get('name')});
       var count = _.size(names) - 1;
       var promises = [];
 
@@ -160,24 +169,48 @@
       this.$('div.all').hide();
     },
 
+    _storeSortedFields: function() {
+      var self = this;
+
+      if (this.model.fieldCount() > 0) {
+        this.sortedFields.reset([]);
+
+        var names = this._getSortedColumnNames();
+        _(names).each(function(name, position) {
+          self.sortedFields.add({
+            name: name,
+            position: position
+          })
+        });
+      }
+    },
+
+    _getSortedColumnNames: function() {
+      var self = this;
+      var names = this.getColumnNames();
+      names.sort(function(a, b) {
+        var pos_a = self.model.getFieldPos(a);
+        var pos_b = self.model.getFieldPos(b);
+        return pos_a - pos_b;
+      });
+      return names;
+    },
     // when fields are sorted in the iu we should recalculate all models positions
     _reasignPositions: function() {
       var self = this;
+      this.sortedFields.reset([]);
+
+      // Get the order of fields 
       this.$el.find('.drag_field').each(function(i, el) {
         var v = self._subviews[$(el).attr('cid')];
         v.model.setFieldProperty(v.fieldName, 'position', i);
         v.position = i;
-      });
-    },
 
-    _getColumnNamesFromView: function() {
-      var self = this;
-      var columnNames = [];
-      this.$el.find('.drag_field').each(function(i, el) {
-        var subview = self._subviews[$(el).attr('cid')];
-        columnNames.push(subview.fieldName);
-      })
-      return columnNames;
+        self.sortedFields.add({
+          name: v.fieldName,
+          position: i
+        })
+      });
     }
 
   });

--- a/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
@@ -86,10 +86,9 @@
     _selectAll: function() {
       var self = this;
 
-      var
-      names    = this.getColumnNames(),
-      count    = _.size(names) - 1,
-      promises = [];
+      var names = this._getColumnNamesFromView();
+      var count = _.size(names) - 1;
+      var promises = [];
 
       _(names).each(function(f) {
         self.working = true;
@@ -135,8 +134,8 @@
       });
 
       _(names).each(function(f, i) {
-        // when there are no fields selected sort using the view list position
-        var pos = self.model.fieldCount() ?  self.model.getFieldPos(f): i;
+        // when there are no fields selected, sort using the view list position
+        var pos = self.model.fieldCount() ?  self.model.getFieldPos(f) : i;
         var v = new cdb.admin.mod.InfowindowField({
           model: self.model,
           field: f,
@@ -146,7 +145,7 @@
         $f.append(v.render().el);
       });
 
-      // Sorteable list, except theme field!
+      // Sortable list, except theme field!
       $f.sortable({
         items: 'li',
         handle: 'span.ellipsis',
@@ -169,6 +168,16 @@
         v.model.setFieldProperty(v.fieldName, 'position', i);
         v.position = i;
       });
+    },
+
+    _getColumnNamesFromView: function() {
+      var self = this;
+      var columnNames = [];
+      this.$el.find('.drag_field').each(function(i, el) {
+        var subview = self._subviews[$(el).attr('cid')];
+        columnNames.push(subview.fieldName);
+      })
+      return columnNames;
     }
 
   });

--- a/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
@@ -50,31 +50,25 @@
     },
 
     renderSelectAll: function() {
-      var select_all = true
-        , self = this;
-      _(this.getColumnNames()).each(function(f) {
-        if (!self.model.containsField(f)) {
-          select_all = false;
-        }
-      });
-
-      this.selectedAll = select_all;
-
+      this.selectedAll = this._allFieldsSelected();
       this._changeSelectAll();
     },
 
-    _changeSelectAll: function() {
-      if (!this.working) {
-        this.$selectAll.removeClass("working");
-
-        if (!this.selectedAll) {
-          this.$selectAll.addClass("disabled").removeClass("enabled");
-        } else {
-          this.$selectAll.addClass("enabled").removeClass("disabled");
+    _allFieldsSelected: function() {
+      var self = this;
+      var selectedAll = true;
+      _(this.getColumnNames()).each(function(field) {
+        if (!self.model.containsField(field)) {
+          selectedAll = false;
         }
-      } else {
-        this.$selectAll.addClass("enabled working");
-      }
+      });
+      return selectedAll;
+    },
+
+    _changeSelectAll: function() {
+      this.$selectAll.toggleClass("working", this.working);
+      this.$selectAll.toggleClass("enabled", this.selectedAll);
+      this.$selectAll.toggleClass("disabled", !this.selectedAll);
     },
 
     _manageAll: function(e) {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
@@ -35,7 +35,7 @@
 
       this.$el.find('.fields').sortable("destroy")
       this.renderFields();
-      this.$selectAll = this.$el.find(".selectall");
+      this.$selectAll = this.$(".selectall");
       this.renderSelectAll();
 
       this._storeSortedFields();

--- a/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
@@ -128,8 +128,8 @@
       }
 
       names.sort(function(a, b) {
-        var pos_a = self.model.getFieldPos(a, 'position');
-        var pos_b = self.model.getFieldPos(b, 'position');
+        var pos_a = self.model.getFieldPos(a);
+        var pos_b = self.model.getFieldPos(b);
         return pos_a - pos_b;
       });
 

--- a/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
@@ -224,9 +224,9 @@ describe("mod.infowindow", function() {
 
       it("should remember the position of the fields when unselecting and re-selecting all the fields", function() {
         model.set('fields', [
-          { name: 'name3', title: false, position: 2 },
-          { name: 'name2', title: false, position: 0},
-          { name: 'name1', title: false, position: 1 }
+          { name: 'name2', title: false, position: 0 },
+          { name: 'name1', title: false, position: 1 },
+          { name: 'name3', title: false, position: 2 }
         ]);
 
         view.render();
@@ -241,8 +241,8 @@ describe("mod.infowindow", function() {
         view.$el.find('.selectall').trigger('click');
 
         // All fields maintain their previous position
-        expect(model.getFieldPos('name1')).toEqual(1);
         expect(model.getFieldPos('name2')).toEqual(0);
+        expect(model.getFieldPos('name1')).toEqual(1);
         expect(model.getFieldPos('name3')).toEqual(2);
       })
 

--- a/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
@@ -222,6 +222,30 @@ describe("mod.infowindow", function() {
         });
       });
 
+      it("should remember the position of the fields when unselecting and re-selecting all the fields", function() {
+        model.set('fields', [
+          { name: 'name3', title: false, position: 2 },
+          { name: 'name2', title: false, position: 0},
+          { name: 'name1', title: false, position: 1 }
+        ]);
+
+        view.render();
+
+        // Unselect all
+        view.$el.find('.selectall').trigger('click');
+
+        // No fields are selected
+        expect(model.fieldCount()).toEqual(0);
+
+        // Select all again
+        view.$el.find('.selectall').trigger('click');
+
+        // All fields maintain their previous position
+        expect(model.getFieldPos('name1')).toEqual(1);
+        expect(model.getFieldPos('name2')).toEqual(0);
+        expect(model.getFieldPos('name3')).toEqual(2);
+      })
+
       it("should toggle titles", function() {
         view.render();
         model.addField('name1').addField('name2');

--- a/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
@@ -12,13 +12,13 @@ describe("mod.infowindow", function() {
     };
 
     table = new cdb.admin.CartoDBTableMetadata({
-        name: 'testTable',
-        schema: [
-          ['name1', 'string'],
-          ['name2', 'number'],
-          ['name3', 'number']
-        ]
-      });
+      name: 'testTable',
+      schema: [
+        ['name1', 'string'],
+        ['name2', 'number'],
+        ['name3', 'number']
+      ]
+    });
 
     view = new cdb.admin.mod.InfoWindow({
       el: $('<div>'),
@@ -222,28 +222,30 @@ describe("mod.infowindow", function() {
         });
       });
 
-      it("should remember the position of the fields when unselecting and re-selecting all the fields", function() {
+      it("should remember the position of the fields after reordering and selecting all", function() {
         model.set('fields', [
           { name: 'name2', title: false, position: 0 },
           { name: 'name1', title: false, position: 1 },
-          { name: 'name3', title: false, position: 2 }
         ]);
 
         view.render();
 
-        // Unselect all
+        expect(model.fieldCount()).toEqual(2);
+
+        // Drag and drop one field
+        var firstField = view.$el.find('.drag_field')[0];
+        view.$el.append(firstField);
+        view._reasignPositions();
+
+        // Select all
         view.$el.find('.selectall').trigger('click');
 
-        // No fields are selected
-        expect(model.fieldCount()).toEqual(0);
+        expect(model.fieldCount()).toEqual(3);
 
-        // Select all again
-        view.$el.find('.selectall').trigger('click');
-
-        // All fields maintain their previous position
-        expect(model.getFieldPos('name2')).toEqual(0);
-        expect(model.getFieldPos('name1')).toEqual(1);
-        expect(model.getFieldPos('name3')).toEqual(2);
+        // Fields are in the right position
+        expect(model.getFieldPos('name1')).toEqual(0);
+        expect(model.getFieldPos('name3')).toEqual(1);
+        expect(model.getFieldPos('name2')).toEqual(2);
       })
 
       it("should toggle titles", function() {


### PR DESCRIPTION
(opened for discussion)

This PR fixes #1970. The way I have been able to reproduce the problem was:

1. Open a visualization where you have some image field.
2. Open the infowindow pane and disable all fields.
3. Reorder some fields and make sure that the field with the image url is at the top.
4. Select all fields using the "All" switch.

The Infowindow will say that the image url is invalid, even if you have a valid url and the field with the image is at the top. The reason is that we're getting the columns from the table and adding them as fields in the wrong order. More specifically, we're just iterating through the names of the columns, without considering the position they are currently in.

I've introduced [this method](https://github.com/CartoDB/cartodb/compare/1970-image-infowindows?expand=1#diff-d643227951c49f2a9a5d811b3fed2f0fR173) that gets the column names from the view, which is the only place where the order is right. But **it doesn't feel right to ask the view for that**.

@xavijam @javisantana @viddo @javierarce Any ideas on how to do it better? 