### PR TITLE
3638 refactor api v1 viz tags

### DIFF
--- a/app/controllers/api/json/tags_controller.rb
+++ b/app/controllers/api/json/tags_controller.rb
@@ -12,7 +12,7 @@ class Api::Json::TagsController < Api::ApplicationController
 
     tag_counts = CartoDB::Visualization::Tags.new(current_user, options)
       .count(params)
-    render_jsonp(tag_counts)
+    render_jsonp(tag_counts.sort { |tc1, tc2| tc1[:name] <=> tc2[:name] })
   end
 end
 

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -8,7 +8,7 @@ class Carto::Api::TagsController < Api::ApplicationController
   def index
     render_jsonp(tag_counts.map { |tag, count|
       { name: tag, count: count }
-    })
+    }.sort { |tc1, tc2| tc1[:name] <=> tc2[:name] })
   end
 
   private

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+
+class Carto::Api::TagsController < Api::ApplicationController
+  ssl_required :index
+
+  def index
+    render_jsonp([])
+  end
+
+end

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -1,10 +1,28 @@
 # encoding: utf-8
 
 class Carto::Api::TagsController < Api::ApplicationController
+  include Carto::Api::VisualizationSearcher
+
   ssl_required :index
 
   def index
-    render_jsonp([])
+    render_jsonp(tag_counts.map { |tag, count|
+      { name: tag, count: count }
+    })
+  end
+
+  private
+
+  def tag_counts
+    tc = visualizations.map(&:tags).flatten
+    tc.inject(Hash.new(0)) { |counts, tag|
+      counts[tag] = counts[tag] += 1
+      counts
+    }
+  end
+
+  def visualizations
+    query_builder_with_filter_from_hash(params).build.all
   end
 
 end

--- a/app/controllers/carto/api/visualization_searcher.rb
+++ b/app/controllers/carto/api/visualization_searcher.rb
@@ -1,0 +1,99 @@
+module Carto
+  module Api
+    module VisualizationSearcher
+
+      FILTER_SHARED_YES = 'yes'
+      FILTER_SHARED_NO = 'no'
+      FILTER_SHARED_ONLY = 'only'
+
+      # Creates a visualization query builder ready
+      # to search based on params hash (can be request params).
+      # It doesn't apply ordering or paging, just filtering.
+      def query_builder_with_filter_from_hash(params)
+        types, total_types = get_types_parameters
+        pattern = params[:q]
+
+        only_liked = params[:only_liked] == 'true'
+        only_shared = params[:only_shared] == 'true'
+        exclude_shared = params[:exclude_shared] == 'true'
+        locked = params[:locked]
+        shared = compose_shared(params[:shared], only_shared, exclude_shared)
+
+        vqb = VisualizationQueryBuilder.new
+            .with_prefetch_user
+            .with_prefetch_table
+            .with_prefetch_permission
+            .with_prefetch_external_source
+            .with_types(types)
+
+        if current_user
+          if only_liked
+            vqb.with_liked_by_user_id(current_user.id)
+          end
+
+          case shared
+          when FILTER_SHARED_YES
+            vqb.with_owned_by_or_shared_with_user_id(current_user.id)
+          when FILTER_SHARED_NO
+            vqb.with_user_id(current_user.id) if !only_liked
+          when FILTER_SHARED_ONLY
+            vqb.with_shared_with_user_id(current_user.id)
+          end
+
+          if locked == 'true'
+            vqb.with_locked(true)
+          elsif locked == 'false'
+            vqb.with_locked(false)
+          end
+        else
+          # TODO: ok, this looks like business logic, refactor
+          subdomain = CartoDB.extract_subdomain(request)
+          vqb.with_user_id(Carto::User.where(username: subdomain).first.id)
+              .with_privacy(Carto::Visualization::PRIVACY_PUBLIC)
+        end
+
+        if pattern.present?
+          vqb.with_partial_match(pattern)
+        end
+
+        vqb
+      end
+
+      private
+
+      def get_types_parameters
+        # INFO: this fits types and type into types, so only types is used for search.
+        # types defaults to type if empty.
+        # types defaults to derived if type is also empty.
+        # total_types are the types used for total counts.
+        types = params.fetch(:types, "").split(',')
+
+        type = params[:type].present? ? params[:type] : (types.empty? ? nil : types[0])
+        # TODO: add this assumption to a test or remove it (this is coupled to the UI)
+        total_types = [(type == Carto::Visualization::TYPE_REMOTE ? Carto::Visualization::TYPE_CANONICAL : type)].compact
+
+        types = [type].compact if types.empty?
+        types = [Carto::Visualization::TYPE_DERIVED] if types.empty?
+
+        return types, total_types
+      end
+
+      def compose_shared(shared, only_shared, exclude_shared)
+        valid_shared = shared if [FILTER_SHARED_ONLY, FILTER_SHARED_NO, FILTER_SHARED_YES].include?(shared)
+        return valid_shared if valid_shared
+
+        if only_shared
+          FILTER_SHARED_ONLY
+        elsif exclude_shared
+          FILTER_SHARED_NO
+        elsif exclude_shared == false
+          FILTER_SHARED_YES
+        else
+          # INFO: exclude_shared == nil && !only_shared
+          nil
+        end
+      end
+
+    end
+  end
+end

