### PR TITLE
Fixing progress quota colors in user settings dropdown + fixing name&account-type space

### DIFF
--- a/app/assets/stylesheets/common/header/settings_dropdown.css.scss
+++ b/app/assets/stylesheets/common/header/settings_dropdown.css.scss
@@ -22,6 +22,7 @@
   @include align-items(center, center);
 }
 .SettingsDropdown-accountType {
+  margin-left: 10px;
   color: $cTypography-secondary;
   text-transform: capitalize;
 }
@@ -34,7 +35,7 @@
   background: #F5F5F5;
   @include progress-bar(6px, 9px, true, false);
 }
-.SettingsDropdown-progressBar.is--inAlert div.progress-bar span { background: $cHighlight-alert!important }
+.SettingsDropdown-progressBar.is--inAlert div.progress-bar span { background: $cHighlight-caution!important }
 .SettingsDropdown-progressBar.is--inDanger div.progress-bar span { background: $cHighlight-negative!important }
 .SettingsDropdown-itemLink {
   font-size: $sFontSize-large;

--- a/app/assets/stylesheets/common/header/settings_dropdown.css.scss
+++ b/app/assets/stylesheets/common/header/settings_dropdown.css.scss
@@ -21,6 +21,11 @@
   @include justify-content(space-between, justify);
   @include align-items(center, center);
 }
+.SettingsDropdown-itemLink:hover {
+  text-decoration: none;
+  .SettingsDropdown-itemLinkText { text-decoration: underline }
+}
+.SettingsDropdown-itemLinkText { font-size: $sFontSize-normal }
 .SettingsDropdown-accountType {
   margin-left: 10px;
   color: $cTypography-secondary;

--- a/app/assets/stylesheets/variables/colors.css.scss
+++ b/app/assets/stylesheets/variables/colors.css.scss
@@ -27,6 +27,7 @@ $cHighlight-negative:  rgba(#C74B43, 1);
 $cHighlight-alert:     rgba(#C67B44, 1);
 $cHighlight-alert2:    rgba(orange, 1);
 $cHighlight-alert3:    rgba(#EA703D, 1);
+$cHighlight-caution:   rgba(#F8B85C, 1);
 
 // Icons
 $cIcons-default: rgba(#CCC, 1);

--- a/app/assets/stylesheets/variables/progress-bar.css.scss
+++ b/app/assets/stylesheets/variables/progress-bar.css.scss
@@ -12,6 +12,7 @@
 
   @import "compass/css3/images";
   @import "./mixins";
+  @import "./colors";
 
 
   @mixin progress-bar($h, $r, $grad, $min) {
@@ -77,8 +78,8 @@
       }
 
       // Danger and caution background
-      .danger { background: #c74b43 }
-      .caution { background: #F8B85C }
+      .danger { background: $cHighlight-negative }
+      .caution { background: $cHighlight-caution }
     }
   }
 

--- a/lib/assets/javascripts/cartodb/common/views/dashboard_header/settings_dropdown.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/dashboard_header/settings_dropdown.jst.ejs
@@ -9,12 +9,14 @@
     </p>
   </li>
   <li class="SettingsDropdown-item">
+    <% if (showUpgradeLink) { %>
+      <a href="<%= upgradeUrl %>" class="SettingsDropdown-itemLink">
+    <% } %>
+
     <p class="SettingsDropdown-sameline">
       <small class="DefaultDescription"><%= usedDataStr %> of <%= availableDataStr %> used</small>
       <% if (showUpgradeLink) { %>
-        <a href="<%= upgradeUrl %>">
-          Upgrade
-        </a>
+        <span class="SettingsDropdown-itemLinkText">Upgrade</span>
       <% } %>
     </p>
     <div class="SettingsDropdown-progressBar <%= progressBarClass %>">
@@ -22,6 +24,10 @@
         <span class="bar-2" style="width: <%= usedDataPct %>%"></span>
       </div>
     </div>
+
+    <% if (showUpgradeLink) { %>
+      </a>
+    <% } %>
   </li>
   <li class="SettingsDropdown-item">
     <p><a class="SettingsDropdown-itemLink" href="<%= publicProfileUrl %>">View your public profile</a></p>


### PR DESCRIPTION
- Set same color for progress when it is close to its limits. I've decided to create a new color "caution" instead of changing the "alert" color preventing no desirable changes in the rest of parts in the new layout.
- Fixed a problem with long names in the user settings dropdown.
![screen shot 2015-06-29 at 14 18 34](https://cloud.githubusercontent.com/assets/132146/8407784/85fbdc82-1e6a-11e5-997d-7fba23e9b756.png)

Review: @viddo.

Fixes #4177 