### PR TITLE
Removed cdn_url property from all the layers

### DIFF
--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -195,7 +195,6 @@ module Carto
             if @layer.options['table_name'] && !viewer_is_owner?
               data['table_name'] = qualify_table_name
             end
-            data['dynamic_cdn'] = @viewer_user.dynamic_cdn_enabled
           end
           data
         end
@@ -234,7 +233,6 @@ module Carto
             sql_api_endpoint:   (@configuration[:sql_api]["public"]["endpoint"] rescue nil),
             sql_api_port:       (@configuration[:sql_api]["public"]["port"] rescue nil),
             layer_name:         name_for(@layer),
-            dynamic_cdn:        @viewer_user ? @viewer_user.dynamic_cdn_enabled : false
           }.merge(
             layer_options.select { |k| TORQUE_ATTRS.include? k })
         }

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -233,7 +233,6 @@ module Carto
             sql_api_domain:     (@configuration[:sql_api]["public"]["domain"] rescue nil),
             sql_api_endpoint:   (@configuration[:sql_api]["public"]["endpoint"] rescue nil),
             sql_api_port:       (@configuration[:sql_api]["public"]["port"] rescue nil),
-            cdn_url:            @configuration.fetch(:cdn_url, nil),
             layer_name:         name_for(@layer),
             dynamic_cdn:        @viewer_user ? @viewer_user.dynamic_cdn_enabled : false
           }.merge(

--- a/app/controllers/carto/api/vizjson_presenter.rb
+++ b/app/controllers/carto/api/vizjson_presenter.rb
@@ -27,8 +27,7 @@ module Carto
           user_name: user.username,
           user_api_key: user.api_key,
           user: user,
-          viewer_user: user,
-          dynamic_cdn_enabled: user.dynamic_cdn_enabled
+          viewer_user: user
         }.merge(options)
         CartoDB::Visualization::VizJSON.new(Carto::Api::VisualizationVizJSONAdapter.new(@visualization, @redis_cache), vizjson_options, Cartodb.config).to_poro
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,13 +98,6 @@ module ApplicationHelper
       config[:statsd_port] = Cartodb.config[:graphite_public]['port']
     end
 
-    if Cartodb.config[:cdn_url].present?
-      config[:cdn_url] = {
-        http:              Cartodb.config[:cdn_url].try("fetch", "http", nil),
-        https:             Cartodb.config[:cdn_url].try("fetch", "https", nil)
-      }
-    end
-
     if Cartodb.config[:error_track].present?
       config[:error_track_url] = Cartodb.config[:error_track]["url"]
       config[:error_track_percent_users] = Cartodb.config[:error_track]["percent_users"]
@@ -131,13 +124,6 @@ module ApplicationHelper
     if Cartodb.config[:graphite_public].present?
       config[:statsd_host] = Cartodb.config[:graphite_public]['host']
       config[:statsd_port] = Cartodb.config[:graphite_public]['port']
-    end
-
-    if Cartodb.config[:cdn_url].present?
-      config[:cdn_url] = {
-        http:              Cartodb.config[:cdn_url].try("fetch", "http", nil),
-        https:             Cartodb.config[:cdn_url].try("fetch", "https", nil)
-      }
     end
 
     if Cartodb.config[:error_track].present?

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -33,7 +33,7 @@ class Carto::User < ActiveRecord::Base
 
   # INFO: select filter is done for security and performance reasons. Add new columns if needed.
   DEFAULT_SELECT = "users.email, users.username, users.admin, users.organization_id, users.id, users.avatar_url," + 
-                   "users.api_key, users.dynamic_cdn_enabled, users.database_schema, users.database_name, users.name," +
+                   "users.api_key, users.database_schema, users.database_name, users.name," +
                    "users.disqus_shortname, users.account_type, users.twitter_username, users.google_maps_key"
 
   SELECT_WITH_DATABASE = DEFAULT_SELECT + ", users.quota_in_bytes, users.database_host"

--- a/app/models/layer/presenter.rb
+++ b/app/models/layer/presenter.rb
@@ -160,7 +160,6 @@ module CartoDB
             sql_api_domain:     (configuration[:sql_api]["public"]["domain"] rescue nil),
             sql_api_endpoint:   (configuration[:sql_api]["public"]["endpoint"] rescue nil),
             sql_api_port:       (configuration[:sql_api]["public"]["port"] rescue nil),
