### PR TITLE
Added properly units to rows count in public datasets view

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -34,7 +34,7 @@ class Admin::PagesController < ApplicationController
 
   def sitemap
     username = CartoDB.extract_subdomain(request)
-    viewed_user = User.where(username: username.strip.downcase).first
+    viewed_user = User.where(user1name: username.strip.downcase).first
 
     if viewed_user.nil?
       org = get_organization_if_exists(username)
@@ -258,7 +258,7 @@ class Admin::PagesController < ApplicationController
       updated_at:  vis.updated_at,
       owner:       vis.user,
       likes_count: vis.likes.count,
-      map_zoom:    1 #vis.map.zoom
+      map_zoom:    vis.map.zoom
     }
   end
 

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -258,7 +258,7 @@ class Admin::PagesController < ApplicationController
       updated_at:  vis.updated_at,
       owner:       vis.user,
       likes_count: vis.likes.count,
-      map_zoom:    vis.map.zoom
+      map_zoom:    1 #vis.map.zoom
     }
   end
 

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -34,7 +34,7 @@ class Admin::PagesController < ApplicationController
 
   def sitemap
     username = CartoDB.extract_subdomain(request)
-    viewed_user = User.where(user1name: username.strip.downcase).first
+    viewed_user = User.where(username: username.strip.downcase).first
 
     if viewed_user.nil?
       org = get_organization_if_exists(username)

--- a/app/views/admin/pages/public_datasets.html.erb
+++ b/app/views/admin/pages/public_datasets.html.erb
@@ -20,10 +20,17 @@
             <div class="DatasetsList-itemSecondaryInfo">
               <div class="DatasetsList-itemMeta">
                 <%= render 'admin/pages/shared/like_button', vis: vis %>
-                <div class="RowsIndicator">
-                  <i class="iconFont iconFont-Rows RowsIndicator-icon"></i>
-                  <%= pluralize(vis[:rows_count], 'row') %>
-                </div>
+                <% if vis[:rows_count] %>
+                  <div class="RowsIndicator">
+                    <i class="iconFont iconFont-Rows RowsIndicator-icon"></i>
+                    <% if vis[:rows_count] < 10000 %>
+                      <%= number_with_delimiter(vis[:rows_count]) %>
+                    <% else %>
+                      <%= number_to_human(vis[:rows_count], units: { unit:"", thousand: "K", million: "M" }, precision: 2, format: '%n%u') %>
+                    <% end %>
+                    <%= 'row'.pluralize(vis[:rows_count]) %>
+                  </div>
+                <% end %>
                 <div class="SizeIndicator">
                   <i class="iconFont iconFont-Floppy SizeIndicator-icon"></i>
                   <%= number_to_human_size(vis[:size_in_bytes]) %>

--- a/app/views/admin/pages/public_datasets.html.erb
+++ b/app/views/admin/pages/public_datasets.html.erb
@@ -20,7 +20,7 @@
             <div class="DatasetsList-itemSecondaryInfo">
               <div class="DatasetsList-itemMeta">
                 <%= render 'admin/pages/shared/like_button', vis: vis %>
-                <% if vis[:rows_count] %>
+                <% if !vis[:rows_count].blank? %>
                   <div class="RowsIndicator">
                     <i class="iconFont iconFont-Rows RowsIndicator-icon"></i>
                     <% if vis[:rows_count] < 10000 %>


### PR DESCRIPTION
Rows count with thousand delimiters + humanize format, like:

5,000 rows
180.32K
2.65M

cc @iriberri.

Fixes #4037.