### PR TITLE
handle fail as usual if there's no result fixes #3376

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -173,7 +173,6 @@ class DataImport < Sequel::Model
       self.error_code = 1002
       self.state      = STATE_FAILURE
       save
-      return self
     end
 
     success ? handle_success : handle_failure


### PR DESCRIPTION
@Kartones after [your explanation](https://github.com/CartoDB/cartodb/issues/3376#issuecomment-109294248) I could understand limits and look for where were limits increased and decreased. Then I saw what might be happening: if `results` is empty `handle_failure` is not called thus count is not decreased. What do you think about removing that line? Had it any actual purpose?