### PR TITLE
Added improvements getting tables list in 'old' merge dialog

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/table_column_selector.js
+++ b/lib/assets/javascripts/cartodb/old_common/table_column_selector.js
@@ -394,15 +394,11 @@ cdb.admin.TableColumnSelector = cdb.core.View.extend({
 
   // Get all user tables
   _getTables: function() {
-
-    var tables = new cdb.admin.Visualizations({ type: "table" });
-
-    var options = { q: "", page: 1, tags: "", per_page: 5000, type: "table" };
-
-    tables.options.set(options);
-    tables.fetch({ data: { o: { updated_at: "desc" }}});
+    var tables = new cdb.admin.Visualizations();
+    tables.options.set({ type: 'table', per_page: 100000, table_data: false });
+    var order = { data: { o: { updated_at: "desc" }, exclude_raster: true }};
     tables.bind('reset', this._setTables, this);
-
+    tables.fetch(order);
   },
 
   // Create tables selector


### PR DESCRIPTION
I've just copied the same code we have in the 'old' add layer dialog:

https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/old_common/import/import_layer_pane.js#L69

Should I make anything else?

cc @javisantana @rafatower @saleiva 
It should mitigate (fixes) #3840 