### PR TITLE
Remove zclip copy on publish modal

### DIFF
--- a/app/assets/stylesheets/editor/publish.css.scss
+++ b/app/assets/stylesheets/editor/publish.css.scss
@@ -8,5 +8,4 @@
   margin-left: $sMargin-element;
   margin-right: $sMargin-element;
   box-sizing: border-box;
-  cursor: pointer;
 }

--- a/lib/assets/javascripts/cartodb/common/dialogs/publish/publish_option_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/publish/publish_option_view.js
@@ -1,5 +1,4 @@
 var cdb = require('cartodb.js');
-var _ = require('underscore');
 
 /**
  * View to handle the visual representation of a publish option.
@@ -9,8 +8,7 @@ module.exports = cdb.core.View.extend({
   className: 'OptionCard OptionCard--static',
 
   events: {
-    'mouseover': '_initZClipOnce',
-    'mouseleave': '_hideTipsy'
+    'click input': '_onClickInput'
   },
 
   initialize: function() {
@@ -27,9 +25,7 @@ module.exports = cdb.core.View.extend({
         model: this.model
       })
     );
-    this.$el[ this.model.isDisabled() ? 'addClass' : 'removeClass' ]('is-disabled');
-
-    this._initZClip(false); // reset to re-enable zclip on re-render since the DOM content is replaced above
+    this.$el.toggleClass('is-disabled', !!this.model.isDisabled());
 
     return this;
   },
@@ -38,57 +34,9 @@ module.exports = cdb.core.View.extend({
     this.model.bind('change', this.render, this);
   },
 
-  // ZClip can only be enabled if element is added to the document, so must be postponed until after (why the mouseover)
-  _initZClipOnce: function(e) {
-    if (e) this.killEvent(e);
-
-    // e.g. if copyable value is still pending to be set from parent.
-    if (this._initZClip() || this.model.isDisabled()) {
-      return;
-    }
-    this._initZClip(true);
-
-    this._tipsy = new cdb.common.TipsyTooltip({
-      el: this._$input(),
-      trigger: 'manual',
-      title: function() {
-        return 'copied!';
-      }
-    });
-    this.addView(this._tipsy);
-
-    var self = this;
-    this._$input().zclip({
-      path: cdb.config.get('assets_url') + '/flash/ZeroClipboard.swf',
-      beforeCopy: function() {
-        self._$input().focus().select();
-      },
-      copy: function() {
-        return self._$input().val();
-      },
-      afterCopy: function() {
-        self._tipsy.showTipsy();
-        self._$input().focus().select();
-      }
-    });
-  },
-
-  _hideTipsy: function() {
-    if (this._tipsy) {
-      this._tipsy.hideTipsy();
-    }
-  },
-
-  _$input: function() {
-    return this.$el.find('input');
-  },
-
-  _initZClip: function(newVal) {
-    if (_.isUndefined(newVal)) {
-      return this.model.get('initializedZClip');
-    } else {
-      // silent to not cause re-render
-      this.model.set('initializedZClip', newVal, { silent: true });
-    }
+  _onClickInput: function(ev) {
+    this.killEvent(ev);
+    this.$('input').select();
   }
+
 });


### PR DESCRIPTION
Fixes #4486 

![zclip-removed](https://cloud.githubusercontent.com/assets/978461/8854321/a332e18a-315f-11e5-9d93-b20fe24ed18b.gif)

This removes the zclip usage on the publish modal, to avoid those black boxes that overlays the inputs when flash is disabled. Unfortunately there's no way to really implement clipboard-copy from JS, so I guess this is as good as it gets for now.