### PR TITLE
Adding default fallback basemap attribute for public organization 

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -270,6 +270,7 @@ class Admin::PagesController < ApplicationController
     set_new_layout_vars({
         most_viewed_vis_map: org.public_vis_by_type(Visualization::Member::TYPE_DERIVED, 1, 1, nil, 'mapviews').first,
         content_type:        content_type,
+        default_fallback_basemap: ApplicationHelper.default_fallback_basemap
       })
     set_shared_layout_vars(org, {
         name:       org.display_name.blank? ? org.name : org.display_name,


### PR DESCRIPTION
review: @lbosque or @Kartones 

Fixes #3162