### PR TITLE
Fixes "No georeferenced data" dialog.

### DIFF
--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -1516,7 +1516,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
    * @method showNoGeorefWarning
    */
   showNoGeoRefWarning: function() {
-    var warningStorageName = 'georefNoContentWarningShowed' + this.table.id;
+    var warningStorageName = 'georefNoContentWarningShowed_' + this.table.id + '_' + this.table.get('map_id');
 
     // if the dialog already has been shown, we don't show it again
     if(!this.noGeoRefDialog && !this.table.isInSQLView() && (!localStorage[warningStorageName])) {

--- a/lib/assets/test/spec/SpecHelper.js
+++ b/lib/assets/test/spec/SpecHelper.js
@@ -11,7 +11,7 @@ var TestUtil = {};
  * @param  {Array} Geometry types, ex: ['ST_Polygon', 'ST_Point']
  * @return {cdb.admin.CarotDBTableMetadata}
  */
-TestUtil.createTable = function(name, schema, geometry_types) {
+TestUtil.createTable = function(name, schema, geometry_types, map_id) {
   if(!schema) {
     schema = [
       ['test', 'number'],
@@ -25,7 +25,8 @@ TestUtil.createTable = function(name, schema, geometry_types) {
     description: 'test description',
     geometry_types: geometry_types || ['ST_Polygon'],
     tags: "",
-    privacy: "private"
+    privacy: "private",
+    map_id: map_id
   });
 };
 

--- a/lib/assets/test/spec/cartodb/table/mapview.spec.js
+++ b/lib/assets/test/spec/cartodb/table/mapview.spec.js
@@ -84,6 +84,30 @@ describe("mapview", function() {
     expect(view.noGeoRefDialog === undefined).toEqual(true);
   });
 
+  it("should trigger the georef warning when there's no geom in the table and there was a table with the same name in the past", function() {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], [], '12345');
+    view.table._data.reset([
+      {'the_geom':'', 'name': 'Benidorm'}
+    ]);
+    view.bindGeoRefCheck();
+    view.render();
+    view.table.trigger("dataLoaded");
+    expect(view.noGeoRefDialog === undefined).toEqual(false);
+
+    // Clean that view to reuse it
+    view.noGeoRefDialog.clean();
+    view.noGeoRefDialog = undefined;
+
+    // New table with the same name (test)
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry']], [], '45678');
+    view.table._data.reset([
+      {'the_geom':''}
+    ]);
+    view.bindGeoRefCheck();
+    view.table.trigger("dataLoaded");
+    expect(view.noGeoRefDialog === undefined).toEqual(false);
+  });
+
   it("should NOT trigger the georef warning when there's no data in the table", function() {
     view.table = TestUtil.createTable('test', [['the_geom', 'geometry']], []);
     view.bindGeoRefCheck();


### PR DESCRIPTION
Fixes #3198.

We were generating the localStorage key using the id (name) of the table. So if you created/imported a new table with the name of a previously existing table, the localStorage key already existed and we din't display that dialog. It's an edge case.

Instead of relying on `table.id`, I added the `map_id` to the key, which is the only attribute that seemed unique in the table metadata (I was planning to use `created_at` but it wasn't present). I'm open to suggestion on better ways to generate a unique id for the table metadata.

@javisantana, this one is for you! :)

