### PR TITLE
Use Travis for frontend tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,65 +1,12 @@
 language: node_js
 node_js:
   - "0.10"
-before_install:
-  - lsb_release -a
-  - sudo mv /etc/apt/sources.list.d/pgdg-source.list* /tmp
-  - sudo apt-get -qq purge postgis* postgresql*
-  - sudo rm -Rf /var/lib/postgresql /etc/postgresql
-  - sudo apt-add-repository --yes ppa:cartodb/postgresql-9.3
-  - sudo apt-add-repository --yes ppa:cartodb/gis
-  - sudo apt-get update 
-  - sudo apt-get install gdal-bin libgdal1-dev python-gdal
-  - sudo apt-get install postgresql-9.3-postgis-2.1 postgresql-plpython-9.3 
-  - sudo apt-get install postgis
-  - sudo apt-get install -q unp zip ruby1.9.3 ruby1.9.1-dev python-pip ruby-rspec libicu-dev 
-  - sudo apt-get install postgresql-contrib-9.3
-  - echo -e "local\tall\tall\ttrust\nhost\tall\tall\t127.0.0.1/32\ttrust\nhost\tall\tall\t::1/128\ttrust" |sudo tee /etc/postgresql/9.3/main/pg_hba.conf
-  - sudo service postgresql restart
-  - sudo su postgres -c "createdb template_postgis"
-  - echo "SELECT VERSION();" | sudo su postgres -c "psql template_postgis"
-  - sudo su postgres -c "echo 'CREATE EXTENSION postgis;' | psql template_postgis"
-  - sudo su postgres -c "echo 'SELECT POSTGIS_FULL_VERSION();' | psql template_postgis"
-  # Needed to build PostgreSQL extensions 
-  - sudo apt-get install postgresql-server-dev-9.3
-  # Install schema_triggers
-  - hg clone https://bitbucket.org/malloclabs/pg_schema_triggers &&
-    cd pg_schema_triggers && make && sudo make install && cd -
-  # Preload schema_triggers module
-  # NOTE: might change if we make it part of the installcheck instead
-  - echo "shared_preload_libraries = 'schema_triggers.so'" |
-    sudo tee -a /etc/postgresql/9.3/main/postgresql.conf &&
-    sudo service postgresql restart
-  # Install cartodb-postgresql from the submodule dir
-  - cd lib/sql
-  - make all && sudo make install 
-  - PGUSER=postgres make installcheck || cat regression.diffs
-  - cd -
 
+install:
+  - npm install
+  
 before_script:
   - npm install -g grunt-cli
 
-install:
-  - gdal-config --version
-  - ruby --version
-  - sudo gem install bundler
-  # http://stackoverflow.com/questions/10916784/error-installing-debugger-linecache-in-ruby-1-9-3
-  - gem install debugger-linecache -v '1.1.2' -- --with-ruby-include=$rvm_path/src/ruby-1.9.3-p484/
-  - bundle install
-  - cp config/app_config.yml.testing config/app_config.yml
-  - cp config/database.yml.sample config/database.yml
-  # Needs fixing first some tests:
-  #- cp services/importer/spec/factories/database.json.sample services/importer/spec/factories/database.json
-  - cat python_requirements.txt | grep -v gdal | sudo pip install -r /dev/stdin
-  - npm install
-
 script:
-  - make travis
-
-env:
-
-#notifications:
-#  irc:
-#    channels:
-#      - "irc.freenode.org#cartodb"
-#    use_notice: true
+  - grunt test

--- a/Makefile
+++ b/Makefile
@@ -169,9 +169,6 @@ check: prepare-test-db check-prepared
 check-frontend:
 	grunt test
 
-travis: check-frontend check
-
-
 # update cartodb.js submodule files
 update_cdb:
 	cd $(CDB_PATH); make cartodb dist/cartodb.css

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](http://clinker.cartodb.net/desktop/plugin/public/status/CartoDB-master-testing)]
 (http://clinker.cartodb.net/jenkins/job/CartoDB-master-testing)
 [![Code Climate](https://codeclimate.com/github/CartoDB/cartodb20.png)](https://codeclimate.com/github/CartoDB/cartodb20)
+[![Build Status](http://travis-ci.org/CartoDB/cartodb.png)]
+(http://travis-ci.org/CartoDB/cartodb)
 
 CartoDB is an open source tool that allows for the storage and
 visualization of geospatial data on the web.


### PR DESCRIPTION
Travis has not been used for the past 6 months, I figured we could utilize it for the frontend tests at least, they only need a `npm install` to run.

So with this we can disable frontend tests and intermediate results-comments on clinker:
![screen shot 2015-03-30 at 09 39 22](https://cloud.githubusercontent.com/assets/978461/6892077/ee56791e-d6c0-11e4-9f39-38511cef9129.png)

..and replace it with the proper Github status:
![screen shot 2015-03-30 at 09 41 55](https://cloud.githubusercontent.com/assets/978461/6892085/0942f874-d6c1-11e4-8639-036bb5811eb9.png)

The test builds take around 2-3 min it seems (except for the the one build that failed for what seems to be a problem due to the DDos attack), see https://github.com/viddo/cartodb/pull/1 for example builds.

Also, if we remove the frontend build/test on clinker we should have faster test results there too.