### PR TITLE
Set a reasonable fallback width when adding a new column to an empty dataset

### DIFF
--- a/lib/assets/javascripts/cartodb/table/header_view.js
+++ b/lib/assets/javascripts/cartodb/table/header_view.js
@@ -6,7 +6,7 @@
 (function() {
 
 var HeaderView = cdb.admin.HeaderView = cdb.core.View.extend({
-  
+
   _TEXTS: {
     no_geo: {
       title:        _t('Georeference your table'),
@@ -92,7 +92,9 @@ var HeaderView = cdb.admin.HeaderView = cdb.core.View.extend({
     // Focus in the input if it is being edited
     // and set the correct width
     if (this.editing_name) {
-      var w = this.$el.find("p.auto").width();
+      // In case the element is not present in DOM or not visible the width would be 0, so fallback on a reasonable
+      // width (e.g. happens for adding a column on an empty dataset)
+      var w = this.$el.find("p.auto").width() || 175;
       this.$el.find("input")
         .css({
           "max-width":  w,
@@ -231,7 +233,7 @@ var HeaderView = cdb.admin.HeaderView = cdb.core.View.extend({
 
     // If submenu was openened before, let's close it.
     if (colOptions.isOpen && columnName == colOptions.column) {
-      colOptions.hide(); 
+      colOptions.hide();
       return false;
     }
 
@@ -263,7 +265,7 @@ var HeaderView = cdb.admin.HeaderView = cdb.core.View.extend({
 
     // If submenu was openened before, let's close it.
     if (colOptions.isOpen && columnName == colOptions.column) {
-      colOptions.hide(); 
+      colOptions.hide();
       return false;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.17.41",
+  "version": "3.17.42",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #4524 

![fix-empty-datasets-column](https://cloud.githubusercontent.com/assets/978461/8849297/e73f3ef8-313e-11e5-9fd8-6b392c135ff0.gif)

The bug was due to one of those problems with timeouts and having jquery-based animations, so query layout props do not always have expected/desired values. Until we have some better way of dealing with timings consistently, I think having reasonable fallbacks values is the best way to go.

@javierarce please review, since you implemented the [original add-column workflow](https://github.com/CartoDB/cartodb/pull/3999/)
cc @josecruz 