### PR TITLE
Add rake to drop permissions to other users from a given user schema

### DIFF
--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -894,6 +894,24 @@ namespace :cartodb do
       end
     end
 
+    desc "Drop other users privileges on user schema"
+    task :drop_other_privileges_on_user_schema, [:username] => :environment do |t,args|
+      user = User.where(:username => args[:username].to_s).first
+      user.in_database({as: :superuser}) do |db|
+        db.transaction do
+          oids = db.fetch("with oids as (select (aclexplode(n.nspacl)).grantee as grantee_oid from pg_catalog.pg_namespace n
+                WHERE n.nspname = '#{user.database_schema}')
+                select distinct pg_roles.rolname from oids, pg_roles where grantee_oid = oid")
+          oids.each do |oid|
+            role = oid[:rolname]
+            unless [user.database_username, CartoDB::PUBLIC_DB_USER].include? role
+              db.run("REVOKE ALL ON SCHEMA #{user.database_schema} FROM \"#{role}\"")
+            end
+          end
+        end
+      end
+    end
+
     desc "Enable oracle_fdw extension in database"
     task :enable_oracle_fdw_extension, [:username, :oracle_url, :remote_user, :remote_password, :remote_schema, :table_definition_json_path] => :environment do |t, args|
       u = User.where(:username => args[:username].to_s).first


### PR DESCRIPTION
On an organization user, sharing an user a table will grant the shared user permissions to use that schema (apart from the table permissions).

This permission is never dropped. So, when we do a pg_dump of a schema, the pg_restore will fail due to trying to recreate that GRANT (even if the shared entities are unshared from the other rake, it only REVOKEs the tables, not the schema)

This performs a cleanup to clean those GRANTs, by removing all entires from the PostgreSQL schema ACL (except schema permissions for the owner user and publicuser)


cc @Kartones 