### PR TITLE
Better exception logging closes #4612

### DIFF
--- a/app/services/visualization/common_data_service.rb
+++ b/app/services/visualization/common_data_service.rb
@@ -57,7 +57,13 @@ module CartoDB
               ExternalSource.new(visualization.id, d['url'], d['geometry_types'], d['rows'], d['size'], 'common-data').save
             end
           rescue => e
-            Rollbar.report_exception(e)
+            CartoDB.notify_exception(e, {
+              name: d.fetch('name', 'ERR: name'),
+              source: d.fetch('source', 'ERR: source'),
+              rows: d.fetch('rows', 'ERR: rows'),
+              updated_at: d.fetch('updated_at', 'ERR: updated_at'),
+              url: d.fetch('url', 'ERR: url')
+            })
             failed += 1
           end
         end

--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -17,7 +17,7 @@ module CartoDB
   def self.notify_exception(e, extra={})
     if Rails.env.development? || Rails.env.test?
       backtrace = e.backtrace ? e.backtrace : ['']
-      ::Logger.new(STDOUT).error "exception: " + extra.delete(:message).to_s + (e.message + "\n " + backtrace.join("\n ")) 
+      ::Logger.new(STDOUT).error "exception: #{extra.delete(:message)} #{e.message}\n#{backtrace.join("\n ")}\nExtra: #{extra}"
     end
     Rollbar.report_exception(e, extra.delete(:request), extra.delete(:user))
   rescue


### PR DESCRIPTION
This closes #4612 because common data loading is already fault-tolerant and we just need proper error logging to know which specific source has wrong metadata. @ethervoid CR this, please.