### PR TITLE
Stream copy uploaded files as opposed to reading in memory

### DIFF
--- a/app/helpers/file_upload_helper.rb
+++ b/app/helpers/file_upload_helper.rb
@@ -88,20 +88,22 @@ module  FileUploadHelper
     def save_body_to_file(params, request, random_token, filename)
       case
         when params[:filename].present? && request.body.present?
-          filedata =
-            params[:filename].read.force_encoding(FILE_ENCODING) rescue request.body.read.force_encoding(FILE_ENCODING)
+          filedata = params[:filename]
         when params[:file].present?
-          filedata = params[:file].read.force_encoding(FILE_ENCODING)
+          filedata = params[:file]
         else
           return
       end
 
       FileUtils.mkdir_p(Rails.root.join(UPLOADS_PATH).join(random_token))
 
-      file = File.new(Rails.root.join(UPLOADS_PATH).join(random_token).join(File.basename(filename)), 'w')
-      file.write filedata
+      src = File.open(filedata.tempfile.path, "r:UTF-8")
+      file = File.new(Rails.root.join(UPLOADS_PATH).join(random_token).join(File.basename(filename)), 'w:UTF-8')
+      IO.copy_stream(src, file)
       file.close
+      src.close
       # Force GC pass to avoid stale memory (dev installations Ruby issue)
+      src = nil
       filedata = nil
       file
     end


### PR DESCRIPTION
Currently, the FileUploadHelper copies the entire contents of the file into memory. Although file sizes are limited to reasonable memory amounts, there is significant improvement by stream copying via IO.copy_stream.

I personally needed this to upload for larger files when hosting locally.