### PR TITLE
Redirect to dashboard when an org user requests / closes #1141

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -189,7 +189,11 @@ class ApplicationController < ActionController::Base
     rewrite_url = !request.params[:dont_rewrite].present?
     if rewrite_url && !current_user.nil? && !current_user.organization.nil? &&
         CartoDB.subdomain_from_request(request) == current_user.username
-      redirect_to CartoDB.base_url(current_user.organization.name, current_user.username) << request.fullpath
+      if request.fullpath == '/'
+        redirect_to CartoDB.url(self, 'dashboard')
+      else
+        redirect_to CartoDB.base_url(current_user.organization.name, current_user.username) << request.fullpath
+      end
     end
   end
 


### PR DESCRIPTION
This closes CartoDB/website#1141, "Going to username.cartodb.com should go to your dashboard if it's your URL" for public reference. @rafatower, CR this, please.