### PR TITLE
Centers icons in the scratch modal (for Firefox)

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view.js
@@ -51,7 +51,7 @@ module.exports = BaseDialog.extend({
   _onOptionClick: function(e) {
     this.killEvent(e);
     this.close();
-    this.trigger("newGeometry", $(e.target).closest('button').data("type"));
+    this.trigger("newGeometry", $(e.target).closest('.js-option').data("type"));
   }
 
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/scratch_view_template.jst.ejs
@@ -9,21 +9,21 @@
 
 <div class="Dialog-body u-inner OptionCards">
   <div class="Dialog-Stretcher Dialog-Stretcher--small">
-    <button class="OptionCard js-option" data-type="point">
+    <div class="OptionCard js-option" data-type="point">
       <div class="OptionCard-icon IllustrationIcon IllustrationIcon--geometryPoint"></div>
       <div class="OptionCard-title">Add points</div>
       <div class="OptionCard-desc">Specially i f you are thinking on POI's and concreet places</div>
-    </button>
-    <button class="OptionCard js-option" data-type="line">
+    </div>
+    <div class="OptionCard js-option" data-type="line">
       <div class="OptionCard-icon IllustrationIcon IllustrationIcon--geometryLine"></div>
       <div class="OptionCard-title">Add lines</div>
       <div class="OptionCard-desc">Perfect for roads, rivers or tracks</div>
-    </button>
-    <button class="OptionCard js-option" data-type="polygon">
+    </div>
+    <div class="OptionCard js-option" data-type="polygon">
       <div class="OptionCard-icon IllustrationIcon IllustrationIcon--geometryPolygon"></div>
       <div class="OptionCard-title">Add polygons</div>
       <div class="OptionCard-desc">Perfect for roads, rivers or tracks</div>
-    </button>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
This PR replaces the <button> tags with divs (like the rest of the new modals) because the flex properties doesn't work on them (at least on Firefox).

Original issue: #4077 