### PR TITLE
Removes the stroke setting the opacity to 0. Adds specs

### DIFF
--- a/app/assets/stylesheets/common/pecan.css.scss
+++ b/app/assets/stylesheets/common/pecan.css.scss
@@ -84,6 +84,7 @@
 .PecanCard-footer {
   position: relative;
   margin-top: 12px;
+  padding: 0;
   border-top: 0;
 }
 .NullCount {

--- a/app/assets/stylesheets/common/pecan.css.scss
+++ b/app/assets/stylesheets/common/pecan.css.scss
@@ -83,7 +83,7 @@
 }
 .PecanCard-footer {
   position: relative;
-  margin-top: 12px;
+  margin: 0;
   padding: 0;
   border-top: 0;
 }

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_card.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_card.js
@@ -69,13 +69,13 @@ module.exports = cdb.core.View.extend({
 
   _generateLayerDefinition: function(type, sql, css) {
     var template = this.options.urlTemplate;
-    var api_key  = this.options.api_key;
-    var maps_api_template = cdb.config.get('maps_api_template');
+    var apiKey  = this.options.api_key;
+    var mapsApiTemplate = cdb.config.get('maps_api_template');
 
     var layerDefinition = {
       user_name: user_data.username,
-      maps_api_template: maps_api_template,
-      api_key: api_key,
+      maps_api_template: mapsApiTemplate,
+      api_key: apiKey,
       layers: [{
         type: "http",
         options: {

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
@@ -193,19 +193,8 @@ module.exports = BaseDialog.extend({
     this.$('.js-navigation').addClass("is-hidden");
   },
 
-  _generateLayerDefinition: function(column) {
-
-    var type = column.get("visualizationType");
-    var sql = column.get("sql");
-    var css = column.get("css");
-    var geometryType = column.get("geometryType");
-
-    var template = this.map.getLayerAt(0).get("urlTemplate");
-    var api_key  = this.user.get("api_key");
-    var maps_api_template = cdb.config.get('maps_api_template');
-
+  _setupCSS: function(css, geometryType) {
     var row_count = this.options.vis.tableMetadata().get("row_count");
-
     var removeStrokeIndex = row_count / (this._CARD_WIDTH * this._CARD_HEIGHT);
     var removeStroke = (removeStrokeIndex > this._STROKE_PX_LIMIT);
 
@@ -213,6 +202,11 @@ module.exports = BaseDialog.extend({
       css = css.replace(/marker-line-opacity: 1;/, "marker-line-opacity: 0;");
       css = css.replace(/line-color-opacity: 1;/, "line-color-opacity: 0;");
     }
+    return css;
+  },
+
+  _setupTemplate: function() {
+    var template = this.map.getLayerAt(0).get("urlTemplate");
 
     if (template) {
       var supportedBasemap = _.find(this._SUPPORTED_BASEMAPS, function(basemap) {
@@ -223,6 +217,20 @@ module.exports = BaseDialog.extend({
     if (!template || !supportedBasemap) {
       template = this._DEFAULT_BASEMAP_TEMPLATE;
     }
+
+    return template;
+  },
+
+  _generateLayerDefinition: function(column) {
+
+    var type = column.get("visualizationType");
+    var sql = column.get("sql");
+    var css = this._setupCSS(column.get("css"), column.get("geometryType"));
+
+    var api_key  = this.user.get("api_key");
+    var maps_api_template = cdb.config.get('maps_api_template');
+
+    var template = this._setupTemplate();
 
     var layerDefinition = {
       user_name: user_data.username,

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
@@ -198,10 +198,11 @@ module.exports = BaseDialog.extend({
     var removeStrokeIndex = row_count / (this._CARD_WIDTH * this._CARD_HEIGHT);
     var removeStroke = (removeStrokeIndex > this._STROKE_PX_LIMIT);
 
-    if (geometryType !== "line" && removeStroke) {
-      css = css.replace(/marker-line-opacity: 1;/, "marker-line-opacity: 0;");
-      css = css.replace(/line-color-opacity: 1;/, "line-color-opacity: 0;");
+    if (geometryType == "point" && removeStroke) {
+      css = css.replace(/marker-line-width: 1;/, "marker-line-width: 0.5;");
+      css = css.replace(/marker-width: 1;/, "marker-width: 0.7;");
     }
+
     return css;
   },
 

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
@@ -10,7 +10,7 @@ module.exports = BaseDialog.extend({
   _CARD_MARGIN: 20,
   _CARD_WIDTH: 288,
   _CARD_HEIGHT: 170,
-  _STROKE_PX_LIMIT: 0.1,
+  _STROKE_PX_LIMIT: 0.04,
   _TABS_PER_ROW: 3,
   _GET_BBOX_FROM_THE_GEOM: true,
   _DEFAULT_BASEMAP_TEMPLATE: "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
@@ -10,6 +10,7 @@ module.exports = BaseDialog.extend({
   _CARD_MARGIN: 20,
   _CARD_WIDTH: 288,
   _CARD_HEIGHT: 170,
+  _STROKE_PX_LIMIT: 0.1,
   _TABS_PER_ROW: 3,
   _GET_BBOX_FROM_THE_GEOM: true,
   _DEFAULT_BASEMAP_TEMPLATE: "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
@@ -59,7 +60,6 @@ module.exports = BaseDialog.extend({
 
     this.vis   = this.options.vis;
     this.map   = this.vis.map;
-    this.table = this.vis.map.table;
     this.user  = this.options.user;
 
     this._panes = new cdb.ui.common.TabPane({
@@ -193,10 +193,26 @@ module.exports = BaseDialog.extend({
     this.$('.js-navigation').addClass("is-hidden");
   },
 
-  _generateLayerDefinition: function(type, sql, css) {
+  _generateLayerDefinition: function(column) {
+
+    var type = column.get("visualizationType");
+    var sql = column.get("sql");
+    var css = column.get("css");
+    var geometryType = column.get("geometryType");
+
     var template = this.map.getLayerAt(0).get("urlTemplate");
     var api_key  = this.user.get("api_key");
     var maps_api_template = cdb.config.get('maps_api_template');
+
+    var row_count = this.options.vis.tableMetadata().get("row_count");
+
+    var removeStrokeIndex = row_count / (this._CARD_WIDTH * this._CARD_HEIGHT);
+    var removeStroke = (removeStrokeIndex > this._STROKE_PX_LIMIT);
+
+    if (geometryType !== "line" && removeStroke) {
+      css = css.replace(/marker-line-opacity: 1;/, "marker-line-opacity: 0;");
+      css = css.replace(/line-color-opacity: 1;/, "line-color-opacity: 0;");
+    }
 
     if (template) {
       var supportedBasemap = _.find(this._SUPPORTED_BASEMAPS, function(basemap) {
@@ -244,7 +260,7 @@ module.exports = BaseDialog.extend({
 
   _generateThumbnail: function(column, callback) {
 
-    var layerDefinition = this._generateLayerDefinition(column.get("visualizationType"), column.get("sql"), column.get("css"));
+    var layerDefinition = this._generateLayerDefinition(column);
 
     var onImageReady = function(error, url) {
       callback && callback(error, url);

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
@@ -199,8 +199,8 @@ module.exports = BaseDialog.extend({
     var removeStroke = (removeStrokeIndex > this._STROKE_PX_LIMIT);
 
     if (geometryType == "point" && removeStroke) {
-      css = css.replace(/marker-line-width: 1;/, "marker-line-width: 0.5;");
-      css = css.replace(/marker-width: 1;/, "marker-width: 0.7;");
+      css = css.replace(/marker-line-width: 10;/, "marker-line-width: 0.5;");
+      css = css.replace(/marker-width: 10;/, "marker-width: 0.7;");
     }
 
     return css;

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view.js
@@ -198,9 +198,9 @@ module.exports = BaseDialog.extend({
     var removeStrokeIndex = row_count / (this._CARD_WIDTH * this._CARD_HEIGHT);
     var removeStroke = (removeStrokeIndex > this._STROKE_PX_LIMIT);
 
-    if (geometryType == "point" && removeStroke) {
-      css = css.replace(/marker-line-width: 10;/, "marker-line-width: 0.5;");
-      css = css.replace(/marker-width: 10;/, "marker-width: 0.7;");
+    if (geometryType !== "line" && removeStroke) {
+      css = css.replace("marker-line-width: 1;", "marker-line-width: 0.7;");
+      css = css.replace("marker-width: 10;", "marker-width: 7;");
     }
 
     return css;

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_view.js
@@ -76,8 +76,8 @@ module.exports = cdb.core.View.extend({
   },
 
   _getGeometryType: function() {
-    var geometry_types = this.table.data().table.get("geometry_types");
-    return this._getSimplifiedGeometryType(geometry_types[0]);
+    var geometryTypes = this.table.data().table.get("geometry_types");
+    return this._getSimplifiedGeometryType(geometryTypes[0]);
   },
 
   _start: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_view.js
@@ -31,7 +31,7 @@ module.exports = cdb.core.View.extend({
   _check: function() {
 
     var tableData     = this.options.table.data();
-    var geometryTypes = tableData.table && tableData.table.get("stats_geometry_types");
+    var geometryTypes = tableData.table && tableData.table.get("geometry_types");
     var hasGeometries = geometryTypes && geometryTypes.length > 0 ? true : false;
 
     var row_count     = tableData.table.get("rows_counted");
@@ -76,7 +76,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _getGeometryType: function() {
-    var geometry_types = this.table.data().table.get("stats_geometry_types");
+    var geometry_types = this.table.data().table.get("geometry_types");
     return this._getSimplifiedGeometryType(geometry_types[0]);
   },
 

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
@@ -62,9 +62,10 @@ describe("PecanDialogView", function() {
     }
 
     this.vis.map = this.map;
-    var fakeMap = sinon.stub(this.map, "getLayerAt");
 
-    fakeMap.returns({
+    this.fakeMap = sinon.stub(this.map, "getLayerAt");
+
+    this.fakeMap.returns({
       get: function(i) {
         return "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
       }
@@ -92,5 +93,37 @@ describe("PecanDialogView", function() {
       expect(layerDefinition.layers[1].options.cartocss).toContain("marker-line-opacity: 0;");
     });
 
+    it("should return the template if it's supported", function() {
+      this.fakeMap.restore();
+      this.fakeMap = sinon.stub(this.map, "getLayerAt");
+      this.fakeMap.returns({
+        get: function(i) {
+          return "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
+        }
+      });
+      expect(this.view._setupTemplate()).toEqual("http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png")
+    });
+
+    it("should return the default template if the template is not supported", function() {
+      this.fakeMap.restore();
+      this.fakeMap = sinon.stub(this.map, "getLayerAt");
+      this.fakeMap.returns({
+        get: function(i) {
+          return "http://{s}.basemaps.cartocdn.com/UNKNOWN_TEMPLATE/{z}/{x}/{y}.png"
+        }
+      });
+      expect(this.view._setupTemplate()).toEqual(this.view._DEFAULT_BASEMAP_TEMPLATE);
+    });
+
+    it("should return the default template if the layer doesn't have one", function() {
+      this.fakeMap.restore();
+      this.fakeMap = sinon.stub(this.map, "getLayerAt");
+      this.fakeMap.returns({
+        get: function(i) {
+          return undefined
+        }
+      });
+      expect(this.view._setupTemplate()).toEqual(this.view._DEFAULT_BASEMAP_TEMPLATE)
+    });
   });
 });

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
@@ -87,10 +87,10 @@ describe("PecanDialogView", function() {
       expect(layerDefinition.layers[1].options.cartocss).toBeDefined();
     });
 
-    it("should remove the strokes if the information density is high", function() {
+    it("should modify the CSS if the information density is high", function() {
       var layerDefinition = this.view._generateLayerDefinition(this.collection.at(0));
-      expect(layerDefinition.layers[1].options.cartocss).not.toContain("marker-line-opacity: 1;");
-      expect(layerDefinition.layers[1].options.cartocss).toContain("marker-line-opacity: 0;");
+      expect(layerDefinition.layers[1].options.cartocss).not.toContain("line-width: 0.5;");
+      expect(layerDefinition.layers[1].options.cartocss).toContain("marker-width: 0.7;");
     });
 
     it("should return the template if it's supported", function() {

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
@@ -1,165 +1,96 @@
-/*var $ = require('jquery');
+var $ = require('jquery');
 var _ = require('underscore');
 var cdb = require('cartodb.js');
-var PecanView = require('../../../../../javascripts/cartodb/common/dialogs/pecan/pecan_view');
+var PecanDialogView = require('../../../../../javascripts/cartodb/common/dialogs/pecan/pecan_dialog_view');
 
-describe("Pecan", function() {
-
-  afterEach(function() {
-    this.view.clean();
-    this.server.restore();
-  });
+describe("PecanDialogView", function() {
 
   beforeEach(function() {
-
-    this.server = sinon.fakeServer.create();
-    this.server.respondWith("GET", "/api/v2/sql?q=select * from (SELECT * FROM table_id) __wrap limit 0", [200, { "Content-Type": "application/json" }, '{ "response": true }']);
-
     window.user_data = { username: 'test' };
 
-    spyOn($, 'ajax');
+    this.user = jasmine.createSpy('cdb.admin.User');
+    this.user.get = function(i) {
+      return 1245;
+    };
 
     this.table = new cdb.admin.CartoDBTableMetadata({
       id: 'table_id',
-      name: 'table_name'
+      name: 'ufo_sightings'
     });
 
-    this.container = $('<div>').css('height', '200px');
+    var css = "/* category style */";
+    css += '#ufo_sightings {';
+    css += ' marker-fill-opacity: 0.9;';
+    css += ' marker-line-color: #FFF;';
+    css += ' marker-line-width: 1;';
+    css += ' marker-line-opacity: 1;';
+    css += ' marker-placement: point;';
+    css += ' marker-type: ellipse;';
+    css += ' marker-width: 10;';
+    css += ' marker-allow-overlap: true;';
+    css += '}';
+    css += '#ufo_sightings[geocode_precision="unmatched"] {';
+    css += ' marker-fill: #A6CEE3;';
+    css += '}';
+    css += '#ufo_sightings[geocode_precision="zip"] {';
+    css += ' marker-fill: #1F78B4;';
+    css += '}';
 
+    var columns = [
+      { table_id: "table_id", css: css, column: "date_sighted", state: "analyzed", geometry_type: "point", success: false },
+      { table_id: "table_id", css: css, column: "date_reported", state: "analyzed", geometry_type: "point", success: true },
+      { table_id: "table_id", css: css, column: "duration", state: "analyzed", geometry_type: "point", success: false },
+      { table_id: "table_id", css: css, column: "city", state: "analyzed", geometry_type: "point", success: false },
+      { table_id: "table_id", css: css, column: "geocode_score", state: "analyzed", geometry_type: "point", success: true },
+      { table_id: "table_id", css: css, column: "geocode_precision", state: "analyzed", geometry_type: "point", success: true }
+    ];
+
+    this.collection = new Backbone.Collection(columns);
+
+    this.vis = new cdb.admin.Visualization({
+      type: 'derived',
+      privacy: 'PUBLIC'
+    });
+
+    this.vis.table = this.table;
     this.map = new cdb.geo.Map();
 
-    this.mapView = new cdb.geo.MapView({
-      el: this.container,
-      map: this.map
-    });
+    this.vis.tableMetadata().get = function(i) {
+      if (i === 'row_count') {
+        return 100000
+      }
+    }
 
-    this.fakeData = sinon.stub(this.table, 'data');
+    this.vis.map = this.map;
+    var fakeMap = sinon.stub(this.map, "getLayerAt");
 
-    this.fakeData.returns({
-      length: 100,
-      table: {
-        get: function(p) {
-          if (p === 'stats_geometry_types') {
-            return ["ST_Point"]
-          }
-        }
-      },
-      query_schema: {
-        cartodb_id: "number",
-        the_geom: "geometry",
-        something: "string",
-        created_at: "number",
-        updated_at: "number"
+    fakeMap.returns({
+      get: function(i) {
+        return "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
       }
     });
 
-
-    this.user = jasmine.createSpy('cdb.admin.User');
-
-    this.view = new PecanView({
+    this.view = new PecanDialogView({
       clean_on_hide: true,
-      query_schema: this.table.data().query_schema,
-      table: this.table,
-      map: this.map,
+      vis: this.vis,
+      collection: this.collection,
       user: this.user
     });
+
   });
 
-  describe("Dialog", function() {
-    xit("should set the base query", function() {
-      this.view._start();
-      expect(this.view.query).toEqual("SELECT * FROM table_id");
+  describe("View", function() {
+
+    it("should generate a layer definition", function() {
+      var layerDefinition = this.view._generateLayerDefinition(this.collection.at(0));
+      expect(layerDefinition.layers[1].options.cartocss).toBeDefined();
     });
 
-    xit("should generate a collection of columns based on the schema", function() {
-      expect(this.view.columns.length).toBe(5);
-      var cols = ["something", "cartodb_id", "created_at", "updated_at", "the_geom"];
-      expect(_.difference(cols, this.view.columns.pluck("name")).length).toBe(0);
+    it("should remove the strokes if the information density is high", function() {
+      var layerDefinition = this.view._generateLayerDefinition(this.collection.at(0));
+      expect(layerDefinition.layers[1].options.cartocss).not.toContain("marker-line-opacity: 1;");
+      expect(layerDefinition.layers[1].options.cartocss).toContain("marker-line-opacity: 0;");
     });
 
-    xit("should analyze each one of the non-excluded columns", function() {
-      spyOn(this.view.sql, "describe")
-      this.view._analyzeColumns();
-      expect(this.view.sql.describe).toHaveBeenCalled();
-      expect(this.view.sql.describe.calls.count()).toBe(2);
-    });
-
-    xit("should return ok if the table is valid", function() {
-      expect(this.view._check()).toBe(true);
-    });
-
-    xit("should return false if the table is not valid", function() {
-
-      this.fakeData.restore();
-      this.fakeData = sinon.stub(this.table, 'data');
-
-      this.fakeData.returns({
-        length: 0,
-        table: {
-          get: function(p) {
-            if (p === 'stats_geometry_types') {
-              return ["ST_Point"]
-            }
-          }
-        },
-        query_schema: {
-          cartodb_id: "number",
-          something: "string",
-          created_at: "number",
-          updated_at: "number",
-          the_geom: "geometry"
-        }
-      });
-
-      expect(this.view._check()).toBe(false);
-    });
-
-    xit("should reject string columns whose weight is < 0.1", function() {
-      var name = "string";
-      var stats = { weight: 0.001 }
-      expect(this.view._analyzeString(name, stats)).toBe(0);
-    });
-
-    xit("should reject string columns whose null_ratio is > 95%", function() {
-      var name = "string";
-      var stats = { null_ratio: 0.972 }
-      expect(this.view._analyzeString(name, stats)).toBe(0);
-    });
-
-    xit("should accept string columns whose weight is > 0.8", function() {
-      var name = "string";
-      var stats = { weight: 0.95 }
-      expect(this.view._analyzeString(name, stats)).toBe(1);
-    });
   });
-
-  describe('date columns', function(){
-    beforeEach(function() {
-      var self = this;
-      this.originalExecute = cdb.admin.SQL.prototype.execute;
-      // Mocked response for a date column
-      cdb.SQL.prototype.execute = function(sql, vars, options, callback){
-        if (sql.indexOf("limit 0") > -1) {
-          vars(sql, vars, options, callback);
-        } else {
-          var fakeResponse = '{"rows":[{"start_time":"2014-02-24T16:50:50+0100","end_time":"2015-04-18T15:18:15+0200","moments":299}],"time":0.44,"fields":{"start_time":{"type":"date"},"end_time":{"type":"date"},"moments":{"type":"number"}},"total_rows":1}';
-          if(typeof vars === 'function') callback = vars;
-          callback(JSON.parse(fakeResponse));
-        }
-      }
-    });
-
-    xit("date columns should be analyzed", function(done){
-      //spyOn(cdb.admin.SQL, "describe")
-      var dateColumn = new cdb.core.Model({ name: "postedtime", type: "date", geometry_type: undefined, bbox: undefined, analyzed: false });
-      this.view._analyzeColumn(dateColumn);
-      expect(true === false);
-      [>expect($.ajax).toHaveBeenCalled();
-        expect($.ajax.calls.argsFor(0)[0].url).toEqual(
-        'http://' + window.user_data.username + '.localhost.lan/api/v2/sql?q=' + encodeURIComponent("select * from (" + this.view.query + ") __wrap limit 0")
-        );
-        expect($.ajax.calls.argsFor(0)[0].type).toEqual('get');
-        expect($.ajax.calls.argsFor(0)[0].dataType).toEqual('json');<]
-    })
-  });
-});*/
+});

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
@@ -89,8 +89,8 @@ describe("PecanDialogView", function() {
 
     it("should modify the CSS if the information density is high", function() {
       var layerDefinition = this.view._generateLayerDefinition(this.collection.at(0));
-      expect(layerDefinition.layers[1].options.cartocss).toContain("marker-width: 0.7;");
-      expect(layerDefinition.layers[1].options.cartocss).toContain("marker-line-width: 0.5;");
+      expect(layerDefinition.layers[1].options.cartocss).toContain("marker-width: 7;");
+      expect(layerDefinition.layers[1].options.cartocss).toContain("marker-line-width: 0.7;");
     });
 
     it("should return the template if it's supported", function() {

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_dialog_view.spec.js
@@ -89,8 +89,8 @@ describe("PecanDialogView", function() {
 
     it("should modify the CSS if the information density is high", function() {
       var layerDefinition = this.view._generateLayerDefinition(this.collection.at(0));
-      expect(layerDefinition.layers[1].options.cartocss).not.toContain("line-width: 0.5;");
       expect(layerDefinition.layers[1].options.cartocss).toContain("marker-width: 0.7;");
+      expect(layerDefinition.layers[1].options.cartocss).toContain("marker-line-width: 0.5;");
     });
 
     it("should return the template if it's supported", function() {

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
@@ -24,7 +24,7 @@ describe("PecanView", function() {
           if (p === 'rows_counted') {
             return (opts && opts.row_count) ? opts.row_count : 100
           }
-          if (p === 'stats_geometry_types') {
+          if (p === 'geometry_types') {
             return ["ST_Point"]
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.17.42",
+  "version": "3.17.43",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.17.41",
+  "version": "3.17.42",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.17.43",
+  "version": "3.17.44",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR removes the stroke of the points that don't pass a certain condition:

```ROW_COUNT / (CARD_WIDTH * CARD_HEIGHT) > STROKE_PX_LIMIT```

where 

* `CARD_WIDTH` = 288
* `CARD_HEIGHT` = 170
* `CARD_WIDTH` * `CARD_HEIGHT` = 48,960
* `STROKE_PX_LIMIT` = 0.04

Therefore if a dataset contains more than ≈ **2,000** rows, the strokes will be hidden.

The method used to disable the strokes consists in setting the opacity of the strokes to zero in the default CSS.

Updated later: instead of hiding the stroke, we'll modify the width and size of the markers. See comment thread for an updated example.

![screen shot 2015-07-23 at 11 33 27](https://cloud.githubusercontent.com/assets/4933/8847410/b3a92712-312e-11e5-958f-c51b7cc28f13.png)

