### PR TITLE
Removes rendering binding so it doesn't get fired every time a map is removed

### DIFF
--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.8.0
+3.8.1

--- a/lib/assets/javascripts/cartodb/new_dashboard/content_controller_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/content_controller_view.js
@@ -25,7 +25,7 @@ module.exports = cdb.core.View.extend({
     this.router.model.bind('change', this._onRouterChange, this);
     this.collection.bind('reset', this._onDataFetched, this);
     this.collection.bind('loading', this._onDataLoading, this);
-    this.collection.bind('add remove', this._onDataChange, this);
+    this.collection.bind('add', this._onDataChange, this);
     this.collection.bind('error', function(col, e, opts) {
       // Old requests can be stopped, so aborted requests are not
       // considered as an error

--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -198,6 +198,7 @@ module.exports = cdb.core.View.extend({
 
     viewModel.bind('DeleteItemsDone', function() {
       this.user.fetch(); // needed in order to keep the "quota" synchronized
+      this.collection.fetch();
     }, this);
 
     var view = new DeleteItemsDialog({

--- a/lib/assets/javascripts/cartodb/new_dashboard/list_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/list_view.js
@@ -68,7 +68,7 @@ module.exports = cdb.core.View.extend({
 
   _initBinds: function() {
     this.collection.bind('loading', this._onItemsLoading, this);
-    this.collection.bind('reset remove', this.render, this);
+    this.collection.bind('reset', this.render, this);
     this.add_related_model(this.collection);
   },
 

--- a/lib/assets/test/spec/cartodb/new_dashboard/content_controller_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/content_controller_view.spec.js
@@ -175,14 +175,12 @@ describe('new_dashboard/content_controller_view', function() {
       expect(this.view._isBlockEnabled('no_results')).toBeTruthy();
     });
 
-    it('should show small_loader when collection has changed (add/remove)', function() {
+    it('should show small_loader when adding an element to the collection', function() {
       this.router.model.set({ content_type: 'datasets' }, { silent: true });
       this.collection.add(this.vis);
       expect(this.view._isBlockEnabled('small_loader')).toBeTruthy();
       this.router.model.set({ content_type: 'maps' });
       expect(this.view._isBlockEnabled('small_loader')).toBeFalsy();
-      this.collection.remove(this.collection.at(0));
-      expect(this.view._isBlockEnabled('small_loader')).toBeTruthy();
     });
 
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See original ticket to understand the problem: https://github.com/CartoDB/cartodb/issues/2921

This is what it seems to be happening: when several maps are removed on a batch in the new dashboard, the [render method]( https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/new_dashboard/list_view.js#L32) of the list view is called once per visualization. Maps that are going to be removed are rendered, but since the method that loads the vizjson to draw the preview is asynchronous, it can happen that we attempt to create a preview of a vizjson that doesn't exist anymore.

Since we are refreshing the collection when the removal of all the elements is finished, we don't need to bind the 'remove' event in the collection.