### PR TITLE
adding saveLayerFinished callback when layers are saved

### DIFF
--- a/lib/assets/javascripts/cartodb/models/map.js
+++ b/lib/assets/javascripts/cartodb/models/map.js
@@ -683,6 +683,7 @@ cdb.admin.Map = cdb.geo.Map.extend({
         self.layers.saveLayers({
           success: function() {
             done && done();
+            self.trigger('savingLayersFinish');
           },
           error: function() {
             cdb.log.error("error saving layer order");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.13.24",
+  "version": "3.13.25",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@xavijam the change you did related to save layers in a sequencial way changed also the number of times ``done`` is called. 

Before your change done was being called as many times as layers and now it's only called once.

Basemaps dialog needs saveLayersFinished in order to enable layers buttons so once you changed the basemaps you couldn't change it again

I'm merging this since this is a hotfix. This needs to be removed and change saveLayers to match the previous behavior.

cc @saleiva 