### PR TITLE
Moving notification after Central creation fixes #3022

### DIFF
--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -65,6 +65,7 @@ class Admin::OrganizationUsersController < ApplicationController
     copy_account_features(current_user, @user)
     @user.save(raise_on_failure: true)
     @user.create_in_central
+    @user.notify_new_organization_user
     redirect_to organization_path(user_domain: params[:user_domain]), flash: { success: "New user created successfully" }
   rescue CartoDB::CentralCommunicationFailure => e
     Rollbar.report_exception(e)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,9 +140,10 @@ class User < Sequel::Model
     monitor_user_notification
     sleep 1
     set_statement_timeouts
-    if self.has_organization_enabled?
-      ::Resque.enqueue(::Resque::UserJobs::Mail::NewOrganizationUser, self.id)
-    end
+  end
+
+  def notify_new_organization_user
+    ::Resque.enqueue(::Resque::UserJobs::Mail::NewOrganizationUser, self.id)
   end
 
   def should_load_common_data?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1269,13 +1269,16 @@ describe User do
 
   end
 
-  it "should notify a new user created from a organization" do
+  # INFO: since user can be also created in Central, and it can fail, we need to request notification explicitly. See #3022 for more info 
+  it "can notify a new user creation" do
 
     ::Resque.stubs(:enqueue).returns(nil)
 
     organization = create_organization_with_owner(quota_in_bytes: 1000.megabytes)
     user1 = new_user(:username => 'test', :email => "client@example.com", :organization => organization, :organization_id => organization.id, :quota_in_bytes => 20.megabytes)
     user1.id = UUIDTools::UUID.timestamp_create.to_s
+
+    user.notify_new_organization_user
 
     ::Resque.expects(:enqueue).with(::Resque::UserJobs::Mail::NewOrganizationUser, user1.id).once
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1278,7 +1278,7 @@ describe User do
     user1 = new_user(:username => 'test', :email => "client@example.com", :organization => organization, :organization_id => organization.id, :quota_in_bytes => 20.megabytes)
     user1.id = UUIDTools::UUID.timestamp_create.to_s
 
-    user.notify_new_organization_user
+    user1.notify_new_organization_user
 
     ::Resque.expects(:enqueue).with(::Resque::UserJobs::Mail::NewOrganizationUser, user1.id).once
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1278,11 +1278,11 @@ describe User do
     user1 = new_user(:username => 'test', :email => "client@example.com", :organization => organization, :organization_id => organization.id, :quota_in_bytes => 20.megabytes)
     user1.id = UUIDTools::UUID.timestamp_create.to_s
 
-    user1.notify_new_organization_user
-
     ::Resque.expects(:enqueue).with(::Resque::UserJobs::Mail::NewOrganizationUser, user1.id).once
 
     user1.save
+    # INFO: if user must be synched with a remote server it should happen before notifying
+    user1.notify_new_organization_user
 
     organization.destroy
   end


### PR DESCRIPTION
@Kartones CR this fix for #3022, please. I don't like moving logic from model to controller, but since user creation and Central synchronization is also done in the opposite way (from Central to box) moving it to the model would probably imply flags to avoid sync and so on. :(