### PR TITLE
2695 provide original file name in the import api

### DIFF
--- a/app/controllers/carto/api/data_import_presenter.rb
+++ b/app/controllers/carto/api/data_import_presenter.rb
@@ -1,0 +1,90 @@
+require 'uri'
+
+module Carto
+  module Api
+    class DataImportPresenter
+
+      def initialize(data_import)
+        @data_import = data_import
+      end
+
+      def api_public_values
+        public_values.reject { |key|
+          NON_API_VISIBLE_ATTRIBUTES.include?(key)
+        }
+      end
+
+      private
+
+      PUBLIC_ATTRIBUTES = [
+        'id',
+        'user_id',
+        'table_id',
+        'data_type',
+        'table_name',
+        'state',
+        'error_code',
+        'queue_id',
+        'tables_created_count',
+        'synchronization_id',
+        'service_name',
+        'service_item_id',
+        'type_guessing',
+        'quoted_fields_guessing',
+        'content_guessing',
+        'server',
+        'host',
+        'upload_host',
+        'resque_ppid',
+        'create_visualization',
+        'visualization_id',
+        # String field containing a json, format:
+        # {
+        #   twitter_credits: Integer
+        # }
+        # No automatic conversion coded
+        'user_defined_limits'
+      ]
+
+      NON_API_VISIBLE_ATTRIBUTES = [
+        'service_item_id',
+        'service_name',
+        'server',
+        'host',
+        'upload_host',
+        'resque_ppid',
+      ]
+
+      def public_values
+        values = Hash[PUBLIC_ATTRIBUTES.map{ |attribute| [attribute, @data_import.send(attribute)] }]
+        values.merge!('get_error_text' => get_error_text)
+        values.merge!('display_name' => display_name)
+        values.merge!('queue_id' => @data_import.id)
+        values.merge!(success: @data_import.success) if @data_import.final_state?
+        values
+      end
+
+      def get_error_text
+        if @data_import.error_code.nil?
+          nil
+        else
+          @data_import.error_code.blank? ? CartoDB::IMPORTER_ERROR_CODES[99999] : CartoDB::IMPORTER_ERROR_CODES[@data_import.error_code]
+        end
+      end
+
+      def display_name
+        url = [@data_import.data_source, @data_import.service_item_id].compact.first
+        display_name = url.nil? ? @data_import.id : extract_filename(url)
+        display_name || @data_import.id
+      rescue => e
+        CartoDB.notify_debug('Error extracting display name', { data_import_id: @data_import.id })
+        @data_import.id
+      end
+
+      def extract_filename(url)
+        File.basename(URI.parse(url).path)
+      end
+
+    end
+  end
+end

--- a/app/controllers/carto/api/data_import_presenter.rb
+++ b/app/controllers/carto/api/data_import_presenter.rb
@@ -73,7 +73,7 @@ module Carto
       end
 
       def display_name
-        url = [@data_import.data_source, @data_import.service_item_id].compact.first
+        url = [@data_import.data_source, @data_import.service_item_id].compact.select { |s| s != '' }.first
         display_name = url.nil? ? @data_import.id : extract_filename(url)
         display_name || @data_import.id
       rescue => e

--- a/app/controllers/carto/api/imports_controller.rb
+++ b/app/controllers/carto/api/imports_controller.rb
@@ -15,7 +15,7 @@ module Carto
         import = DataImportsService.new.process_by_id(params[:id])
         render_404 and return if import.nil?
 
-        data = import.api_public_values
+        data = Carto::Api::DataImportPresenter.new(import).api_public_values
         if import.state == Carto::DataImport::STATE_COMPLETE
           data[:any_table_raster] = import.is_raster?
 

--- a/app/models/carto/data_import.rb
+++ b/app/models/carto/data_import.rb
@@ -24,73 +24,15 @@ module Carto
 
     belongs_to :user
 
