### PR TITLE
Remove broken geocoding timeout logic #2941

### DIFF
--- a/spec/models/geocoding_spec.rb
+++ b/spec/models/geocoding_spec.rb
@@ -117,7 +117,8 @@ describe Geocoding do
       geocoding.state.should eq 'failed'
     end
 
-    it 'raises a timeout error if geocoding takes more than 15 minutes to start' do
+    # TODO: decide what kind of timeout makes sense and test properly (legacy implementation did not work)
+    pending 'raises a timeout error if geocoding takes more than 15 minutes to start' do
       geocoding = FactoryGirl.create(:geocoding, user: @user, user_table: @table, formatter: 'b')
       geocoding.class.stubs(:processable_rows).returns 10
       CartoDB::TableGeocoder.any_instance.stubs(:run).returns true

--- a/spec/models/geocoding_spec.rb
+++ b/spec/models/geocoding_spec.rb
@@ -117,20 +117,6 @@ describe Geocoding do
       geocoding.state.should eq 'failed'
     end
 
-    # TODO: decide what kind of timeout makes sense and test properly (legacy implementation did not work)
-    pending 'raises a timeout error if geocoding takes more than 15 minutes to start' do
-      geocoding = FactoryGirl.create(:geocoding, user: @user, user_table: @table, formatter: 'b')
-      geocoding.class.stubs(:processable_rows).returns 10
-      CartoDB::TableGeocoder.any_instance.stubs(:run).returns true
-      CartoDB::TableGeocoder.any_instance.stubs(:process_results).returns true
-      CartoDB::Geocoder.any_instance.stubs(:status).returns 'submitted'
-      CartoDB::Geocoder.any_instance.stubs(:update_status).returns true
-      geocoding.run_timeout = 0.1
-      geocoding.run!
-      geocoding.reload.state.should eq 'failed'
-      geocoding.run_timeout = Geocoding::DEFAULT_TIMEOUT
-    end
-
     it 'sends a payload with duration information' do
       geocoding = FactoryGirl.build(:geocoding, user: @user, user_table: @table, kind: 'admin0', geometry_type: 'polygon', formatter: 'b')
       geocoding.class.stubs(:processable_rows).returns 10


### PR DESCRIPTION
@Kartones asking for early feedback (not merging yet):
- I made sure the active polling of state makes no sense and that the timeout exception was never raised. That piece of code confused us all and for me it's the main reason to delete it.
- The original intent of the timeout was to kill the job if it took more than 15 min to enter the queue. I don't think that makes sense but to set a timeout if the job is taking too much time to process.
- We can wait to have more info in kibana about the typical times for geocodings
- We can add a process timeout adjusted based on geocodifiable rows or something like that.

Comments? suggestions?