### PR TITLE
Add type-guessing choice for synchronization imports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,13 @@
 ---------
 * Sort category names alphabetically in legends [3218](https://github.com/CartoDB/cartodb/pull/3218)
 * Editable descriptions and tags in the maps and datasets view [3129](https://github.com/CartoDB/cartodb/pull/3129)
-* fixed interaction when there are hidden layers #3090
 * Add caching of geometry types [#3157](https://github.com/CartoDB/cartodb/pull/3157)
 * Do not store session for api_key auth [#3208](https://github.com/CartoDB/cartodb/pull/3208)
+Bugfixes:
+* Fixed interaction when there are hidden layers [#3090](https://github.com/CartoDB/cartodb/pull/3090)
 * Fix http cancelled requests [#3227](https://github.com/CartoDB/cartodb/pull/3227)
 * Fix for "Cannot read property 'layers'" [#3302](https://github.com/CartoDB/cartodb/pull/3302)
+* Fix for type guessing in synchronization imports [#3264](http://github.com/CartoDB/cartodb/issues/3264)
 
 3.10.0 (2015-04-08)
 -------------------

--- a/lib/assets/javascripts/cartodb/models/synchronization.js
+++ b/lib/assets/javascripts/cartodb/models/synchronization.js
@@ -24,7 +24,8 @@
       error_message: '',
       service_name: '',
       service_item_id: '',
-      content_guessing: false
+      content_guessing: true,
+      type_guessing: true
     },
 
     initialize: function() {
@@ -39,7 +40,8 @@
       var d = {
         url:      c.url,
         interval: c.interval,
-        content_guessing: c.content_guessing
+        content_guessing: c.content_guessing,
+        type_guessing: c.type_guessing
       };
 
       if(c.id !== undefined) {

--- a/lib/assets/test/spec/cartodb/models/synchronization.spec.js
+++ b/lib/assets/test/spec/cartodb/models/synchronization.spec.js
@@ -6,9 +6,32 @@ describe("TableSynchronization", function() {
     sync = new cdb.admin.TableSynchronization();
   });
 
-  //
-  //
-  //
+  describe('JSON stringification', function() {
+    
+    it("should return guessing parameters, interval and URL when it doesn't come from a service", function() {
+      sync.set({
+        content_guessing: true,
+        fake_guessing: false
+      });
+      var d = sync.toJSON();
+      expect(_.size(d)).toBe(4);
+      expect(d.type_guessing).not.toBeUndefined();
+      expect(d.url).not.toBeUndefined();
+      expect(d.interval).not.toBeUndefined();
+      expect(d.fake_guessing).toBeUndefined();
+    });
+
+    it("should add service attributes when it comes from a service", function() {
+      sync.set({
+        service_name: 'follower' 
+      });
+      var d = sync.toJSON();
+      expect(_.size(d)).toBe(6);
+      expect(d.service_name).not.toBeUndefined();
+      expect(d.service_item_id).not.toBeUndefined();
+    });
+  });
+  
   describe("linkToTable", function() {
 
     it("should assign id from table it exists and not fetch", function() {


### PR DESCRIPTION
Basically, in the JSON stringification method inside the sync model, we weren't adding the new ```type_guessing``` attribute.

Fixes #3264 

REVIEWER: @viddo 