### PR TITLE
Adds rake tasks that add/remove a feature for one/all users/organizations as well as list available features

### DIFF
--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -1,5 +1,8 @@
 namespace :cartodb do
   namespace :features do
+
+    # WARNING: Not for use in central. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "enable feature for all users"
     task :enable_feature_for_all_users, [:feature] => :environment do |t, args|
       
@@ -13,6 +16,8 @@ namespace :cartodb do
       end
     end
 
+    # WARNING: Not for use in central. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "enable feature for a given user"
     task :enable_feature_for_user, [:feature, :username] => :environment do |t, args|
       
@@ -29,6 +34,8 @@ namespace :cartodb do
       end
     end
 
+    # WARNING: Not for use in central. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "enable feature for a given organization"
     task :enable_feature_for_organization, [:feature, :org_name] => :environment do |t, args|
       
@@ -45,6 +52,8 @@ namespace :cartodb do
       end
     end
 
+    # WARNING: Not for use in central. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "disable feature for all users"
     task :disable_feature_for_all_users, [:feature] => :environment do |t, args|
       
@@ -59,6 +68,8 @@ namespace :cartodb do
       end
     end
 
+    # WARNING: Not for use in central. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "disable feature for a given user"
     task :disable_feature_for_user, [:feature, :username] => :environment do |t, args|
       
@@ -75,6 +86,8 @@ namespace :cartodb do
       end
     end
 
+    # WARNING: Not for use in central. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "disable feature for a given organization"
     task :disable_feature_for_organization, [:feature, :org_name] => :environment do |t, args|
       
@@ -93,6 +106,8 @@ namespace :cartodb do
       end
     end
 
+    # WARNING: Not for use in central. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "list all features"
     task :list_all_features => :environment do
 

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -5,7 +5,7 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        puts "[ERROR] Feature '#{args[:feature]}' does not exist"
+        except 'Feature', args[:feature]
         break
       end
 
@@ -21,13 +21,13 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        puts "[ERROR] Feature '#{args[:feature]}' does not exist"
+        except 'Feature', args[:feature]
         break
       end
 
       user = User[username: args[:username]] 
       if user.nil?
-        puts "[ERROR] User '#{args[:username]}' does not exist"
+        except 'User', args[:username]
         break
       end
 
@@ -38,12 +38,34 @@ namespace :cartodb do
       end
     end
 
+    desc "enable feature for a given organization"
+    task :enable_feature_for_organization, [:feature, :org_name] => :environment do |t, args|
+      
+      ff = FeatureFlag[:name => args[:feature]]
+      if ff.nil?
+        except 'Feature', args[:feature]
+        break
+      end
+
+      organization = Organization[name: args[:org_name]] 
+      if organization.nil?
+        except 'Organization', args[:org_name]
+        break
+      end
+
+      organization.users.each do |user|
+        if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
+            FeatureFlagsUser.new(feature_flag_id: ff.id, user_id: user.id).save
+        end
+      end
+    end
+
     desc "disable feature for all users"
     task :disable_feature_for_all_users, [:feature] => :environment do |t, args|
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        puts "[ERROR] Feature '#{args[:feature]}' does not exist"
+        except 'Feature', args[:feature]
         break
       end
 
@@ -60,13 +82,13 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        puts "[ERROR] Feature '#{args[:feature]}' does not exist"
+        except 'Feature', args[:feature]
         break
       end
 
       user = User[username: args[:username]]
       if user.nil?
-        puts "[ERROR] User '#{args[:username]}' does not exist"
+        except 'User', args[:username]
         break
       end
 
@@ -77,6 +99,30 @@ namespace :cartodb do
       end
     end
 
+    desc "disable feature for a given organization"
+    task :disable_feature_for_organization, [:feature, :org_name] => :environment do |t, args|
+      
+      ff = FeatureFlag[:name => args[:feature]]
+      if ff.nil?
+        except 'Feature', args[:feature]
+        break
+      end
+
+      organization = Organization[name: args[:org_name]] 
+      if organization.nil?
+        except 'Organization', args[:org_name]
+        break
+      end
+
+      organization.users.each do |user|
+        if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
+          puts "[INFO]  Feature '#{args[:feature]}' was already disabled for user '#{args[:username]}'"
+        else
+          FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].destroy
+        end
+      end
+    end
+
     desc "list all features"
     task :list_all_features => :environment do
 
