### PR TITLE
Fixes some issues with editable descriptions and tags

### DIFF
--- a/app/assets/stylesheets/new_common/map-card.css.scss
+++ b/app/assets/stylesheets/new_common/map-card.css.scss
@@ -39,6 +39,7 @@ $opacityTransition: 250ms;
 .MapCard-desc {
   flex: 1;
   height: 2 * $sLineHeight-normal;
+  width: 100%;
 
   .DefaultDescription {
     @include line-clamp(2);

--- a/app/assets/stylesheets/new_dashboard/editable-field.css.scss
+++ b/app/assets/stylesheets/new_dashboard/editable-field.css.scss
@@ -12,6 +12,7 @@ $fieldBorderColor: #DFE8EC;
   .EditableField-button {
     font-style: italic;
     color: $cTypography-link;
+    margin-right: 0;
   }
   .EditableField-input {
     background: none;
@@ -29,6 +30,8 @@ $fieldBorderColor: #DFE8EC;
 
     background: -webkit-linear-gradient(bottom, $fieldBorderColor 0%, $fieldBgColor 8%) 0 0px;
     background: -moz-linear-gradient(bottom, $fieldBorderColor 0%, $fieldBgColor 8%) 0 0px;
+    background: -ms-linear-gradient(bottom, $fieldBorderColor 0%, $fieldBgColor 8%) 0 0px;
+    background: -o-linear-gradient(bottom, $fieldBorderColor 0%, $fieldBgColor 8%) 0 0px;
     background: linear-gradient(bottom, $fieldBorderColor 0%, $fieldBgColor 8%) 0 0px;
     background-size: 100% $sLineHeight-normal;
   }

--- a/lib/assets/javascripts/cartodb/new_dashboard/editable_fields/editable_description.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/editable_fields/editable_description.js
@@ -76,6 +76,7 @@ module.exports = cdb.core.View.extend({
       description: this.$('.js-field-input').val()
     };
     this.model.save(attributes);
+    this.$el.removeClass('is-editing');
     this.render();
   },
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/editable_fields/editable_tags.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/editable_fields/editable_tags.js
@@ -57,6 +57,7 @@ module.exports = cdb.core.View.extend({
     this.model.save({
       tags: tags
     });
+    this.$el.removeClass('is-editing');
     this.render();
   },
 

--- a/lib/assets/test/spec/cartodb/new_dashboard/editable_fields/editable_description.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/editable_fields/editable_description.spec.js
@@ -84,6 +84,7 @@ describe('new_dashboard/editable_fields/editable_description', function() {
       // Model has been saved
       expect(model.save).toHaveBeenCalled();
       expect(model.get('description')).toEqual('wadus');
+      expect(view.el.classList).not.toContain('is-editing');
     });
 
     it('should cancel edition if esc is pressed', function() {

--- a/lib/assets/test/spec/cartodb/new_dashboard/editable_fields/editable_tags.spec.js
+++ b/lib/assets/test/spec/cartodb/new_dashboard/editable_fields/editable_tags.spec.js
@@ -92,6 +92,7 @@ describe('new_dashboard/editable_fields/editable_tags', function() {
         tags: ['wadus1', 'wadus2', 'wadus3']
       });
 
+      expect(view.el.classList).not.toContain('is-editing');
       expect(view.$('.DefaultTags-item').length).toBe(3);
     });
 


### PR DESCRIPTION
- Removes right margin on the "Add tags" button.
- Sets width of .MapCard-desc to fix long descriptions and line clamping on IE.
- Fixes linear gradient on IE (field background).
- Changes to remove "is-editing" class after field is saved.

@xavijam PTAL. thx!