### PR TITLE
Privacy modal improvements

### DIFF
--- a/app/assets/stylesheets/common/change-privacy.css.scss
+++ b/app/assets/stylesheets/common/change-privacy.css.scss
@@ -39,8 +39,11 @@
   margin-right: $sMargin-element;
 }
 .ChangePrivacy-passwordInput {
-  width: 200px;
-  margin-right: 120px;
+  position: absolute;
+  left: 9px;
+  bottom: 9px;
+  width: 172px;
+  outline:none;
 }
 .Dialog-body.ChangePrivacy-ShareDialog-body {
   padding-top: 0px;

--- a/app/assets/stylesheets/common/option-card.css.scss
+++ b/app/assets/stylesheets/common/option-card.css.scss
@@ -35,6 +35,7 @@
   background-color: $cStructure-mainBkg;
 }
 .OptionCard--privacy {
+  position:relative;
   max-width: 230px; // set a max-width to appear nicer for dataset privacy dialog
 }
 .OptionCard--onlyIcons {

--- a/app/assets/stylesheets/common/option-card.css.scss
+++ b/app/assets/stylesheets/common/option-card.css.scss
@@ -37,7 +37,15 @@
 .OptionCard--privacy {
   position:relative;
   max-width: 230px; // set a max-width to appear nicer for dataset privacy dialog
+  padding: 33px 33px 27px 33px;
 }
+.OptionCard--privacy .OptionCard-title {
+  margin-bottom: 0;
+}
+.OptionCard--privacy .OptionCard-desc {
+  margin-bottom: 0;
+}
+
 .OptionCard--onlyIcons {
   // Arbitrary size really, but gives a "square" like look where used (only export modal for now).
   // If need to use the same style but with other amount of items we need to rethink this…

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/options_collection.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/options_collection.js
@@ -23,7 +23,7 @@ var ALL_OPTIONS = [{
   privacy: 'PASSWORD',
   illustrationType: 'alert',
   iconFontType: 'Unlock--withEllipsis',
-  title: 'Password protect',
+  title: 'Password protected',
   desc: 'Only the people with the password can view it'
 }, {
   privacy: 'PRIVATE',

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/password_option_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/password_option_model.js
@@ -13,9 +13,9 @@ var PasswordOptionModel = OptionModel.extend({
 
     // Initially a default fake password is set, but if option is selected (like switching option) it's reset
     this.set('password', PasswordOptionModel.DEFAULT_FAKE_PASSWORD);
-    this.bind('change:selected', function() {
-      this.set('password', '');
-    }, this);
+    //this.bind('change:selected', function() {
+      //this.set('password', '');
+    //}, this);
   },
 
   /**

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/password_option_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/password_option_model.js
@@ -13,9 +13,6 @@ var PasswordOptionModel = OptionModel.extend({
 
     // Initially a default fake password is set, but if option is selected (like switching option) it's reset
     this.set('password', PasswordOptionModel.DEFAULT_FAKE_PASSWORD);
-    //this.bind('change:selected', function() {
-      //this.set('password', '');
-    //}, this);
   },
 
   /**

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start.jst.ejs
@@ -15,7 +15,11 @@
         <i class="iconFont iconFont-<%= m.get('iconFontType') %>"></i>
       </div>
       <div class="OptionCard-title"><%= m.get('title') %></div>
+      <% if (m.get('privacy') == 'PASSWORD') { %>
+        <input class="js-password-input Input ChangePrivacy-passwordInput" placeholder="Type your password here" value="<%= pwdOption.get('password') %>" type="password" />
+      <% } else { %>
       <div class="OptionCard-desc"><%= m.get('desc') %></div>
+      <% } %>
     </div>
   <% }); %>
 </div>
@@ -86,9 +90,6 @@
 <% } %>
 
 <div class="Dialog-footer Dialog-footer--simple u-inner ChangePrivacy-startFooter">
-  <% if (showPasswordInput) { %>
-    <input class="js-password-input Input ChangePrivacy-passwordInput" placeholder="Type your password here" value="<%= pwdOption.get('password') %>" type="password" />
-  <% } %>
   <button class="Button Button--secondary Dialog-footerBtn cancel">
     <span>cancel</span>
   </button>

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start.jst.ejs
@@ -16,7 +16,7 @@
       </div>
       <div class="OptionCard-title"><%= m.get('title') %></div>
       <% if (m.get('privacy') == 'PASSWORD') { %>
-        <input class="js-password-input Input ChangePrivacy-passwordInput" placeholder="Type your password here" value="<%= pwdOption.get('password') %>" type="password" />
+        <input class="js-password-input Input ChangePrivacy-passwordInput" placeholder="Type your password here" value="<%= password %>" type="password" />
       <% } else { %>
       <div class="OptionCard-desc"><%= m.get('desc') %></div>
       <% } %>

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start_view.js
@@ -28,6 +28,7 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function() {
+
     var pwdOption = this.options.privacyOptions.passwordOption();
     var selectedOption = this.options.privacyOptions.selectedOption();
     var upgradeUrl = cdb.config.get('upgrade_url');
@@ -37,7 +38,6 @@ module.exports = cdb.core.View.extend({
       this.template({
         vis: this.options.vis,
         privacyOptions: this.options.privacyOptions,
-        showPasswordInput: pwdOption === selectedOption,
         pwdOption: pwdOption,
         saveBtnClassNames: selectedOption.canSave() ? '' : DISABLED_SAVE_CLASS_NAME,
         showUpgradeBanner: upgradeUrl && this.options.privacyOptions.any(function(o) { return !!o.get('disabled'); }),
@@ -68,6 +68,11 @@ module.exports = cdb.core.View.extend({
     if (!option.get('disabled')) {
       option.set('selected', true);
     }
+
+    if (option.get("privacy") === "PASSWORD") {
+      $(".js-password-input").focus();
+    }
+
   },
 
   _updatePassword: function(ev) {

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start_view.js
@@ -70,7 +70,7 @@ module.exports = cdb.core.View.extend({
     }
 
     if (option.get("privacy") === "PASSWORD") {
-      $(".js-password-input").focus();
+      this.$(".js-password-input").focus();
     }
 
   },

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start_view.js
@@ -29,7 +29,9 @@ module.exports = cdb.core.View.extend({
 
   render: function() {
 
-    var pwdOption = this.options.privacyOptions.passwordOption();
+    this.pwdOption = this.options.privacyOptions.passwordOption();
+    password = this.pwdOption.get("password");
+
     var selectedOption = this.options.privacyOptions.selectedOption();
     var upgradeUrl = cdb.config.get('upgrade_url');
     var sharedEntities = this.options.vis.permission.getUsersWithAnyPermission();
@@ -38,7 +40,7 @@ module.exports = cdb.core.View.extend({
       this.template({
         vis: this.options.vis,
         privacyOptions: this.options.privacyOptions,
-        pwdOption: pwdOption,
+        password: password,
         saveBtnClassNames: selectedOption.canSave() ? '' : DISABLED_SAVE_CLASS_NAME,
         showUpgradeBanner: upgradeUrl && this.options.privacyOptions.any(function(o) { return !!o.get('disabled'); }),
         upgradeUrl: upgradeUrl,
@@ -70,7 +72,10 @@ module.exports = cdb.core.View.extend({
     }
 
     if (option.get("privacy") === "PASSWORD") {
-      this.$(".js-password-input").focus();
+      this.$(".js-password-input").val("").focus();;
+      this._updateOkButtonStatus("");
+    } else {
+      this.$(".js-password-input").val(this.pwdOption.get("password"));
     }
 
   },
@@ -79,6 +84,10 @@ module.exports = cdb.core.View.extend({
     // Reflect state directly in DOM instead of re-rendering to avoid loosing the focus on input
     var pwd = ev.target.value;
     this.options.privacyOptions.passwordOption().set({ password: pwd }, { silent: true });
+    this._updateOkButtonStatus(pwd);
+  },
+
+  _updateOkButtonStatus: function(pwd) {
     this.$('.ok')[ _.isEmpty(pwd) ? 'addClass' : 'removeClass' ](DISABLED_SAVE_CLASS_NAME);
   },
 

--- a/lib/assets/test/spec/cartodb/common/dialogs/change_privacy/password_option_model.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/change_privacy/password_option_model.spec.js
@@ -20,17 +20,6 @@ describe('common/dialogs/change_privacy/password_option_model', function() {
     expect(this.model.get('password')).toEqual(PasswordPrivacyOption.DEFAULT_FAKE_PASSWORD);
   });
 
-  describe('when selected', function() {
-    beforeEach(function() {
-      this.model = new PasswordPrivacyOption();
-      this.model.set('selected', true);
-    });
-
-    it('should reset the password (so the placeholder in the UI is displayed)', function() {
-      expect(this.model.get('password')).toEqual('');
-    });
-  });
-
   describe('.canSave' , function() {
     describe('given option is enabled and has a password string set', function() {
       beforeEach(function() {

--- a/lib/assets/test/spec/cartodb/common/dialogs/change_privacy/start_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/change_privacy/start_view.spec.js
@@ -51,8 +51,8 @@ describe('common/dialogs/change_privacy/start_view', function() {
     expect(this.innerHTML()).not.toContain('upgrade');
   });
 
-  it('should not render the password input', function() {
-    expect(this.innerHTML()).not.toContain('<input');
+  it('should render the password input', function() {
+    expect(this.innerHTML()).toContain('<input');
   });
 
   it('should not disable the save button', function() {


### PR DESCRIPTION
This PR updates the privacy modal putting the password field inside of the card.

![password](https://cloud.githubusercontent.com/assets/4933/8158077/0ab4088a-135a-11e5-88fd-9c1bfe63b830.gif)

I've removed the code that emptied the password when the card was selected. Currently the input field is shown all the time and it would look weird that checking and unchecked the password card would clear it.

Original ticket: https://github.com/CartoDB/cartodb/issues/3753