### PR TITLE
drop from 512 to 256 default steps

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
@@ -630,7 +630,7 @@ var sharedForTorqueAndTorqueCat = {
     {
       name: 'Steps',
       form: {
-        'torque-frame-count': { type: 'select', value: 512, extra: [1, 64, 128, 256, 512, 1024, 2048] }
+        'torque-frame-count': { type: 'select', value: 256, extra: [1, 64, 128, 256, 512, 1024, 2048] }
       }
     },
     {


### PR DESCRIPTION
through a year of testing i have found that 256 steps tends to be a more optimal starting point for torque visualizations
512 steps often makes the data appear very sparse.

i've updated here cc @fdansv @javisantana