### PR TITLE
Making public map bigger for mobile devices on landscape orientation

### DIFF
--- a/lib/assets/javascripts/cartodb/new_dashboard/content_controller_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/content_controller_view.js
@@ -55,6 +55,7 @@ module.exports = cdb.core.View.extend({
 
     var filtersView = new FiltersView({
       el:           this.$('.Filters'),
+      headerHeight: this.options.headerHeight,
       user:         this.user,
       router:       this.router,
       collection:   this.collection,

--- a/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/filters_view.js
@@ -357,7 +357,7 @@ module.exports = cdb.core.View.extend({
 
   _onWindowScroll: function() {
     var offset = $(window).scrollTop();
-    var anchorPoint = 81 /* header */ + ( this.user.get('notification') ? 81 : 0 );
+    var anchorPoint = this.options.headerHeight + ( this.user.get('notification') ? this.options.headerHeight : 0 );
     this.$el[ offset > anchorPoint ? 'addClass' : 'removeClass' ]('is-fixed')
   },
 

--- a/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/main_view.js
@@ -125,6 +125,9 @@ module.exports = cdb.core.View.extend({
 
     this.controllerView = new ContentControllerView({
       el:           this.$('#content-controller'),
+      // Pass the whole element for only calculating
+      // the height is not "fair"
+      headerHeight: this.$('#header').height(), 
       user:         this.user,
       router:       this.router,
       collection:   this.collection,

--- a/lib/assets/javascripts/cartodb/new_public_dashboard/fav_map_view.js
+++ b/lib/assets/javascripts/cartodb/new_public_dashboard/fav_map_view.js
@@ -44,6 +44,7 @@ module.exports = cdb.core.View.extend({
       legends:           false,
       time_slider:       false,
       loader:            false,
+      fullscreen:        false,
       no_cdn:            false
     }));
   },

--- a/lib/assets/javascripts/cartodb/public_map/public_map_window.js
+++ b/lib/assets/javascripts/cartodb/public_map/public_map_window.js
@@ -66,7 +66,7 @@ module.exports = cdb.core.View.extend({
     if (this.options.isMobileDevice) {
 
       if (landscapeMode) {
-        h = headerHeight;
+        h = headerHeight - 20;
       } else {
         if (windowHeight > 670) {
           h = 220;
@@ -96,7 +96,7 @@ module.exports = cdb.core.View.extend({
     // If landscape, let's scroll to show the map, and
     // leave the header hidden
     if (this.options.isMobileDevice && landscapeMode && $(window).scrollTop() < headerHeight) {
-      this.$body.animate({ scrollTop: headerHeight }, 500);
+      this.$body.animate({ scrollTop: headerHeight }, 600);
     }
 
     if (this.map_view) this.map_view.invalidateMap();

--- a/lib/assets/javascripts/cartodb/public_map/public_map_window.js
+++ b/lib/assets/javascripts/cartodb/public_map/public_map_window.js
@@ -52,24 +52,28 @@ module.exports = cdb.core.View.extend({
     // Reset disqus
     DISQUS && DISQUS.reset({ reload: true });
     // Resize window orientation
-    this._setupMapDimensions(true);
+    this._setupMapDimensions(true,true);
   },
 
   // When window is resized, let's touch some things ;)
-  _setupMapDimensions: function(animated) {
+  _setupMapDimensions: function(animated, orientationChange) {
     var windowHeight = this.$el.height();
     var mainInfoHeight = this.$body.find('.PublicMap-title').height() + 90 /* meta + margins */;
     var headerHeight = this.$body.find('.Header').height();
+    var landscapeMode = orientationChange && ( this.outerWidth > this.outerHeight );
     var h, height, top;
 
     if (this.options.isMobileDevice) {
 
-      if (windowHeight > 670) {
-        h = 220;
-      } else { // iPhone, etc.
-        h = 140;
+      if (landscapeMode) {
+        h = headerHeight;
+      } else {
+        if (windowHeight > 670) {
+          h = 220;
+        } else { // iPhone, etc.
+          h = 140;
+        }        
       }
-
     } else {
       h = 260;
     }
@@ -87,6 +91,12 @@ module.exports = cdb.core.View.extend({
         // On non mobile devices
         this.$map.css({ height: windowHeight - ( mainInfoHeight + headerHeight), opacity: 1 })
       }
+    }
+
+    // If landscape, let's scroll to show the map, and
+    // leave the header hidden
+    if (landscapeMode && $(window).scrollTop() < headerHeight) {
+      this.$body.animate({ scrollTop: headerHeight }, 200);
     }
 
     if (this.map_view) this.map_view.invalidateMap();

--- a/lib/assets/javascripts/cartodb/public_map/public_map_window.js
+++ b/lib/assets/javascripts/cartodb/public_map/public_map_window.js
@@ -60,7 +60,7 @@ module.exports = cdb.core.View.extend({
     var windowHeight = this.$el.height();
     var mainInfoHeight = this.$body.find('.PublicMap-title').height() + 90 /* meta + margins */;
     var headerHeight = this.$body.find('.Header').height();
-    var landscapeMode = orientationChange && ( this.outerWidth > this.outerHeight );
+    var landscapeMode = this.el.matchMedia && this.el.matchMedia("(orientation: landscape)").matches;
     var h, height, top;
 
     if (this.options.isMobileDevice) {
@@ -95,8 +95,8 @@ module.exports = cdb.core.View.extend({
 
     // If landscape, let's scroll to show the map, and
     // leave the header hidden
-    if (landscapeMode && $(window).scrollTop() < headerHeight) {
-      this.$body.animate({ scrollTop: headerHeight }, 200);
+    if (this.options.isMobileDevice && landscapeMode && $(window).scrollTop() < headerHeight) {
+      this.$body.animate({ scrollTop: headerHeight }, 500);
     }
 
     if (this.map_view) this.map_view.invalidateMap();


### PR DESCRIPTION
When device changes to landscape, it will scroll to the map content and will take up all the space up to "cut" the map title.

![screenshot_2015-05-04-18-41-50_720](https://cloud.githubusercontent.com/assets/132146/7457603/19e41184-f28e-11e4-8b64-8fa9b9696c56.png)
![image2](https://cloud.githubusercontent.com/assets/132146/7457604/19fc1e46-f28e-11e4-82d4-852e83a616cf.PNG)
![image1](https://cloud.githubusercontent.com/assets/132146/7457605/1a11dd94-f28e-11e4-94da-b625300b95ec.PNG)

Fixes #3460
And fixes the "jump" problem with fixed header in private dashboard.

cc @saleiva 
REVIEWER: @javierarce 