### PR TITLE
Multiplies opacity by [value] by default

### DIFF
--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -162,8 +162,11 @@ function simple_polygon_generator(table, props, changed, callback) {
   // layer with non-text properties
   var generalLayer = "#" + table.getUnqualifiedName() + "{\n" + generalLayerProps.join('\n') + "\n}";
   var textLayer = '';
-  if(_.size(textLayerProps)) {
+  if (_.size(textLayerProps)) {
     textLayer = "\n\n#" + table.getUnqualifiedName() + "::labels {\n" + textLayerProps.join('\n') + "\n}\n";
+  }
+  if (typeof props['image-filters'] !== 'undefined' && props["image-filters"].indexOf('colorize') > -1) {
+    generalLayer = generalLayer.replace("marker-fill-opacity:", "marker-fill-opacity: [value]*");
   }
 
   // text properties layer

--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -165,9 +165,6 @@ function simple_polygon_generator(table, props, changed, callback) {
   if (_.size(textLayerProps)) {
     textLayer = "\n\n#" + table.getUnqualifiedName() + "::labels {\n" + textLayerProps.join('\n') + "\n}\n";
   }
-  if (typeof props['image-filters'] !== 'undefined' && props["image-filters"].indexOf('colorize') > -1) {
-    generalLayer = generalLayer.replace("marker-fill-opacity:", "marker-fill-opacity: [value]*");
-  }
 
   // text properties layer
   callback(generalLayer + textLayer);

--- a/lib/assets/javascripts/cartodb/models/carto/torque.js
+++ b/lib/assets/javascripts/cartodb/models/carto/torque.js
@@ -33,6 +33,9 @@ cdb.admin.carto.torque = {
 
     simple_polygon_generator(table, carto_props, changed, function(css) {
       // add trails
+      if (carto_props['type'] === 'torque_heat') {
+        css = css.replace("marker-fill-opacity:", "marker-fill-opacity: [value]*");
+      }
       for (var i = 1; i <= props['torque-trails']; ++i) {
        var trail = "\n#" + table.getUnqualifiedName() + "[frame-offset=" + i  +"] {\n marker-width:" + (props['marker-width'] + 2*i) + ";\n marker-fill-opacity:" + (props['marker-opacity']/(2*i)) +"; \n}";
        css += trail;

--- a/lib/assets/javascripts/cartodb/models/carto/torque.js
+++ b/lib/assets/javascripts/cartodb/models/carto/torque.js
@@ -34,7 +34,7 @@ cdb.admin.carto.torque = {
     simple_polygon_generator(table, carto_props, changed, function(css) {
       // add trails
       if (carto_props['type'] === 'torque_heat') {
-        var alreadyValue = css.split("\n").some(function(e){e.indexOf("marker-fill-opacity")>-1 && e.indexOf("[value]")>-1});
+        var alreadyValue = css.split("\n").some(function(e){return e.indexOf("marker-fill-opacity")>-1 && e.indexOf("[value]")>-1});
         if(!alreadyValue){
           css = css.replace("marker-fill-opacity:", "marker-fill-opacity: [value]*");
         }

--- a/lib/assets/javascripts/cartodb/models/carto/torque.js
+++ b/lib/assets/javascripts/cartodb/models/carto/torque.js
@@ -34,7 +34,10 @@ cdb.admin.carto.torque = {
     simple_polygon_generator(table, carto_props, changed, function(css) {
       // add trails
       if (carto_props['type'] === 'torque_heat') {
-        css = css.replace("marker-fill-opacity:", "marker-fill-opacity: [value]*");
+        var alreadyValue = css.split("\n").some(function(e){e.indexOf("marker-fill-opacity")>-1 && e.indexOf("[value]")>-1});
+        if(!alreadyValue){
+          css = css.replace("marker-fill-opacity:", "marker-fill-opacity: [value]*");
+        }
       }
       for (var i = 1; i <= props['torque-trails']; ++i) {
        var trail = "\n#" + table.getUnqualifiedName() + "[frame-offset=" + i  +"] {\n marker-width:" + (props['marker-width'] + 2*i) + ";\n marker-fill-opacity:" + (props['marker-opacity']/(2*i)) +"; \n}";

--- a/lib/assets/javascripts/cartodb/models/carto/torque.js
+++ b/lib/assets/javascripts/cartodb/models/carto/torque.js
@@ -30,15 +30,14 @@ cdb.admin.carto.torque = {
       carto_props['comp-op'] = props['torque-blend-mode'];
     }
 
+    if (carto_props['type'] === 'torque_heat') {
+      if(typeof carto_props['marker-opacity'] === 'number'){
+        carto_props['marker-opacity'] += "*[value]";
+      }
+    }
 
     simple_polygon_generator(table, carto_props, changed, function(css) {
       // add trails
-      if (carto_props['type'] === 'torque_heat') {
-        var alreadyValue = css.split("\n").some(function(e){return e.indexOf("marker-fill-opacity")>-1 && e.indexOf("[value]")>-1});
-        if(!alreadyValue){
-          css = css.replace("marker-fill-opacity:", "marker-fill-opacity: [value]*");
-        }
-      }
       for (var i = 1; i <= props['torque-trails']; ++i) {
        var trail = "\n#" + table.getUnqualifiedName() + "[frame-offset=" + i  +"] {\n marker-width:" + (props['marker-width'] + 2*i) + ";\n marker-fill-opacity:" + (props['marker-opacity']/(2*i)) +"; \n}";
        css += trail;

--- a/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
@@ -687,7 +687,7 @@ cdb.admin.forms.torque_heat = {
     {
       name: 'Opacity',
       form: {
-        'marker-opacity': { type: 'opacity' , value: "0.4" }
+        'marker-opacity': { type: 'opacity' , value: 0.4 }
       }
     },
     {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
@@ -687,7 +687,7 @@ cdb.admin.forms.torque_heat = {
     {
       name: 'Opacity',
       form: {
-        'marker-opacity': { type: 'opacity' , value: 0.4 }
+        'marker-opacity': { type: 'opacity' , value: "0.4" }
       }
     },
     {


### PR DESCRIPTION
Ref #2125 

By default, appends ```*[value]``` to the ```marker-fill-opacity``` rule of the torque visualisation's cartocss. This makes heatmaps be weighed by the value generated through ```-torque-aggregation-function```.

The change is not applied retroactively, but any change to the visualisation through the wizard will trigger it.

@javisantana 
cc @iriberri, @andrewxhill  