### PR TITLE
keys: prevent flash in firefox and IE

### DIFF
--- a/lib/assets/javascripts/cartodb/keys/entry.js
+++ b/lib/assets/javascripts/cartodb/keys/entry.js
@@ -68,7 +68,7 @@ $(function() {
 
     $('.js-copy-value').each(function() {
       // Copy
-      if ($.browser.mozilla || ($.browser.msie && $.browser.version<9)) {
+      if (!$.browser.mozilla && !($.browser.msie && $.browser.version<9)) {
         $('.Header').zclip({
           path: cdb.config.get('assets_url') + "/flash/ZeroClipboard.swf",
           copy: function(){

--- a/lib/assets/javascripts/cartodb/keys/entry.js
+++ b/lib/assets/javascripts/cartodb/keys/entry.js
@@ -68,12 +68,14 @@ $(function() {
 
     $('.js-copy-value').each(function() {
       // Copy
-      $(this).zclip({
-        path: cdb.config.get('assets_url') + "/flash/ZeroClipboard.swf",
-        copy: function(){
-          return $(this).parent().find(".js-input").val();
-        }
-      });
+      if ($.browser.mozilla || ($.browser.msie && $.browser.version<9)) {
+        $('.Header').zclip({
+          path: cdb.config.get('assets_url') + "/flash/ZeroClipboard.swf",
+          copy: function(){
+            return $(this).parent().find(".js-input").val();
+          }
+        });
+      }
 
       // Tooltip
       var tooltip = new cdb.common.TipsyTooltip({


### PR DESCRIPTION
we're showing a black square where flash buttons (for copy functionality) should appear as explained in https://github.com/CartoDB/cartodb/issues/3067

This issue has been laying around for quite some time because it was't really blocking and I've tried several libraries such http://zeroclipboard.org/ (looks better). Not even the homepage of zclip works on last firefox

![screen shot 2015-06-03 at 16 27 29](https://cloud.githubusercontent.com/assets/36676/7963103/4dcbfe54-0a11-11e5-84bd-d573efee0b45.png)

I simply workarounded the black squares fix; if you propose a better solution or maybe we could replace the library, I wouldn't mind at all.

CR @CartoDB/frontend 