### PR TITLE
Bump cartodb.js to latest dev HEAD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,15 @@ See [doc/frontend.md](doc/frontend.md) for more in-depth documentation.
 
 Until our guidelines are publically available follow the existing file/directory and style structure.
 
+### Update CartoDB.js
+
+Follow these steps to update to get latest changes:
+
+- go to `lib/assets/javascripts/cdb/`
+- `git checkout develop && git pull`
+- go back to root and run `grunt cdb`
+- commit both the new revision of the submodule and the generated file `vendor/assets/javascripts/cartodb.uncompressed.js`
+
 ### Writing & running tests
 
 Tests reside in the `lib/assets/test` directory. We use

--- a/vendor/assets/javascripts/cartodb.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.uncompressed.js
@@ -1,6 +1,6 @@
 // cartodb.js version: 3.15.1
 // uncompressed version: cartodb.uncompressed.js
-// sha: ac595ce758863bd2ae54d0342733636a6c0d7977
+// sha: 96897e1d4789cdb6bc755582f51276409676a0d4
 (function() {
   var root = this;
 
@@ -27446,6 +27446,7 @@ cdb.geo.Map = cdb.core.Model.extend({
     if(z === null) {
       return;
     }
+
     // project -> calculate center -> unproject
     var swPoint = cdb.geo.Map.latlngToMercator(bounds[0], z);
     var nePoint = cdb.geo.Map.latlngToMercator(bounds[1], z);
@@ -27461,6 +27462,8 @@ cdb.geo.Map = cdb.core.Model.extend({
   },
 
   // adapted from leaflat src
+  // @return {Number, null} Calculated zoom from given bounds or the maxZoom if no appropriate zoom level could be found
+  //   or null if given mapSize has no size.
   getBoundsZoom: function(boundsSWNE, mapSize) {
     // sometimes the map reports size = 0 so return null
     if(mapSize.x === 0 || mapSize.y === 0) return null;
@@ -27484,7 +27487,7 @@ cdb.geo.Map = cdb.core.Model.extend({
     } while (zoomNotFound && zoom <= maxZoom);
 
     if (zoomNotFound) {
-      return null;
+      return maxZoom;
     }
 
     return zoom - 1;


### PR DESCRIPTION
This fixes #4552 which need the latest changes, due to the [fix setBounds/fitBounds for map w/o suitable zoom](https://github.com/CartoDB/cartodb.js/pull/610).

Would there be any issue with updating cartodb.js to latest version of HEAD from cartodb.js? ping  @javierarce @fdansv @alonsogarciapablo? asking you since you're the ones that committed stuff there most recently.