### PR TITLE
Fixed tests removing unused config

### DIFF
--- a/config/app_config.yml.testing
+++ b/config/app_config.yml.testing
@@ -157,20 +157,7 @@ defaults: &defaults
     background:
       kind: "background"
       options: { color: '#ffffff' }
-    base:
-      kind: "tiled"
       options:
-        visible:      true
-        type:         "Tiled"
-        urlTemplate:  "https://maps.nlp.nokia.com/maptiler/v2/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?lg=eng&token=A7tBPacePg9Mj_zghvKt9Q&app_id=KuYppsdXZznpffJsKT24"
-        name:         'Nokia Day'
-        className:    "nokia_day"
-        attribution:  "©2012 Nokia <a href='http://here.net/services/terms' target='_blank'>Terms of use</a>"
-    gmaps:
-      kind: "gmapsbase"
-      options:
-        base_type: "roadmap"
-        style: ""
   cartodb_com_hosted: true
   cartodb_central_domain_name: 'cartodb.com'
   cartodb_central_api:

--- a/spec/models/layer_spec.rb
+++ b/spec/models/layer_spec.rb
@@ -35,12 +35,6 @@ describe Layer do
       l = Layer.create(Cartodb.config[:layer_opts]["background"]).reload
       l.kind.should == 'background'
       l.options.should == Cartodb.config[:layer_opts]["background"]["options"]
-      l = Layer.create(Cartodb.config[:layer_opts]["base"]).reload
-      l.kind.should == 'tiled'
-      l.options.should == Cartodb.config[:layer_opts]["base"]["options"]
-      l = Layer.create(Cartodb.config[:layer_opts]["gmaps"]).reload
-      l.kind.should == 'gmapsbase'
-      l.options.should == Cartodb.config[:layer_opts]["gmaps"]["options"]
     end
 
     it "should not allow to create layers of unkown types" do


### PR DESCRIPTION
Removed unused configuration and fixed tests that try to use it. This change was made by @javisantana in [this commit] (https://github.com/CartoDB/cartodb/commit/0a9f6cc797d210041f4a7c56429da3b53f820b62). This fixes #4302.

@juanignaciosl pls review this PR :)