### PR TITLE
Don't stop event propagation when action dialogs are opened

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/datasets/datasets_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/datasets/datasets_item.js
@@ -122,10 +122,7 @@ module.exports = cdb.core.View.extend({
     // Let links use default behaviour
     if (ev.target.tagName !== 'A') {
       this.killEvent(ev);
-      // var isOwner = this.model.permission.isOwner(this.user);
-      // if (isOwner && this.model.get('type') !== "remote") {
-        this.model.set('selected', !this.model.get('selected'));  
-      // }
+      this.model.set('selected', !this.model.get('selected'));
     }
   }
 });

--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -190,7 +190,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _openDeleteItemsDialog: function(e) {
-    this.killEvent(e);
+    e.preventDefault();
 
     var viewModel = new DeleteItemsViewModel(this._selectedItems(), {
       contentType: this.router.model.get('content_type')
@@ -211,7 +211,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _openChangeLockDialog: function(e) {
-    this.killEvent(e);
+    e.preventDefault();
 
     var viewModel = new ChangeLockViewModel(this._selectedItems());
     viewModel.bind('ProcessItemsDone', function() {
@@ -229,7 +229,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _openPrivacyDialog: function(e) {
-    this.killEvent(e);
+    e.preventDefault();
     cdb.god.trigger('openPrivacyDialog', this._selectedItems()[0]);
   },
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -123,10 +123,10 @@ module.exports = cdb.core.View.extend({
     cdb.god.trigger('openPrivacyDialog', this.model);
   },
 
-  _onCardClick: function(e) {
+  _onCardClick: function(ev) {
     // Let links use default behaviour
-    if (!$(e.target).closest('a')[0]) {
-      this.killEvent(e);
+    if (!$(ev.target).closest('a')[0]) {
+      this.killEvent(ev);
       var isOwner = this.model.permission.isOwner(this.user);
       if (isOwner) {
         this.model.set('selected', !this.model.get('selected'));  


### PR DESCRIPTION
Basically, it could be fixed just preventing map_item and dataset_item click events. But it causes problems with our ```cdb.god``` (:pray:), which if it notices that an event arrives, it fires a ```closeDialogs``` event ([code](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/new_dashboard/main_view.js#L131)). And finally, that provokes unselect all current selected items ([code](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js#L109)).
So, right now, I've found the solution committed easy and painless, what do you think?

cc @viddo @alonsogarciapablo 

It fixes #2939.