-    # Meant to be used when calling from API endpoints (hides some fields not needed at editor scope)
-    def api_public_values
-      public_values.reject { |key|
-        NON_API_VISIBLE_ATTRIBUTES.include?(key)
-      }
-    end
-
     def is_raster?
       ::JSON.parse(self.stats).select{ |item| item['type'] == '.tif' }.length > 0
     end
 
+    def final_state?
+      [STATE_COMPLETE, STATE_FAILURE, STATE_STUCK].include? state
+    end
+
     private
-
-    PUBLIC_ATTRIBUTES = [
-      'id',
-      'user_id',
-      'table_id',
-      'data_type',
-      'table_name',
-      'state',
-      'error_code',
-      'queue_id',
-      'get_error_text',
-      'tables_created_count',
-      'synchronization_id',
-      'service_name',
-      'service_item_id',
-      'type_guessing',
-      'quoted_fields_guessing',
-      'content_guessing',
-      'server',
-      'host',
-      'upload_host',
-      'resque_ppid',
-      'create_visualization',
-      'visualization_id',
-      # String field containing a json, format:
-      # {
-      #   twitter_credits: Integer
-      # }
-      # No automatic conversion coded
-      'user_defined_limits'
-    ]
-
-    NON_API_VISIBLE_ATTRIBUTES = [
-      'service_item_id',
-      'service_name',
-      'server',
-      'host',
-      'upload_host',
-      'resque_ppid',
-    ]
-
-    def public_values
-      values = Hash[PUBLIC_ATTRIBUTES.map{ |attribute| [attribute, send(attribute)] }]
-      values.merge!('queue_id' => id)
-      values.merge!(success: success) if (state == STATE_COMPLETE || state == STATE_FAILURE || state == STATE_STUCK)
-      values
-    end
-
-    def get_error_text
-      if self.error_code.nil?
-        nil
-      else
-        self.error_code.blank? ? CartoDB::IMPORTER_ERROR_CODES[99999] : CartoDB::IMPORTER_ERROR_CODES[self.error_code]
-      end
-    end
 
   end
 end

--- a/spec/requests/carto/api/imports_controller_spec.rb
+++ b/spec/requests/carto/api/imports_controller_spec.rb
@@ -80,6 +80,7 @@ describe Carto::Api::ImportsController do
 
     import = JSON.parse(response.body)
     import['state'].should be == 'complete'
+    import['display_name'].should be == 'wadus.csv'
   end
 
   it 'gets the detail of an import stuck unpacking' do
@@ -114,6 +115,7 @@ describe Carto::Api::ImportsController do
     response.code.should be == '200'
     import = JSON.parse(response.body)
     import['state'].should be == 'complete'
+    import['display_name'].should be == 'Weird_Filename_(2).tgz'
   end
 
   it 'fails with password protected files' do


### PR DESCRIPTION
This closes #2695. @Kartones CR this, please.

@xavijam: if this gets @Kartones :es: , import api will display a new `display_name` field. Example:
```
{"id":"16135ab1-33cc-48bc-b733-77f4141ff2fc","user_id":"c043713d-1655-4b9d-b909-f0193021150e","table_id":"df15b092-081d-403c-83c4-5b173b4482c5","data_type":"url","table_name":"county_usa","state":"complete","error_code":null,"queue_id":"16135ab1-33cc-48bc-b733-77f4141ff2fc","tables_created_count":1,"synchronization_id":null,"type_guessing":true,"quoted_fields_guessing":true,"content_guessing":true,"create_visualization":true,"visualization_id":"a3696fe0-2b9a-11e5-a295-04014675d001","user_defined_limits":"{\"twitter_credits_limit\":0}","get_error_text":null,"display_name":"county_usa.zip","success":true,"any_table_raster":false,"derived_visualization_id":"a3696fe0-2b9a-11e5-a295-04014675d001"}
```

I've tried to always return something. If I can't parse a filename I will return the id. But prepare frontend to display the id if `display_name`is empty or nil, please.