### PR TITLE
New method User#private_maps_enabled? #3404

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -130,6 +130,7 @@ class User < Sequel::Model
       end
       self.max_layers ||= 6
       self.private_tables_enabled ||= true
+      self.private_maps_enabled ||= true
       self.sync_tables_enabled ||= true
     end
   end #before_save
@@ -807,10 +808,11 @@ class User < Sequel::Model
     self[:soft_twitter_datasource_limit] = !val
   end
 
-  def private_maps_enabled
-    enabled = super
-    return enabled if enabled.present? && enabled == true
-    /(FREE|MAGELLAN|JOHN SNOW|ACADEMY|ACADEMIC|ON HOLD)/i.match(self.account_type) ? false : true
+  def private_maps_enabled?
+    flag_enabled = self.private_maps_enabled
+    return true if flag_enabled.present? && flag_enabled == true
+    return true if self.private_tables_enabled # Note private_tables_enabled => private_maps_enabled
+    return false
   end
 
   def import_quota

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -811,6 +811,10 @@ class User < Sequel::Model
   def private_maps_enabled?
     flag_enabled = self.private_maps_enabled
     return true if flag_enabled.present? && flag_enabled == true
+
+    #TODO: remove this after making sure we have flags inline with account types
+    return true if not self.account_type.match(/FREE|MAGELLAN|JOHN SNOW|ACADEMY|ACADEMIC|ON HOLD/i)
+
     return true if self.private_tables_enabled # Note private_tables_enabled => private_maps_enabled
     return false
   end

