### PR TITLE
Use package.json version for frontend assets

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -134,6 +134,9 @@ module CartoDB
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    frontend_assets_version = JSON::parse(File.read(Rails.root.join('package.json')))['version']
+    config.action_controller.relative_url_root = "/assets/#{frontend_assets_version}"
   end
 end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,9 +65,6 @@ CartoDB::Application.configure do
 
   config.assets.initialize_on_precompile = true
 
-  frontend_version = YAML::load(File.read(Rails.root.join('config', 'frontend.yml')))
-  config.action_controller.relative_url_root = "/assets/" + frontend_version
-
   config.action_controller.asset_host = Proc.new do
     Cartodb.asset_path
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,9 +61,6 @@ CartoDB::Application.configure do
 
   config.assets.initialize_on_precompile = true
 
-  frontend_version = YAML::load(File.read(Rails.root.join('config', 'frontend.yml')))
-  config.action_controller.relative_url_root = "/assets/" + frontend_version
-
   config.action_controller.asset_host = Proc.new do
     Cartodb.asset_path
   end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -61,9 +61,6 @@ CartoDB::Application.configure do
 
   config.assets.initialize_on_precompile = true
 
-  frontend_version = YAML::load(File.read(Rails.root.join('config', 'frontend.yml')))
-  config.action_controller.relative_url_root = "/assets/" + frontend_version
-
   config.action_controller.asset_host = Proc.new do
     Cartodb.asset_path
   end

--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -1,2 +1,0 @@
-#This file defines the version of the frontend code that is going to be loaded.
-3.13.5


### PR DESCRIPTION
Removes the need to have that config/frontend.yml file and duplicate the version nr. From what I can see there's no reason to have both really.