--- a/app/controllers/carto/api/visualization_searcher.rb
+++ b/app/controllers/carto/api/visualization_searcher.rb
@@ -18,6 +18,8 @@ module Carto
         exclude_shared = params[:exclude_shared] == 'true'
         locked = params[:locked]
         shared = compose_shared(params[:shared], only_shared, exclude_shared)
+        tags = params.fetch(:tags, '').split(',')
+        tags = nil if tags.empty?
 
         vqb = VisualizationQueryBuilder.new
             .with_prefetch_user
@@ -25,6 +27,7 @@ module Carto
             .with_prefetch_permission
             .with_prefetch_external_source
             .with_types(types)
+            .with_tags(tags)
 
         if current_user
           if only_liked

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -5,6 +5,7 @@ require_relative '../../../models/visualization/stats'
 module Carto
   module Api
     class VisualizationsController < ::Api::ApplicationController
+      include VisualizationSearcher
 
       # TODO: compare with older, there seems to be more optional authentication endpoints
       skip_before_filter :api_authorization_required, only: [:index, :vizjson2]
@@ -15,10 +16,6 @@ module Carto
       before_filter :load_visualization, only: [:likes_count, :likes_list, :is_liked, :show, :stats]
       ssl_required :index, :show
       ssl_allowed  :vizjson2, :likes_count, :likes_list, :is_liked
-
-      FILTER_SHARED_YES = 'yes'
-      FILTER_SHARED_NO = 'no'
-      FILTER_SHARED_ONLY = 'only'
 
       def id_and_schema_from_params
         if params.fetch('id', nil) =~ /\./
@@ -58,54 +55,11 @@ module Carto
       end
 
       def index
-        types, total_types = get_types_parameters
         page = (params[:page] || 1).to_i
         per_page = (params[:per_page] || 20).to_i
         order = (params[:order] || 'updated_at').to_sym
-        pattern = params[:q]
-
-        only_liked = params[:only_liked] == 'true'
-        only_shared = params[:only_shared] == 'true'
-        exclude_shared = params[:exclude_shared] == 'true'
-        locked = params[:locked]
-        shared = compose_shared(params[:shared], only_shared, exclude_shared)
-
-        vqb = VisualizationQueryBuilder.new
-            .with_prefetch_user
-            .with_prefetch_table
-            .with_prefetch_permission
-            .with_prefetch_external_source
-            .with_types(types)
-
-        if current_user
-          if only_liked
-            vqb.with_liked_by_user_id(current_user.id)
-          end
-
-          case shared
-          when FILTER_SHARED_YES
-            vqb.with_owned_by_or_shared_with_user_id(current_user.id)
-          when FILTER_SHARED_NO
-            vqb.with_user_id(current_user.id) if !only_liked
-          when FILTER_SHARED_ONLY
-            vqb.with_shared_with_user_id(current_user.id)
-          end
-
-          if locked == 'true'
-            vqb.with_locked(true)
-          elsif locked == 'false'
-            vqb.with_locked(false)
-          end
-        else
-          # TODO: ok, this looks like business logic, refactor
-          subdomain = CartoDB.extract_subdomain(request)
-          vqb.with_user_id(Carto::User.where(username: subdomain).first.id)
-              .with_privacy(Carto::Visualization::PRIVACY_PUBLIC)
-        end
-
-        if pattern.present?
-          vqb.with_partial_match(pattern)
-        end
+        types, total_types = get_types_parameters
+        vqb = query_builder_with_filter_from_hash(params)
 
         # TODO: undesirable table hardcoding, needed for disambiguation. Look for
         # a better approach and/or move it to the query builder
