### PR TITLE
Indexes are not dropped in sync tables

### DIFF
--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -181,12 +181,31 @@ module CartoDB
                                  destination_table_name: destination_table_name } )
       end
 
+      # Store all indexes to re-create them after "syncing" the table by reimporting and swapping it
+      # INFO: As upon import geom index names are not enforced, they might "not collide" and generate one on the new import
+      # plus the one already existing, so we skip those
       def generate_index_statements(origin_schema, origin_table_name)
+        # INFO: This code discerns gist indexes like lib/sql/CDB_CartodbfyTable.sql -> _CDB_create_the_geom_columns
         user.in_database(as: :superuser)[%Q(
           SELECT indexdef AS indexdef
           FROM pg_indexes
           WHERE schemaname = '#{origin_schema}'
           AND tablename = '#{origin_table_name}'
+          AND indexname NOT IN (
+            SELECT ir.relname
+              FROM pg_am am, pg_class ir,
+                pg_class c, pg_index i,
+                pg_attribute a
+              WHERE c.oid  = '#{origin_schema}.#{origin_table_name}'::regclass::oid AND i.indrelid = c.oid
+                    AND (a.attname = '#{::Table::THE_GEOM}' OR a.attname = '#{::Table::THE_GEOM_WEBMERCATOR}')
+                    AND i.indexrelid = ir.oid 
+                    AND i.indnatts = 1
+                    AND i.indkey[0] = a.attnum 
+                    AND a.attrelid = c.oid
+                    AND NOT a.attisdropped 
+                    AND am.oid = ir.relam
+                    AND am.amname = 'gist'
+                  )
         )].map { |record|
           record.fetch(:indexdef)
         }


### PR DESCRIPTION
Fixes #3876 

Issue was that some imports, upon sync create a new the_geom index, and as sync tables store old indexes, they are added and added until you have thousands. Logic to cartodbfy is smart only creating a single the_geom gist index if not present, but afterwards recreation adds the old ones not doing any check.

New logic excludes from export those gist indexes that comply with same set of rules (either original table or cartodbfication will always provide a valid gist index). This code also keeps (as cartodbfication does) other custom indexes an advanced user might have added).