### PR TITLE
New delete layer

### DIFF
--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.11.12
+3.11.13

--- a/lib/assets/javascripts/cartodb/editor.js
+++ b/lib/assets/javascripts/cartodb/editor.js
@@ -15,6 +15,7 @@ cdb.editor = {
 
   DeleteItemsView: require('./new_common/dialogs/delete_items_view'),
   DeleteItemsViewModel: require('./new_common/dialogs/delete_items_view_model'),
+  DeleteLayerView: require('./new_common/dialogs/delete_layer/delete_layer_view'),
 
   PublishView: require('./new_common/dialogs/publish/publish_view'),
   UrlShortener: require('./new_common/url_shortener'),

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/delete_layer/delete_layer_view.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/delete_layer/delete_layer_view.js
@@ -1,0 +1,64 @@
+var cdb = require('cartodb.js');
+var BaseDialog = require('../../views/base_dialog/view');
+var ViewFactory = require('../../view_factory');
+var randomQuote = require('../../view_helpers/random_quote');
+
+/**
+ * Create a vis from a dataset, required for some contexts to have a vis before be able to carry out next task
+ *  - duplicate vis
+ *  - add layer
+ */
+module.exports = BaseDialog.extend({
+
+  initialize: function() {
+    this.elder('initialize');
+    if (!this.model) throw new Error('model is required (layer)');
+    this._initViews();
+    this._initBinds();
+  },
+
+  render_content: function() {
+    return this._panes.getActivePane().render().el;
+  },
+
+  _initViews: function() {
+    this._panes = new cdb.ui.common.TabPane({
+      el: this.el
+    });
+    this.addView(this._panes);
+    this._panes.addTab('confirm',
+      ViewFactory.createByTemplate('new_common/dialogs/delete_layer/template', {
+      })
+    );
+    this._panes.addTab('loading',
+      ViewFactory.createByTemplate('new_common/templates/loading', {
+        title: 'Deleting layer…',
+        quote: randomQuote()
+      })
+    );
+    this._panes.addTab('fail',
+      ViewFactory.createByTemplate('new_common/templates/fail', {
+        msg: 'Could not delete layer for some reason'
+      })
+    );
+    this._panes.active('confirm');
+  },
+
+  _initBinds: function() {
+    this._panes.bind('tabEnabled', this.render, this);
+  },
+
+  ok: function() {
+    this._panes.active('loading');
+    var self = this;
+    this.model.destroy({
+      wait: true,
+      success: function() {
+        self.clean();
+      },
+      error: function() {
+        self._panes.active('fail');
+      }
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/delete_layer/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/delete_layer/template.jst.ejs
@@ -1,0 +1,16 @@
+<div class="Dialog-header u-inner">
+  <div class="Dialog-headerIcon Dialog-headerIcon--negative">
+    <i class="iconFont iconFont-Trash"></i>
+  </div>
+  <p class="Dialog-headerTitle">You are about to delete this layer</p>
+  <p class="Dialog-headerText">Doing so won't delete your dataset, only this map will be affected.</p>
+</div>
+
+<div class="Dialog-footer u-inner DeleteItems-footer">
+  <button class="Button Button--secondary Dialog-footerBtn cancel">
+    <span>cancel</span>
+  </button>
+  <button class="Button Button--negative ok">
+    <span>Ok, delete</span>
+  </button>
+</div>

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -147,8 +147,9 @@
 
         v.bind('toggle',    self._toggle, self);
         v.bind('switchTo',  self._switchTo, self);
-        v.bind('delete',    self._remove, self);
+        v.bind('delete',    self._openDeleteLayerDialog, self);
         v.bind('show',      self.show, self);
+        v.bind('destroy',   self._removeLayer, self);
 
         self.addTab(layer.cid, v, { after: 0 });
         v.setActiveWorkView(self.model.get('activeWorkView'));
@@ -165,16 +166,16 @@
       }
     },
 
-    _removeLayer: function(cid) {
-      var layer_view = this.getPane(cid);
+    _removeLayer: function(dataLayerCid) {
+      var layer_view = this.getPane(dataLayerCid);
       var self = this;
 
       this.layer_panels = _.filter(this.layer_panels, function(view) {
         if (view != layer_view) return view;
       });
 
-      var tabBind = function(cid) {
-        var view = self.getPane(cid);
+      var tabBind = function(dataLayerCid) {
+        var view = self.getPane(dataLayerCid);
         self.trigger('switch', view);
         self.vis.save('active_layer_id', view.dataLayer.id);
         self.show(view.panels.activeTab);
@@ -184,9 +185,12 @@
       this.bind('tabEnabled', tabBind);
 
       this._unbindLayerTooltip(layer_view);
-      this.removeTab(cid);
+      this.removeTab(dataLayerCid);
       this._checkLayers();
       this._manageLayers();
+      if (self.map.layers.getDataLayers().length === 1) {
+        self.map.layers.last().set('visible', true);
+      }
     },
 
     _setDefaultLayer: function() {
@@ -754,8 +758,15 @@
     // We need to review this method, it is not easy to
     // make operations when the view is cleaning/removing
     // For now the model destroy is happening here
-    _remove: function(layer_view) {
-      var cid = layer_view.dataLayer.cid;
+    _openDeleteLayerDialog: function(layer_view) {
+      if (this.options.user.featureEnabled('new_modals')) {
+        var view = new cdb.editor.DeleteLayerView({
+          model: layer_view.model
+        });
+        view.appendToBody();
+        return;
+      }
+
       var self = this;
       var permitted = true;
 
@@ -780,17 +791,8 @@
       });
 
       if (permitted) {
-        // If user confirms, app removes this panel view,
-        // including the map layer
         this.remove_dlg.ok = function() {
-          // Destroy layer model
           layer_view.model.destroy({
-            success: function() {
-              self._removeLayer(cid);
-              if(self.map.layers.getDataLayers().length === 1) {
-                self.map.layers.last().set('visible', true);
-              }
-            },
             error: function(){
               self.globalError.showError(self._TEXTS.error.default, 'error', 3000);
             },

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -58,7 +58,6 @@
 
       // Set current panel view and data layer
       this.activeWorkView = 'table';
-      this.currentPanelView;
       this.setDataLayer(this.model);
 
       // New added layers need to wait to get model id
@@ -69,6 +68,9 @@
       this.model.bind('change:type',    this._setLayerType, this);
       // Show message when layer is not visible
       this.model.bind('change:visible', this.setVisibleMsg, this);
+      this.model.bind('destroy', function() {
+        this.trigger('destroy', this.dataLayer.cid);
+      }, this);
 
       // When status change binding
       this.view_model.bind('change:state', this._onChangeStatus, this);

--- a/lib/assets/test/spec/cartodb/new_common/dialogs/delete_layer/delete_layer_view.spec.js
+++ b/lib/assets/test/spec/cartodb/new_common/dialogs/delete_layer/delete_layer_view.spec.js
@@ -1,0 +1,63 @@
+var CreateVisFirstView = require('../../../../../../javascripts/cartodb/new_common/dialogs/delete_layer/delete_layer_view');
+
+describe('new_common/dialogs/delete_layer/delete_layer_view', function() {
+  beforeEach(function() {
+    this.layer = new cdb.admin.CartoDBLayer({
+    });
+
+    spyOn(this.layer, 'destroy');
+
+    this.view = new CreateVisFirstView({
+      model: this.layer
+    });
+    this.view.render();
+  });
+
+  it('should render the confirm view first', function() {
+    expect(this.innerHTML()).toContain('ok');
+  });
+
+  describe('when click ok to delete layer', function() {
+    beforeEach(function() {
+      this.view.$('.ok').click();
+    });
+
+    it('should change to the loading view', function() {
+      expect(this.innerHTML()).not.toContain('ok');
+      expect(this.innerHTML()).toContain('Deleting layer');
+    });
+
+    it('should call to destroy the model', function() {
+      expect(this.layer.destroy).toHaveBeenCalled();
+    });
+
+    it('should not remove layer from owning collection until after confirmed deleted', function() {
+      expect(this.layer.destroy.calls.argsFor(0)[0]).toEqual(jasmine.objectContaining({ wait: true }));
+    });
+
+    describe('when successfully deleted', function() {
+      beforeEach(function() {
+        spyOn(this.view, 'clean');
+        this.layer.destroy.calls.argsFor(0)[0].success();
+      });
+
+      it('should clean this view', function() {
+        expect(this.view.clean).toHaveBeenCalled();
+      });
+    });
+
+    describe('when fails to delete layer', function() {
+      beforeEach(function() {
+        this.layer.destroy.calls.argsFor(0)[0].error();
+      });
+
+      it('should show the fail view', function() {
+        expect(this.innerHTML()).toContain('Could not delete layer');
+      });
+    });
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+});

--- a/lib/assets/test/spec/cartodb/table/actions_menu.spec.js
+++ b/lib/assets/test/spec/cartodb/table/actions_menu.spec.js
@@ -17,8 +17,14 @@ describe("Actions menu", function() {
 
     vis.map.layers.reset([
       new cdb.geo.MapLayer(),
-      new cdb.admin.CartoDBLayer({ table_name: 'test_table_1'}),
-      new cdb.admin.CartoDBLayer({ table_name: 'test_table_2'})
+      new cdb.admin.CartoDBLayer({
+        type: 'CartoDB',
+        table_name: 'test_table_1'
+      }),
+      new cdb.admin.CartoDBLayer({
+        type: 'CartoDB',
+        table_name: 'test_table_2'
+      })
     ]);
 
     server = sinon.fakeServer.create();
@@ -37,7 +43,7 @@ describe("Actions menu", function() {
       user: new_user,
       globalError: new cdb.admin.GlobalError({ el: $('<div>') })
     });
-    
+
     expect(new_view._MAX_LAYERS).toBe(10)
   });
 
@@ -50,7 +56,7 @@ describe("Actions menu", function() {
       user: new_user,
       globalError: new cdb.admin.GlobalError({ el: $('<div>') })
     });
-    
+
     expect(new_view._MAX_LAYERS).toBe(3)
   });
 
@@ -63,7 +69,7 @@ describe("Actions menu", function() {
       user: new_user,
       globalError: new cdb.admin.GlobalError({ el: $('<div>') })
     });
-    
+
     expect(new_view._MAX_LAYERS).toBe(3)
   });
 
@@ -130,30 +136,22 @@ describe("Actions menu", function() {
 
   it("should remove a layer if there are 2 or more, change current layer and send trigger", function() {
     var last_layer = view.layer_panels[1];
-    var switch_trigger = false;
-    var switch_layer;
-    
-    last_layer.model.destroy = function(opts) { opts.success(); }
+    var switch_trigger = jasmine.createSpy('switch trigger');
+
+    spyOn(last_layer.model, 'destroy').and.callFake(function() {
+      last_layer.model.trigger('destroy');
+    });
     last_layer.trigger('delete', last_layer);
     spyOn(view.vis, 'save');
     spyOn(view, '_unbindLayerTooltip');
     expect(view.remove_dlg).toBeTruthy();
-    view.bind('switch', function(l) {
-      switch_layer = l;
-      switch_trigger = true;
-    });
-    spyOn(last_layer.model, 'destroy').and.callFake(function(opts) {
-      opts.success();
-    });
+    view.bind('switch', switch_trigger);
 
     view.remove_dlg.$('a.ok').click();
     expect(view.vis.save).toHaveBeenCalled();
     expect(view._unbindLayerTooltip).toHaveBeenCalled();
-    expect(switch_trigger).toBeTruthy();
-    //expect(switch_layer).not.toEqual(undefined);
-    // check layer.remove has been called with wait: true
-    expect(last_layer.model.destroy).toHaveBeenCalled();
-    expect(last_layer.model.destroy.calls.mostRecent().args[0].wait).toEqual(true);
+    expect(switch_trigger).toHaveBeenCalled();
+    expect(last_layer.model.destroy).toHaveBeenCalledWith(jasmine.objectContaining({ wait: true }));
     view.remove_dlg.clean();
   });
 
@@ -210,7 +208,7 @@ describe("Actions menu", function() {
 
     server.respondWith('/api/v1/viz', [200, { "Content-Type": "application/json" }, '{}']);
     server.respond();
-    
+
     expect(view.create_vis_dialog.ok).toHaveBeenCalled();
     view.create_vis_dialog.clean();
     view.new_layer_dlg.clean();
@@ -218,9 +216,10 @@ describe("Actions menu", function() {
 
   it("should order layers when removes a layer", function() {
     var last_layer = view.layer_panels[1];
-    
-    last_layer.model.destroy = function(opts) { opts.success() }
-    last_layer.trigger('delete', last_layer);
+
+    spyOn(last_layer.model, 'destroy').and.callFake(function() {
+      last_layer.model.trigger('destroy');
+    });    last_layer.trigger('delete', last_layer);
     spyOn(view, '_manageLayers');
     view.remove_dlg.$('a.ok').click();
     expect(view._manageLayers).toHaveBeenCalled();
@@ -248,7 +247,7 @@ describe("Actions menu", function() {
       new cdb.geo.MapLayer(),
       new cdb.admin.CartoDBLayer({ table_name: 'test_table_1' })
     ]);
-    
+
     expect(view._switchTo).toHaveBeenCalled();
   });
 

--- a/lib/assets/test/spec/cartodb/table/layer_panel_view.spec.js
+++ b/lib/assets/test/spec/cartodb/table/layer_panel_view.spec.js
@@ -344,4 +344,17 @@ describe("cdb.admin.LayerPanelView", function() {
       view.newGeomDropdown.clean();
     });
   });
+
+  describe('when model is destroyed', function() {
+    beforeEach(function() {
+      this.destroySpy = jasmine.createSpy('destroy');
+      view.bind('destroy', this.destroySpy);
+      view.model.destroy();
+    });
+
+    it('should trigger a destroy event with the view cid its dataLayer as param', function() {
+      expect(this.destroySpy).toHaveBeenCalled();
+      expect(this.destroySpy).toHaveBeenCalledWith(view.dataLayer.cid);
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.11.12",
+  "version": "3.11.13",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
![delete-layer](https://cloud.githubusercontent.com/assets/978461/7457864/f066905a-f28f-11e4-81cf-aa0adb58489a.gif)

This implements the new delete-layer modal, essentially the same as existing delete-map/dataset modal but w/ different text and side-effects.

Regarding the solution I'll add comments inline in code to explain some details.