### PR TITLE
Add rake task to unshare all shared entities for an user

### DIFF
--- a/lib/tasks/tables.rake
+++ b/lib/tasks/tables.rake
@@ -44,6 +44,17 @@ namespace :cartodb do
         end
       end
     end
-  
+
+    desc "Unshare all entities for a given user"
+    task :unshare_all_entities, [:user] => :environment do |t, args|
+      user = User.find(username: args[:user])
+      CartoDB::Permission.where(owner_id: user.id).each do |permission|
+        unless permission.acl.empty?
+          puts "Deleting permission: #{permission.acl}"
+          permission.acl = []
+          permission.save
+        end
+      end
+    end
   end
 end

--- a/lib/tasks/tables.rake
+++ b/lib/tasks/tables.rake
@@ -47,11 +47,24 @@ namespace :cartodb do
 
     desc "Unshare all entities for a given user"
     task :unshare_all_entities, [:user] => :environment do |t, args|
+      # First unshare everything owned by the user itself
       user = User.find(username: args[:user])
       CartoDB::Permission.where(owner_id: user.id).each do |permission|
         unless permission.acl.empty?
           puts "Deleting permission: #{permission.acl}"
           permission.acl = []
+          permission.save
+        end
+      end
+
+      # Then, remove permissions of everything he has access to
+      CartoDB::SharedEntity.where(recipient_id: user.id).each do |shared_entity|
+        permissions = CartoDB::Permission.where(entity_id: shared_entity.entity_id)
+        permissions.each do |permission|
+          acl = permission.acl
+          puts "Dropping permission from: #{permission.acl}"
+          acl.reject!{|acl_entry| acl_entry[:type] == 'user' && acl_entry[:id] == user.id}
+          permission.acl = acl
           permission.save
         end
       end


### PR DESCRIPTION
This rake unshares everything the user might have shared with other members of the organization, and also removes ACL entries of elements shared with that user (useful for moving users around).

does this look fine @Kartones @rafatower?