### PR TITLE
Removes use of URL object for pathname obtention

### DIFF
--- a/lib/assets/javascripts/cartodb/app.js
+++ b/lib/assets/javascripts/cartodb/app.js
@@ -38,7 +38,10 @@ cdb.config.prefixUrlPathname = function() {
   var prefix = this.prefixUrl();
   if (prefix !== '') {
     try {
-      var url = new URL(this.prefixUrl()).pathname;
+      if (prefix && prefix.indexOf('/') === -1) throw new TypeError('invalid URL');
+      var a = document.createElement('a');
+      a.href = prefix;
+      var url = a.pathname;
       // remove trailing slash
       return url.replace(/\/$/, '');
     } catch(e) {


### PR DESCRIPTION
Fixes #3692

Uses the 'a' element to get the pathname of the URL, as an alternative of using the URL object (unsupported in IE) or a regular expression.

@javisantana 