@@ -166,23 +120,6 @@ module Carto
 
       private
 
-      def get_types_parameters
-        # INFO: this fits types and type into types, so only types is used for search.
-        # types defaults to type if empty.
-        # types defaults to derived if type is also empty.
-        # total_types are the types used for total counts.
-        types = params.fetch(:types, "").split(',')
-
-        type = params[:type].present? ? params[:type] : (types.empty? ? nil : types[0])
-        # TODO: add this assumption to a test or remove it (this is coupled to the UI)
-        total_types = [(type == Carto::Visualization::TYPE_REMOTE ? Carto::Visualization::TYPE_CANONICAL : type)].compact
-
-        types = [type].compact if types.empty?
-        types = [Carto::Visualization::TYPE_DERIVED] if types.empty?
-
-        return types, total_types
-      end
-
       def set_vizjson_response_headers_for(visualization)
         # We don't cache non-public vis
         if @visualization.is_publically_accesible?
@@ -199,22 +136,6 @@ module Carto
       def to_hash(visualization)
         # TODO: previous controller uses public_fields_only option which I don't know if is still used
         VisualizationPresenter.new(visualization, current_viewer).to_poro
-      end
-
-      def compose_shared(shared, only_shared, exclude_shared)
-        valid_shared = shared if [FILTER_SHARED_ONLY, FILTER_SHARED_NO, FILTER_SHARED_YES].include?(shared)
-        return valid_shared if valid_shared
-
-        if only_shared
-          FILTER_SHARED_ONLY
-        elsif exclude_shared
-          FILTER_SHARED_NO
-        elsif exclude_shared == false
-          FILTER_SHARED_YES
-        else
-          # INFO: exclude_shared == nil && !only_shared
-          nil
-        end
       end
 
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -275,6 +275,9 @@ CartoDB::Application.routes.draw do
 
     get '(/user/:user_domain)(/u/:user_domain)/api/v2_1/viz/:id/viz'                        => 'visualizations#vizjson2', as: :api_v2_1_visualizations_vizjson, constraints: { id: /[^\/]+/ }
 
+    # Tags
+    get     '(/user/:user_domain)(/u/:user_domain)/api/v1_1/viz/tags'                           => 'tags#index',                     as: :api_v1_1_visualizations_tags_index
+
     # Tables
     get '(/user/:user_domain)(/u/:user_domain)/api/v1_1/tables/:id'                         => 'tables#show',       as: :api_v1_1_tables_show, constraints: { id: /[^\/]+/ }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -419,6 +419,7 @@ CartoDB::Application.routes.draw do
     delete  '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/like'                       => 'visualizations#remove_like',     as: :api_v1_visualizations_remove_like,     constraints: { id: /[^\/]+/ }
 
 # Tags
+    # TODO: deprecated?
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/tags' => 'tags#index', as: :api_v1_tags_index
 
     # Common data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,7 @@ CartoDB::Application.routes.draw do
     get '(/user/:user_domain)(/u/:user_domain)/api/v2_1/viz/:id/viz'                        => 'visualizations#vizjson2', as: :api_v2_1_visualizations_vizjson, constraints: { id: /[^\/]+/ }
 
     # Tags
+    # TODO: deprecated?
     get     '(/user/:user_domain)(/u/:user_domain)/api/v1_1/viz/tags'                           => 'tags#index',                     as: :api_v1_1_visualizations_tags_index
 
     # Tables
@@ -308,8 +309,10 @@ CartoDB::Application.routes.draw do
     get '(/user/:user_domain)(/u/:user_domain)/api/v1_1/viz/:visualization_id/overlays/:id' => 'overlays#show',     as: :api_v1_1_visualizations_overlays_show,   constraints: { visualization_id: /[^\/]+/ }
 
     # Synchronizations
+    # TODO: deprecated?
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1_1/synchronizations'              => 'synchronizations#index',    as: :api_v1_1_synchronizations_index
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1_1/synchronizations/:id'          => 'synchronizations#show',     as: :api_v1_1_synchronizations_show
+    # TODO: deprecated?
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1_1/synchronizations/:id/sync_now' => 'synchronizations#syncing?', as: :api_v1_1_synchronizations_syncing
   end
 
