### PR TITLE
Saves the z-index position of the overlay

### DIFF
--- a/lib/assets/javascripts/cartodb/table/overlays/overlay_properties_bar.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/overlay_properties_bar.js
@@ -161,9 +161,10 @@ cdb.admin.OverlayPropertiesBar =  cdb.core.View.extend({
     var zIndex   = _.min(indexes);
 
     var style = _.clone(model.get("style"));
-    style["z-index"] = zIndex - 1;
-    model.set("style", style);
-
+    if (zIndex > 1) {
+      style["z-index"] = zIndex - 1;
+    }
+    this.style.set(style);
   },
 
   _increaseOverlayZIndex: function(model) {
@@ -173,8 +174,7 @@ cdb.admin.OverlayPropertiesBar =  cdb.core.View.extend({
 
     var style = _.clone(model.get("style"));
     style["z-index"] = zIndex + 1;
-    model.set("style", style);
-
+    this.style.set(style);
   },
 
   /*

--- a/lib/assets/javascripts/cartodb/table/overlays/overlays.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/overlays.js
@@ -80,7 +80,7 @@ cdb.admin.models.Overlay = cdb.core.Model.extend({
       _.extend(resp, {
         x:            options.x,
         y:            options.y,
-        oder:         options.order,
+        order:        options.order,
         device:       options.device,
         extra:        options.extra,
         style:        options.style,

--- a/lib/assets/test/spec/cartodb/table/overlay_properties_bar.spec.js
+++ b/lib/assets/test/spec/cartodb/table/overlay_properties_bar.spec.js
@@ -18,11 +18,34 @@ describe("OverlayPropertiesBar", function() {
 
       var vis = new cdb.vis.Vis({});
 
-      var overlays = [];
-      var model = new cdb.core.Model();
+      var overlays = new Backbone.Collection([
+        new cdb.core.Model({
+        device: "screen",
+        type: "text",
+        style: {
+          "z-index": 9
+        }
+      }),
+      new cdb.core.Model({
+        type: "text",
+        device: "screen",
+        style: {
+          "z-index": 2
+        }
+      })
+      ]);
+
+      var model = new cdb.core.Model({
+        style: {
+          "z-index": 3
+        }
+      });
+
+      var canvas = new cdb.core.Model({ mode: "screen" });
 
       view = new cdb.admin.OverlayPropertiesBar({
         model: model,
+        canvas: canvas,
         overlays: overlays,
         vis: vis,
         form_data: form_data
@@ -41,5 +64,18 @@ describe("OverlayPropertiesBar", function() {
     expect(view.$("li.actions").length).toEqual(1);
     expect(view.$("li.actions a.btn").length).toEqual(4);
   });
+
+  it("should send to back", function() {
+    view.render();
+    view.$(".btn-zIndexInc").click();
+    expect(view.model.get("style")["z-index"]).toBe(10);
+  });
+
+  it("should send to front", function() {
+    view.render();
+    view.$(".btn-zIndexDec").click();
+    expect(view.model.get("style")["z-index"]).toBe(1);
+  });
+
 
 });

--- a/lib/assets/test/spec/cartodb/table/overlay_properties_bar.spec.js
+++ b/lib/assets/test/spec/cartodb/table/overlay_properties_bar.spec.js
@@ -37,7 +37,7 @@ describe("OverlayPropertiesBar", function() {
 
       var model = new cdb.core.Model({
         style: {
-          "z-index": 3
+          "z-index": 2
         }
       });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.5",
+  "version": "3.18.6",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes a bug that preventing saving the z-index position of the overlays. It also add missing specs to test the feature.

Original ticket: 3554-overlay-order