### PR TITLE
Locked liked maps/datasets are not being appearing in Liked section

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
@@ -69,7 +69,7 @@ module.exports = cdb.core.View.extend({
       tags:           params.tag,
       per_page:       this.collection[ "_" + ( params.content_type === "datasets" ? 'TABLES' : 'ITEMS') + '_PER_PAGE'],
       shared:         params.shared,
-      locked:         params.locked,
+      locked:         params.liked ? '' : params.locked, // If not locked liked items are not rendered
       only_liked:     params.liked,
       order:          order,
       types:          types,


### PR DESCRIPTION
This attribute ```{  locked: false }``` was sent through our visualizations endpoint, and locked liked maps/datasets weren't being rendered in the dashboard liked list.

Fixes #3396 

cc @saleiva 