### PR TITLE
Fix georef header to use expected color

### DIFF
--- a/app/assets/stylesheets/common/dialog.css.scss
+++ b/app/assets/stylesheets/common/dialog.css.scss
@@ -154,6 +154,13 @@ body.is-inDialog {
   color: $cHighlight-main;
   border-color: $cHighlight-main;
 }
+.Dialog-headerIcon--neutral {
+  // TODO: !important to not be overrided by .CreateDialog-headerIcon overriding stuff over here :(
+  border-color: $cIcons-active !important;
+  .iconFont {
+    color: $cIcons-active !important;
+  }
+}
 .Dialog-headerIcon--negative {
   color: $cHighlight-negative;
   border-color: $cHighlight-negative;

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
@@ -10,7 +10,7 @@
             <i class="iconFont iconFont-Marker"></i>
           </div>
           <p class="Dialog-headerTitle">Georeference your dataset</p>
-          <p class="Dialog-headerText">This is the key point to visualize your data</p>
+          <p class="Dialog-headerText">Transform your data into coordinates</p>
         </li>
       </ul>
     </div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
@@ -5,8 +5,8 @@
   <div class="Dialog-contentWrapper">
     <div class="Dialog-header Dialog-header--expanded CreateDialog-header">
       <ul class="CreateDialog-headerSteps">
-        <li class="CreateDialog-headerStep CreateDialog-headerStep--single is-selected">
-          <div class="Dialog-headerIcon">
+        <li class="CreateDialog-headerStep CreateDialog-headerStep--single">
+          <div class="Dialog-headerIcon Dialog-headerIcon--neutral">
             <i class="iconFont iconFont-Marker"></i>
           </div>
           <p class="Dialog-headerTitle">Georeference your dataset</p>


### PR DESCRIPTION
Solves the 1st issue in #4262

> #666 header icons color and change header copy to Transform your data into coordinates:

<img width="1677" alt="screen shot 2015-07-09 at 10 47 07" src="https://cloud.githubusercontent.com/assets/978461/8591378/31a31b80-2628-11e5-83e5-f39b8927b7c0.png">

At first I started out to refactor the header to accommodate this, but the more I tried to do things right the more stuff I had to change. Since we've planned to redo the [inconsistent styles in modal headers](https://github.com/CartoDB/cartodb/issues/4175) #4175 I went with this quick solution for now, let's retake take this into account when we redo the header styles to avoid this kind of situations.

@javierarce please review