### PR TITLE
Shows the name of the first item in case we just delete one element

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -67,6 +67,7 @@ module.exports = BaseDialog.extend({
     var affectedVisData = this._viewModel.affectedVisData();
 
     return cdb.templates.getTemplate('common/dialogs/delete_items_view_template')({
+      firstItemName: this._getFirstItemName(),
       selectedCount: this._viewModel.length,
       isDatasets: this._viewModel.isDeletingDatasets(),
       pluralizedContentType: this._pluralizedContentType(),
@@ -139,6 +140,16 @@ module.exports = BaseDialog.extend({
       this._viewModel.isDeletingDatasets() ? 'dataset' : 'map',
       this._viewModel.length
     );
+  },
+
+  _getFirstItemName: function() {
+    if (!this.options.viewModel) return;
+
+    var firstItem = this.options.viewModel.at(0);
+
+    if (firstItem) {
+      return firstItem.get("name");
+    }
   }
 
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view_template.jst.ejs
@@ -3,7 +3,13 @@
     <i class="iconFont iconFont-Trash"></i>
     <span class="Badge Badge--negative Dialog-headerIconBadge"><%= selectedCount %></span>
   </div>
-  <p class="Dialog-headerTitle">You are about to delete <%= selectedCount %> <%= pluralizedContentType %>.</p>
+  <p class="Dialog-headerTitle">
+    <% if (selectedCount > 1) { %>
+    You are about to delete <%= selectedCount %> <%= pluralizedContentType %>.
+    <% } else { %>
+    You are about to delete the '<%- firstItemName %>' <%= pluralizedContentType %>.
+    <% } %>
+  </p>
   <p class="Dialog-headerText">
     <% if (affectedVisCount > 0) { %>
       Doing so will imply changes in <strong><%= affectedVisCount %> affected <%= pluralizedMaps %></strong>.


### PR DESCRIPTION
This PR adds a change to show the name of the first item in case the user is deleting one single element (map or dataset).

Original ticket: https://github.com/CartoDB/cartodb/issues/4142

![screen shot 2015-07-02 at 11 23 52](https://cloud.githubusercontent.com/assets/4933/8474950/663ce548-20b4-11e5-9aa8-0da2bb0f385d.png)

![screen shot 2015-07-02 at 11 24 03](https://cloud.githubusercontent.com/assets/4933/8474951/664427c2-20b4-11e5-986f-ebf804e671c3.png)
