### PR TITLE
Removed tour link + logo as link in the footer

### DIFF
--- a/app/views/admin/shared/_new_footer.html.erb
+++ b/app/views/admin/shared/_new_footer.html.erb
@@ -1,12 +1,12 @@
 <div class="Footer">
   <div class="u-inner Footer-inner">
     <ul class="Footer-list Footer-list--primary">
-      <li class="Footer-listItem"><a class="Footer-listLink" href="http://cartodb.com/tour/">Feature tour</a></li>
+      <li class="Footer-listItem"><a class="Footer-listLink" href="http://cartodb.com/gallery/">Explore</a></li>
       <li class="Footer-listItem"><a class="Footer-listLink" href="http://docs.cartodb.com/tutorials.html">Getting started</a></li>
     </ul>
-    <span class="Footer-logo Logo Logo--grey">
+    <a class="Footer-logo Logo Logo--grey" href="http://cartodb.com">
       <i class="iconFont iconFont-CartoFante"></i>
-    </span>
+    </a>
     <ul class="Footer-list Footer-list--secondary">
       <li class="Footer-listItem"><a class="Footer-listLink" href="http://docs.cartodb.com">Documentation</a></li>
       <li class="Footer-listItem"><a class="Footer-listLink" href="mailto:support@cartodb.com">Support</a></li>


### PR DESCRIPTION
Replaced tour link by explore, sounds good @saleiva?

![screen shot 2015-04-26 at 19 39 08](https://cloud.githubusercontent.com/assets/132146/7338437/ee16b9d2-ec4b-11e4-8f0d-71e987115cbb.png)


Fixes #3370.