### PR TITLE
Move map box layer factory to old common

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/add_custom_basemap/mapbox/mapbox_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/add_custom_basemap/mapbox/mapbox_model.js
@@ -40,7 +40,7 @@ module.exports = cdb.core.Model.extend({
     });
 
     var self = this;
-    var mf = new cdb.editor.MapboxToTileLayerFactory({
+    var mf = new cdb.admin.MapboxToTileLayerFactory({
       url: url,
       accessToken: accessToken
     });

--- a/lib/assets/javascripts/cartodb/editor.js
+++ b/lib/assets/javascripts/cartodb/editor.js
@@ -4,8 +4,6 @@
 // Expected to be loaded after cdb.js but before table.js
 var cdb = require('cartodb.js');
 cdb.editor = {
-  MapboxToTileLayerFactory: require('./common/dialogs/add_custom_basemap/mapbox/mapbox_to_tile_layer_factory.js'),
-
   CreateVisFirstView: require('./common/dialogs/create_vis_first/create_vis_first_view'),
   ImportsCollection: require('./common/background_importer/imports_collection'),
   BackgroundImporterModel: require('./editor/background_importer_model'),

--- a/lib/assets/javascripts/cartodb/old_common/mapbox_to_tile_layer_factory.js
+++ b/lib/assets/javascripts/cartodb/old_common/mapbox_to_tile_layer_factory.js
@@ -1,12 +1,9 @@
-var cdb = require('cartodb.js');
-var _ = require('underscore');
-var $ = require('jquery');
-
 /**
  * Factory to create a cdb.admin.TileLayer from a given URL and access token tuple for Mapbox.
-* Extracted from mapbox_basemap_pane to maintain current logic, since it's rather complex…
+ * Extracted from mapbox_basemap_pane to maintain current logic, since it's rather complex…
+ * TODO: should be moved to common/dialogs/add_custom_basemap/mapbox/ once old dialogs are removed
  */
-module.exports = cdb.core.Model.extend({
+cdb.admin.MapboxToTileLayerFactory = cdb.core.Model.extend({
 
   defaults: {
     url: '',

--- a/lib/assets/javascripts/cartodb/table/basemap/basemap_dialog/mapbox_basemap_pane.js
+++ b/lib/assets/javascripts/cartodb/table/basemap/basemap_dialog/mapbox_basemap_pane.js
@@ -96,7 +96,7 @@
       $input.attr('disabled');
 
       var self = this;
-      var mf = new cdb.editor.MapboxToTileLayerFactory({
+      var mf = new cdb.admin.MapboxToTileLayerFactory({
         url: val,
         accessToken: access_token
       });

--- a/lib/assets/test/spec/cartodb/common/dialogs/add_custom_basemap/mapbox/mapbox_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/add_custom_basemap/mapbox/mapbox_view.spec.js
@@ -15,13 +15,13 @@ describe('common/dialog/add_custom_basemap/mapbox/mapbox_view', function() {
 
   describe('when click save', function() {
     beforeEach(function() {
-      this.mapboxToTileLayerFactory = new cdb.editor.MapboxToTileLayerFactory({
+      this.mapboxToTileLayerFactory = new cdb.admin.MapboxToTileLayerFactory({
         url: 'mapbox/URL',
         accessToken: 'abc123'
       });
       spyOn(this.mapboxToTileLayerFactory, 'createTileLayer');
       var self = this;
-      spyOn(cdb.editor, 'MapboxToTileLayerFactory').and.callFake(function() {
+      spyOn(cdb.admin, 'MapboxToTileLayerFactory').and.callFake(function() {
         return self.mapboxToTileLayerFactory;
       });
       spyOn(this.model, 'save').and.callThrough();

--- a/lib/assets/test/spec/cartodb/old_common/mapbox_to_tile_layer_factory.spec.js
+++ b/lib/assets/test/spec/cartodb/old_common/mapbox_to_tile_layer_factory.spec.js
@@ -1,11 +1,7 @@
-var cdb = require('cartodb.js');
-var MapboxToTileLayerFactory = require('../../../../../../../javascripts/cartodb/common/dialogs/add_custom_basemap/mapbox/mapbox_to_tile_layer_factory.js');
-var $ = require('jquery');
-
-describe('common/dialog/add_custom_basemap/mapbox/mapbox_to_tile_layer_factory', function() {
+describe('cdb.admin.MapboxToTileLayerFactory', function() {
   beforeEach(function() {
     this.baseLayers = new cdb.admin.UserLayers();
-    this.factory = new MapboxToTileLayerFactory({
+    this.factory = new cdb.admin.MapboxToTileLayerFactory({
       url: 'https://a.tiles.mapbox.com/v4/username.123abc45d/',
       accessToken: 'x.y123zwv456'
     });
@@ -13,12 +9,12 @@ describe('common/dialog/add_custom_basemap/mapbox/mapbox_to_tile_layer_factory',
 
   describe('._fixHTTPS', function() {
     it('should fix mapbox https url', function() {
-      var url = MapboxToTileLayerFactory.prototype._fixHTTPS('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json', {
+      var url = cdb.admin.MapboxToTileLayerFactory.prototype._fixHTTPS('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json', {
         protocol: 'https:'
       });
       expect(url).toEqual('https://dnv9my2eseobd.cloudfront.net/v4/examples.map-4l7djmvo.json');
 
-      url = MapboxToTileLayerFactory.prototype._fixHTTPS('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json', {
+      url = cdb.admin.MapboxToTileLayerFactory.prototype._fixHTTPS('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json', {
         protocol: 'http:'
       });
       expect(url).toEqual('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json')


### PR DESCRIPTION
Fixes the old add custom basemap modal to work for the mapbox category again (the moved piece was only loaded for users w/ access to new modals)