### PR TITLE
Fixing bug showing flash thing over the whole header

### DIFF
--- a/lib/assets/javascripts/cartodb/keys/entry.js
+++ b/lib/assets/javascripts/cartodb/keys/entry.js
@@ -69,7 +69,7 @@ $(function() {
     $('.js-copy-value').each(function() {
       // Copy
       if (!$.browser.mozilla && !($.browser.msie && $.browser.version<9)) {
-        $('.Header').zclip({
+        $(this).zclip({
           path: cdb.config.get('assets_url') + "/flash/ZeroClipboard.swf",
           copy: function(){
             return $(this).parent().find(".js-input").val();


### PR DESCRIPTION
@matallo, we were adding flash content over the header :S instead of the "this" target as we used to have.

https://github.com/CartoDB/cartodb/pull/3908/files#diff-f4a94ab1bbf8dc3927348cd3f9b62d9aL71

![screen_shot_2015-06-08_at_19 56 42_1024](https://cloud.githubusercontent.com/assets/132146/8047897/08ecaf98-0e19-11e5-8d84-a0ed0117ae97.png)