### PR TITLE
Content guessing toggler enabled despite of the fact that the upload is not valid

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/create/footer/guessing_toggler.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/footer/guessing_toggler.jst.ejs
@@ -1,5 +1,5 @@
 <% if (importState !== "twitter") { %>
-  <div class="js-toggle Checkbox <%= isUploadValid ? '' : 'is-disabled' %>">
+  <div class="js-toggle Checkbox">
     <button class="Checkbox-input <%= isGuessingEnabled ? 'is-checked' : '' %>"></button>
     <label class="Checkbox-label">Let CartoDB automatically guess data types and content on import.</label>
   </div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/footer/guessing_toggler_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/footer/guessing_toggler_view.js
@@ -43,10 +43,8 @@ module.exports = cdb.core.View.extend({
   },
 
   _toggle: function() {
-    if (this.createModel.upload.isValidToUpload()) {
-      var value = !this.model.get('guessing');
-      this.model.set('guessing', value);
-      this.createModel.upload.setGuessing(value);
-    }
+    var value = !this.model.get('guessing');
+    this.model.set('guessing', value);
+    this.createModel.upload.setGuessing(value);
   }
 });

--- a/lib/assets/test/spec/cartodb/dashboard/dialogs/create/footer/guessing_toggler.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/dialogs/create/footer/guessing_toggler.spec.js
@@ -52,16 +52,16 @@ describe('dashboard/dialogs/create/footer/guessing_toggler', function() {
     expect(this.model.upload.get('type_guessing')).toBeFalsy();
   });
 
-  it('shouldn\'t change type and content guessing attributes when upload is not valid', function() {
+  it('should change type and content guessing attributes when upload isn\'t valid', function() {
     // Non valid "upload"
     this.model.upload.set({
       type: 'url',
       value: 'hello'
     })
     this.view.$('.js-toggle').click();
-    expect(this.view.model.get('guessing')).toBeTruthy();
-    expect(this.model.upload.get('content_guessing')).toBeTruthy();
-    expect(this.model.upload.get('type_guessing')).toBeTruthy();
+    expect(this.view.model.get('guessing')).toBeFalsy();
+    expect(this.model.upload.get('content_guessing')).toBeFalsy();
+    expect(this.model.upload.get('type_guessing')).toBeFalsy();
   });
 
   it('should have no leaks', function() {


### PR DESCRIPTION
Content guessing toggler enabled.

![screen shot 2015-07-08 at 11 57 59](https://cloud.githubusercontent.com/assets/132146/8567802/9c8188b2-2568-11e5-8515-0823ed776bf7.png)

REVIEWER: @javierarce 
Fixes #4344.