### PR TITLE
Setting url_prefix for any public page

### DIFF
--- a/app/views/admin/visualizations/public/_embed_map_inline_js.html.erb
+++ b/app/views/admin/visualizations/public/_embed_map_inline_js.html.erb
@@ -62,6 +62,8 @@
 
   // On load...
   $(function(){
+    // Set visualization user url prefix
+    cartodb.config.set('url_prefix', '<%= @visualization.user.public_url(nil, request.protocol == "https://" ? "https" : "http") %>');
 
     var bool_fn = function(v) { return v == 'true' };
     var is_custom_install = <%= Cartodb.config[:cartodb_com_hosted].present? %>;

--- a/app/views/admin/visualizations/public_table.html.erb
+++ b/app/views/admin/visualizations/public_table.html.erb
@@ -32,6 +32,7 @@
     var auth_token          = <%= safe_js_object @auth_tokens.to_json %>;
     var use_https           = <%= @use_https =%>;
     var api_key             = <%= safe_js_object @api_key.to_json %>;
+    var base_url            = '<%= @table.owner.public_url(nil, request.protocol == "https://" ? "https" : "http") %>';
 
     var debug = false;
     <% if Rails.env.development? || Cartodb.config[:no_cdn] == true %>

--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -91,6 +91,7 @@
     <script type="text/javascript">
       var config = <%= safe_js_object frontend_config_public({https_apis: request.protocol == 'https://' }) %>;
       var account_host = '<%= CartoDB.account_host %>';
+      var base_url = '<%= @user.public_url(nil, request.protocol == "https://" ? "https" : "http") %>';
       var favMapViewAttrs = {
         el: '#<%= fav_map_target_id %>',
         <% if @most_viewed_vis_map %>

--- a/lib/assets/javascripts/cartodb/public_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/public_dashboard/entry.js
@@ -12,6 +12,7 @@ var LikeView = require('../common/views/likes/view');
 $(function() {
   cdb.init(function() {
     cdb.templates.namespace = 'cartodb/';
+    cdb.config.set('url_prefix', window.base_url);
 
     $(document.body).bind('click', function() {
       cdb.god.trigger('closeDialogs');

--- a/lib/assets/javascripts/cartodb/public_map/entry.js
+++ b/lib/assets/javascripts/cartodb/public_map/entry.js
@@ -22,6 +22,7 @@ $(function() {
 
   cdb.init(function() {
     cdb.templates.namespace = 'cartodb/';
+    cdb.config.set('url_prefix', window.base_url);
 
     $(document.body).bind('click', function() {
       cdb.god.trigger('closeDialogs');

--- a/lib/assets/javascripts/cartodb/public_table/public_table.js
+++ b/lib/assets/javascripts/cartodb/public_table/public_table.js
@@ -15,6 +15,7 @@ $(function() {
   cdb.init(function() {
     cdb.config.set(config);
     if (api_key) cdb.config.set("api_key", api_key);
+    cdb.config.set('url_prefix', window.base_url);
     cdb.templates.namespace = 'cartodb/';
 
     // Check if device is a mobile


### PR DESCRIPTION
Visiting the public profile of an organization user, we have checked that requests to backend were:

```
http://:orgname.cartodb.com/api/v1...(whatever)
```
It didn't include the url_prefix ```/u/:username```, so it makes fail, for example, the like endpoint as we describe in #4522.

So we have added ```url_prefix``` variable and set it in the cdb.config to let Backbone model point to the right url.

Fixes #4522.

REVIEW: @kartones and @viddo 