### PR TITLE
revamp public map [DO NOT MERGE]

### DIFF
--- a/app/assets/stylesheets/common/header.css.scss
+++ b/app/assets/stylesheets/common/header.css.scss
@@ -39,13 +39,17 @@ $cHeader-dark:  rgba(#3A91D7, 1);
   line-height: $sLineHeight-largest;
   color: rgba(white, 0.6);
 }
+.Header-navigationItem {
+  margin-left: $sMargin-elementLarge;
+}
 .Header-navigationLink {
-  font-size: $sFontSize-largest;
-  font-weight: $sFontWeight-lighter;
+  font-weight: $sFontWeight-normal;
+  font-size: $sFontSize-smallUpperCase;
   line-height: $sLineHeight-largest;
+  text-transform: uppercase;
   color: rgba(white, 0.6);
   &:hover {
-    text-decoration: underline;
+    text-decoration: none;
     color: white;
   }
 }
@@ -77,18 +81,19 @@ $cHeader-dark:  rgba(#3A91D7, 1);
 }
 .Header-settingsItem {
   position: relative;
-  margin-left: $sMargin-element;
-  font-size: $sFontSize-larger;
+  margin-left: $sMargin-elementLarge;
+  font-weight: $sFontWeight-normal;
+  font-size: $sFontSize-smallUpperCase;
   line-height: $sLineHeight-larger;
+  text-transform: uppercase;
 }
-.Header-settingsItem--avatar { height: 42px }
+.Header-settingsItem--avatar { height: 46px }
 .Header-settingsLink {
-  font-weight: $sFontWeight-lighter;
   color: rgba(white, 0.6);
 
   &:hover {
     color: white;
-    text-decoration: underline;
+    text-decoration: none;
   }
 }
 

