### PR TITLE
Mixpanel reporting shouldn't report to Rollbar. Fixes #4441

### DIFF
--- a/lib/cartodb/mixpanel.rb
+++ b/lib/cartodb/mixpanel.rb
@@ -31,10 +31,8 @@ module CartoDB
       case event
       when :import
         mixpanel_event("Import failed", mixpanel_payload(event, metric_payload))
-        Rollbar.report_message("Failed import", "error", error_info: metric_payload)
       when :geocoding
         mixpanel_event("Geocoding failed", mixpanel_payload(event, metric_payload))
-        Rollbar.report_message("Failed geocoding", "error", error_info: metric_payload)
       end
     end #report_failure
 


### PR DESCRIPTION
@matallo CR this fix for #4441, please. I've checked that the only places where Mixpanel reporting is invoked ([DataImport](https://github.com/CartoDB/cartodb/blob/master/app/models/data_import.rb#L741) and [Geocoding](https://github.com/CartoDB/cartodb/blob/master/app/models/geocoding.rb#L159)) metrics are being reported as well, so we won't lose any Rollbar errors. I shouldn't delete Mixpanel yet, should I?