### PR TITLE
1003 improve tmp dir security

### DIFF
--- a/services/table-geocoder/lib/internal_geocoder.rb
+++ b/services/table-geocoder/lib/internal_geocoder.rb
@@ -18,7 +18,6 @@ module CartoDB
         @sql_api              = CartoDB::SQLApi.new arguments.fetch(:internal)
         @connection           = arguments.fetch(:connection)
         @working_dir          = Dir.mktmpdir
-        `chmod 777 #{@working_dir}`
         @table_name           = arguments[:table_name]
         @table_schema         = arguments[:table_schema]
         @qualified_table_name = arguments[:qualified_table_name]

--- a/services/table-geocoder/lib/internal_geocoder.rb
+++ b/services/table-geocoder/lib/internal_geocoder.rb
@@ -46,7 +46,7 @@ module CartoDB
         raise e
       ensure
         drop_temp_table
-        FileUtils.rm_rf @working_dir
+        FileUtils.remove_entry_secure @working_dir
       end
 
       def download_results


### PR DESCRIPTION
@Kartones small review

This comes from a suggestion you made time ago. I've been reviewing the code and it should be perfectly safe because no user input is involved in the temp directory nor file paths creation.

Nevertheless I modified a couple of things that should make it better:

- do not grant permissions to third party users `chmod 777` since there's no need
- use `remove_entry_secure`

http://ruby-doc.org/stdlib-1.9.3/libdoc/tmpdir/rdoc/Dir.html#method-c-mktmpdir
http://ruby-doc.org/stdlib-1.9.3/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure