### PR TITLE
Adds more reserved keywords 

### DIFF
--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -48,7 +48,7 @@ class UserTable < Sequel::Model
     values
   }
 
-  RESERVED_TABLE_NAMES = %W{ layergroup all }
+  RESERVED_TABLE_NAMES = %W{ all and any array as asc before both cast desc end fetch for from group intersect layergroup not offset on or select table then to union when where with }
 
   PRIVACY_PRIVATE = 0
   PRIVACY_PUBLIC = 1


### PR DESCRIPTION
Fixes #2718 

I've added a selection of keywords from the complete list of reserved and non-reserved Postgres keywords (below). Not all of them fail in the import process, so I have selected the most common ones which fail.

`all and any array as asc before both cast desc end fetch for from group intersect not offset on or select table then to union when where with`

Complete list:

````
PASSWORD, MODE, ABORT, ABSOLUTE, ACCESS, ACTION, ADD,
 ADMIN, AFTER, AGGREGATE, ALL, ALSO, ALTER, ANALYSE,
 ANALYZE, AND, ANY, ARRAY, AS, ASC, ASSERTION, ASSIGNMENT,
 ASYMMETRIC, AT, BACKWARD, BEFORE, BEGIN, BOTH, BY, CACHE,
 CALLED, CASCADE, CASE, CAST, CHAIN, CHARACTERISTICS, CHECK,
 CHECKPOINT, CLASS, CLOSE, CLUSTER, COLLATE, COLUMN,
 COMMENT, COMMIT, COMMITTED, CONNECTION, CONSTRAINT,
 CONSTRAINTS, CONVERSION, COPY, CREATE, CREATEDB, 
CREATEROLE, CREATEUSER, CSV, CURRENT_DATE,
 CURRENT_ROLE, CURRENT_TIME, CURRENT_TIMESTAMP,
 CURRENT_USER, CURSOR, CYCLE, DATABASE, DAY, DEALLOCATE,
 DECLARE, DEFAULT, DEFAULTS, DEFERRABLE, DEFERRED,
 DEFINER, DELETE, DELIMITER, DELIMITERS, DESC, DISABLE,
 DISTINCT, DO, DOMAIN, DOUBLE, DROP, EACH, ELSE, ENABLE,
 ENCODING, ENCRYPTED, END, ESCAPE, EXCEPT, EXCLUDING,
 EXCLUSIVE, EXECUTE, EXPLAIN, EXTERNAL, FALSE, FETCH,
 FIRST, FOR, FORCE, FOREIGN, FORWARD, FROM, FUNCTION,
 GLOBAL, GRANT, GRANTED, GROUP, HANDLER, HAVING,
 HEADER, HOLD, HOUR, IMMEDIATE, IMMUTABLE, IMPLICIT,
 IN, INCLUDING, INCREMENT, INDEX, INHERIT, INHERITS, INITIALLY,
 INPUT, INSENSITIVE, INSERT, INSTEAD, INTERSECT, INTO, INVOKER,
 ISOLATION, KEY, LANCOMPILER, LANGUAGE, LARGE, LAST,
 LEADING, LEVEL, LIMIT, LISTEN, LOAD, LOCAL, LOCALTIME,
 LOCALTIMESTAMP, LOCATION, LOCK, LOGIN, MATCH, MAXVALUE,
 MINUTE, MINVALUE, MONTH, MOVE, NAMES, NEW, NEXT, NO,
 NOCREATEDB, NOCREATEROLE, NOCREATEUSER, NOINHERIT,
 NOLOGIN, NOSUPERUSER, NOT, NOTHING, NOTIFY, NOWAIT, NULL,
 OBJECT, OF, OFF, OFFSET, OIDS, OLD, ON, ONLY, OPERATOR,
 OPTION, OR, ORDER, OWNER, PARTIAL, PLACING, PREPARE,
 PREPARED, PRESERVE, PRIMARY, PRIOR, PRIVILEGES, PROCEDURAL,
 PROCEDURE, QUOTE, READ, RECHECK, REFERENCES, REINDEX,
 RELATIVE, RELEASE, RENAME, REPEATABLE, REPLACE, RESET,
 RESTART, RESTRICT, RETURNS, REVOKE, ROLE, ROLLBACK,
 ROWS, RULE, SAVEPOINT, SCHEMA, SCROLL, SECOND, SECURITY,
 UNTIL, SELECT, SEQUENCE, SERIALIZABLE, SESSION, SESSION_USER,
 SET, SHARE, SHOW, SIMPLE, SOME, STABLE, START, STATEMENT,
 STATISTICS, STDIN, STDOUT, STORAGE, STRICT, SUPERUSER,
 SYMMETRIC, SYSID, SYSTEM, TABLE, TABLESPACE, TEMP, TEMPLATE,
 TEMPORARY, THEN, TO, TOAST, TRAILING, TRANSACTION, TRIGGER,
 TRUE, TRUNCATE, TRUSTED, TYPE, UNCOMMITTED, UNENCRYPTED,
 UNION, UNIQUE, UNKNOWN, UNLISTEN, UPDATE, USER, USING,
 VACUUM, VALID, VALIDATOR, VALUES, VARYING, VIEW, VOLATILE,
 WHEN, WHERE, WITH, WITHOUT, WORK, WRITE, YEAR, ZONE
````

