### PR TITLE
Fix create from scratch

### DIFF
--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.12.4
+3.12.5

--- a/lib/assets/javascripts/cartodb/new_common/dialogs/create/create_loading.js
+++ b/lib/assets/javascripts/cartodb/new_common/dialogs/create/create_loading.js
@@ -61,7 +61,7 @@ module.exports = cdb.core.View.extend({
   _initBinds: function() {
     this.model.bind('change:state change:tableIdsArray change:currentImport', this.render, this);
     // Dataset
-    this.createModel.bind('datasetError', this._datasetError, this);
+    this.createModel.bind('datasetError', this._onDatasetError, this);
     this.createModel.bind('creatingDataset', this._creatingDataset, this);
 
     // Map

--- a/lib/assets/javascripts/cartodb/new_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/entry.js
@@ -37,7 +37,7 @@ $(function() {
     }
     if (currentUser.featureEnabled('active_record_table_vis_endpoint')) {
       applyPatchNewTableUrls();
-    }    
+    }
 
     cdb.config.set('user', currentUser);
     var router = new Router({
@@ -104,6 +104,7 @@ $(function() {
           window.location = vis.viewUrl(currentUser).edit();
         } else {
           var vis = new cdb.admin.Visualization({ name: DEFAULT_VIS_NAME });
+          vis.permission.owner = currentUser;
           vis.save({
             tables: [ tableMetadata.get('id') ]
           },{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.12.4",
+  "version": "3.12.5",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is the quickfix to solve the reported issue w/ creating empty map not working:
- Call correct callback on error in loading view ... https://github.com/CartoDB/cartodb/commit/e4dc5efa020930745e396d1dc56a49f4f5be4df7
- Make sure the vis has the appropriate permission owner … https://github.com/CartoDB/cartodb/commit/7085e7f020d631f807bf6f4b74e5a4d0a6fb387a

Found another issue with the creating empty dataset also failing when reached table quota (not handling the error properly).

The proper fixes for this is more complicated, I'll create separate issues and reference the fix here to explain the situation more in detail.