### PR TITLE
4690 fix upload file

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/data_import/data_form_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/data_import/data_form_view.js
@@ -48,6 +48,7 @@ module.exports = cdb.core.View.extend({
         if (this.files && this.files.length > 0) {
           self._onFileChanged(this.files);
         }
+        this.value = "";
       });
 
       this._initDropzone();

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/import_data_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/import_data_view.js
@@ -122,7 +122,7 @@ module.exports = ImportDefaultView.extend({
   _checkState: function() {
     if (this.model.previous('state') === "selected") {
       this.model.set({
-        type: 'url',
+        type: undefined,
         value: '',
         service_name: '',
         service_item_id: '',

--- a/lib/assets/test/spec/cartodb/common/dialogs/create/listing/imports/import_data_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/create/listing/imports/import_data_view.spec.js
@@ -38,6 +38,13 @@ describe('common/dialogs/create/imports/import_data_view', function() {
     expect(this.view.model.bind.calls.argsFor(0)[0]).toEqual('change:state');
   });
 
+  it('should return to a default state', function() {
+    this.view.model.set({ state: "selected", value: "http://www.cartodb.com" });
+    this.view.model.set({ state: "idle" });
+    expect(this.view.model.get("type")).toEqual(undefined);
+    expect(this.view.model.get("value")).toEqual('');
+  });
+
   it("should not have leaks", function() {
     expect(this.view).toHaveNoLeaks();
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.6",
+  "version": "3.18.7",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR solves a couple of issues:

* A bug that prevented uploading a dataset after going back to the file dataset selector.
* A bug that prevented uploading the same dataset twice.

The problem with #1 was that the [_checkState method](https://github.com/CartoDB/cartodb/blob/4690-fix-upload-file/lib/assets/javascripts/cartodb/common/dialogs/create/listing/imports/import_data_view.js#L122) left the model in an invalid state (type == 'url' and value == '', which is an invalid URL). 

Original issue: #4690
