### PR TITLE
Replace table and visualization by dataset and map

### DIFF
--- a/app/assets/stylesheets/table/table_panel/layer-sidebar.css.scss
+++ b/app/assets/stylesheets/table/table_panel/layer-sidebar.css.scss
@@ -92,7 +92,7 @@
       // Edit menu
       &.edit {
         bottom:0;
-        a.merge_tables {border-top:1px solid rgba(#999999,0.25);}
+        a.merge_datasets {border-top:1px solid rgba(#999999,0.25);}
       }
 
       a {
@@ -120,7 +120,7 @@
         // tool buttons
         &.add_row {@include table-sprite(table_icons, $offset-x:22px, $offset-y:-307px);}
         &.add_column {@include table-sprite(table_icons, $offset-x:22px, $offset-y:-247px);}
-        &.merge_tables {@include table-sprite(table_icons, $offset-x:21px, $offset-y:-186px);}
+        &.merge_datasets {@include table-sprite(table_icons, $offset-x:21px, $offset-y:-186px);}
 
         &.add_feature {
           border-top:1px solid rgba(#999999,0.25);

--- a/app/views/admin/visualizations/public_table.html.erb
+++ b/app/views/admin/visualizations/public_table.html.erb
@@ -89,7 +89,7 @@
                 <h4>by <%= @name %></h4>
               </a>
 
-              <h5><%= "#{@public_tables_count} #{@public_tables_count != 1 ? "tables" :"table"} created" %></h5>
+              <h5><%= "#{@public_tables_count} dataset#{@public_tables_count != 1 ? "s" :""} created" %></h5>
             </div>
 
             <a href="<%= public_datasets_home_url %>" title="Datasets by <%= @name %>" class="content">
@@ -125,7 +125,7 @@
         <div class="map-info embed-right-col">
           <div class="content">
 
-            <h2>Visualizations using this data</h2>
+            <h2>Maps using this data</h2>
             <ul>
 
               <% if @total_visualizations.count == 0 && @total_nonpublic_total_vis_count == 0 %>
@@ -143,7 +143,7 @@
               <% if @total_nonpublic_total_vis_count > 0 %>
 
                 <li class="private">
-                  <%= @total_nonpublic_total_vis_count %> private visualization<%= @total_nonpublic_total_vis_count != 1 ? 's' : '' %><span class="help" original-title="This table is used in <%= @total_nonpublic_total_vis_count %> map<%= @total_nonpublic_total_vis_count != 1 ? 's' : '' %> made private by the publisher">(?)</span>
+                  <%= @total_nonpublic_total_vis_count %> private map<%= @total_nonpublic_total_vis_count != 1 ? 's' : '' %><span class="help" original-title="This dataset is used in <%= @total_nonpublic_total_vis_count %> map<%= @total_nonpublic_total_vis_count != 1 ? 's' : '' %> made private by the publisher">(?)</span>
                 </li>
               <% end %>
             </ul>

--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.8.0
+3.8.1

--- a/lib/assets/javascripts/cartodb/common/create_dialog/create_dialog_content.js
+++ b/lib/assets/javascripts/cartodb/common/create_dialog/create_dialog_content.js
@@ -37,7 +37,7 @@
       },
       scratch:  {
         method: '_genScratchPane',
-        title:  _t('Empty table')
+        title:  _t('Empty dataset')
       },
       instagram: {
         type:     'other',

--- a/lib/assets/javascripts/cartodb/common/create_dialog/create_dialog_states.js
+++ b/lib/assets/javascripts/cartodb/common/create_dialog/create_dialog_states.js
@@ -24,9 +24,9 @@
       abort: { enabled: false },
       ok: {
         text: {
-          default:  _t('Create table'),
+          default:  _t('Create dataset'),
           layer:    _t('Add layer'),
-          scratch:  _t('Create empty table')
+          scratch:  _t('Create empty dataset')
         },
         classes: 'ok button green',
         parent: 'to_right'
@@ -50,9 +50,9 @@
       abort: { enabled: false },
       ok: {
         text: {
-          default:  _t('Create table'),
+          default:  _t('Create dataset'),
           layer:    _t('Add layer'),
-          scratch:  _t('Create empty table')
+          scratch:  _t('Create empty dataset')
         },
         classes: 'ok button green',
         parent: 'to_right '
@@ -75,8 +75,8 @@
       abort: { enabled: false },
       ok: {
         text: {
-          default:  _t('Create table'),
-          scratch:  _t('Create empty table')
+          default:  _t('Create dataset'),
+          scratch:  _t('Create empty dataset')
         },
         classes: 'ok button green',
         parent: 'to_right'
@@ -213,7 +213,7 @@
           gdrive:   _t('Importing your Google Drive file'),
           dropbox:  _t('Importing your Dropbox file'),
           layer:    _t(''),
-          scratch:  _t('Importing your table'),
+          scratch:  _t('Importing your dataset'),
           twitter:  _t('Importing. Depending on the amount of tweets, this can take a while'),
           arcgis:  _t('Importing your ArcGIS data')
         }
@@ -233,7 +233,7 @@
           gdrive:   _t('Guessing geocodable content on your Google Drive file'),
           dropbox:  _t('Guessing geocodable content on your Dropbox file'),
           layer:    _t(''),
-          scratch:  _t('Guessing geocodable content on your table'),
+          scratch:  _t('Guessing geocodable content on your dataset'),
           twitter:  _t('Guessing content. Depending on the amount of tweets, this can take a while'),
           arcgis:  _t('Guessing geocodable content of your ArcGIS data')
         }
@@ -253,7 +253,7 @@
           gdrive:   _t('Geocoding your Google Drive file'),
           dropbox:  _t('Geocoding your Dropbox file'),
           layer:    _t(''),
-          scratch:  _t('Geocoding your table'),
+          scratch:  _t('Geocoding your dataset'),
           twitter:  _t('Geocoding. Depending on the amount of tweets, this can take a while'),
           arcgis:  _t('Geocoding your ArcGIS data')
         }
@@ -288,14 +288,14 @@
       progress: {
         enabled: true,
         text:     {
-          default:  _t('Creating your table'),
-          file:     _t('Creating your table'),
-          gdrive:   _t('Creating your table'),
-          dropbox:  _t('Creating your table'),
-          layer:    _t('Creating your table'),
-          scratch:  _t('Creating your table'),
-          twitter:  _t('Creating your table'),
-          arcgis:   _t('Creating your table')
+          default:  _t('Creating your dataset'),
+          file:     _t('Creating your dataset'),
+          gdrive:   _t('Creating your dataset'),
+          dropbox:  _t('Creating your dataset'),
+          layer:    _t('Creating your dataset'),
+          scratch:  _t('Creating your dataset'),
+          twitter:  _t('Creating your dataset'),
+          arcgis:   _t('Creating your dataset')
         }
       },
       close: { enabled: false },
@@ -328,7 +328,7 @@
       ok: {
         text: {
           default:  _t(''),
-          twitter:  _t('Go to table')
+          twitter:  _t('Go to dataset')
         },
         classes: 'ok button grey',
         parent: 'middle'
@@ -352,9 +352,9 @@
       abort: { enabled: false },
       ok: {
         text: {
-          default:  _t('Create table'),
+          default:  _t('Create dataset'),
           layer:    _t('Add layer'),
-          scratch:  _t('Create empty table')
+          scratch:  _t('Create empty dataset')
         },
         classes: 'ok button green',
         parent: 'to_right'

--- a/lib/assets/javascripts/cartodb/common/delete_dialog.js
+++ b/lib/assets/javascripts/cartodb/common/delete_dialog.js
@@ -103,9 +103,9 @@ cdb.admin.DeleteDialog = cdb.admin.BaseDialog.extend({
   },
 
   _TEXTS: {
-    title: _t("Delete this table"),
-    default_message: _t("You are about to delete this table. Doing so will result in the deletion of this dataset."),
-    delete_vis_message: _t("You are about to delete this table. Doing so will result in the deletion of this dataset. Also, deleting this layer will affect the following visualizations."),
+    title: _t("Delete this dataset"),
+    default_message: _t("You are about to delete this dataset. Doing so will result in the deletion of this layer."),
+    delete_vis_message: _t("You are about to delete this dataset. Doing so will result in the deletion of this layer. Also, deleting this layer will affect the following maps."),
     cancel_title: _t("Export my data first"),
     ok_title: _t("Ok, delete")
   },

--- a/lib/assets/javascripts/cartodb/common/delete_visualization_dialog.js
+++ b/lib/assets/javascripts/cartodb/common/delete_visualization_dialog.js
@@ -13,18 +13,18 @@
   cdb.admin.DeleteVisualizationDialog = cdb.admin.BaseDialog.extend({
 
     _TEXTS: {
-      users_visibility: _t('Also, by deteleting this visualization you will be revoking access to the \
+      users_visibility: _t('Also, by deteleting this map you will be revoking access to the \
                             following users within your organization:')
     },
 
     initialize: function(options) {
       _.extend(this.options, {
-        title: "Delete this visualization",
+        title: "Delete this map",
         template_name: 'common/views/dialog_base',
         clean_on_hide: true,
         enter_to_confirm: true,
         ok_button_classes: "button grey",
-        ok_title: "Delete this visualization",
+        ok_title: "Ok, delete",
         cancel_button_classes: "underline margin15",
         modal_type: "confirmation",
         width: 510,

--- a/lib/assets/javascripts/cartodb/common/lock_visualization_dialog.js
+++ b/lib/assets/javascripts/cartodb/common/lock_visualization_dialog.js
@@ -40,7 +40,7 @@
         isOwner:            this.model.permission.isOwner(this.user),
         isVisLock:          this.model.get('locked'),
         visName:            this.model.get('name'),
-        visType:            !this.model.isVisualization() ? "table" : "visualization",
+        visType:            !this.model.isVisualization() ? "dataset" : "map",
         belongsOrg:         this.options.user.isInsideOrg(),
         sharedPeople:       this.model.permission.acl.size()
       });

--- a/lib/assets/javascripts/cartodb/common/privacy/privacy_dialog.js
+++ b/lib/assets/javascripts/cartodb/common/privacy/privacy_dialog.js
@@ -18,13 +18,13 @@ cdb.admin.PrivacyDialog = cdb.admin.BaseDialog.extend({
 
   _TEXTS: {
     title:    {
-      vis:        _t("Visualization privacy settings"),
-      table:      _t("Table privacy settings")
+      vis:        _t("Map privacy settings"),
+      table:      _t("Dataset privacy settings")
     },
     privacy_change: {
-      table:          _t("If you change the privacy of this table, you will be deleting or changing the visualizations of the \
+      table:          _t("If you change the privacy of this dataset, you will be deleting or changing the maps of the \
                           following users within your organization:"),
-      visualization:  _t("If you change the privacy of this visualization you will be revoking access to it to the \
+      visualization:  _t("If you change the privacy of this map you will be revoking access to it to the \
                           following users within your organization:"),
     },
     ok_title:         _t("Save settings")

--- a/lib/assets/javascripts/cartodb/common/table_column_selector.js
+++ b/lib/assets/javascripts/cartodb/common/table_column_selector.js
@@ -432,7 +432,7 @@ cdb.admin.TableColumnSelector = cdb.core.View.extend({
     $select.removeAttr("disabled");
 
     $select.select2({
-      placeholder:  'Select one of your tables',
+      placeholder:  'Select one of your datasets',
       minimumResultsForSearch: 20
     });
   },

--- a/lib/assets/javascripts/cartodb/common/views/delete_dialog_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/delete_dialog_item.jst.ejs
@@ -1,10 +1,10 @@
 <div class="msg <%= type %>">
   <% if (type == "dependent") { %>
-    <a href="#/open" class="open"><%= visualizations.length %> <%= visualizations.length == 1 ? "visualization" : "visualizations" %></a> will be deleted since this is the only layer on them.
+    <a href="#/open" class="open"><%= visualizations.length %> map<%= visualizations.length == 1 ? "" : "s" %></a> will be deleted since this is the only layer on them.
   <% } else if (type == "non_dependent") { %>
-    This layer will disapear from <a href="#/close" class="open"><%= visualizations.length %> <%= visualizations.length == 1 ? "visualization" : "visualizations" %></a>
+    This layer will disappear from <a href="#/close" class="open"><%= visualizations.length %> map<%= visualizations.length == 1 ? "" : "s" %></a>
   <% } else if (type == "synced"){ %>
-    This table is synced by url, if you delete it, it will stop synchronizing.
+    This dataset is synced by url, if you delete it, it will stop synchronizing.
   <% } %>
 </div>
 <div class="visualizations">

--- a/lib/assets/javascripts/cartodb/common/views/delete_visualization_dialog.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/delete_visualization_dialog.jst.ejs
@@ -1,1 +1,1 @@
-<p>You are about to delete this visualization. You will lose all your published maps.</p>
+<p>You are about to delete this map. You will lose it wherever it is already published...</p>

--- a/lib/assets/javascripts/cartodb/common/views/import/import_layer.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/import/import_layer.jst.ejs
@@ -1,12 +1,12 @@
-<span class="loader">Getting tables...</span>
-<p class="warning error">Something went wrong getting your tables, please try again later...</p>
+<span class="loader">Getting datasets...</span>
+<p class="warning error">Something went wrong getting your datasets, please try again later...</p>
 <div class="options">
-  <p class="message small light">Select an available layer to be added in your visualization.</p>
+  <p class="message small light">Select an available layer to be added in your map.</p>
   <div class="combo_wrapper margin10">
     <div class="tableListCombo"></div>
   </div>
   <div>
     <p class="warning geo">This layer doesn't have any georeference data.</p>
-    <p class="warning permission">Only tables shared across all users in the visualisation are permitted.</p>
+    <p class="warning permission">Only datasets shared across all users in the maps are permitted.</p>
   </div>
 </div>

--- a/lib/assets/javascripts/cartodb/common/views/lock_visualization_dialog.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/lock_visualization_dialog.jst.ejs
@@ -17,7 +17,7 @@
         <% if (isOwner) { %>
           <% if (!isVisLock) { %>
             Locking your <strong><%= visName %></strong> <%= visType %> will hide it from your <%= visType %>s dashboard, but it will be visible clicking over the link at the bottom of that section.
-            <% if (sharedPeople > 0 && visType === 'table') { %>
+            <% if (sharedPeople > 0 && visType === 'dataset') { %>
               <br/><br/>Also, people with write permission over this <%= visType %> will still be able to edit it.
             <% } %>
           <% } else { %>

--- a/lib/assets/javascripts/cartodb/common/views/table_column_selector.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/table_column_selector.jst.ejs
@@ -2,7 +2,7 @@
   <% if (name) { %>
     <div class="select tables"><%= name %></div>
   <% } else { %>
-    <div class="select tables">Select one of your tables</div>
+    <div class="select tables">Select one of your datasets</div>
     <p class="small"><%= choose_table_text %></p>
   <% } %>
 </div>
@@ -24,5 +24,5 @@
 </div>
 
 <% if (source == 'destiny') { %>
-<div class='cover'><p>This will count the number of features in your table intersecting the geometries in a second table.</p></div>
+<div class='cover'><p>This will count the number of features in your dataset intersecting the geometries in a second dataset.</p></div>
 <% } %>

--- a/lib/assets/javascripts/cartodb/dashboard/views/name_visualization_dialog.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/name_visualization_dialog.jst.ejs
@@ -3,7 +3,7 @@
 <% } %>
 
 <div class="margin15">
-  <input type="text" placeholder="Name your visualization" value="" name="name" />
+  <input type="text" placeholder="Name your map" value="" name="name" />
   <div class="info">
     <p><%= error_messages.blank %></p>
   </div>

--- a/lib/assets/javascripts/cartodb/dashboard/visualizations/name_visualization_dialog.js
+++ b/lib/assets/javascripts/cartodb/dashboard/visualizations/name_visualization_dialog.js
@@ -9,7 +9,7 @@
 
     _TEXTS: {
       title:  _t('Save your map'),
-      desc:   _t('A map is a mix of layers, styles and sql. Your \
+      desc:   _t('A map is a mix of layers, styles and SQL. Your \
               maps are now accessible from your dashboard.'),
       button: _t('Create map'),
       error:  _t('The map name can\'t be blank')

--- a/lib/assets/javascripts/cartodb/dashboard/visualizations/name_visualization_dialog.js
+++ b/lib/assets/javascripts/cartodb/dashboard/visualizations/name_visualization_dialog.js
@@ -8,11 +8,11 @@
   cdb.admin.NameVisualization = cdb.admin.BaseDialog.extend({
 
     _TEXTS: {
-      title:  _t('Save your visualization'),
-      desc:   _t('A visualization is a mix of layers, styles and sql. Your \
-              visualizations are now accessible from your dashboard.'),
-      button: _t('Create visualization'),
-      error:  _t('The visualization name can\'t be blank')
+      title:  _t('Save your map'),
+      desc:   _t('A map is a mix of layers, styles and sql. Your \
+              maps are now accessible from your dashboard.'),
+      button: _t('Create map'),
+      error:  _t('The map name can\'t be blank')
     },
 
     events: cdb.core.View.extendEvents({

--- a/lib/assets/javascripts/cartodb/public/public_dropdown.js
+++ b/lib/assets/javascripts/cartodb/public/public_dropdown.js
@@ -9,8 +9,8 @@ cdb.open.AccountDropdown = cdb.admin.DropdownMenu.extend({
 
   _TEMPLATE: ' \
     <ul>\
-      <li><a class="small" href="<%- urls[0] %>">View your tables</a></li>\
-      <li><a class="small" href="<%- urls[0] %>/visualizations">View your visualizations</a></li>\
+      <li><a class="small" href="<%- urls[0] %>">View your datasets</a></li>\
+      <li><a class="small" href="<%- urls[0] %>/visualizations">View your maps</a></li>\
       <li><a class="small" href="<%- urls[0].replace("dashboard", "logout") %>">Close session</a></li>\
     </ul>\
   ',

--- a/lib/assets/javascripts/cartodb/table/header/create_visualization_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/header/create_visualization_dialog.js
@@ -8,7 +8,7 @@
 
     _TEXTS: {
       title:  _t('Save your map'),
-      desc:   _t('A map is a mix of layers, styles and sql. Your \
+      desc:   _t('A map is a mix of layers, styles and SQL. Your \
               maps are now accessible from your dashboard.'),
       button: _t('Create map'),
       error:  _t('The map name can\'t be blank'),

--- a/lib/assets/javascripts/cartodb/table/header/create_visualization_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/header/create_visualization_dialog.js
@@ -7,11 +7,11 @@
   cdb.admin.CreateVizDialog = cdb.admin.BaseDialog.extend({
 
     _TEXTS: {
-      title:  _t('Save your visualization'),
-      desc:   _t('A visualization is a mix of layers, styles and sql. Your \
-              visualizations are now accessible from your dashboard.'),
-      button: _t('Create visualization'),
-      error:  _t('The visualization name can\'t be blank'),
+      title:  _t('Save your map'),
+      desc:   _t('A map is a mix of layers, styles and sql. Your \
+              maps are now accessible from your dashboard.'),
+      button: _t('Create map'),
+      error:  _t('The map name can\'t be blank'),
       creation: {
         error: {
           description:  _t('Something has failed in the process.'),

--- a/lib/assets/javascripts/cartodb/table/header/duplicate_table_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/header/duplicate_table_dialog.js
@@ -20,12 +20,12 @@ cdb.admin.DuplicateTableDialog = cdb.admin.BaseDialog.extend({
 
   _TEXTS: {
     title: {
-      normal:   _t('Name for your copy of this table'),
-      query:    _t('Name your new table from this query')
+      normal:   _t('Name for your copy of this dataset'),
+      query:    _t('Name your new dataset from this query')
     },
     ok_button: {
-      normal:   _t('Duplicate table'),
-      query:    _t('Create table')
+      normal:   _t('Duplicate dataset'),
+      query:    _t('Create dataset')
     },
     error: {
       default:  _t('Sorry, something went wrong and we\'re not sure what. Contact us at \

--- a/lib/assets/javascripts/cartodb/table/header/duplicate_visualization_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/header/duplicate_visualization_dialog.js
@@ -20,8 +20,8 @@
 cdb.admin.DuplicateVisDialog = cdb.admin.BaseDialog.extend({
 
   _TEXTS: {
-    title: _t('Name for your copy of this visualization'),
-    ok_button: _t('Duplicate visualization'),
+    title: _t('Name for your copy of this map'),
+    ok_button: _t('Duplicate map'),
     error: _t('Sorry, something went wrong and we\'re not sure what. Contact us at \
                   <a href="mailto:support@cartodb.com">support@cartodb.com</a>.')
   },

--- a/lib/assets/javascripts/cartodb/table/header/merge_tables_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/header/merge_tables_dialog.js
@@ -28,8 +28,8 @@ cdb.admin.MergeTablesDialog = cdb.admin.BaseDialog.extend({
       column: {
         title:  _t("Column Join"),
         desc:   _t("Create a new dataset by selecting two datasets and the columns containing the shared value. \
-                First, select the columns you want to matching between datasets and then select and deselect \
-                columns you want and don't want in your new dataset. You can only merge datasets by joining by \
+                First, select the matching column in both datasets and then select or deselect \
+                columns you want or not in your new dataset. You can only merge datasets by joining by \
                 columns of the same type (e.g. number to a number)."),
       },
       spatial: {

--- a/lib/assets/javascripts/cartodb/table/header/merge_tables_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/header/merge_tables_dialog.js
@@ -29,7 +29,7 @@ cdb.admin.MergeTablesDialog = cdb.admin.BaseDialog.extend({
         title:  _t("Column Join"),
         desc:   _t("Create a new dataset by selecting two datasets and the columns containing the shared value. \
                 First, select the matching column in both datasets and then select or deselect \
-                columns you want or not in your new dataset. You can only merge datasets by joining by \
+                the columns you want in your new dataset. You can only merge datasets by joining by \
                 columns of the same type (e.g. number to a number)."),
       },
       spatial: {

--- a/lib/assets/javascripts/cartodb/table/header/merge_tables_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/header/merge_tables_dialog.js
@@ -19,29 +19,29 @@ cdb.admin.MergeTablesModel = cdb.core.Model.extend({
 cdb.admin.MergeTablesDialog = cdb.admin.BaseDialog.extend({
 
   _TEXTS: {
-    title:      _t("Merge with another table"),
-    desc:       _t("Table merging is useful if you want to combine data from two tables into a single \
-                new table. You can merge tables by a column attribute or as a spatial intersection."),
+    title:      _t("Merge with another dataset"),
+    desc:       _t("Dataset merging is useful if you want to combine data from two datasets into a single \
+                new dataset. You can merge datasets by a column attribute or as a spatial intersection."),
     next:       _t("Next"),
     back:       _t("Go back"),
     merge: {
       column: {
         title:  _t("Column Join"),
-        desc:   _t("Create a new table by selecting two tables and the columns containing the shared value. \
-                First, select the columns you want to matching between tables and then select and deselect \
-                columns you want and don't want in your new table. You can only merge tables by joining by \
+        desc:   _t("Create a new dataset by selecting two datasets and the columns containing the shared value. \
+                First, select the columns you want to matching between datasets and then select and deselect \
+                columns you want and don't want in your new dataset. You can only merge datasets by joining by \
                 columns of the same type (e.g. number to a number)."),
       },
       spatial: {
         title:  _t("Spatial join"),
-        desc:   _t("Calculate the intersecting geospatial records between two tables (ex. points in polygons). \
+        desc:   _t("Calculate the intersecting geospatial records between two datasets (ex. points in polygons). \
                 You'll need to decide the operation to perform: COUNT calculates the number of intersecting records, \
                 SUM sums of a column value for all intersecting records, AVG provides the average value of a column \
                 for all intersecting records.")
       },
-      name:     _t("Name for your merge table"),
-      choose:   _t('Choose a table to merge with {{ table_name }}'),
-      next:     _t('Merge tables')
+      name:     _t("Name for your merge dataset"),
+      choose:   _t('Choose a dataset to merge with {{ table_name }}'),
+      next:     _t('Merge datasets')
     },
     errors: {
       sorry:    _t('Sorry, something went wrong and we\'re not sure what. Contact us at \

--- a/lib/assets/javascripts/cartodb/table/header/share_controller.js
+++ b/lib/assets/javascripts/cartodb/table/header/share_controller.js
@@ -18,9 +18,9 @@
 
     _TEXTS: {
       create_visualization: {
-        msg:        _t('If you want to share your map you need to create a visualization.')
+        msg:        _t('If you want to share your map you need to create it first.')
       },
-      next_button:  _t('Check tables')
+      next_button:  _t('Check datasets')
     },
 
     // Add to the stack then number of actions we need to do

--- a/lib/assets/javascripts/cartodb/table/header/share_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/header/share_dialog.js
@@ -8,7 +8,7 @@
     },
 
     _TEXTS: {
-      title: _t('Share your visualization'),
+      title: _t('Share your map'),
       close: _t('Close'),
     },
 

--- a/lib/assets/javascripts/cartodb/table/header/views/create_visualization_dialog.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/create_visualization_dialog.jst.ejs
@@ -3,7 +3,7 @@
 <% } %>
 
 <div class="margin15">
-  <input type="text" placeholder="Name your visualization" value="" name="name" />
+  <input type="text" placeholder="Name your map" value="" name="name" />
   <div class="info">
     <p><%= error_messages.blank %></p>
   </div>

--- a/lib/assets/javascripts/cartodb/table/header/views/create_visualization_dialog_base.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/create_visualization_dialog_base.jst.ejs
@@ -21,7 +21,7 @@
   <section class="block modal error">
     <a href="#close" class="close">x</a>
     <div class="head">
-      <h3>An error occurred creating your visualization</h3>
+      <h3>An error occurred creating your new map</h3>
     </div>
     <div class="error_content"></div>
     <div class="foot">

--- a/lib/assets/javascripts/cartodb/table/header/views/duplicate_table_dialog_base.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/duplicate_table_dialog_base.jst.ejs
@@ -23,7 +23,7 @@
     <a href="#close" class="close">x</a>
     <div class="head">
       <h3>
-        An error occurred creating your table
+        An error occurred creating your dataset
       </h3>
     </div>
     <div class="error_content"></div>

--- a/lib/assets/javascripts/cartodb/table/header/views/duplicate_vis_dialog_base.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/duplicate_vis_dialog_base.jst.ejs
@@ -23,7 +23,7 @@
     <a href="#close" class="close">x</a>
     <div class="head">
       <h3>
-        An error occurred duplicating your visualization
+        An error occurred duplicating your map
       </h3>
     </div>
     <div class="error_content"></div>

--- a/lib/assets/javascripts/cartodb/table/header/views/merge_tables_content.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/merge_tables_content.jst.ejs
@@ -5,12 +5,12 @@
 
   <li<% if (!regularMerge) { %> class="disabled"<% } %>>
   <a href="#" class="radiobutton<% if (!regularMerge) { %> disabled<% } %>" data-merge-flavor="regular"><span class="radio"></span>Column Join</a>
-  <p>Merge two tables based a shared value (ex. ISO codes in both tables).</p>
+  <p>Merge two datasets based a shared value (ex. ISO codes in both datasets).</p>
   </li>
 
   <li<% if (!spatialMerge) { %> class="disabled"<% } %>>
   <a href="#" class="radiobutton<% if (!spatialMerge) { %> disabled<% } %>" data-merge-flavor="spatial"><span class="radio"></span>Spatial Join</a>
-  <p>Measure the number of intersecting records between two tables, (ex. count points inside polygons).</p>
+  <p>Measure the number of intersecting records between two datasets, (ex. count points inside polygons).</p>
   </li>
 
 </ul>
@@ -23,6 +23,6 @@
 <div class="table_name">
   <input type="text" class="text name" value="tables_merge">
   <div class="info error">
-    <p>The name of the new table shouldn't be blank and different than actual table.</p>
+    <p>The name of the new dataset shouldn't be blank and different than actual dataset.</p>
   </div>
 </div>

--- a/lib/assets/javascripts/cartodb/table/header/views/merge_tables_dialog_base.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/merge_tables_dialog_base.jst.ejs
@@ -17,7 +17,7 @@
   <section class="block modal merging">
     <div class="merging_content">
       <div class="loader">
-        <p>Merging tables and generating the new one</p>
+        <p>Merging datasets and generating the new one</p>
       </div>
     </div>
   </section>
@@ -25,7 +25,7 @@
   <section class="block modal error">
     <a href="#close" class="close">x</a>
     <div class="head">
-      <h3>An error occurred merging these tables</h3>
+      <h3>An error occurred merging these datasets</h3>
     </div>
     <div class="error_content"></div>
     <div class="foot">

--- a/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
@@ -3,7 +3,7 @@
     <li class="<% if (table.isInSQLView() && dataLayer && !dataLayer.get('query')) { %>disabled<% } %>"><a class="small export_table" href="#/export">Export...</a></li>
     
     <% if (table.isInSQLView()) { %>
-      <li><a class="small duplicate_table" href="#/table-from-query">Table from query</a></li>
+      <li><a class="small duplicate_table" href="#/table-from-query">Dataset from query</a></li>
     <% } else { %>
       <li class="<% if (table.isSync()) { %>disabled<% } %>">
         <a class="small georeference" href="#/georeference">
@@ -13,8 +13,8 @@
           </div>
         </a>
       </li>
-      <li><a class="small duplicate_table" href="#/duplicate">Duplicate table...</a></li>
-      <li><a class="small merge_tables" href="#/merge-tables">Merge with table...</a></li>
+      <li><a class="small duplicate_table" href="#/duplicate">Duplicate dataset...</a></li>
+      <li><a class="small merge_tables" href="#/merge-tables">Merge with dataset...</a></li>
       
       <!-- Change privacy?  -->
       <% if (isLayerOwner) { %>
@@ -34,10 +34,10 @@
 
     <% if (isLayerOwner) { %>
       <!-- Lock? -->
-      <li><a class="small lock_vis" href="#/lock-table">Lock table</a></li>
+      <li><a class="small lock_vis" href="#/lock-table">Lock dataset</a></li>
 
       <!-- Delete? -->
-      <li><a class="small delete_table red" href="#/delete">Delete this table...</a></li>
+      <li><a class="small delete_table red" href="#/delete">Delete this dataset...</a></li>
     <% } %>
 
   <% } else { %>
@@ -56,13 +56,13 @@
       <% } %>
     <% } %>
 
-    <!-- Visualization options  -->
-    <li><a class="small duplicate_vis" href="#/duplicate">Duplicate visualization</a></li>
+    <!-- Map options  -->
+    <li><a class="small duplicate_vis" href="#/duplicate">Duplicate map</a></li>
     <% if (isVisOwner) { %>
-      <li><a class="small lock_vis" href="#/lock-vis">Lock visualization</a></li>
+      <li><a class="small lock_vis" href="#/lock-vis">Lock map</a></li>
     <% } %>
     <% if (isVisOwner) { %>
-      <li><a class="small delete_vis red" href="#/delete">Delete visualization</a></li>
+      <li><a class="small delete_vis red" href="#/delete">Delete map</a></li>
     <% } %>
     
   <% } %>

--- a/lib/assets/javascripts/cartodb/table/header/views/share_dialog.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/share_dialog.jst.ejs
@@ -14,7 +14,7 @@
           <i></i>
 
           <% if (privacy == "PRIVATE") { %>
-          <h4>Your visualization<br />is private</h4>
+          <h4>Your map<br />is private</h4>
           <% } else { %>
           <h4>Get the link</h4>
           <% } %>
@@ -25,9 +25,9 @@
           </div>
 
           <% if (privacy == "PASSWORD") { %>
-          <p>*Remember that your visualization is protected by password.</p>
+          <p>*Remember that your map is protected by password.</p>
           <% } else if (privacy == "PRIVATE") { %>
-          <p>Change <a href="#" class="change-privacy">your privacy</a> settings to share your visualization. Right now it's private.</p>
+          <p>Change <a href="#" class="change-privacy">your privacy</a> settings to share your map. Right now it's private.</p>
           <% } else { %>
           <p>And send it to your friends, co-workers or post in your social networks</p>
           <% } %>
@@ -37,7 +37,7 @@
           <i></i>
 
           <% if (privacy == "PRIVATE") { %>
-          <h4>Your visualization<br />is private</h4>
+          <h4>Your map<br />is private</h4>
           <% } else { %>
           <h4>Embed it</h4>
           <% } %>
@@ -48,9 +48,9 @@
           </div>
 
           <% if (privacy == "PASSWORD") { %>
-          <p>*Remember that your visualization is protected by password. <a href="#" class="simple_url">Get a simple URL</a></p>
+          <p>*Remember that your map is protected by password. <a href="#" class="simple_url">Get a simple URL</a></p>
           <% } else if (privacy == "PRIVATE") { %>
-          <p>Change <a href="#" class="change-privacy">your privacy</a> settings to embed your visualization. Right now it's private.</p>
+          <p>Change <a href="#" class="change-privacy">your privacy</a> settings to embed your map. Right now it's private.</p>
           <% } else { %>
           <p>Get your map into your blog, website or simple application. <a href="#" class="simple_url">Get a simple URL</a></p>
           <% } %>

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -469,7 +469,7 @@
       self.addModule(this.filters.render(), ['table', 'tableLite', 'map', 'mapLite']);
 
       /* Lateral menu modules */
-      var mergeTables = self.addToolButton("merge_tables", 'table');
+      var mergeTables = self.addToolButton("merge_datasets", 'table');
       var addRow      = self.addToolButton('add_row', 'table');
       var addColumn   = self.addToolButton('add_column', 'table');
       var addGeom     = self.addToolButton('add_feature', 'map');

--- a/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_html_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_html_pane.js
@@ -11,7 +11,7 @@
 
     _TEXTS: {
       tip:            _t('To link data write your column names within {{}}. \
-                          &lt;script&gt; tags could break your visualization.'),
+                          &lt;script&gt; tags could break your map.'),
       template_error: _t('Error in line {{line}}: {{msg}}'),
       empty_error:    _t('Template can\'t be empty')
     },

--- a/lib/assets/javascripts/cartodb/table/menu_modules/legends/legend_html_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/legends/legend_html_pane.js
@@ -9,7 +9,7 @@
     _STORAGE_NAMESPACE: "cdb.localStorage.legend.",
 
     _TEXTS: {
-      tip:            _t('&lt;script&gt; tags could break your visualization.'),
+      tip:            _t('&lt;script&gt; tags could break your map.'),
       template_error: _t('Error in line {{line}}: {{msg}}')
     },
 

--- a/lib/assets/javascripts/cartodb/table/menu_modules/views/carto_wizard.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/views/carto_wizard.jst.ejs
@@ -1,4 +1,4 @@
-<h3>Visualization wizard</h3>
+<h3>Map wizard</h3>
 <div>
   <div class="wizard_wrap">
     <ul class="vis_options"></ul>

--- a/lib/assets/javascripts/cartodb/table/menu_modules/views/carto_wizard.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/views/carto_wizard.jst.ejs
@@ -1,4 +1,4 @@
-<h3>Map wizard</h3>
+<h3>Map layer wizard</h3>
 <div>
   <div class="wizard_wrap">
     <ul class="vis_options"></ul>

--- a/lib/assets/javascripts/cartodb/table/menu_modules/wizards/bubble_wizard.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/wizards/bubble_wizard.js
@@ -5,7 +5,7 @@ cdb.admin.mod.BubbleWizard = cdb.admin.mod.SimpleWizard.extend({
 
   //TODO: put this in a template
   error_msg: {
-    NO_CONTENT_MSG: _t('There are no numeric columns on your table to make a bubble visualization.<br/>If you have numbers on your table, but you don\'t see them here is likely they are set as String.')
+    NO_CONTENT_MSG: _t('There are no numeric columns on your dataset to make a bubble map.<br/>If you have numbers on your dataset, but you don\'t see them here is likely they are set as String.')
   },
 
   initialize: function() {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/wizards/choropleth_wizard.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/wizards/choropleth_wizard.js
@@ -5,7 +5,7 @@
 
     //TODO: put this in a template
     error_msg: {
-      NO_CONTENT_MSG: _t('There are no numeric columns on your table to make a choropleth visualization.<br/>If you have numbers on your table, but you don\'t see them here is likely they are set as String.')
+      NO_CONTENT_MSG: _t('There are no numeric columns on your dataset to make a choropleth map.<br/>If you have numbers on your dataset, but you don\'t see them here is likely they are set as String.')
     },
 
     initialize: function() {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/wizards/torque.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/wizards/torque.js
@@ -15,9 +15,9 @@ cdb.admin.mod.TorqueWizard = cdb.admin.mod.SimpleWizard.extend({
   ],
 
   error_msg: {
-    NO_CONTENT_MSG: _t('There are no numeric or date columns on your table to make an animated visualization.<br/>If you have numbers on your table, but you don\'t see them here is likely they are set as String.'),
-    LAYER_ON_TOP: _t('Animated layers should be on top of the visualization.'),
-    ONLY_ONE_TORQUE_LAYER: _t('Sorry, but for the moment only one Torque layer is allowed per visualization.')
+    NO_CONTENT_MSG: _t('There are no numeric or date columns on your dataset to make an animated map.<br/>If you have numbers on your dataset, but you don\'t see them here is likely they are set as String.'),
+    LAYER_ON_TOP: _t('Animated layers should be on top of the map.'),
+    ONLY_ONE_TORQUE_LAYER: _t('Sorry, but for the moment only one Torque layer is allowed per map.')
   },
 
   initialize: function() {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/wizards/torque_category.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/wizards/torque_category.js
@@ -15,9 +15,9 @@ cdb.admin.mod.TorqueCategoryWizard = cdb.admin.mod.CategoryWizard.extend({
   ],
 
   error_msg: {
-    NO_CONTENT_MSG: _t('There are no numeric or date columns on your table to make an animated visualization.<br/>If you have numbers on your table, but you don\'t see them here is likely they are set as String.'),
-    LAYER_ON_TOP: _t('Animated layers should be on top of the visualization.'),
-    ONLY_ONE_TORQUE_LAYER: _t('Sorry, but for the moment only one Torque layer is allowed per visualization.')
+    NO_CONTENT_MSG: _t('There are no numeric or date columns on your dataset to make an animated map.<br/>If you have numbers on your dataset, but you don\'t see them here is likely they are set as String.'),
+    LAYER_ON_TOP: _t('Animated layers should be on top of the map.'),
+    ONLY_ONE_TORQUE_LAYER: _t('Sorry, but for the moment only one Torque layer is allowed per map.')
   },
 
   initialize: function() {

--- a/lib/assets/javascripts/cartodb/table/metadata_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/metadata_dialog.js
@@ -21,8 +21,8 @@
 
     _TEXTS: {
       title: {
-        table:  _t('Table metadata'),
-        vis:    _t('Visualization metadata')
+        table:  _t('Dataset metadata'),
+        vis:    _t('Map metadata')
       },
       ok: _t('Save settings')
     },

--- a/lib/assets/javascripts/cartodb/table/views/sql_view_notice.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/sql_view_notice.jst.ejs
@@ -5,7 +5,7 @@
         <%= warnMsg %> ·
       <% } %>
       <% if (!isVisualization) { %>
-        <a href="#/export-query" class="export_query">create table from query</a> or <a href="#/clear-view" class="clearview">clear view</a>
+        <a href="#/export-query" class="export_query">create dataset from query</a> or <a href="#/clear-view" class="clearview">clear view</a>
       <% } else { %>
         <a href="#/clear-view" class="clearview">clear this sql view</a>
       <% } %>

--- a/lib/assets/test/spec/cartodb/dashboard/name_visualization_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/name_visualization_dialog.spec.js
@@ -8,7 +8,7 @@ describe("Name visualization dialog", function() {
   it("should render properly", function() {
     name_dialog.render();
     expect(name_dialog.$('input[type="text"]').length).toEqual(1);
-    expect(name_dialog.$('input[type="text"]').attr('placeholder')).toEqual('Name your visualization');
+    expect(name_dialog.$('input[type="text"]').attr('placeholder')).toEqual('Name your map');
     expect(name_dialog.$('div.info').length).toEqual(1);
   });
 

--- a/lib/assets/test/spec/cartodb/table/header/create_visualization_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/create_visualization_dialog.spec.js
@@ -13,7 +13,7 @@ describe("Create visualization dialog", function() {
   it("should render properly", function() {
     view.render();
     expect(view.$('input[type="text"]').length).toEqual(1);
-    expect(view.$('input[type="text"]').attr('placeholder')).toEqual('Name your visualization');
+    expect(view.$('input[type="text"]').attr('placeholder')).toEqual('Name your map');
     expect(view.$('div.info').length).toEqual(1);
     expect(view.$('.modal').size()).toBe(3)
   });

--- a/lib/assets/test/spec/cartodb/table/header/duplicate_table_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/duplicate_table_dialog.spec.js
@@ -12,7 +12,7 @@ describe("Duplicate table", function() {
 
   it("should open the duplicate rename dialog", function() {
     duplicate_dialog.render();
-    expect(duplicate_dialog.$el.find(".modal:eq(0) div.head h3").text()).toEqual('Name for your copy of this table');
+    expect(duplicate_dialog.$el.find(".modal:eq(0) div.head h3").text()).toEqual('Name for your copy of this dataset');
   });
 
   it("should show an error if the name of the new table is empty or same as actual table", function() {
@@ -57,7 +57,7 @@ describe("Duplicate table", function() {
     duplicate_dialog.$el.find(".modal:eq(0) div.foot a.button").click();
     this.server.respond();
 
-    expect(duplicate_dialog.$el.find(".modal:eq(0) div.head h3").text()).toMatch("An error occurred creating your table");
+    expect(duplicate_dialog.$el.find(".modal:eq(0) div.head h3").text()).toMatch("An error occurred creating your dataset");
     this.server.restore();
   });
 
@@ -69,6 +69,6 @@ describe("Duplicate table", function() {
       model: table
     }).render();
 
-    expect(duplicate_dialog.$el.find(".modal:eq(0) div.head h3").text()).toEqual('Name your new table from this query');
+    expect(duplicate_dialog.$el.find(".modal:eq(0) div.head h3").text()).toEqual('Name your new dataset from this query');
   });
 });

--- a/lib/assets/test/spec/cartodb/table/header/duplicate_vis_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/duplicate_vis_dialog.spec.js
@@ -8,7 +8,7 @@ describe("Duplicate vis", function() {
 
   it("should open the duplicate rename dialog", function() {
     duplicate_dialog.render();
-    expect(duplicate_dialog.$el.find(".modal:eq(0) div.head h3").text()).toEqual('Name for your copy of this visualization');
+    expect(duplicate_dialog.$el.find(".modal:eq(0) div.head h3").text()).toEqual('Name for your copy of this map');
     expect(duplicate_dialog.$el.find(".modal").size()).toEqual(3);
     expect(duplicate_dialog.$el.find(".modal.creation").size()).toEqual(1);
     expect(duplicate_dialog.$el.find(".modal.error").size()).toEqual(1);

--- a/lib/assets/test/spec/cartodb/table/header/merge_tables_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/merge_tables_dialog.spec.js
@@ -655,7 +655,7 @@ describe("MergeDialog", function() {
 
     it("should have title", function() {
       dialog.render();
-      expect(dialog.$el.find("section:first-child .head > h3").text()).toEqual("Merge with another table");
+      expect(dialog.$el.find("section:first-child .head > h3").text()).toEqual("Merge with another dataset");
     });
 
     it("should have two selector tables", function() {
@@ -677,7 +677,7 @@ describe("MergeDialog", function() {
 
       expect(dialog.$title).toBeDefined();
       expect(dialog.$title.length > 0).toBeTruthy();
-      expect(dialog.$title.text()).toEqual('Merge with another table');
+      expect(dialog.$title.text()).toEqual('Merge with another dataset');
 
     });
 

--- a/lib/assets/test/spec/cartodb/table/header/metadata_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/metadata_dialog.spec.js
@@ -34,9 +34,9 @@ describe("Metadata dialog", function() {
 
   it("should render properly", function(done) {
     view.render();
-    expect(view.$('section.modal:eq(0) h3').text()).toBe('Table metadata');
+    expect(view.$('section.modal:eq(0) h3').text()).toBe('Dataset metadata');
     expect(view.$('input[name="name"]').val()).toBe('test_table');
-    expect(view.$('textarea[name="description"]').val()).toBe('Table description');
+    expect(view.$('textarea[name="description"]').val()).toBe('Dataset description');
     // expect(view.$('input[name="source"]').val()).toBe('');
     // expect(view.$('input[name="license"]').val()).toBe('');
     expect(view.$('ul li.tagit-choice').size()).toBe(2);
@@ -57,7 +57,7 @@ describe("Metadata dialog", function() {
       user: user
     });
     new_view.render();
-    expect(new_view.$('section.modal:eq(0) h3').text()).toBe('Visualization metadata');
+    expect(new_view.$('section.modal:eq(0) h3').text()).toBe('Map metadata');
     new_view.clean();
   });
 

--- a/lib/assets/test/spec/cartodb/table/header/metadata_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/metadata_dialog.spec.js
@@ -5,7 +5,7 @@ describe("Metadata dialog", function() {
   beforeEach(function() {
     vis = new cdb.admin.Visualization({
       name:             "test_table",
-      description:      "Table description",
+      description:      "Dataset description",
       tags:             ["jam","testing"],
       privacy:          "PUBLIC",
       type:             "table"

--- a/lib/assets/test/spec/cartodb/table/header/options_menu.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/options_menu.spec.js
@@ -50,7 +50,7 @@ describe("Header options menu", function() {
     options_menu.render();
     expect(options_menu.$el.find("li").size()).toEqual(7);
     expect(options_menu.$el.find("div.progress-bar").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Duplicate table')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Duplicate dataset')").size()).toEqual(1);
   });
 
   it("should create geocoding progress bar correctly", function() {
@@ -106,9 +106,9 @@ describe("Header options menu", function() {
     expect(options_menu.$el.find("li").size()).toEqual(5);
     expect(options_menu.$el.find("li:contains('Export layer')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Georeference layer')").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Duplicate visualization')").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Lock visualization')").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Delete visualization')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Duplicate map')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Lock map')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Delete map')").size()).toEqual(1);
   });
 
   it("shouldn't display the 'Georeference layer' option if table has a sql applied in visualization mode", function() {
@@ -119,9 +119,9 @@ describe("Header options menu", function() {
     options_menu.render();
     expect(options_menu.$el.find("li").size()).toEqual(4);
     expect(options_menu.$el.find("li:contains('Export layer')").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Duplicate visualization')").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Lock visualization')").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Delete visualization')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Duplicate map')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Lock map')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Delete map')").size()).toEqual(1);
   });
 
   it("shouldn't have disabled export and duplicate links if a query is applied in table mode", function() {
@@ -130,7 +130,7 @@ describe("Header options menu", function() {
     this.vis.map.layers.last().table.useSQLView(sqlView);
     options_menu.render();
     expect(options_menu.$el.find("li.disabled").size()).toEqual(0);
-    expect(options_menu.$el.find("li:contains('Table from query')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Dataset from query')").size()).toEqual(1);
   });
 
   it("should have disabled export and duplicate links if a query is applied but it is not valid in table mode", function() {
@@ -138,7 +138,7 @@ describe("Header options menu", function() {
     this.vis.map.layers.last().table.useSQLView(sqlView);
     options_menu.render();
     expect(options_menu.$el.find("li.disabled").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Table from query')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Dataset from query')").size()).toEqual(1);
   });
 
   it("shouldn't offer 'delete table' and 'change privacy' options if user is not the owner", function() {
@@ -148,7 +148,7 @@ describe("Header options menu", function() {
     options_menu.render();
     expect(options_menu.$("li a:contains('Change privacy')").length).toBe(0);
     expect(options_menu.$("li a:contains('Sync settings')").length).toBe(0);
-    expect(options_menu.$("li a:contains('Delete this table')").length).toBe(0);
+    expect(options_menu.$("li a:contains('Delete this dataset')").length).toBe(0);
   });
 
   it("shouldn't offer 'delete visualization' if user is not the owner", function() {
@@ -167,8 +167,8 @@ describe("Header options menu", function() {
     this.vis.map.layers.last().table.useSQLView(sqlView);
     options_menu.render();
     expect(options_menu.$el.find("li.disabled").size()).toEqual(0);
-    expect(options_menu.$el.find("li:contains('Duplicate visualization')").size()).toEqual(1);
-    expect(options_menu.$el.find("li:contains('Delete visualization')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Duplicate map')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Delete map')").size()).toEqual(1);
   });
 
 });

--- a/lib/assets/test/spec/cartodb/table/header/share_controller.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/share_controller.spec.js
@@ -86,7 +86,7 @@
         var dlg = controller._subviews[i];
       }
       // expect(dlg.mapOptions).toBeDefined();
-      expect(dlg.$('h3:eq(0)').text()).toBe('Share your visualization');
+      expect(dlg.$('h3:eq(0)').text()).toBe('Share your map');
     });
 
     xit("should only open the 'share dialog'", function() {
@@ -106,7 +106,7 @@
         var dlg = controller._subviews[i];
       }
       expect(dlg.mapOptions).toBeDefined();
-      expect(dlg.$('h3:eq(0)').text()).toBe('Share your visualization');
+      expect(dlg.$('h3:eq(0)').text()).toBe('Share your map');
     });
 
     xit("should turn vis to public and show share dialog", function() {
@@ -144,7 +144,7 @@
       }
 
       expect(dlg.mapOptions).toBeDefined();
-      expect(dlg.$('h3:eq(0)').text()).toBe('Share your visualization');
+      expect(dlg.$('h3:eq(0)').text()).toBe('Share your map');
 
     });
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Basically that, no more visualization or table texts. From now on:

Visualizations -> Map
Table -> Dataset

---

Parts reviewed:

- [x] Editor:
  - [x] Right panel
  - [x] Item metadata
  - [x] Item privacy
  - [x] Dataset creation dialog
  - [x] Item options
  - [x] Map creation dialog 
  - [x] Share map dialog
- [x] Public table/map

---

Fixes #2748