### PR TITLE
Disabling 'export image' functionality if provider is google maps

### DIFF
--- a/lib/assets/javascripts/cartodb/models/map.js
+++ b/lib/assets/javascripts/cartodb/models/map.js
@@ -741,7 +741,7 @@ cdb.admin.Map = cdb.geo.Map.extend({
   },
 
   isProviderGmaps: function() {
-    var provider = this.map.get("provider");
+    var provider = this.get("provider");
     return provider && provider.toLowerCase().indexOf("googlemaps") !== -1
   },
 

--- a/lib/assets/javascripts/cartodb/models/map.js
+++ b/lib/assets/javascripts/cartodb/models/map.js
@@ -740,6 +740,11 @@ cdb.admin.Map = cdb.geo.Map.extend({
     }
   },
 
+  isProviderGmaps: function() {
+    var provider = this.map.get("provider");
+    return provider && provider.toLowerCase().indexOf("googlemaps") !== -1
+  },
+
   clone: function(m) {
     m = m || new cdb.admin.Map();
     var attrs = _.clone(this.attributes)

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -1491,10 +1491,12 @@ cdb.admin.MapTab = cdb.core.View.extend({
     .removeClass("table");
 
     this.$el.addClass(this.vis.isVisualization() ? 'derived': 'table');
-
+    var provider = this.map.get("provider");
+    
     this.$el.append(this.template({
       slides_enabled: this.user.featureEnabled('slides'),
-      type: this.vis.get('type')
+      type: this.vis.get('type'),
+      exportEnabled: provider.toLowerCase().indexOf("googlemaps") === -1
     }));
 
     return this;

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -398,12 +398,11 @@ cdb.admin.MapTab = cdb.core.View.extend({
     this.render();
 
     var baseLayer = this.map.getBaseLayer();
-    var provider  = this.map.get("provider");
 
     // check if this user has google maps enabled. In case not and the provider is google maps
     // show a message 
     if ( typeof cdb.admin.GoogleMapsMapView === 'undefined') {
-      if (baseLayer && provider && provider.toLowerCase().indexOf("googlemaps") !== -1) {
+      if (baseLayer && this.map.isProviderGmaps()) {
         this._showGMapsDeprecationDialog();
         return;
       }
@@ -1497,7 +1496,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
     this.$el.append(this.template({
       slides_enabled: this.user.featureEnabled('slides'),
       type: this.vis.get('type'),
-      exportEnabled: provider.toLowerCase().indexOf("googlemaps") === -1
+      exportEnabled: !this.map.isProviderGmaps()
     }));
 
     return this;

--- a/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
@@ -29,13 +29,15 @@
       </div>
     </li>
 
-    <li class="button export_image">
-      <a href="#" class="thumb"></a>
-      <div class="info">
-        <h5>Export</h5>
-        <strong class="name">Image</strong>
-      </div>
-    </li>
+    <% if (exportEnabled) { %>
+      <li class="button export_image">
+        <a href="#" class="thumb"></a>
+        <div class="info">
+          <h5>Export</h5>
+          <strong class="name">Image</strong>
+        </div>
+      </li>
+    <% } %>
 
     <% } else { %>
 


### PR DESCRIPTION
Basically it will check the map provider and if it is GMaps, 'image export' option won't be available.

![export-image-leaflet-no-gmaps](https://cloud.githubusercontent.com/assets/132146/7880224/d20063b8-05f7-11e5-8e7c-7b25490afc25.gif)

Fixes https://github.com/CartoDB/cartodb-management/issues/3818
cc @javisantana @jatorre @saleiva 