### PR TITLE
4397 customize the login with org name button color just like background

### DIFF
--- a/app/controllers/google_plus_controller.rb
+++ b/app/controllers/google_plus_controller.rb
@@ -32,7 +32,7 @@ class GooglePlusController < ApplicationController
   end
 
   def load_button_color
-    @button_color = params[:button_color].nil? ? nil : "##{params[:button_color]}"
+    @button_color = params[:button_color].nil? ? nil : "##{params[:button_color].tr('^A-Za-z0-9', '')}"
   end
   
 end

--- a/app/controllers/google_plus_controller.rb
+++ b/app/controllers/google_plus_controller.rb
@@ -4,6 +4,7 @@ require_dependency 'google_plus_api'
 class GooglePlusController < ApplicationController
 
   layout 'frontend'
+  before_filter :load_button_color
 
   def google_plus
     signup_url = Cartodb::Central.sync_data_with_cartodb_central? ? Cartodb::Central.new.google_signup_url : CartoDB.path(self, 'google_plus_signup')
@@ -28,6 +29,10 @@ class GooglePlusController < ApplicationController
     user.create_in_central
 
     redirect_to CartoDB.path(self, 'dashboard', {trailing_slash: true})
+  end
+
+  def load_button_color
+    @button_color = params[:button_color].nil? ? nil : "##{params[:button_color]}"
   end
   
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,12 +3,14 @@ require_dependency 'google_plus_api'
 require_dependency 'google_plus_config'
 
 class SessionsController < ApplicationController
+  include LoginHelper
+
   layout 'frontend'
   ssl_required :new, :create, :destroy, :show, :unauthenticated
 
+  before_filter :load_organization
   before_filter :initialize_google_plus_config
   before_filter :api_authorization_required, :only => :show
-  before_filter :load_organization
   # Don't force org urls
   skip_before_filter :ensure_org_url_if_org_user
   skip_before_filter :ensure_account_has_been_activated, :only => :account_token_authentication_error
@@ -81,7 +83,7 @@ class SessionsController < ApplicationController
 
   def initialize_google_plus_config
     signup_action = Cartodb::Central.sync_data_with_cartodb_central? ? Cartodb::Central.new.google_signup_url : '/google/signup'
-    @google_plus_config = ::GooglePlusConfig.instance(CartoDB, Cartodb.config, signup_action)
+    @google_plus_config = ::GooglePlusConfig.instance(CartoDB, Cartodb.config, signup_action, 'google_access_token', @organization.nil? || @organization.color.nil? ? nil : organization_color(@organization))
   end
 
   def extract_username(request, params)

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -19,6 +19,10 @@ module LoginHelper
     "#%02x%02x%02x" % rgb
   end
 
+  def organization_color(organization)
+    !organization.nil? ? darken_color(organization.color, 0.7) : "#292E33"
+  end
+
   def login_org_avatar
     @organization && @organization.name != "team" && !@organization.avatar_url.blank?
   end

--- a/app/views/google_plus/google_plus.html.erb
+++ b/app/views/google_plus/google_plus.html.erb
@@ -53,16 +53,17 @@
         font-family: 'Proxima Nova W01', 'Helvetica Neue', Helvetica, Arial, sans-serif;
         text-transform: uppercase;
       }
-    </style>
-  </head>
-  <body>
-    <% if !@button_color.nil? %>
-      <style>
+      <% if !@button_color.nil? %>
         #signinButton span {
           background: <%= @button_color %>;
         }
-      </style>
-    <% end %>
+        #signinButton span:hover {
+          color: <%= @button_color %>;
+        }
+      <% end %>
+    </style>
+  </head>
+  <body>
     <div id="gSignInWrapper">
       <div id="signinButton" class="customGPlusSignIn">
         <span

--- a/app/views/google_plus/google_plus.html.erb
+++ b/app/views/google_plus/google_plus.html.erb
@@ -55,7 +55,14 @@
       }
     </style>
   </head>
-   <body>
+  <body>
+    <% if !@button_color.nil? %>
+      <style>
+        #signinButton span {
+          background: <%= @button_color %>;
+        }
+      </style>
+    <% end %>
     <div id="gSignInWrapper">
       <div id="signinButton" class="customGPlusSignIn">
         <span

--- a/lib/google_plus_config.rb
+++ b/lib/google_plus_config.rb
@@ -4,21 +4,24 @@ class GooglePlusConfig
 
   # @param app_module CartoDB Module containing global functions
   # @param config CartoDB config
-  # @param signup_action mixed
+  # @param signup_action Signup action, usually without subdomain. Google login button requires request to come from a known subdomain, so we can't use subdomain schema.
   # @param access_token_field_id String
-  def self.instance(app_module, config, signup_action, access_token_field_id = 'google_access_token')
+  # @param button_color: hex for the color
+  def self.instance(app_module, config, signup_action, access_token_field_id = 'google_access_token', button_color = nil)
     config[:oauth].present? && config[:oauth]['google_plus'].present? ?
-      GooglePlusConfig.new(app_module, config, signup_action, access_token_field_id) : nil
+      GooglePlusConfig.new(app_module, config, signup_action, access_token_field_id, button_color) : nil
   end
 
-  def initialize(app_module, config, signup_action, access_token_field_id = 'google_access_token')
+  def initialize(app_module, config, signup_action, access_token_field_id = 'google_access_token', button_color = nil)
     schema = Rails.env.development? ? 'http' : 'https'
 
     @domain = config[:domain_name].present? ? config[:domain_name] : app_module.account_host.scan(/([^:]*)(:.*)?/).first.first
 
     @signup_action = signup_action
 
-    @iframe_src = app_module.account_host.present? ? "#{schema}://#{app_module.account_host}/google_plus" : "#{@domain}/google_plus"
+    button_color_param = button_color.nil? ? '' : "?button_color=#{button_color}".gsub('#', '')
+
+    @iframe_src = app_module.account_host.present? ? "#{schema}://#{app_module.account_host}/google_plus#{button_color_param}" : "#{@domain}/google_plus#{button_color_param}"
 
     @access_token_field_id = access_token_field_id
 


### PR DESCRIPTION
This closes #4397. @matallo CR this, please. It involves passing the color through the URL because we explicitly need to remove subdomain because of google button referral check, and because color is not available in Central. This works both in the box and in Central