### PR TITLE
Read config/database.yml from Rails root

### DIFF
--- a/config/initializers/sequel.rb
+++ b/config/initializers/sequel.rb
@@ -2,7 +2,7 @@ require 'active_record'
 
 ::Sequel::DATABASES.each{|d| d.sql_log_level = :debug }
 
-@dbconfig = YAML.load(File.read('config/database.yml'))
+@dbconfig = YAML.load(File.read(File.join(Rails.root, 'config/database.yml'))))
 # INFO: our current database.yml sets Sequel PostgreSQL adapter, which is called 'postgres'. Rails' is 'postgresql'
 @dbconfig[Rails.env]['adapter'] = 'postgresql'
 ActiveRecord::Base.establish_connection @dbconfig[Rails.env]

--- a/config/initializers/sequel.rb
+++ b/config/initializers/sequel.rb
@@ -2,7 +2,7 @@ require 'active_record'
 
 ::Sequel::DATABASES.each{|d| d.sql_log_level = :debug }
 
-@dbconfig = YAML.load(File.read(File.join(Rails.root, 'config/database.yml'))))
+@dbconfig = YAML.load(File.read(File.join(Rails.root, 'config/database.yml')))
 # INFO: our current database.yml sets Sequel PostgreSQL adapter, which is called 'postgres'. Rails' is 'postgresql'
 @dbconfig[Rails.env]['adapter'] = 'postgresql'
 ActiveRecord::Base.establish_connection @dbconfig[Rails.env]


### PR DESCRIPTION
It seems the Sequel/ActiveRecord autoloading now reads the sequel.rb initialized whenever the spec_helper runs.

Previously I could run any spec by moving to spec/ and then running
`bundle exec rspec whatever/my_spec.rb`
but now it will crash with:

```
/home/ubuntu/cartodb/config/initializers/sequel.rb:5:in `read': No such file or directory - config/database.yml (Errno::ENOENT)
	from /home/ubuntu/cartodb/config/initializers/sequel.rb:5:in `<top (required)>'
	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:245:in `load'
	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:245:in `block in load'
	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:245:in `load'
	from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/railties-3.2.2/lib/rails/engine.rb:588:in `block (2 levels) in <class:Engine>'
```

It seems it was reading `config/database.yml` assuming that the current path is the Rails root, but it might not be.

This fixes the issue and makes running specs from relative paths work again