### PR TITLE
This initializer interferes with the load of constants, reverting

### DIFF
--- a/config/initializers/load_resque.rb
+++ b/config/initializers/load_resque.rb
@@ -12,14 +12,4 @@ if redis_conf[:tcp_keepalive] and redis_conf[:tcp_keepalive].is_a? Hash
   redis_conf[:tcp_keepalive] = redis_conf[:tcp_keepalive].symbolize_keys
 end
 
-#https://github.com/resque/resque/issues/447
-if Rails.env == "development"
-  unless Rails.application.config.cache_classes
-    Resque.after_fork do |job|
-      ActionDispatch::Reloader.cleanup!
-      ActionDispatch::Reloader.prepare!
-    end
-  end
-end
-
 Resque.redis = Redis.new(redis_conf)


### PR DESCRIPTION
I put this code in the Rails initializer to enable hot reload in Resque but today I've found that interferes with the load of constants so I've to revert it :(