### PR TITLE
Fix old undeterministic delete-dialog tests

### DIFF
--- a/lib/assets/test/spec/cartodb/old_common/delete_dialog.spec.js
+++ b/lib/assets/test/spec/cartodb/old_common/delete_dialog.spec.js
@@ -91,8 +91,28 @@ describe("cdb.admin.DeleteDialog", function() {
       table_visualization:      { id: 1 }
     });
 
-    // Success! forcing to show visualizations
-    table_1.fetch = function(o) { o.success() };
+    // Mock fadeIn/Out to remove timeout issues
+    var originalfadeIn = $.prototype.fadeIn;
+    var originalfadeOut = $.prototype.fadeOut;
+    spyOn($.prototype, 'fadeIn').and.callFake(function(ms, callback) {
+      if (callback) callback();
+      originalfadeIn.apply(this, arguments);
+    });
+    spyOn($.prototype, 'fadeOut').and.callFake(function(ms, callback) {
+      if (callback) callback();
+      originalfadeOut.apply(this, arguments);
+    });
+
+    table_1.fetch = function(o) {
+      // Success! forcing to show visualizations
+      o.success();
+
+      // Assert side-effects:
+      expect(view.$('.visualizations').length).toBe(1);
+      expect(view.$('.visualizations a:eq(0)').text()).toBe('test_vis jar (Created by jar)');
+      view.clean();
+      done();
+    }.bind(this);
 
     var view = new cdb.admin.DeleteDialog({
       model: table_1,
@@ -103,25 +123,36 @@ describe("cdb.admin.DeleteDialog", function() {
     });
 
     view.render();
-
-    setTimeout(function() {
-      expect(view.$('.visualizations').length).toBe(1);
-      expect(view.$('.visualizations a:eq(0)').text()).toBe('test_vis jar (Created by jar)');
-      view.clean();
-      done();
-    }, 500);
-  
   });
 
   it("shouldn't show dependent visualizations owner if user doesn't belong to a org", function(done) {
     var user = TestUtil.createUser('test');
-    
+
     table = TestUtil.createTable('test');
     table.set("dependent_visualizations", [vis.toJSON(), vis2.toJSON()]);
     table.set("table_visualization", { id: 1 });
 
+    // Mock fadeIn/Out to remove timeout issues
+    var originalfadeIn = $.prototype.fadeIn;
+    var originalfadeOut = $.prototype.fadeOut;
+    spyOn($.prototype, 'fadeIn').and.callFake(function(ms, callback) {
+      if (callback) callback();
+      originalfadeIn.apply(this, arguments);
+    });
+    spyOn($.prototype, 'fadeOut').and.callFake(function(ms, callback) {
+      if (callback) callback();
+      originalfadeOut.apply(this, arguments);
+    });
+
     // Success! forcing to show visualizations
-    table.fetch = function(o) { o.success() };
+    table.fetch = function(o) {
+      o.success();
+
+      expect(view.$('.visualizations').length).toBe(1);
+      expect(view.$('.visualizations a:eq(0)').text()).toBe('fake_2');
+      view.clean();
+      done();
+    };
 
     var view = new cdb.admin.DeleteDialog({
       model: table,
@@ -132,13 +163,6 @@ describe("cdb.admin.DeleteDialog", function() {
     });
 
     view.render();
-
-    setTimeout(function() {
-      expect(view.$('.visualizations').length).toBe(1);
-      expect(view.$('.visualizations a:eq(0)').text()).toBe('fake_2');
-      view.clean();
-      done();
-    }, 500);
   });
 
   it("should render the ok button text", function() {


### PR DESCRIPTION
Call the callbacks on fadeIn/fadeOut directly, so the test don’t have to have the manual timeouts to do the assertions