### PR TITLE
Includes user full name in auth user response

### DIFF
--- a/app/controllers/api/json/users_controller.rb
+++ b/app/controllers/api/json/users_controller.rb
@@ -72,7 +72,7 @@ class Api::Json::UsersController < Api::ApplicationController
       urls: ["#{CartoDB.base_url(current_viewer.username, organization_name)}#{CartoDB.path(self, 'dashboard_bis')}"],
       can_fork: can_fork,
       username: current_viewer.username,
-      name: current_viewer.name,
+      name: current_viewer.name_or_username(),
       avatar_url: current_viewer.avatar_url,
       email: current_viewer.email,
       organization: current_viewer.organization.nil? ? nil : current_viewer.organization.to_poro,

--- a/app/controllers/api/json/users_controller.rb
+++ b/app/controllers/api/json/users_controller.rb
@@ -72,6 +72,7 @@ class Api::Json::UsersController < Api::ApplicationController
       urls: ["#{CartoDB.base_url(current_viewer.username, organization_name)}#{CartoDB.path(self, 'dashboard_bis')}"],
       can_fork: can_fork,
       username: current_viewer.username,
+      name: current_viewer.name,
       avatar_url: current_viewer.avatar_url,
       email: current_viewer.email,
       organization: current_viewer.organization.nil? ? nil : current_viewer.organization.to_poro,

--- a/app/controllers/api/json/users_controller.rb
+++ b/app/controllers/api/json/users_controller.rb
@@ -72,7 +72,7 @@ class Api::Json::UsersController < Api::ApplicationController
       urls: ["#{CartoDB.base_url(current_viewer.username, organization_name)}#{CartoDB.path(self, 'dashboard_bis')}"],
       can_fork: can_fork,
       username: current_viewer.username,
-      name: current_viewer.name_or_username(),
+      name: current_viewer.name_or_username,
       avatar_url: current_viewer.avatar_url,
       email: current_viewer.email,
       organization: current_viewer.organization.nil? ? nil : current_viewer.organization.to_poro,


### PR DESCRIPTION
Fixes #3335 

Includes the full name of the viewing user in the response from the backend, so that it's rendered in the dropdown instead of the username.

Also my first PR in Ruby!

![](http://bitbillions.net/wp-content/uploads/2014/05/ruby2.gif)

@Kartones @javisantana 