### PR TITLE
Table name schema generation fixing #3680

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -422,7 +422,7 @@ class Admin::VisualizationsController < ApplicationController
     vqb.with_excluded_ids([excluded_visualization.id]) if excluded_visualization
     visualizations = vqb.build_paged(1, MAX_MORE_VISUALIZATIONS)
     visualizations.map { |v|
-      Carto::Admin::VisualizationPublicMapAdapter.new(v, current_viewer)
+      Carto::Admin::VisualizationPublicMapAdapter.new(v, current_user)
     }
   end
 
@@ -562,7 +562,7 @@ class Admin::VisualizationsController < ApplicationController
     user_id = user ? user.id : nil
     visualization = Carto::VisualizationQueryBuilder.new.with_id_or_name(table_id).with_user_id(user_id).build.first
     return get_visualization_and_table_from_table_id(table_id) if visualization.nil?
-    return Carto::Admin::VisualizationPublicMapAdapter.new(visualization, current_viewer), visualization.table_service
+    return Carto::Admin::VisualizationPublicMapAdapter.new(visualization, current_user), visualization.table_service
   end
 
   def get_visualization_and_table_from_table_id(table_id)
@@ -570,7 +570,7 @@ class Admin::VisualizationsController < ApplicationController
     user_table = Carto::UserTable.where({ id: table_id }).first
     return nil, nil if user_table.nil?
     visualization = user_table.visualization
-    return Carto::Admin::VisualizationPublicMapAdapter.new(visualization, current_viewer), visualization.table_service
+    return Carto::Admin::VisualizationPublicMapAdapter.new(visualization, current_user), visualization.table_service
   end
 
   # TODO: remove this method and use  app/helpers/carto/uuidhelper.rb. Not used yet because this changed was pushed before

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -422,7 +422,7 @@ class Admin::VisualizationsController < ApplicationController
     vqb.with_excluded_ids([excluded_visualization.id]) if excluded_visualization
     visualizations = vqb.build_paged(1, MAX_MORE_VISUALIZATIONS)
     visualizations.map { |v|
-      Carto::Admin::VisualizationPublicMapAdapter.new(v)
+      Carto::Admin::VisualizationPublicMapAdapter.new(v, current_viewer)
     }
   end
 
@@ -562,7 +562,7 @@ class Admin::VisualizationsController < ApplicationController
     user_id = user ? user.id : nil
     visualization = Carto::VisualizationQueryBuilder.new.with_id_or_name(table_id).with_user_id(user_id).build.first
     return get_visualization_and_table_from_table_id(table_id) if visualization.nil?
-    return Carto::Admin::VisualizationPublicMapAdapter.new(visualization), visualization.table_service
+    return Carto::Admin::VisualizationPublicMapAdapter.new(visualization, current_viewer), visualization.table_service
   end
 
   def get_visualization_and_table_from_table_id(table_id)
@@ -570,7 +570,7 @@ class Admin::VisualizationsController < ApplicationController
     user_table = Carto::UserTable.where({ id: table_id }).first
     return nil, nil if user_table.nil?
     visualization = user_table.visualization
-    return Carto::Admin::VisualizationPublicMapAdapter.new(visualization), visualization.table_service
+    return Carto::Admin::VisualizationPublicMapAdapter.new(visualization, current_viewer), visualization.table_service
   end
 
   # TODO: remove this method and use  app/helpers/carto/uuidhelper.rb. Not used yet because this changed was pushed before

--- a/app/controllers/carto/admin/visualization_public_map_adapter.rb
+++ b/app/controllers/carto/admin/visualization_public_map_adapter.rb
@@ -22,7 +22,7 @@ module Carto
 
       attr_reader :visualization
 
-      def initialize(visualization, current_viewer = nil)
+      def initialize(visualization, current_viewer)
         @visualization = visualization
         @current_viewer = current_viewer
       end

--- a/app/controllers/carto/admin/visualization_public_map_adapter.rb
+++ b/app/controllers/carto/admin/visualization_public_map_adapter.rb
@@ -22,8 +22,9 @@ module Carto
 
       attr_reader :visualization
 
-      def initialize(visualization)
+      def initialize(visualization, current_viewer = nil)
         @visualization = visualization
+        @current_viewer = current_viewer
       end
 
       def to_vizjson(options = {})
@@ -36,7 +37,7 @@ module Carto
 
       def to_hash(options={})
         # TODO: using an Api presenter here smells, refactor
-        presenter = Carto::Api::VisualizationPresenter.new(@visualization, nil, options)
+        presenter = Carto::Api::VisualizationPresenter.new(@visualization, @current_viewer, options)
         options.delete(:public_fields_only) === true ? presenter.to_public_poro : presenter.to_poro
       end
 
@@ -75,7 +76,7 @@ module Carto
 
       def related_visualizations
         @visualization.related_visualizations.map { |rv|
-          Carto::Admin::VisualizationPublicMapAdapter.new(rv) if rv.is_public?
+          Carto::Admin::VisualizationPublicMapAdapter.new(rv, @current_viewer) if rv.is_public?
         }.compact
       end
 

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -7,8 +7,8 @@ module Carto
     class VisualizationsController < ::Api::ApplicationController
 
       # TODO: compare with older, there seems to be more optional authentication endpoints
-      skip_before_filter :api_authorization_required, only: [:index, :vizjson2]
-      before_filter :optional_api_authorization, only: [:index, :vizjson2]
+      skip_before_filter :api_authorization_required, only: [:index, :vizjson2, :is_liked]
+      before_filter :optional_api_authorization, only: [:index, :vizjson2, :is_liked]
 
       before_filter :id_and_schema_from_params
       before_filter :load_table, only: [:vizjson2]

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -53,7 +53,9 @@ module Carto
     end
 
     def name_for_user(other_user)
-      is_owner?(other_user) ? name : fully_qualified_name
+      # TODO: this patch makes url be wrong
+      #is_owner?(other_user) ? name : fully_qualified_name
+      name
     end
 
     def private?

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -53,9 +53,7 @@ module Carto
     end
 
     def name_for_user(other_user)
-      # TODO: this patch makes url be wrong
-      #is_owner?(other_user) ? name : fully_qualified_name
-      name
+      is_owner?(other_user) ? name : fully_qualified_name
     end
 
     def private?

--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -595,15 +595,7 @@ cdb.admin.Header = cdb.core.View.extend({
     if (this.model.isVisualization()) {
       url += '/viz/' + this.model.get('id');
     } else {
-      var isOwner = this.model.permission.isOwner(this.options.user);
-
-      // Qualify table urls if user is not the owner
-      if (!isOwner) {
-        var owner_username = this.model.permission.owner.get('username');
-        url += '/tables/' + owner_username + '.' + this.model.get('table').name;
-      } else {
-        url += '/tables/' + this.model.get('table').name;
-      }
+      url += '/tables/' + this.model.get('table').name;
     }
 
     // Get scenario parameter from event or current url (table or map)


### PR DESCRIPTION
@Kartones take a look at the patch, please. The main change is ` app/models/carto/user_table.rb`, the rest is better but not actually mandatory (I think). The change fixes the url juggling that led to watching error, but I added it on purpose, so I need more testing before "fixing" (I haven't reproduced the original problem yet).