### PR TITLE
Order by size failing on new viz list new endpoint

### DIFF
--- a/lib/assets/javascripts/cartodb/dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/main_view.js
@@ -50,6 +50,12 @@ module.exports = cdb.core.View.extend({
     // Get order from localStorage if it is not defined or
     // come from other type (tables or visualizations)
     var order = this.localStorage.get("dashboard.order") || 'updated_at';
+    // Maps doesn't have size order, so if that order is set
+    // in maps section we will show with 'updated_at' order
+    if (params.content_type === "maps" && order === "size") {
+      order = 'updated_at'
+    }
+    
     var types = params.content_type === "datasets" ? 'table' : 'derived';
 
     // Requesting data library items?


### PR DESCRIPTION
If dashboard order attribute is set as ```size```, in maps section, that order will be ```updated_at``` because size doesn't exist and it throws an error.

cc @viddo @Kartones @chriswhong 

Fixes #3701