### PR TITLE
Increases font size and uses the right red color

### DIFF
--- a/app/assets/stylesheets/common/form-content.css.scss
+++ b/app/assets/stylesheets/common/form-content.css.scss
@@ -68,6 +68,9 @@ $sLabel-width: 140px;
   @include nicer-lato-typography();
   color: $cTypography-paragraphs;
 }
+.Form-label.Form-label--large {
+  font-size: $sFontSize-large;
+}
 .Form-rowPreview {
   width: 735px;
 }
@@ -340,6 +343,7 @@ $sLabel-width: 140px;
   color: $cTypography-secondary;
   font-size: $sFontSize-normal;
 }
+
 .Form-fileLabel--error {
   display: none;
   color: $cHighlight-negative;

--- a/app/assets/stylesheets/common/forms/radiobutton.css.scss
+++ b/app/assets/stylesheets/common/forms/radiobutton.css.scss
@@ -47,6 +47,15 @@
 .RadioButton.is-checked .RadioButton-label {
   color: $cTypography-linkSelected;
 }
+.RadioButton.is-alert .RadioButton-label {
+  color: $cHighlight-alert3;
+}
+.RadioButton.is-alert .RadioButton-input {
+  border-color: $cHighlight-alert3;
+  &:before {
+    background: $cHighlight-alert3;
+  }
+}
 .RadioButton.is-warning .RadioButton-label {
   color: $cHighlight-alert;
 }

--- a/app/assets/stylesheets/variables/colors.css.scss
+++ b/app/assets/stylesheets/variables/colors.css.scss
@@ -26,6 +26,7 @@ $cHighlight-positive:  rgba(#8FB83F, 1);
 $cHighlight-negative:  rgba(#C74B43, 1);
 $cHighlight-alert:     rgba(#C67B44, 1);
 $cHighlight-alert2:    rgba(orange, 1);
+$cHighlight-alert3:    rgba(#EA703D, 1);
 
 // Icons
 $cIcons-default: rgba(#CCC, 1);

--- a/lib/assets/javascripts/cartodb/common/dialogs/map/sync/interval_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/sync/interval_template.jst.ejs
@@ -1,4 +1,4 @@
-<div class="RadioButton js-interval<%= checked ? ' is-checked' : '' %><%= interval === 0 ? ' is-warning' : '' %>">
+<div class="RadioButton js-interval<%= checked ? ' is-checked' : '' %><%= interval === 0 ? ' is-alert' : '' %>">
   <button class="RadioButton-input js-input<%= checked ? ' is-checked' : '' %>"></button>
   <label class="RadioButton-label"><%- name %></label>
 </div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/map/sync_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/sync_view_template.jst.ejs
@@ -8,7 +8,7 @@
 <div class="Dialog-body Dialog-body--small">
   <div class="Form-row">
     <div class="Form-rowLabel Form-rowLabel--leftAligned">
-      <label class="Form-label">Sync my data</label>
+      <label class="Form-label Form-label--large">Sync my data</label>
     </div>
     <div class="Form-rowData Form-rowData--noMargin Form-rowData--full">
       <ul class="DatasetSelected-syncOptionsList SyncDialogDatasetSelected-syncOptionsList js-intervals"></ul>


### PR DESCRIPTION
This PR fixes the size of the label (to 15px) and updates the red color of the radio button.

I defined a new red color, called $cHighlight-alert3 (I'm not sure if this is the way to go, or if we should use a different name, but since we had a $cHighlight-alert2 I went for this solution)

![screen shot 2015-06-08 at 10 25 14](https://cloud.githubusercontent.com/assets/4933/8030679/190f1596-0dc9-11e5-8644-c7c1a2ba04e4.png)
