### PR TITLE
add vis/uuid/static/:w/:h.png

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 * Updated cartodb.js to 3.14.6
 * Defaults Time Column to first date column or cartodb_id in Torque wizards [#4136](https://github.com/CartoDB/cartodb/pull/4136)
 * Added more customized Google basemaps.
+* New optional config option `maps_api_cdn_template` for static maps [#4153](https://github.com/CartoDB/cartodb/issues/4153)
+* New `api/v2/viz/{id}/static/{width}/{height}.png` endpoint for retrieving static maps
 
 Bugfixes:
 * Fixed deletion of layers upon disconnecting synced datasources [#3718](https://github.com/CartoDB/cartodb/pull/3718)

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -98,18 +98,17 @@ module Carto
       end
 
       def static_map
-        visualization = VisualizationQueryBuilder.new.with_id(params.fetch('id', nil)).build.first
         # Abusing here of .to_i fallback to 0 if not a proper integer
         map_width = params.fetch('width',nil).to_i
         map_height = params.fetch('height', nil).to_i
 
         # @see https://github.com/CartoDB/Windshaft-cartodb/blob/b59e0a00a04f822154c6d69acccabaf5c2fdf628/docs/Map-API.md#limits
-        if map_width < 2 || map_height < 2 || map_width > 8192 || map_height > 8192 || visualization.nil?
+        if map_width < 2 || map_height < 2 || map_width > 8192 || map_height > 8192
           return(head 400)
         end
 
         final_url = static_maps_base_url(CartoDB.extract_subdomain(request)) + 
-                    static_maps_image_url_fragment(visualization.id, map_width, map_height)
+                    static_maps_image_url_fragment(@visualization.id, map_width, map_height)
 
         redirect_to final_url
       end

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -16,11 +16,12 @@ module Carto
 
       # TODO: compare with older, there seems to be more optional authentication endpoints
       skip_before_filter :api_authorization_required, only: [:index, :vizjson2, :is_liked, :static_map]
-      before_filter :optional_api_authorization, only: [:index, :vizjson2, :is_liked]
+      before_filter :optional_api_authorization, only: [:index, :vizjson2, :is_liked, :static_map]
 
       before_filter :id_and_schema_from_params
       before_filter :load_by_name_or_id, only: [:vizjson2]
-      before_filter :load_visualization, only: [:likes_count, :likes_list, :is_liked, :show, :stats, :list_watching]
+      before_filter :load_visualization, only: [:likes_count, :likes_list, :is_liked, :show, :stats, :list_watching,
+                                                :static_map]
 
       def show
         render_jsonp(to_json(@visualization))

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -234,7 +234,7 @@ class Carto::Visualization < ActiveRecord::Base
 
   def get_named_map
     return nil if type == TYPE_REMOTE
-    data = named_maps.get(CartoDB::NamedMapsWrapper::NamedMap.normalize_name(id))
+    data = named_maps.get(CartoDB::NamedMapsWrapper::NamedMap.template_name(id))
     data.nil? ? false : data
   end
 

--- a/app/models/named_map/presenter.rb
+++ b/app/models/named_map/presenter.rb
@@ -14,7 +14,7 @@ module CartoDB
         @options          = options
         @configuration    = configuration
         @layergroup_data  = layergroup
-        @named_map_name   = NamedMap.normalize_name(@visualization.id)
+        @named_map_name   = NamedMap.template_name(@visualization.id)
       end
 
       # Prepares additional data to decorate layers in the LAYER_TYPES_TO_DECORATE list
@@ -135,12 +135,12 @@ module CartoDB
               verifycert: (@configuration[:tiler]['internal']['verifycert'] rescue true)
             }
           )
-        @named_map = named_maps.get(NamedMap.normalize_name(@visualization.id))
+        @named_map = named_maps.get(NamedMap.template_name(@visualization.id))
         unless @named_map.nil?
           if @visualization.parent_id.nil?
             @named_map_template = @named_map.template.fetch(:template)
           else
-            parent_named_map = named_maps.get(NamedMap.normalize_name(@visualization.parent_id))
+            parent_named_map = named_maps.get(NamedMap.template_name(@visualization.parent_id))
             @named_map_template = parent_named_map.template.fetch(:template).merge(@named_map.template.fetch(:template))
           end
         end

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -446,7 +446,7 @@ module CartoDB
       def get_named_map
         return false if type == TYPE_REMOTE
 
-        data = named_maps.get(CartoDB::NamedMapsWrapper::NamedMap.normalize_name(id))
+        data = named_maps.get(CartoDB::NamedMapsWrapper::NamedMap.template_name(id))
         if data.nil?
           false
         else

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -10,6 +10,7 @@ defaults: &defaults
   subdomainless_urls: false
   http_port:           3000 # nil|integer. HTTP port to use when building urls. Leave empty to use default (80)
   https_port:          # nil|integer. HTTPS port to use when building urls. Leave empty to use default (443)
+  maps_api_cdn_template: # nil|string. E.g. '{protocol}://{zone}.cartocdn/{user}/api/v1/map/static/named/{tpl_id}/{width}/{height}.png'
   secret_token:       '71c2b25921b84a1cb21c71503ab8fb23'
   account_host:       'localhost.lan:3000'
   account_path:       '/account'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -346,7 +346,8 @@ CartoDB::Application.routes.draw do
 
     # Visualizations
 
-    get '(/user/:user_domain)(/u/:user_domain)/api/v2/viz/:id/viz' => 'visualizations#vizjson2', as: :api_v2_visualizations_vizjson, constraints: { id: /[^\/]+/ }
+    get '(/user/:user_domain)(/u/:user_domain)/api/v2/viz/:id/viz'                       => 'visualizations#vizjson2',   as: :api_v2_visualizations_vizjson,    constraints: { id: /[^\/]+/ }
+    get '(/user/:user_domain)(/u/:user_domain)/api/v2/viz/:id/static/:width/:height.png' => 'visualizations#static_map', as: :api_v2_visualizations_static_map, constraints: { id: /[^\/]+/ }
 
   end
 

--- a/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
+++ b/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
@@ -104,7 +104,7 @@ module CartoDB
       end
 
       # Normalize a name to make it "named map valid"
-      def self.normalize_name( raw_name )
+      def self.template_name(raw_name)
         (NAME_PREFIX + raw_name).gsub(/[^a-zA-Z0-9\-\_.]/, '').gsub('-', '_')
       end
 
@@ -123,7 +123,7 @@ module CartoDB
         # 1) general data
         template_data = {
           version:      NAMED_MAPS_VERSION,
-          name:         self.normalize_name(visualization.id),
+          name:         self.template_name(visualization.id),
           auth:         {
                           method:   auth_type
                         },

--- a/spec/models/named_maps_spec.rb
+++ b/spec/models/named_maps_spec.rb
@@ -43,7 +43,7 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
     @user.destroy
   end
 
-  describe '#normalize_name' do
+  describe '#template_name' do
     it 'tests normalization of names' do
       name_1 = '08fee512-97cf-11e3-a775-30f9edfe5da6'
       expected_name_1 = CartoDB::NamedMapsWrapper::NamedMap::NAME_PREFIX + '08fee512_97cf_11e3_a775_30f9edfe5da6'
@@ -51,13 +51,13 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       name_2 = '!&32 += 01Z'
       expected_name_2 = CartoDB::NamedMapsWrapper::NamedMap::NAME_PREFIX + '3201Z'
 
-      normalized_name_1 = CartoDB::NamedMapsWrapper::NamedMap.normalize_name(name_1)
+      normalized_name_1 = CartoDB::NamedMapsWrapper::NamedMap.template_name(name_1)
       normalized_name_1.should eq expected_name_1
 
-      normalized_name_2 = CartoDB::NamedMapsWrapper::NamedMap.normalize_name(name_2)
+      normalized_name_2 = CartoDB::NamedMapsWrapper::NamedMap.template_name(name_2)
       normalized_name_2.should eq expected_name_2
     end
-  end #normalize_name
+  end
 
   describe 'password_protected_visualization' do
     it 'tests visualization auth capabilities for password restricted type' do
@@ -119,7 +119,7 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
                 Typhoeus::Response.new( code: 200, body: JSON::dump( { template_id: 'tpl_fakeid' } ) )
               )
 
-      template_id = CartoDB::NamedMapsWrapper::NamedMap.normalize_name(derived_vis.id)
+      template_id = CartoDB::NamedMapsWrapper::NamedMap.template_name(derived_vis.id)
 
       Typhoeus::Expectation.clear()
       # Retrieval
@@ -197,7 +197,7 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       collection.add(derived_vis)
       collection.store()
 
-      template_id = CartoDB::NamedMapsWrapper::NamedMap.normalize_name(derived_vis.id)
+      template_id = CartoDB::NamedMapsWrapper::NamedMap.template_name(derived_vis.id)
 
       named_map_template_data = {
         template_id: template_id
@@ -888,7 +888,7 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
     table = create_table( user_id: @user.id )
     derived_vis = CartoDB::Visualization::Copier.new(@user, table.table_visualization).copy
     derived_vis.privacy = visualization_privacy
-    template_id = CartoDB::NamedMapsWrapper::NamedMap.normalize_name(derived_vis.id)
+    template_id = CartoDB::NamedMapsWrapper::NamedMap.template_name(derived_vis.id)
 
     Typhoeus.stub( tiler_regex )
             .and_return(

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -174,6 +174,32 @@ describe Carto::Api::VisualizationsController do
       last_response.location.should == "http://#{@user1.username}.localhost.lan:8181/api/v1/map/static/named/#{tpl_id}/#{width}/#{height}.png"
     end
 
+    it 'tests varnish keys' do
+      width = 123
+      height = 456
+
+      table1 = create_random_table(@user1)
+
+      Carto::Api::VisualizationsController.any_instance
+                                          .stubs(:get_static_maps_api_cdn_config)
+                                          .returns("{protocol}://cdn.local.lan/{user}")
+
+      get api_v2_visualizations_static_map_url({
+          user_domain: @user1.username, 
+          #api_key: @user1.api_key,
+          id: table1.table_visualization.id,
+          width: width,
+          height: height
+        }),
+        @headers
+      last_response.status.should == 302
+      last_response.headers["X-Cache-Channel"].should include(table1.name)
+      last_response.headers["X-Cache-Channel"].should include(table1.table_visualization.varnish_key)
+      last_response.headers["Surrogate-Key"].should_not be_empty
+      last_response.headers["Surrogate-Key"].should include(CartoDB::SURROGATE_NAMESPACE_VIZJSON)
+      last_response.headers["Surrogate-Key"].should include(table1.table_visualization.surrogate_key)
+    end
+
   end
 
   describe 'index' do

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -68,7 +68,8 @@ describe Carto::Api::VisualizationsController do
       @headers = {'CONTENT_TYPE'  => 'application/json'}
       host! "#{@user1.subdomain}.localhost.lan"
 
-      CartoDB.unstub(:get_session_domain)
+      @user1.private_tables_enabled = false
+      @user1.save
     end
 
     it 'tests with non-existing cdn config, which uses maps_api_template url' do
@@ -85,7 +86,6 @@ describe Carto::Api::VisualizationsController do
 
       get api_v2_visualizations_static_map_url({
           user_domain: @user1.username, 
-          api_key: @user1.api_key,
           id: table1.table_visualization.id,
           width: width,
           height: height
@@ -109,7 +109,7 @@ describe Carto::Api::VisualizationsController do
 
       get api_v2_visualizations_static_map_url({
           user_domain: @user1.username, 
-          api_key: @user1.api_key,
+          #api_key: @user1.api_key,
           id: table1.table_visualization.id,
           width: width,
           height: height
@@ -119,6 +119,59 @@ describe Carto::Api::VisualizationsController do
 
       tpl_id = CartoDB::NamedMapsWrapper::NamedMap.template_name(table1.table_visualization.id)
       last_response.location.should == "http://cdn.local.lan/#{@user1.username}/api/v1/map/static/named/#{tpl_id}/#{width}/#{height}.png"
+    end
+
+    it 'tests privacy of static_maps calls' do
+      # As privacy is equal to other visualizations controller methods, no need to test every option, just generally
+
+      width = 123
+      height = 456
+
+      public_table = create_random_table(@user1)
+
+      # By default no private tables so all are created public
+      @user1.private_tables_enabled = true
+      @user1.save
+
+      private_table = create_random_table(@user1)
+
+      Carto::Api::VisualizationsController.any_instance
+                                          .stubs(:get_static_maps_api_cdn_config)
+                                          .returns(nil)
+      ApplicationHelper.stubs(:maps_api_template)
+                       .returns("http://#{@user1.username}.localhost.lan:8181")
+
+      get api_v2_visualizations_static_map_url({
+          user_domain: @user1.username, 
+          id: public_table.table_visualization.id,
+          width: width,
+          height: height
+        }),
+        @headers
+      last_response.status.should == 302
+      tpl_id = CartoDB::NamedMapsWrapper::NamedMap.template_name(public_table.table_visualization.id)
+      last_response.location.should == "http://#{@user1.username}.localhost.lan:8181/api/v1/map/static/named/#{tpl_id}/#{width}/#{height}.png"
+
+      get api_v2_visualizations_static_map_url({
+          user_domain: @user1.username, 
+          id: private_table.table_visualization.id,
+          width: width,
+          height: height
+        }),
+        @headers
+      last_response.status.should == 403
+
+      get api_v2_visualizations_static_map_url({
+          user_domain: @user1.username, 
+          api_key: @user1.api_key,
+          id: private_table.table_visualization.id,
+          width: width,
+          height: height
+        }),
+        @headers
+      last_response.status.should == 302
+      tpl_id = CartoDB::NamedMapsWrapper::NamedMap.template_name(private_table.table_visualization.id)
+      last_response.location.should == "http://#{@user1.username}.localhost.lan:8181/api/v1/map/static/named/#{tpl_id}/#{width}/#{height}.png"
     end
 
   end


### PR DESCRIPTION
Closes #4153

Note: `normalize_name` change to `template_name` is because old one was not as clear, new one fits better, but is a simple replace without touching logic.