### PR TITLE
Script to delete inconsistent vizs #3286

### DIFF
--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -1,0 +1,44 @@
+namespace :cartodb do
+  namespace :vizs do
+
+    desc "Purges broken visualizations due to bug during deletion."
+    task :delete_inconsistent, [:username] => :environment do |t, args|
+      username = args[:username]
+      raise "You should pass a username param" unless username
+      user = User[username: username]
+      collection = CartoDB::Visualization::Collection.new.fetch(user_id: user.id)
+
+      collection.each do |viz|
+        if is_inconsistent?(viz)
+          delete_with_confirmation(viz)
+        end
+      end
+    end
+
+    def is_inconsistent?(viz)
+      (viz.table? && viz.related_tables.empty?) || (viz.derived? && viz.map.nil?)
+    end
+
+    def delete_with_confirmation(viz)
+      display_info(viz)
+      if ok_to_delete?
+        viz.delete
+        STDOUT.puts "deleted!"
+      end
+    end
+
+    def display_info(viz)
+      STDOUT.puts "\nviz.name = #{viz.name}"
+      STDOUT.puts "viz.type = #{viz.type}"
+      STDOUT.puts "viz.related_tables = #{viz.related_tables.map {|t| t.name}}"
+      STDOUT.puts "viz.map_id = #{viz.map_id}"
+    end
+
+    def ok_to_delete?
+      STDOUT.puts "About to delete. Are you sure? (y/n)"
+      input = STDIN.gets.strip
+      return input == 'y'
+    end
+    
+  end
+end


### PR DESCRIPTION
@Kartones Can you please review? what kind of stuff I might be missing when deleting those?

I'm gonna try to reproduce the conditions of the bug. Dropping the table via sql is not enough (as ghost tables resque sanitizes the vizs). I will try it first locally then in staging. Then I'd try with any of the 15-20 users who suffered the delete viz bug, with least traffic to the offending vizs.