### PR TITLE
Avoiding request other pages than the first one when a search is submitted

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/create/listing/navigation_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/listing/navigation_view.js
@@ -185,6 +185,7 @@ module.exports = cdb.core.View.extend({
     var q = val.search(':') !== 0 ? val : '';
 
     this.routerModel.set({
+      page: 1,
       tag: tag,
       q: q,
       shared: 'yes'

--- a/lib/assets/test/spec/cartodb/dashboard/dialogs/create/listing/navigation_view.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/dialogs/create/listing/navigation_view.spec.js
@@ -107,6 +107,13 @@ describe('dashboard/dialogs/create/listing/navigation_view', function() {
     expect(args[0]).toEqual('reset');
   });
 
+  it('should search starting for the first page', function() {
+    this.visFetchModel.set('page', 2);
+    this.view.$('.js-search-input').val('test');
+    this.view.$('.js-search-form').submit();
+    expect(this.visFetchModel.get('page')).toBe(1);
+  });
+
   it('should change router model and listing model when a link is clicked', function() {
     var routerChanged = false;
     var stateChanged = false;


### PR DESCRIPTION
This was fixed in the dashboard search and now it is fixed in the create dialog search.

REVIEWER: @ethervoid :dancer: 
Fixes #4291.