@@ -84,6 +130,11 @@ namespace :cartodb do
       FeatureFlag.all.each do |feature|
         puts "  - #{feature.name}"
       end
+    end
+
+    private
+    def except(type, value)
+      puts "[ERROR] #{type} '#{value}' does not exist"
     end
 
   end # Features

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -4,9 +4,7 @@ namespace :cartodb do
     task :enable_feature_for_all_users, [:feature] => :environment do |t, args|
       
       ff = FeatureFlag[:name => args[:feature]]
-      if ff.nil?
-        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
-      end
+      raise "[ERROR]  Feature '#{args[:feature]}' does not exist" if ff.nil?
 
       User.all.each do |user|
         if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
@@ -19,13 +17,10 @@ namespace :cartodb do
     task :enable_feature_for_user, [:feature, :username] => :environment do |t, args|
       
       ff = FeatureFlag[:name => args[:feature]]
-      if ff.nil?
-        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
-      end
+      raise "[ERROR]  Feature '#{args[:feature]}' does not exist" if ff.nil?
 
       user = User[username: args[:username]] 
-      if user.nil?
-      end
+      raise "[ERROR]  User '#{args[:username]}' does not exist" if user.nil?
 
       if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
         FeatureFlagsUser.new(feature_flag_id: ff.id, user_id: user.id).save
@@ -38,14 +33,10 @@ namespace :cartodb do
     task :enable_feature_for_organization, [:feature, :org_name] => :environment do |t, args|
       
       ff = FeatureFlag[:name => args[:feature]]
-      if ff.nil?
-        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
-      end
+      raise "[ERROR]  Feature '#{args[:feature]}' does not exist" if ff.nil?
 
       organization = Organization[name: args[:org_name]] 
-      if organization.nil?
-        raise "[ERROR]  Organization '#{args[:org_name]}' does not exist"
-      end
+      raise "[ERROR]  Organization '#{args[:org_name]}' does not exist" if organization.nil?
 
       organization.users.each do |user|
         if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
@@ -58,9 +49,7 @@ namespace :cartodb do
     task :disable_feature_for_all_users, [:feature] => :environment do |t, args|
       
       ff = FeatureFlag[:name => args[:feature]]
-      if ff.nil?
-        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
-      end
+      raise "[ERROR]  Feature '#{args[:feature]}' does not exist" if ff.nil?
 
       ffus = FeatureFlagsUser[:feature_flag_id => ff.id]
       if ffus.nil?
@@ -74,14 +63,10 @@ namespace :cartodb do
     task :disable_feature_for_user, [:feature, :username] => :environment do |t, args|
       
       ff = FeatureFlag[:name => args[:feature]]
-      if ff.nil?
-        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
-      end
+      raise "[ERROR]  Feature '#{args[:feature]}' does not exist" if ff.nil?
 
       user = User[username: args[:username]]
-      if user.nil?
-        raise "[ERROR]  User '#{args[:username]}' does not exist"
-      end
+      raise "[ERROR]  User '#{args[:username]}' does not exist" if user.nil?
 
       if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
         puts "[INFO]  Feature '#{args[:feature]}' was already disabled for user '#{args[:username]}'"
@@ -94,14 +79,10 @@ namespace :cartodb do
     task :disable_feature_for_organization, [:feature, :org_name] => :environment do |t, args|
       
       ff = FeatureFlag[:name => args[:feature]]
-      if ff.nil?
-        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
-      end
+      raise "[ERROR]  Feature '#{args[:feature]}' does not exist" if ff.nil?
 
       organization = Organization[name: args[:org_name]] 
-      if organization.nil?
-        raise "[ERROR]  Organization '#{args[:org_name]}' does not exist"
-      end
+      raise "[ERROR]  Organization '#{args[:org_name]}' does not exist" if organization.nil?
 
       organization.users.each do |user|
         if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -1,7 +1,7 @@
 namespace :cartodb do
   namespace :features do
 
-    # WARNING: Not for use in central. 
+    # WARNING: For use only at development, opensource and custom installs. 
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "enable feature for all users"
     task :enable_feature_for_all_users, [:feature] => :environment do |t, args|