@@ -394,6 +397,7 @@ CartoDB::Application.routes.draw do
     put  '(/user/:user_domain)(/u/:user_domain)/api/v1/geocodings/:id'                            => 'geocodings#update',               as: :api_v1_geocodings_update
 
     # Visualizations
+    # TODO: deprecated?
     get     '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/tags'                           => 'tags#index',                     as: :api_v1_visualizations_tags_index
     get     '(/user/:user_domain)(/u/:user_domain)/api/v1/viz'                                => 'visualizations#index',           as: :api_v1_visualizations_index
     post    '(/user/:user_domain)(/u/:user_domain)/api/v1/viz'                                => 'visualizations#create',          as: :api_v1_visualizations_create
@@ -421,11 +425,13 @@ CartoDB::Application.routes.draw do
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/common_data' => 'common_data#index', as: :api_v1_common_data_index
 
     # Synchronizations
+    # TODO: deprecated?
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations'              => 'synchronizations#index',    as: :api_v1_synchronizations_index
     post   '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations'              => 'synchronizations#create',   as: :api_v1_synchronizations_create
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id'          => 'synchronizations#show',     as: :api_v1_synchronizations_show
     put    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id'          => 'synchronizations#update',   as: :api_v1_synchronizations_update
     delete '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id'          => 'synchronizations#destroy',  as: :api_v1_synchronizations_destroy
+    # TODO: deprecated?
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id/sync_now' => 'synchronizations#syncing?', as: :api_v1_synchronizations_syncing
     put    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id/sync_now' => 'synchronizations#sync_now', as: :api_v1_synchronizations_sync_now
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,7 +312,7 @@ CartoDB::Application.routes.draw do
     # TODO: deprecated?
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1_1/synchronizations'              => 'synchronizations#index',    as: :api_v1_1_synchronizations_index
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1_1/synchronizations/:id'          => 'synchronizations#show',     as: :api_v1_1_synchronizations_show
-    # TODO: deprecated?
+    # INFO: sync_now is public API
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1_1/synchronizations/:id/sync_now' => 'synchronizations#syncing?', as: :api_v1_1_synchronizations_syncing
   end
 
@@ -431,7 +431,7 @@ CartoDB::Application.routes.draw do
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id'          => 'synchronizations#show',     as: :api_v1_synchronizations_show
     put    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id'          => 'synchronizations#update',   as: :api_v1_synchronizations_update
     delete '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id'          => 'synchronizations#destroy',  as: :api_v1_synchronizations_destroy
-    # TODO: deprecated?
+    # INFO: sync_now is public API
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id/sync_now' => 'synchronizations#syncing?', as: :api_v1_synchronizations_syncing
     put    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id/sync_now' => 'synchronizations#sync_now', as: :api_v1_synchronizations_sync_now
 

--- a/spec/factories/visualization_creation_helpers.rb
+++ b/spec/factories/visualization_creation_helpers.rb
@@ -28,6 +28,7 @@ shared_context 'visualization creation helpers' do
   end
 
   before(:each) do
+    CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
     delete_user_data @user1
     delete_user_data @user2
   end

--- a/spec/requests/api/json/tags_controller_shared_examples.rb
+++ b/spec/requests/api/json/tags_controller_shared_examples.rb
@@ -1,21 +1,46 @@
 # encoding: utf-8
 
 shared_examples_for 'tags controllers' do
+  include CacheHelper
 
   describe 'index' do
     include_context 'visualization creation helpers'
 
     before(:each) do
-      login_as(@user1, scope: @user1.subdomain)
       @headers = {'CONTENT_TYPE'  => 'application/json'}
       host! "#{@user1.username}.localhost.lan"
     end
 
     it 'returns an empty array for a user without tagged visualizations' do
+      login_as(@user1, scope: @user1.subdomain)
       get api_v1_visualizations_tags_index_url(api_key: @api_key)
       last_response.status.should == 200
       body = JSON.parse(last_response.body)
       body.should == []