--- a/app/assets/stylesheets/common/user-avatar.css.scss
+++ b/app/assets/stylesheets/common/user-avatar.css.scss
@@ -32,7 +32,9 @@
   text-align: center;
 }
 .UserAvatar-img {
-  border: 1px solid transparent;
+  border: 3px solid transparent;
+  border-left: 0;
+  border-right: 0;
 }
 .UserAvatar-img--no-src {
   background-image: image-url("avatars/avatar_ghost_red.png");

--- a/app/assets/stylesheets/variables/sizes.css.scss
+++ b/app/assets/stylesheets/variables/sizes.css.scss
@@ -2,12 +2,13 @@
 $sLayout-width: 940px;
 
 // Margins
-$sMargin-section:       40px; // To separate main section
-$sMargin-group:         28px; // To separate groups inside a section
-$sMargin-element:       20px; // To separate elements inside a group
-$sMargin-elementInline: 12px; // To separate inline elements
-$sMargin-min:           4px;  // Minimum margin, special cases only
-$sMargin-formRow:       20px; // Each row in a form should have a margin-bottom of this value.
+$sMargin-section:            40px; // To separate main section
+$sMargin-group:              28px; // To separate groups inside a section
+$sMargin-element:            20px; // To separate elements inside a group
+$sMargin-elementLarge:       40px; // To separate elements inside a group (large separation)
+$sMargin-elementInline:      12px; // To separate inline elements
+$sMargin-min:                4px;  // Minimum margin, special cases only
+$sMargin-formRow:            20px; // Each row in a form should have a margin-bottom of this value.
 
 // Font sizes
 $sFontSize-smaller:        10px;

--- a/app/views/admin/shared/_dashboard_header.erb
+++ b/app/views/admin/shared/_dashboard_header.erb
@@ -3,40 +3,37 @@
     <div class="Header-navigation">
       <ul class="Header-navigationList">
         <li class="js-logo">
-          <% if cartodb_com_hosted? %>
-            <a href="<%= CartoDB.url(self, 'root') %>">
-          <% else %>
-            <a href="http://cartodb.com">
-          <% end %>
+          <% logo_url = cartodb_com_hosted? ? CartoDB.url(self, 'root') : "http://cartodb.com" %>
+          <a href="<%= logo_url %>">
             <span class="Logo Logo--avatar">
               <i class="iconFont iconFont-CartoFante"></i>
             </span>
-            <span class="Logo Logo--text Header-logoText u-hideOnMobile">
-              <i class="iconFont iconFont-CartoDB"></i>
-            </span>
           </a>
         </li>
+
+        <li class="Header-navigationItem"><a href="<%= logo_url %>" class="Header-navigationLink u-hideOnMobile">CartoDB</a></li>
+        <% unless cartodb_com_hosted? %>
+          <li class="Header-navigationItem"><a href="http://docs.cartodb.com/" class="Header-navigationLink u-hideOnMobile">Learn</a></li>
+          <li class="Header-navigationItem"><a href="mailto:enterprise-support@cartodb.com" class="Header-navigationLink u-hideOnMobile">Support</a></li>
+          <li class="Header-navigationItem"><a href="http://cartodb.com/gallery/" class="Header-navigationLink u-hideOnMobile">Explore</a></li>
+        <% end %>
       </ul>
     </div>
+
     <div class="Header-settings">
-      <ul class="Header-settingsList">
+      <ul class="Header-settingsList js-user-settings">
         <% unless cartodb_com_hosted? %>
-        <li class="Header-settingsItem u-hideOnMobile">
-          <a href="http://cartodb.com/gallery/" class="Header-settingsLink">Explore</a>
-        </li>
-        <li class="Header-settingsItem js-login">
-          <a href="<%= CartoDB.url(self, 'login') %>" class="Header-settingsLink">Login</a>
-        </li>
-        <li class="Header-settingsItem js-learn" style="display:none;">
-          <a href="http://docs.cartodb.com/" class="Header-settingsLink">Learn</a>
-        </li>
+          <li class="Header-settingsItem js-login">
+            <a href="<%= CartoDB.url(self, 'login') %>" class="Header-settingsLink">Login</a>
+          </li>
         <% end %>
-        <li class="Header-settingsItem Header-settingsItem--avatar js-user-settings">
-            <% unless cartodb_com_hosted? %>
-                <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
-                  <span>Sign up</span>
-                </a>
-            <% end %>
+
+        <li class="Header-settingsItem">
+          <% unless cartodb_com_hosted? %>
+            <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
+              <span>Sign up</span>
+            </a>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/app/views/admin/shared/_dashboard_header.erb
+++ b/app/views/admin/shared/_dashboard_header.erb
@@ -1,0 +1,44 @@
+<div class="Header" id="header">
+  <div class="u-inner Header-inner">
+    <div class="Header-navigation">
+      <ul class="Header-navigationList">
+        <li class="js-logo">
+          <% if cartodb_com_hosted? %>
+            <a href="<%= CartoDB.url(self, 'root') %>">
+          <% else %>
+            <a href="http://cartodb.com">
+          <% end %>
+            <span class="Logo Logo--avatar">
+              <i class="iconFont iconFont-CartoFante"></i>
+            </span>
+            <span class="Logo Logo--text Header-logoText u-hideOnMobile">
+              <i class="iconFont iconFont-CartoDB"></i>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div class="Header-settings">
+      <ul class="Header-settingsList">
+        <% unless cartodb_com_hosted? %>
+        <li class="Header-settingsItem u-hideOnMobile">
+          <a href="http://cartodb.com/gallery/" class="Header-settingsLink">Explore</a>
+        </li>
+        <li class="Header-settingsItem js-login">
+          <a href="<%= CartoDB.url(self, 'login') %>" class="Header-settingsLink">Login</a>
+        </li>
+        <li class="Header-settingsItem js-learn" style="display:none;">
+          <a href="http://docs.cartodb.com/" class="Header-settingsLink">Learn</a>
+        </li>
+        <% end %>
+        <li class="Header-settingsItem Header-settingsItem--avatar js-user-settings">
+            <% unless cartodb_com_hosted? %>
+                <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
+                  <span>Sign up</span>
+                </a>
+            <% end %>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_dashboard_header.erb
+++ b/app/views/admin/shared/_dashboard_header.erb
@@ -11,29 +11,36 @@
           </a>
         </li>
 
-        <li class="Header-navigationItem"><a href="<%= logo_url %>" class="Header-navigationLink u-hideOnMobile">CartoDB</a></li>
         <% unless cartodb_com_hosted? %>
-          <li class="Header-navigationItem"><a href="http://docs.cartodb.com/" class="Header-navigationLink u-hideOnMobile">Learn</a></li>
-          <li class="Header-navigationItem"><a href="mailto:enterprise-support@cartodb.com" class="Header-navigationLink u-hideOnMobile">Support</a></li>
-          <li class="Header-navigationItem"><a href="http://cartodb.com/gallery/" class="Header-navigationLink u-hideOnMobile">Explore</a></li>
+          <li class="Header-navigationItem"><a href="http://docs.cartodb.com/" class="Header-navigationLink u-hideOnMobile" target="_blank">Learn</a></li>
+          <li class="Header-navigationItem js-user-support"><a href="mailto:support@cartodb.com" class="Header-navigationLink u-hideOnMobile" target="_blank">Support</a></li>
+          <li class="Header-navigationItem"><a href="http://cartodb.com/gallery/" class="Header-navigationLink u-hideOnMobile" target="_blank">Explore</a></li>
         <% end %>
       </ul>
     </div>
 
     <div class="Header-settings">
-      <ul class="Header-settingsList js-user-settings">
+      <ul class="Header-settingsList">
+        <li class="Header-settingsItem u-hideOnMobile">
+          <a href="<%= maps_index_path %>" class="Header-settingsLink">Maps</a>
+        </li>
+
+        <li class="Header-settingsItem u-hideOnMobile">
+          <a href="<%= datasets_index_path %>" class="Header-settingsLink">Datasets</a>
+        </li>
+
         <% unless cartodb_com_hosted? %>
-          <li class="Header-settingsItem js-login">
-            <a href="<%= CartoDB.url(self, 'login') %>" class="Header-settingsLink">Login</a>
-          </li>
+        <li class="Header-settingsItem Header-settingsItemNotifications js-user-notifications">
+          <a href="#/notifications" class="UserNotifications">
+            <i class="UserNotifications-Icon iconFont iconFont-Alert"></i>
+          </a>
+        </li>
         <% end %>
 
-        <li class="Header-settingsItem">
-          <% unless cartodb_com_hosted? %>
-            <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
-              <span>Sign up</span>
-            </a>
-          <% end %>
+        <li class="Header-settingsItem Header-settingsItem--avatar">
+          <button class="UserAvatar js-settings-dropdown">
+            <%= image_tag current_user.avatar, :class => 'UserAvatar-img UserAvatar-img--medium' %>
+          </button>
         </li>
       </ul>
     </div>

--- a/app/views/admin/shared/_public_header.erb
+++ b/app/views/admin/shared/_public_header.erb
@@ -3,40 +3,37 @@
     <div class="Header-navigation">
       <ul class="Header-navigationList">
         <li class="js-logo">
-          <% if cartodb_com_hosted? %>
-            <a href="<%= CartoDB.url(self, 'root') %>">
-          <% else %>
-            <a href="http://cartodb.com">
-          <% end %>
+          <% logo_url = cartodb_com_hosted? ? CartoDB.url(self, 'root') : "http://cartodb.com" %>
+          <a href="<%= logo_url %>">
             <span class="Logo Logo--avatar">
               <i class="iconFont iconFont-CartoFante"></i>
             </span>
-            <span class="Logo Logo--text Header-logoText u-hideOnMobile">
-              <i class="iconFont iconFont-CartoDB"></i>
-            </span>
           </a>
         </li>
+
+        <li class="Header-navigationItem"><a href="<%= logo_url %>" class="Header-navigationLink u-hideOnMobile">CartoDB</a></li>
+        <% unless cartodb_com_hosted? %>
+          <li class="Header-navigationItem"><a href="#/industries" class="Header-navigationLink u-hideOnMobile">Industries</a></li>
+          <li class="Header-navigationItem"><a href="http://cartodb.com/gallery/" class="Header-navigationLink u-hideOnMobile">Explore</a></li>
+          <li class="Header-navigationItem"><a href="http://cartodb.com/pricing/" class="Header-navigationLink u-hideOnMobile">Pricing</a></li>
+        <% end %>
       </ul>
     </div>
+
     <div class="Header-settings">
       <ul class="Header-settingsList">
         <% unless cartodb_com_hosted? %>
-        <li class="Header-settingsItem u-hideOnMobile">
-          <a href="http://cartodb.com/gallery/" class="Header-settingsLink">Explore</a>
-        </li>
-        <li class="Header-settingsItem js-login">
-          <a href="<%= CartoDB.url(self, 'login') %>" class="Header-settingsLink">Login</a>
-        </li>
-        <li class="Header-settingsItem js-learn" style="display:none;">
-          <a href="http://docs.cartodb.com/" class="Header-settingsLink">Learn</a>
-        </li>
+          <li class="Header-settingsItem js-login">
+            <a href="<%= CartoDB.url(self, 'login') %>" class="Header-settingsLink">Login</a>
+          </li>
         <% end %>
+
         <li class="Header-settingsItem Header-settingsItem--avatar js-user-settings">
-            <% unless cartodb_com_hosted? %>
-                <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
-                  <span>Sign up</span>
-                </a>
-            <% end %>
+          <% unless cartodb_com_hosted? %>
+            <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
+              <span>Sign up</span>
+            </a>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/app/views/admin/shared/_public_header.erb
+++ b/app/views/admin/shared/_public_header.erb
@@ -13,7 +13,7 @@
 
         <li class="Header-navigationItem"><a href="<%= logo_url %>" class="Header-navigationLink u-hideOnMobile">CartoDB</a></li>
         <% unless cartodb_com_hosted? %>
-          <li class="Header-navigationItem"><a href="#/industries" class="Header-navigationLink u-hideOnMobile">Industries</a></li>
+          <li class="Header-navigationItem js-user-industries"><a href="#/industries" class="Header-navigationLink u-hideOnMobile js-dropdown-target">Industries</a></li>
           <li class="Header-navigationItem"><a href="http://cartodb.com/gallery/" class="Header-navigationLink u-hideOnMobile">Explore</a></li>
           <li class="Header-navigationItem"><a href="http://cartodb.com/pricing/" class="Header-navigationLink u-hideOnMobile">Pricing</a></li>
         <% end %>
@@ -21,14 +21,14 @@
     </div>
 
     <div class="Header-settings">
-      <ul class="Header-settingsList">
+      <ul class="Header-settingsList js-user-settings">
         <% unless cartodb_com_hosted? %>
           <li class="Header-settingsItem js-login">
             <a href="<%= CartoDB.url(self, 'login') %>" class="Header-settingsLink">Login</a>
           </li>
         <% end %>
 
-        <li class="Header-settingsItem Header-settingsItem--avatar js-user-settings">
+        <li class="Header-settingsItem">
           <% unless cartodb_com_hosted? %>
             <a href="http://cartodb.com/signup" class="Button Button--headerPositive">
               <span>Sign up</span>

--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -26,7 +26,7 @@
     <%= stylesheet_link_tag 'cartodb', 'common', 'public_dashboard' %>
   </head>
   <body class="PublicBody">
-    <%= render 'admin/shared/dashboard_header' %>
+    <%= render 'admin/shared/public_header' %>
     <div class="FavMap is-pre-loading" id="<%= fav_map_target_id = 'fav-map-container' %>">
       <div class="Spinner FavMap-spinner"></div>
     </div>

--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -26,7 +26,7 @@
     <%= stylesheet_link_tag 'cartodb', 'common', 'public_dashboard' %>
   </head>
   <body class="PublicBody">
-    <%= render 'admin/shared/public_header' %>
+    <%= render 'admin/shared/dashboard_header' %>
     <div class="FavMap is-pre-loading" id="<%= fav_map_target_id = 'fav-map-container' %>">
       <div class="Spinner FavMap-spinner"></div>
     </div>

--- a/lib/assets/javascripts/cartodb/common/views/dashboard_header/user_support_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/dashboard_header/user_support_template.jst.ejs
@@ -1,0 +1,7 @@
+<% if (userType === 'org') { %>
+  <a href="mailto:enterprise-support@cartodb.com" class="Header-navigationLink u-hideOnMobile">Support</a>
+<% } else if (userType === 'client' || userType === 'internal') { %>
+  <a href="mailto:support@cartodb.com" class="Header-navigationLink u-hideOnMobile">Support</a>
+<% } else { %>
+  <a href="http://gis.stackexchange.com/questions/tagged/cartodb" class="Header-navigationLink u-hideOnMobile">Support</a>
+<% } %>

--- a/lib/assets/javascripts/cartodb/common/views/dashboard_header/user_support_view.js
+++ b/lib/assets/javascripts/cartodb/common/views/dashboard_header/user_support_view.js
@@ -1,0 +1,40 @@
+var cdb = require('cartodb.js');
+var $ = require('jquery');
+
+/**
+ * View to render the user support link in the header.
+ * Expected to be created from existing DOM element.
+ */
+module.exports = cdb.core.View.extend({
+
+  initialize: function() {
+    this.user = this.model;
+    this.template_base = cdb.templates.getTemplate('common/views/dashboard_header/user_support_template');
+  },
+
+  render: function() {
+    this.$el.html(
+      this.template_base({
+        userType: this._getUserType()
+      })
+    )
+
+    return this;
+  },
+
+  _getUserType: function() {
+    var accountType = this.user.get('account_type').toLowerCase();
+
+    // Get user type
+    if (this.user.isInsideOrg()) {
+      return 'org';
+    } else if (accountType === "internal" || accountType === "partner" || accountType === "ambassador") {
+      return 'internal'
+    } else if (accountType !== "free") {
+      return 'client';
+    } else {
+      return 'regular'
+    }
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/common/views/dashboard_header_view.js
+++ b/lib/assets/javascripts/cartodb/common/views/dashboard_header_view.js
@@ -3,6 +3,7 @@ var cdb = require('cartodb.js');
 var SettingsDropdown = require('./dashboard_header/settings_dropdown_view');
 var BreadcrumbsDropdown = require('./dashboard_header/breadcrumbs/dropdown_view');
 var UserNotifications = require('./dashboard_header/notifications/view');
+var UserSupportView = require('./dashboard_header/user_support_view');
 
 /**
  * Responsible for the header part of the layout.
@@ -31,6 +32,7 @@ module.exports = cdb.core.View.extend({
     this.clearSubViews();
 
     this._renderBreadcrumbsDropdownLink();
+    this._renderSupportLink();
     this._renderNotifications();
     this._renderLogoLink();
 
@@ -90,6 +92,14 @@ module.exports = cdb.core.View.extend({
 
     this.$('.js-user-notifications').html(userNotifications.render().el);
     this.addView(userNotifications);
+  },
+
+  _renderSupportLink: function() {
+    var userSupportView = new UserSupportView({
+      el: $('.js-user-support'),
+      model: this.model
+    });
+    userSupportView.render();
   },
 
   _renderLogoLink: function() {

--- a/lib/assets/javascripts/cartodb/public_common/user_industries/dropdown_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/public_common/user_industries/dropdown_template.jst.ejs
@@ -1,0 +1,14 @@
+<ul class="SettingsDropdown">
+  <li class="SettingsDropdown-item">
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/banking-and-finance/">Banking and Finance</p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/business-intelligence-and-analytics/">BI and Analytics</a></p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/earth-observation-and-space/">Earth Observation and Space</a></p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/education-and-research/">Education and Research</a></p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/government/">Government</a></p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/journalism/">Journalism and New Media</a></p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/natural-resources/">Natural Resources</a></p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/non-profits/">Non-profits</a></p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/real-estate/">Real Estate</a></p>
+    <p><a class="SettingsDropdown-itemLink" href="https://cartodb.com/industries/web-mobile/">Web and Mobile Development</a>
+  </li>
+</ul>

--- a/lib/assets/javascripts/cartodb/public_common/user_industries/dropdown_view.js
+++ b/lib/assets/javascripts/cartodb/public_common/user_industries/dropdown_view.js
@@ -1,0 +1,39 @@
+var cdb = require('cartodb.js');
+cdb.admin = require('cdb.admin');
+var $ = require('jquery');
+
+/**
+ * The content of the dropdown menu opened by the industries link in the header, e.g.:
+ *   CartoDB, Industries, Explore, Pricing
+ *             ______/\____
+ *            |            |
+ *            |    this    |
+ *            |____________|
+ */
+module.exports = cdb.admin.DropdownMenu.extend({
+  className: 'Dropdown',
+
+  initialize: function() {
+    this.elder('initialize');
+    this.template_base = cdb.templates.getTemplate('public_common/user_industries/dropdown_template');
+
+    // Necessary to hide dialog on click outside popup, for example.
+    cdb.god.bind('closeDialogs', this.hide, this);
+  },
+
+  render: function() {
+    this.$el.html(this.template_base());
+
+    // TODO: taken from existing code, how should dropdowns really be added to the DOM?
+    $('body').append(this.el);
+
+    return this;
+  },
+
+  clean: function() {
+    // Until https://github.com/CartoDB/cartodb.js/issues/238 is resolved:
+    $(this.options.target).unbind('click', this._handleClick);
+    this.constructor.__super__.clean.apply(this);
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/public_common/user_industries_view.js
+++ b/lib/assets/javascripts/cartodb/public_common/user_industries_view.js
@@ -12,19 +12,6 @@ module.exports = cdb.core.View.extend({
     'click .js-dropdown-target': '_createDropdown'
   },
 
-  initialize: function() {
-    debugger;
-  },
-
-  render: function() {
-    debugger;
-    this.$el.html(
-      cdb.templates.getTemplate('public_common/user_industries_template')()
-    );
-
-    return this;
-  },
-
   _createDropdown: function(ev) {
     this.killEvent(ev);
     cdb.god.trigger('closeDialogs');

--- a/lib/assets/javascripts/cartodb/public_common/user_industries_view.js
+++ b/lib/assets/javascripts/cartodb/public_common/user_industries_view.js
@@ -1,9 +1,9 @@
 var cdb = require('cartodb.js');
-var SettingsDropdown = require('./user_settings/dropdown_view');
+var IndustriesDropdown = require('./user_industries/dropdown_view');
 var $ = require('jquery');
 
 /**
- * View to render the user settings section in the header.
+ * View to render the user industries section in the header.
  * Expected to be created from existing DOM element.
  */
 module.exports = cdb.core.View.extend({
@@ -12,17 +12,14 @@ module.exports = cdb.core.View.extend({
     'click .js-dropdown-target': '_createDropdown'
   },
 
-  render: function() {
-    var dashboardUrl = this.model.viewUrl().dashboard();
-    var datasetsUrl = dashboardUrl.datasets();
-    var mapsUrl = dashboardUrl.maps();
+  initialize: function() {
+    debugger;
+  },
 
+  render: function() {
+    debugger;
     this.$el.html(
-      cdb.templates.getTemplate('public_common/user_settings_template')({
-        avatarUrl: this.model.get('avatar_url'),
-        mapsUrl: mapsUrl,
-        datasetsUrl: datasetsUrl
-      })
+      cdb.templates.getTemplate('public_common/user_industries_template')()
     );
 
     return this;
@@ -32,9 +29,8 @@ module.exports = cdb.core.View.extend({
     this.killEvent(ev);
     cdb.god.trigger('closeDialogs');
 
-    var view = new SettingsDropdown({
+    var view = new IndustriesDropdown({
       target: $(ev.target),
-      model: this.model, // user
       horizontal_offset: 18
     });
     view.render();

--- a/lib/assets/javascripts/cartodb/public_common/user_settings_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/public_common/user_settings_template.jst.ejs
@@ -1,3 +1,13 @@
-<button class="UserAvatar js-dropdown-target">
-  <img src="<%= avatarUrl %>" class="UserAvatar-img UserAvatar-img--medium js-user-avatar-img" />
-</button >
+<li class="Header-settingsItem u-hideOnMobile">
+  <a href="<%- mapsUrl %>" class="Header-settingsLink">Maps</a>
+</li>
+
+<li class="Header-settingsItem u-hideOnMobile">
+  <a href="<%- datasetsUrl %>" class="Header-settingsLink">Datasets</a>
+</li>
+
+<li class="Header-settingsItem Header-settingsItem--avatar">
+  <button class="UserAvatar js-dropdown-target">
+    <img src="<%- avatarUrl %>" class="UserAvatar-img UserAvatar-img--medium js-user-avatar-img" />
+  </button>
+</li>

--- a/lib/assets/javascripts/cartodb/public_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/public_dashboard/entry.js
@@ -5,6 +5,7 @@ var UserInfoView = require('./user_info_view');
 var PaginationModel = require('../common/views/pagination/model');
 var PaginationView = require('../common/views/pagination/view');
 var UserSettingsView = require('../public_common/user_settings_view');
+var UserIndustriesView = require('../public_common/user_industries_view');
 var MapCardPreview = require('../common/views/mapcard_preview');
 var LikeView = require('../common/views/likes/view');
 
@@ -14,6 +15,10 @@ $(function() {
 
     $(document.body).bind('click', function() {
       cdb.god.trigger('closeDialogs');
+    });
+
+    var userIndustriesView = new UserIndustriesView({
+      el: $('.js-user-industries'),
     });
 
     var authenticatedUser = new cdb.open.AuthenticatedUser();

--- a/lib/assets/javascripts/cartodb/public_map/entry.js
+++ b/lib/assets/javascripts/cartodb/public_map/entry.js
@@ -1,6 +1,7 @@
 var $ = require('jquery');
 var cdb = require('cartodb.js');
 var UserSettingsView = require('../public_common/user_settings_view');
+var UserIndustriesView = require('../public_common/user_industries_view');
 var PublicMapWindow = require('./public_map_window');
 var MapCardPreview = require('../common/views/mapcard_preview');
 var LikeView = require('../common/views/likes/view');
@@ -24,6 +25,10 @@ $(function() {
 
     $(document.body).bind('click', function() {
       cdb.god.trigger('closeDialogs');
+    });
+
+    var userIndustriesView = new UserIndustriesView({
+      el: $('.js-user-industries'),
     });
 
     var authenticatedUser = new cdb.open.AuthenticatedUser();


### PR DESCRIPTION
first commit, familiarizing myself with the code and so, just made the changes in the header for now

- created a `dashboard_header`, do we want to change them only in the public pages or in the dashboard , too? Inevitably the styles will change

<img width="970" alt="screen shot 2015-07-07 at 16 48 29" src="https://cloud.githubusercontent.com/assets/36676/8548975/697c47f4-24c8-11e5-9d26-21a86095b027.png">

then, already in the `public_header` 

- left the links with a bit of opacity to keep the hover states, didn't found them in the mockups, **is it white with underline, do I leave them like this**?

- do we lose "Learn" in favour of "Industries" + "Pricing" ?
- I suppose the link "Login" was left with no update, applied the same style **please confirm you want it different**

<img width="1197" alt="screen shot 2015-07-07 at 16 46 47" src="https://cloud.githubusercontent.com/assets/36676/8549003/95f0ea7e-24c8-11e5-97d8-422fcaca608c.png">

- had to modify `.UserAvatar-img` in order to the signup button to be aligned. Avatar is 42px with that transparent border (what is it for?), button is 44px :/

- despite we already have a size variable for `40px` I created a new one for the items separation, modifying `$sMargin-element` wasn't feasible, so many side changes.

- finally, I created `.Header-navigationItem` as we have `.Header-settingsItem`, actually, don't you think we should consolidate them both in a single class? the same with `.Header-navigationLink`

will go on with this, but as I first dove here I prefer to check these before going any further ^^^

/cc @CartoDB/frontend 