### PR TITLE
Adds option to "create table from query" from a visualisation:

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Bugfixes:
 * Fixed deletion of layers upon disconnecting synced datasources [#3718](https://github.com/CartoDB/cartodb/pull/3718)
 * Fixed some cache invalidation problems upon changes in privacy (embeds & vizjson) [#3755](https://github.com/CartoDB/cartodb/pull/3755)
 * Fixed corner case with ghost table renames [#3762](https://github.com/CartoDB/cartodb/pull/3762)
+* Added options to create dataset from query while on the map view [#3771](https://github.com/CartoDB/cartodb/pull/3771)
 
 3.10.2 (2015-05-20)
 ---------

--- a/lib/assets/javascripts/cartodb/common/dialogs/duplicate_dataset_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/duplicate_dataset_view.js
@@ -12,9 +12,8 @@ module.exports = BaseDialog.extend({
 
   initialize: function() {
     this.elder('initialize');
-    if (!this.model) throw new Error('model is required (cdb.admin.Visualization)');
+    if (!this.model) throw new Error('model is required (cdb.admin.CartoDBTableMetadata)');
     if (!this.options.user) throw new Error('user is required');
-    if (!this.options.table) throw new Error('table is required');
     this.elder('initialize');
     this._initViews();
     this._initBinds();
@@ -45,8 +44,8 @@ module.exports = BaseDialog.extend({
 
   _duplicateDataset: function(newName) {
     var self = this;
-    var newName = this.options.table.get('name') + '_copy';
-    this.options.table.duplicate(newName, {
+    var newName = this.model.get('name') + '_copy';
+    this.model.duplicate(newName, {
       success: function(newTable) {
         self._redirectTo(newTable.viewUrl());
       },

--- a/lib/assets/javascripts/cartodb/common/dialogs/duplicate_dataset_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/duplicate_dataset_view.js
@@ -6,7 +6,7 @@ var randomQuote = require('../view_helpers/random_quote');
 var ErrorDetailsView = require('../views/error_details_view');
 
 /**
- * Dialog to manage duplication process of a cdb.admin.Visualization object.
+ * Dialog to manage duplication process of a cdb.admin.CartoDBTableMetadata object.
  */
 module.exports = BaseDialog.extend({
 
@@ -14,10 +14,11 @@ module.exports = BaseDialog.extend({
     this.elder('initialize');
     if (!this.model) throw new Error('model is required (cdb.admin.Visualization)');
     if (!this.options.user) throw new Error('user is required');
+    if (!this.options.table) throw new Error('table is required');
     this.elder('initialize');
     this._initViews();
     this._initBinds();
-    this._duplicateMap();
+    this._duplicateDataset();
   },
 
   render_content: function() {
@@ -31,7 +32,7 @@ module.exports = BaseDialog.extend({
     this.addView(this._panes);
     this._panes.addTab('loading',
       ViewFactory.createByTemplate('common/templates/loading', {
-        title: 'Duplicating your map',
+        title: 'Duplicating your dataset',
         quote: randomQuote()
       })
     );
@@ -42,14 +43,12 @@ module.exports = BaseDialog.extend({
     this._panes.bind('tabEnabled', this.render, this);
   },
 
-  _duplicateMap: function(newName) {
+  _duplicateDataset: function(newName) {
     var self = this;
-    var newName = this.model.get('name') + ' copy';
-    this.model.copy({
-      name: newName
-    }, {
-      success: function(newVis) {
-        self._redirectTo(newVis.viewUrl(self.options.user).edit().toString());
+    var newName = this.options.table.get('name') + '_copy';
+    this.options.table.duplicate(newName, {
+      success: function(newTable) {
+        self._redirectTo(newTable.viewUrl());
       },
       error: self._showError.bind(self)
     });

--- a/lib/assets/javascripts/cartodb/editor.js
+++ b/lib/assets/javascripts/cartodb/editor.js
@@ -26,6 +26,7 @@ cdb.editor = {
   ChangeLockView: require('./common/dialogs/change_lock/change_lock_view'),
 
   DuplicateVisView: require('./common/dialogs/duplicate_vis_view'),
+  DuplicateDatasetView:  require('./common/dialogs/duplicate_dataset_view'),
 
   AddCustomBasemapView: require('./common/dialogs/add_custom_basemap/add_custom_basemap_view'),
   ViewFactory: require('./common/view_factory')

--- a/lib/assets/javascripts/cartodb/table/header/options_menu.js
+++ b/lib/assets/javascripts/cartodb/table/header/options_menu.js
@@ -156,8 +156,7 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
 
     if (this.user.featureEnabled('new_modals')) {
       var dialog = new cdb.editor.DuplicateDatasetView({
-        model: this.model, //vis
-        table: this.table,
+        model: this.table,
         user: this.user,
         clean_on_hide: true
       });

--- a/lib/assets/javascripts/cartodb/table/header/options_menu.js
+++ b/lib/assets/javascripts/cartodb/table/header/options_menu.js
@@ -26,14 +26,14 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
   events: {
     'click .lock_vis':        '_lockVis',
     'click .export_table':    '_exportTable',
-    'click .duplicate_table': '_duplicateTable',
+    'click .duplicate_table': '_duplicateDataset',
+    'click .duplicate_vis':   '_duplicateVis',
     'click .append_data':     '_appendData',
     'click .delete_table':    '_deleteItem',
     'click .georeference':    '_georeference',
     'click .merge_tables':    '_mergeTables',
     'click .change_privacy':  '_changePrivacy',
     'click .sync_settings':   '_syncSettings',
-    'click .duplicate_vis':   '_duplicateVis',
     'click .delete_vis':      '_deleteItem'
   },
 
@@ -149,13 +149,19 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
   },
 
   /**
-   *  Duplicate table
+   *  Duplicate dataset
    */
-  _duplicateTable: function(e){
+  _duplicateDataset: function(e){
     e.preventDefault();
 
     if (this.user.featureEnabled('new_modals')) {
-      return this._duplicate();
+      var dialog = new cdb.editor.DuplicateDatasetView({
+        model: this.model, //vis
+        table: this.table,
+        user: this.user,
+        clean_on_hide: true
+      });
+      return dialog.appendToBody().open();
     }
 
     if (!this.model.isVisualization()) {
@@ -169,14 +175,29 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
     }
   },
 
-  _duplicate: function() {
-    var dialog = new cdb.editor.DuplicateVisView({
-      model: this.model, //vis
-      table: this.table,
-      user: this.user,
-      clean_on_hide: true
-    });
-    dialog.appendToBody().open();
+  /**
+   *  Duplicate a visualization
+   */
+  _duplicateVis: function(e) {
+    e.preventDefault();
+
+    if (this.user.featureEnabled('new_modals')) {
+      var dialog = new cdb.editor.DuplicateVisView({
+        model: this.model, //vis
+        table: this.table,
+        user: this.user,
+        clean_on_hide: true
+      });
+      return dialog.appendToBody().open();
+    }
+
+    if (this.model.isVisualization()) {
+      var duplicate_dialog = new cdb.admin.DuplicateVisDialog({ model: this.model });
+
+      duplicate_dialog
+        .appendToBody()
+        .open();
+    }
   },
 
   _changePrivacy: function(e) {
@@ -320,25 +341,6 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
     }
 
     cdb.log.info('No geocoder option for ' + data.kind, obj);
-  },
-
-  /**
-   *  Duplicate a visualization
-   */
-  _duplicateVis: function(e) {
-    e.preventDefault();
-
-    if (this.user.featureEnabled('new_modals')) {
-      return this._duplicate();
-    }
-
-    if (this.model.isVisualization()) {
-      var duplicate_dialog = new cdb.admin.DuplicateVisDialog({ model: this.model });
-
-      duplicate_dialog
-        .appendToBody()
-        .open();
-    }
   },
 
   /**

--- a/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
@@ -43,6 +43,9 @@
   <% } else { %>
     <% if (dataLayer) { %>
       <li><a class="small export_table" href="#/export">Export layer</a></li>
+      <% if (table.isInSQLView()) { %>
+        <li><a class="small duplicate_table" href="#/table-from-query">Dataset from query</a></li>
+      <% }%>
 
       <% if (!dataLayer.get('query')) { %>
         <li class="<% if (table.isSync()) { %>disabled<% } %>">

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -1591,7 +1591,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
     var duplicate_dialog;
     if (this.user.featureEnabled('new_modals')) {
-      duplicate_dialog = new cdb.editor.DuplicateVisView({
+      duplicate_dialog = new cdb.editor.DuplicateDatasetView({
         model: this.vis,
         table: this.table,
         user: this.user,

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -1592,8 +1592,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
     var duplicate_dialog;
     if (this.user.featureEnabled('new_modals')) {
       duplicate_dialog = new cdb.editor.DuplicateDatasetView({
-        model: this.vis,
-        table: this.table,
+        model: this.table,
         user: this.user,
         clean_on_hide: true
       });

--- a/lib/assets/javascripts/cartodb/table/tableview.js
+++ b/lib/assets/javascripts/cartodb/table/tableview.js
@@ -299,7 +299,7 @@
 
         var duplicate_dialog;
         if (this.user.featureEnabled('new_modals')) {
-          duplicate_dialog = new cdb.editor.DuplicateVisView({
+          duplicate_dialog = new cdb.editor.DuplicateDatasetView({
             model: this.vis,
             table: this.model,
             user: this.user,

--- a/lib/assets/javascripts/cartodb/table/tableview.js
+++ b/lib/assets/javascripts/cartodb/table/tableview.js
@@ -300,8 +300,7 @@
         var duplicate_dialog;
         if (this.user.featureEnabled('new_modals')) {
           duplicate_dialog = new cdb.editor.DuplicateDatasetView({
-            model: this.vis,
-            table: this.model,
+            model: this.model,
             user: this.user,
             clean_on_hide: true
           });

--- a/lib/assets/javascripts/cartodb/table/views/sql_view_notice.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/sql_view_notice.jst.ejs
@@ -4,11 +4,7 @@
       <% if (warnMsg) { %>
         <%= warnMsg %> ·
       <% } %>
-      <% if (!isVisualization) { %>
-        <a href="#/export-query" class="export_query">create dataset from query</a> or <a href="#/clear-view" class="clearview">clear view</a>
-      <% } else { %>
-        <a href="#/clear-view" class="clearview">clear this sql view</a>
-      <% } %>
+      <a href="#/export-query" class="export_query">create dataset from query</a> or <a href="#/clear-view" class="clearview">clear view</a>
     <% } else { %>
       No resulting rows for this query, <a href="#/clear-view" class="clearview">clear this sql view</a>
     <% } %>

--- a/lib/assets/test/spec/cartodb/common/dialogs/duplicate_dataset_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/duplicate_dataset_view.spec.js
@@ -4,22 +4,17 @@ var cdb = require('cartodb.js');
 describe('common/dialogs/duplicate_dataset_view', function() {
 
   beforeEach(function() {
-    this.vis = new cdb.admin.Visualization({
-      type: 'table',
-      name: 'my name',
-      table: {
-        name: 'table_name'
-      }
+    this.table = new cdb.admin.CartoDBTableMetadata({
+      id: 'table_id',
+      name: 'table_name'
     });
-    this.table = this.vis.tableMetadata();
+
     this.user = jasmine.createSpy('cdb.admin.User');
 
     spyOn(this.table, 'duplicate');
-    spyOn(this.vis, 'isVisualization');
 
     this.view = new DuplicateDatasetView({
-      model: this.vis,
-      table: this.vis.tableMetadata(),
+      model: this.table,
       user: this.user
     });
     this.view.render();

--- a/lib/assets/test/spec/cartodb/common/dialogs/duplicate_dataset_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/duplicate_dataset_view.spec.js
@@ -1,0 +1,61 @@
+var DuplicateDatasetView = require('../../../../../javascripts/cartodb/common/dialogs/duplicate_dataset_view');
+var cdb = require('cartodb.js');
+
+describe('common/dialogs/duplicate_dataset_view', function() {
+
+  beforeEach(function() {
+    this.vis = new cdb.admin.Visualization({
+      type: 'table',
+      name: 'my name',
+      table: {
+        name: 'table_name'
+      }
+    });
+    this.table = this.vis.tableMetadata();
+    this.user = jasmine.createSpy('cdb.admin.User');
+
+    spyOn(this.table, 'duplicate');
+    spyOn(this.vis, 'isVisualization');
+
+    this.view = new DuplicateDatasetView({
+      model: this.vis,
+      table: this.vis.tableMetadata(),
+      user: this.user
+    });
+    this.view.render();
+  });
+
+  it('should start the duplication process right away with creating an import', function() {
+    expect(this.table.duplicate).toHaveBeenCalled();
+    expect(this.table.duplicate.calls.argsFor(0)[0]).toEqual('table_name_copy');
+  });
+
+  it('should render the loading initially', function() {
+    expect(this.innerHTML()).toContain('Duplicating your dataset');
+  });
+
+  describe('when duplication finishes successfully', function() {
+
+    beforeEach(function() {
+      var newTable = jasmine.createSpyObj('table', ['viewUrl']);
+      newTable.viewUrl.and.returnValue('http://cartodb.com/user/pepe/table/my_table_copy');
+      spyOn(this.view, '_redirectTo');
+      this.table.duplicate.calls.argsFor(0)[1].success(newTable);
+    });
+
+    it("should redirect to the new table's edit page", function() {
+      expect(this.view._redirectTo).toHaveBeenCalledWith('http://cartodb.com/user/pepe/table/my_table_copy');
+    });
+  });
+
+  describe('when duplicates fails', function() {
+
+    beforeEach(function() {
+      this.table.duplicate.calls.argsFor(0)[1].error();
+    });
+
+    it('should render the fail view', function() {
+      expect(this.innerHTML()).toContain('Sorry, something went wrong');
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb/common/dialogs/duplicate_vis_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/duplicate_vis_view.spec.js
@@ -2,131 +2,84 @@ var DuplicateVisView = require('../../../../../javascripts/cartodb/common/dialog
 var cdb = require('cartodb.js');
 
 describe('common/dialogs/duplicate_vis_view', function() {
-  describe('when given a map', function() {
+
+  beforeEach(function() {
+    this.vis = new cdb.admin.Visualization({
+      type: 'derived',
+      name: 'my name'
+    });
+    this.user = new cdb.admin.User({
+      username: 'pepe'
+    });
+    spyOn(this.vis, 'copy');
+    this.table = this.vis.tableMetadata();
+
+    this.view = new DuplicateVisView({
+      model: this.vis,
+      table: this.table,
+      user: this.user
+    });
+
+    this.view.render();
+  });
+
+  it('should start the duplication process right away', function() {
+    expect(this.vis.copy).toHaveBeenCalled();
+  });
+
+  it('should the name of the duplicate vis should be suffixed with copy', function() {
+    expect(this.vis.copy.calls.argsFor(0)[0].name).toEqual('my name copy');
+  });
+
+  it('should render the loading initially', function() {
+    expect(this.innerHTML()).toContain('Duplicating your map');
+  });
+
+  describe('when duplication successfully finished', function() {
+
     beforeEach(function() {
-      this.vis = new cdb.admin.Visualization({
-        type: 'derived',
-        name: 'my name'
-      });
-      this.user = new cdb.admin.User({
-        username: 'pepe'
-      });
-      spyOn(this.vis, 'copy');
-      this.table = this.vis.tableMetadata();
-
-      this.view = new DuplicateVisView({
-        model: this.vis,
-        table: this.table,
-        user: this.user
-      });
-
-      this.view.render();
+      this.newVis = new cdb.admin.Visualization({});
+      this.url = new cdb.common.MapUrl({ base_url: 'http://cartodb.com/user/pepe/viz/abc-123' });
+      spyOn(this.newVis, 'viewUrl').and.returnValue(this.url);
+      spyOn(this.view, '_redirectTo');
+      this.vis.copy.calls.argsFor(0)[1].success(this.newVis);
     });
 
-    it('should start the duplication process right away', function() {
-      expect(this.vis.copy).toHaveBeenCalled();
-    });
-
-    it('should the name of the duplicate vis should be suffixed with copy', function() {
-      expect(this.vis.copy.calls.argsFor(0)[0].name).toEqual('my name copy');
-    });
-
-    it('should render the loading initially', function() {
-      expect(this.innerHTML()).toContain('Duplicating your');
-    });
-
-    describe('when duplication successfully finished', function() {
-      beforeEach(function() {
-        this.newVis = new cdb.admin.Visualization({});
-        this.url = new cdb.common.MapUrl({ base_url: 'http://cartodb.com/user/pepe/viz/abc-123' });
-        spyOn(this.newVis, 'viewUrl').and.returnValue(this.url);
-        spyOn(this.view, '_redirectTo');
-        this.vis.copy.calls.argsFor(0)[1].success(this.newVis);
-      });
-
-      it('should redirect to the edit url', function() {
-        expect(this.view._redirectTo).toHaveBeenCalledWith(this.url.edit().toString());
-        expect(this.newVis.viewUrl).toHaveBeenCalledWith(this.user);
-      });
-    });
-
-    describe('when duplication fails with a general error', function() {
-      beforeEach(function() {
-        this.vis.copy.calls.argsFor(0)[1].error();
-      });
-
-      it('should render a fail template', function() {
-        expect(this.innerHTML()).toContain('Sorry, something went wrong');
-      });
-    });
-
-    describe('when duplication fails from import error', function() {
-      beforeEach(function() {
-        var importModel = new cdb.admin.Import({
-          item_queue_id: 'abc-123',
-          error_code: 8003,
-          get_error_text: {
-            title: 'Error creating table from SQL query',
-            what_about: 'We could not create table from your query.'
-          }
-        });
-        this.vis.copy.calls.argsFor(0)[1].error(importModel);
-      });
-
-      it('should render a the more detailed fail template', function() {
-        expect(this.innerHTML()).toContain('Error creating table');
-        expect(this.innerHTML()).toContain('We could not create table from your query');
-        expect(this.innerHTML()).toContain('Persisting error?');
-      });
+    it('should redirect to the edit url', function() {
+      expect(this.view._redirectTo).toHaveBeenCalledWith(this.url.edit().toString());
+      expect(this.newVis.viewUrl).toHaveBeenCalledWith(this.user);
     });
   });
 
-  describe('when given a dataset', function() {
+  describe('when duplication fails with a general error', function() {
+
     beforeEach(function() {
-      this.vis = new cdb.admin.Visualization({
-        type: 'table',
-        name: 'my name'
-      });
-      this.table = this.vis.tableMetadata();
-      this.user = jasmine.createSpy('cdb.admin.User');
-
-      spyOn(this.table, 'duplicate');
-      spyOn(this.vis, 'isVisualization');
-
-      this.view = new DuplicateVisView({
-        model: this.vis,
-        table: this.vis.tableMetadata(),
-        user: this.user
-      });
-      this.view.render();
+      this.vis.copy.calls.argsFor(0)[1].error();
     });
 
-    it('should start the duplication process right away with creating an import', function() {
-      expect(this.table.duplicate).toHaveBeenCalled();
-      expect(this.table.duplicate.calls.argsFor(0)[0]).toEqual('my name copy');
+    it('should render a fail template', function() {
+      expect(this.innerHTML()).toContain('Sorry, something went wrong');
+    });
+  });
+
+  describe('when duplication fails from import error', function() {
+
+    beforeEach(function() {
+      var importModel = new cdb.admin.Import({
+        item_queue_id: 'abc-123',
+        error_code: 8003,
+        get_error_text: {
+          title: 'Error creating table from SQL query',
+          what_about: 'We could not create table from your query.'
+        }
+      });
+      this.vis.copy.calls.argsFor(0)[1].error(importModel);
     });
 
-    describe('when duplication finishes successfully', function() {
-      beforeEach(function() {
-        var newTable = jasmine.createSpyObj('table', ['viewUrl']);
-        newTable.viewUrl.and.returnValue('http://cartodb.com/user/pepe/table/my_table_copy');
-        spyOn(this.view, '_redirectTo');
-        this.table.duplicate.calls.argsFor(0)[1].success(newTable);
-      });
-
-      it("should redirect to the new table's edit page", function() {
-        expect(this.view._redirectTo).toHaveBeenCalledWith('http://cartodb.com/user/pepe/table/my_table_copy');
-      });
-    });
-
-    describe('when duplicates fails', function() {
-      beforeEach(function() {
-        this.table.duplicate.calls.argsFor(0)[1].error();
-      });
-
-      it('should render the fail view', function() {
-        expect(this.innerHTML()).toContain('Sorry, something went wrong');
-      });
+    it('should render a the more detailed fail template', function() {
+      expect(this.innerHTML()).toContain('Error creating table');
+      expect(this.innerHTML()).toContain('We could not create table from your query');
+      expect(this.innerHTML()).toContain('Persisting error?');
     });
   });
 });

--- a/lib/assets/test/spec/cartodb/table/header/options_menu.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/options_menu.spec.js
@@ -117,8 +117,9 @@ describe("Header options menu", function() {
     cartodb_layer.set('query', 'select * from test');
     this.vis.map.layers.last().table.useSQLView(sqlView);
     options_menu.render();
-    expect(options_menu.$el.find("li").size()).toEqual(4);
+    expect(options_menu.$el.find("li").size()).toEqual(5);
     expect(options_menu.$el.find("li:contains('Export layer')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Dataset from query')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Duplicate map')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Lock map')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Delete map')").size()).toEqual(1);


### PR DESCRIPTION
Fixes #3192.

With this PR, it's now possible to "create a new dataset from a SQL query" while viewing a visualisation. This option has been added to the SQL warning and to the options menu displayed in the header.

@viddo what do you think?
