### PR TITLE
Fixing public logo url

### DIFF
--- a/app/views/admin/shared/_public_header.erb
+++ b/app/views/admin/shared/_public_header.erb
@@ -4,9 +4,9 @@
       <ul class="Header-navigationList">
         <li class="js-logo">
           <% if cartodb_com_hosted? %>
-            <a href="http://cartodb.com">
-          <% else %>
             <a href="<%= CartoDB.url(self, 'root') %>">
+          <% else %>
+            <a href="http://cartodb.com">
           <% end %>
             <span class="Logo Logo--avatar">
               <i class="iconFont iconFont-CartoFante"></i>


### PR DESCRIPTION
if ```cartodb_com_hosted?``` is:

- **true**: not SaaS, custom installation, so it goes to root url.
- **false**: SaaS, it should go to ```cartodb.com```.

As code explains [here](https://github.com/CartoDB/cartodb/blob/master/app/helpers/application_helper.rb#L227).

cc @saleiva 