@@ -16,7 +16,7 @@ namespace :cartodb do
       end
     end
 
-    # WARNING: Not for use in central. 
+    # WARNING: For use only at development, opensource and custom installs. 
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "enable feature for a given user"
     task :enable_feature_for_user, [:feature, :username] => :environment do |t, args|
@@ -34,7 +34,7 @@ namespace :cartodb do
       end
     end
 
-    # WARNING: Not for use in central. 
+    # WARNING: For use only at development, opensource and custom installs. 
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "enable feature for a given organization"
     task :enable_feature_for_organization, [:feature, :org_name] => :environment do |t, args|
@@ -52,7 +52,7 @@ namespace :cartodb do
       end
     end
 
-    # WARNING: Not for use in central. 
+    # WARNING: For use only at development, opensource and custom installs. 
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "disable feature for all users"
     task :disable_feature_for_all_users, [:feature] => :environment do |t, args|
@@ -68,7 +68,7 @@ namespace :cartodb do
       end
     end
 
-    # WARNING: Not for use in central. 
+    # WARNING: For use only at development, opensource and custom installs. 
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "disable feature for a given user"
     task :disable_feature_for_user, [:feature, :username] => :environment do |t, args|
@@ -86,7 +86,7 @@ namespace :cartodb do
       end
     end
 
-    # WARNING: Not for use in central. 
+    # WARNING: For use only at development, opensource and custom installs. 
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "disable feature for a given organization"
     task :disable_feature_for_organization, [:feature, :org_name] => :environment do |t, args|
@@ -106,7 +106,7 @@ namespace :cartodb do
       end
     end
 
-    # WARNING: Not for use in central. 
+    # WARNING: For use only at development, opensource and custom installs. 
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "list all features"
     task :list_all_features => :environment do

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -1,0 +1,90 @@
+namespace :cartodb do
+  namespace :features do
+    desc "enable feature for all users"
+    task :enable_feature_for_all_users, [:feature] => :environment do |t, args|
+      
+      ff = FeatureFlag[:name => args[:feature]]
+      if ff.nil?
+        puts "[ERROR] Feature '#{args[:feature]}' does not exist"
+        break
+      end
+
+      User.all.each do |user|
+        if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
+            FeatureFlagsUser.new(feature_flag_id: ff.id, user_id: user.id).save
+        end
+      end
+    end
+
+    desc "enable feature for a given user"
+    task :enable_feature_for_user, [:feature, :username] => :environment do |t, args|
+      
+      ff = FeatureFlag[:name => args[:feature]]
+      if ff.nil?
+        puts "[ERROR] Feature '#{args[:feature]}' does not exist"
+        break
+      end
+
+      user = User[username: args[:username]] 
+      if user.nil?
+        puts "[ERROR] User '#{args[:username]}' does not exist"
+        break
+      end
+
+      if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
+        FeatureFlagsUser.new(feature_flag_id: ff.id, user_id: user.id).save
+      else
+        puts "[INFO]  Feature '#{args[:feature]}' was already enabled for user '#{args[:username]}'"
+      end
+    end
+
+    desc "disable feature for all users"
+    task :disable_feature_for_all_users, [:feature] => :environment do |t, args|
+      
+      ff = FeatureFlag[:name => args[:feature]]
+      if ff.nil?
+        puts "[ERROR] Feature '#{args[:feature]}' does not exist"
+        break
+      end
+
+      ffus = FeatureFlagsUser[:feature_flag_id => ff.id]
+      if ffus.nil?
+        puts "[INFO]  No users had feature '#{args[:feature]}' enabled"
+      else
+        ffus.destroy
+      end
+    end
+
+    desc "disable feature for a given user"
+    task :disable_feature_for_user, [:feature, :username] => :environment do |t, args|
+      
+      ff = FeatureFlag[:name => args[:feature]]
+      if ff.nil?
+        puts "[ERROR] Feature '#{args[:feature]}' does not exist"
+        break
+      end
+
+      user = User[username: args[:username]]
+      if user.nil?
+        puts "[ERROR] User '#{args[:username]}' does not exist"
+        break
+      end
+
+      if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
+        puts "[INFO]  Feature '#{args[:feature]}' was already disabled for user '#{args[:username]}'"
+      else
+        FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].destroy
+      end
+    end
+
+    desc "list all features"
+    task :list_all_features => :environment do
+
+      puts "Available features:"
+      FeatureFlag.all.each do |feature|
+        puts "  - #{feature.name}"
+      end
+    end
+
+  end # Features
+end # CartoDB

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -5,8 +5,7 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        except 'Feature', args[:feature]
-        break
+        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
       end
 
       User.all.each do |user|
