### PR TITLE
Fix tooltips in the legend editor

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/legend_editor.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/legend_editor.js
@@ -363,10 +363,7 @@ cdb.admin.mod.LegendEditor = cdb.admin.Module.extend({
       var options = {
         html: true,
         live: true,
-        fade: true,
-        title: function() {
-          return $(this).data('tipsy-title');
-        }
+        fade: true
       }
 
       // Tipsy: Toggle fields and titles

--- a/lib/assets/javascripts/cartodb/table/menu_modules/legend_editor.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/legend_editor.js
@@ -320,6 +320,7 @@ cdb.admin.mod.LegendEditor = cdb.admin.Module.extend({
     },
 
     _setupLegendPane: function() {
+      this._setupTipsy();
 
       this.legend_tabs = new cdb.admin.Tabs({
         el: this.$('.menu ul'),
@@ -356,7 +357,29 @@ cdb.admin.mod.LegendEditor = cdb.admin.Module.extend({
       this.legend_tabs.activate(active_tab);
 
       this.legend_panes.bind('tabEnabled', this._onEnableTab, this);
+    },
 
+    _setupTipsy: function() {
+      var options = {
+        html: true,
+        live: true,
+        fade: true,
+        title: function() {
+          return $(this).data('tipsy-title');
+        }
+      }
+
+      // Tipsy: Toggle fields and titles
+      options.el = this.$(".menu a[href='#/fields']");
+      options.gravity = 's'
+      var toggleFieldstooltip = new cdb.common.TipsyTooltip(options)
+      this.addView(toggleFieldstooltip);
+
+      // Tipsy: Change HTML
+      options.el = this.$(".menu a[href='#/html']");
+      options.gravity = 'se'
+      var changeHTMLTooltip = new cdb.common.TipsyTooltip(options)
+      this.addView(changeHTMLTooltip);
     },
 
     _toggleContent: function() {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/legends/views/legends.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/legends/views/legends.jst.ejs
@@ -4,8 +4,8 @@
 </div>
 <div class="menu">
   <ul>
-    <li class="editor"><a href="#/fields" data-tipsy="Toggle fields and titles"></a></li>
-    <li class="html_editor"><a href="#/html" data-tipsy="Change HTML"></a></li>
+    <li class="editor"><a href="#/fields" data-tipsy-title="Toggle fields and titles"></a></li>
+    <li class="html_editor"><a href="#/html" data-tipsy-title="Change HTML"></a></li>
   </ul>
   <div class="tip"></div>
 </div>

--- a/lib/assets/javascripts/cartodb/table/menu_modules/legends/views/legends.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/legends/views/legends.jst.ejs
@@ -4,8 +4,8 @@
 </div>
 <div class="menu">
   <ul>
-    <li class="editor"><a href="#/fields" data-tipsy-title="Toggle fields and titles"></a></li>
-    <li class="html_editor"><a href="#/html" data-tipsy-title="Change HTML"></a></li>
+    <li class="editor"><a href="#/fields" title="Toggle fields and titles"></a></li>
+    <li class="html_editor"><a href="#/html" title="Change HTML"></a></li>
   </ul>
   <div class="tip"></div>
 </div>

--- a/lib/assets/test/spec/cartodb/table/menu_modules/legend_editor.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/legend_editor.spec.js
@@ -259,6 +259,19 @@ describe('cdb.admin.mod.LegendEditor ', function() {
 
   });
 
+  it('should render tipsys ', function() {
+
+    // Tipsy: Toggle fields and titles
+    var toggleFieldsLink = legendEditor.$("a[href='#/fields']");
+    toggleFieldsLink.trigger('mouseenter');
+    expect(toggleFieldsLink.data('tipsy')).not.toBeUndefined();
+
+    // Tipsy: Change HTML
+    var changeHTMLLink = legendEditor.$("a[href='#/html']");
+    changeHTMLLink.trigger('mouseenter');
+    expect(changeHTMLLink.data('tipsy')).not.toBeUndefined();
+  });
+
   it("should not have leaks", function() {
     expect(view).toHaveNoLeaks();
   })


### PR DESCRIPTION
Fixes #2168.

![tooltips](https://cloud.githubusercontent.com/assets/390398/7296656/d3f05982-e9c1-11e4-97c4-0f9688f8a68d.gif)

@viddo PTAL. thanks!