### PR TITLE
Expose sync tables logs to superadmin endpoints

### DIFF
--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -4,7 +4,8 @@ class Superadmin::UsersController < Superadmin::SuperadminController
   respond_to :json
 
   ssl_required :show, :create, :update, :destroy, :index if Rails.env.production? || Rails.env.staging?
-  before_filter :get_user, only: [:update, :destroy, :show, :dump, :data_imports, :data_import]
+  before_filter :get_user, only: [ :update, :destroy, :show, :dump, :data_imports, :data_import ]
+  before_filter :get_carto_user, only: [ :synchronizations, :synchronization ]
 
   layout 'application'
 
@@ -99,10 +100,34 @@ class Superadmin::UsersController < Superadmin::SuperadminController
                  })
   end
 
+  def synchronizations
+    respond_with(@user.synchronizations.map { |entry|
+      {
+        id: entry.id,
+        data_type: entry.service_name,
+        date: entry.updated_at,
+        status: entry.success?
+      }
+    })
+  end
+
+  def synchronization
+    synchronization = Carto::Synchronization.where(id: params[:synchronization_id]).first
+    respond_with({
+                   data: synchronization,
+                   log: synchronization.nil? ? nil : synchronization.log.to_s
+                 })
+  end
+
   private
 
   def get_user
     @user = User[params[:id]]
+    render json: { error: 'User not found' }, status: 404 unless @user
+  end
+
+  def get_carto_user
+    @user = Carto::User.where(id: params[:id]).first
     render json: { error: 'User not found' }, status: 404 unless @user
   end
 

--- a/app/models/carto/synchronization.rb
+++ b/app/models/carto/synchronization.rb
@@ -1,7 +1,17 @@
 require 'active_record'
 
 class Carto::Synchronization < ActiveRecord::Base
+  
   belongs_to :user
+
+  STATE_CREATED   = 'created'
+  # Already at resque, waiting for slot
+  STATE_QUEUED   = 'queued'
+  # Actually syncing
+  STATE_SYNCING   = 'syncing'
+  STATE_SUCCESS   = 'success'
+  STATE_FAILURE   = 'failure'
+
 
   def authorize?(user)
     user.id == user_id && !!user.sync_tables_enabled
@@ -13,6 +23,15 @@ class Carto::Synchronization < ActiveRecord::Base
 
   def to_hash
     attributes.to_hash
+  end
+
+  def success?
+    state == STATE_SUCCESS
+  end
+
+  # TODO: Properly migrate log to AR and remove this
+  def log
+    CartoDB::Log[self.log_id]
   end
 
 end

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -24,6 +24,7 @@ class Carto::User < ActiveRecord::Base
   has_many :geocodings, inverse_of: :user
   has_many :synchronization_oauths, class_name: Carto::SynchronizationOauth, inverse_of: :user, dependent: :destroy
   has_many :search_tweets, inverse_of: :user
+  has_many :synchronizations, inverse_of: :user
 
   delegate [ 
       :database_username, :database_password, :in_database, :load_cartodb_functions, :rebuild_quota_trigger,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -473,6 +473,8 @@ CartoDB::Application.routes.draw do
         get '/:id/dump' => 'users#dump'
         get '/:id/data_imports' => 'users#data_imports'
         get '/:id/data_imports/:data_import_id' => 'users#data_import'
+        get '/:id/synchronizations' => 'users#synchronizations'
+        get '/:id/synchronizations/:synchronization_id' => 'users#synchronization'
       end
     end
     resources :organizations


### PR DESCRIPTION
Closes #4561 

Motivation: After fixing a sync bug regarding its log, now we can't see superadmin sync logs because they have the proper type. This solves the issue by adding their appropiate endpoint.