### PR TITLE
zero'd out the line width on default torque

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
@@ -616,7 +616,7 @@ var sharedForTorqueAndTorqueCat = {
     {
       name: 'Marker Stroke',
       form: {
-        'marker-line-width': { type: 'width', value: 1.5 },
+        'marker-line-width': { type: 'width', value: 0 },
         'marker-line-color': { type: 'color' , value: '#FFF' },
         'marker-line-opacity': { type: 'opacity', value: 1.0 }
       }


### PR DESCRIPTION
Default torque visualizations always have a stroke and it looks subpar. Modifying to default stroke of 0