### PR TITLE
Changes background color of editable field inputs

### DIFF
--- a/app/assets/stylesheets/new_dashboard/editable-field.css.scss
+++ b/app/assets/stylesheets/new_dashboard/editable-field.css.scss
@@ -5,7 +5,7 @@
 @import "../new_variables/sizes";
 @import "../new_variables/mixins";
 
-$fieldBgColor: #FEFCEA;
+$fieldBgColor: transparent;
 $fieldBorderColor: #DFE8EC;
 
 .EditableField {


### PR DESCRIPTION
Editable field inputs had a yellow background and are now transparent:

![captura de pantalla 2015-04-17 a las 12 03 41](https://cloud.githubusercontent.com/assets/390398/7200095/e41b9a28-e4f9-11e4-816d-bcaa529da74b.png)

@viddo PTAL. thx
