### PR TITLE
4360 viz json can be fetch by tablename and the user is not taken into account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ WORKING_SPECS_2 = \
 
 WORKING_SPECS_2b = \
 	spec/helpers/uuidhelper_spec.rb \
+	spec/helpers/carto_db_spec.rb \
   $(NULL)
 
 WORKING_SPECS_3 = \

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -143,7 +143,7 @@ module Carto
         return render(text: 'Visualization does not exist', status: 404) if @visualization.nil?
         return render(text: 'Visualization not viewable', status: 403) if !@visualization.is_viewable_by_user?(current_viewer)
         subdomain = CartoDB.extract_subdomain(request)
-        return render(text: 'Visualization of that user does not exist', status: 404) if subdomain && subdomain != @visualization.user.username && !@visualization.has_read_permission?(current_viewer)
+        return render(text: 'Visualization of that user does not exist', status: 404) if subdomain && !subdomain.empty? && subdomain != @visualization.user.username && !@visualization.has_read_permission?(current_viewer)
       end
 
       def id_and_schema_from_params

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -142,6 +142,8 @@ module Carto
 
         return render(text: 'Visualization does not exist', status: 404) if @visualization.nil?
         return render(text: 'Visualization not viewable', status: 403) if !@visualization.is_viewable_by_user?(current_viewer)
+        subdomain = CartoDB.extract_subdomain(request)
+        return render(text: 'Visualization of that user does not exist', status: 404) if subdomain && subdomain != @visualization.user.username && !@visualization.has_read_permission?(current_viewer)
       end
 
       def id_and_schema_from_params

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -143,6 +143,7 @@ module Carto
         return render(text: 'Visualization does not exist', status: 404) if @visualization.nil?
         return render(text: 'Visualization not viewable', status: 403) if !@visualization.is_viewable_by_user?(current_viewer)
         subdomain = CartoDB.extract_subdomain(request)
+        # INFO: subdomain checking is not part of previous permission checking (and should not be), so we add an additional check here: subdomain must match visualization username.
         return render(text: 'Visualization of that user does not exist', status: 404) if subdomain && !subdomain.empty? && subdomain != @visualization.user.username && !@visualization.has_read_permission?(current_viewer)
       end
 

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -234,6 +234,10 @@ class Carto::Visualization < ActiveRecord::Base
     table.nil? ? nil : table.service
   end
 
+  def has_read_permission?(user)
+    user && (is_owner_user?(user) || (permission && permission.user_has_read_permission?(user)))
+  end
+
   private
 
   def get_named_map
@@ -297,10 +301,6 @@ class Carto::Visualization < ActiveRecord::Base
 
   def get_related_visualizations
     Carto::Visualization.where(map_id: related_tables.collect(&:map_id), type: TYPE_CANONICAL).all
-  end
-
-  def has_read_permission?(user)
-    user && (is_owner_user?(user) || (permission && permission.user_has_read_permission?(user)))
   end
 
   def has_write_permission?(user)

--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -61,17 +61,9 @@ module CartoDB
     user_domain.nil? ? self.subdomain_from_request(request) : user_domain
   end
 
-  # Subdomain extraction from request taking subdomainless_urls into account
-  def self.subdomain_from_request(request)
-    self.subdomainless_urls? ? '' : extract_subdomain_from_request(request)
-  end
-
   # Raw subdomain extraction from request
-  def self.extract_subdomain_from_request(request)
-    host = request.host.to_s
-    # If host doesn't contain session domain subdomain is empty.
-    # A simple replacement won't work because session_domain doesn't contain beginning dot and host does
-    host =~ /#{self.session_domain}/ ? host.gsub(self.session_domain, '') : ''
+  def self.subdomain_from_request(request)
+    self.subdomainless_urls? ? '' : request.host.to_s.gsub(self.session_domain, '')
   end
 
   # Flexible subdomain extraction: If /u/xxx or /user/xxxx present uses it, else uses request host (xxx.cartodb.com)

--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -61,9 +61,17 @@ module CartoDB
     user_domain.nil? ? self.subdomain_from_request(request) : user_domain
   end
 
-  # Raw subdomain extraction from request
+  # Subdomain extraction from request taking subdomainless_urls into account
   def self.subdomain_from_request(request)
-    self.subdomainless_urls? ? '' : request.host.to_s.gsub(self.session_domain, '')
+    self.subdomainless_urls? ? '' : extract_subdomain_from_request(request)
+  end
+
+  # Raw subdomain extraction from request
+  def self.extract_subdomain_from_request(request)
+    host = request.host.to_s
+    # If host doesn't contain session domain subdomain is empty.
+    # A simple replacement won't work because session_domain doesn't contain beginning dot and host does
+    host =~ /#{self.session_domain}/ ? host.gsub(self.session_domain, '') : ''
   end
 
   # Flexible subdomain extraction: If /u/xxx or /user/xxxx present uses it, else uses request host (xxx.cartodb.com)

