### PR TITLE
Fixes "all" infowindow field switch

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_fields_pane.js
@@ -172,27 +172,27 @@
     _storeSortedFields: function() {
       var self = this;
 
-      if (this.model.fieldCount() > 0) {
-        this.sortedFields.reset([]);
+      this.sortedFields.reset([]);
 
-        var names = this._getSortedColumnNames();
-        _(names).each(function(name, position) {
-          self.sortedFields.add({
-            name: name,
-            position: position
-          })
-        });
-      }
+      var names = this._getSortedColumnNames();
+      _(names).each(function(name, position) {
+        self.sortedFields.add({
+          name: name,
+          position: position
+        })
+      });
     },
 
     _getSortedColumnNames: function() {
       var self = this;
       var names = this.getColumnNames();
-      names.sort(function(a, b) {
-        var pos_a = self.model.getFieldPos(a);
-        var pos_b = self.model.getFieldPos(b);
-        return pos_a - pos_b;
-      });
+      if (this.model.fieldCount() > 0) {
+        names.sort(function(a, b) {
+          var pos_a = self.model.getFieldPos(a);
+          var pos_b = self.model.getFieldPos(b);
+          return pos_a - pos_b;
+        });
+      }
       return names;
     },
     // when fields are sorted in the iu we should recalculate all models positions

--- a/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
@@ -200,6 +200,23 @@ describe("mod.infowindow", function() {
         expect($(view.$el.find('.switch')[1]).hasClass('enabled')).toEqual(true);
       });
 
+      it("should enable/disable all fields", function() {
+        view.render();
+
+        expect($(view.$el.find('.fields .switch:not(.enabled)')).length).toEqual(3);
+
+        // Select all
+        view.$el.find('.selectall').trigger('click');
+
+        expect($(view.$el.find('.fields .switch.enabled')).length).toEqual(3);
+
+        // Unselect all
+        view.$el.find('.selectall').trigger('click');
+
+        expect($(view.$el.find('.fields .switch:not(.enabled)')).length).toEqual(3);
+      });
+
+
       it("should disable select-all when all chosen", function() {
         view.render();
         model.addField('name1').addField('name2').addField('name3');


### PR DESCRIPTION
Fixes #3008. The internal `sortedFields` attribute was not being properly set when no fields were selected. I have added a test that reproduces the bug :)

@xavijam can you please take a look? thx!