### PR TITLE
Visualization stats endpoint

### DIFF
--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -1,4 +1,5 @@
 require_relative 'visualization_presenter'
+require_relative '../../../models/visualization/stats'
 
 module Carto
 
@@ -7,8 +8,8 @@ module Carto
     class VisualizationsController < ::Api::ApplicationController
 
       before_filter :table_and_schema_from_params
-      before_filter :load_visualization, only: [:likes_count, :likes_list, :is_liked, :show]
-      ssl_required :index
+      before_filter :load_visualization, only: [:likes_count, :likes_list, :is_liked, :show, :stats]
+      ssl_required :index, :show
       skip_before_filter :api_authorization_required, only: [:index]
       before_filter :optional_api_authorization, only: [:index]
 
@@ -129,6 +130,10 @@ module Carto
           likes: @visualization.likes.count,
           liked: @visualization.is_liked_by_user_id?(current_viewer.id)
         })
+      end
+
+      def stats
+        render_jsonp(CartoDB::Visualization::Stats.new(@visualization).to_poro)
       end
 
       private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,7 @@ CartoDB::Application.routes.draw do
     get     '(/user/:user_domain)(/u/:user_domain)/api/v1_1/viz/:id/likes'                      => 'visualizations#likes_count',     as: :api_v1_1_visualizations_likes_count,     constraints: { id: /[^\/]+/ }
     get     '(/user/:user_domain)(/u/:user_domain)/api/v1_1/viz/:id/likes/detailed'             => 'visualizations#likes_list',      as: :api_v1_1_visualizations_likes_list,      constraints: { id: /[^\/]+/ }
     get     '(/user/:user_domain)(/u/:user_domain)/api/v1_1/viz/:id/like'                       => 'visualizations#is_liked',        as: :api_v1_1_visualizations_is_liked,        constraints: { id: /[^\/]+/ }
+    get     '(/user/:user_domain)(/u/:user_domain)/api/v1_1/viz/:id/stats'                      => 'visualizations#stats',           as: :api_v1_1_visualizations_stats,           constraints: { id: /[^\/]+/ }
   end
 
   scope :module => 'api/json', :format => :json do

--- a/lib/assets/javascripts/cartodb/new_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/entry.js
@@ -20,7 +20,6 @@ function applyPatchNewVisualizationUrl() {
   //cdb.config.setUrlVersion('visualization', 'v1_1')
   cdb.config.setUrlVersion('like', 'v1_1')
   //cdb.config.setUrlVersion('overlays', 'v1_1')
-  cdb.config.setUrlVersion('stats', 'v1_1')
 }
 /**
  * Entry point for the new dashboard, bootstraps all dependency models and application.

--- a/lib/assets/javascripts/cartodb/new_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/entry.js
@@ -20,6 +20,7 @@ function applyPatchNewVisualizationUrl() {
   //cdb.config.setUrlVersion('visualization', 'v1_1')
   cdb.config.setUrlVersion('like', 'v1_1')
   //cdb.config.setUrlVersion('overlays', 'v1_1')
+  cdb.config.setUrlVersion('stats', 'v1_1')
 }
 /**
  * Entry point for the new dashboard, bootstraps all dependency models and application.

--- a/spec/requests/api/json/visualizations_controller_shared_examples.rb
+++ b/spec/requests/api/json/visualizations_controller_shared_examples.rb
@@ -907,7 +907,6 @@ shared_examples_for "visualization controllers" do
     end
 
     describe 'GET /api/v1/viz' do
-      # TODO: I'm not sure about stubbing this tiler request, I've taken it from existing tests
       before(:each) do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
         CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
@@ -1032,6 +1031,29 @@ shared_examples_for "visualization controllers" do
         response.fetch('tags')            .should_not be_empty
         response.fetch('description')     .should_not be_nil
         response.fetch('related_tables')  .should_not be_nil
+      end
+    end
+
+    describe 'GET /api/v1/viz/:id/stats' do
+
+      before(:each) do
+        CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        delete_user_data(@user)
+      end
+
+      it 'returns view stats for the visualization' do
+        payload = factory(@user)
+
+        post "/api/v1/viz?api_key=#{@api_key}",
+          payload.to_json, @headers
+        id = JSON.parse(last_response.body).fetch('id')
+
+        get "/api/v1/viz/#{id}/stats?api_key=#{@api_key}", {}, @headers
+
+        last_response.status.should == 200
+        response = JSON.parse(last_response.body)
+        response.keys.length.should == 30
       end
     end
 

--- a/spec/requests/api/visualizations_spec.rb
+++ b/spec/requests/api/visualizations_spec.rb
@@ -231,23 +231,6 @@ describe Api::Json::VisualizationsController do
     end
   end # GET /api/v1/viz
 
-  describe 'GET /api/v1/viz/:id/stats' do
-    it 'returns view stats for the visualization' do
-      pending
-      payload = factory
-
-      post "/api/v1/viz?api_key=#{@api_key}",
-        payload.to_json, @headers
-      id = JSON.parse(last_response.body).fetch('id')
-
-      get "/api/v1/viz/#{id}/stats?api_key=#{@api_key}", {}, @headers
-
-      last_response.status.should == 200
-      response = JSON.parse(last_response.body)
-      response.keys.length.should == 30
-    end
-  end # GET /api/v1/viz/:id/stats
-
   describe 'PUT /api/v1/viz/:id' do
     it 'updates an existing visualization' do
       pending

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -27,6 +27,7 @@ describe Carto::Api::VisualizationsController do
         get     '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/likes'                      => 'visualizations#likes_count',     as: :api_v1_visualizations_likes_count,     constraints: { id: /[^\/]+/ }
         get     '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/likes/detailed'             => 'visualizations#likes_list',      as: :api_v1_visualizations_likes_list,      constraints: { id: /[^\/]+/ }
         get     '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/like'                       => 'visualizations#is_liked',        as: :api_v1_visualizations_is_liked,        constraints: { id: /[^\/]+/ }
+        get     '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/stats'                      => 'visualizations#stats',           as: :api_v1_visualizations_stats,           constraints: { id: /[^\/]+/ }
       end
 
       # old controller


### PR DESCRIPTION
@rafatower CR, please. This closes #3169.

@javisantana [this](https://github.com/CartoDB/cartodb/compare/3169-describe_GET_api_v1_viz_id_stats?expand=1#diff-29edfe9aebf974e765602af4cddc7bedR23) is the only needed thing to enable the endpoint, isn't it?