### PR TITLE
Launches the modal when adding geometries from the layer pane

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view.js
@@ -11,6 +11,10 @@ module.exports = BaseDialog.extend({
     "click .js-skip"   : "_onSkipClick"
   }),
 
+  options: {
+    skipDisabled: false
+  },
+
   initialize: function() {
     this.elder('initialize');
 
@@ -34,7 +38,7 @@ module.exports = BaseDialog.extend({
   render_content: function() {
     return this._template({
       name: this.table.get("name"),
-      skipDisabled: this.options.skipDisabled || false
+      skipDisabled: this.options.skipDisabled 
     });
   },
 

--- a/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view.js
@@ -6,10 +6,10 @@ var BaseDialog = require('../../views/base_dialog/view');
  */
 module.exports = BaseDialog.extend({
 
-  events: {
+  events: cdb.core.View.extendEvents({
     "click .js-option" : "_onOptionClick",
     "click .js-skip"   : "_onSkipClick"
-  },
+  }),
 
   initialize: function() {
     this.elder('initialize');
@@ -33,7 +33,8 @@ module.exports = BaseDialog.extend({
   // implements cdb.ui.common.Dialog.prototype.render
   render_content: function() {
     return this._template({
-      name: this.table.get("name")
+      name: this.table.get("name"),
+      skipDisabled: this.options.skipDisabled || false
     });
   },
 

--- a/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view_template.jst.ejs
@@ -28,7 +28,13 @@
 </div>
 
 <div class="Dialog-footer Dialog-footer Dialog-footer--simple u-inner">
+  <% if (skipDisabled) { %>
+  <button class="Button Button--secondary close">
+    <span>Close</span>
+  </button>
+  <% } else { %>
   <button class="Button Button--secondary ok js-skip">
     <span>Skip</span>
   </button>
+  <% } %>
 </div>

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -647,36 +647,57 @@
       if (this.table.isGeoreferenced()) {
         this._addGeometry();
       } else {
-        // Add feature dropdown
-        // and removed it if it was created previously
-        this.newGeomDropdown && this.newGeomDropdown.clean();
-        this.newGeomDropdown = new cdb.admin.NewGeometryDropdown({
-          position: 'position',
-          template_base: "table/views/table_new_geom",
-          tick: "bottom",
-          horizontal_position: "right"
+
+        if (this.user.featureEnabled('new_modals')) {
+          this._showScratchDialog();
+        } else {
+
+          // Add feature dropdown
+          // and removed it if it was created previously
+          this.newGeomDropdown && this.newGeomDropdown.clean();
+          this.newGeomDropdown = new cdb.admin.NewGeometryDropdown({
+            position: 'position',
+            template_base: "table/views/table_new_geom",
+            tick: "bottom",
+            horizontal_position: "right"
+          });
+
+          this.newGeomDropdown.bind('onDropdownHidden', function() {
+            cdb.god.unbind(null, null, this.newGeomDropdown);
+            this.newGeomDropdown && this.newGeomDropdown.clean();
+          }, this);
+
+          this.newGeomDropdown.bind('onDropdownShown', function() {
+            cdb.god.unbind("closeDialogs", this.newGeomDropdown.hide, this.newGeomDropdown);
+            cdb.god.trigger("closeDialogs");
+            cdb.god.bind("closeDialogs", this.newGeomDropdown.hide, this.newGeomDropdown);
+          }, this);
+
+          this.newGeomDropdown.bind('newGeometry', function(geomType) {
+            this._addGeometry(geomType);
+          }, this);
+
+          $('body').append(this.newGeomDropdown.render().el);
+
+          var pos = this.tabs.getTab(mod).offset();
+          this.newGeomDropdown.openAt(pos.left - 165, pos.top - 77);
+        }
+      }
+    },
+
+    _showScratchDialog: function() {
+
+        this.scratchDialog = new cdb.editor.ScratchView({
+          table: this.table,
+          skipDisabled: true
         });
 
-        this.newGeomDropdown.bind('onDropdownHidden', function() {
-          cdb.god.unbind(null, null, this.newGeomDropdown);
-          this.newGeomDropdown && this.newGeomDropdown.clean();
+        this.scratchDialog.appendToBody();
+
+        this.scratchDialog.bind("newGeometry", function(type) {
+          this._addGeometry(type);
         }, this);
 
-        this.newGeomDropdown.bind('onDropdownShown', function() {
-          cdb.god.unbind("closeDialogs", this.newGeomDropdown.hide, this.newGeomDropdown);
-          cdb.god.trigger("closeDialogs");
-          cdb.god.bind("closeDialogs", this.newGeomDropdown.hide, this.newGeomDropdown);
-        }, this);
-
-        this.newGeomDropdown.bind('newGeometry', function(geomType) {
-          this._addGeometry(geomType);
-        }, this);
-
-        $('body').append(this.newGeomDropdown.render().el);
-
-        var pos = this.tabs.getTab(mod).offset();
-        this.newGeomDropdown.openAt(pos.left - 165, pos.top - 77);
-      }
     },
 
     _addGeometry: function(type) {
@@ -684,7 +705,6 @@
       type = type || this.table.geomColumnTypes()[0];
       this.dataLayer.trigger("startEdition", type);
     },
-
 
     /* Module functions */
 

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -663,7 +663,6 @@ cdb.admin.MapTab = cdb.core.View.extend({
           table: this.options.table
         });
 
-        this.addView(this.scratchDialog);
         this.scratchDialog.appendToBody();
 
         this.scratchDialog.bind("newGeometry", function(type) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.13.22",
+  "version": "3.13.23",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR allows to use the Scratch modal to add geometries from the layer pane addFeature button. It also fixes a bug that prevented using the close button in that modal.

![add](https://cloud.githubusercontent.com/assets/4933/8107007/71d58f46-1046-11e5-95d2-10bc57823801.gif)