### PR TITLE
Fixing JS error in upload_model

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/map/image_picker/upload_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/image_picker/upload_model.js
@@ -11,7 +11,7 @@ var _ = require('underscore');
  */
 module.exports = Backbone.Model.extend({
 
-  url: function(model) {
+  url: function(method) {
     var version = cdb.config.urlVersion('asset', method);
     return '/api/' + version + '/users/' + this.userId + '/assets'
   },


### PR DESCRIPTION
Basically it fixes #4079.
REVIEWER: @javierarce 

Problem introduced with the backend refactor: https://github.com/CartoDB/cartodb/blame/master/lib/assets/javascripts/cartodb/common/dialogs/map/image_picker/upload_model.js#L15
cc @CartoDB/backend 