### PR TITLE
Don't enable background importer polling when it is initialized in table view

### DIFF
--- a/lib/assets/javascripts/cartodb/common/background_importer/background_importer_view.js
+++ b/lib/assets/javascripts/cartodb/common/background_importer/background_importer_view.js
@@ -85,10 +85,13 @@ module.exports = cdb.core.View.extend({
     }
   },
 
+  // Enable background polling checking
+  // ongoing imports
   enable: function() {
     this.collection.pollCheck();
   },
 
+  // Disable/stop background polling
   disable: function() {
     this.collection.destroyCheck();
   },

--- a/lib/assets/javascripts/cartodb/dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/main_view.js
@@ -101,6 +101,9 @@ module.exports = cdb.core.View.extend({
       user: this.user
     });
     this.$el.append(this._backgroundImporterView.render().el);
+    // Background importer collection on/off --
+    // We have to enable the background importer in order to
+    // start checking/polling ongoing imports.
     this._backgroundImporterView.enable();
     this.addView(this._backgroundImporterView);
 

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -228,7 +228,6 @@ $(function() {
           user: this.user
         });
         this.$el.append(bgImporterView.render().el);
-        bgImporterView.enable();
         this.addView(bgImporterView);
       }
     },

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -228,6 +228,10 @@ $(function() {
           user: this.user
         });
         this.$el.append(bgImporterView.render().el);
+        // Background importer collection on/off --
+        // We can't enable it because it will start checking/polling
+        // imports not related with this dataset/map view.
+        // bgImporterView.enable()
         this.addView(bgImporterView);
       }
     },


### PR DESCRIPTION
Not starting the polling is the key, it won't check if any import is in process and it will only listen to imports created in that dataset/map view.

Fixes #3827 and fixes #3837.

REVIEW: @viddo 

cc @saleiva 