### PR TITLE
Fixes privacy modal not opening for tables

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/start_view.js
@@ -29,8 +29,10 @@ module.exports = cdb.core.View.extend({
 
   render: function() {
 
-    this.pwdOption = this.options.privacyOptions.passwordOption();
-    password = this.pwdOption.get("password");
+    if (this.options.privacyOptions && this.options.privacyOptions.passwordOption()) {
+      this.pwdOption = this.options.privacyOptions.passwordOption();
+      var password = this.pwdOption.get("password");
+    }
 
     var selectedOption = this.options.privacyOptions.selectedOption();
     var upgradeUrl = cdb.config.get('upgrade_url');
@@ -74,7 +76,7 @@ module.exports = cdb.core.View.extend({
     if (option.get("privacy") === "PASSWORD") {
       this.$(".js-password-input").val("").focus();;
       this._updateOkButtonStatus("");
-    } else {
+    } else if (this.pwdOption){
       this.$(".js-password-input").val(this.pwdOption.get("password"));
     }
 


### PR DESCRIPTION
This PR fixes an error that prevented opening the privacy modal for the datasets.