### PR TITLE
Adjust tablename limit to 63 chars (as per docs) fixes #3747

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -30,6 +30,9 @@ class Table
   NO_GEOMETRY_TYPES_CACHING_TIMEOUT = 5.minutes
   GEOMETRY_TYPES_PRESENT_CACHING_TIMEOUT = 24.hours
 
+  # See http://www.postgresql.org/docs/9.3/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+  TABLENAME_MAX_LENGTH = 63
+
   # @see services/importer/lib/importer/column.rb -> RESERVED_WORDS
   # @see config/initializers/carto_db.rb -> RESERVED_COLUMN_NAMES
   RESERVED_COLUMN_NAMES = %W{ oid tableoid xmin cmin xmax cmax ctid ogc_fid }
@@ -1486,7 +1489,7 @@ class Table
   end
 
   # Gets a valid postgresql table name for a given database
-  # See http://www.postgresql.org/docs/9.1/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+  # See http://www.postgresql.org/docs/9.3/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
   def self.get_valid_table_name(name, options = {})
     # Initial name cleaning
     name = name.to_s.squish #.downcase
@@ -1499,7 +1502,7 @@ class Table
     name = name.gsub(/[^a-z0-9]/,'_').gsub(/_{2,}/, '_')
 
     # Postgresql table name limit
-    name = name[0..45]
+    name = name[0...TABLENAME_MAX_LENGTH]
 
     return name if name == options[:current_name]
 
@@ -1517,7 +1520,7 @@ class Table
     while existing_names.include?(name)
       count = count + 1
       suffix = "_#{count}"
-      name = name[0..62-suffix.length]
+      name = name[0...TABLENAME_MAX_LENGTH-suffix.length]
       name = name[rx] ? name.gsub(rx, suffix) : "#{name}#{suffix}"
       # Re-check for duplicated underscores
       name = name.gsub(/_{2,}/, '_')


### PR DESCRIPTION
@javisantana I think this should be fine. The `alter table` through the sql api should fail in other cases. I'm testing it locally and waiting for this to pass the tests.