### PR TITLE
New georeference modal base

### DIFF
--- a/app/assets/stylesheets/common/create/listing/import_panel.css.scss
+++ b/app/assets/stylesheets/common/create/listing/import_panel.css.scss
@@ -38,8 +38,10 @@ $w: 780px;
   font-weight: $sFontWeight-lighter;
   line-height: $sLineHeight-normal;
 }
+.ImportPanel-headerDescription--normalWeight { font-weight: $sFontWeight-normal; }
+.ImportPanel-headerDescription--withoutWidth { width: auto }
 .ImportPanel-headerDescription--negative { color: $cHighlight-negative }
-.ImportPanel-headerDescription--negative 
+.ImportPanel-headerDescription--negative
 .ImportPanel-headerDescriptionLink {
   color: $cHighlight-negative;
   text-decoration: underline;
@@ -49,7 +51,7 @@ $w: 780px;
   position: absolute;
   left: 0;
   top: 50%;
-  margin-top: -20px; 
+  margin-top: -20px;
 }
 .ImportPanel-headerLink { margin-top: 30px }
 .ImportPanel-body {

--- a/app/assets/stylesheets/common/form-content.css.scss
+++ b/app/assets/stylesheets/common/form-content.css.scss
@@ -7,7 +7,6 @@
 
 $sLabel-width: 140px;
 
-.Form {}
 .Form--minHeight { min-height: 400px }
 .Form-title {
   display: block;
@@ -48,6 +47,24 @@ $sLabel-width: 140px;
 .Form-row.Form-row--centered {
   @include justify-content(center);
 }
+.Form-row.Form-row--step {
+  @include justify-content(space-between, justify);
+  @include align-items(center);
+  &:before {
+    content: '';
+    border-radius: 50px;
+    padding: 5px 10px;
+    margin-right: $sMargin-elementInline;
+    border: 1px solid $cStructure-mainLine;
+    font-size: $sFontSize-smallUpperCase;
+    font-weight: $sFontWeight-small;
+    color: $cTypography-paragraphs;
+    line-height: $sLineHeight-small;
+  }
+  &:first-child:before { content: '1' }
+  &:nth-child(2):before { content: '2' }
+  &:nth-child(3):before { content: '3' }
+}
 .Form-row.has-label {
   // compensate for label width, to make the rowData appear as centered
   margin-left: -$sLabel-width;
@@ -70,12 +87,9 @@ $sLabel-width: 140px;
   @include nicer-lato-typography();
   color: $cTypography-paragraphs;
 }
-.Form-label.Form-label--large {
-  font-size: $sFontSize-large;
-}
-.Form-rowPreview {
-  width: 735px;
-}
+.Form-label.Form-label--large { font-size: $sFontSize-large }
+.Form-label.Form-label--step { @include flex-grow(1) }
+.Form-rowPreview { width: 735px }
 .Form-separator {
   position: relative;
   display: block;
@@ -137,6 +151,10 @@ $sLabel-width: 140px;
 .Form-rowData--long { width: 380px }
 .Form-rowData--med { width: 300px }
 .Form-rowData--short { width: 170px }
+.Form-rowData--step {
+  width: 260px;
+  margin-right: 0;
+}
 
 .Form-input {
   position: relative;

--- a/app/assets/stylesheets/editor/georeference.css.scss
+++ b/app/assets/stylesheets/editor/georeference.css.scss
@@ -1,0 +1,7 @@
+.Georeference-content {
+  // Should match the width as the .Filters-type container has with the current set of tabs,
+  // so the content is aligned width the filters' item
+  width: 636px;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions/admin_regions_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions/admin_regions_model.js
@@ -1,0 +1,20 @@
+var cdb = require('cartodb.js');
+var ViewFactory = require('../../../view_factory');
+
+/**
+ * Model for the administrative regions georeference option.
+ */
+module.exports = cdb.core.Model.extend({
+
+  tabLabel: 'Admin. Regions',
+
+  initialize: function() {
+  },
+
+  createView: function() {
+    return ViewFactory.createByTemplate('common/templates/loading', {
+      title: 'Sorry, pending implementation!',
+      quote: 'Poco a poco se anda lejos'
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions/admin_regions_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions/admin_regions_model.js
@@ -8,13 +8,19 @@ module.exports = cdb.core.Model.extend({
 
   tabLabel: 'Admin. Regions',
 
-  initialize: function() {
+  createView: function() {
+    // Reset state
+    this.set({
+      canContinue: false
+    });
+
+    return ViewFactory.createByTemplate('common/templates/fail', {
+      msg: 'TBD, pending implementation for new tab'
+    });
   },
 
-  createView: function() {
-    return ViewFactory.createByTemplate('common/templates/loading', {
-      title: 'Sorry, pending implementation!',
-      quote: 'Poco a poco se anda lejos'
-    });
+  geocodeData: function() {
+    // TODO: stub, implement actual logic
   }
+
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names/city_names_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names/city_names_model.js
@@ -1,0 +1,20 @@
+var cdb = require('cartodb.js');
+var ViewFactory = require('../../../view_factory');
+
+/**
+ * Model for the city names georeference option.
+ */
+module.exports = cdb.core.Model.extend({
+
+  tabLabel: 'City Names',
+
+  initialize: function() {
+  },
+
+  createView: function() {
+    return ViewFactory.createByTemplate('common/templates/loading', {
+      title: 'Sorry, pending implementation!',
+      quote: 'Poco a poco se anda lejos'
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names/city_names_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names/city_names_model.js
@@ -8,13 +8,19 @@ module.exports = cdb.core.Model.extend({
 
   tabLabel: 'City Names',
 
-  initialize: function() {
+  createView: function() {
+    // Reset state
+    this.set({
+      canContinue: false
+    });
+
+    return ViewFactory.createByTemplate('common/templates/fail', {
+      msg: 'TBD, pending implementation for new tab'
+    });
   },
 
-  createView: function() {
-    return ViewFactory.createByTemplate('common/templates/loading', {
-      title: 'Sorry, pending implementation!',
-      quote: 'Poco a poco se anda lejos'
-    });
+  geocodeData: function() {
+    // TODO: stub, implement actual logic
   }
+
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
@@ -1,0 +1,51 @@
+<div class="Dialog-content Dialog-content--expanded">
+  <div class="Dialog-contentWrapper">
+    <div class="Dialog-header Dialog-header--expanded CreateDialog-header">
+      <ul class="CreateDialog-headerSteps">
+        <li class="CreateDialog-headerStep CreateDialog-headerStep--single is-selected">
+          <div class="Dialog-headerIcon">
+            <i class="iconFont iconFont-Marker"></i>
+          </div>
+          <p class="Dialog-headerTitle">Georeference your dataset</p>
+          <p class="Dialog-headerText">This is the key point to visualize your data</p>
+        </li>
+      </ul>
+    </div>
+
+    <div class="Dialog-body Dialog-body--expanded CreateDialog-body">
+      <div class="CreateDialog-listing">
+        <div class="Filters Filters--navListing">
+          <div class="u-inner">
+            <div class="Filters-inner">
+              <div class="Filters-row Filters-row--centered">
+                <div class="Filters-type">
+                  <span class="Filters-separator"></span>
+                  <ul class="Filters-list js-tabs"></ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="u-inner js-tab-content"></div>
+      </div>
+    </div>
+
+    <div class="Dialog-footer Dialog-footer--expanded CreateDialog-footer">
+      <div>
+        <div class="CreateDialog-footerShadow"></div>
+        <div class="CreateDialog-footerLine"></div>
+        <div class="CreateDialog-footerInner ">
+          <div class="CreateDialog-footerInfo">
+            <i class="iconFont iconFont-Info CreateDialog-footerInfoIcon"></i>
+            New on CartoDB? Start with one of our <a href="<%- templatesURL %>">templates</a>
+          </div>
+          <div class="CreateDialog-footerActions">
+            <button class="Button Button--main ok is-disabled">
+              <span>Continue</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
@@ -26,7 +26,7 @@
             </div>
           </div>
         </div>
-        <div class="u-inner js-tab-content"></div>
+        <div class="Georeference-content js-tab-content"></div>
       </div>
     </div>
 

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
@@ -1,0 +1,55 @@
+var Backbone = require('backbone');
+var cdb = require('cartodb.js');
+var LonLatColumnsModel = require('./lon_lat_columns/lon_lat_columns_model');
+var CityNamesModel = require('./city_names/city_names_model');
+var AdminRegionsModel = require('./admin_regions/admin_regions_model');
+var PostalCodesModel = require('./postal_codes/postal_codes_model');
+var IpAddresses = require('./ip_addresses/ip_addresses_model');
+var StreetAddressesModel = require('./street_addresses/street_addresses_model');
+
+/**
+ * View model for merge datasets view.
+ */
+module.exports = cdb.core.Model.extend({
+
+  defaults: {
+    options: undefined // Collection, created with model
+  },
+
+  initialize: function(attrs) {
+    // if (!attrs.table) throw new Error('table is required');
+    this._initOptions();
+  },
+
+  changedSelectedTab: function(newTab) {
+    this.get('options').chain()
+      .without(newTab).each(this._deselect);
+  },
+
+  selectedTabModel: function() {
+    return this.get('options').find(this._isSelected);
+  },
+
+  _isSelected: function(m) {
+    return m.get('selected');
+  },
+
+  _deselect: function(m) {
+    m.set('selected', false);
+  },
+
+  _initOptions: function() {
+    var options = new Backbone.Collection([
+      new LonLatColumnsModel({
+        selected: true
+      }),
+      new CityNamesModel(),
+      new AdminRegionsModel(),
+      new PostalCodesModel(),
+      new IpAddresses(),
+      new StreetAddressesModel()
+    ]);
+    this.set('options', options);
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
@@ -1,4 +1,5 @@
 var Backbone = require('backbone');
+var _ = require('underscore');
 var cdb = require('cartodb.js');
 var LonLatColumnsModel = require('./lon_lat_columns/lon_lat_columns_model');
 var CityNamesModel = require('./city_names/city_names_model');
@@ -12,12 +13,14 @@ var StreetAddressesModel = require('./street_addresses/street_addresses_model');
  */
 module.exports = cdb.core.Model.extend({
 
+  _EXCLUDED_COLUMN_NAMES: ['cartodb_id', 'the_geom', 'updated_at', 'created_at', 'cartodb_georef_status'],
+
   defaults: {
     options: undefined // Collection, created with model
   },
 
   initialize: function(attrs) {
-    // if (!attrs.table) throw new Error('table is required');
+    if (!attrs.table) throw new Error('table is required');
     this._initOptions();
   },
 
@@ -30,6 +33,24 @@ module.exports = cdb.core.Model.extend({
     return this.get('options').find(this._isSelected);
   },
 
+  columnsNames: function() {
+    return _.chain(this.get('table').get('schema'))
+    .map(this._columnNameFromRawSchemaItem)
+    .difference(this._EXCLUDED_COLUMN_NAMES)
+    .value();
+  },
+
+  continue: function() {
+    var tabModel = this.selectedTabModel();
+    if (tabModel.get('canContinue')) {
+      this.set('geocodeData', tabModel.geocodeData());
+    }
+  },
+
+  _columnNameFromRawSchemaItem: function(rawColumn) {
+    return rawColumn[0];
+  },
+
   _isSelected: function(m) {
     return m.get('selected');
   },
@@ -39,9 +60,11 @@ module.exports = cdb.core.Model.extend({
   },
 
   _initOptions: function() {
+    var columnsNames = this.columnsNames();
     var options = new Backbone.Collection([
       new LonLatColumnsModel({
-        selected: true
+        selected: true,
+        columnsNames: columnsNames
       }),
       new CityNamesModel(),
       new AdminRegionsModel(),

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_view.js
@@ -12,11 +12,14 @@ var TabItemView = require('./tab_item_view');
 module.exports = BaseDialog.extend({
 
   initialize: function() {
+    if (!this.options.user) throw new Error('user is required');
     this.options.clean_on_hide = true;
-    this.options.enter_to_confirm = false;
+    this.options.enter_to_confirm = true;
     this.elder('initialize');
 
-    this.model = new GeoreferenceModel();
+    this.model = new GeoreferenceModel({
+      table: this.options.table
+    });
     this._initViews();
     this._initBinds();
   },
@@ -31,10 +34,9 @@ module.exports = BaseDialog.extend({
   },
 
   render_content: function() {
-    var templatesURL = '';//this.model.get('user').viewUrl().dashboard().maps() + '?open-create-map-tutorials';
     var $el = $(
       this.getTemplate('common/dialogs/georeference/georeference')({
-        templatesURL: templatesURL
+        templatesURL: this.options.user.viewUrl().dashboard().maps() + '?open-create-map-tutorials'
       })
     );
     this._renderTabs($el.find('.js-tabs'));
@@ -52,10 +54,6 @@ module.exports = BaseDialog.extend({
   },
 
   _initViews: function() {
-    this._initTabs();
-  },
-
-  _initTabs: function() {
     this._tabViews = this.model.get('options').map(this._createDefaultTabView, this);
   },
 
@@ -71,37 +69,39 @@ module.exports = BaseDialog.extend({
     return view.render().el;
   },
 
+  _renderTabContent: function($target) {
+    if (this._tabContentView) {
+      this._tabContentView.clean();
+    }
+    this._tabContentView = this.model.selectedTabModel().createView();
+    $target.find('.js-tab-content').html(this._tabContentView.render().el);
+  },
+
   _initBinds: function() {
     var options = this.model.get('options');
     options.bind('change:selected', this._onChangeSelectedTab, this);
     options.bind('change:canContinue', this._onChangeCanContinue, this);
-    options.bind('change:geocodeData', this._onChangeGeocodeData, this);
     this.add_related_model(options);
+
+    this.model.bind('change:geocodeData', this._onChangeGeocodeData, this);
   },
 
   _onChangeSelectedTab: function(tabModel, isSelected) {
     if (isSelected) {
       this.model.changedSelectedTab(tabModel);
-      if (this._tabContentView) {
-        this._tabContentView.clean();
-      }
+      this._onChangeCanContinue(tabModel, false);
       this._renderTabContent(this.$el);
     }
   },
 
   _onChangeCanContinue: function(tabModel, canContinue) {
-    this.$('.ok').toggleClass('is-disabled', canContinue);
+    this.$('.ok').toggleClass('is-disabled', !canContinue);
   },
 
   _onChangeGeocodeData: function(tabModel, geocodeData) {
     // To adhere to existing workflow, trigger same events as old modal upon clicking continue
     this.trigger('geocodingChosen', geocodeData);
     this.hide();
-  },
-
-  _renderTabContent: function($target) {
-    this._tabContentView = this.model.selectedTabModel().createView();
-    $target.find('.js-tab-content').html(this._tabContentView.render().el);
   }
 
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_view.js
@@ -1,0 +1,107 @@
+var $ = require('jquery');
+var _ = require('underscore');
+var BaseDialog = require('../../views/base_dialog/view.js');
+var GeoreferenceModel = require('./georeference_model');
+var TabItemView = require('./tab_item_view');
+
+/**
+ * Dialog to georeference a table.
+ * This view only acts as a high-level view, that managed the general view logic for the modal.
+ * What is supposed to happen is delegated to the model and in turn the selected georeference option.
+ */
+module.exports = BaseDialog.extend({
+
+  initialize: function() {
+    this.options.clean_on_hide = true;
+    this.options.enter_to_confirm = false;
+    this.elder('initialize');
+
+    this.model = new GeoreferenceModel();
+    this._initViews();
+    this._initBinds();
+  },
+
+  /**
+   * @override BaseDialog.prototype.render
+   */
+  render: function() {
+    BaseDialog.prototype.render.apply(this, arguments);
+    this.$('.content').addClass('Dialog-contentWrapper');
+    return this;
+  },
+
+  render_content: function() {
+    var templatesURL = '';//this.model.get('user').viewUrl().dashboard().maps() + '?open-create-map-tutorials';
+    var $el = $(
+      this.getTemplate('common/dialogs/georeference/georeference')({
+        templatesURL: templatesURL
+      })
+    );
+    this._renderTabs($el.find('.js-tabs'));
+    this._renderTabContent($el);
+
+    return $el;
+  },
+
+  _renderTabs: function($target) {
+    $target.append.apply($target, _.map(this._tabViews, this._getRenderedElement));
+  },
+
+  ok: function() {
+    this.model.continue();
+  },
+
+  _initViews: function() {
+    this._initTabs();
+  },
+
+  _initTabs: function() {
+    this._tabViews = this.model.get('options').map(this._createDefaultTabView, this);
+  },
+
+  _createDefaultTabView: function(model) {
+    var view = new TabItemView({
+      model: model
+    });
+    this.addView(view);
+    return view;
+  },
+
+  _getRenderedElement: function(view) {
+    return view.render().el;
+  },
+
+  _initBinds: function() {
+    var options = this.model.get('options');
+    options.bind('change:selected', this._onChangeSelectedTab, this);
+    options.bind('change:canContinue', this._onChangeCanContinue, this);
+    options.bind('change:geocodeData', this._onChangeGeocodeData, this);
+    this.add_related_model(options);
+  },
+
+  _onChangeSelectedTab: function(tabModel, isSelected) {
+    if (isSelected) {
+      this.model.changedSelectedTab(tabModel);
+      if (this._tabContentView) {
+        this._tabContentView.clean();
+      }
+      this._renderTabContent(this.$el);
+    }
+  },
+
+  _onChangeCanContinue: function(tabModel, canContinue) {
+    this.$('.ok').toggleClass('is-disabled', canContinue);
+  },
+
+  _onChangeGeocodeData: function(tabModel, geocodeData) {
+    // To adhere to existing workflow, trigger same events as old modal upon clicking continue
+    this.trigger('geocodingChosen', geocodeData);
+    this.hide();
+  },
+
+  _renderTabContent: function($target) {
+    this._tabContentView = this.model.selectedTabModel().createView();
+    $target.find('.js-tab-content').html(this._tabContentView.render().el);
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/ip_addresses/ip_addresses_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/ip_addresses/ip_addresses_model.js
@@ -1,0 +1,20 @@
+var cdb = require('cartodb.js');
+var ViewFactory = require('../../../view_factory');
+
+/**
+ * Model for the IP addresses georeference option.
+ */
+module.exports = cdb.core.Model.extend({
+
+  tabLabel: 'IP Addresses',
+
+  initialize: function() {
+  },
+
+  createView: function() {
+    return ViewFactory.createByTemplate('common/templates/loading', {
+      title: 'Sorry, pending implementation!',
+      quote: 'Poco a poco se anda lejos'
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/ip_addresses/ip_addresses_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/ip_addresses/ip_addresses_model.js
@@ -8,13 +8,19 @@ module.exports = cdb.core.Model.extend({
 
   tabLabel: 'IP Addresses',
 
-  initialize: function() {
+  createView: function() {
+    // Reset state
+    this.set({
+      canContinue: false
+    });
+
+    return ViewFactory.createByTemplate('common/templates/fail', {
+      msg: 'TBD, pending implementation for new tab'
+    });
   },
 
-  createView: function() {
-    return ViewFactory.createByTemplate('common/templates/loading', {
-      title: 'Sorry, pending implementation!',
-      quote: 'Poco a poco se anda lejos'
-    });
+  geocodeData: function() {
+    // TODO: stub, implement actual logic
   }
+
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns.jst.ejs
@@ -1,0 +1,24 @@
+<div class="ImportPanel-header">
+    <h3 class="DefaultTitle">Select the columns containing your Lon/Lat columns</h3>
+    <p class="ImportPanel-headerDescription ImportPanel-headerDescription--withoutWidth">
+      No matter the type of the columns you select, we will transform them to number for georeferencing.
+    </p>
+</div>
+<div>
+  <div class="Form-row Form-row--step">
+    <div class="Form-label Form-label--step">
+      <label class="ImportPanel-headerDescription ImportPanel-headerDescription--normalWeight">
+        Select your longitude column
+      </label>
+    </div>
+    <div class="Form-rowData Form-rowData--step js-lon-column"></div>
+  </div>
+  <div class="Form-row Form-row--centered Form-row--step">
+    <div class="Form-label Form-label--step">
+      <label class="ImportPanel-headerDescription ImportPanel-headerDescription--normalWeight">
+        Select your latitude column
+      </label>
+    </div>
+    <div class="Form-rowData Form-rowData--step js-lat-column"></div>
+  </div>
+</div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_model.js
@@ -1,5 +1,5 @@
 var cdb = require('cartodb.js');
-var ViewFactory = require('../../../view_factory');
+var LonLatColumnsView = require('./lon_lat_columns_view');
 
 /**
  * Model for the Lon/Lat georeference option.
@@ -8,13 +8,36 @@ module.exports = cdb.core.Model.extend({
 
   tabLabel: 'Lon/Lat Columns',
 
-  initialize: function() {
+  defaults: {
+    columnsNames: []
+  },
+
+  initialize: function(attrs) {
+    if (!attrs.columnsNames) throw new Error('columnsNames is required');
   },
 
   createView: function() {
-    return ViewFactory.createByTemplate('common/templates/loading', {
-      title: 'Sorry, pending implementation! latitude column',
-      quote: 'Poco a poco se anda lejos'
+    this.set({
+      canContinue: false,
+      lonColumnName: '',
+      latColumnName: ''
     });
+
+    return new LonLatColumnsView({
+      model: this
+    });
+  },
+
+  assertIfCanContinue: function() {
+    var canContinue = !!(this.get('lonColumnName') && this.get('latColumnName'));
+    this.set('canContinue', canContinue);
+  },
+
+  geocodeData: function() {
+    return {
+      type: 'lonlat',
+      longitude: this.get('lonColumnName'),
+      latitude: this.get('latColumnName')
+    };
   }
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_model.js
@@ -1,0 +1,20 @@
+var cdb = require('cartodb.js');
+var ViewFactory = require('../../../view_factory');
+
+/**
+ * Model for the Lon/Lat georeference option.
+ */
+module.exports = cdb.core.Model.extend({
+
+  tabLabel: 'Lon/Lat Columns',
+
+  initialize: function() {
+  },
+
+  createView: function() {
+    return ViewFactory.createByTemplate('common/templates/loading', {
+      title: 'Sorry, pending implementation! latitude column',
+      quote: 'Poco a poco se anda lejos'
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_view.js
@@ -1,0 +1,49 @@
+var $ = require('jquery');
+var cdb = require('cartodb.js');
+
+/**
+ * View to select long/lat couple to do the georeference.
+ */
+module.exports = cdb.core.View.extend({
+
+  className: 'Georeference-content',
+
+  initialize: function() {
+    this._initViews();
+    this._initBinds();
+  },
+
+  render: function() {
+    var $el = $(
+        this.getTemplate('common/dialogs/georeference/lon_lat_columns/lon_lat_columns')({
+      })
+    );
+    $el.find('.js-lon-column').append(this._lonColumnView.render().el);
+    $el.find('.js-lat-column').append(this._latColumnView.render().el);
+    this.$el.html($el);
+    return this;
+  },
+
+  _initViews: function() {
+    this._lonColumnView = this._createSelectView('lonColumnName');
+    this._latColumnView = this._createSelectView('latColumnName');
+  },
+
+  _createSelectView: function(attrName) {
+    var view = new cdb.forms.Combo({
+      model: this.model,
+      property: attrName,
+      className: 'Select',
+      width: '100%',
+      placeholder: '…',
+      extra: this.model.get('columnsNames')
+    });
+    this.addView(view);
+    return view;
+  },
+
+  _initBinds: function() {
+    this.model.bind('change:lonColumnName change:latColumnName', this.model.assertIfCanContinue, this.model);
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/postal_codes/postal_codes_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/postal_codes/postal_codes_model.js
@@ -8,13 +8,19 @@ module.exports = cdb.core.Model.extend({
 
   tabLabel: 'Postal Codes',
 
-  initialize: function() {
+  createView: function() {
+    // Reset state
+    this.set({
+      canContinue: false
+    });
+
+    return ViewFactory.createByTemplate('common/templates/fail', {
+      msg: 'TBD, pending implementation for new tab'
+    });
   },
 
-  createView: function() {
-    return ViewFactory.createByTemplate('common/templates/loading', {
-      title: 'Sorry, pending implementation!',
-      quote: 'Poco a poco se anda lejos'
-    });
+  geocodeData: function() {
+    // TODO: stub, implement actual logic
   }
+
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/postal_codes/postal_codes_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/postal_codes/postal_codes_model.js
@@ -1,0 +1,20 @@
+var cdb = require('cartodb.js');
+var ViewFactory = require('../../../view_factory');
+
+/**
+ * Model for the postal codes georeference option.
+ */
+module.exports = cdb.core.Model.extend({
+
+  tabLabel: 'Postal Codes',
+
+  initialize: function() {
+  },
+
+  createView: function() {
+    return ViewFactory.createByTemplate('common/templates/loading', {
+      title: 'Sorry, pending implementation!',
+      quote: 'Poco a poco se anda lejos'
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_model.js
@@ -8,13 +8,19 @@ module.exports = cdb.core.Model.extend({
 
   tabLabel: 'Street Addresses',
 
-  initialize: function() {
+  createView: function() {
+    // Reset state
+    this.set({
+      canContinue: false
+    });
+
+    return ViewFactory.createByTemplate('common/templates/fail', {
+      msg: 'TBD, pending implementation for new tab'
+    });
   },
 
-  createView: function() {
-    return ViewFactory.createByTemplate('common/templates/loading', {
-      title: 'Sorry, pending implementation!',
-      quote: 'Poco a poco se anda lejos'
-    });
+  geocodeData: function() {
+    // TODO: stub, implement actual logic
   }
+
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_model.js
@@ -1,0 +1,20 @@
+var cdb = require('cartodb.js');
+var ViewFactory = require('../../../view_factory');
+
+/**
+ * Model for the street addresses georeference option.
+ */
+module.exports = cdb.core.Model.extend({
+
+  tabLabel: 'Street Addresses',
+
+  initialize: function() {
+  },
+
+  createView: function() {
+    return ViewFactory.createByTemplate('common/templates/loading', {
+      title: 'Sorry, pending implementation!',
+      quote: 'Poco a poco se anda lejos'
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/tab_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/tab_item.jst.ejs
@@ -1,0 +1,3 @@
+<button class="Filters-typeLink">
+  <span><%- label %></span>
+</button>

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/tab_item_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/tab_item_view.js
@@ -1,0 +1,42 @@
+var cdb = require('cartodb.js');
+
+/**
+ * View for an indvidual tab item
+ */
+module.exports = cdb.core.View.extend({
+
+  tagName: 'li',
+  className: 'Filters-typeItem',
+
+  events: {
+    'click': '_onClick'
+  },
+
+  initialize: function() {
+    this._initBinds();
+  },
+
+  render: function() {
+    this.$el.html(
+      this.getTemplate('common/dialogs/georeference/tab_item')({
+        label: this.model.tabLabel
+      })
+    );
+    this._onChangeSelected(this.model, this.model.get('selected'));
+
+    return this;
+  },
+
+  _initBinds: function() {
+    this.model.bind('change:selected', this._onChangeSelected, this);
+  },
+
+  _onChangeSelected: function(m, isSelected) {
+    this.$('button').toggleClass('is-selected', !!isSelected);
+  },
+
+  _onClick: function(ev) {
+    this.killEvent(ev);
+    this.model.set('selected', true);
+  }
+});

--- a/lib/assets/javascripts/cartodb/editor.js
+++ b/lib/assets/javascripts/cartodb/editor.js
@@ -36,6 +36,7 @@ cdb.editor = {
   ExportView: require('./common/dialogs/export/export_view'),
 
   MergeDatasetsView: require('./common/dialogs/merge_datasets/merge_datasets_view'),
+  GeoreferenceView: require('./common/dialogs/georeference/georeference_view'),
 
   AddCustomBasemapView: require('./common/dialogs/add_custom_basemap/add_custom_basemap_view'),
   ViewFactory: require('./common/view_factory'),

--- a/lib/assets/javascripts/cartodb/table/header/options_menu.js
+++ b/lib/assets/javascripts/cartodb/table/header/options_menu.js
@@ -308,8 +308,8 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
     e.preventDefault();
 
     if (!this.options.geocoder.isGeocoding() && !this.table.isSync() && !this.table.isInSQLView()) {
-
-      dlg = new cdb.admin.GeocodingDialog({
+      var GeorefView = this.user.featureEnabled('new_modals') ? cdb.editor.GeoreferenceView : cdb.admin.GeocodingDialog;
+      var dlg = new GeorefView({
         table:  this.table,
         user:   this.user,
         tabs:   ['lonlat', 'city', 'admin', 'postal', 'ip', 'address'],

--- a/lib/assets/javascripts/cartodb/table/noGeoRefData_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/noGeoRefData_dialog.js
@@ -1,7 +1,7 @@
 
 /**
  *  No georeference data dialog appears when there is no data or data georeferenced
- *  
+ *
  *  var dlg = new cdb.admin.NoGeoRefDataDialog({
  *    model: table_model,
  *    geocoder: geocoder
@@ -10,7 +10,7 @@
  */
 
 cdb.admin.NoGeoRefDataDialog = cdb.admin.BaseDialog.extend({
-  
+
   _TEXTS: {
     title:      _t('No georeferenced data on your layer'),
     content:    _t('Although we can see you have data, it does not \
@@ -48,7 +48,7 @@ cdb.admin.NoGeoRefDataDialog = cdb.admin.BaseDialog.extend({
   render_content: function() {
     this.hasContent = (this.model._data.length  > 0);
     this.$('a.ok').text(this._TEXTS.georef);
-    
+
     return this._TEXTS.content;
   },
 
@@ -74,7 +74,8 @@ cdb.admin.NoGeoRefDataDialog = cdb.admin.BaseDialog.extend({
       var dlg;
       if (!this.options.geocoder.isGeocoding() && !this.model.isSync()) {
 
-        dlg = new cdb.admin.GeocodingDialog({
+        var GeorefView = this.user.featureEnabled('new_modals') ? cdb.editor.GeoreferenceView : cdb.admin.GeocodingDialog;
+        dlg = new GeorefView({
           table:  this.model,
           user:   this.user,
           tabs:   ['lonlat', 'city', 'admin', 'postal', 'ip', 'address'],

--- a/lib/assets/javascripts/cartodb/table/tableview.js
+++ b/lib/assets/javascripts/cartodb/table/tableview.js
@@ -539,7 +539,8 @@
             var dlg;
             if (!this.options.geocoder.isGeocoding() && !this.model.isSync()) {
 
-              dlg = new cdb.admin.GeocodingDialog({
+              var GeorefView = this.user.featureEnabled('new_modals') ? cdb.editor.GeoreferenceView : cdb.admin.GeocodingDialog;
+              dlg = new GeorefView({
                 table:  this.model,
                 user:   this.user,
                 tabs:   ['lonlat', 'city', 'admin', 'postal', 'ip', 'address'],
@@ -568,7 +569,7 @@
 
           this.addView(v);
 
-          if (this.newColumnName == column[0]) { 
+          if (this.newColumnName == column[0]) {
             setTimeout(function() {
               v.renameColumn();
               self.newColumnName = null;

--- a/lib/assets/test/spec/cartodb/common/dialogs/georeference/georeference_model.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/georeference/georeference_model.spec.js
@@ -1,0 +1,40 @@
+var GeoreferenceModel = require('../../../../../../javascripts/cartodb/common/dialogs/georeference/georeference_model');
+
+describe('common/dialog/georeference/georeference_model', function() {
+  beforeEach(function() {
+    this.table = TestUtil.createTable('a', [
+      ['cartodb_id', 'string'],
+      ['the_geom', 'geometry'],
+      ['lon', 'number'],
+      ['lat', 'number'],
+      ['cartodb_georef_status', 'string'],
+      ['foobar', 'boolean'],
+      ['updated_at', 'date'],
+      ['created_at', 'date']
+    ]);
+    this.model = new GeoreferenceModel({
+      table: this.table
+    });
+  });
+
+  describe('.selectedTabModel', function() {
+    it('should return the currently selected item', function() {
+      expect(this.model.selectedTabModel()).toBe(this.model.get('options').first());
+
+      var newOpt = this.model.get('options').last();
+      newOpt.set('selected', true);
+      this.model.changedSelectedTab(newOpt);
+      expect(this.model.selectedTabModel()).toBe(this.model.get('options').last());
+    });
+  });
+
+  describe('.columnsNames', function() {
+    beforeEach(function() {
+      this.results = this.model.columnsNames();
+    });
+
+    it('should return an array with only valid column names to be selectable in UI', function() {
+      expect(this.results).toEqual(['lon', 'lat', 'foobar']);
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb/common/dialogs/georeference/georeference_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/georeference/georeference_view.spec.js
@@ -2,9 +2,18 @@ var cdb = require('cartodb.js');
 var $ = require('jquery');
 var GeoreferenceView = require('../../../../../../javascripts/cartodb/common/dialogs/georeference/georeference_view');
 
-fdescribe('common/dialog/georeference/georeference_view', function() {
+describe('common/dialog/georeference/georeference_view', function() {
   beforeEach(function() {
-    this.table = TestUtil.createTable('a');
+    this.table = TestUtil.createTable('a', [
+      ['cartodb_id', 'string'],
+      ['the_geom', 'geometry'],
+      ['lon', 'number'],
+      ['lat', 'number'],
+      ['cartodb_georef_status', 'string'],
+      ['foobar', 'boolean'],
+      ['updated_at', 'date'],
+      ['created_at', 'date']
+    ]);
     this.user = new cdb.admin.User({
       base_url: 'http://pepe.cartodb.com'
     });
@@ -48,6 +57,36 @@ fdescribe('common/dialog/georeference/georeference_view', function() {
 
     it('should change the content', function() {
       expect(this.innerHTML()).not.toContain('latitude');
+    });
+  });
+
+  describe('when canContinue changes on the current selected tab model', function() {
+    it('should update the disabled state on the continue button', function() {
+      expect(this.view.$('.ok').hasClass('is-disabled')).toBe(true);
+      this.view.model.selectedTabModel().set('canContinue', true);
+      expect(this.view.$('.ok').hasClass('is-disabled')).toBe(false);
+    });
+  });
+
+  describe('when geocodeData changes on the model', function() {
+    beforeEach(function() {
+      spyOn(this.view, 'hide');
+      this.geocodingChosenSpy = jasmine.createSpy('geocodingChosen');
+      this.view.bind('geocodingChosen', this.geocodingChosenSpy);
+      this.geocodeData = { foobar: 'baz!' };
+      this.view.model.set('geocodeData', this.geocodeData);
+    });
+
+    it('should hide the view', function() {
+      expect(this.view.hide).toHaveBeenCalled();
+
+      // should also delete on hide, so assert it's set too
+      expect(this.view.options.clean_on_hide).toBe(true);
+    });
+
+    it('should trigger geocodingChosen event with the data set', function() {
+      expect(this.geocodingChosenSpy).toHaveBeenCalled();
+      expect(this.geocodingChosenSpy.calls.argsFor(0)[0]).toEqual(this.geocodeData);
     });
   });
 

--- a/lib/assets/test/spec/cartodb/common/dialogs/georeference/georeference_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/georeference/georeference_view.spec.js
@@ -1,0 +1,57 @@
+var cdb = require('cartodb.js');
+var $ = require('jquery');
+var GeoreferenceView = require('../../../../../../javascripts/cartodb/common/dialogs/georeference/georeference_view');
+
+fdescribe('common/dialog/georeference/georeference_view', function() {
+  beforeEach(function() {
+    this.table = TestUtil.createTable('a');
+    this.user = new cdb.admin.User({
+      base_url: 'http://pepe.cartodb.com'
+    });
+    this.view = new GeoreferenceView({
+      table: this.table,
+      user: this.user
+    });
+    this.view.render();
+  });
+
+  it('should not have leaks', function() {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should render the different tabs', function() {
+    expect(this.innerHTML()).toContain('Lon/Lat Columns');
+    expect(this.innerHTML()).toContain('City Names');
+    expect(this.innerHTML()).toContain('Admin. Regions');
+    expect(this.innerHTML()).toContain('Postal Codes');
+    expect(this.innerHTML()).toContain('IP Addresses');
+    expect(this.innerHTML()).toContain('Street Addresses');
+  });
+
+  it('should start on the lon/lat column', function() {
+    var $selectedTabs = this.view.$('.js-tabs .is-selected');
+    expect($selectedTabs.length).toEqual(1);
+    expect($selectedTabs[0].innerHTML).toContain('Lon/Lat');
+    expect(this.innerHTML()).toContain('latitude');
+  });
+
+  describe('when selecting another tab', function() {
+    beforeEach(function() {
+      $(this.view.$('.js-tabs button').last()).click();
+    });
+
+    it('should unselect current item and select the new one', function() {
+      var $selectedTabs = this.view.$('.js-tabs .is-selected');
+      expect($selectedTabs.length).toEqual(1);
+      expect($selectedTabs[0].innerHTML).toContain('Street');
+    });
+
+    it('should change the content', function() {
+      expect(this.innerHTML()).not.toContain('latitude');
+    });
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+});

--- a/lib/assets/test/spec/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_model.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_model.spec.js
@@ -1,0 +1,29 @@
+var LonLatColumnsModel = require('../../../../../../../javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_model');
+
+describe('common/dialog/georeference/lon_lat_columns/lon_lat_columns_model', function() {
+  beforeEach(function() {
+    this.model = new LonLatColumnsModel({
+      columnsNames: ['foo', 'lon', 'bar', 'lat']
+    });
+  });
+
+  describe('.geocodeData', function() {
+    beforeEach(function() {
+      this.model.set({
+        lonColumnName: 'lon1',
+        latColumnName: 'lat2'
+      });
+
+      this.results = this.model.geocodeData();
+    });
+
+    it('should have a type of value lonlat set', function() {
+      expect(this.results.type).toEqual('lonlat');
+    });
+
+    it('should also contain the table column names to use for lon/lat geocoding', function() {
+      expect(this.results.longitude).toEqual('lon1');
+      expect(this.results.latitude).toEqual('lat2');
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_view.spec.js
@@ -1,0 +1,32 @@
+var LonLatColumnsModel = require('../../../../../../../javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_model');
+var LonLatColumnsView = require('../../../../../../../javascripts/cartodb/common/dialogs/georeference/lon_lat_columns/lon_lat_columns_view');
+
+describe('common/dialog/georeference/lon_lat_columns/lon_lat_columns_view', function() {
+  beforeEach(function() {
+    this.model = new LonLatColumnsModel({
+      columnsNames: ['foo', 'lon', 'bar', 'lat']
+    });
+    this.view = new LonLatColumnsView({
+      model: this.model
+    });
+    this.view.render();
+  });
+
+  it('should not have leaks', function() {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should change canContinue once a column is selected for each', function() {
+    expect(this.model.get('canContinue')).toBeFalsy();
+
+    this.model.set('lonColumnName', 'lon');
+    expect(this.model.get('canContinue')).toBeFalsy();
+
+    this.model.set('latColumnName', 'lat');
+    expect(this.model.get('canContinue')).toBe(true);
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+});


### PR DESCRIPTION
First step to finish #4158

![screen shot 2015-06-24 at 20 23 42](https://cloud.githubusercontent.com/assets/978461/8338083/f76c8bc4-1aae-11e5-890b-2679bf932081.png)

Implements the base for the new modal. I followed more or less the same pattern as for the merge modal that worked great there, i.e.
- one model/view couple per geocoder option.
- a parent view (georeference_view) that handles the life-cycle and high-level changes of the view, details are delegated to the currently selected geocoder option.

All the tabs are there as can be seen in the screenshot but the others are just stub models, and will be implemented separately, as outlined in the [referenced issue above](https://github.com/CartoDB/cartodb/issues/4158). 