### PR TITLE
New create map first modal

### DIFF
--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.11.11
+3.11.12

--- a/lib/assets/javascripts/cartodb/common/header.js
+++ b/lib/assets/javascripts/cartodb/common/header.js
@@ -100,7 +100,6 @@ cdb.admin.Header = cdb.core.View.extend({
     this.model.bind('change:type',        this.setInfo,             this);
     this.model.bind('change:privacy',     this._setPrivacy,      this);
     this.model.bind('change:permission',  this._setSharedCount,  this);
-    this.model.bind('change:id', this.setInfo, this); // might happen on map<->dataset change w/o reloading
   },
 
   _openOptionsMenu: function(e) {

--- a/lib/assets/javascripts/cartodb/common/header.js
+++ b/lib/assets/javascripts/cartodb/common/header.js
@@ -32,6 +32,7 @@ cdb.admin.Header = cdb.core.View.extend({
       share:        _t('SHARE'),
       visualize:    _t('VISUALIZE')
     },
+    publish:        'PUBLISH',
     share_privacy: {
       ok_next:      _t('Share it now!')
     },
@@ -66,7 +67,7 @@ cdb.admin.Header = cdb.core.View.extend({
     this.$body = $('body');
     this.dataLayer = null;
     this.globalError = this.options.globalError;
-    this.createBindings();
+    this._initBinds();
 
     // Display all the visualization info
     this.setInfo();
@@ -94,11 +95,12 @@ cdb.admin.Header = cdb.core.View.extend({
 
   },
 
-  createBindings: function() {
+  _initBinds: function() {
     this.model.bind('change:name',        this._setName,            this);
     this.model.bind('change:type',        this.setInfo,             this);
     this.model.bind('change:privacy',     this._setPrivacy,      this);
     this.model.bind('change:permission',  this._setSharedCount,  this);
+    this.model.bind('change:id', this.setInfo, this); // might happen on map<->dataset change w/o reloading
   },
 
   _openOptionsMenu: function(e) {
@@ -142,18 +144,24 @@ cdb.admin.Header = cdb.core.View.extend({
 
     if (this.options.user.featureEnabled('new_modals')) {
       if (this.model.isVisualization()) {
-        var view = new cdb.editor.PublishView({
+        this._createPublishView();
+      } else {
+        var self = this;
+        var createVisFirstView = new cdb.editor.CreateVisFirstView({
           clean_on_hide: true,
           enter_to_confirm: true,
-          user: this.options.user,
-          model: this.model // vis
+          model: this.model,
+          router: window.table_router,
+          title: 'A map is required to publish',
+          explanation: 'A map is a shareable mix of layers, styles and queries. You can view all your maps in your dashboard.',
+          success: function() {
+            self._createPublishView();
+          }
         });
-        view.render().appendToBody();
-        return;
-      } else {
-        // TODO: a dataset cannot be shared, have to create a map first
-        // for now use old modal, TBD replaced w/ same flow as for add-layer (modal to confirm creating vis before continue)
+        createVisFirstView.appendToBody();
       }
+
+      return;
     }
 
     this.controller && this.controller.clean();
@@ -162,6 +170,16 @@ cdb.admin.Header = cdb.core.View.extend({
       user:   this.options.user,
       config: this.options.config
     });
+  },
+
+  _createPublishView: function() {
+    var view = new cdb.editor.PublishView({
+      clean_on_hide: true,
+      enter_to_confirm: true,
+      user: this.options.user,
+      model: this.model // vis
+    });
+    view.render().appendToBody();
   },
 
   _showPrivacyDialog: function(e) {
@@ -362,20 +380,20 @@ cdb.admin.Header = cdb.core.View.extend({
    */
   _setVisualization: function() {
     // Change visualization type
-    var $vis_type        = this.$('span.type');
     var $back            = this.$('a.back');
     var $share           = this.$('a.share');
     var is_visualization = this.model.isVisualization();
+    var publishText      = this.options.user.featureEnabled('new_modals') ? this._TEXTS.publish : undefined;
 
     if (is_visualization) {
-      $share.find("span").text(this._TEXTS.share.share);
+      $share.find("span").text(publishText ? publishText : this._TEXTS.share.share);
       this._setPrivacy();
-      var route = cdb.config.prefixUrl() + "/dashboard/visualizations";
+      var route = cdb.config.prefixUrl() + "/dashboard/maps";
       $back.attr("href", route );
     } else {
-      $share.find("span").text(this._TEXTS.share.visualize);
+      $share.find("span").text(publishText ? publishText : this._TEXTS.share.visualize);
       this._setPrivacy();
-      var route = cdb.config.prefixUrl() + "/dashboard/tables";
+      var route = cdb.config.prefixUrl() + "/dashboard/datasets";
       $back.attr("href", route );
     }
   },

--- a/lib/assets/javascripts/cartodb/editor.js
+++ b/lib/assets/javascripts/cartodb/editor.js
@@ -4,6 +4,7 @@
 // Expected to be loaded after cdb.js but before table.js
 var cdb = require('cartodb.js');
 cdb.editor = {
+  CreateVisFirstView: require('./new_common/dialogs/create_vis_first/create_vis_first_view'),
   ImportsCollection: require('./new_common/background_importer/imports_collection'),
   BackgroundImporterModel: require('./editor/background_importer_model'),
   BackgroundImporterView: require('./new_common/background_importer/background_importer_view'),

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/change_privacy_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/change_privacy_view.js
@@ -57,6 +57,10 @@ module.exports = BaseDialog.extend({
     this.clean();
   },
 
+  ok: function() {
+    this.model.save();
+  },
+
   _renderStart: function() {
     return this._getRenderedElements('_startView');
   },

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/share_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/share_view.js
@@ -11,7 +11,6 @@ module.exports = cdb.core.View.extend({
   className: 'Dialog-expandedSubContent',
 
   events: {
-    'click .js-save': '_onClickSave',
     'click .js-search-link': '_onSearchClick',
     'click .js-clean-search': '_onCleanSearchClick',
     'keydown .js-search-input': '_onKeyDown',
@@ -93,11 +92,6 @@ module.exports = cdb.core.View.extend({
   _onSearchClick: function(e) {
     if (e) this.killEvent(e);
     this.$('.js-search-input').focus();
-  },
-
-  _onClickSave: function(ev) {
-    this.killEvent(ev);
-    this._viewModel.save();
   },
 
   _onCleanSearchClick: function(ev) {

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/share_view/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/share_view/template.jst.ejs
@@ -38,7 +38,7 @@
       <button class="Button Button--secondary Dialog-footerBtn cancel">
         <span>cancel</span>
       </button>
-      <button class="js-save Button Button--positive">
+      <button class="ok Button Button--positive">
         <span>Save settings</span>
       </button>
     </div>

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/start_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/start_view.js
@@ -11,7 +11,6 @@ var DISABLED_SAVE_CLASS_NAME = 'is-disabled';
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-save' : '_onClickSave',
     'click .js-option' : '_selectOption',
     'click .js-share' : '_onClickShare',
     'keyup .js-password-input' : '_updatePassword'
@@ -74,10 +73,5 @@ module.exports = cdb.core.View.extend({
       this.killEvent(ev);
       this._viewModel.changeState('Share');
     }
-  },
-
-  _onClickSave: function(ev) {
-    this.killEvent(ev);
-    this._viewModel.save();
   }
 });

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/start_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/change_privacy/start_view_template.jst.ejs
@@ -50,7 +50,7 @@
   <button class="Button Button--secondary Dialog-footerBtn cancel">
     <span>cancel</span>
   </button>
-  <button class="js-save Button Button--positive <%= saveBtnClassNames %>">
+  <button class="ok Button Button--positive <%= saveBtnClassNames %>">
     <span>Save settings</span>
   </button>
 </div>

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view.js
@@ -1,5 +1,4 @@
 var cdb = require('cartodb.js');
-var _ = require('underscore');
 var BaseDialog = require('../../views/base_dialog/view');
 var ViewFactory = require('../../view_factory');
 var randomQuote = require('../../view_helpers/random_quote');
@@ -11,12 +10,6 @@ var randomQuote = require('../../view_helpers/random_quote');
  */
 module.exports = BaseDialog.extend({
 
-  events: function() {
-    return _.extend({}, BaseDialog.prototype.events, {
-      'click .js-ok': '_createMap'
-    });
-  },
-
   initialize: function() {
     this.elder('initialize');
     if (!this.model) throw new Error('model is required (cdb.admin.Visualization)');
@@ -24,7 +17,6 @@ module.exports = BaseDialog.extend({
     if (!this.options.explanation) throw new Error('title is required');
     if (!this.options.success) throw new Error('success callback is required');
     if (!this.options.router) throw new Error('router callback is required');
-    this.elder('initialize');
     this._initViews();
     this._initBinds();
   },
@@ -62,8 +54,7 @@ module.exports = BaseDialog.extend({
     this._panes.bind('tabEnabled', this.render, this);
   },
 
-  _createMap: function(ev) {
-    this.killEvent(ev);
+  ok: function() {
     this._panes.active('loading');
     var self = this;
     this.model.changeToVisualization({

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view.js
@@ -1,0 +1,80 @@
+var cdb = require('cartodb.js');
+var _ = require('underscore');
+var BaseDialog = require('../../views/base_dialog/view');
+var ViewFactory = require('../../view_factory');
+var randomQuote = require('../../view_helpers/random_quote');
+
+/**
+ * Create a vis from a dataset, required for some contexts to have a vis before be able to carry out next task
+ *  - duplicate vis
+ *  - add layer
+ */
+module.exports = BaseDialog.extend({
+
+  events: function() {
+    return _.extend({}, BaseDialog.prototype.events, {
+      'click .js-ok': '_createMap'
+    });
+  },
+
+  initialize: function() {
+    this.elder('initialize');
+    if (!this.model) throw new Error('model is required (cdb.admin.Visualization)');
+    if (!this.options.title) throw new Error('title is required');
+    if (!this.options.explanation) throw new Error('title is required');
+    if (!this.options.success) throw new Error('success callback is required');
+    if (!this.options.router) throw new Error('router callback is required');
+    this.elder('initialize');
+    this._initViews();
+    this._initBinds();
+  },
+
+  render_content: function() {
+    return this._panes.getActivePane().render().el;
+  },
+
+  _initViews: function() {
+    this._panes = new cdb.ui.common.TabPane({
+      el: this.el
+    });
+    this.addView(this._panes);
+    this._panes.addTab('confirm',
+      ViewFactory.createByTemplate('new_common/dialogs/create_vis_first/template', {
+        title: this.options.title,
+        explanation: this.options.explanation
+      })
+    );
+    this._panes.addTab('loading',
+      ViewFactory.createByTemplate('new_common/templates/loading', {
+        title: 'Creating map…',
+        quote: randomQuote()
+      })
+    );
+    this._panes.addTab('fail',
+      ViewFactory.createByTemplate('new_common/templates/fail', {
+        msg: 'Could not create map for some reason'
+      })
+    );
+    this._panes.active('confirm');
+  },
+
+  _initBinds: function() {
+    this._panes.bind('tabEnabled', this.render, this);
+  },
+
+  _createMap: function(ev) {
+    this.killEvent(ev);
+    this._panes.active('loading');
+    var self = this;
+    this.model.changeToVisualization({
+      success: function(vis) {
+        self.options.router.changeToVis(vis);
+        self.options.success(vis);
+        self.clean();
+      },
+      error: function() {
+        self._panes.active('fail');
+      }
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create_vis_first/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create_vis_first/template.jst.ejs
@@ -10,7 +10,7 @@
   <button class="Button Button--secondary Dialog-footerBtn cancel">
     <span>cancel</span>
   </button>
-  <button class="Button Button--positive js-ok">
+  <button class="Button Button--positive ok">
     <span>Ok, create map</span>
   </button>
 </div>

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create_vis_first/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create_vis_first/template.jst.ejs
@@ -1,0 +1,16 @@
+<div class="Dialog-header u-inner">
+  <div class="Dialog-headerIcon Dialog-headerIcon--positive">
+    <i class="iconFont iconFont-Map"></i>
+  </div>
+  <p class="Dialog-headerTitle"><%= title %></p>
+  <p class="Dialog-headerText"><%= explanation %></p>
+</div>
+
+<div class="Dialog-footer u-inner DeleteItems-footer">
+  <button class="Button Button--secondary Dialog-footerBtn cancel">
+    <span>cancel</span>
+  </button>
+  <button class="Button Button--positive js-ok">
+    <span>Ok, create map</span>
+  </button>
+</div>

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/delete_items_view.js
@@ -3,7 +3,6 @@ var BaseDialog = require('../views/base_dialog/view');
 var pluralizeString = require('../view_helpers/pluralize_string');
 var randomQuote = require('../view_helpers/random_quote');
 var MapCardPreview = require('../views/mapcard_preview');
-var _ = require('underscore');
 var $ = require('jquery');
 var moment = require('moment');
 
@@ -14,12 +13,6 @@ var AFFECTED_VIS_COUNT = 3;
  * Delete items dialog
  */
 module.exports = BaseDialog.extend({
-
-  events: function() {
-    return _.extend({}, BaseDialog.prototype.events, {
-      'click .js-ok': '_ok'
-    });
-  },
 
   initialize: function() {
     this.elder('initialize');
@@ -104,10 +97,9 @@ module.exports = BaseDialog.extend({
   },
 
   /**
-   * @overrides BaseDialog.prototype._ok
+   * @overrides BaseDialog.prototype.ok
    */
-  _ok: function(e) {
-    this.killEvent(e);
+  ok: function() {
     this._viewModel.deleteItems();
     this.render();
   },

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/delete_items_view_template.jst.ejs
@@ -72,7 +72,7 @@
   <button class="Button Button--secondary Dialog-footerBtn cancel">
     <span>cancel</span>
   </button>
-  <button class="Button Button--negative js-ok">
+  <button class="Button Button--negative ok">
     <span>Ok, delete</span>
   </button>
 </div>

--- a/lib/assets/javascripts/cartodb/new_common/views/base_dialog/view.js
+++ b/lib/assets/javascripts/cartodb/new_common/views/base_dialog/view.js
@@ -74,14 +74,14 @@ module.exports = BaseDialog.extend({
   },
 
   close: function() {
-    this._close(null, '_cancel');
+    this._close('_cancel');
   },
 
-  _close: function(ev, finishFnName) {
+  _close: function(finishFnName, ev) {
     if (ev) {
       this.killEvent(ev);
     }
-    this.$el.addClass('is-closing');
+    this.$el.removeClass('is-opening').addClass('is-closing');
 
     // Use timeout instead of event listener on animation since the event triggered differs depending on browser
     // Timing won't perhaps be 100% accurate but it's good enough
@@ -100,15 +100,23 @@ module.exports = BaseDialog.extend({
     $('body')[action + 'Class']('is-inDialog');
   },
 
+  /**
+   * @override cdb.ui.common.Dialog.prototype._ok to not hide dialog by default if there's an ok method defined.
+   */
   _ok: function(ev) {
-    this._close(ev, '_ok');
+    this.killEvent(ev);
+    if (this.ok) {
+      this.ok();
+    } else {
+      this.close();
+    }
   },
 
   /**
    * @override cdb.ui.common.Dialog.prototype._cancel to implement animation upon closing the dialog
    */
   _cancel: function(ev) {
-    this._close(ev, '_cancel');
+    this._close('_cancel', ev);
   }
 
 });

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -248,11 +248,23 @@
       this.killEvent(e);
 
       if (this.options.user.featureEnabled('new_modals')) {
-        cdb.god.trigger('openAddLayerDialog', {
-          vis: this.vis,
-          map: this.map,
-          user: this.options.user
-        });
+        if (this.vis.isVisualization()) {
+          this._createAddLayerDialog();
+        } else {
+          var self = this;
+          var createVisFirstView = new cdb.editor.CreateVisFirstView({
+            clean_on_hide: true,
+            enter_to_confirm: true,
+            model: this.vis,
+            router: window.table_router,
+            title: 'A map is required to add layers',
+            explanation: 'A map is a shareable mix of layers, styles and queries. You can view all your maps in your dashboard.',
+            success: function() {
+              self._createAddLayerDialog();
+            }
+          });
+          createVisFirstView.appendToBody();
+        }
       } else {
         // Clean previous 'new layer' dialog
         this.new_layer_dlg && this.new_layer_dlg.clean();
@@ -273,6 +285,19 @@
 
         this.new_layer_dlg.appendToBody().open({ center: true });
       }
+    },
+
+    _createAddLayerDialog: function() {
+      var model = new cdb.editor.AddLayerModel({}, {
+        vis: this.vis,
+        map: this.map,
+        user: this.options.user
+      });
+      var dialog = new cdb.editor.AddLayerView({
+        model: model,
+        user: this.options.user
+      });
+      dialog.appendToBody();
     },
 
     _showUpgrade: function() {

--- a/lib/assets/javascripts/cartodb/table/header/share_controller.js
+++ b/lib/assets/javascripts/cartodb/table/header/share_controller.js
@@ -93,13 +93,7 @@
     },
 
     _changeToVis: function(vis) {
-      // Get scenario param (table or map)
-      var last_route = window.table_router.history.length > 0 && _.last(window.table_router.history).split('/');
-      // Create url
-      var url = "/viz/" + vis.get("id") + "/" + ( last_route[2] || 'table' );
-      // Navigate
-      window.table_router.navigate(url, { trigger: false });
-      window.table_router.addToHistory();
+      window.table_router.changeToVis(vis);
     },
 
     // Do next step until the end

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -182,25 +182,7 @@ $(function() {
       $(window).bind("resize", this._onResize);
 
       if (this.user.featureEnabled('new_modals')) {
-        /**
-         * NOTE: Dependencies loaded in editor.js bundle!
-         * @param {Object} opts where keys are:
-         *   user: {cdb.admin.User}
-         *   addVisLayer: {Function} taking two args: {cdb.admin.Visualization} and {cdb.core.View}
-         */
-        cdb.god.bind('openAddLayerDialog', function(opts) {
-          var model = new cdb.editor.AddLayerModel({}, {
-            vis: opts.vis,
-            map: opts.map,
-            user: opts.user
-          });
-          var dialog = new cdb.editor.AddLayerView({
-            model: model,
-            user: opts.user
-          });
-          dialog.appendToBody();
-        });
-
+        // Used for add layer modal, to handle import of datasets before adding them as layers
         var importsCollection = new cdb.editor.ImportsCollection(null, {
           user: this.user
         });

--- a/lib/assets/javascripts/cartodb/table/table_router.js
+++ b/lib/assets/javascripts/cartodb/table/table_router.js
@@ -24,6 +24,16 @@
       this.addToHistory();
     },
 
+    changeToVis: function(vis) {
+      // Get scenario param (table or map)
+      var last_route = this.history.length > 0 && _.last(this.history).split('/');
+      // Create url
+      var url = "/viz/" + vis.get("id") + "/" + ( last_route[2] || 'table' );
+      // Navigate
+      this.navigate(url, { trigger: false });
+      this.addToHistory();
+    },
+
     addToHistory: function() {
       if (Backbone.history.fragment) {
         // I hate you double quotes!
@@ -84,7 +94,7 @@
 
       // Function to change to visualization
       function toVis(new_id) {
-        self.table.vis
+        self.table.master_vis
           .set('id', new_id)
           .fetch({
             wait: true,

--- a/lib/assets/test/spec/cartodb/new_common/dialogs/change_privacy/share_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/dialogs/change_privacy/share_view.spec.js
@@ -86,20 +86,6 @@ describe('new_common/dialogs/change_privacy/share_view', function() {
     });
   });
 
-  describe('on click .js-save', function() {
-    beforeEach(function() {
-      this.view.$('.js-save').click();
-    });
-
-    it('should kill event', function() {
-      expect(this.view.killEvent).toHaveBeenCalled();
-    });
-
-    it('should stop listening on events while processing', function() {
-      expect(this.viewModel.save).toHaveBeenCalled();
-    });
-  });
-
   describe('filtering users', function() {
 
     it('should re-render when then the search changes', function() {

--- a/lib/assets/test/spec/cartodb/new_common/dialogs/change_privacy/start_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/dialogs/change_privacy/start_view.spec.js
@@ -187,18 +187,4 @@ describe('new_common/dialogs/change_privacy/start_view', function() {
       });
     });
   });
-
-  describe('on click .js-save', function() {
-    beforeEach(function() {
-      this.view.$('.js-save').click();
-    });
-
-    it('should kill event', function() {
-      expect(this.view.killEvent).toHaveBeenCalled();
-    });
-
-    it('should stop listening on events while processing', function() {
-      expect(this.viewModel.save).toHaveBeenCalled();
-    });
-  });
 });

--- a/lib/assets/test/spec/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view.spec.js
@@ -1,0 +1,86 @@
+var CreateVisFirstView = require('../../../../../../javascripts/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view');
+
+describe('new_common/dialogs/create_vis_first/create_vis_first_view', function() {
+  beforeEach(function() {
+    this.successCallback = jasmine.createSpy('success callback');
+    this.vis = new cdb.admin.Visualization({
+      name: 'my_table',
+      type: 'table'
+    });
+    this.router = new cdb.admin.TableRouter();
+
+    spyOn(this.vis, 'changeToVisualization');
+    spyOn(this.router, 'changeToVis');
+
+    this.view = new CreateVisFirstView({
+      model: this.vis,
+      router: this.router,
+      title: 'This test expects an title',
+      explanation: 'This test expects an explanation',
+      success: this.successCallback
+    });
+    this.view.render();
+  });
+
+  it('should render the confirm view first', function() {
+    expect(this.innerHTML()).toContain('ok');
+  });
+
+  it('should render the title and explanation', function() {
+    expect(this.innerHTML()).toContain('This test expects an title');
+    expect(this.innerHTML()).toContain('This test expects an explanation');
+  });
+
+  describe('when confirm/ok to create map first', function() {
+    beforeEach(function() {
+      this.view.$el.find('.js-ok').click();
+    });
+
+    it('should change to the loading view', function() {
+      expect(this.innerHTML()).not.toContain('This test expects');
+      expect(this.innerHTML()).toContain('Creating map');
+    });
+
+    it('should call the change-to-visualization on the model', function() {
+      expect(this.vis.changeToVisualization).toHaveBeenCalled();
+      expect(this.vis.changeToVisualization).toHaveBeenCalledWith(jasmine.objectContaining({
+        success: jasmine.any(Function),
+        error: jasmine.any(Function)
+      }));
+    });
+
+    describe('when successfully changed', function() {
+      beforeEach(function() {
+        spyOn(this.view, 'clean');
+        this.vis.changeToVisualization.calls.argsFor(0)[0].success(this.vis);
+      });
+
+      it('should tell router to change to map', function() {
+        expect(this.router.changeToVis).toHaveBeenCalled();
+        expect(this.router.changeToVis).toHaveBeenCalledWith(this.vis);
+      });
+
+      it('should call the given success callback', function() {
+        expect(this.successCallback).toHaveBeenCalled();
+      });
+
+      it('should clean this view', function() {
+        expect(this.view.clean).toHaveBeenCalled();
+      });
+    });
+
+    describe('when fails to create map', function() {
+      beforeEach(function() {
+        this.vis.changeToVisualization.calls.argsFor(0)[0].error();
+      });
+
+      it('should show the fail view', function() {
+        expect(this.innerHTML()).toContain('Could not create map');
+      });
+    });
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+});

--- a/lib/assets/test/spec/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/dialogs/create_vis_first/create_vis_first_view.spec.js
@@ -33,7 +33,7 @@ describe('new_common/dialogs/create_vis_first/create_vis_first_view', function()
 
   describe('when confirm/ok to create map first', function() {
     beforeEach(function() {
-      this.view.$el.find('.js-ok').click();
+      this.view.$el.find('.ok').click();
     });
 
     it('should change to the loading view', function() {

--- a/lib/assets/test/spec/cartodb/new_common/dialogs/delete_items_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/dialogs/delete_items_view.spec.js
@@ -91,7 +91,7 @@ describe('new_common/dialogs/delete_items_view', function() {
           beforeEach(function() {
             spyOn(this.viewModel, 'deleteItems');
             spyOn(this.view, 'close').and.callThrough();
-            this.view.$('.js-ok').click();
+            this.view.$('.ok').click();
             this.viewModel.setState('DeletingItems');
           });
 

--- a/lib/assets/test/spec/cartodb/new_common/views/base_dialog/view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/views/base_dialog/view.spec.js
@@ -6,7 +6,9 @@ describe('new_common/views/base_dialog/view', function() {
   beforeEach(function() {
     var DialogExample = BaseDialog.extend({
       render_content: function() {
-        return '<blink>foobar content</blink>';
+        return '<blink>foobar content</blink>' +
+        '<button class="cancel">cancel</button>' +
+        '<button class="ok">OK</button>';
       }
     });
 
@@ -21,15 +23,10 @@ describe('new_common/views/base_dialog/view', function() {
     }, this);
 
     this.view.render();
-    this.html = function() {
-      // To get HTML including the view's own root element:
-      return $('<div />').append($(this.view.el).clone()).html();
-    };
-
   });
 
   it('should render a close button', function() {
-    expect(this.html()).toContain('close');
+    expect(this.innerHTML()).toContain('close');
   });
 
   it('should trigger a dialogOpened event on the global eventbus', function() {
@@ -37,18 +34,18 @@ describe('new_common/views/base_dialog/view', function() {
   });
 
   it('should render the content of .render_content', function() {
-    expect(this.html()).toContain('foobar content');
+    expect(this.innerHTML()).toContain('foobar content');
   });
 
   it('should expected the implementing child view to escape its content', function() {
-    expect(this.html()).toContain('<blink>');
+    expect(this.innerHTML()).toContain('<blink>');
   });
 
   it('should have no leaks', function() {
     expect(this.view).toHaveNoLeaks();
   });
 
-  describe('click close', function() {
+  describe('when click close', function() {
     beforeEach(function() {
       jasmine.clock().install();
       $('body').append(this.view.$el); // necessary for .is-assertions below
@@ -56,29 +53,7 @@ describe('new_common/views/base_dialog/view', function() {
     });
 
     it('should start the scale-out animation', function() {
-      expect(this.html()).toContain('is-closing');
-    });
-
-    it('should hide but after the animation finished', function() {
-      expect(this.view.$el.is(':visible')).toBeTruthy();
-      jasmine.clock().tick(101);
-      expect(this.view.$el.is(':hidden')).toBeTruthy();
-    });
-
-    afterEach(function() {
-      jasmine.clock().uninstall();
-    });
-  });
-
-  describe('.close', function() {
-    beforeEach(function() {
-      jasmine.clock().install();
-      $('body').append(this.view.$el); // necessary for .is-assertions below
-      this.view.close();
-    });
-
-    it('should start the scale-out animation', function() {
-      expect(this.html()).toContain('is-closing');
+      expect(this.view.el.className).toContain('is-closing');
     });
 
     it('should hide but after the animation finished', function() {
@@ -95,6 +70,40 @@ describe('new_common/views/base_dialog/view', function() {
 
     afterEach(function() {
       jasmine.clock().uninstall();
+    });
+  });
+
+  describe('when click ok', function() {
+    beforeEach(function() {
+      spyOn(this.view, 'close');
+      this.clickOK = function() {
+        this.view.$el.find('.ok').click();
+      };
+    });
+
+    describe('when there is no ok method defined', function() {
+      beforeEach(function() {
+        this.clickOK();
+      });
+
+      it('should close the view by default', function() {
+        expect(this.view.close).toHaveBeenCalled();
+      });
+    });
+
+    describe('when there is a ok method defined on view', function() {
+      beforeEach(function() {
+        this.view.ok = jasmine.createSpy('ok');
+        this.clickOK();
+      });
+
+      it('should not close the view', function() {
+        expect(this.view.close).not.toHaveBeenCalled();
+      });
+
+      it('should have called the ok method instead', function() {
+        expect(this.view.ok).toHaveBeenCalled();
+      });
     });
   });
 

--- a/lib/assets/test/spec/cartodb/table/header/header.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/header.spec.js
@@ -273,19 +273,19 @@ describe("Table/Visualization Header tests", function() {
 
   it("should change href of back button when user belongs to an organization", function() {
     this.vis.set('type', 'derived');
-    expect(this.header.$('a.back').attr('href')).toBe('/dashboard/visualizations');
+    expect(this.header.$('a.back').attr('href')).toBe('/dashboard/maps');
 
     this.vis.set('type', 'table');
-    expect(this.header.$('a.back').attr('href')).toBe('/dashboard/tables');
+    expect(this.header.$('a.back').attr('href')).toBe('/dashboard/datasets');
 
     var originalPrefixUrl = cdb.config.prefixUrl;
     cdb.config.prefixUrl = function() { return '/u/staging20' };
 
     this.header._setVisualization();
-    expect(this.header.$('a.back').attr('href')).toBe('/u/staging20/dashboard/tables');
+    expect(this.header.$('a.back').attr('href')).toBe('/u/staging20/dashboard/datasets');
 
     this.vis.set('type', 'derived');
-    expect(this.header.$('a.back').attr('href')).toBe('/u/staging20/dashboard/visualizations');
+    expect(this.header.$('a.back').attr('href')).toBe('/u/staging20/dashboard/maps');
 
     // Restore cdb.config to not affect other tests
     cdb.config.prefixUrl = originalPrefixUrl;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.11.11",
+  "version": "3.11.12",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
![fix-create-map-first](https://cloud.githubusercontent.com/assets/978461/7454580/66f08480-f275-11e4-9a7e-6aa028b4853a.gif)

This PR solves the issue that a map needs to be created from current dataset before it can be published or have more layers added. Basically, the new modal replaces the current "create new map first" dialog that already exists, with one using the new styles.

This also fixes #3388 (enter key not saving modals), which was because some internal changes to the base modal that just closed the modal as a default. This fix also removed some boilerplate code for the existing modals.