### PR TITLE
New modals fix

### DIFF
--- a/app/views/admin/visualizations/show.html.erb
+++ b/app/views/admin/visualizations/show.html.erb
@@ -6,7 +6,12 @@
   <% end %>
 
   <% content_for(:css) do %>
-    <%= stylesheet_link_tag 'old_common.css', 'common.css', 'cdb.css', 'table.css', 'editor.css', 'map.css', :media => 'all' %>
+    <% if current_user.has_feature_flag?('new_modals') %>
+      <%= stylesheet_link_tag 'old_common_without_core.css', :media => 'all' %>
+    <% else %>
+      <%= stylesheet_link_tag 'old_common.css', :media => 'all' %>
+    <% end %>
+    <%= stylesheet_link_tag  'common.css', 'cdb.css', 'table.css', 'editor.css', 'map.css', :media => 'all' %>
   <% end %>
 
   <script type="text/javascript" id="dropboxjs" src="//www.dropbox.com/static/api/1/dropins.js" data-app-key="<%= Cartodb.config[:dropbox_api_key] %>"></script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,6 +88,7 @@ module CartoDB
       public_like.js
       common.js
       old_common.js
+      old_common_without_core.js
       templates.js
       templates_mustache.js
       specs.js

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -205,7 +205,9 @@ $(function() {
           this._initTableMap();
           this.table.trigger('change', this.table);
         }
-        this.backgroundTab.setActiveLayer(layerView);
+        if (this.backgroundTab) {
+          this.backgroundTab.setActiveLayer(layerView);  
+        }
         this.tableTab.setActiveLayer(layerView);
         this.mapTab.setActiveLayer(layerView);
         this.header.setActiveLayer(layerView);

--- a/lib/build/files/css_files.js
+++ b/lib/build/files/css_files.js
@@ -12,6 +12,14 @@ module.exports = css_files = {
     '<%= assets_dir %>/stylesheets/plugins/**/*.css'
   ],
 
+  old_common_without_core: [
+    '<%= assets_dir %>/stylesheets/old_common/**/*.css',
+    '<%= assets_dir %>/stylesheets/old_elements/**/*.css',
+    '<%= assets_dir %>/stylesheets/plugins/**/*.css',
+    // Core is replaced by a retrofitted set of styles, to make the old core styles work with new_common/default
+    '!<%= assets_dir %>/stylesheets/old_common/core.css',
+  ],
+
   common: [
     '<%= assets_dir %>/stylesheets/old_common/video_player.css',
     '<%= assets_dir %>/stylesheets/common/utilities.css',
@@ -91,8 +99,6 @@ module.exports = css_files = {
   ],
 
   editor: [
-    // Core is replaced by a retrofitted set of styles, to make the old core styles work with new_common/default
-    // '!<%= assets_dir %>/stylesheets/old_common/core.css',
     '<%= assets_dir %>/stylesheets/editor/core_retrofit.css',
 
     // From table bundle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.17.33",
+  "version": "3.17.34",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] Correct CSS for new modals, removing old common core file.
- [x] Found bug in table class that tries to apply the new layer to an undefined variable called ```this.backgroundTab```. It doesn't exist when new_modals feature flag is enabled (it comes from https://github.com/CartoDB/cartodb/pull/4565/files#diff-c29efcffff8403c70464f45c249c4ab4L211).

REVIEWER: @viddo 