### PR TITLE
Avoing upload unnecesary assets to S3

### DIFF
--- a/lib/build/tasks/s3.js
+++ b/lib/build/tasks/s3.js
@@ -16,7 +16,11 @@ module.exports = {
           gzip: true
         },
         cwd: '<%= assets_dir %>',
-        src: ["**/*.js", "**/*.map"],
+        src: [
+          "javascripts/*.js",
+          "javascripts/**/*.map",
+          "!javascripts/all.js"
+        ],
         dest: "cartodbui/assets/<%= pkg.version %>/"
      },
      css: {
@@ -28,7 +32,10 @@ module.exports = {
           gzip: true
         },
         cwd: '<%= assets_dir %>',
-        src: "**/*.css",
+        src: [
+          "stylesheets/*.css",
+          "!stylesheets/all_css.css"
+        ],
         dest: "cartodbui/assets/<%= pkg.version %>/"
      },
      images: {
@@ -51,7 +58,7 @@ module.exports = {
           }
         },
         cwd: '<%= assets_dir %>',
-        src: "fonts/**/*",
+        src: "fonts/*",
         dest: "cartodbui/assets/<%= pkg.version %>/"
       },
 
@@ -64,7 +71,7 @@ module.exports = {
           }
         },
         cwd: '<%= assets_dir %>',
-        src: "flash/**/*",
+        src: "flash/*.swf",
         dest: "cartodbui/assets/<%= pkg.version %>/"
       },
 
@@ -76,7 +83,7 @@ module.exports = {
           }
         },
         cwd: '<%= assets_dir %>',
-        src: "favicons/**/*",
+        src: "favicons/*",
         dest: "cartodbui/assets/<%= pkg.version %>/"
       },
 
@@ -100,7 +107,7 @@ module.exports = {
           }
         },
         cwd: '<%= assets_dir %>',
-        src: "images/avatars/**/*",
+        src: "images/avatars/*.png",
         dest: "cartodbui/assets/unversioned/"
       }
 


### PR DESCRIPTION
Trying to not upload all assets to S3, only those are necessary in each page/view.

### HOW TO TEST IT
- Check in each view that we are not having 404 errors requesting cartodb ui assets.

cc @javisantana @viddo 