### PR TITLE
toString JS error when a link without href is clicked within header breadcrumb dropdown

### DIFF
--- a/lib/assets/javascripts/cartodb/common/view_helpers/navigate_through_router.js
+++ b/lib/assets/javascripts/cartodb/common/view_helpers/navigate_through_router.js
@@ -60,7 +60,7 @@ module.exports = function(ev) {
   // We always kill the default behaviour of the event, since container around view might have other click behavior.
   // In case of a cmd/ctrl click by an user.
   this.killEvent(ev);
-  var url = $(ev.target).attr('href');
+  var url = $(ev.target).closest('a').attr('href');
 
   if (!url) {
     return false;

--- a/lib/assets/javascripts/cartodb/common/view_helpers/navigate_through_router.js
+++ b/lib/assets/javascripts/cartodb/common/view_helpers/navigate_through_router.js
@@ -62,6 +62,10 @@ module.exports = function(ev) {
   this.killEvent(ev);
   var url = $(ev.target).attr('href');
 
+  if (!url) {
+    return false;
+  }
+
   if (!isLinuxMiddleOrRightClick(ev) && !isMacCmdKeyPressed(ev)) {
     this.router.navigate(url, { trigger: true });
   } else if (isCtrlKeyPressed(ev) || isMacCmdKeyPressed(ev)) {

--- a/lib/assets/javascripts/cartodb/dashboard/router.js
+++ b/lib/assets/javascripts/cartodb/dashboard/router.js
@@ -148,7 +148,7 @@ module.exports = Router.extend({
   },
 
   normalizeFragmentOrUrl: function(fragmentOrUrl) {
-    return fragmentOrUrl.toString().replace(this._dashboardUrl, '');
+    return fragmentOrUrl && fragmentOrUrl.toString().replace(this._dashboardUrl, '') || this.currentDashboardUrl().toString();
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.17.36",
+  "version": "3.17.37",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Checking [this error](https://my.trackjs.com/details/58cb06f9332b4d4bbc2af4e1ffc78bad) I've seen that if a link in the "breadcrumb" element doesn't have a href attribute, dashboard router fails and can't redirect to any location.
If you check the stack trace you will check that it comes from there.

cc @iriberri 

REVIEWER: @viddo 

Fixes #4593 