### PR TITLE
Set the default basemap at initialization time

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,7 +62,7 @@ module ApplicationHelper
   end
 
   def default_fallback_basemap
-    Cartodb.config[:basemaps].present? ? Cartodb.config[:basemaps]['CartoDB']['positron_rainbow'] : {}
+    Cartodb.config[:basemaps].present? and Cartodb.config[:basemaps]['default'].present? ? Cartodb.config[:basemaps]['default'] : {}
   end
 
   module_function :default_fallback_basemap

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -263,6 +263,7 @@ defaults: &defaults
   basemaps:
     CartoDB:
       positron_rainbow:
+        default: true
         url: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
         subdomains: 'abcd'
         minZoom: '0'

--- a/config/initializers/01_app_config.rb
+++ b/config/initializers/01_app_config.rb
@@ -42,6 +42,21 @@ module Cartodb
         :authentication       => Cartodb.config[:mailer]['authentication'],
         :enable_starttls_auto => Cartodb.config[:mailer]['enable_starttls_auto'] }
     end
+
+    if @config[:basemaps].present?
+      default_attrs = {}
+      @config[:basemaps].each do |bfamily,ba|
+        ba.each do |bname,battrs|
+          if battrs['default']
+            default_attrs = battrs
+            break
+          end
+        end
+      end
+      if !@config[:basemaps]['default'].present?
+        @config[:basemaps]['default'] = default_attrs
+      end
+    end
   end
 
   def self.error_codes

--- a/config/initializers/01_app_config.rb
+++ b/config/initializers/01_app_config.rb
@@ -43,18 +43,18 @@ module Cartodb
         :enable_starttls_auto => Cartodb.config[:mailer]['enable_starttls_auto'] }
     end
 
-    if @config[:basemaps].present?
-      default_attrs = {}
+    if @config[:basemaps].present? && !@config[:basemaps]['default'].present?
+      @config[:basemaps]['default'] = {}
+      new_default = false
       @config[:basemaps].each do |bfamily,ba|
+        break if new_default
         ba.each do |bname,battrs|
           if battrs['default']
-            default_attrs = battrs
+            @config[:basemaps]['default'] = battrs
+            new_default = true
             break
           end
         end
-      end
-      if !@config[:basemaps]['default'].present?
-        @config[:basemaps]['default'] = default_attrs
       end
     end
   end


### PR DESCRIPTION
It requires to have a default attribute in any of the basemaps in the config. It will set the first it finds iterating and will stop looking for more.

@Kartones @javisantana please review