### PR TITLE
[oracle_fdw] drop foreign table if already exists

### DIFF
--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -911,6 +911,7 @@ namespace :cartodb do
           tables["tables"].each do |table_name, th|
             table_readonly = th["read_only"] ? "true" : "false"
             table_columns = th["columns"].map {|name,attrs| "#{name} #{attrs['column_type']}"}
+            db.run("DROP FOREIGN TABLE IF EXISTS #{table_name}")
             db.run("CREATE FOREIGN TABLE #{table_name} (#{table_columns.join(', ')}) SERVER #{server_name} OPTIONS (schema '#{args[:remote_schema]}', table '#{th["remote_table"]}', readonly '#{table_readonly}')")
             db.run("GRANT SELECT ON #{table_name} TO \"#{u.database_username}\"")
             db.run("GRANT SELECT ON #{table_name} TO \"#{CartoDB::PUBLIC_DB_USER}\"")


### PR DESCRIPTION
This PR adds a new SQL statement to remove foreign tables if they already exists whilst configuring `oracle_fdw` extension, the aim is to avoid issues when launching FDW re-configurations.

@lbosque @zenitraM can you review? thanks.