### PR TITLE
Adding config attribute within public dashboard views

### DIFF
--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -89,6 +89,7 @@
 
     <%= render 'admin/shared/footer' %>
     <script type="text/javascript">
+      var config = <%= safe_js_object frontend_config_public({https_apis: request.protocol == 'https://' }) %>;
       var account_host = '<%= CartoDB.account_host %>';
       var favMapViewAttrs = {
         el: '#<%= fav_map_target_id %>',


### PR DESCRIPTION
Having these data available under public pages, we could manage how to load fonts under onpremise or com-hosted instances, for example.

Fixes #3597.