--- a/app/models/user/user_decorator.rb
+++ b/app/models/user/user_decorator.rb
@@ -52,7 +52,7 @@ module CartoDB
         show_upgraded_message: (self.account_type.downcase != 'free' && self.upgraded_at && self.upgraded_at + 15.days > Date.today ? true : false),
         actions: {
           private_tables: self.private_tables_enabled,
-          private_maps: self.private_maps_enabled,
+          private_maps: self.private_maps_enabled?,
           dedicated_support: self.dedicated_support?,
           import_quota: self.import_quota,
           remove_logo: self.remove_logo?,

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -493,7 +493,7 @@ module CartoDB
       end
 
       def supports_private_maps?
-        !user.nil? && user.private_maps_enabled
+        !user.nil? && user.private_maps_enabled?
       end
 
       # @param other_vis CartoDB::Visualization::Member|nil

--- a/lib/assets/javascripts/cartodb/models/map.js
+++ b/lib/assets/javascripts/cartodb/models/map.js
@@ -504,7 +504,7 @@ cdb.admin.Map = cdb.geo.Map.extend({
       return false;
     }
 
-    if (old) { 
+    if (old) {
       // if the layer type is the same just update the values
       if (old.get('type') === layer.get('type')) {
         var old_attribution = old.get('attribution');
@@ -762,11 +762,9 @@ cdb.admin.Map = cdb.geo.Map.extend({
             if (newLayer.wizard_properties.get('type') === 'torque' && self.layers.getTorqueLayers().length) {
               newLayer.wizard_properties.active('polygon');
             }
-            self.layers.add(newLayer);
-            // check if there was error checking if the layer is added
-            if (newLayer.collection) {
-              newLayer.save(null, opts);
-            }
+            // wait: true is used to make sure the layer is not added until confirmed it was added successfully
+            // pass opts for success/error callbacks to be triggered as expected
+            self.layers.create(newLayer, _.extend({ wait: true }, opts));
           }
 
           // Wait until the layer is totally ready in order to add it to the layers and save it

--- a/spec/models/layer_spec.rb
+++ b/spec/models/layer_spec.rb
@@ -5,7 +5,7 @@ describe Layer do
   before(:all) do
     @quota_in_bytes = 500.megabytes
     @table_quota = 500
-    @user = create_user(:quota_in_bytes => @quota_in_bytes, :table_quota => @table_quota)
+    @user = create_user(:quota_in_bytes => @quota_in_bytes, :table_quota => @table_quota, :private_tables_enabled => true)
   end
 
   after(:all) do

--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -9,7 +9,8 @@ describe Map do
     @table_quota    = 500
     @user           = create_user(
                         quota_in_bytes: @quota_in_bytes,
-                        table_quota:    @table_quota
+                        table_quota:    @table_quota,
+                        private_tables_enabled: true
                       )
   end
 

--- a/spec/models/named_maps_spec.rb
+++ b/spec/models/named_maps_spec.rb
@@ -43,7 +43,7 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
     Visualization.repository = DataRepository::Backend::Sequel.new(Rails::Sequel.connection, :visualizations)
 
     puts "\n[rspec][#{SPEC_NAME}] Creating test user database..."
-    @user = create_user( :quota_in_bytes => 524288000, :table_quota => 100 )
+    @user = create_user( :quota_in_bytes => 524288000, :table_quota => 100, :private_tables_enabled => true )
 
     puts "[rspec][#{SPEC_NAME}] Running..."
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -491,8 +491,14 @@ describe User do
       user_without_private_maps.private_maps_enabled?.should eq false
     end
 
-    it 'should have private maps if he has private_tables_enabled even if disabled' do
-      user_without_private_maps = create_user :email => 'user_opm3@example.com',  :username => 'useropm3',  :password => 'useropm3', :private_tables_enabled => true
+    it 'should have private maps if he has private_tables_enabled, even if disabled' do
+      user_without_private_maps = create_user :email => 'user_opm3@example.com',  :username => 'useropm3',  :password => 'useropm3', :private_maps_enabled => false, :private_tables_enabled => true
+      user_without_private_maps.private_maps_enabled?.should eq true
+    end
+
+    it 'should have private maps if he is AMBASSADOR even if disabled' do
+      user_without_private_maps = create_user :email => 'user_opm2@example.com',  :username => 'useropm2',  :password => 'useropm2', :private_maps_enabled => false
+      user_without_private_maps.stubs(:account_type).returns('AMBASSADOR')
       user_without_private_maps.private_maps_enabled?.should eq true
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -475,26 +475,25 @@ describe User do
     end
   end
 
-  describe '#private_maps_enabled' do
+  describe '#private_maps_enabled?' do
     it 'should not have private maps enabled by default' do
       user_missing_private_maps = create_user :email => 'user_mpm@example.com',  :username => 'usermpm',  :password => 'usermpm'
-      user_missing_private_maps.private_maps_enabled.should eq false
+      user_missing_private_maps.private_maps_enabled?.should eq false
     end
 
     it 'should have private maps if enabled' do
       user_with_private_maps = create_user :email => 'user_wpm@example.com',  :username => 'userwpm',  :password => 'userwpm', :private_maps_enabled => true
-      user_with_private_maps.private_maps_enabled.should eq true
+      user_with_private_maps.private_maps_enabled?.should eq true
     end
 
     it 'should not have private maps if disabled' do
       user_without_private_maps = create_user :email => 'user_opm@example.com',  :username => 'useropm',  :password => 'useropm', :private_maps_enabled => false
-      user_without_private_maps.private_maps_enabled.should eq false
+      user_without_private_maps.private_maps_enabled?.should eq false
     end
 
-    it 'should have private maps if he is AMBASSADOR even if disabled' do
-      user_without_private_maps = create_user :email => 'user_opm2@example.com',  :username => 'useropm2',  :password => 'useropm2', :private_maps_enabled => false
-      user_without_private_maps.stubs(:account_type).returns('AMBASSADOR')
-      user_without_private_maps.private_maps_enabled.should eq true
+    it 'should have private maps if he has private_tables_enabled even if disabled' do
+      user_without_private_maps = create_user :email => 'user_opm3@example.com',  :username => 'useropm3',  :password => 'useropm3', :private_tables_enabled => true
+      user_without_private_maps.private_maps_enabled?.should eq true
     end
 
   end

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -400,11 +400,10 @@ describe Visualization::Collection do
     it 'counts total liked' do
       restore_vis_backend_to_normal_table_so_relator_works
 
-      user1 = create_user(:quota_in_bytes => 524288000, :table_quota => 500)
+      user1 = create_user(:quota_in_bytes => 524288000, :table_quota => 500, :private_tables_enabled => true)
       user1.stubs(:organization).returns(nil)
 
-      user2 = create_user(:quota_in_bytes => 524288000, :table_quota => 500)
-      user2.stubs(:private_tables_enabled).returns(true)
+      user2 = create_user(:quota_in_bytes => 524288000, :table_quota => 500, :private_tables_enabled => true)
       user2.stubs(:organization).returns(nil)
 
       table11 = create_table(user1)
@@ -507,9 +506,9 @@ describe Visualization::Collection do
     it "checks filtering by 'liked' " do
       restore_vis_backend_to_normal_table_so_relator_works
 
-      user = create_user(:quota_in_bytes => 524288000, :table_quota => 500)
-      user2 = create_user(:quota_in_bytes => 524288000, :table_quota => 500)
-      user3 = create_user(:quota_in_bytes => 524288000, :table_quota => 500)
+      user = create_user(:quota_in_bytes => 524288000, :table_quota => 500, :private_tables_enabled => true)
+      user2 = create_user(:quota_in_bytes => 524288000, :table_quota => 500, :private_tables_enabled => true)
+      user3 = create_user(:quota_in_bytes => 524288000, :table_quota => 500, :private_tables_enabled => true)
       CartoDB::Visualization::Relator.any_instance.stubs(:user).returns(user)
 
       table1 = Table.new

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -425,7 +425,7 @@ describe Visualization::Member do
       visualization.user_id = user_id
 
       # Private maps allowed
-      @user_mock.stubs(:private_maps_enabled).returns(true)
+      @user_mock.stubs(:private_maps_enabled?).returns(true)
 
       # Forces internal "dirty" flag
       visualization.privacy = Visualization::Member::PRIVACY_PUBLIC
@@ -436,7 +436,7 @@ describe Visualization::Member do
       # -------------
 
       # No private maps allowed
-      @user_mock.stubs(:private_maps_enabled).returns(false)
+      @user_mock.stubs(:private_maps_enabled?).returns(false)
 
       visualization.privacy = Visualization::Member::PRIVACY_PUBLIC
       visualization.privacy = Visualization::Member::PRIVACY_PRIVATE
@@ -472,7 +472,7 @@ describe Visualization::Member do
           type:     Visualization::Member::TYPE_CANONICAL,
           user_id:  user_id
       )
-      @user_mock.stubs(:private_maps_enabled).returns(true)
+      @user_mock.stubs(:private_maps_enabled?).returns(true)
 
       # Careful, do a user mock after touching user_data as it does some checks about user too
       user_mock = mock

--- a/spec/requests/admin/visualizations_spec.rb
+++ b/spec/requests/admin/visualizations_spec.rb
@@ -23,7 +23,7 @@ describe Admin::VisualizationsController do
       username: 'test',
       email:    'test@test.com',
       password: 'test12',
-      private_table_enabled: true
+      private_tables_enabled: true
     )
     @api_key = @user.api_key
     @user.stubs(:should_load_common_data?).returns(false)

--- a/spec/requests/admin/visualizations_spec.rb
+++ b/spec/requests/admin/visualizations_spec.rb
@@ -22,7 +22,8 @@ describe Admin::VisualizationsController do
     @user = create_user(
       username: 'test',
       email:    'test@test.com',
-      password: 'test12'
+      password: 'test12',
+      private_table_enabled: true
     )
     @api_key = @user.api_key
     @user.stubs(:should_load_common_data?).returns(false)

--- a/spec/requests/api/tables_spec.rb
+++ b/spec/requests/api/tables_spec.rb
@@ -6,7 +6,7 @@ describe "Tables API" do
 
   before(:all) do
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
-    @user = create_user(:username => 'test', :email => "client@example.com", :password => "clientex")
+    @user = create_user(:username => 'test', :email => "client@example.com", :password => "clientex", :private_tables_enabled => true)
     @another_user = create_user
   end
 

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -44,7 +44,7 @@ module CartoDB
       user.password              = attributes[:password] || user.email.split('@').first
       user.password_confirmation = user.password
       user.admin                 = attributes[:admin] == false ? false : true
-      user.private_tables_enabled = attributes[:private_tables_enabled] == false ? false : true
+      user.private_tables_enabled = attributes[:private_tables_enabled] == true ? true : false
       user.private_maps_enabled  = attributes[:private_maps_enabled] == true ? true : false
       user.enabled               = attributes[:enabled] == false ? false : true
       user.table_quota           = attributes[:table_quota]     if attributes[:table_quota]


### PR DESCRIPTION
Remove details about accounts that should not be the concern of the
user model.

@Kartones can you please review? I finally opted for removing the account types stuff out of the user model, we shouldn't have that code there. I know it might cause some trouble (not bigger than what we have now) but it should be fixed in the flags instead.

cc/ @viddo (edit: fixes #3404 to close automatically when merged)