### PR TITLE
Fix lock icon not updating on privacy change 

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -110,8 +110,7 @@ cdb.admin.Header = cdb.core.View.extend({
     // Options menu
     this.options_menu = new cdb.admin.HeaderOptionsMenu({
       target: $(e.target),
-      // use the current visualization instead the master one
-      model: this.options.visualization,
+      model: this.model, // master_vis
       dataLayer: this.dataLayer,
       user: this.options.user,
       private_tables: this.options.user.get("actions").private_tables,


### PR DESCRIPTION
Fixes #4312
_(moved the explanation from issue to this PR instead)_

This happens because the options menu is actually not using `master_vis` ("master visualization"), but the [`this.options.visualization`](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/table/table.js#L62) (current vis being edited), so we're not using the same model as is used in the [header](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/old_common/header.js#L190) (which uses `master_vis`).

It's been like this since [fixes update table when geocode, fix #1934](https://github.com/CartoDB/cartodb/commit/52eca2cfc8b90d27945d6ef6ac9b005d22aff0d9), looking at the code at that point in time I guess it made sense since the [`this.table`](https://github.com/CartoDB/cartodb/blob/52eca2cfc8b90d27945d6ef6ac9b005d22aff0d9/lib/assets/javascripts/cartodb/table/header/options_menu.js#L42) was derived from the given vis model (which is the actually [used model for the geocoding](https://github.com/CartoDB/cartodb/blob/52eca2cfc8b90d27945d6ef6ac9b005d22aff0d9/lib/assets/javascripts/cartodb/table/header/options_menu.js#L238-L241)). 

But since then things have changed, [now the table is set from the given dataLayer instead](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/table/header/options_menu.js#L44), so the [comment](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/old_common/header.js#L113-L114) is no longer valid.

AFAIK, the `master_vis` should be the correct model to use, so we should probably [change the model given](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/old_common/header.js#L113-L114) to that (the change in this PR).

There are more stuff in the [`options_menu` view](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/table/header/options_menu.js) that's possibly not using the correct model (e.g. lock/unlock, duplicate, permissions) either.

@javisantana since you did the last change, can you confirm if my change proposal makes sense? Testing this locally seems to work fine, but want to be sure I have the correct mental model here.