### PR TITLE
Adds type checking for torque symbolizers

### DIFF
--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -800,6 +800,21 @@ cdb.admin.CartoParser.prototype = {
                   index: r.index
               });
           }
+          else{
+            var type = symbolizers[r.name].type;
+            var element = r.value.value[0].value[0];
+            if(!(function(e){
+              if (type === "number" || type === "float") return typeof e.value === "number";
+              else if (type === "string") return typeof e.value === "string";
+              else if (type === "color") return typeof e.rgb !== "undefined";
+              else return true;
+            })(element)){
+              parse_env.error({
+                  message: 'Expected type ' + type + '.' ,
+                  index: r.index
+              });
+            }
+          }
         });
       }
       var defs = carto.inheritDefinitions(defs, parse_env);

--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -806,7 +806,11 @@ cdb.admin.CartoParser.prototype = {
             if(!(function(e){
               if (type === "number" || type === "float") return typeof e.value === "number";
               else if (type === "string") return typeof e.value === "string";
-              else if (type === "color") return typeof e.rgb !== "undefined";
+              else if (type === "color"){
+                return typeof e.rgb !== "undefined" || 
+                  (e.name === "rgb" || e.name === "hsl" && e.args.length === 3) ||
+                  (e.name === "rgba" || e.name === "hsla" && e.args.length === 4);
+              } 
               else return true;
             })(element)){
               parse_env.error({

--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -812,7 +812,7 @@ cdb.admin.CartoParser.prototype = {
                   (e.name === "rgba" || e.name === "hsla" && e.args.length === 4);
               } 
               else if (type.constructor === Array){
-                return type.indexOf(element.value) > -1;
+                return type.indexOf(element.value) > -1 || element.value === "linear";
               }
               else return true;
             })(element)){

--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -811,6 +811,9 @@ cdb.admin.CartoParser.prototype = {
                   (e.name === "rgb" || e.name === "hsl" && e.args.length === 3) ||
                   (e.name === "rgba" || e.name === "hsla" && e.args.length === 4);
               } 
+              else if (type.constructor === Array){
+                return type.indexOf(element.value) > -1;
+              }
               else return true;
             })(element)){
               parse_env.error({

--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -757,7 +757,7 @@ cdb.admin.CartoParser.prototype = {
   RESERVED_VARIABLES: ['mapnik-geometry-type', 'points_density', 'points_count', 'src', 'value'], // value due to torque
 
   parse: function(cartocss) {
-
+    var self = this;
     var parse_env = this.parse_env = {
       validation_data: false,
       frames: [],
@@ -803,19 +803,7 @@ cdb.admin.CartoParser.prototype = {
           else{
             var type = symbolizers[r.name].type;
             var element = r.value.value[0].value[0];
-            if(!(function(e){
-              if (type === "number" || type === "float") return typeof e.value === "number";
-              else if (type === "string") return typeof e.value === "string";
-              else if (type === "color"){
-                return typeof e.rgb !== "undefined" || 
-                  (e.name === "rgb" || e.name === "hsl" && e.args.length === 3) ||
-                  (e.name === "rgba" || e.name === "hsla" && e.args.length === 4);
-              } 
-              else if (type.constructor === Array){
-                return type.indexOf(element.value) > -1 || element.value === "linear";
-              }
-              else return true;
-            })(element)){
+            if(!self._checkValidType(element, type)){
               parse_env.error({
                   message: 'Expected type ' + type + '.' ,
                   index: r.index
@@ -844,6 +832,20 @@ cdb.admin.CartoParser.prototype = {
     }
     this.ruleset = ruleset;
     return this;
+  },
+
+  _checkValidType: function(e, type){
+    if (type === "number" || type === "float") return typeof e.value === "number";
+    else if (type === "string") return typeof e.value === "string";
+    else if (type === "color"){
+      return typeof e.rgb !== "undefined" || 
+        (e.name === "rgb" || e.name === "hsl" && e.args.length === 3) ||
+        (e.name === "rgba" || e.name === "hsla" && e.args.length === 4);
+    } 
+    else if (type.constructor === Array){
+      return type.indexOf(e.value) > -1 || e.value === "linear";
+    }
+    else return true;
   },
 
   /**

--- a/lib/assets/javascripts/cartodb/table/menu_modules/carto_editor.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/carto_editor.js
@@ -433,7 +433,8 @@ cdb.admin.mod.CartoCSSEditor = cdb.admin.Module.extend({
     var style = this.codeEditor.getValue();
     var cartoParser = new cdb.admin.CartoParser(style);
     if(cartoParser.errors().length) {
-      this._showError(this._parseError(cartoParser.errors()));
+      var errors = this._parseError(cartoParser.errors());
+      if(errors) this._showError(errors);
     } else {
       // check variables used
       var err = this.checkVariables(cartoParser.variablesUsed());

--- a/lib/assets/test/spec/cartodb/table/menu_modules/carto.spec.js
+++ b/lib/assets/test/spec/cartodb/table/menu_modules/carto.spec.js
@@ -94,6 +94,22 @@ describe('mod.carto', function() {
       });
     });
 
+    it ("should throw type errors in torque symbolizer", function() {
+      cartoMod.render();
+      spyOn(cartoMod, '_parseError');
+      layer.set({tile_style: ['Map {',
+                    '-torque-frame-count:"512";',
+                    '-torque-animation-duration:"10";',
+                    '-torque-time-attribute: 23;',
+                    '-torque-aggregation-function:count(cartodb_id);',
+                    '-torque-resolution:"2";',
+                    '-torque-data-aggregation: manolo;',
+                    '}'].join("\n")});
+      cartoMod.applyStyle();
+      expect(cartoMod._parseError.calls.argsFor(0)[0].length).toEqual(6);
+
+    });
+
   });
 
 });


### PR DESCRIPTION
Fixes #3970, also related to https://github.com/CartoDB/Windshaft/issues/150

Prevents the editor from sending torque-specific rules with the wrong type. E.g.:

![type](https://cloud.githubusercontent.com/assets/3707222/8105347/c70e9ca4-1038-11e5-8f90-5f034312d696.gif)

@javisantana 