### PR TITLE
Upgrade CTA dialog will appear when import fails with error 8001

### DIFF
--- a/lib/assets/javascripts/cartodb/common/views/error_details_view.js
+++ b/lib/assets/javascripts/cartodb/common/views/error_details_view.js
@@ -11,7 +11,9 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function() {
-    var sizeError = this.err.error_code && this.err.error_code === '8001';
+    // Preventing problems checking if the error_code is a number or a string
+    // we make the comparision with only double =.
+    var sizeError = this.err.error_code && this.err.error_code == '8001';
     var userCanUpgrade = !cdb.config.get('custom_com_hosted') && (!this.user.isInsideOrg() || this.user.isOrgAdmin());
 
     var template = cdb.templates.getTemplate(

--- a/lib/assets/javascripts/cartodb/common/views/error_details_view.js
+++ b/lib/assets/javascripts/cartodb/common/views/error_details_view.js
@@ -13,7 +13,7 @@ module.exports = cdb.core.View.extend({
   render: function() {
     // Preventing problems checking if the error_code is a number or a string
     // we make the comparision with only double =.
-    var sizeError = this.err.error_code && this.err.error_code == '8001';
+    var sizeError = this.err.error_code && parseInt(this.err.error_code) === 8001;
     var userCanUpgrade = !cdb.config.get('custom_com_hosted') && (!this.user.isInsideOrg() || this.user.isOrgAdmin());
 
     var template = cdb.templates.getTemplate(


### PR DESCRIPTION
Basically backend is returning error code as a number and we expected a string. Avoiding comparison problems, we will use only double = and not triple.

REVIEWER: @viddo.

Fixes #4297.