### PR TITLE
Checking if user_data object exists before getting user email for metrics purposes

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/export_table_dialog.js
+++ b/lib/assets/javascripts/cartodb/old_common/export_table_dialog.js
@@ -150,7 +150,7 @@ cdb.admin.ExportTableDialog = cdb.admin.BaseDialog.extend({
 
     // Event tracking "Exported table data"
     cdb.god.trigger('metrics', 'export_table', {
-      email: window.user_data.email,
+      email: window.user_data && window.user_data.email,
       data: {
         filename: this.$('form input[name="filename"]').val(),
         type: this.$('form input[name="format"]').val()

--- a/lib/assets/javascripts/cartodb/old_common/export_table_options.js
+++ b/lib/assets/javascripts/cartodb/old_common/export_table_options.js
@@ -153,7 +153,7 @@ cdb.admin.ExportTableOptions = cdb.core.View.extend({
 
     // Event tracking "Exported table data"
     cdb.god.trigger('metrics', 'export_table', {
-      email: window.user_data.email,
+      email: window.user_data && window.user_data.email,
       data: {
         filename: this.$('form input[name="filename"]').val(),
         type: this.$('form input[name="format"]').val()


### PR DESCRIPTION
Basically we are trying to get the user email for metrics purposes, and ```user_data``` object is not defined in that view.

Fixes #3913

cc @matallo @saleiva @viddo