### PR TITLE
Do not show the "No georeference data dialog" when the dataset is empty

### DIFF
--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -633,13 +633,14 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
   checkGeoRef: function() {
     if(this.options && this.table) {
-      if(!this.table.isGeoreferenced()) {
-        this.showNoGeoRefWarning();
-        this.georeferenced = false;
-      } else {
-        this.georeferenced = true;
+      this.georeferenced = this.table.isGeoreferenced();
+      if(this.georeferenced) {
         if(this.noGeoRefDialog) {
           this.noGeoRefDialog.hide();
+        }
+      } else {
+        if (this.table.data().length > 0) {
+          this.showNoGeoRefWarning();
         }
       }
     }
@@ -1521,12 +1522,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
    * @method showNoGeorefWarning
    */
   showNoGeoRefWarning: function() {
-    var warningStorageName = '';
-    if(this.table.data().length > 0) {
-      warningStorageName = 'georefContentWarningShowed' + this.table.id;
-    } else {
-      warningStorageName = 'georefNoContentWarningShowed' + this.table.id;
-    }
+    var warningStorageName = 'georefNoContentWarningShowed' + this.table.id;
 
     // if the dialog already has been shown, we don't show it again
     if(!this.noGeoRefDialog && !this.table.isInSQLView() && (!localStorage[warningStorageName])) {

--- a/lib/assets/javascripts/cartodb/table/noGeoRefData_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/noGeoRefData_dialog.js
@@ -17,10 +17,6 @@ cdb.admin.NoGeoRefDataDialog = cdb.admin.BaseDialog.extend({
                 appear to be georeferenced. You will not see anything on the map if \
                 your records are not georeferenced. Click on Georeference if you want \
                 to use a geocoder to get location out of your data, or cancel.'),
-    no_content: _t('There seems to be no data on this layer, so there is nothing \
-                to represent on the map. You can add some data or run SQL queries \
-                to select some.'),
-    close:      _t('Ok, close'),
     georef:     _t('Georeference'),
     cancel:     _t('Cancel')
   },
@@ -51,13 +47,9 @@ cdb.admin.NoGeoRefDataDialog = cdb.admin.BaseDialog.extend({
    */
   render_content: function() {
     this.hasContent = (this.model._data.length  > 0);
-    this.$('a.ok').text(this.hasContent ? this._TEXTS.georef : this._TEXTS.close );
+    this.$('a.ok').text(this._TEXTS.georef);
     
-    if (!this.hasContent) {
-      this.$('a.cancel').hide();
-    }
-    
-    return this.hasContent ? this._TEXTS.content : this._TEXTS.no_content;
+    return this._TEXTS.content;
   },
 
   _onGeocodingChosen: function(data) {

--- a/lib/assets/test/spec/cartodb/table/mapview.spec.js
+++ b/lib/assets/test/spec/cartodb/table/mapview.spec.js
@@ -58,65 +58,52 @@ describe("mapview", function() {
     expect(view.$('.basemap_dropdown').length).toEqual(1);
   });
 
-  it("should trigger the georef warning when there's no geom in the table", function() {
+  it("should trigger the georef warning when none of the rows contain geom info", function() {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], []);
+    view.table._data.reset([
+      {'the_geom':'', 'name': 'Benidorm'},
+      {'the_geom':'', 'name': 'San Juan'},
+    ]);
     view.bindGeoRefCheck();
     view.render();
     view.table.trigger("dataLoaded");
     expect(view.noGeoRefDialog).toBeTruthy()
   });
 
-  it("should trigger the georef warning when there's no data in the table", function() {
+  it("should trigger the georef warning only once when there's no geom in the table", function() {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], []);
+    view.table._data.reset([
+      {'the_geom':'', 'name': 'Benidorm'}
+    ]);
+    view.bindGeoRefCheck();
+    view.render();
+    view.table.trigger("dataLoaded");
+    view.noGeoRefDialog.clean();
+    view.noGeoRefDialog = undefined;
+    view.table.trigger("dataLoaded");
+    expect(view.noGeoRefDialog === undefined).toEqual(true);
+  });
+
+  it("should NOT trigger the georef warning when there's no data in the table", function() {
     view.table = TestUtil.createTable('test', [['the_geom', 'geometry']], []);
     view.bindGeoRefCheck();
     view.render();
     view.table.trigger("dataLoaded");
-    expect(view.noGeoRefDialog).toBeTruthy()
+    expect(view.noGeoRefDialog === undefined).toEqual(true);
   });
 
-  it("should NOT trigger the georef warning when there the_geom and data in the table", function() {
-    view.table = TestUtil.createTable('test', [['the_geom', 'geometry']], []);
-    view.table._data.reset([{'the_geom':'{"type":"Point","coordinates":["1","1"]}'}]);
+  it("should NOT trigger the georef warning when there is some data with geom info", function() {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], []);
+    view.table._data.reset([
+      {'the_geom':'{"type":"Point","coordinates":["1","1"]}', 'name': 'Benidorm'},
+      {'the_geom':'', 'name': 'San Juan'},
+    ]);
     view.bindGeoRefCheck();
     view.render();
-
     view.table.trigger("dataLoaded");
     // toBeFalsy failes due a infinite loop in jasmine formatter
     expect(view.noGeoRefDialog === undefined).toEqual(true);
   });
-
-  it("should trigger the georef warning only once when there's no geom in the table", function() {
-    view.bindGeoRefCheck();
-    view.render();
-    view.table.trigger("dataLoaded");
-    view.noGeoRefDialog.clean();
-    view.noGeoRefDialog = undefined;
-    view.table.trigger("dataLoaded");
-    expect(view.noGeoRefDialog === undefined).toEqual(true);
-  });
-
-  it("should trigger the georef only once warning when there's no data in the table", function() {
-    view.table = TestUtil.createTable('test', [['the_geom', 'geometry']], []);
-    view.bindGeoRefCheck();
-    view.render();
-    view.table.trigger("dataLoaded");
-    view.noGeoRefDialog.clean();
-    view.noGeoRefDialog = undefined;
-    view.table.trigger("dataLoaded");
-    expect(view.noGeoRefDialog === undefined).toEqual(true);
-  });
-
-  it("should trigger the georef again when formerly there were any data and now there are data but not georeferenced", function() {
-    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], []);
-    view.bindGeoRefCheck();
-    view.render();
-    view.table.trigger("dataLoaded");
-    view.noGeoRefDialog.clean();
-    view.noGeoRefDialog = undefined;
-    view.table._data.reset([{'name':'tralará'}]);
-    view.table.trigger("dataLoaded");
-    expect(view.noGeoRefDialog).toBeTruthy();
-  });
-
 
   it("should have a geocoding binding each time map view is rendered", function() {
     view.render();


### PR DESCRIPTION
The dialog is now only displayed when there are some rows but none of them have geom info.

Fixes #2873.

@xavijam @javisantana PTAL. thx!