+    end
+
+    it 'returns an array with one tag with count one for a user with one tagged visualization' do
+      visualization = create_visualization(@user1, { tags: ['tag1'] })
+
+      login_as(@user1, scope: @user1.subdomain)
+      get api_v1_visualizations_tags_index_url(api_key: @api_key)
+      last_response.status.should == 200
+      body = JSON.parse(last_response.body)
+      body.should == [{ 'name' => 'tag1', 'count' => 1 }]
+    end
+
+    it 'returns an array with correct tag count with several visualizations' do
+      visualization = create_visualization(@user1, { tags: ['tag1'] })
+      visualization = create_visualization(@user1, { tags: ['tag1', 'tag2'] })
+
+      login_as(@user1, scope: @user1.subdomain)
+      get api_v1_visualizations_tags_index_url(api_key: @api_key)
+      last_response.status.should == 200
+      body = JSON.parse(last_response.body)
+      body.should == [
+        { 'name' => 'tag1', 'count' => 2 },
+        { 'name' => 'tag2', 'count' => 1 }
+      ]
     end
 
   end

--- a/spec/requests/api/json/tags_controller_shared_examples.rb
+++ b/spec/requests/api/json/tags_controller_shared_examples.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+
+shared_examples_for 'tags controllers' do
+
+  describe 'index' do
+    include_context 'visualization creation helpers'
+
+    before(:each) do
+      login_as(@user1, scope: @user1.subdomain)
+      @headers = {'CONTENT_TYPE'  => 'application/json'}
+      host! "#{@user1.username}.localhost.lan"
+    end
+
+    it 'returns an empty array for a user without tagged visualizations' do
+      get api_v1_visualizations_tags_index_url(api_key: @api_key)
+      last_response.status.should == 200
+      body = JSON.parse(last_response.body)
+      body.should == []
+    end
+
+  end
+
+end

--- a/spec/requests/api/json/tags_controller_shared_examples.rb
+++ b/spec/requests/api/json/tags_controller_shared_examples.rb
@@ -27,6 +27,12 @@ shared_examples_for 'tags controllers' do
       last_response.status.should == 200
       body = JSON.parse(last_response.body)
       body.should == [{ 'name' => 'tag1', 'count' => 1 }]
+
+      login_as(@user2, scope: @user2.subdomain)
+      get api_v1_visualizations_tags_index_url(api_key: @api_key)
+      last_response.status.should == 200
+      body = JSON.parse(last_response.body)
+      body.should == [{ 'name' => 'tag1', 'count' => 1 }]
     end
 
     it 'returns an array with correct tag count with several visualizations' do

--- a/spec/requests/api/json/tags_controller_spec.rb
+++ b/spec/requests/api/json/tags_controller_spec.rb
@@ -1,0 +1,14 @@
+# encoding: utf-8
+
+require_relative '../../../spec_helper'
+require_relative 'tags_controller_shared_examples'
+require_relative '../../../../app/controllers/api/json/tags_controller'
+
+describe Api::Json::TagsController do
+  it_behaves_like 'tags controllers' do
+  end
+
+  include Rack::Test::Methods
+  include Warden::Test::Helpers
+  include CacheHelper
+end

--- a/spec/requests/api/json/visualizations_controller_shared_examples.rb
+++ b/spec/requests/api/json/visualizations_controller_shared_examples.rb
@@ -36,7 +36,7 @@ shared_examples_for "visualization controllers" do
   end
 
   def factory(user, attributes={})
-    visualization_template(user)
+    visualization_template(user, attributes)
   end
 
   def table_factory(options={})

--- a/spec/requests/api/json/visualizations_controller_shared_examples.rb
+++ b/spec/requests/api/json/visualizations_controller_shared_examples.rb
@@ -36,19 +36,7 @@ shared_examples_for "visualization controllers" do
   end
 
   def factory(user, attributes={})
-    {
-      name:                     attributes.fetch(:name, "visualization #{rand(9999)}"),
-      tags:                     attributes.fetch(:tags, ['foo', 'bar']),
-      map_id:                   attributes.fetch(:map_id, ::Map.create(user_id: user.id).id),
-      description:              attributes.fetch(:description, 'bogus'),
-      type:                     attributes.fetch(:type, 'derived'),
-      privacy:                  attributes.fetch(:privacy, 'public'),
-      source_visualization_id:  attributes.fetch(:source_visualization_id, nil),
-      parent_id:                attributes.fetch(:parent_id, nil),
-      locked:                   attributes.fetch(:locked, false),
-      prev_id:                  attributes.fetch(:prev_id, nil),
-      next_id:                  attributes.fetch(:next_id, nil)
-    }
+    visualization_template(user)
   end
 
   def table_factory(options={})
