### PR TITLE
Added owner name tooltip for maps and datasets items within new dashboard

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/datasets/datasets_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/datasets/datasets_item.js
@@ -100,11 +100,23 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderTooltips: function() {
-    // Tooltip
+    // Synchronization
     if (!_.isEmpty(this.model.get("synchronization"))) {
       this.addView(
         new cdb.common.TipsyTooltip({
           el: this.$('.DatasetsList-itemStatus'),
+          title: function(e) {
+            return $(this).attr('data-title')
+          }
+        })
+      )
+    }
+
+    // Owner
+    if (!this.model.permission.isOwner(this.user)) {
+      this.addView(
+        new cdb.common.TipsyTooltip({
+          el: this.$('.UserAvatar'),
           title: function(e) {
             return $(this).attr('data-title')
           }

--- a/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/maps/maps_item.js
@@ -60,6 +60,7 @@ module.exports = cdb.core.View.extend({
     this._renderMapviewsGraph();
     this._renderLikesIndicator();
     this._renderMapThumbnail();
+    this._renderTooltips();
     this._checkSelected();
 
     return this;
@@ -86,8 +87,18 @@ module.exports = cdb.core.View.extend({
     this.addView(graph.render());
   },
 
-  _checkSelected: function() {
-    this.$(".MapCard")[this.model.get("selected") ? "addClass" : "removeClass"]("is-selected");
+  _renderTooltips: function() {
+    // Owner
+    if (!this.model.permission.isOwner(this.user)) {
+      this.addView(
+        new cdb.common.TipsyTooltip({
+          el: this.$('.UserAvatar'),
+          title: function(e) {
+            return $(this).attr('data-title')
+          }
+        })
+      )
+    }
   },
 
   _renderMapThumbnail: function() {
@@ -116,6 +127,10 @@ module.exports = cdb.core.View.extend({
     });
 
     this.addView(mapCardPreview);
+  },
+
+  _checkSelected: function() {
+    this.$(".MapCard")[this.model.get("selected") ? "addClass" : "removeClass"]("is-selected");
   },
 
   _openPrivacyDialog: function(ev) {

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/datasets_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/datasets_item.jst.ejs
@@ -51,8 +51,8 @@
           <%= timeDiff %>
           <% if (!isOwner) { %>
             by
-            <span class="UserAvatar">
-              <img class="UserAvatar-img UserAvatar-img--smaller" src="<%= owner.avatar_url %>" alt="<%= owner.name || owner.username  %>" title="<%= owner.name || owner.username  %>" />
+            <span class="UserAvatar" data-title="<%= owner.name || owner.username  %>">
+              <img class="UserAvatar-img UserAvatar-img--smaller" src="<%= owner.avatar_url %>" />
             </span>
           <% } %>
       </span>

--- a/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_dashboard/views/maps_item.jst.ejs
@@ -46,8 +46,8 @@
           <%= timeDiff %>
           <% if (!isOwner) { %>
             by
-            <span class="UserAvatar">
-              <img class="UserAvatar-img UserAvatar-img--smaller" src="<%= owner.avatar_url %>" alt="<%= owner.name || owner.username  %>" title="<%= owner.name || owner.username  %>" />
+            <span class="UserAvatar" data-title="<%= owner.name || owner.username  %>">
+              <img class="UserAvatar-img UserAvatar-img--smaller" src="<%= owner.avatar_url %>" />
             </span>
           <% } %>
         </div>

--- a/lib/assets/test/spec/cartodb/new_dashboard/maps/maps_item.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/maps/maps_item.spec.js
@@ -114,7 +114,7 @@ describe('new_dashboard/maps/maps_item', function() {
 
       this.renderView();
       expect(this.view.$('.UserAvatar').length).toBe(1);
-      expect(this.view.$('.UserAvatar img').attr('title')).toBe('whoknows');
+      expect(this.view.$('.UserAvatar').attr('data-title')).toBe('whoknows');
     });
 
   });


### PR DESCRIPTION
Basically:
![screen shot 2015-04-06 at 18 44 12](https://cloud.githubusercontent.com/assets/132146/7007807/1c76fa68-dc8d-11e4-98f9-39251b0d02e1.png)
![screen shot 2015-04-06 at 18 44 34](https://cloud.githubusercontent.com/assets/132146/7007808/1c78c15e-dc8d-11e4-892e-b2615c7c8a03.png)

Fixes #2844.