### PR TITLE
Adds a delete confirmation dialog

### DIFF
--- a/lib/assets/javascripts/cartodb/table/slides/panel.js
+++ b/lib/assets/javascripts/cartodb/table/slides/panel.js
@@ -312,12 +312,6 @@ cdb.admin.SlideView = cdb.core.View.extend({
       width: 500
     });
 
-    this.delete_confirmation = delete_confirmation;
-    this.delete_confirmation.on('clean', function _c() {
-      self.delete_confirmation.unbind('clean', _c);
-      self.delete_confirmation = null;
-    });
-
     // If user confirms, remove slide
     delete_confirmation.ok = function() {
       self.model.destroy();

--- a/lib/assets/javascripts/cartodb/table/slides/panel.js
+++ b/lib/assets/javascripts/cartodb/table/slides/panel.js
@@ -295,7 +295,37 @@ cdb.admin.SlideView = cdb.core.View.extend({
 
   _onClickClose: function(e) {
     this.killEvent(e);
-    this.model.destroy();
+
+    var self = this;
+
+    var delete_confirmation = new cdb.admin.BaseDialog({
+      title: "Delete slide",
+      description: "Are you sure you want to delete this slide?",
+      template_name: 'common/views/confirm_dialog',
+      clean_on_hide: true,
+      enter_to_confirm: true,
+      ok_button_classes: "right button grey",
+      ok_title: "Yes, do it",
+      cancel_button_classes: "underline margin15",
+      cancel_title: "Cancel",
+      modal_type: "confirmation",
+      width: 500
+    });
+
+    this.delete_confirmation = delete_confirmation;
+    this.delete_confirmation.on('clean', function _c() {
+      self.delete_confirmation.unbind('clean', _c);
+      self.delete_confirmation = null;
+    });
+
+    // If user confirms, remove slide
+    delete_confirmation.ok = function() {
+      self.model.destroy();
+    };
+
+    delete_confirmation
+      .appendToBody()
+      .open();
   },
 
   _onDestroy: function() {


### PR DESCRIPTION
This PR adds a confirmation dialog before removing a slide.

Fixes #1754

![screen shot 2015-04-20 at 17 29 43](https://cloud.githubusercontent.com/assets/4933/7233720/02afa66a-e783-11e4-901b-bcebb7e7639d.png)