@@ -407,9 +395,7 @@ shared_examples_for "visualization controllers" do
             password: 'clientex',
         )
 
-        post api_v1_visualizations_create_url(user_domain: @user.username, api_key: @api_key),
-          factory(@user).to_json, @headers
-        vis_1_id = JSON.parse(last_response.body).fetch('id')
+        vis_1_id = create_visualization(@user).id
 
         get api_v1_visualizations_likes_count_url(user_domain: @user.username, id: vis_1_id, api_key: @api_key)
         JSON.parse(last_response.body).fetch('likes').to_i.should eq 0

--- a/spec/requests/carto/api/tags_controller_spec.rb
+++ b/spec/requests/carto/api/tags_controller_spec.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+require_relative '../../../spec_helper'
+require_relative '../../api/json/tags_controller_shared_examples'
+require_relative '../../../../app/controllers/carto/api/tags_controller'
+
+describe Carto::Api::TagsController do
+  it_behaves_like 'tags controllers' do
+  end
+
+  before(:all) do
+    Rails.application.routes.draw do
+
+      # new controller
+      scope :module => 'carto/api', :format => :json do
+        get     '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/tags'                           => 'tags#index',                     as: :api_v1_visualizations_tags_index
+      end
+    end
+  end
+
+  include Rack::Test::Methods
+  include Warden::Test::Helpers
+  include CacheHelper
+end
+

--- a/spec/requests/carto/api/tags_controller_spec.rb
+++ b/spec/requests/carto/api/tags_controller_spec.rb
@@ -15,6 +15,11 @@ describe Carto::Api::TagsController do
       scope :module => 'carto/api', :format => :json do
         get     '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/tags'                           => 'tags#index',                     as: :api_v1_visualizations_tags_index
       end
+
+      # old controller
+      scope :module => 'api/json', :format => :json do
+        post    '(/user/:user_domain)(/u/:user_domain)/api/v1/viz'                                => 'visualizations#create',          as: :api_v1_visualizations_create
+      end
     end
   end
 

--- a/spec/support/factories/tables.rb
+++ b/spec/support/factories/tables.rb
@@ -23,7 +23,30 @@ module CartoDB
       table = new_table(attributes)
       table.save
       table.reload
+    end
 
+    def create_visualization(user, attributes = {})
+      headers = {'CONTENT_TYPE'  => 'application/json'}
+      CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
+      post api_v1_visualizations_create_url(user_domain: user.username, api_key: user.api_key), visualization_template(user, attributes).to_json, headers
+      id = JSON.parse(last_response.body).fetch('id')
+      CartoDB::Visualization::Member.new(id: id).fetch
+    end
+
+    def visualization_template(user, attributes = {})
+      {
+        name:                     attributes.fetch(:name, "visualization #{rand(9999)}"),
+        tags:                     attributes.fetch(:tags, ['foo', 'bar']),
+        map_id:                   attributes.fetch(:map_id, ::Map.create(user_id: user.id).id),
+        description:              attributes.fetch(:description, 'bogus'),
+        type:                     attributes.fetch(:type, 'derived'),
+        privacy:                  attributes.fetch(:privacy, 'public'),
+        source_visualization_id:  attributes.fetch(:source_visualization_id, nil),
+        parent_id:                attributes.fetch(:parent_id, nil),
+        locked:                   attributes.fetch(:locked, false),
+        prev_id:                  attributes.fetch(:prev_id, nil),
+        next_id:                  attributes.fetch(:next_id, nil)
+    }
     end
   end
 end


### PR DESCRIPTION
@Kartones , @rafatower CR this fix for #3638, please. Take a look at the extraction of visualization filter parameter extraction to a mixin. Even if we finally delete the tags endpoint we might want to keep that extraction for other controllers that search for visualizations. It'd be interesting for you to see [old tags controller](https://github.com/CartoDB/cartodb/blob/master/app/controllers/api/json/tags_controller.rb) and [old tags "model"](https://github.com/CartoDB/cartodb/blob/master/app/models/visualization/tags.rb), since new design is quite different.

What do you think about "marked as deprecated endpoints"? I have contradictory feelings about deleting them. I don't feel confident enough to delete them, since searching for actual uses is almost impossible.