### PR TITLE
Using URI.escape fixes downloader issues with accented characters

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -2,6 +2,7 @@
 require 'fileutils'
 require 'typhoeus'
 require 'open3'
+require 'uri'
 require_relative './exceptions'
 require_relative './source_file'
 require_relative '../../../data-repository/filesystem/local'
@@ -54,6 +55,7 @@ module CartoDB
           @translated_url = translator.translate(url)
           @custom_filename = translator.respond_to?(:rename_destination) ? translator.rename_destination(url) : nil
         end
+        @translated_url = URI.escape(@translated_url) unless @translated_url.nil?
       end
 
       def provides_stream?

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -55,7 +55,8 @@ module CartoDB
           @translated_url = translator.translate(url)
           @custom_filename = translator.respond_to?(:rename_destination) ? translator.rename_destination(url) : nil
         end
-        @translated_url = URI.escape(@translated_url) unless @translated_url.nil?
+        # INFO: runner_spec.rb uses File instead of String, so we chose to support both
+        @translated_url = URI.escape(@translated_url) if !@translated_url.nil? && @translated_url.kind_of?(String)
       end
 
       def provides_stream?

--- a/services/importer/spec/fixtures/política_agraria_común.csv
+++ b/services/importer/spec/fixtures/política_agraria_común.csv
@@ -1,0 +1,3 @@
+Column A,Column B
+1,2
+3,4

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -72,6 +72,14 @@ describe Downloader do
       downloader.source_file.name.should eq 'INDEX'
     end
 
+    it 'supports accented URLs' do
+      # TODO: change this request to master
+      accented_url = 'https://raw.githubusercontent.com/CartoDB/cartodb/3315-Uploading_of_files_with_accents_on_the_filename_dont_work/services/importer/spec/fixtures/política_agraria_común.csv'
+      downloader = Downloader.new(accented_url)
+      downloader.run
+      downloader.source_file.name.should eq 'política_agraria_común'
+    end
+
     it "doesn't download the file if ETag hasn't changed" do
       etag = 'bogus'
       stub_download(


### PR DESCRIPTION
@Kartones CR this fix for #3315, please.