### PR TITLE
Adds sync modal loader

### DIFF
--- a/app/assets/stylesheets/common/dialog.css.scss
+++ b/app/assets/stylesheets/common/dialog.css.scss
@@ -38,6 +38,9 @@ body.is-inDialog {
   /* "forwards" to keep the last keyframe's styles after animation ended */
   @include animation(fade-and-scale-out 80ms ease-in forwards);
 }
+.Dialog.is-sticky .Dialog-closeBtn {
+  display: none;
+}
 .Dialog-closeBtn {
   position: fixed;
   top: $sMargin-section;

--- a/lib/assets/javascripts/cartodb/common/view_factory.js
+++ b/lib/assets/javascripts/cartodb/common/view_factory.js
@@ -7,6 +7,10 @@ var BaseDialog = require('./views/base_dialog/view');
  */
 module.exports = {
 
+  createDialogByTemplateWithOptions: function(templateOrStr, templateData, dialogOptions) {
+    return this.createDialogByView(this.createByTemplate(templateOrStr, templateData), dialogOptions);
+  },
+
   createDialogByTemplate: function(templateOrStr, templateData) {
     return this.createDialogByView(this.createByTemplate(templateOrStr, templateData));
   },
@@ -28,7 +32,10 @@ module.exports = {
     return view;
   },
 
-  createDialogByView: function(contentView) {
+  createDialogByView: function(contentView, dialogOptions) {
+
+    var options = _.extend({ clean_on_hide: true, enter_to_confirm: true }, dialogOptions);
+
     return new (BaseDialog.extend({
       initialize: function() {
         this.elder('initialize');
@@ -38,9 +45,6 @@ module.exports = {
       render_content: function() {
         return contentView.render().el;
       }
-    }))({
-      clean_on_hide: true,
-      enter_to_confirm: true
-    });
+    }))(options);
   }
 };

--- a/lib/assets/javascripts/cartodb/common/view_factory.js
+++ b/lib/assets/javascripts/cartodb/common/view_factory.js
@@ -7,12 +7,8 @@ var BaseDialog = require('./views/base_dialog/view');
  */
 module.exports = {
 
-  createDialogByTemplateWithOptions: function(templateOrStr, templateData, dialogOptions) {
+  createDialogByTemplate: function(templateOrStr, templateData, dialogOptions) {
     return this.createDialogByView(this.createByTemplate(templateOrStr, templateData), dialogOptions);
-  },
-
-  createDialogByTemplate: function(templateOrStr, templateData) {
-    return this.createDialogByView(this.createByTemplate(templateOrStr, templateData));
   },
 
   /**

--- a/lib/assets/javascripts/cartodb/common/views/base_dialog/view.js
+++ b/lib/assets/javascripts/cartodb/common/views/base_dialog/view.js
@@ -87,10 +87,6 @@ module.exports = BaseDialog.extend({
    * @override cdb.ui.common.Dialog.prototype.hide to implement animation
    */
   hide: function() {
-    if (this._isSticky()) {
-      return;
-    }
-
     BaseDialog.prototype.hide.apply(this, arguments);
     this.trigger('hide');
   },

--- a/lib/assets/javascripts/cartodb/common/views/base_dialog/view.js
+++ b/lib/assets/javascripts/cartodb/common/views/base_dialog/view.js
@@ -37,7 +37,10 @@ module.exports = BaseDialog.extend({
     // Override defaults of parent
     _.defaults(this.options, this.overrideDefaults);
     this.elder('initialize');
+    this._initBinds();
+  },
 
+  _initBinds: function() {
     this.bind('show', this._setBodyForDialogMode.bind(this, 'add'));
     this.bind('hide', this._setBodyForDialogMode.bind(this, 'remove'));
   },
@@ -59,8 +62,21 @@ module.exports = BaseDialog.extend({
   render: function() {
     BaseDialog.prototype.render.apply(this, arguments);
     this.$('.content').addClass('is-newContent');
+
+    if (this._isSticky()) {
+      this.$el.addClass('is-sticky');
+    }
+
     this.show();
     return this;
+  },
+
+  _isSticky: function() {
+    if (this.options && this.options.sticky) {
+      return true;
+    } else {
+      return false;
+    }
   },
 
   close: function() {
@@ -79,6 +95,10 @@ module.exports = BaseDialog.extend({
    * @override cdb.ui.common.Dialog.prototype.hide to implement animation
    */
   hide: function() {
+    if (this.options.sticky) {
+      return;
+    }
+
     BaseDialog.prototype.hide.apply(this, arguments);
     this.trigger('hide');
   },
@@ -88,6 +108,11 @@ module.exports = BaseDialog.extend({
    */
   _cancel: function(ev, skipCancelCallback) {
     if (ev) this.killEvent(ev);
+
+    if (this._isSticky) {
+      return;
+    }
+
     this.$el.removeClass('is-opening').addClass('is-closing');
 
     // Use timeout instead of event listener on animation since the event triggered differs depending on browser

--- a/lib/assets/javascripts/cartodb/common/views/base_dialog/view.js
+++ b/lib/assets/javascripts/cartodb/common/views/base_dialog/view.js
@@ -37,10 +37,6 @@ module.exports = BaseDialog.extend({
     // Override defaults of parent
     _.defaults(this.options, this.overrideDefaults);
     this.elder('initialize');
-    this._initBinds();
-  },
-
-  _initBinds: function() {
     this.bind('show', this._setBodyForDialogMode.bind(this, 'add'));
     this.bind('hide', this._setBodyForDialogMode.bind(this, 'remove'));
   },

--- a/lib/assets/javascripts/cartodb/common/views/base_dialog/view.js
+++ b/lib/assets/javascripts/cartodb/common/views/base_dialog/view.js
@@ -72,11 +72,7 @@ module.exports = BaseDialog.extend({
   },
 
   _isSticky: function() {
-    if (this.options && this.options.sticky) {
-      return true;
-    } else {
-      return false;
-    }
+    return this.options && this.options.sticky;
   },
 
   close: function() {
@@ -95,7 +91,7 @@ module.exports = BaseDialog.extend({
    * @override cdb.ui.common.Dialog.prototype.hide to implement animation
    */
   hide: function() {
-    if (this.options.sticky) {
+    if (this._isSticky()) {
       return;
     }
 
@@ -109,7 +105,7 @@ module.exports = BaseDialog.extend({
   _cancel: function(ev, skipCancelCallback) {
     if (ev) this.killEvent(ev);
 
-    if (this._isSticky) {
+    if (this._isSticky()) {
       return;
     }
 

--- a/lib/assets/javascripts/cartodb/editor.js
+++ b/lib/assets/javascripts/cartodb/editor.js
@@ -28,6 +28,5 @@ cdb.editor = {
   DuplicateVisView: require('./common/dialogs/duplicate_vis_view'),
 
   AddCustomBasemapView: require('./common/dialogs/add_custom_basemap/add_custom_basemap_view'),
-
   ViewFactory: require('./common/view_factory')
 };

--- a/lib/assets/javascripts/cartodb/table/header/header_sync_info.js
+++ b/lib/assets/javascripts/cartodb/table/header/header_sync_info.js
@@ -214,7 +214,7 @@
         var modal = this.sync_now = cdb.editor.ViewFactory.createDialogByTemplate('common/templates/loading', {
           title: 'Your dataset is being synced…',
           quote: "This action will take some time. In the meantime you can't perform any UI action, but APIs will work as usual."
-        }).render();
+        }, { sticky: true }).render();
 
         $('body').append(modal.$el);
 

--- a/lib/assets/javascripts/cartodb/table/header/header_sync_info.js
+++ b/lib/assets/javascripts/cartodb/table/header/header_sync_info.js
@@ -209,14 +209,24 @@
     _showSyncNow: function(e) {
       if (e) this.killEvent(e);
 
-      // Show mamufas loader
-      var modal = this.sync_now = new cdb.admin.SyncNowModal({
-        table: this.table
-      });
+      if (this.options.user.featureEnabled('new_modals')) {
 
-      modal
+        var modal = this.sync_now = cdb.editor.ViewFactory.createDialogByTemplate('common/templates/loading', {
+          title: 'Your dataset is being synced…',
+          quote: "This action will take some time. In the meantime you can't perform any UI action, but APIs will work as usual."
+        }).render();
+
+        $('body').append(modal.$el);
+
+      } else {
+        var modal = this.sync_now = new cdb.admin.SyncNowModal({
+          table: this.table
+        });
+
+        modal
         .appendToBody()
         .open();
+      }
     },
 
     _hideSyncNow: function() {

--- a/lib/assets/javascripts/cartodb/table/header/header_sync_info.js
+++ b/lib/assets/javascripts/cartodb/table/header/header_sync_info.js
@@ -213,7 +213,7 @@
 
         var modal = this.sync_now = cdb.editor.ViewFactory.createDialogByTemplate('common/templates/loading', {
           title: 'Your dataset is being synced…',
-          quote: "This action will take some time. In the meantime you can't perform any UI action, but APIs will work as usual."
+          quote: "This action will take some time. In the meantime the UI is disabled, but APIs will work as usual."
         }, { sticky: true }).render();
 
         $('body').append(modal.$el);

--- a/lib/assets/test/spec/cartodb/common/view_factory.spec.js
+++ b/lib/assets/test/spec/cartodb/common/view_factory.spec.js
@@ -24,6 +24,23 @@ describe('common/view_factory', function() {
     });
   });
 
+  describe('.createDialogByTemplate', function() {
+    beforeEach(function() {
+      this.template = jasmine.createSpy('compiled template');
+      this.template.and.returnValue('<div>foo bar!</div>');
+      this.templateData = { foo: 'bar'};
+
+      this.view = ViewFactory.createDialogByTemplate(this.template, this.templateData, { sticky: true });
+      spyOn(this.view.$el, 'html');
+      this.view.render();
+    });
+
+    it('should send the dialog options to the view', function() {
+      expect(this.view.options.sticky).toBeTruthy();
+    });
+
+  });
+
   describe('.createDialogByView', function() {
     beforeEach(function() {
       this.contentView = new cdb.core.View();

--- a/lib/assets/test/spec/cartodb/common/views/base_dialog/view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/base_dialog/view.spec.js
@@ -12,8 +12,7 @@ describe('common/views/base_dialog/view', function() {
       }
     });
 
-    this.view = new DialogExample({
-    });
+    this.view = new DialogExample();
 
     cdb.god.bind('dialogOpened', function() {
       this.dialogOpened = true;
@@ -47,6 +46,47 @@ describe('common/views/base_dialog/view', function() {
 
   it('should have no leaks', function() {
     expect(this.view).toHaveNoLeaks();
+  });
+
+  describe('sticky', function() {
+    beforeEach(function() {
+      jasmine.clock().install();
+
+      var DialogExample = BaseDialog.extend({
+        render_content: function() {
+          return '<blink>foobar content</blink>' +
+            '<button class="cancel">cancel</button>' +
+            '<button class="ok">OK</button>';
+        }
+      });
+
+      this.stickyView = new DialogExample({ sticky: true });
+      this.stickyView.render();
+      $('body').append(this.stickyView.$el); // necessary for .is-assertions below
+
+      this.hideCallback = jasmine.createSpy('hide');
+      this.stickyView.bind('hide', this.hideCallback);
+      this.stickyView.$('.cancel').click();
+    });
+
+    it("should be sticky", function() {
+      expect(this.stickyView._isSticky()).toBeTruthy();
+    });
+
+    it("shouldn\'t trigger a hide event", function() {
+      expect(this.hideCallback).not.toHaveBeenCalled();
+      jasmine.clock().tick(101);
+      expect(this.hideCallback.calls.count()).toEqual(0);
+    });
+
+    it("should add the sticky class", function() {
+      expect(this.stickyView.$el.hasClass("is-sticky")).toBeTruthy();
+    });
+
+    afterEach(function() {
+      this.stickyView.clean();
+      jasmine.clock().uninstall();
+    });
   });
 
   describe('when click close', function() {

--- a/lib/assets/test/spec/cartodb/common/views/base_dialog/view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/base_dialog/view.spec.js
@@ -41,6 +41,10 @@ describe('common/views/base_dialog/view', function() {
     expect(this.innerHTML()).toContain('<blink>');
   });
 
+  it('should return false if is not sticky', function() {
+    expect(this.view._isSticky()).toBeFalsy();
+  });
+
   it('should have no leaks', function() {
     expect(this.view).toHaveNoLeaks();
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.13.11",
+  "version": "3.13.12",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR replaces this modal:

![cab811aa-fe54-11e4-9214-af19518ecddc](https://cloud.githubusercontent.com/assets/4933/7728771/6ad58070-ff11-11e4-8206-610b582f344a.png)

with this one:
![screen shot 2015-05-20 at 16 57 12](https://cloud.githubusercontent.com/assets/4933/7728743/49e8f9c8-ff11-11e4-9f81-85d2a649cca8.png)

It also adds a new property for the dialogs called `sticky` that prevents them for being closed by the users   and adds a new helper to create dialogs `createDialogByTemplateWithOptions`