### PR TITLE
Removed unnecessary tooltip for wizards

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard.js
@@ -268,11 +268,6 @@ cdb.admin.mod.CartoCSSWizard = cdb.admin.Module.extend({
     this.tabs.setElement(this.$('ul.vis_options'));
     this.enableTabs();
 
-    // apply tipsy for nav - a
-    this.$('ul.vis_options li a').each(function(i,ele) {
-      $(ele).tipsy({ gravity: 's', fade: true });
-    });
-
     // render the wizards
     this.renderWizards();
 


### PR DESCRIPTION
Basically, this tooltip said the same we have below the wizard thumbnails.

cc @saleiva

Fixes #3838