### PR TITLE
Offdatabase ordering proposal

### DIFF
--- a/app/queries/carto/offdatabase_query_adapter.rb
+++ b/app/queries/carto/offdatabase_query_adapter.rb
@@ -1,0 +1,56 @@
+class Carto::OffdatabaseQueryAdapter
+
+  def initialize(query, order_by_asc_or_desc_by_attribute)
+    @query = query
+    @order_by_asc_or_desc_by_attribute = order_by_asc_or_desc_by_attribute
+    @offset = 0
+    @limit = nil
+  end
+
+  def offset(offset)
+    @offset = offset
+    self
+  end
+
+  def limit(limit)
+    @limit = limit
+    self
+  end
+
+  def all
+    results
+  end
+
+  def map
+    results.map { |a|
+      yield(a)
+    }
+  end
+
+  def count
+    results.count 
+  end
+
+  private
+
+  def results
+    @results ||= get_results
+  end
+
+  def get_results
+    all = @query.all
+    @order_by_asc_or_desc_by_attribute.each { |attribute, asc_or_desc|
+      all = all.sort { |x, y|
+        x_attribute = x.send(attribute)
+        y_attribute = y.send(attribute)
+        asc_or_desc == :asc ? x_attribute <=> y_attribute : y_attribute <=> x_attribute
+      }
+    }
+    all[@offset, last_index(all)]
+  end
+
+  def last_index(array)
+    @limit.nil? ? array.count - 1 : (@offset + @limit - 1)
+  end
+
+end


### PR DESCRIPTION
@Kartones @rafatower take a look at my proposal for off-database attributes support, which would close #3608 .

The key is implementing in-memory sorting in `Carto:: OffdatabaseQueryAdapter`. That class should implement as many methods as needed, as it mimics an ActiveRecord query. The nice thing of this adapter is that is model-agnostic, you can use it with any class.

I'm not sure whether checking if an attribute is offdatabase or not must be inside the QueryBuilder or the OffdatabaseQueryAdapter.

This is obviously slow as hell for mapviews or likes, since it has to fetch collections or mapviews (in Redis), but optimization can come later.