### PR TITLE
2941 timeout for geocodings

### DIFF
--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -115,7 +115,7 @@ class Geocoding < Sequel::Model
     self.update state: 'started', processable_rows: processable_rows
     @started_at = Time.now
 
-    Timeout::timeout(PROCESSING_TIMEOUT_SECONDS, ProcessingTimeoutException) do
+    Timeout::timeout(processing_timeout_seconds, ProcessingTimeoutException) do
       # INFO: this is where the real stuff is done
       table_geocoder.run
     end
@@ -141,6 +141,10 @@ class Geocoding < Sequel::Model
     CartoDB::notify_exception(e, user: user)
     self.report(e)
   end # run!
+
+  def processing_timeout_seconds
+    @processing_timeout_seconds ||= PROCESSING_TIMEOUT_SECONDS
+  end
 
   def report(error = nil)
     payload = metrics_payload(error)

--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -22,8 +22,6 @@ class Geocoding < Sequel::Model
   attr_reader :table_geocoder
   attr_reader :started_at, :finished_at
 
-  class ProcessingTimeoutException < StandardError; end
-
   def public_values
     Hash[PUBLIC_ATTRIBUTES.map{ |k| [k, (self.send(k) rescue self[k].to_s)] }]
   end
@@ -263,6 +261,8 @@ class Geocoding < Sequel::Model
 
     payload
   end
+
+  class ProcessingTimeoutException < StandardError; end
 
   private
 


### PR DESCRIPTION
@Kartones can you please review?

Things done here:
- Change DB timeout to 100 minutes. Why? because max processing time since we got metrics is that for a failing geocoding. So most likely that time should be 1 order of magnitude smaller, at most.
- Set a processing time timeout to 200 minutes, double of max execution time for a failing geocoding.
- Use Ruby's stdlib http://ruby-doc.org/stdlib-1.9.3/libdoc/timeout/rdoc/Timeout.html to implement the timeout
- Add a test for it (not really necessary IMO since it relies on the library and I also tested it manually but a convenience for the future).