### PR TITLE
Fixing favicon for public dashboard pages

### DIFF
--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link id="favicon" rel="shortcut icon" href="/favicons/favicon.ico" />
+    <%= favicon_link_tag "/favicons/favicon.ico" %>
     <title><%= yield :title %></title>
     <meta name="description" content="<%= yield :description %>">
     <meta name="keywords" content="<%= @name %>, datasets, maps, data visualization, spatial data, geospatial, cartodb">


### PR DESCRIPTION
- Public dashboard pages (BAD): 
![screen shot 2015-07-09 at 17 32 59](https://cloud.githubusercontent.com/assets/132146/8599408/96355d96-2660-11e5-8b86-3a82b58b8c69.png)

- Public map page, for example (GOOD):
![screen shot 2015-07-09 at 17 33 04](https://cloud.githubusercontent.com/assets/132146/8599423/a957a2f8-2660-11e5-8c44-71974d3d2352.png)

REVIEWER: @matallo 