### PR TITLE
Gmaps fix

### DIFF
--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -121,7 +121,7 @@ class Carto::User < ActiveRecord::Base
   # this may have change in the future but in any case this method provides a way to abstract what
   # basemaps are active for the user
   def basemaps
-    google_maps_enabled = !!google_maps_api_key
+    google_maps_enabled = !google_maps_api_key.nil? && !google_maps_api_key.empty?
     basemaps = Cartodb.config[:basemaps]
     if basemaps
       basemaps.select { |group| 

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -121,7 +121,7 @@ class Carto::User < ActiveRecord::Base
   # this may have change in the future but in any case this method provides a way to abstract what
   # basemaps are active for the user
   def basemaps
-    google_maps_enabled = !google_maps_api_key.nil? && !google_maps_api_key.empty?
+    google_maps_enabled = !google_maps_api_key.blank?
     basemaps = Cartodb.config[:basemaps]
     if basemaps
       basemaps.select { |group| 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2324,7 +2324,7 @@ TRIGGER
   # that organization has api key it's used
   def google_maps_api_key
     if has_organization?
-      self.organization.google_maps_key || self.google_maps_key
+      self.organization.google_maps_key.blank? ? self.google_maps_key : self.organization.google_maps_key
     else
       self.google_maps_key
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2336,7 +2336,7 @@ TRIGGER
   # this may have change in the future but in any case this method provides a way to abstract what
   # basemaps are active for the user
   def basemaps
-    google_maps_enabled = !google_maps_api_key.nil? && !google_maps_api_key.empty?
+    google_maps_enabled = !google_maps_api_key.blank?
     basemaps = Cartodb.config[:basemaps]
     if basemaps
       basemaps.select { |group| 

--- a/app/views/admin/visualizations/index.html.erb
+++ b/app/views/admin/visualizations/index.html.erb
@@ -2,7 +2,7 @@
   <%= current_user.username -%> |
 <% end -%>
 <%= content_for(:js) do -%>
-  <% if !@google_maps_api_key.nil? && !@google_maps_api_key.empty?%>
+  <% if !@google_maps_api_key.blank? %>
         <script type="text/javascript"
             src="https://maps.google.com/maps/api/js?sensor=false&v=3.12&api_key=<%= @google_maps_api_key %>">
         </script>

--- a/app/views/admin/visualizations/index.html.erb
+++ b/app/views/admin/visualizations/index.html.erb
@@ -2,7 +2,7 @@
   <%= current_user.username -%> |
 <% end -%>
 <%= content_for(:js) do -%>
-  <% if @google_maps_api_key %>
+  <% if !@google_maps_api_key.nil? && !@google_maps_api_key.empty?%>
         <script type="text/javascript"
             src="https://maps.google.com/maps/api/js?sensor=false&v=3.12&api_key=<%= @google_maps_api_key %>">
         </script>

--- a/app/views/admin/visualizations/show.html.erb
+++ b/app/views/admin/visualizations/show.html.erb
@@ -21,7 +21,7 @@
   </script>
 
   <% content_for(:js) do %>
-  <% if !@google_maps_api_key.nil? && !@google_maps_api_key.empty?%>
+  <% if !@google_maps_api_key.blank? %>
         <script type="text/javascript"
             src="https://maps.google.com/maps/api/js?sensor=false&v=3.12&api_key=<%= @google_maps_api_key %>">
         </script>

--- a/app/views/admin/visualizations/show.html.erb
+++ b/app/views/admin/visualizations/show.html.erb
@@ -21,7 +21,7 @@
   </script>
 
   <% content_for(:js) do %>
-  <% if @google_maps_api_key %>
+  <% if !@google_maps_api_key.nil? && !@google_maps_api_key.empty?%>
         <script type="text/javascript"
             src="https://maps.google.com/maps/api/js?sensor=false&v=3.12&api_key=<%= @google_maps_api_key %>">
         </script>


### PR DESCRIPTION
In short, it will check if google maps attribute is valid (blank is not valid). If so, it will enable Google Maps basemaps.

Possible cases with the user:

- Feature flag **enabled** and ```google_maps_key``` attribute empty -> only custom basemaps

![screen shot 2015-05-18 at 17 29 44](https://cloud.githubusercontent.com/assets/132146/7684062/7ec0ce30-fd83-11e4-9ca9-e753c65d275a.png)

---

- Feature flag **enabled** and ```google_maps_key``` attribute filled -> custom and gmaps basemaps

![screen shot 2015-05-18 at 17 30 40](https://cloud.githubusercontent.com/assets/132146/7684074/9e789b2c-fd83-11e4-82a1-47042e747ab2.png)

---

- Feature flag **disabled** and ```google_maps_key``` attribute empty  -> Here, CartoDB, Stamen and custom basemaps.

![screen shot 2015-05-18 at 17 33 02](https://cloud.githubusercontent.com/assets/132146/7684115/f3fa2930-fd83-11e4-89b8-8bfebadcc5e7.png)

---

- Feature flag **disabled** and ```google_maps_key``` attribute filled  -> GMaps basemaps.

![screen shot 2015-05-18 at 17 30 40](https://cloud.githubusercontent.com/assets/132146/7684108/db457b92-fd83-11e4-9477-953ef9a0e86f.png)

---
Same behaviour belonging to an organization. Also, these tests have been run without last @juanignaciosl [patch](https://github.com/CartoDB/cartodb-central/commit/b98f7cab959c0dccb01d06c0ee5bdfa7fac48468) in central.