### PR TITLE
Fix guessing on import by setting the log #4639

### DIFF
--- a/services/importer/lib/importer/georeferencer.rb
+++ b/services/importer/lib/importer/georeferencer.rb
@@ -243,8 +243,9 @@ module CartoDB
 
           begin
             geocoding = Geocoding.new config.slice(:kind, :geometry_type, :formatter, :table_name, :country_column, :country_code)
-            geocoding.force_geocoder(geocoder)
             geocoding.user = user
+            geocoder.set_log(geocoding.log)
+            geocoding.force_geocoder(geocoder)
             geocoding.data_import_id = data_import.id unless data_import.nil?
             geocoding.raise_on_save_failure = true
             geocoding.run_geocoding!(row_count)

--- a/services/table-geocoder/lib/internal_geocoder.rb
+++ b/services/table-geocoder/lib/internal_geocoder.rb
@@ -36,6 +36,10 @@ module CartoDB
         @log = arguments[:log]
       end # initialize
 
+      def set_log(log)
+        @log = log
+      end
+
       def run
         log.append 'run()'
         @state = 'processing'


### PR DESCRIPTION
@Kartones @ethervoid please review

This solution is not the best, but better to keep it working and then rethink it

I was tempted to pass the geocoding model to the table geocoder when I implemented it, to avoid passing N arguments in constructors. The problem is that it would introduce more circular dependencies and here we have a good example of the problems it could have.