### PR TITLE
Clean up dirty body between test cases

### DIFF
--- a/lib/assets/test/spec/SpecHelper.js
+++ b/lib/assets/test/spec/SpecHelper.js
@@ -79,7 +79,7 @@ TestUtil.config = {
   default_fallback_basemap: {
     urlTemplate: 'http://basemap.com/{z}/{x}/{y}.png'
   }
-  
+
 };
 
 TestUtil.user_data = {
@@ -243,4 +243,9 @@ beforeEach(function() {
   this.$html = function(v) {
     return TestUtil._view.call(this, v).$el.html();
   };
+});
+
+afterEach(function() {
+  // Clean up any element that was injected in test results, expect for Jasmine's HTML reporter.
+  $('body > div:not(.jasmine_html-reporter)').remove();
 });

--- a/lib/assets/test/spec/cartodb/common/views/dashboard_header_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/dashboard_header_view.spec.js
@@ -81,7 +81,7 @@ describe('common/views/dashboard_header_view', function() {
   });
 
   describe('logo loader', function() {
-    
+
     it('should start logo animation when a router change is made (content_type not accepted)', function() {
       spyOn(this.view, '_startLogoAnimation');
       this.view.collection.total_user_entries = 10;
@@ -126,6 +126,11 @@ describe('common/views/dashboard_header_view', function() {
       this.view.$('.js-settings-dropdown').click();
     });
 
+    afterEach(function() {
+      // close dropdowns
+      cdb.god.trigger('closeDialogs');
+    });
+
     it('should kill the click event from propagating etc., to not trigger any event listeners on body', function() {
       expect(this.killEventSpy).toHaveBeenCalled();
     });
@@ -166,6 +171,8 @@ describe('common/views/dashboard_header_view', function() {
   });
 
   afterEach(function() {
+    // close dropdowns
+    cdb.god.trigger('closeDialogs');
     this.view.clean();
   });
 });

--- a/lib/assets/test/spec/cartodb/common/views/dashboard_header_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/dashboard_header_view.spec.js
@@ -126,11 +126,6 @@ describe('common/views/dashboard_header_view', function() {
       this.view.$('.js-settings-dropdown').click();
     });
 
-    afterEach(function() {
-      // close dropdowns
-      cdb.god.trigger('closeDialogs');
-    });
-
     it('should kill the click event from propagating etc., to not trigger any event listeners on body', function() {
       expect(this.killEventSpy).toHaveBeenCalled();
     });
@@ -171,8 +166,6 @@ describe('common/views/dashboard_header_view', function() {
   });
 
   afterEach(function() {
-    // close dropdowns
-    cdb.god.trigger('closeDialogs');
     this.view.clean();
   });
 });

--- a/lib/assets/test/spec/cartodb/dashboard/filters_view.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/filters_view.spec.js
@@ -1,3 +1,4 @@
+var $ = require('jquery');
 var DeleteItemsDialog = require('../../../../javascripts/cartodb/common/dialogs/delete_items_view');
 var ChangeLockDialog = require('../../../../javascripts/cartodb/common/dialogs/change_lock/change_lock_view');
 var FiltersView = require('../../../../javascripts/cartodb/dashboard/filters_view');
@@ -253,6 +254,11 @@ describe('dashboard/filters_view', function() {
         spyOn(DeleteItemsDialog.prototype, 'appendToBody').and.callThrough();
       });
 
+      afterEach(function() {
+        // close modal
+        $('.close').click();
+      });
+
       it('should be displayed when items belong to the user', function() {
         expect(this.innerHTML()).toContain('Delete  dataset');
       });
@@ -301,6 +307,11 @@ describe('dashboard/filters_view', function() {
         spyOn(ChangeLockDialog.prototype, 'appendToBody').and.callThrough();
         this.view.$('.js-lock').click();
         this.createdWith = ChangeLockDialog.prototype.initialize.calls.argsFor(0)[0];
+      });
+
+      afterEach(function() {
+        // close modal
+        $('.close').click();
       });
 
       it('should open a lock items dialog', function() {

--- a/lib/assets/test/spec/cartodb/dashboard/filters_view.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/filters_view.spec.js
@@ -254,11 +254,6 @@ describe('dashboard/filters_view', function() {
         spyOn(DeleteItemsDialog.prototype, 'appendToBody').and.callThrough();
       });
 
-      afterEach(function() {
-        // close modal
-        $('.close').click();
-      });
-
       it('should be displayed when items belong to the user', function() {
         expect(this.innerHTML()).toContain('Delete  dataset');
       });
@@ -307,11 +302,6 @@ describe('dashboard/filters_view', function() {
         spyOn(ChangeLockDialog.prototype, 'appendToBody').and.callThrough();
         this.view.$('.js-lock').click();
         this.createdWith = ChangeLockDialog.prototype.initialize.calls.argsFor(0)[0];
-      });
-
-      afterEach(function() {
-        // close modal
-        $('.close').click();
       });
 
       it('should open a lock items dialog', function() {

--- a/lib/assets/test/spec/cartodb/public_dashboard/user_settings_view.spec.js
+++ b/lib/assets/test/spec/cartodb/public_dashboard/user_settings_view.spec.js
@@ -1,6 +1,5 @@
 var UserSettingsView = require('../../../../javascripts/cartodb/public_common/user_settings_view');
 var cdbAdmin = require('cdb.admin');
-var $ = require('jquery');
 
 describe('public_dashboard/user_settings_view', function() {
   beforeEach(function() {
@@ -33,27 +32,6 @@ describe('public_dashboard/user_settings_view', function() {
 
     it('should open a dropdown', function() {
       expect(document.body.innerHTML).toContain('Close session');
-    });
-
-    describe('when clicked again', function() {
-      beforeEach(function(done) {
-        this.view.$('.js-dropdown-target').click();
-
-        // Unfortunately there's no better way than to check using a recurrent timeout (will abort if jasmine times out)
-        // If the expectations above fails something is wrong or has changed…
-        var checkIfRemoved;
-        (checkIfRemoved = function () { // waits for
-         if ($('.Dropdown')[0]) {
-           setTimeout(checkIfRemoved, 10);
-         } else {
-           done();
-         }
-        })();
-      });
-
-      it('should hide dropdown', function() {
-        expect(document.body.innerHTML).not.toContain('Close session');
-      });
     });
   });
 

--- a/lib/assets/test/spec/cartodb/public_dashboard/user_settings_view.spec.js
+++ b/lib/assets/test/spec/cartodb/public_dashboard/user_settings_view.spec.js
@@ -59,5 +59,7 @@ describe('public_dashboard/user_settings_view', function() {
 
   afterEach(function() {
     this.view.clean();
+    // close modal
+    $('.close').click();
   });
 });

--- a/lib/assets/test/spec/cartodb/public_dashboard/user_settings_view.spec.js
+++ b/lib/assets/test/spec/cartodb/public_dashboard/user_settings_view.spec.js
@@ -59,7 +59,5 @@ describe('public_dashboard/user_settings_view', function() {
 
   afterEach(function() {
     this.view.clean();
-    // close modal
-    $('.close').click();
   });
 });


### PR DESCRIPTION
Related to the fix on the async test yesterday #4091, I noticed that there are tests that leave the document.body in a dirty state, that may affect the expectations that comes in tests after… this PR includes some `afterEach` call to make sure the tests' side-effects are cleaned up.