### PR TITLE
ArcGIS MapServer won't import but individual layers do

### DIFF
--- a/services/datasources/lib/datasources/base.rb
+++ b/services/datasources/lib/datasources/base.rb
@@ -32,7 +32,7 @@ module CartoDB
       # @param resource_metadata Hash { :size, ... }
       # @return bool
       def has_resource_size?(resource_metadata)
-        resource_metadata[:size] > NO_CONTENT_SIZE_PROVIDED
+        resource_metadata[:size] && resource_metadata[:size] > NO_CONTENT_SIZE_PROVIDED
       end
 
       # Factory method

--- a/services/datasources/lib/datasources/url/arcgis.rb
+++ b/services/datasources/lib/datasources/url/arcgis.rb
@@ -192,7 +192,8 @@ module CartoDB
             {
               # Store original id, not the sanitized one
               id:           id,
-              subresources: get_layers_list(@url)
+              subresources: get_layers_list(@url),
+              size:         NO_CONTENT_SIZE_PROVIDED
             }
           else
             sub_id = get_subresource_id(id)

--- a/services/datasources/lib/datasources/url/arcgis.rb
+++ b/services/datasources/lib/datasources/url/arcgis.rb
@@ -192,8 +192,7 @@ module CartoDB
             {
               # Store original id, not the sanitized one
               id:           id,
-              subresources: get_layers_list(@url),
-              size:         NO_CONTENT_SIZE_PROVIDED
+              subresources: get_layers_list(@url)
             }
           else
             sub_id = get_subresource_id(id)

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -283,7 +283,7 @@ module CartoDB
             @importer_stats.timing('datasource_metadata') do
               # TODO: Support sending user and options to the datasource factory
               datasource = CartoDB::Datasources::DatasourcesFactory.get_datasource(
-                @downloader.datasource.class::DATASOURCE_NAME, nil, nil)
+                @downloader.datasource.class::DATASOURCE_NAME, nil, additional_config = {})
               item_metadata = datasource.get_resource_metadata(subresource[:id])
             end
 


### PR DESCRIPTION
Fixes #4449 

NOTE: There's another issue, importer right now only imports first table, so the remaining layers won't import, only first one.