@@ -21,14 +20,11 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        except 'Feature', args[:feature]
-        break
+        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
       end
 
       user = User[username: args[:username]] 
       if user.nil?
-        except 'User', args[:username]
-        break
       end
 
       if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
@@ -43,14 +39,12 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        except 'Feature', args[:feature]
-        break
+        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
       end
 
       organization = Organization[name: args[:org_name]] 
       if organization.nil?
-        except 'Organization', args[:org_name]
-        break
+        raise "[ERROR]  Organization '#{args[:org_name]}' does not exist"
       end
 
       organization.users.each do |user|
@@ -65,8 +59,7 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        except 'Feature', args[:feature]
-        break
+        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
       end
 
       ffus = FeatureFlagsUser[:feature_flag_id => ff.id]
@@ -82,14 +75,12 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        except 'Feature', args[:feature]
-        break
+        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
       end
 
       user = User[username: args[:username]]
       if user.nil?
-        except 'User', args[:username]
-        break
+        raise "[ERROR]  User '#{args[:username]}' does not exist"
       end
 
       if FeatureFlagsUser[feature_flag_id: ff.id, user_id: user.id].nil?
@@ -104,14 +95,12 @@ namespace :cartodb do
       
       ff = FeatureFlag[:name => args[:feature]]
       if ff.nil?
-        except 'Feature', args[:feature]
-        break
+        raise "[ERROR]  Feature '#{args[:feature]}' does not exist"
       end
 
       organization = Organization[name: args[:org_name]] 
       if organization.nil?
-        except 'Organization', args[:org_name]
-        break
+        raise "[ERROR]  Organization '#{args[:org_name]}' does not exist"
       end
 
       organization.users.each do |user|
@@ -130,11 +119,6 @@ namespace :cartodb do
       FeatureFlag.all.each do |feature|
         puts "  - #{feature.name}"
       end
-    end
-
-    private
-    def except(type, value)
-      puts "[ERROR] #{type} '#{value}' does not exist"
     end
 
   end # Features

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -108,6 +108,39 @@ namespace :cartodb do
 
     # WARNING: For use only at development, opensource and custom installs. 
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
+    desc "add feature flag"
+    task :add_feature_flag, [:feature] => :environment do |t, args|
+      
+      ff = FeatureFlag[:name => args[:feature]]
+      if ff.nil?
+        ff = FeatureFlag.new(name: args[:feature], restricted: true)
+        ff.id = FeatureFlag.order(:id).last.id + 1
+        ff.save
+      else
+        raise "[ERROR]  Feature '#{args[:feature]}' already exists"
+      end
+    end
+
+    # WARNING: For use only at development, opensource and custom installs. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
+    desc "remove feature flag"
+    task :remove_feature_flag, [:feature] => :environment do |t, args|
+      
+      ff = FeatureFlag[:name => args[:feature]]
+      raise "[ERROR]  Feature '#{args[:feature]}' does not exist" if ff.nil?
+
+      ffus = FeatureFlagsUser[:feature_flag_id => ff.id]
+      if ffus.nil?
+        puts "[INFO]  No users had feature '#{args[:feature]}' enabled"
+      else
+        ffus.destroy
+      end
+
+      ff.destroy()
+    end
+
+    # WARNING: For use only at development, opensource and custom installs. 
+    # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
     desc "list all features"
     task :list_all_features => :environment do
 


### PR DESCRIPTION
This code solves issue [#4677](https://github.com/CartoDB/cartodb/issues/4677)

It adds rake tasks:

rake cartodb:features:disable_feature_for_all_users[feature] # disable feature for all users
rake cartodb:features:disable_feature_for_user[feature,username] # disable feature for a given user
rake cartodb:features:enable_feature_for_all_users[feature] # enable feature for all users
rake cartodb:features:enable_feature_for_user[feature,username] # enable feature for a given user
rake cartodb:features:list_all_features # list all features

CC @javisantana