### PR TITLE
Remove ward to avoid cache in dynamic_cdn field

### DIFF
--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -326,8 +326,4 @@ class Carto::User < ActiveRecord::Base
     return false
   end
 
-  def self.columns
-    super.reject { |c| c.name == "dynamic_cdn_enabled" }
-  end
-
 end


### PR DESCRIPTION
With this we remove the ward put to avoid cache in the field `dynamic_cdn_enabled` before the migration.

Pls @juanignaciosl take a look