### PR TITLE
Fixes alignment of the number inside the zoom info overlay

### DIFF
--- a/app/assets/stylesheets/map/overlays.css.scss
+++ b/app/assets/stylesheets/map/overlays.css.scss
@@ -627,11 +627,11 @@ div.cartodb-zoom .info {
   display:block;
   margin:17px 0 0 0;
   width: 28px;
-  height:28px;
+  padding: 8px 0 7px 0;
   font:normal 13px "Helvetica",Arial;
+  line-height: normal;
   color:#858585;
   text-align: center;
-  line-height: 28px;
   -webkit-box-shadow: rgba(0, 0, 0, 0.2) 0 0 4px 2px;
   -moz-box-shadow: rgba(0, 0, 0, 0.2) 0 0 4px 2px;
   box-shadow: rgba(0, 0, 0, 0.2) 0 0 4px 2px;


### PR DESCRIPTION
![screen shot 2015-05-07 at 11 31 16](https://cloud.githubusercontent.com/assets/4933/7512365/b94bbb62-f4ac-11e4-83e8-6041c36f8cc9.png)
![screen shot 2015-05-07 at 11 31 37](https://cloud.githubusercontent.com/assets/4933/7512366/b967db80-f4ac-11e4-8655-ce46ba7682e1.png)

Original issue: #3550