### PR TITLE
Load gmaps lib before cartodb.js for public pages

### DIFF
--- a/app/views/layouts/new_public_dashboard.html.erb
+++ b/app/views/layouts/new_public_dashboard.html.erb
@@ -104,6 +104,7 @@
         <% end %>
       };
     </script>
+    <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
     <%= javascript_include_tag 'cdb.js', 'templates', 'new_public_dashboard_deps', 'new_public_dashboard' %>
     <%= yield :js %>
   </body>

--- a/app/views/layouts/new_public_dashboard.html.erb
+++ b/app/views/layouts/new_public_dashboard.html.erb
@@ -104,7 +104,9 @@
         <% end %>
       };
     </script>
-    <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <% if @most_viewed_vis_map && @most_viewed_vis_map.map.provider == 'googlemaps' %>
+      <script type="text/javascript" src="//maps.google.com/maps/api/js?sensor=false&v=3.12"></script>
+    <% end %>
     <%= javascript_include_tag 'cdb.js', 'templates', 'new_public_dashboard_deps', 'new_public_dashboard' %>
     <%= yield :js %>
   </body>


### PR DESCRIPTION
Fixes #3074, using same gmaps lib include as on old public pages, https://github.com/CartoDB/cartodb/blob/master/app/views/admin/pages/public_dashboard.html.erb#L27