### PR TITLE
Message in background importer when user tries to import more files that is allowed

### DIFF
--- a/app/assets/stylesheets/new_dashboard/background_importer_item.css.scss
+++ b/app/assets/stylesheets/new_dashboard/background_importer_item.css.scss
@@ -13,6 +13,11 @@
   margin: 0 20px;
   border-bottom: 1px solid $cStructure-mainLine;
 }
+.ImportItem--sticky {
+  padding: 0 20px;
+  margin: 0;
+  background: $cCard-hoverFill; 
+}
 .ImportItem:last-child { border: none }
 .ImportItem-text {
   display: block;
@@ -22,6 +27,9 @@
   overflow: hidden;
   font-size: $sFontSize-normal;
   color: $cTypography-paragraphs;
+}
+.ImportItem-text.is-long {
+  width: 380px;
 }
 .ImportItem-textState {
   text-transform: capitalize;
@@ -43,6 +51,7 @@
 .ImportItem-closeButton {
   width: 24px;
   height: 24px;
+  margin-left: 5px;
   line-height: 26px;
   border: 1px solid $cNavButton-default;
   border-radius: 22px;

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_limit_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_limit_view.js
@@ -1,0 +1,34 @@
+var cdb = require('cartodb.js');
+
+/**
+ *  Import limit message within background importer
+ *
+ */
+
+module.exports = cdb.core.View.extend({
+
+  className: 'ImportItem ImportItem--sticky',
+  tagName: 'li',
+
+  initialize: function() {
+    this.user = this.options.user;
+    this.template = cdb.templates.getTemplate('new_dashboard/views/background_importer/background_importer_limit_view');
+  },
+
+  render: function() {
+    var userActions = this.user.get('actions');
+    var importQuota = ( userActions && userActions.import_quota ) || 1;
+    var isUpgradeable = !cdb.config.get('custom_com_hosted') && importQuota === 1;
+
+    this.$el.html(
+      this.template({
+        upgradeUrl: window.upgrade_url,
+        isUpgradeable: isUpgradeable,
+        importQuota: importQuota
+      })
+    );
+
+    return this;
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/background_importer_view.js
@@ -2,6 +2,7 @@ var $ = require('jquery');
 var cdb = require('cartodb.js');
 var ImportsCollection = require('../../new_dashboard/background_importer/imports_collection');
 var ImportItem = require('../../new_dashboard/background_importer/background_importer_item_view');
+var ImportLimitItem = require('../../new_dashboard/background_importer/background_importer_limit_view');
 var ImportsModel = require('../../new_common/imports_model');
 
 /**
@@ -19,6 +20,7 @@ module.exports = cdb.core.View.extend({
     this.user = this.options.user;
     this.items = this.options.items;
     this.router = this.options.router;
+    this.model = new cdb.core.Model();
     this.collection = new ImportsCollection(null, { user: this.user });
     this.template = cdb.templates.getTemplate('new_dashboard/views/background_importer/background_importer_view');
     this._initBinds();
@@ -81,7 +83,8 @@ module.exports = cdb.core.View.extend({
 
     // Redirect to dataset/map url?
     if (( this.collection.size() - failed ) === 1 && mdl && mdl.get('state') === "complete" &&
-      c && c.changes && c.changes.state && imp.tables_created_count === 1 && imp.service_name !== "twitter_search") {
+      c && c.changes && c.changes.state && imp.tables_created_count === 1 && imp.service_name !== "twitter_search"
+      && !this.model.get('importLimit')) {
       this._goTo(mdl);
     }
 
@@ -117,6 +120,14 @@ module.exports = cdb.core.View.extend({
 
   _addDataset: function(d) {    
     if (d) {
+
+      if (!this.collection.canImport()) {
+        this._addLimitItem();
+        return false;
+      } else {
+        this._removeLimitItem();
+      }
+
       var imp = new ImportsModel({ upload: d }, { user: this.user });
       this.collection.add(imp);
     }
@@ -124,6 +135,14 @@ module.exports = cdb.core.View.extend({
 
   _onDroppedFile: function(files) {
     if (files) {
+
+      if (!this.collection.canImport()) {
+        this._addLimitItem();
+        return false;
+      } else {
+        this._removeLimitItem();
+      }
+
       var imp = new ImportsModel(
         {
           upload: {
@@ -138,6 +157,26 @@ module.exports = cdb.core.View.extend({
         }
       );
       this.collection.add(imp);
+    }
+  },
+
+  _addLimitItem: function() {
+    if (!this.model.get('importLimit')) {
+      var v = new ImportLimitItem({
+        user: this.user
+      });
+      this.$('.BackgroundImporter-list').prepend(v.render().el);
+      this.addView(v);
+      this.model.set('importLimit', v);
+    }
+  },
+
+  _removeLimitItem: function() {
+    var v = this.model.get('importLimit');
+    if (v) {
+      v.clean();
+      this.removeView(v);
+      this.model.unset('importLimit');
     }
   },
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/background_importer/imports_collection.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/background_importer/imports_collection.js
@@ -40,6 +40,21 @@ module.exports = Backbone.Collection.extend({
     return this.models
   },
 
+  canImport: function() {
+    var userActions = this.user.get('actions');
+    var importQuota = ( userActions && userActions.import_quota ) || 1;
+    var total = this.size();
+    var finished = 0;
+
+    this.each(function(m) {
+      if (m.hasFailed() || m.hasCompleted()) {
+        ++finished;
+      }
+    });
+
+    return (total - finished) < importQuota;
+  },
+
   pollCheck: function(i) {
     if (this.pollTimer) return;
     

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/background_importer/background_importer_limit_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/background_importer/background_importer_limit_view.jst.ejs
@@ -1,0 +1,7 @@
+<div class="ImportItem-text is-long">
+  <% if (isUpgradeable) { %>
+    In a hurry? <a href="<%= upgradeUrl %>">Upgrade your account</a> to import more files at a time
+  <% } else { %>
+    Unfortunally you can import up to <%= importQuota %> at the same time
+  <% } %>
+</div>

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/background_importer/background_importer_limit_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/background_importer/background_importer_limit_view.jst.ejs
@@ -1,7 +1,7 @@
 <div class="ImportItem-text is-long">
   <% if (isUpgradeable) { %>
-    In a hurry? <a href="<%= upgradeUrl %>">Upgrade your account</a> to import more files at a time
+    In a hurry? <a href="<%= upgradeUrl %>">Upgrade your account</a> to import several files at a time
   <% } else { %>
-    Unfortunally you can import up to <%= importQuota %> at the same time
+    Unfortunately you can only import up to <%= importQuota %> files at the same time
   <% } %>
 </div>

--- a/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/background_importer/background_importer_view.spec.js
@@ -29,6 +29,14 @@ describe('new_dashboard/background_importer/background_importer_view', function(
       user: this.user
     });
 
+    this.createImportsModel = function(state) {
+      return new ImportsModel({
+        state: state
+      }, {
+        user: this.user
+      });
+    }.bind(this);
+
     this.view.collection.pollCheck = function() {};
   });
 
@@ -95,21 +103,13 @@ describe('new_dashboard/background_importer/background_importer_view', function(
 
     spyOn(this.view, '_redirect');
 
-    var createImportsModel = function(state) {
-      return new ImportsModel({
-        state: state
-      }, {
-        user: this.user
-      });
-    }.bind(this);
-
-    var mdl = createImportsModel('error');
+    var mdl = this.createImportsModel('error');
     this.view.collection.add(mdl);
     expect(this.view._redirect).not.toHaveBeenCalled();
-    var mdl1 = createImportsModel('pending');
+    var mdl1 = this.createImportsModel('pending');
     this.view.collection.add(mdl1);
     expect(this.view._redirect).not.toHaveBeenCalled();
-    var mdl2 = createImportsModel('pending');
+    var mdl2 = this.createImportsModel('pending');
     this.view.collection.add(mdl2);
     expect(this.view._redirect).not.toHaveBeenCalled();
     mdl1.set('state', 'complete');
@@ -118,6 +118,79 @@ describe('new_dashboard/background_importer/background_importer_view', function(
     mdl2.imp.set({ table_name: 'jur', tables_created_count: 1 });
     mdl2.set({ state: 'complete' });
     expect(this.view._redirect).toHaveBeenCalledWith('http://paco.cartodb.com/tables/jur');
+  });
+
+  describe('import limits', function() {
+
+    beforeEach(function() {
+      this.user.set('actions', { import_quota: 2 });
+    });
+
+    it("should check if user can import before add the item", function() {
+      spyOn(this.view.collection, 'canImport');
+      this.view._addDataset({ hello: 'hello' });
+      expect(this.view.collection.canImport).toHaveBeenCalled();
+      expect(this.view.collection.canImport.calls.count()).toBe(1);
+      this.view._onDroppedFile([{ hello: 'hello' }]);
+      expect(this.view.collection.canImport.calls.count()).toBe(2);
+    });
+
+    it("should add limits view when user has reached his/her import quota", function() {
+      _.times(2, function(){
+        this.view.collection.add(
+          this.createImportsModel('pending')
+        );
+      }, this);
+
+      this.view._addDataset({ hello: 'hello' });
+      expect(this.view.model.get('importLimit')).not.toBe(undefined);
+    });
+
+    it("should remove limits view when user has available slots", function() {
+      _.times(2, function(){
+        this.view.collection.add(
+          this.createImportsModel('pending')
+        );
+      }, this);
+
+      this.view._addDataset({ hello: 'hello' });
+      expect(this.view.model.get('importLimit')).not.toBe(undefined);
+
+      this.view.collection.each(function(m, i) {
+        if (i < 2) {
+          m.set({
+            step: 'upload',
+            state: 'error'
+          });
+        }
+      });
+
+      this.view._addDataset({ hello: 'hello' });
+      expect(this.view.model.get('importLimit')).toBe(undefined);
+    });
+
+    it('should not redirect to item url when it is imported if limits view is included', function() {
+      spyOn(this.view, '_goTo');
+      this.user.set('actions', { import_quota: 1 });
+
+      _.times(1, function(){
+        this.view.collection.add(
+          this.createImportsModel('pending')
+        );
+      }, this);
+
+      this.view._addDataset({ hello: 'hello' });
+      expect(this.view.model.get('importLimit')).not.toBe(undefined);
+      var m = this.view.collection.at(0);
+      spyOn(m, 'hasCompleted').and.returnValue(true);
+      m.set({
+        state: 'success',
+        step: 'import'
+      });
+
+      expect(this.view._goTo).not.toHaveBeenCalled();
+    });
+
   });
 
   it('should have no leaks', function() {


### PR DESCRIPTION
So, if the user tries to import at the same time, more files than allowed, those messages will appear:

- If user can upgrade his/her account:
![screen shot 2015-04-06 at 16 42 48](https://cloud.githubusercontent.com/assets/132146/7006878/e6b7c89c-dc84-11e4-8559-dbca94b8ce8c.png)

- If user can't upgrade (already paid or open source):
![screen shot 2015-04-06 at 16 42 55](https://cloud.githubusercontent.com/assets/132146/7006879/e7e7122c-dc84-11e4-98aa-2230b937dd9a.png)
(* Number is irrelevant :D)

Related things:
- If limits view appears meanwhile an import is happening, and it finishes, we won't redirect to the dataset/map if that view is there.
- If limits view is there, and old imports have finished, if you try to import a new one, it will let you and the limit view will disappear.

Fixes #2856.

Reviewer: @javierarce, please.
