### PR TITLE
Fix link_deleted_tables failing when there were tables with no OIDs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1211,7 +1211,7 @@ class User < Sequel::Model
     metadata_tables_ids = metadata_tables.select{ |table| !syncs.include?(table[:name]) }
                                          .map{ |table| table[:table_id] }
 
-    dropped_tables = metadata_tables_ids - real_tables.map{|t| t[:oid]}
+    dropped_tables = metadata_tables_ids - real_tables.map{|t| t[:oid]} - [nil]
 
     # Remove tables with oids that don't exist on the db
     self.tables.where(table_id: dropped_tables).all.each do |user_table|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1225,7 +1225,8 @@ class User < Sequel::Model
     end if dropped_tables.present?
 
     # Remove tables with null oids unless the table name exists on the db
-    self.tables.filter(table_id: nil).all.each do |t|
+    self.tables.filter(table_id: nil).all.each do |user_table|
+      t = Table.new(user_table: user_table)
       t.keep_user_database_table = true
       t.destroy unless self.real_tables.map { |t| t[:relname] }.include?(t.name)
     end if dropped_tables.present? && dropped_tables.include?(nil)


### PR DESCRIPTION
The user `link_deleted_tables` method, when there is a table with no table_id set (blank OID in metadata), matches the existing tables with the tables on the user database by name (and refills the table_id).

This behavior is (ab)used by the relocator. When it dumps/restores an user, the table OIDs will inevitably change, which will cause oddities (metadata tables being dropped, as the OID does not exist, and registered again with the new OID from scratch, losing their privacy), so the relocator sets OIDs to blank and expects this method to do its job.

However, seems like due to the change to use the UserTable class, when there are user_tables with blank OIDs link_deleted_tables fails with due to `t.keep_user_database_table` not existing.

This PR fixes this by using the Table model back, instead of UserTable.

cc @rafatower @Kartones 