### PR TITLE
Fixes custom image header templates

### DIFF
--- a/lib/assets/javascripts/cartodb/table/infowindow.js
+++ b/lib/assets/javascripts/cartodb/table/infowindow.js
@@ -41,7 +41,7 @@
       if (this._containsCover) this._createHelpDialog();
 
       // Set live tipsy when geom is enabled or disabled
-      this.$el.find("div.cartodb-edit-buttons a.button").tipsy({
+      this.$("div.cartodb-edit-buttons a.button").tipsy({
         live:true,
         fade:true,
         gravity: 's',
@@ -123,7 +123,7 @@
       if((!fields || (fields && !fields.length)) && (!this.model.get('template'))) {
 
         // Add empty fields to the infowindow
-        this.$el.find('.cartodb-popup').addClass("no_fields");
+        this.$('.cartodb-popup').addClass("no_fields");
 
         // Check if the infowindow has header or not
         var popup_class = '.cartodb-popup-content';
@@ -136,7 +136,7 @@
           '<p><a class="margin5 underline open_infowindow_panel" href="#/select-fields">' + this._TEXTS._NO_FIELDS_SELECTED_BUTTON + '</a></p>'
         )
       } else {
-        this.$el.find('.cartodb-popup').removeClass("no_fields");
+        this.$('.cartodb-popup').removeClass("no_fields");
       }
 
 
@@ -149,8 +149,8 @@
       }
 
       if (this._containsCover()) { // bind the help link to the helpDialog
-        this.$el.find(".image_not_found a.help").off("click");
-        this.$el.find(".image_not_found a.help").on("click", function() {
+        this.$(".image_not_found a.help").off("click");
+        this.$(".image_not_found a.help").on("click", function() {
           $('body').append(self.helpDialog.render().el);
           self.helpDialog.open();
         });
@@ -222,8 +222,8 @@
 
       if (!this._containsCover()) return;
 
-      var $cover = this.$el.find(".cover");
-      var $imageNotFound = this.$el.find(".image_not_found");
+      var $cover = this.$(".cover");
+      var $imageNotFound = this.$(".image_not_found");
       var $img = $cover.find("img");
       var url = this._getCoverURL();
 

--- a/lib/assets/javascripts/cartodb/table/infowindow.js
+++ b/lib/assets/javascripts/cartodb/table/infowindow.js
@@ -218,19 +218,18 @@
      *  Attempts to load the cover URL and show it
      */
     _loadCover: function() {
+      var self = this;
 
       if (!this._containsCover()) return;
 
-      var self = this;
-
-      var
-      $cover         = this.$el.find(".cover"),
-      $imageNotFound = this.$el.find(".image_not_found");
-
+      var $cover = this.$el.find(".cover");
+      var $imageNotFound = this.$el.find(".image_not_found");
+      var $img = $cover.find("img");
       var url = this._getCoverURL();
 
       if (!this._isValidURL(url)) {
         $imageNotFound.fadeIn(250);
+        $img.hide();
         return;
       }
 
@@ -241,8 +240,6 @@
       spinner = new Spinner(opts).spin(target);
 
       // create the image
-      var $img = $cover.find("img");
-
       $imageNotFound.hide();
 
       $img.hide(function() {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_html_pane.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/infowindow/infowindow_html_pane.js
@@ -303,11 +303,12 @@
     },
 
     _generateFields: function() {
+      var self = this;
       var columns = this.getColumnNames();
       var fields = [];
 
-      _.each(columns, function(col_name, i) {
-        fields.push({ position: i, name: col_name, title: true });
+      _.each(columns, function(column, i) {
+        fields.push({ position: self.model.getFieldPos(column), name: column, title: true });
       });
 
       return fields;

--- a/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/infowindow.spec.js
@@ -523,6 +523,21 @@ describe("mod.infowindow", function() {
         expect(model.get('template')).toBe('<div>{{name3}}</div>');
         expect(model.get('old_template_name')).toBe('infowindow_light');
       });
+
+      it("should respect the position of fields", function() {
+        model.set('fields', [
+          { name: 'name3', title: true, position: 3 },
+          { name: 'name1', title: true, position: 1 },
+          { name: 'name2', title: true, position: 2 }
+        ]);
+
+        view.render();
+        view._apply();
+
+        expect(model.getFieldPos('name1')).toEqual(1);
+        expect(model.getFieldPos('name2')).toEqual(2);
+        expect(model.getFieldPos('name3')).toEqual(3);
+      });
     }); // Infowindow tab tests (same for tooltip pane)
   
   }); // Infowindow module tests


### PR DESCRIPTION
Fixes #2235 and hides the `<img>` tag when an infowindow doesn't have a valid cover URL (different issue).

![image_infowindows](https://cloud.githubusercontent.com/assets/390398/7345786/7ee0dae2-ecd8-11e4-9ca0-53f8efbf0d3f.gif)

cc/ @cshirky