### PR TITLE
Delete column modal issue

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
@@ -58,6 +58,6 @@ module.exports = BaseDialog.extend({
   ok: function() {
     this._panes.active('loading');
     this.table.deleteColumn(this.column);
-    this.clean();
+    this.hide();
   }
 });

--- a/lib/assets/javascripts/cartodb/table/header_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/header_dropdown.js
@@ -150,7 +150,8 @@ cdb.admin.HeaderDropdown = cdb.admin.DropdownMenu.extend({
 
       var view = new cdb.editor.DeleteColumnView({
         table: this.table,
-        column: this.column
+        column: this.column,
+        clean_on_hide: true
       });
 
       view.appendToBody();


### PR DESCRIPTION
Being in the dataset, when the new delete-column-dialog is opened and the column is deleted, body element doesn't recover the scroll status and user can paginate the dataset, for example.

cc @javierarce @saleiva 