### PR TITLE
Edit feature metadata fixes

### DIFF
--- a/app/assets/stylesheets/editor/edit_field.css.scss
+++ b/app/assets/stylesheets/editor/edit_field.css.scss
@@ -124,11 +124,11 @@
 }
 
 // @include edit-type-field(date, #F5A623, true);
-// @include edit-type-field(number, #4DC964, true);
 // @include edit-type-field(string, #AAA, true);
 // @include edit-type-field(boolean, #AAA, true);
 
 @include edit-type-field('', #999, true);
+@include edit-type-field(EditField-select--number, #4DC964, false);
 @include edit-type-field(has-failed, $cHighlight-negative, false);
 
 .EditField-info {

--- a/app/assets/stylesheets/editor/edit_field.css.scss
+++ b/app/assets/stylesheets/editor/edit_field.css.scss
@@ -33,7 +33,7 @@
   border: none;
   outline: none;
   height: 100%;
-  width: 100%;
+  width: 120px;
   margin-top: 10px;
   overflow: hidden;
   text-align: right;

--- a/lib/assets/javascripts/cartodb/common/dialogs/feature_data/add_column/add_column_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/feature_data/add_column/add_column_view.js
@@ -40,19 +40,12 @@ module.exports = cdb.core.View.extend({
     // Loading
     this.model.set('state', 'loading');
 
-    // we could use table.addColumn method
-    // but we need to have more info when
-    // request fails
-    var c = new cdb.admin.Column({
-      table: this.table,
-      _name: new Date().getTime(),
-      type: 'string'
-    }).save(null, {
-      success: function(r) {
-        self.trigger('newColumn', r, this);
+    this.table.addColumn('column_' + new Date().getTime(), 'string', {
+      success: function(mdl, data) {
+        self.trigger('newColumn', mdl, this);
         self.model.set('state', 'idle');
       },
-      error: function(e, resp) {
+      error: function() {
         self.model.set('state', 'error');
       }
     });

--- a/lib/assets/javascripts/cartodb/common/dialogs/feature_data/feature_data_dialog.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/feature_data/feature_data_dialog.jst.ejs
@@ -16,7 +16,7 @@
     <form class="Form FeatureData-formContent js-form">
       <div class="Dialog-stickyFooter">
         <div class="Dialog-footer FeatureData-formFooter">
-          <button class="Button Button--secondary Button--inline cancel">
+          <button type="button" class="Button Button--secondary Button--inline cancel">
             <span>cancel</span>
           </button>
           <button type="submit" class="Button Button--positive Button--inline js-submit">

--- a/lib/assets/javascripts/cartodb/common/dialogs/feature_data/feature_data_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/feature_data/feature_data_dialog_view.js
@@ -110,7 +110,7 @@ module.exports = BaseDialog.extend({
     // Unset columns already not present in the
     // new form data
     _.each(this.row.attributes, function(val, key) {
-      if (newData[key] === undefined) {
+      if (newData[key] === undefined && !cdb.admin.Row.isReservedColumn(key) && key !== "id") {
         self.row.unset(key) 
       }
       oldData[key] = val;

--- a/lib/assets/javascripts/cartodb/common/dialogs/feature_data/feature_data_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/feature_data/feature_data_dialog_view.js
@@ -190,7 +190,6 @@ module.exports = BaseDialog.extend({
   },
 
   _cancel: function() {
-    this.options.onDone && this.options.onDone();
     this.elder('_cancel');
   }
 

--- a/lib/assets/javascripts/cartodb/common/dialogs/feature_data/form_field/form_field_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/feature_data/form_field/form_field_view.js
@@ -85,13 +85,18 @@ module.exports = cdb.core.View.extend({
     this.addView(fieldTooltip);
 
     // Column type combo
+    // Current value has to be available in the extra array,
+    // if not select will place first item as value
+    var types = [this.fieldModel.get('type')].concat(_.filter(['string', 'boolean', 'number', 'date'], function(type){
+      return self.table.isTypeChangeAllowed(self.fieldModel.get('attribute'), type)
+    }));
     var combo = new cdb.forms.Combo({
       el: this.$('.js-fieldType'),
       model: this.fieldModel,
       property: 'type',
       disabled: this.fieldModel.get('readOnly'),
       width: '85px',
-      extra: ['string', 'boolean', 'number', 'date']
+      extra: types
     });
 
     this.$(".js-fieldType").append(combo.render());

--- a/lib/assets/javascripts/cartodb/common/dialogs/feature_data/form_field/form_field_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/feature_data/form_field/form_field_view.js
@@ -31,7 +31,7 @@ module.exports = cdb.core.View.extend({
       typeError: '',
       fieldError: ''
     });
-    this.column = this.options.column;
+    this.table = this.options.table;
     this.row = this.options.row;
     this.fieldModel = this.options.fieldModel;
     this.template = cdb.templates.getTemplate('common/dialogs/feature_data/form_field/form_field');
@@ -132,13 +132,7 @@ module.exports = cdb.core.View.extend({
     // Readonly everything
     this.fieldModel.set('readOnly', true);
 
-    // Remove old model "sets"
-    this.column.unset('new_name');
-    this.column.unset('old_value');
-
-    this.column.save({
-      type: this.fieldModel.get('type')
-    },{
+    this.table.changeColumnType(this.fieldModel.get('attribute'), this.fieldModel.get('type'), {
       success: function() {
         // refresh record data after change
         // readOnly to false
@@ -146,7 +140,7 @@ module.exports = cdb.core.View.extend({
           self.fieldModel.set('readOnly', false);
         })
       },
-      error: function(mdl, e) {
+      error: function() {
         // Avoiding silent:true and the event trigger
         // when other attribute is changed
         self.fieldModel.attributes.readOnly = false;
@@ -159,7 +153,7 @@ module.exports = cdb.core.View.extend({
         } catch (e) {}
         self.render();
       }
-    })
+    });
   },
 
   _onInputChange: function(ev) {
@@ -180,11 +174,14 @@ module.exports = cdb.core.View.extend({
         readOnly: true
       });
 
-      this.column.save({
-        old_value: oldVal,
-        new_name: val,
-        type: this.fieldModel.get('type')
-      },{
+      this.table.renameColumn(oldVal, val, {
+        success: function(mdl, data) {
+          self.model.set('columnError', '');
+          self.fieldModel.set({
+            attribute: data.name,
+            readOnly: false
+          });
+        },
         error: function(mdl, err) {
           try {
             var msg = JSON.parse(err.responseText).errors[0];
@@ -192,13 +189,6 @@ module.exports = cdb.core.View.extend({
           } catch (e) {}
           self.fieldModel.set({
             attribute: oldVal,
-            readOnly: false
-          });
-        },
-        success: function(mdl, data) {
-          self.model.set('columnError', '');
-          self.fieldModel.set({
-            attribute: data.name,
             readOnly: false
           });
         }

--- a/lib/assets/javascripts/cartodb/common/dialogs/feature_data/form_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/feature_data/form_view.js
@@ -56,11 +56,7 @@ module.exports = cdb.core.View.extend({
   _renderField: function(mdl) {
     var v = new FormFieldView({
       fieldModel: mdl,
-      column:  new cdb.admin.Column({
-        table: this.table,
-        name: mdl.get('attribute'),
-        type: mdl.get('type')
-      }),
+      table: this.table,
       row: this.row
     });
     this.$('.js-addField').before(v.render().el);
@@ -72,7 +68,7 @@ module.exports = cdb.core.View.extend({
     var newColumn = new AddColumnView({ table: this.table });
     newColumn.bind('newColumn', function(d){
       // add it to the form
-      var mdl = this._generateModel(d.get('name'), d.get('cartodb_type'), null);
+      var mdl = this._generateModel(d.get('_name'), d.get('type'), null);
       this.collection.add(mdl);
       this._renderField(mdl);
     }, this);

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -392,6 +392,19 @@
       });
     },
 
+    isTypeChangeAllowed: function(columnName, newType) {
+      var deactivateMatrix = {
+        'number': ['date'],
+        'boolean': ['date'],
+        'date': ['boolean']
+      };
+      var c = this._getColumn(columnName);
+      var type = c.get('type');
+      var deactivated = deactivateMatrix[type] || [];
+      deactivated = deactivated.concat([type])
+      return !_.contains(deactivated, newType);
+    },
+
     isTypeChangeDestructive: function(columnName, newType) {
       var columnType = this.getColumnType(columnName);
 

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -399,6 +399,9 @@
         'date': ['boolean']
       };
       var c = this._getColumn(columnName);
+      if (!c) {
+        return true;
+      }
       var type = c.get('type');
       var deactivated = deactivateMatrix[type] || [];
       deactivated = deactivated.concat([type])

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -322,7 +322,7 @@
       return;
     },
 
-    addColumn: function(columnName, columnType, callback) {
+    addColumn: function(columnName, columnType, opts) {
       var self = this;
       var c = new cdb.admin.Column({
         table: this,
@@ -331,20 +331,21 @@
       });
       this.notice(self._TEXTS.columnAdding, 'load', 0);
       c.save(null, {
-          success: function() {
+          success: function(mdl, obj) {
             self.notice(self._TEXTS.columnAdded, 'info');
             self.trigger('columnAdd', columnName);
             self.data().fetch();
-            callback && callback();
+            opts && opts.success && opts.success(mdl,obj);
           },
           error: function(e, resp) {
             self.error('error adding column', resp);
+            opts && opts.error && opts.error(e);
           },
           wait: true
       });
     },
 
-    deleteColumn: function(columnName) {
+    deleteColumn: function(columnName, opts) {
       var self = this;
       var c = this._getColumn(columnName);
       if (c !== undefined) {
@@ -354,16 +355,18 @@
               self.trigger('columnDelete', columnName);
               self.notice(self._TEXTS.columnDeleted, 'info');
               self.data().fetch();
+              opts && opts.success && opts.success();
             },
             error: function(e, resp) {
               self.error('error deleting column', resp);
+              opts && opts.error && opts.error();
             },
             wait: true
         });
       }
     },
 
-    renameColumn: function(columnName, newName) {
+    renameColumn: function(columnName, newName, opts) {
       if(columnName == newName) return;
       var self = this;
       var c = this._getColumn(columnName);
@@ -374,14 +377,16 @@
       });
       this.notice('renaming column', 'load', 0);
       c.save(null,  {
-          success: function() {
+          success: function(mdl, data) {
             self.notice('Column has been renamed', 'info');
             self.trigger('columnRename', newName, oldName);
             self.data().fetch();
+            opts && opts.success && opts.success(mdl, data);
           },
           error: function(e, resp) {
             cdb.log.error("can't rename column");
             self.error('error renaming column', resp);
+            opts && opts.error && opts.error(e, resp);
           },
           wait: true
       });
@@ -419,17 +424,18 @@
       return destructiveMatrix[columnType][newType]
     },
 
-    changeColumnType: function(columnName, newType) {
+    changeColumnType: function(columnName, newType, opts) {
       var self = this;
       var c = this._getColumn(columnName);
 
       if(this.getColumnType(columnName) == newType) {
+        opts && opts.success && opts.success();
         return;
       }
-      this.saveNewColumnType(c, newType);
+      this.saveNewColumnType(c, newType, opts);
     },
 
-    saveNewColumnType: function(column, newType) {
+    saveNewColumnType: function(column, newType, opts) {
       var self = this;
       column.set({ type: newType});
       this.notice('Changing column type', 'load', 0);
@@ -438,10 +444,12 @@
             self.notice('Column type has been changed', 'info');
             self.trigger('typeChanged', newType); // to make it testable
             self.data().fetch();
+            opts && opts.success && opts.success();
           },
           error: function(e, resp) {
             self.trigger('typeChangeFailed', newType, e); // to make it testable
             self.error('error changing column type', resp);
+            opts && opts.error && opts.error(e, resp);
           },
           wait: true
       });

--- a/lib/assets/javascripts/cartodb/table/column_type_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/column_type_dropdown.js
@@ -7,11 +7,6 @@ cdb.admin.ColumntypeDropdown = cdb.admin.DropdownMenu.extend({
 
   className: 'dropdown border',
   dialogContainer: 'body',
-  deactivateMatrix: {
-      'number': ['date'],
-      'boolean': ['date'],
-      'date': ['boolean']
-  },
 
   events: {
     'click .string': 'setString',
@@ -31,8 +26,11 @@ cdb.admin.ColumntypeDropdown = cdb.admin.DropdownMenu.extend({
     this.column = column;
     var type = this.table.getColumnType(column);
     this._disableColumn(type);
-    var deactivate = this.deactivateMatrix[type] || [];
-    _(deactivate).each(function(c) { self._disableColumn(c, { keep_disabled: true }); });
+    _(["string", "number", "boolean", "date"]).each(function(c) {
+      if (!self.table.isTypeChangeAllowed(self.column,c)) {
+        self._disableColumn(c, { keep_disabled: true });  
+      }
+    });
   },
 
   // Disable current selected column
@@ -76,34 +74,27 @@ cdb.admin.ColumntypeDropdown = cdb.admin.DropdownMenu.extend({
     }
   },
 
-  //TODO: move to the model
-  _canCast: function(type, newType) {
-    var deactivated = this.deactivateMatrix[type] || [];
-    deactivated = deactivated.concat([type])
-    return !_.contains(deactivated, newType);
-  },
-
   setString: function(e) {
     this.killEvent(e);
-    if (this._canCast(this.table.getColumnType(this.column), 'string'))
+    if (this.table.isTypeChangeAllowed(this.column, 'string'))
       this.setColumnTypeChange('string');
   },
 
   setNumber: function(e) {
     this.killEvent(e);
-    if (this._canCast(this.table.getColumnType(this.column), 'number'))
+    if (this.table.isTypeChangeAllowed(this.column, 'number'))
       this.setColumnTypeChange('number');
   },
 
   setDate: function(e) {
     this.killEvent(e);
-    if (this._canCast(this.table.getColumnType(this.column), 'date'))
+    if (this.table.isTypeChangeAllowed(this.column, 'date'))
       this.setColumnTypeChange('date');
   },
 
   setBool: function(e) {
     this.killEvent(e);
-    if (this._canCast(this.table.getColumnType(this.column), 'boolean'))
+    if (this.table.isTypeChangeAllowed(this.column, 'boolean'))
       this.setColumnTypeChange('boolean');
   }
 

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -1333,7 +1333,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
             user: self.user,
             clean_on_hide: true,
             onDone: function() {
-              self.table.data().fetch();
+              self.table.trigger('data:saved');
             }
           });
         } else {

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -1333,7 +1333,8 @@ cdb.admin.MapTab = cdb.core.View.extend({
             user: self.user,
             clean_on_hide: true,
             onDone: function() {
-              self.table.trigger('data:saved');
+              // Refreshing layer when changes have been done
+              self.updateDataLayerView()
             }
           });
         } else {

--- a/lib/assets/test/spec/cartodb/common/dialogs/feature_data_dialog_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/feature_data_dialog_view.spec.js
@@ -214,6 +214,18 @@ describe('common/dialogs/feature_data_dialog', function() {
       expect(called).toBeTruthy();
     });
 
+    it('should not unset reserved columns or model id if attributes have changed', function(){
+      var data = {};
+      this.rowModel.save = function(d,opts) { data = d };
+      this.view._changeAttributes([{ attribute: 'test', value: 'phew' }]);
+      expect(data.id).toBeUndefined();
+      expect(data.cartodb_id).toBeUndefined();
+      expect(data.the_geom).toBeUndefined();
+      expect(data.the_geom_webmercator).toBeUndefined();
+      expect(data.updated_at).toBeUndefined();
+      expect(data.created_at).toBeUndefined();
+    });
+
     it('should show loading when model is saving', function(){
       var self = this;
       this.rowModel.sync = function(a,b,opts) {};

--- a/lib/assets/test/spec/cartodb/common/dialogs/feature_data_dialog_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/feature_data_dialog_view.spec.js
@@ -79,12 +79,12 @@ describe('common/dialogs/feature_data_dialog', function() {
       });
 
       it('should change the name of the column if it is valid', function() {
-        this.firstFieldView.column.sync = function(a,b,opts) {
+        cdb.admin.Column.prototype.sync = function(a,b,opts) {
           opts.success(
             new cdb.core.Model({
-              name: 'paco'
+              _name: 'paco'
             })
-            , { name: 'paco' }
+            , { _name: 'paco' }
           );
         };
         this.$columnNameInput
@@ -96,7 +96,7 @@ describe('common/dialogs/feature_data_dialog', function() {
       });
 
       it('shouldn\'t change the name of the column if it is invalid', function() {
-        this.firstFieldView.column.sync = function(a,b,opts) {
+        cdb.admin.Column.prototype.sync = function(a,b,opts) {
           opts.error('{"errors": ["this is an error"]}');
         };
         this.$columnNameInput
@@ -116,12 +116,12 @@ describe('common/dialogs/feature_data_dialog', function() {
 
       it('should change the type of the column if it works', function() {
         var self = this;
-        this.firstFieldView.column.sync = function(a,b,opts) {
+        cdb.admin.Column.prototype.sync = function(a,b,opts) {
           opts.success(
             new cdb.core.Model({
-              name: 'paco'
+              _name: 'paco'
             })
-            , { name: 'paco' }
+            , { _name: 'paco' }
           );
         };
 
@@ -143,7 +143,7 @@ describe('common/dialogs/feature_data_dialog', function() {
 
       it('shouldn\'t change the column type if it fails', function() {
         var self = this;
-        this.firstFieldView.column.sync = function(a,b,opts) {
+        cdb.admin.Column.prototype.sync = function(a,b,opts) {
           opts.error('{"errors": ["this is an error"]}');
         };
         
@@ -167,18 +167,15 @@ describe('common/dialogs/feature_data_dialog', function() {
     describe('add column', function() {
 
       it('should add a column when link is clicked', function() {
+        var columnName = '';
         cdb.admin.Column.prototype.sync = function(a,b,opts) {
-          opts.success(
-            new cdb.core.Model({
-              name: 'new_column',
-              cartodb_type: 'string'
-            })
-          )
+          columnName = b.get('_name');
+          opts.success(b)
         };
         this.form.$('.js-addColumn').click();
         expect(this.form.collection.size(5));
         expect(this.form.$('.Form-row').length).toBe(6);
-        expect(this.form.collection.last().get('attribute')).toBe('new_column');
+        expect(this.form.collection.last().get('attribute')).toBe(columnName);
         expect(this.form.collection.last().get('value')).toBeNull();
         expect(this.form.collection.last().get('type')).toBe('string');
       });

--- a/lib/assets/test/spec/cartodb/models/table.spec.js
+++ b/lib/assets/test/spec/cartodb/models/table.spec.js
@@ -525,8 +525,10 @@ describe("admin table", function() {
       table.bind('columnAdd', function() {
         signalCalled = true;
       });
-      table.addColumn('irrelevant1', 'string', function() {
-        succeded = true;
+      table.addColumn('irrelevant1', 'string', {
+        success: function() {
+          succeded = true;
+        }
       })
       server.respond();
       expect(succeded).toBeTruthy();

--- a/lib/assets/test/spec/cartodb/models/table.spec.js
+++ b/lib/assets/test/spec/cartodb/models/table.spec.js
@@ -582,11 +582,16 @@ describe("admin table", function() {
       expect(table._data.fetch).toHaveBeenCalled();
     })
 
+    it("should be able to say if a type change is possible", function() {
+      expect(table.isTypeChangeAllowed("test2","string")).toBeTruthy();
+      expect(table.isTypeChangeAllowed("test2","date")).toBeFalsy();
+      expect(table.isTypeChangeAllowed("test","date")).toBeTruthy();
+    });
+
     it("should be able to say if a type change is destructive", function() {
       expect(table.isTypeChangeDestructive("test2","string")).toBeFalsy();
       expect(table.isTypeChangeDestructive("test","number")).toBeTruthy();
-
-    })
+    });
 
     it("should change the type of a column", function() {
       var server = sinon.fakeServer.create();


### PR DESCRIPTION

![screen shot 2015-06-17 at 20 31 00](https://cloud.githubusercontent.com/assets/132146/8215416/f16101bc-152f-11e5-9488-b96d96ac8b33.png)



- [x] Error editing the metadata of a geometry (fixes #4076, big :hankey: :disappointed:  ).
- [x] When the column type selector is number type, it will be styles as green.
- [x] Replaced all local column modifications, now using table column methods (@javisantana).
- [x] Only show which types transform are allowed in the column type selector (validator method moved to the model logic).

cc @saleiva
REVIEWER: @javierarce 