### PR TITLE
Don't concatenate numbers to candidate map names fixes #2846

### DIFF
--- a/app/models/visualization/name_generator.rb
+++ b/app/models/visualization/name_generator.rb
@@ -13,10 +13,10 @@ module CartoDB
 
       def name(candidate=PATTERN, iteration=0)
         candidate = (candidate || PATTERN).strip
-        return candidate if checker.available?(candidate)
+        new_candidate = iteration > 0 ? "#{candidate} #{iteration}" : candidate
+        return new_candidate if checker.available?(new_candidate)
 
-        new_candidate = "#{candidate} #{iteration}"
-        name(new_candidate, iteration + 1)
+        name(candidate, iteration + 1)
       end
 
       private

--- a/spec/models/visualization/name_generator_spec.rb
+++ b/spec/models/visualization/name_generator_spec.rb
@@ -55,26 +55,30 @@ describe Visualization::NameGenerator do
       generator   = Visualization::NameGenerator.new(user, checker)
       generator.name(nil).should == Visualization::NameGenerator::PATTERN
     end
+
+    it 'assigns an incremental number' do
+      user = Object.new
+      candidate = 'Untitled map'
+      Visualization::NameGenerator.new(user, negative_checker([])).name(candidate).should == candidate
+      Visualization::NameGenerator.new(user, negative_checker([candidate])).name(candidate).should == "#{candidate} 1"
+      Visualization::NameGenerator.new(user, negative_checker([candidate, "#{candidate} 1"])).name(candidate).should == "#{candidate} 2"
+      Visualization::NameGenerator.new(user, negative_checker([candidate, "#{candidate} 1", "#{candidate} 2"])).name(candidate).should == "#{candidate} 3"
+    end
   end
 
   def positive_checker
     checker = Object.new
     def checker.available?(*args); true; end
     checker
-  end #positive_checker
+  end
 
-  def negative_checker
-    checker = Object.new
+  def negative_checker(existing = [ 'visualization 1', 'Untitled visualization', 'Untitled visualization 0', 'Untitled visualization 1'])
+    checker = OpenStruct.new
+    checker.existing = existing
     def checker.available?(candidate)
-      existing = [
-        'visualization 1',
-        'Untitled visualization',
-        'Untitled visualization 0',
-        'Untitled visualization 1',
-      ]
       !existing.include?(candidate)
     end
     checker
-  end #negative_checker
-end # Visualization::NameGenerator
+  end
+end
 


### PR DESCRIPTION
@Kartones CR this, please.

@xavijam Now when I create a new map (new dashboard) it gets 'Untitled Map' by default. Bug or feature? I guess it happens since map creation allows multi dataset selection.