### PR TITLE
change default Torque color to #0F3B82

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
@@ -609,7 +609,7 @@ var sharedForTorqueAndTorqueCat = {
       name: 'Marker Fill',
       form: {
         'marker-width': { type: 'width', value: 6 },
-        'marker-fill': { type: 'color' , value: '#FF9900' },
+        'marker-fill': { type: 'color' , value: '#0F3B82' },
         'marker-opacity': { type: 'opacity' , value: 0.9 }
       }
     },


### PR DESCRIPTION
Given that we have the light basemap, the default torque color isn't cutting it anymore. I'm changing it here to a dark blue. #0F3B82. Combined with the blend mode (lighter) it also gives a really nice intensity effect but still pops on the map when there are few circles.

cc @saleiva @javierarce (this should likely be the same setting for pecan)