### PR TITLE
3879 named maps everywhere

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Mailchimp decorator enables category wizard and legends [#3874](https://github.com/CartoDB/cartodb/pull/3874)
 * Cache public and with link embeds in redis [#3733](https://github.com/CartoDB/cartodb/pull/3733)
 * Unify caching of vizjsons and version keys [#3726](https://github.com/CartoDB/cartodb/pull/3726)
+* Named maps created for all visualizations, regardless of layers privacy [#3879](https://github.com/CartoDB/cartodb/issues/3879)
 
 Bugfixes:
 * Fixed deletion of layers upon disconnecting synced datasources [#3718](https://github.com/CartoDB/cartodb/pull/3718)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,8 @@ class User < Sequel::Model
 
   GEOCODING_BLOCK_SIZE = 1000
 
+  TRIAL_DURATION_DAYS = 15
+
   self.raise_on_typecast_failure = false
   self.raise_on_save_failure = false
 
@@ -759,8 +761,8 @@ class User < Sequel::Model
   end
 
   def trial_ends_at
-    if account_type.to_s.downcase == 'magellan' && upgraded_at && upgraded_at + 15.days > Date.today
-      upgraded_at + 15.days
+    if account_type.to_s.downcase == 'magellan' && upgraded_at && upgraded_at + TRIAL_DURATION_DAYS.days > Date.today
+      upgraded_at + TRIAL_DURATION_DAYS.days
     else
       nil
     end

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -316,7 +316,7 @@ module CartoDB
         privacy = privacy.downcase if privacy
         self.privacy_changed = true if ( privacy != @privacy && !@privacy.nil? )
         super(privacy)
-      end #privacy=
+      end
 
       def tags=(tags)
         tags.reject!(&:blank?) if tags
@@ -618,8 +618,6 @@ module CartoDB
       end
 
 
-
-
       private
 
       attr_reader   :repository, :name_checker, :validator
@@ -711,10 +709,10 @@ module CartoDB
           permission.clear
         end
 
-        if type == TYPE_CANONICAL || type == TYPE_REMOTE
-          if organization?
-            save_named_map
-          end
+        if type == TYPE_REMOTE
+          propagate_privacy_and_name_to(table) if table and propagate_changes
+        elsif type == TYPE_CANONICAL
+          save_named_map if organization?
           propagate_privacy_and_name_to(table) if table and propagate_changes
         else
           save_named_map
@@ -751,15 +749,10 @@ module CartoDB
 
       def save_named_map
         named_map = has_named_map?
-        if retrieve_named_map?
-            if named_map
-              update_named_map(named_map)
-             else
-              create_named_map
-            end
+        if named_map
+          update_named_map(named_map)
         else
-          # Privacy changed, remove the map
-          named_map.delete if named_map
+          create_named_map
         end
       end
 
@@ -840,9 +833,7 @@ module CartoDB
 
       def related_layers_from(table)
         layers(:cartodb).select do |layer|
-          (layer.affected_tables.map(&:name) +
-            [layer.options.fetch('table_name', nil)]
-          ).include?(table.name)
+          (layer.affected_tables.map(&:name) + [layer.options.fetch('table_name', nil)]).include?(table.name)
         end
       end
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -712,7 +712,7 @@ module CartoDB
         if type == TYPE_REMOTE
           propagate_privacy_and_name_to(table) if table and propagate_changes
         elsif type == TYPE_CANONICAL
-          save_named_map if organization?
+          save_named_map
           propagate_privacy_and_name_to(table) if table and propagate_changes
         else
           save_named_map

--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -15,6 +15,28 @@ namespace :cartodb do
       end
     end
 
+    desc "Create named maps for all eligible existing visualizations"
+    task :create_named_maps, [:dry_run] => :environment do |t, args|
+      dry_run = args[:dry_run] == 'true'
+
+      puts "Dry run of create_named_maps rake" if dry_run
+
+      collection = CartoDB::Visualization::Collection.new.fetch({
+        'types' => [CartoDB::Visualization::Member::TYPE_CANONICAL, CartoDB::Visualization::Member::TYPE_DERIVED]
+        })
+
+      puts "Fetched ##{collection.count} items"
+
+      collection.each do |viz|
+        viz.store unless dry_run
+        puts "#{CartoDB::NamedMapsWrapper::NamedMap::normalize_name(viz.id)}"
+      end
+
+      puts "\nFinished"
+    end
+
+    private
+
     def is_inconsistent?(viz)
       (viz.table? && viz.related_tables.empty?) || (viz.derived? && viz.map.nil?)
     end

--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -23,7 +23,7 @@ namespace :cartodb do
 
       collection = CartoDB::Visualization::Collection.new.fetch({
         'types' => [CartoDB::Visualization::Member::TYPE_CANONICAL, CartoDB::Visualization::Member::TYPE_DERIVED],
-        per_page: ALL_RECORDS
+        per_page: CartoDB::Visualization::Collection::ALL_RECORDS
         })
 
       puts "Fetched ##{collection.count} items"

--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -26,19 +26,21 @@ namespace :cartodb do
         per_page: CartoDB::Visualization::Collection::ALL_RECORDS
         })
 
-      puts "Fetched ##{collection.count} items"
+      count = collection.count
+
+      puts "Fetched ##{count} items"
 
       collection.each do |viz|
         begin
           viz.store unless dry_run
-          puts "OK:  #{CartoDB::NamedMapsWrapper::NamedMap::normalize_name(viz.id)}"
-        rescue ex
+          puts "OK:  #{CartoDB::NamedMapsWrapper::NamedMap::normalize_name(viz.id)} :: User: #{viz.user_id}"
+        rescue => ex
           puts "ERR: #{viz.id}"
           puts ex.inspect
         end
       end
 
-      puts "\nFinished"
+      puts "\nFinished ##{count} items"
     end
 
     private

--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -22,14 +22,20 @@ namespace :cartodb do
       puts "Dry run of create_named_maps rake" if dry_run
 
       collection = CartoDB::Visualization::Collection.new.fetch({
-        'types' => [CartoDB::Visualization::Member::TYPE_CANONICAL, CartoDB::Visualization::Member::TYPE_DERIVED]
+        'types' => [CartoDB::Visualization::Member::TYPE_CANONICAL, CartoDB::Visualization::Member::TYPE_DERIVED],
+        per_page: ALL_RECORDS
         })
 
       puts "Fetched ##{collection.count} items"
 
       collection.each do |viz|
-        viz.store unless dry_run
-        puts "#{CartoDB::NamedMapsWrapper::NamedMap::normalize_name(viz.id)}"
+        begin
+          viz.store unless dry_run
+          puts "OK:  #{CartoDB::NamedMapsWrapper::NamedMap::normalize_name(viz.id)}"
+        rescue ex
+          puts "ERR: #{viz.id}"
+          puts ex.inspect
+        end
       end
 
       puts "\nFinished"

--- a/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
+++ b/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
@@ -95,7 +95,7 @@ module CartoDB
             timeout:          HTTP_REQUEST_TIMEOUT
           } )
         raise HTTPResponseError, "DELETE:#{response.code} #{response.request.url} #{response.body}" unless response.code == 204
-      end #delete
+      end
 
       # Url to access a named map's tiles
       def url
@@ -104,7 +104,7 @@ module CartoDB
 
       # Normalize a name to make it "named map valid"
       def self.normalize_name( raw_name )
-        ( NAME_PREFIX + raw_name ).gsub( /[^a-zA-Z0-9\-\_.]/ , '' ).gsub( '-', '_' )
+        (NAME_PREFIX + raw_name).gsub(/[^a-zA-Z0-9\-\_.]/, '').gsub('-', '_')
       end
 
       def self.get_template_data( visualization, parent )

--- a/spec/factories/visualization_creation_helpers.rb
+++ b/spec/factories/visualization_creation_helpers.rb
@@ -11,8 +11,7 @@ end
 
 def bypass_named_maps
   CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-  CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
-  CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:create).returns(true)
+  CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 end
 
 def random_username

--- a/spec/models/automatic_geocoding_spec.rb
+++ b/spec/models/automatic_geocoding_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 describe AutomaticGeocoding do
   before(:all) do
     @user  = create_user(geocoding_quota: 200)
+
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     @table = FactoryGirl.create(:table, user_id: @user.id)
   end
 

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -13,7 +13,7 @@ describe Carto::Visualization do
   end
 
   before(:each) do
-    CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
     delete_user_data(@user)
   end
 

--- a/spec/models/geocoding_spec.rb
+++ b/spec/models/geocoding_spec.rb
@@ -9,7 +9,7 @@ describe Geocoding do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
   end
 
   after(:all) do

--- a/spec/models/geocoding_spec.rb
+++ b/spec/models/geocoding_spec.rb
@@ -5,6 +5,8 @@ require 'ruby-debug'
 describe Geocoding do
   before(:all) do
     @user  = create_user(geocoding_quota: 200, geocoding_block_price: 1500)
+    
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     @table = FactoryGirl.create(:user_table, user_id: @user.id)
   end
 

--- a/spec/models/layer_spec.rb
+++ b/spec/models/layer_spec.rb
@@ -280,7 +280,7 @@ describe Layer do
 
   describe '#uses_private_tables?' do
     it 'returns true if any of the affected tables is private' do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:create).returns(true)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
       map     = Map.create(:user_id => @user.id, :table_id => @table.id)
       source  = @table.table_visualization

--- a/spec/models/layer_spec.rb
+++ b/spec/models/layer_spec.rb
@@ -15,6 +15,7 @@ describe Layer do
   end
 
   before(:each) do
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
 
     CartoDB::Overlay::Member.any_instance.stubs(:can_store).returns(true)

--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -16,12 +16,12 @@ describe Map do
 
   after(:all) do
     CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     @user.destroy
   end
 
   before(:each) do
-    # For Named Maps API wrapper
-    # Using Mocha stubs until we update RSpec (@see http://gofreerange.com/mocha/docs/Mocha/ClassMethods.html)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
 
     @table = Table.new

--- a/spec/models/named_maps_spec.rb
+++ b/spec/models/named_maps_spec.rb
@@ -124,6 +124,13 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
         }
       }
 
+      # Post: to create (as now all tables/viz create named maps)
+      Typhoeus.stub( named_maps_url(@user.api_key),
+        { method: :post } )
+              .and_return(
+                Typhoeus::Response.new( code: 200, body: JSON::dump( { template_id: 'tpl_fakeid' } ) )
+              )
+
       table = create_table( user_id: @user.id )
       table.privacy = UserTable::PRIVACY_PUBLIC
       table.save()
@@ -134,12 +141,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       derived_vis.privacy = CartoDB::Visualization::Member::PRIVACY_PROTECTED
       derived_vis.password = password
 
-      # get: not present
-      Typhoeus.stub( tiler_regex,
-      { method: :get}  )
-            .and_return(
-              Typhoeus::Response.new(code: 404, body: "")
-            )
       # Post: to create
       Typhoeus.stub( named_maps_url(@user.api_key),
         { method: :post } )
@@ -168,7 +169,15 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
 
 
   describe 'public_table' do
-    it 'public map with public visualization does not create a named map' do
+    it 'public map with public visualization creates a named map' do
+      #Post to create
+      new_template_body = { template_id: 'tpl_fakeid' }
+
+      Typhoeus.stub( named_maps_url(@user.api_key) )
+              .and_return(
+                Typhoeus::Response.new( code: 200, body: JSON::dump( new_template_body ) )
+              )
+
       table = create_table( user_id: @user.id )
       table.privacy = UserTable::PRIVACY_PUBLIC
       table.save()
@@ -190,11 +199,18 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       table.affected_visualizations[1].id.should eq derived_vis.id
       table.affected_visualizations[0].id.should_not eq table.affected_visualizations[1].id
     end
-  end #public_table_public_vis
-
+  end
 
   describe 'private_table' do
     it 'private map with public visualization should create a named map' do
+      #Post to create
+      new_template_body = { template_id: 'tpl_fakeid' }
+
+      Typhoeus.stub( named_maps_url(@user.api_key) )
+              .and_return(
+                Typhoeus::Response.new( code: 200, body: JSON::dump( new_template_body ) )
+              )
+
       table = create_table( user_id: @user.id )
 
       derived_vis = CartoDB::Visualization::Copier.new(@user, table.table_visualization).copy()
@@ -204,14 +220,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       Typhoeus.stub( tiler_regex )
               .and_return(
                 Typhoeus::Response.new(code: 404, body: "")
-              )
-
-      #Post to create
-      new_template_body = { template_id: 'tpl_fakeid' }
-
-      Typhoeus.stub( named_maps_url(@user.api_key) )
-              .and_return(
-                Typhoeus::Response.new( code: 200, body: JSON::dump( new_template_body ) )
               )
 
       derived_vis.store()
@@ -341,53 +349,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
               )
 
       derived_vis.delete()  # This will trigger a delete
-    end
-  end #named_map_updated_on_visualization_updated
-
-
-  describe 'named_map_deleted_on_table_made_public' do
-    it 'checks that when you make a table public and the visualization had a named map, it gets deleted' do
-      template_data = {
-        template: {
-          version: '0.0.1',
-          name: '@@PLACEHOLDER@@',
-          auth: {
-            method: 'open'
-          },
-          placeholders: {
-            layer0: {
-              type: "number",
-              default: 1
-            }
-          },
-          layergroup: {
-            layers: [
-              {
-                type: "cartodb",
-                options: {
-                  sql: "WITH wrapped_query AS (select * from test1) SELECT * from wrapped_query where <%= layer0 %>=1",
-                  layer_name: "test1",
-                  cartocss: "/** */",
-                  cartocss_version: "2.1.1",
-                  interactivity: "cartodb_id"
-                }
-              }
-            ]
-          }
-        }
-      }
-
-      table, derived_vis, template_id = create_private_table_with_public_visualization(template_data)
-
-      Typhoeus.stub( named_map_url(template_id,@user.api_key), 
-        { method: :delete } )
-              .and_return(
-                Typhoeus::Response.new( code: 204, body: "" )
-              )
-
-      table.privacy = UserTable::PRIVACY_PUBLIC
-      table.save()
-      table.reload()  # Will trigger a DELETE
     end
   end #named_map_updated_on_visualization_updated
 
@@ -756,6 +717,14 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
   # NOTE: Leaves stubbed calls to GET the template so they return the correct template data
   def create_private_table_with_public_visualization(template_data, 
       visualization_privacy = CartoDB::Visualization::Member::PRIVACY_PUBLIC)
+
+    #Tables/canonical vis also nave named maps
+    new_template_body = { template_id: 'tpl_fakeid' }
+    Typhoeus.stub( named_maps_url(@user.api_key) )
+            .and_return(
+              Typhoeus::Response.new( code: 200, body: JSON::dump( new_template_body ) )
+            )
+
     table = create_table( user_id: @user.id )
     derived_vis = CartoDB::Visualization::Copier.new(@user, table.table_visualization).copy
     derived_vis.privacy = visualization_privacy
@@ -801,6 +770,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
             )
 
     return table, derived_vis, template_id
-  end #create_map_with_public_visualization
+  end
 
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -229,7 +229,8 @@ describe Organization do
 
   describe '#org_shared_vis' do
     it "checks fetching all shared visualizations of an organization's members " do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      
       # Don't check/handle DB permissions
       Permission.any_instance.stubs(:revoke_previous_permissions).returns(nil)
       Permission.any_instance.stubs(:grant_db_permission).returns(nil)

--- a/spec/models/table/relator_spec.rb
+++ b/spec/models/table/relator_spec.rb
@@ -5,6 +5,8 @@ require_relative '../../spec_helper'
 describe CartoDB::TableRelator do
   describe '.rows_and_size' do
     before do
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+
       quota_in_bytes  = 524288000
       table_quota     = 500
       @user           = create_user(
@@ -36,6 +38,8 @@ describe CartoDB::TableRelator do
 
   describe '.serialize_dependent_visualizations' do
     before :each do
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+
       table = mock('Table')
       table.stubs(:id).returns(2)
       @affected_vis_records = [
@@ -63,6 +67,8 @@ describe CartoDB::TableRelator do
 
     describe 'given there are at least one dependent visualization' do
       before :each do
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+
         CartoDB::Visualization::Member.any_instance.stubs(:dependent?).returns(true, false, true)
         @dependents = @table_relator.serialize_dependent_visualizations
       end
@@ -85,6 +91,8 @@ describe CartoDB::TableRelator do
 
   describe '.serialize_non_dependent_visualizations' do
     before :each do
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+
       table = mock('Table')
       table.stubs(:id).returns(2)
       @affected_vis_records = [
@@ -103,6 +111,8 @@ describe CartoDB::TableRelator do
 
     describe 'given there are no dependent visualizations' do
       before :each do
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+
         @non_dependents = @table_relator.serialize_non_dependent_visualizations
       end
 
@@ -113,6 +123,8 @@ describe CartoDB::TableRelator do
 
     describe 'given there are at least one non_dependent visualization' do
       before :each do
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+        
         CartoDB::Visualization::Member.any_instance.stubs(:non_dependent?).returns(true, false, false)
         @non_dependents = @table_relator.serialize_non_dependent_visualizations
       end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -42,7 +42,7 @@ describe Table do
   before(:each) do
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
 
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
     CartoDB::Overlay::Member.any_instance.stubs(:can_store).returns(true)
   end
@@ -242,11 +242,10 @@ describe Table do
         @user, table.table_visualization
       ).copy
 
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:create).returns(true)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       derived_vis.store
       table.reload
 
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
       table.privacy = UserTable::PRIVACY_PUBLIC
       table.save
 
@@ -274,11 +273,10 @@ describe Table do
           @user, table.table_visualization
       ).copy
 
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:create).returns(true)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       derived_vis.store
       table.reload
 
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
       table.privacy = UserTable::PRIVACY_LINK
       table.save
       table.reload
@@ -584,7 +582,8 @@ describe Table do
   end
 
   it "should remove varnish cache when updating the table privacy" do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    
     @user.private_tables_enabled = true
     @user.save
     table = create_table(user_id: @user.id, name: "varnish_privacy", privacy: UserTable::PRIVACY_PRIVATE)
@@ -609,7 +608,8 @@ describe Table do
 
   context "when removing the table" do
     before(:all) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      
       CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
       @doomed_table = create_table(user_id: @user.id)
       @automatic_geocoding = FactoryGirl.create(:automatic_geocoding, table: @doomed_table)
@@ -617,7 +617,7 @@ describe Table do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     end
 
     it "should remove the automatic_geocoding" do
@@ -659,7 +659,7 @@ describe Table do
     end
 
     it 'deletes derived visualizations that depend on this table' do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:create).returns(true)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       table   = create_table(name: 'bogus_name', user_id: @user.id)
       source  = table.table_visualization
       derived = CartoDB::Visualization::Copier.new(@user, source).copy
@@ -2219,7 +2219,7 @@ describe Table do
       table.save
       table.should be_private
 
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:create).returns(true)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       source  = table.table_visualization
       derived = CartoDB::Visualization::Copier.new(@user, source).copy
       derived.store

--- a/spec/models/user_presenter_spec.rb
+++ b/spec/models/user_presenter_spec.rb
@@ -5,6 +5,7 @@ require_relative '../spec_helper'
 describe Carto::Api::UserPresenter do
 
   it "Compares old and new ways of 'presenting' user data" do
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
     # Non-org user
     user = create_user({ 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -951,7 +951,7 @@ describe User do
     @user.trial_ends_at.should_not be_nil
     @user.stubs(:upgraded_at).returns(nil)
     @user.trial_ends_at.should be_nil
-    @user.stubs(:upgraded_at).returns(Time.now - 15.days)
+    @user.stubs(:upgraded_at).returns(Time.now - (User::TRIAL_DURATION_DAYS - 1).days)
     @user.trial_ends_at.should_not be_nil
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,8 @@ require_relative '../spec_helper'
 
 describe User do
   before(:all) do
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    
     @user_password = 'admin123'
     puts "\n[rspec][user_spec] Creating test user databases..."
     @user     = create_user :email => 'admin@example.com', :username => 'admin', :password => @user_password

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ describe User do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
     User.any_instance.stubs(:enable_remote_db_user).returns(true)
   end
@@ -1143,7 +1143,7 @@ describe User do
     it 'Checks that shared tables include not only owned ones' do
       require_relative '../../app/models/visualization/collection'
       CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       # No need to really touch the DB for the permissions
       Table::any_instance.stubs(:add_read_permission).returns(nil)
 

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -25,8 +25,7 @@ describe Visualization::Collection do
     Visualization::Migrator.new(@db).migrate(@relation)
     Visualization.repository = @repository
 
-    # Using Mocha stubs until we update RSpec (@see http://gofreerange.com/mocha/docs/Mocha/ClassMethods.html)
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
     # For relator->permission
     user_id = UUIDTools::UUID.timestamp_create.to_s

--- a/spec/models/visualization/locator_spec.rb
+++ b/spec/models/visualization/locator_spec.rb
@@ -21,8 +21,7 @@ describe Visualization::Locator do
   end
 
   before do
-    # Using Mocha stubs until we update RSpec (@see http://gofreerange.com/mocha/docs/Mocha/ClassMethods.html)
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
     @db = Rails::Sequel.connection
     Sequel.extension(:pagination)

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -19,7 +19,7 @@ describe Visualization::Member do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
     # For relator->permission
     user_id = UUIDTools::UUID.timestamp_create.to_s

--- a/spec/models/visualization/presenter_spec.rb
+++ b/spec/models/visualization/presenter_spec.rb
@@ -15,7 +15,7 @@ describe Visualization::Member do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
     user_id = UUIDTools::UUID.timestamp_create.to_s
     user_name = 'whatever'

--- a/spec/models/visualization/relator_spec.rb
+++ b/spec/models/visualization/relator_spec.rb
@@ -17,7 +17,7 @@ describe Visualization::Relator do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
     # For relator->permission
     user_id = UUIDTools::UUID.timestamp_create.to_s

--- a/spec/models/visualization/tags_spec.rb
+++ b/spec/models/visualization/tags_spec.rb
@@ -13,7 +13,7 @@ describe Visualization::Tags do
     @db = Rails::Sequel.connection
     Visualization.repository  = DataRepository::Backend::Sequel.new(@db, :visualizations)
 
-    NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
     # For relator->permission
     user_id = UUIDTools::UUID.timestamp_create.to_s

--- a/spec/requests/admin/tables_spec.rb
+++ b/spec/requests/admin/tables_spec.rb
@@ -24,6 +24,7 @@ describe Admin::TablesController do
   end
 
   before(:each) do
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
     @db = Rails::Sequel.connection
     delete_user_data @user

--- a/spec/requests/admin/visualizations_spec.rb
+++ b/spec/requests/admin/visualizations_spec.rb
@@ -32,6 +32,7 @@ describe Admin::VisualizationsController do
 
   before(:each) do
     CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     
     @db = Rails::Sequel.connection
     Sequel.extension(:pagination)

--- a/spec/requests/api/geocodings_spec.rb
+++ b/spec/requests/api/geocodings_spec.rb
@@ -9,7 +9,7 @@ describe "Geocodings API" do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     delete_user_data @user
     host! 'test.localhost.lan'
   end

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -9,7 +9,7 @@ describe "Imports API" do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     delete_user_data @user
     host! 'test.localhost.lan'
   end

--- a/spec/requests/api/json/columns_controller_shared_examples.rb
+++ b/spec/requests/api/json/columns_controller_shared_examples.rb
@@ -10,7 +10,7 @@ shared_examples_for "columns controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end

--- a/spec/requests/api/json/geocodings_controller_shared_examples.rb
+++ b/spec/requests/api/json/geocodings_controller_shared_examples.rb
@@ -12,7 +12,7 @@ shared_examples_for "geocoding controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       delete_user_data @user
       host! 'test.localhost.lan'
       login_as(@user)

--- a/spec/requests/api/json/imports_controller_shared_examples.rb
+++ b/spec/requests/api/json/imports_controller_shared_examples.rb
@@ -11,7 +11,7 @@ shared_examples_for "imports controllers" do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
     delete_user_data @user
     host! 'test.localhost.lan'
   end

--- a/spec/requests/api/json/layer_presenter_shared_examples.rb
+++ b/spec/requests/api/json/layer_presenter_shared_examples.rb
@@ -21,7 +21,7 @@ shared_examples_for "layer presenters" do |tested_klass, model_klass|
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       delete_user_data @user_1
       delete_user_data @user_2
     end

--- a/spec/requests/api/json/layers_controller_shared_examples.rb
+++ b/spec/requests/api/json/layers_controller_shared_examples.rb
@@ -122,7 +122,7 @@ shared_examples_for "layers controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end

--- a/spec/requests/api/json/maps_controller_shared_examples.rb
+++ b/spec/requests/api/json/maps_controller_shared_examples.rb
@@ -15,7 +15,7 @@ shared_examples_for "maps controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end

--- a/spec/requests/api/json/overlays_controller_shared_examples.rb
+++ b/spec/requests/api/json/overlays_controller_shared_examples.rb
@@ -16,7 +16,7 @@ shared_examples_for "overlays controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end

--- a/spec/requests/api/json/records_controller_shared_examples.rb
+++ b/spec/requests/api/json/records_controller_shared_examples.rb
@@ -16,7 +16,7 @@ shared_examples_for "records controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end

--- a/spec/requests/api/json/tables_controller_shared_examples.rb
+++ b/spec/requests/api/json/tables_controller_shared_examples.rb
@@ -11,6 +11,7 @@ shared_examples_for "tables controllers" do
     end
 
     before(:each) do
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
       delete_user_data @user
     end
 

--- a/spec/requests/api/json/visualizations_controller_shared_examples.rb
+++ b/spec/requests/api/json/visualizations_controller_shared_examples.rb
@@ -79,6 +79,8 @@ shared_examples_for "visualization controllers" do
     include_context 'users helper'
 
     before(:each) do
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+
       login(@user1)
       @headers = {'CONTENT_TYPE'  => 'application/json'}
       host! "#{@user1.subdomain}.localhost.lan"
@@ -144,6 +146,8 @@ shared_examples_for "visualization controllers" do
     end
 
     before(:each) do
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      
       CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
       @db = Rails::Sequel.connection
       Sequel.extension(:pagination)
@@ -170,7 +174,6 @@ shared_examples_for "visualization controllers" do
 
     it 'tests exclude_shared and only_shared filters' do
       CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
       user_1 = create_user(
         username: "test#{rand(9999)}-1",

--- a/spec/requests/api/json/visualizations_controller_shared_examples.rb
+++ b/spec/requests/api/json/visualizations_controller_shared_examples.rb
@@ -170,7 +170,7 @@ shared_examples_for "visualization controllers" do
 
     it 'tests exclude_shared and only_shared filters' do
       CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
       user_1 = create_user(
         username: "test#{rand(9999)}-1",
@@ -392,7 +392,7 @@ shared_examples_for "visualization controllers" do
 
       it 'tests like endpoints' do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
         user_2 = create_user(
             username: "test#{rand(9999)}-2",
@@ -463,7 +463,7 @@ shared_examples_for "visualization controllers" do
 
       it 'tests totals calculations' do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
         user_1 = create_user(
             username: "test#{rand(9999)}-1",
@@ -659,7 +659,7 @@ shared_examples_for "visualization controllers" do
 
       it 'tests normal users authenticated and unauthenticated calls' do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
         user_2 = create_user(
           username: 'testindexauth',
@@ -717,7 +717,7 @@ shared_examples_for "visualization controllers" do
 
       it 'tests organization users authenticated and unauthenticated calls' do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
         organization = test_organization.save
 
@@ -789,7 +789,7 @@ shared_examples_for "visualization controllers" do
 
       it 'tests privacy of vizjsons' do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
         user_1 = create_user(
           username: "test#{rand(9999)}-1",
@@ -950,7 +950,7 @@ shared_examples_for "visualization controllers" do
     describe 'GET /api/v1/viz' do
       before(:each) do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
         delete_user_data(@user)
       end
 
@@ -1101,7 +1101,7 @@ shared_examples_for "visualization controllers" do
 
       before(:each) do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
         delete_user_data(@user)
       end
 
@@ -1128,7 +1128,7 @@ shared_examples_for "visualization controllers" do
     describe 'GET /api/v2/viz/:id/viz' do
       before(:each) do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
         delete_user_data(@user)
       end
 
@@ -1154,8 +1154,7 @@ shared_examples_for "visualization controllers" do
       end
 
       it "comes with proper surrogate-key" do
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:create).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
         table                 = table_factory(privacy: 1)
         source_visualization  = table.fetch('table_visualization')
 
@@ -1186,12 +1185,12 @@ shared_examples_for "visualization controllers" do
     describe 'tests visualization listing filters' do
       before(:each) do
         CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
         delete_user_data(@user)
       end
 
       it 'uses locked filter' do
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
         post api_v1_visualizations_create_url(api_key: @api_key), factory(@user, locked: true).to_json, @headers
         vis_1_id = JSON.parse(last_response.body).fetch('id')
@@ -1269,7 +1268,7 @@ shared_examples_for "visualization controllers" do
       it 'returns an empty array if no other user is watching' do
         CartoDB::Visualization::Watcher.any_instance.stubs(:list).returns([])
 
-        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+        CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
         login(@user_1)
         post api_v1_visualizations_create_url(api_key: @user_1.api_key), factory(@user_1, locked: true).to_json, @headers

--- a/spec/requests/api/map_layers_spec.rb
+++ b/spec/requests/api/map_layers_spec.rb
@@ -9,6 +9,8 @@ feature "API 1.0 map layers management" do
   end
 
   before(:each) do
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    
     delete_user_data @user
     host! 'test.localhost.lan'
     @table = create_table(user_id: @user.id)

--- a/spec/requests/api/user_layers_spec.rb
+++ b/spec/requests/api/user_layers_spec.rb
@@ -9,7 +9,8 @@ feature "API 1.0 user layers management" do
   end
 
   before(:each) do
-    CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    
     delete_user_data @user
     host! 'test.localhost.lan'
     @table = create_table(:user_id => @user.id)

--- a/spec/requests/api/visualizations_spec.rb
+++ b/spec/requests/api/visualizations_spec.rb
@@ -421,7 +421,7 @@ describe Api::Json::VisualizationsController do
   describe '#slides_sorting' do
     it 'checks proper working of prev/next' do
       CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
       map_id = ::Map.create(user_id: @user.id).id
 
@@ -582,7 +582,7 @@ describe Api::Json::VisualizationsController do
   describe '#source_visualization_id_and_hierarchy' do
     it 'checks proper working of parent_id' do
       CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get).returns(nil)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
       map_id = ::Map.create(user_id: @user.id).id
 


### PR DESCRIPTION
Relates to first two points of #3879

Rake to execute: 
`bundle exec rake cartodb:vizs:create_named_maps[true]` (dry run)
`bundle exec rake cartodb:vizs:create_named_maps`

@javisantana CR please