### PR TITLE
Fix subheader for georeference modal

### DIFF
--- a/app/assets/stylesheets/common/dialog.css.scss
+++ b/app/assets/stylesheets/common/dialog.css.scss
@@ -231,14 +231,6 @@ $sStickyHeight: 97px;
 .Dialog-expandedSubContentInner {
   position: relative; // necessary to position subHeader properly
 }
-.Dialog-stickySubHeader {
-  position: fixed;
-  background-color: $cStructure-grayBkg;
-  padding: $sMargin-group 0;
-  border-bottom: 1px solid $cStructure-mainLine;
-  width: $sLayout-width;
-  z-index: 100; // for underlying content not to be visible
-}
 .Dialog-body--expanded.is-expandedWithSubHeader {
   padding-top: $sStickyHeight + $sMargin-group;
 }
@@ -253,6 +245,15 @@ $sStickyHeight: 97px;
   bottom: 0;
   width: 100%;
   height: $sStickyHeight;
+}
+.Dialog-contentSubHeader {
+  @include display-flex();
+  @include justify-content(space-between, justify);
+  @include align-items(center, center);
+  width: 100%;
+  padding-top: $sMargin-group;
+  padding-bottom: $sMargin-group;
+  border-bottom: 1px solid $cStructure-mainLine;
 }
 
 @include keyframes(fade-and-scale-in) {

--- a/app/assets/stylesheets/common/filters.css.scss
+++ b/app/assets/stylesheets/common/filters.css.scss
@@ -75,6 +75,10 @@
   &:first-child { margin-left: 0 }
   &:last-child { margin-right: 0 }
 }
+.Filters-typeItem.Filters-typeItem--moreMargins {
+  margin-left: 15px;
+  margin-right: 15px;
+}
 
 .Filters-searchLink {
   margin-right: 15px;

--- a/app/assets/stylesheets/editor/georeference.css.scss
+++ b/app/assets/stylesheets/editor/georeference.css.scss
@@ -4,7 +4,7 @@
 @import "../variables/progress-bar";
 
 $sIcon: 70px;
-$sWidth: 636px;
+$sWidth: 681px;
 
 .Georeference-content {
   // Should match the width as the .Filters-type container has with the current set of tabs,
@@ -69,7 +69,7 @@ $sWidth: 636px;
   border-top: 1px solid $cStructure-mainLine;
 }
 .Georeference-estimation {
-  width: 340px;
+  width: 380px;
   @include display-flex();
   @include justify-content(flex-start, start);
   @include align-items(center, center);

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/choose_geometry.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/choose_geometry.jst.ejs
@@ -1,0 +1,12 @@
+<div class="Dialog-contentSubHeader">
+  <button class="NavButton js-back">
+    <i class="iconFont iconFont-ArrowPrev"></i>
+  </button>
+  <p class="DefaulTitle">
+    Georeference your data
+  </p>
+  <div>
+    <%/* Empty div to render the prev node in center, based on the layout */%>
+  </div>
+</div>
+<div class="Georeference-contentItem OptionCards js-items"></div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/choose_geometry_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/choose_geometry_view.js
@@ -1,3 +1,4 @@
+var $ = require('jquery');
 var _ = require('underscore');
 var cdb = require('cartodb.js');
 var GeometryItemView = require('./geometry_item_view');
@@ -9,8 +10,6 @@ var randomQuote = require('../../view_helpers/random_quote');
  */
 module.exports = cdb.core.View.extend({
 
-  className: 'Georeference-contentItem OptionCards',
-
   initialize: function() {
     this.availableGeometries = new cdb.admin.Geocodings.AvailableGeometries();
 
@@ -20,20 +19,23 @@ module.exports = cdb.core.View.extend({
 
   render: function() {
     this.clearSubViews();
-    if (this.availableGeometries.get('available_geometries')) {
-      this._appendGeometryViews();
-    } else {
-      this.$el.html(this._createLoadingView());
-    }
+    this.$el.html(
+      this.getTemplate('common/dialogs/georeference/choose_geometry')()
+    );
+    _.each(
+      this.availableGeometries.get('available_geometries') ? this._createItemsViews() : [this._createLoadingView()],
+      this._appendView, this
+    );
     return this;
   },
 
   _appendView: function(view) {
-    this.$el.append(view.render().$el);
+    this.addView(view);
+    this.$('.js-items').append(view.render().el);
   },
 
-  _appendGeometryViews: function() {
-    this.$el.append(
+  _createItemsViews: function() {
+    return [
       this._createItemView({
         type: 'point',
         titles: {
@@ -50,25 +52,21 @@ module.exports = cdb.core.View.extend({
             'For example, if you are geocoding placenames we can only give you points for where those places exist.'
         }
       })
-    );
+    ];
   },
 
   _createItemView: function(d) {
-    var view = new GeometryItemView(_.extend({
+    return new GeometryItemView(_.extend({
       model: this.model,
       availableGeometries: this.availableGeometries
     }, d));
-    this.addView(view);
-    return view.render().$el;
   },
 
   _createLoadingView: function() {
-    var view = ViewFactory.createByTemplate('common/templates/loading', {
+    return ViewFactory.createByTemplate('common/templates/loading', {
       title: 'Checking for available geometries…',
       quote: randomQuote()
     });
-    this.addView(view);
-    return view.render().$el;
   },
 
   _initBinds: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference.jst.ejs
@@ -1,7 +1,4 @@
 <div class="Dialog-content Dialog-content--expanded">
-  <button class="NavButton Dialog-backBtn js-back" style="display: none;">
-    <i class="iconFont iconFont-ArrowPrev"></i>
-  </button>
   <div class="Dialog-contentWrapper">
     <div class="Dialog-header Dialog-header--expanded CreateDialog-header">
       <ul class="CreateDialog-headerSteps">

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/tab_item_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/tab_item_view.js
@@ -7,7 +7,7 @@ var cdb = require('cartodb.js');
 module.exports = cdb.core.View.extend({
 
   tagName: 'li',
-  className: 'Filters-typeItem',
+  className: 'Filters-typeItem Filters-typeItem--moreMargins',
 
   events: {
     'click .js-btn': '_onClick'


### PR DESCRIPTION
More issues fixed from #4262 

<img width="1035" alt="screen shot 2015-07-09 at 16 33 42" src="https://cloud.githubusercontent.com/assets/978461/8597968/9cd8ab92-2658-11e5-912c-e6cd0b5ed6b8.png">

- Fixes the subheader (more width between the tab items), used the width defined in the sketch file for the inner contents
- Add sub-subheader for the back button and subtitle

@xavijam + @josecruz 