### PR TITLE
User pages enhancements

### DIFF
--- a/app/assets/stylesheets/new_common/filters.css.scss
+++ b/app/assets/stylesheets/new_common/filters.css.scss
@@ -282,6 +282,10 @@ a.Filters-cleanSearch { line-height:32px }
   @include progress-bar(6px, 9px, true, false);
   width: 178px;
 }
+.Filters-link:hover {
+  text-decoration: none;
+  .Filters-progressSize { color: $cTypography-paragraphs }
+}
 @media only screen and (max-width: 959px) {
   .Filters-row {
     padding: 0 20px;

--- a/app/assets/stylesheets/new_organization/organization_user_details.css.scss
+++ b/app/assets/stylesheets/new_organization/organization_user_details.css.scss
@@ -56,15 +56,7 @@
   line-height: 24px;
   font-size: 24px;
 }
-
-
-
-// <div class="OrganizationUser">
-//       <ul class="OrganizationUser-stats">
-//         <li class="OrganizationUser-stat">
-//           <i class="iconFont iconFont-Document OrganizationUser-statIcon"></i>
-//           <div class="OrganizationUser-statInfo">
-//             <em class="OrganizationUser-statTitle"><%= @user.tables.count %></em>
-//             <label class="OrganizationUser-statLabel"><%= "Dataset".pluralize(@user.tables.count) %></label>
-//           </div>
-//         </li>
+.iconFont-Twitter.OrganizationUser-statIcon {
+  line-height: 32px;
+  font-size: 22px;
+}

--- a/app/views/admin/organization_users/new_edit.html.erb
+++ b/app/views/admin/organization_users/new_edit.html.erb
@@ -64,6 +64,15 @@
               <label class="OrganizationUser-statLabel"><%= "Georeferenced row".pluralize(@user.get_geocoding_calls) %></label>
             </div>
           </li>
+          <% if ( @user.organization.present? && @user.organization.twitter_datasource_enabled ) || @user.twitter_datasource_enabled %>
+            <li class="OrganizationUser-stat">
+              <i class="iconFont iconFont-Twitter OrganizationUser-statIcon"></i>
+              <div class="OrganizationUser-statInfo">
+                <em class="OrganizationUser-statTitle"><%= number_with_delimiter(@user.get_twitter_imports_count) %></em>
+                <label class="OrganizationUser-statLabel"><%= "Tweet".pluralize(@user.get_twitter_imports_count) %> imported</label>
+              </div>
+            </li>
+          <% end %>
           <li class="OrganizationUser-stat">
             <i class="iconFont iconFont-ProgressBar OrganizationUser-statIcon"></i>
             <div class="OrganizationUser-statInfo">

--- a/app/views/admin/shared/_new_org_subheader.html.erb
+++ b/app/views/admin/shared/_new_org_subheader.html.erb
@@ -13,6 +13,10 @@
           </ul>
         </div>
         <div class="Filters-order"> 
+          <% if (!Cartodb.config[:cartodb_com_hosted].present? && (!current_user.organization.present? || current_user.organization_owner?))  %>
+            <a class="Filters-link" href="<%= current_user.plan_url(request.protocol) %>">
+          <% end %>
+          
           <div class="Filters-progress">
             <% per = (current_user.organization.users.count * 100) / current_user.organization.seats %>
             <% className = '' %>
@@ -26,8 +30,12 @@
               <div class="progress-bar">
                 <span class="bar-2 <%= className %>" style="width:<%= per %>%"></span>
               </div>
-            </div>
+            </div>  
           </div>
+
+          <% if (!Cartodb.config[:cartodb_com_hosted].present? && (!current_user.organization.present? || current_user.organization_owner?))  %>
+            </a>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/admin/shared/_new_pages_subheader.html.erb
+++ b/app/views/admin/shared/_new_pages_subheader.html.erb
@@ -15,6 +15,10 @@
           </ul>
         </div>
         <div class="Filters-order"> 
+          <% if !Cartodb.config[:cartodb_com_hosted].present? %>
+            <a class="Filters-link" href="<%= current_user.plan_url(request.protocol) %>">
+          <% end %>
+
           <div class="Filters-progress">
             <% per = (current_user.db_size_in_bytes * 100) / current_user.quota_in_bytes %>
             <% className = '' %>
@@ -30,6 +34,10 @@
               </div>
             </div>
           </div>
+
+          <% if !Cartodb.config[:cartodb_com_hosted].present? %>
+            </a>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
![screen shot 2015-04-06 at 18 24 56](https://cloud.githubusercontent.com/assets/132146/7007441/3e63c74e-dc8a-11e4-8f77-2216e03a41b9.png)

- [x] Display imported tweets at user account page (fixes #3030).
- [x] Clicking on the small quota bar on the account pages should go to the plan tab (fixes #2949). 

@juanignaciosl could you check it please? :)