### PR TITLE
Keep vis and permission model synced

### DIFF
--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,2 @@
 #This file defines the version of the frontend code that is going to be loaded.
-3.12.5
+3.12.6

--- a/lib/assets/javascripts/cartodb/models/vis.js
+++ b/lib/assets/javascripts/cartodb/models/vis.js
@@ -136,6 +136,11 @@ cdb.admin.Visualization = cdb.core.Model.extend({
       this.set('permission', this.permission.attributes, { silent: true });
       this.trigger('change:permission', this);
     }, this);
+
+    // Keep permission model in sync, e.g. on vis.save
+    this.bind('change:permission', function() {
+      this.permission.set(this.get('permission'));
+    }, this);
   },
 
   isLoaded: function() {

--- a/lib/assets/javascripts/cartodb/new_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/new_dashboard/entry.js
@@ -104,7 +104,6 @@ $(function() {
           window.location = vis.viewUrl(currentUser).edit();
         } else {
           var vis = new cdb.admin.Visualization({ name: DEFAULT_VIS_NAME });
-          vis.permission.owner = currentUser;
           vis.save({
             tables: [ tableMetadata.get('id') ]
           },{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.12.5",
+  "version": "3.12.6",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Revert #3571 for the create-empty-map, reintroducing the bind that kept vis <-> permission in sync that was removed in https://github.com/CartoDB/cartodb/commit/0f6748a4e6899b1afe5a8fee7bbee7d2b4d1f367, so now synced/consistent both ways.