### PR TITLE
Replaces uses of `layers.last()` by `_.last(layers.getDataLayers())`:

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -581,8 +581,9 @@ cdb.admin.Header = cdb.core.View.extend({
     if (this.model.isVisualization()) {
       return true;
     } else {
-
-      var table = this.model.map.layers && this.model.map.layers.last() &&  this.model.map.layers.last().table;
+      var lastDataLayer = this.model.map.layers &&
+        _.last(this.model.map.layers.getDataLayers());
+      var table = lastDataLayer && lastDataLayer.table;
 
       if (!table) {
         return false;

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -194,7 +194,7 @@
       this._checkLayers();
       this._manageLayers();
       if (self.map.layers.getDataLayers().length === 1) {
-        self.map.layers.last().set('visible', true);
+        _.last(self.map.layers.getDataLayers()).set('visible', true);
       }
     },
 

--- a/lib/assets/javascripts/cartodb/table/metadata_dialog.js
+++ b/lib/assets/javascripts/cartodb/table/metadata_dialog.js
@@ -136,12 +136,14 @@
     _isMetadataEditable: function() {
       if (this.model.isVisualization()) {
         if (this.model.permission.isOwner(this.user)) {
-          return true
+          return true;
         } else {
-          return false
+          return false;
         }
       } else {
-        var table = this.vis.map.layers && this.vis.map.layers.last() &&  this.vis.map.layers.last().table;
+        var lastDataLayer = this.vis.map.layers &&
+          _.last(this.vis.map.layers.getDataLayers());
+        var table = lastDataLayer && lastDataLayer.table;
         if (!table) {
           return false;
         } else if (table && (table.isInSQLView() || !table.permission.isOwner(this.user))) {
@@ -156,12 +158,15 @@
     _isTitleEditable: function() {
       if (this.model.isVisualization()) {
         if (this.model.permission.isOwner(this.user)) {
-          return true
+          return true;
         } else {
-          return false
+          return false;
         }
       } else {
-        var table = this.vis.map.layers && this.vis.map.layers.last().table;
+        var lastDataLayer = this.vis.map.layers &&
+          _.last(this.vis.map.layers.getDataLayers());
+        var table = lastDataLayer && lastDataLayer.table;
+
         if (!table) {
           return false;
         } else if (table && (table.isReadOnly() || !table.permission.isOwner(this.user))) {


### PR DESCRIPTION
Fixes #4438. The last layer of the collection might now be a Tiled layer with labels and that was causing some issues when determining if a dataset/map was editable.

@xavijam PTAL. Thanks!