### PR TITLE
Fix city addr geocoding for free text region

### DIFF
--- a/app/assets/stylesheets/common/flash-message.css.scss
+++ b/app/assets/stylesheets/common/flash-message.css.scss
@@ -19,6 +19,7 @@
   position: fixed;
   top: 157px;
   border-bottom: 1px solid $cStructure-mainLine;
+  z-index: 2; // to place any scrolled content under the flash message
   & > .u-inner { @include justify-content(center, center) }
 }
 .FlashMessage--success { background: #E8F0D6 }

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names/city_names_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names/city_names_model.js
@@ -57,7 +57,9 @@ module.exports = cdb.core.Model.extend({
       continueLabel: undefined,
       column_name: '',
       location: '',
-      region: ''
+      isLocationFreeText: false,
+      region: '',
+      isRegionFreeText: false
     });
   },
 
@@ -83,6 +85,7 @@ module.exports = cdb.core.Model.extend({
     var region = this.get('region');
     if (!_.isEmpty(region)) {
       d.region = region;
+      d.region_text = this.get('isRegionFreeText');
     }
 
     this.set('geocodeData', d);

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
@@ -15,7 +15,7 @@
       </ul>
     </div>
 
-    <div class="Dialog-body Dialog-body--expanded CreateDialog-body">
+    <div class="Dialog-body Dialog-body--expanded is-expandedWithSubFooter CreateDialog-body">
       <div class="CreateDialog-listing <%- hasNoGeoferencedData ? 'CreateDialog-listing--withFlashMessage': '' %>">
         <% if (hasNoGeoferencedData) { %>
           <div class="FlashMessage FlashMessage--inDialogWithFiltersNavListing">

--- a/lib/assets/test/spec/cartodb/common/dialogs/georeference/city_names/city_names_model.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/georeference/city_names/city_names_model.spec.js
@@ -85,13 +85,19 @@ describe('common/dialog/georeference/city_names/city_names_model', function() {
         describe('when have also set a region', function() {
           beforeEach(function() {
             this.model.set('region', 'val');
-            this.model.continue();
           });
 
-          it('should also set geocode data with region', function() {
+          it('should set geocode data with region', function() {
+            this.model.continue();
             var d = this.model.get('geocodeData');
             expect(d.region).toEqual('val');
-            expect(d.region_text).toEqual(true);
+            expect(d.region_text).toBeFalsy();
+
+            this.model.set('isRegionFreeText', true);
+            this.model.continue();
+            d = this.model.get('geocodeData');
+            expect(d.region).toEqual('val');
+            expect(d.region_text).toBe(true);
           });
         });
       });

--- a/lib/assets/test/spec/cartodb/common/dialogs/georeference/city_names/city_names_model.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/georeference/city_names/city_names_model.spec.js
@@ -72,15 +72,27 @@ describe('common/dialog/georeference/city_names/city_names_model', function() {
           expect(d.type).toEqual('city');
           expect(d.kind).toEqual('namedplace');
           expect(d.column_name).toEqual('col');
-          expect(d.region).toBeUndefined();
           expect(d.location).toEqual('loc');
           expect(d.geometry_type).toEqual('point');
+        });
 
-          // region should only be set if actually has a value
-          this.model.set('region', 'val');
-          this.model.continue();
-          d = this.model.get('geocodeData');
-          expect(d.region).toEqual('val');
+        it('should not set geocode data with optional stuff', function() {
+          var d = this.model.get('geocodeData');
+          expect(d.region).toBeUndefined();
+          expect(d.region_text).toBeUndefined();
+        });
+
+        describe('when have also set a region', function() {
+          beforeEach(function() {
+            this.model.set('region', 'val');
+            this.model.continue();
+          });
+
+          it('should also set geocode data with region', function() {
+            var d = this.model.get('geocodeData');
+            expect(d.region).toEqual('val');
+            expect(d.region_text).toEqual(true);
+          });
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.15.08",
+  "version": "3.15.09",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #4290 

Wasn't sending the expected `region_text` param when region was entered as a free text value instead of a selected column. 

Also fixed two minor visual issues I saw while at it.

@xavijam please review + cc @iriberri for reporting