### PR TITLE
3560 domainless root redirection

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -41,12 +41,14 @@ class Admin::PagesController < ApplicationController
   def index_subdomainless
     if current_user && current_viewer && current_user.id == current_viewer.id
       redirect_to CartoDB.url(self, 'dashboard')
-    elsif current_viewer    # Asummes either current_user nil or at least different from current_viewer
+    elsif current_user.nil? && current_viewer
+      # current_viewer always returns a user with a session
+      redirect_to CartoDB.url(self, 'dashboard', {}, current_viewer)
+    elsif CartoDB.username_from_request(request)
       redirect_to CartoDB.url(self, 'public_maps_home')
-    elsif CartoDB.username_from_request(request).nil?
-      redirect_to login_url
     else
-      redirect_to CartoDB.url(self, 'public_maps_home')
+      # We cannot get any user information from domain, path or session
+      redirect_to login_url
     end
   end
 

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -24,10 +24,10 @@ class Admin::PagesController < ApplicationController
   # Just an entrypoint to dispatch to different places according to
   def index
     # username.cartodb.com should redirect to the user dashboard in the maps view if the user is logged in
-    if !current_user.nil? && !current_viewer.nil? && current_user.id == current_viewer.id
+    if current_user && current_viewer && current_user.id == current_viewer.id
       redirect_to CartoDB.url(self, 'dashboard')
     # username.cartodb.com should redirect to the public user dashboard in the maps view if the username is not the user's username
-    elsif !current_viewer.nil?    # Asummes either current_user nil or at least different from current_viewer
+    elsif current_viewer    # Asummes either current_user nil or at least different from current_viewer
       redirect_to CartoDB.url(self, 'public_maps_home')
     elsif CartoDB.subdomainless_urls? && CartoDB.username_from_request(request).nil?
       # This is kind of special case for on-premise: there's no user info at all in the request

--- a/spec/requests/admin/pages_controller_spec.rb
+++ b/spec/requests/admin/pages_controller_spec.rb
@@ -133,8 +133,6 @@ describe Admin::PagesController do
       uri = URI.parse(last_response.location)
       uri.host.should == 'localhost.lan'
       uri.path.should == '/user/anyuser/dashboard'
-      follow_redirect!
-      last_response.status.should == 200
     end
 
   end

--- a/spec/requests/admin/pages_controller_spec.rb
+++ b/spec/requests/admin/pages_controller_spec.rb
@@ -120,6 +120,23 @@ describe Admin::PagesController do
       last_response.status.should == 200
     end
 
+    it 'redirects and loads the dashboard if the user is logged in' do
+      anyuser = prepare_user('anyuser')
+      host! 'localhost.lan'
+      login_as anyuser
+      CartoDB.stubs(:session_domain).returns('localhost.lan')
+      CartoDB.stubs(:subdomainless_urls?).returns(true)
+
+      get '', {}, JSON_HEADER
+
+      last_response.status.should == 302
+      uri = URI.parse(last_response.location)
+      uri.host.should == 'localhost.lan'
+      uri.path.should == '/user/anyuser/dashboard'
+      follow_redirect!
+      last_response.status.should == 200
+    end
+
   end
 
   def prepare_user(user_name, org_user=false, belongs_to_org=false)


### PR DESCRIPTION
@Kartones please review. Mi recommendation is to see it side-by-side (split).

The domainfull part is functionally equivalent, though I removed the double negations `if !obj.nil?` and merged the final else "default" case with a preceding one.

The domainless part takes advantage of the fact that `current_viewer` is taken from the session.

cc/ @javisantana  