--- a/spec/helpers/carto_db_spec.rb
+++ b/spec/helpers/carto_db_spec.rb
@@ -1,0 +1,29 @@
+require 'rails'
+require 'ostruct'
+require_relative '../rspec_configuration'
+require_relative '../../config/initializers/carto_db'
+
+module CartoDB
+  class Cartodb
+    def config
+      {}
+    end
+  end
+end
+
+describe 'CartoDB' do
+
+  describe 'extract_subdomain' do
+
+    it 'extracts subdomain' do
+      CartoDB::Cartodb.stubs(:config).returns({ subdomainless_urls: false })
+      CartoDB.stubs(:session_domain).returns('.localhost.lan')
+      CartoDB.extract_subdomain(OpenStruct.new(host: 'localhost.lan', params: { user_domain: ''})).should == ''
+      CartoDB.extract_subdomain(OpenStruct.new(host: 'auser.localhost.lan', params: { user_domain: 'auser'})).should == 'auser'
+      CartoDB.extract_subdomain(OpenStruct.new(host: 'localhost.lan', params: { user_domain: 'auser'})).should == 'auser'
+      CartoDB.extract_subdomain(OpenStruct.new(host: 'auser.localhost.lan', params: { user_domain: 'otheruser'})).should == 'otheruser'
+    end
+
+  end
+
+end

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1249,6 +1249,14 @@ describe Carto::Api::VisualizationsController do
         ::JSON.parse(last_response.body).keys.length.should > 1
       end
 
+      it 'returns 200 if subdomain is empty' do
+        viz = api_visualization_creation(@user, @headers, { privacy: Visualization::Member::PRIVACY_PUBLIC, type: Visualization::Member::TYPE_DERIVED })
+        # INFO: I couldn't get rid of subdomain, so I stubbed
+        CartoDB.stubs(:extract_subdomain).returns('')
+        get api_v2_visualizations_vizjson_url(id: viz.id)
+        last_response.status.should == 200
+      end
+
       it 'returns 200 if subdomain matches' do
         viz = api_visualization_creation(@user, @headers, { privacy: Visualization::Member::PRIVACY_PUBLIC, type: Visualization::Member::TYPE_DERIVED })
         get api_v2_visualizations_vizjson_url(user_domain: @user.username, id: viz.id)

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1013,6 +1013,13 @@ describe Carto::Api::VisualizationsController do
         body = JSON.parse(last_response.body)
         body['id'].should eq u1_vis_1_id
 
+        # Check visualization id under wrong subdomain triggers 404
+        get api_v2_visualizations_vizjson_url(user_domain: @user.username, id: u1_vis_1_id, api_key: @user.api_key)
+        last_response.status.should == 404
+
+        # Check visualization id under shared with user subdomain triggers 200
+        get api_v2_visualizations_vizjson_url(user_domain: user_2.username, id: u1_vis_1_id, api_key: user_2.api_key)
+        last_response.status.should == 200
       end
 
       it 'Sanitizes vizjson callback' do
@@ -1235,12 +1242,23 @@ describe Carto::Api::VisualizationsController do
       end
 
       it 'renders vizjson v2' do
-        table_attributes  = table_factory
-        table_id          = table_attributes.fetch('id')
+        table_id          = table_factory.fetch('id')
         get "/api/v2/viz/#{table_id}/viz?api_key=#{@api_key}",
           {}, @headers
         last_response.status.should == 200
         ::JSON.parse(last_response.body).keys.length.should > 1
+      end
+
+      it 'returns 200 if subdomain matches' do
+        viz = api_visualization_creation(@user, @headers, { privacy: Visualization::Member::PRIVACY_PUBLIC, type: Visualization::Member::TYPE_DERIVED })
+        get api_v2_visualizations_vizjson_url(user_domain: @user.username, id: viz.id)
+        last_response.status.should == 200
+      end
+
+      it 'returns 404 if subdomain does not match' do
+        viz = api_visualization_creation(@user, @headers, { privacy: Visualization::Member::PRIVACY_PUBLIC, type: Visualization::Member::TYPE_DERIVED })
+        get api_v2_visualizations_vizjson_url(user_domain: 'whatever', id: viz.id)
+        last_response.status.should == 404
       end
 
       it 'returns children (slides) vizjson' do


### PR DESCRIPTION
@Kartones CR this fix for #4360, please.

- If subdomain doesn't match visualization username it will throw a 404. Exception: if current viewer has read permissions (visualization has been shared with him).
- Empty subdomains are allowed.