-            cdn_url:            configuration.fetch(:cdn_url, nil),
             layer_name:         name_for(layer),
             dynamic_cdn:        options[:viewer_user] ? options[:viewer_user].dynamic_cdn_enabled : false
           }.merge(

--- a/app/models/layer/presenter.rb
+++ b/app/models/layer/presenter.rb
@@ -161,7 +161,6 @@ module CartoDB
             sql_api_endpoint:   (configuration[:sql_api]["public"]["endpoint"] rescue nil),
             sql_api_port:       (configuration[:sql_api]["public"]["port"] rescue nil),
             layer_name:         name_for(layer),
-            dynamic_cdn:        options[:viewer_user] ? options[:viewer_user].dynamic_cdn_enabled : false
           }.merge(
             layer_options.select { |k| TORQUE_ATTRS.include? k })
         }
@@ -220,7 +219,6 @@ module CartoDB
             unless data['user_name'] == viewer.username
               data['table_name'] = "\"#{data['user_name']}\".#{data['table_name']}"
             end
-            data['dynamic_cdn'] = viewer.dynamic_cdn_enabled
           end
           data
         end

--- a/app/models/layer_group/presenter.rb
+++ b/app/models/layer_group/presenter.rb
@@ -32,7 +32,6 @@ module CartoDB
             sql_api_domain:     (configuration[:sql_api]["public"]["domain"] rescue nil),
             sql_api_endpoint:   (configuration[:sql_api]["public"]["endpoint"] rescue nil),
             sql_api_port:       (configuration[:sql_api]["public"]["port"] rescue nil),
