### PR TITLE
Fix create-map map template icons being displaced

### DIFF
--- a/app/assets/stylesheets/new_common/create/create_templates.css.scss
+++ b/app/assets/stylesheets/new_common/create/create_templates.css.scss
@@ -63,7 +63,7 @@ $w: 700px;
 }
 .CreateDialog-templatesItem {
   float: left;
-  margin-bottom: $sMargin-element; 
+  margin-bottom: $sMargin-element;
   margin-right: $sMargin-element;
 }
 .CreateDialog-templatesItem:nth-child(3n) { margin-right: 0 }
@@ -103,6 +103,8 @@ $w: 700px;
   border: 1px solid #6F9FD0;
   color: #6F9FD0;
   background: transparent;
+  margin-left: auto;
+  margin-right: auto;
 }
 // Templates icons
 .CreateDialog-templateItemIcon.iconFont-People {

--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.9.12
+3.9.13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.9.12",
+  "version": "3.9.13",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently:
![screen shot 2015-04-22 at 11 43 46](https://cloud.githubusercontent.com/assets/978461/7271953/6a406aca-e8e7-11e4-92f5-0a9f79a575fd.png)

Fixes in Chrome + IE(10)
![screen shot 2015-04-22 at 11 50 10](https://cloud.githubusercontent.com/assets/978461/7271955/6eba212c-e8e7-11e4-8f2d-425ff7378817.png)
![screen shot 2015-04-22 at 11 59 24](https://cloud.githubusercontent.com/assets/978461/7271956/6ed371ea-e8e7-11e4-8336-a99658769ba1.png)
