### PR TITLE
3815 error generating vizjson if affected table does not exist

### DIFF
--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -59,7 +59,7 @@ module Carto
       ::Table.get_all_user_tables_by_names(affected_table_names, user)
     rescue => exception
       # INFO: this covers changes that CartoDB can't track. For example, if layer SQL contains wrong SQL (uses a table that doesn't exist, or uses an invalid operator).
-      CartoDB.notify_debug('Could not retrieve tables fro query', { user: user, layer: self })
+      CartoDB.notify_debug('Could not retrieve tables from query', { user: user, layer: self })
       []
     end
 

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -57,6 +57,10 @@ module Carto
 
     def tables_from_query_option
       ::Table.get_all_user_tables_by_names(affected_table_names, user)
+    rescue => exception
+      # INFO: this covers changes that CartoDB can't track. For example, if layer SQL contains wrong SQL (uses a table that doesn't exist, or uses an invalid operator).
+      CartoDB.notify_debug('Could not retrieve tables fro query', { user: user, layer: self })
+      []
     end
 
     def affected_table_names

--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -29,6 +29,10 @@ module CartoDB
     Rollbar.report_message(message, 'error', additional_data)
   end
 
+  def self.notify_debug(message, additional_data={})
+    Rollbar.report_message(message, 'debug', additional_data)
+  end
+
   def self.notify_warning_exception(exception)
     Rollbar.report_exception(exception, nil, nil, 'warning')
   end


### PR DESCRIPTION
This fixes #3815 by restoring old behaviour. A layer with invalid SQL can now be opened in the editor. @Kartones can you CR this, please?