-            cdn_url:            configuration.fetch(:cdn_url, nil),
             dynamic_cdn:        @options.fetch(:dynamic_cdn_enabled, false),
             filter:             @configuration[:tiler].fetch('filter', DEFAULT_TILER_FILTER),
             layer_definition:   {

--- a/app/models/layer_group/presenter.rb
+++ b/app/models/layer_group/presenter.rb
@@ -32,7 +32,6 @@ module CartoDB
             sql_api_domain:     (configuration[:sql_api]["public"]["domain"] rescue nil),
             sql_api_endpoint:   (configuration[:sql_api]["public"]["endpoint"] rescue nil),
             sql_api_port:       (configuration[:sql_api]["public"]["port"] rescue nil),
-            dynamic_cdn:        @options.fetch(:dynamic_cdn_enabled, false),
             filter:             @configuration[:tiler].fetch('filter', DEFAULT_TILER_FILTER),
             layer_definition:   {
               stat_tag:           options.fetch(:visualization_id),

--- a/app/models/named_map/presenter.rb
+++ b/app/models/named_map/presenter.rb
@@ -61,7 +61,6 @@ module CartoDB
               tiler_port:       @visualization.password_protected? ?
                                   @configuration[:tiler]['private']['port'] :
                                   @configuration[:tiler]['public']['port'],
-              dynamic_cdn:        @options.fetch(:dynamic_cdn_enabled),
               filter:           @configuration[:tiler].fetch('filter', DEFAULT_TILER_FILTER),
               named_map:        {
                 name:     @named_map_name,

--- a/app/models/named_map/presenter.rb
+++ b/app/models/named_map/presenter.rb
@@ -61,7 +61,6 @@ module CartoDB
               tiler_port:       @visualization.password_protected? ?
                                   @configuration[:tiler]['private']['port'] :
                                   @configuration[:tiler]['public']['port'],
-              cdn_url:          @configuration.fetch(:cdn_url, nil),
               dynamic_cdn:        @options.fetch(:dynamic_cdn_enabled),
               filter:           @configuration[:tiler].fetch('filter', DEFAULT_TILER_FILTER),
               named_map:        {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,7 +195,7 @@ class User < Sequel::Model
     rebuild_quota_trigger    if changes.include?(:quota_in_bytes)
     if changes.include?(:account_type) || changes.include?(:available_for_hire) || changes.include?(:disqus_shortname) || changes.include?(:email) || \
        changes.include?(:website) || changes.include?(:name) || changes.include?(:description) || \
-       changes.include?(:twitter_username) || changes.include?(:dynamic_cdn_enabled)
+       changes.include?(:twitter_username)
       invalidate_varnish_cache(regex: '.*:vizjson')
     end
     if changes.include?(:database_host)
@@ -2474,7 +2474,7 @@ TRIGGER
     CartoDB::Visualization::RedisVizjsonCache.new().purge(vizs)
   end
 
-  # returns google maps api key. If the user is in an organization and 
+  # returns google maps api key. If the user is in an organization and
   # that organization has api key it's used
   def google_maps_api_key
     if has_organization?
@@ -2514,7 +2514,7 @@ TRIGGER
     google_maps_enabled = !google_maps_api_key.blank?
     basemaps = Cartodb.config[:basemaps]
     if basemaps
-      basemaps.select { |group| 
+      basemaps.select { |group|
         g = group == 'GMaps'
         google_maps_enabled ? g : !g
       }

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -638,8 +638,7 @@ module CartoDB
           user_name: user.username,
           user_api_key: user.api_key,
           user: user,
-          viewer_user: user,
-          dynamic_cdn_enabled: user != nil ? user.dynamic_cdn_enabled: false
+          viewer_user: user
         }.merge(options)
         VizJSON.new(self, vizjson_options, configuration).to_poro
       end

--- a/app/models/visualization/vizjson.rb
+++ b/app/models/visualization/vizjson.rb
@@ -100,7 +100,6 @@ module CartoDB
           presenter_options = {
             user_name: options.fetch(:user_name),
             api_key: options.delete(:user_api_key),
-            dynamic_cdn_enabled: @user != nil ? @user.dynamic_cdn_enabled: false,
             https_request: options.fetch(:https_request, false),
             viewer_user: @user,
             owner: visualization.user

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -162,7 +162,7 @@ defaults: &defaults
     public_opts: ["type", "active", "query", "opacity", "auto_bound",
                   "interactivity", "debug", "visible", "tiler_domain",
                   "tiler_port", "tiler_protocol", "sql_domain", "sql_port",
-                  "sql_protocol", "extra_params", "cdn_url", "table_name",
+                  "sql_protocol", "extra_params", "table_name",
                   "user_name", "style_version", "tile_style", "query_wrapper"]
     default_tile_styles:
       point: "{\n  marker-fill: #FF6600;\n  marker-opacity: 0.9;\n  marker-width: 12;\n  marker-line-color: white;\n  marker-line-width: 3;\n  marker-line-opacity: 0.9;\n  marker-placement: point;\n  marker-type: ellipse;\n  marker-allow-overlap: true;\n}"
@@ -186,7 +186,6 @@ defaults: &defaults
         sql_port:           "80"
         sql_protocol:       "http"
         extra_params:       { cache_policy: 'persist' }
-        cdn_url:            ""
         tile_style_history: []
         style_version:      "2.1.1"
       infowindow:

--- a/config/app_config.yml.testing
+++ b/config/app_config.yml.testing
@@ -114,18 +114,18 @@ defaults: &defaults
         className: 'googlemaps'
     CartoDB:
       positron_rainbow:
-        url: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png' 
-        subdomains: 'abcd' 
-        minZoom: '0' 
-        maxZoom: '18' 
-        name: 'Positron' 
-        className: 'positron_rainbow' 
-        attribution: '© <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href= "http://cartodb.com/attributions">CartoDB</a>' 
+        url: 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
+        subdomains: 'abcd'
+        minZoom: '0'
+        maxZoom: '18'
+        name: 'Positron'
+        className: 'positron_rainbow'
+        attribution: '© <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href= "http://cartodb.com/attributions">CartoDB</a>'
   layer_opts:
-    public_opts: ["type", "active", "query", "opacity", "auto_bound", 
-                  "interactivity", "debug", "visible", "tiler_domain", 
-                  "tiler_port", "tiler_protocol", "sql_domain", "sql_port", 
-                  "sql_protocol", "extra_params", "cdn_url", "table_name", 
+    public_opts: ["type", "active", "query", "opacity", "auto_bound",
+                  "interactivity", "debug", "visible", "tiler_domain",
+                  "tiler_port", "tiler_protocol", "sql_domain", "sql_port",
+                  "sql_protocol", "extra_params", "table_name",
                   "user_name", "style_version", "tile_style", "query_wrapper"]
     default_tile_styles:
       point: "{\n  marker-fill: #FF6600;\n  marker-opacity: 0.9;\n  marker-width: 12;\n  marker-line-color: white;\n  marker-line-width: 3;\n  marker-line-opacity: 0.9;\n  marker-placement: point;\n  marker-type: ellipse;\n  marker-allow-overlap: true;\n}"
@@ -149,7 +149,6 @@ defaults: &defaults
         sql_port:           "80"
         sql_protocol:       "http"
         extra_params:       { cache_policy: 'persist' }
-        cdn_url:            ""
         tile_style_history: []
         style_version:      "2.1.1"
       infowindow:
@@ -177,7 +176,7 @@ defaults: &defaults
     kinds: ['stars', 'mountains']
     colors: ['red', 'blue']
   dropbox_api_key: ""
-  gdrive: 
+  gdrive:
     api_key: ""
     app_id: ""
   enforce_non_empty_layer_css: false

--- a/spec/models/named_maps_spec.rb
+++ b/spec/models/named_maps_spec.rb
@@ -384,7 +384,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       vizjson[:layers][1][:options][:sql_api_domain].should eq 'localhost.lan'
       vizjson[:layers][1][:options][:sql_api_endpoint].should eq '/api/v1/sql'
       vizjson[:layers][1][:options][:sql_api_port].should eq 8080
-      vizjson[:layers][1][:options].include?(:cdn_url).should eq true
       vizjson[:layers][1][:options].include?(:layer_name).should eq true
       vizjson[:layers][1][:options].include?(:table_name).should eq true
       vizjson[:layers][1][:options].include?(:tile_style).should eq true
@@ -449,7 +448,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       vizjson[:layers][1][:options][:tiler_protocol].should eq 'http'
       vizjson[:layers][1][:options][:tiler_domain].should eq 'localhost.lan'
       vizjson[:layers][1][:options][:tiler_port].should eq public_tiler_port
-      vizjson[:layers][1][:options].include?(:cdn_url).should eq true
       vizjson[:layers][1][:options].include?(:named_map).should eq true
       vizjson[:layers][1][:options][:named_map][:name].should eq template_id
       vizjson[:layers][1][:options][:named_map][:params].size.should eq 1
@@ -536,7 +534,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       vizjson[:layers][1][:options][:tiler_protocol].should eq 'http'
       vizjson[:layers][1][:options][:tiler_domain].should eq 'localhost.lan'
       vizjson[:layers][1][:options][:tiler_port].should eq public_tiler_port
-      vizjson[:layers][1][:options].include?(:cdn_url).should eq true
       vizjson[:layers][1][:options].include?(:named_map).should eq true
       vizjson[:layers][1][:options][:named_map][:name].should eq template_id
       vizjson[:layers][1][:options][:named_map][:params].size.should eq 1
@@ -556,7 +553,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       vizjson[:layers][2][:options][:sql_api_domain].should eq 'localhost.lan'
       vizjson[:layers][2][:options][:sql_api_endpoint].should eq '/api/v1/sql'
       vizjson[:layers][2][:options][:sql_api_port].should eq 8080
-      vizjson[:layers][2][:options].include?(:cdn_url).should eq true
       vizjson[:layers][2][:options].include?(:layer_name).should eq true
       vizjson[:layers][2][:options].include?(:table_name).should eq true
       vizjson[:layers][2][:options].include?(:tile_style).should eq true
@@ -649,7 +645,6 @@ describe CartoDB::NamedMapsWrapper::NamedMaps do
       vizjson[:layers][1][:options][:tiler_protocol].should eq 'http'
       vizjson[:layers][1][:options][:tiler_domain].should eq 'localhost.lan'
       vizjson[:layers][1][:options][:tiler_port].should eq public_tiler_port
-      vizjson[:layers][1][:options].include?(:cdn_url).should eq true
       vizjson[:layers][1][:options].include?(:named_map).should eq true
       vizjson[:layers][1][:options][:named_map][:name].should eq template_id
       vizjson[:layers][1][:options][:named_map][:params].size.should eq 2

--- a/spec/models/visualization/organization_visualization_spec.rb
+++ b/spec/models/visualization/organization_visualization_spec.rb
@@ -245,7 +245,6 @@ describe Visualization::Member do
                 :cache_policy => 'persist',
                 :cache_buster => 1404930437358
             },
-            :cdn_url => '',
             :maxZoom => 28,
             :auto_bound => false,
             :visible => true,

--- a/spec/requests/api/json/layer_presenter_shared_examples.rb
+++ b/spec/requests/api/json/layer_presenter_shared_examples.rb
@@ -331,7 +331,6 @@ shared_examples_for "layer presenters" do |tested_klass, model_klass|
             sql_api_domain: nil,
             sql_api_endpoint: nil,
             sql_api_port: nil,
-            cdn_url: nil,
             layer_name: layer.options['table_name'],
             dynamic_cdn: false, 
             'table_name' => layer.options['table_name'], 

--- a/spec/requests/api/json/layer_presenter_shared_examples.rb
+++ b/spec/requests/api/json/layer_presenter_shared_examples.rb
@@ -332,7 +332,6 @@ shared_examples_for "layer presenters" do |tested_klass, model_klass|
             sql_api_endpoint: nil,
             sql_api_port: nil,
             layer_name: layer.options['table_name'],
-            dynamic_cdn: false, 
             'table_name' => layer.options['table_name'], 
             'query' => "select * from #{layer.options['table_name']}"
           }

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -62,7 +62,6 @@ module CartoDB
       user.organization          = attributes[:organization] || nil
       user.twitter_datasource_enabled = attributes[:twitter_datasource_enabled] || false
       user.avatar_url            = user.default_avatar
-      user.dynamic_cdn_enabled   = attributes[:dynamic_cdn_enabled] || false
 
       user
     end


### PR DESCRIPTION
Removed `cdn_url` property from `viz.json` because this info now comes from the tile and is not necessary here for compatibility reasons.

After this change is commited I assume that a `bundle exec rake cartodb:redis:purge_vizjson` task should be launched to remove old vizs from cache.

**This PR fixes #3983**

/cc @javisantana