### PR TITLE
Migration to remove dynamic_cdn_enable column from user model

### DIFF
--- a/db/migrate/20150715133959_remove_dynamic_enable_field.rb
+++ b/db/migrate/20150715133959_remove_dynamic_enable_field.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    drop_column :users, :dynamic_cdn_enabled
+  end
+
+  down do
+    add_column :users, :dynamic_cdn_enabled, :boolean, default: false
+  end
+end


### PR DESCRIPTION
Second part of the unused properties. This time the `dynamic_cdn_enabled` column is deleted

**This PR is for issue #4379**