### PR TITLE
changing link on logo

### DIFF
--- a/app/views/admin/shared/_public_header.erb
+++ b/app/views/admin/shared/_public_header.erb
@@ -3,10 +3,10 @@
     <div class="Header-navigation">
       <ul class="Header-navigationList">
         <li class="js-logo">
-          <% if !Cartodb.config[:cartodb_com_hosted].present? %>
-            <a href="<%= CartoDB.url(self, 'root') %>">
-          <% else %>
+          <% if cartodb_com_hosted? %>
             <a href="http://cartodb.com">
+          <% else %>
+            <a href="<%= CartoDB.url(self, 'root') %>">
           <% end %>
             <span class="Logo Logo--avatar">
               <i class="iconFont iconFont-CartoFante"></i>

--- a/app/views/admin/shared/_public_header.erb
+++ b/app/views/admin/shared/_public_header.erb
@@ -3,7 +3,11 @@
     <div class="Header-navigation">
       <ul class="Header-navigationList">
         <li class="js-logo">
-          <a href="<%= CartoDB.url(self, 'root') %>">
+          <% if !Cartodb.config[:cartodb_com_hosted].present? %>
+            <a href="<%= CartoDB.url(self, 'root') %>">
+          <% else %>
+            <a href="http://cartodb.com">
+          <% end %>
             <span class="Logo Logo--avatar">
               <i class="iconFont iconFont-CartoFante"></i>
             </span>


### PR DESCRIPTION
In not self hosted version logo goes to cartodb.com on the public dashboard, and the public map page - close #3564