### PR TITLE
Preventing problem within form view when import model is service type

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/data_import/data_form_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/data_import/data_form_view.js
@@ -181,8 +181,12 @@ module.exports = cdb.core.View.extend({
     this.trigger('urlSelected', this);
 
     // Change model
+
+    // We set import type to 'url' preventing a previous file upload.
+    // But if import model is a service type, it shouldn't be changed.
+    var importType = this.model.get('service_name') ? 'service' : 'url';
     this.model.set({
-      type: 'url',
+      type: importType,
       value: value,
       service_item_id: value,
       state: 'idle'

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/data_import/data_form_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/data_import/data_form_view.js
@@ -181,9 +181,6 @@ module.exports = cdb.core.View.extend({
     this.trigger('urlSelected', this);
 
     // Change model
-
-    // We set import type to 'url' preventing a previous file upload.
-    // But if import model is a service type, it shouldn't be changed.
     var importType = this.model.get('service_name') ? 'service' : 'url';
     this.model.set({
       type: importType,

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/import_arcgis_selected_dataset_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/import_arcgis_selected_dataset_view.js
@@ -35,6 +35,7 @@ module.exports = SelectedDataset.extend({
         interval: this.model.get('interval'),
         importCanSync: this.options.acceptSync && this._isArcGISLayer(title),
         userCanSync: userCanSync,
+        showTrial: this.user.canStartTrial(),
         showUpgrade: !userCanSync && !customInstall && upgradeUrl && !this.user.isInsideOrg(),
         upgradeUrl: upgradeUrl
       })

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/import_arcgis_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/import_arcgis_view.js
@@ -16,7 +16,7 @@ module.exports = ImportDataView.extend({
 
   options: {
     fileExtensions: [],
-    type: 'url',
+    type: 'service',
     service: 'arcgis',
     acceptSync: true,
     fileEnabled: false,
@@ -26,7 +26,6 @@ module.exports = ImportDataView.extend({
       description: ''
     }
   },
-
 
   _initViews: function() {
     // Data header

--- a/lib/assets/test/spec/cartodb/common/dialogs/create/listing/imports/import_data/data_form_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/create/listing/imports/import_data/data_form_view.spec.js
@@ -77,6 +77,19 @@ describe('common/dialogs/create/imports/data_import/data_form_view', function() 
     expect(this.model.get('state')).toBe('selected');
   });
 
+  it("shouldn't change type attribute when a url is submitted and is valid", function() {
+    this.model.set({
+      type: 'service',
+      service_name: 'arcgis'
+    });
+    this.view.render();
+    this.view.$('.js-textInput')
+      .val('http://cartodb.com')
+      .trigger('keyup');
+    this.view.$('.js-form').submit();
+    expect(this.model.get('type')).toBe('service');
+  });
+
   it("should show error when url is invalid", function() {
     spyOn(this.view, '_showTextError');
     this.view.$('.js-textInput')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.16.8",
+  "version": "3.16.9",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Basically, when a url was submitted, form data view was resetting the import model type, so it was always 'url' type :(. Also, ArcGIS was considered as url, so double fault.

REVIEWER: @javierarce 
Fixes #4080 

cc @Kartones @iriberri 