### PR TITLE
Reverse order of varnish/redis invalidation #3555

### DIFF
--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -421,8 +421,8 @@ module CartoDB
       end
 
       def invalidate_cache
-        invalidate_varnish_cache
         invalidate_redis_cache
+        invalidate_varnish_cache
         parent.invalidate_cache unless parent_id.nil?
       end
 


### PR DESCRIPTION
That prevents issues when editing a published map with heavy traffic
(re-cache in varnish staled embed/vizjson when still not invalidated in
redis).

@Kartones can you please review?

it does not fix the issue #3555 but it's kind of related and should be fixed anyway.