### PR TITLE
Fixing problems related with delete and lock dialogs

### DIFF
--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create/listing/datasets_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create/listing/datasets_view.js
@@ -27,7 +27,7 @@ module.exports = cdb.core.View.extend({
     this.routerModel.bind('change', this._onRouterChange, this);
     this.collection.bind('loading', this._onDataLoading, this);
     this.collection.bind('reset', this._onDataFetched, this);
-    this.collection.bind('error', function() {
+    this.collection.bind('error', function(e) {
       // Old requests can be stopped, so aborted requests are not
       // considered as an error
       if (!e || (e && e.statusText !== "abort")) {

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_lock_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/change_lock_view.js
@@ -42,10 +42,6 @@ module.exports = BaseDialog.extend({
     return this['_render' + this._viewModel.state()]();
   },
 
-  cancel: function() {
-    this.clean();
-  },
-
   _renderConfirmChangeLock: function() {
     // An entity can be an User or Organization
     var itemsCount = this._viewModel.length;

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
@@ -33,9 +33,7 @@ module.exports = BaseDialog.extend({
     this._viewModel = this.options.viewModel;
     this._viewModel.loadPrerequisites();
     this._viewModel.bind('change', function() {
-      debugger;
       if (this._viewModel.state() === 'DeleteItemsDone') {
-        debugger;
         this.close();
       } else {
         this.render();

--- a/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/dialogs/delete_items_view.js
@@ -33,7 +33,9 @@ module.exports = BaseDialog.extend({
     this._viewModel = this.options.viewModel;
     this._viewModel.loadPrerequisites();
     this._viewModel.bind('change', function() {
+      debugger;
       if (this._viewModel.state() === 'DeleteItemsDone') {
+        debugger;
         this.close();
       } else {
         this.render();
@@ -53,10 +55,6 @@ module.exports = BaseDialog.extend({
    */
   render_content: function() {
     return this['_render' + this._viewModel.state()]();
-  },
-
-  cancel: function() {
-    this.clean();
   },
 
   _renderLoadingPrerequisites: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -205,7 +205,6 @@ module.exports = cdb.core.View.extend({
       clean_on_hide: true,
       enter_to_confirm: true
     });
-    this.addView(view);
 
     view.appendToBody();
   },
@@ -224,7 +223,6 @@ module.exports = cdb.core.View.extend({
       clean_on_hide: true,
       enter_to_confirm: true
     });
-    this.addView(view);
 
     view.appendToBody();
   },

--- a/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
@@ -90,9 +90,11 @@ module.exports = cdb.core.View.extend({
     });
 
     cdb.god.bind('dialogOpened', function() {
+      console.log("dialog opened");
       mamufasView.disable();
     }, this);
     cdb.god.bind('dialogClosed', function() {
+      console.log("dialog closed");
       mamufasView.enable();
     }, this);
 
@@ -128,8 +130,11 @@ module.exports = cdb.core.View.extend({
 
   // In case user clicks out of any dialog "body" will fire
   // a closeDialogs event
-  _onClick: function() {
-    cdb.god.trigger("closeDialogs");
+  _onClick: function(e) {
+    var $dialog = $(e.target).closest('.Dialog');
+    if ($dialog.length === 0) {
+      cdb.god.trigger("closeDialogs");
+    }
   }
 
 });

--- a/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
@@ -90,11 +90,9 @@ module.exports = cdb.core.View.extend({
     });
 
     cdb.god.bind('dialogOpened', function() {
-      console.log("dialog opened");
       mamufasView.disable();
     }, this);
     cdb.god.bind('dialogClosed', function() {
-      console.log("dialog closed");
       mamufasView.enable();
     }, this);
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/mamufas_import_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/mamufas_import_view.js
@@ -83,15 +83,21 @@ module.exports = cdb.core.View.extend({
   },
 
   enable: function() {
-    this._createDragster();
-    this._createDropzone();
-    this._initBinds();
+    if (!this.model.get('visible')) {
+      this._createDragster();
+      this._createDropzone();
+      this._initBinds();
+      this.model.set('visible', true);
+    }
   },
 
   disable: function() {
-    this._removeBinds();
-    this._destroyDragster();
-    this._destroyDropzone();
+    if (this.model.get('visible')) {
+      this._removeBinds();
+      this._destroyDragster();
+      this._destroyDropzone();  
+      this.model.set('visible', false);
+    }
   },
 
   clean: function() {


### PR DESCRIPTION
Several fixes here:

1) We have a bind in new-dashboard main view that if you click anywhere, it triggers a 'closeDialog' event. That is a bit strange when you are viewing a dialog, so it will check if user is already in a dialog and it will not trigger that event (fixes #2935).

2) We have a problem with ```Lock``` and ```Delete``` dialogs in ```Filters``` view. After creating the object, we usually add them as a subview in ```Filters```, so it provoked a problem when filters view was rendered again, because that view clears all subviews, where those dialogs were added. It is not necessary because each dialog is deleted from the DOM when they are closed (fixes #2936).

3) ```Lock``` and ```Delete``` dialogs don't need to overwrite cancel methods. Because if we execute clean functions there, we'd lose default hide function with closeDialog trigger and so on.

I feel @viddo you should review it :).
cc @juanignaciosl.