### PR TITLE
Enables debugging in Pecan

### DIFF
--- a/lib/assets/javascripts/cartodb/common/background_polling/models/analysis_collection.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/analysis_collection.js
@@ -37,11 +37,16 @@ module.exports = Backbone.Collection.extend({
     }
 
     var idleItems = _.first(this.where({ state: 'idle' }),batchAnalysisCount);
-    
+
     if (idleItems.length > 0) {
       this._nextAnalysisItems = idleItems;
 
       _.each(this._nextAnalysisItems, function(mdl) {
+        mdl.bind('print_stats', function(stats) {
+          if (this.user.featureEnabled('pecan_debugging')) {
+            this._printStats(stats);
+          }
+        }, this);
         mdl.bind('change:state', function(mdl, state) {
           if (mdl.isAnalyzed()) {
             var arePendingAnalysis = _.find(this._nextAnalysisItems, function(analysis) {
@@ -55,6 +60,45 @@ module.exports = Backbone.Collection.extend({
         mdl.getData();
       }, this);
     }
+  },
+
+  _printStats: function(stats) {
+    var name        = stats.column;
+    var type        = stats.type;
+    var weight      = stats.weight;
+    var skew        = stats.skew;
+    var distinct    = stats.distinct;
+    var count       = stats.count;
+    var null_ratio  = stats.null_ratio;
+    var dist_type   = stats.dist_type;
+    var calc_weight = (weight + cdb.CartoCSS.getWeightFromShape(dist_type)) / 2;
+
+    var distinctPercentage = (distinct / count) * 100;
+
+    cdb.log.info("%cAnalyzing %c" + name, "text-decoration:underline; font-weight:bold", "text-decoration:underline; font-weight:normal");
+
+    cdb.log.info('%c · %ctype%c = ' + type, 'color:#666;', 'color: #666; font-weight:bold;', "color: #666; font-weight:normal");
+    cdb.log.info('%c · %cdistinctPercentage%c = ' + distinctPercentage, 'color:#666;', 'color: #666; font-weight:bold;', "color: #666; font-weight:normal");
+    cdb.log.info('%c · %ccount%c = ' + count, 'color:#666;', 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
+    cdb.log.info('%c · %cnull ratio%c = ' + null_ratio, 'color:#666;', 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
+
+    if (dist_type) {
+      cdb.log.info('%c · %cdist_type%c = ' + dist_type, 'color:#666;', 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
+      cdb.log.info('%c · %ccalc_weight%c = ' + calc_weight, 'color:#666;', 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
+    }
+
+    if (skew) {
+      cdb.log.info("%c · %cskew%c: " + skew.toFixed(2), "color:#666;", 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
+    }
+
+    if (weight) {
+      cdb.log.info("%c · %cweight%c: " + weight.toFixed(2), "color: #666;", "color:#666; font-weight:bold;", "color:#666;font-weight:normal");
+    }
+
+    if (stats.density) {
+      cdb.log.info("%c · %cdensity%c: " + stats.density, "color:#666;", 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
+    }
+
   },
 
   destroyCheck: function() {

--- a/lib/assets/javascripts/cartodb/common/background_polling/models/analysis_collection.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/analysis_collection.js
@@ -42,11 +42,11 @@ module.exports = Backbone.Collection.extend({
       this._nextAnalysisItems = idleItems;
 
       _.each(this._nextAnalysisItems, function(mdl) {
-        mdl.bind('print_stats', function(stats) {
-          if (this.user.featureEnabled('pecan_debugging')) {
+        if (this.user.featureEnabled('pecan_debugging')) {
+          mdl.bind('print_stats', function(stats) {
             this._printStats(stats);
-          }
-        }, this);
+          }, this);
+        }
         mdl.bind('change:state', function(mdl, state) {
           if (mdl.isAnalyzed()) {
             var arePendingAnalysis = _.find(this._nextAnalysisItems, function(analysis) {

--- a/lib/assets/javascripts/cartodb/common/background_polling/models/pecan_model.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/pecan_model.js
@@ -10,7 +10,7 @@ module.exports = cdb.core.Model.extend({
 
   _REJECT: 0,
   _KEEP: 1,
-  _PRINT_STATS: false,
+  _PRINT_STATS: true,
 
   defaults: {
     table_id: '',
@@ -20,7 +20,6 @@ module.exports = cdb.core.Model.extend({
 
   initialize: function() {
     _.bindAll(this, "_onDescribe");
-
     this.sql = cdb.admin.SQL();
     this.query = 'SELECT * FROM ' + this.get("table_id");
   },
@@ -63,7 +62,7 @@ module.exports = cdb.core.Model.extend({
     var type = stats.type;
 
     if (this._PRINT_STATS) {
-      this._printStats(stats);
+      this.trigger("print_stats", stats, this);
     }
 
     var result = this._REJECT;
@@ -80,10 +79,6 @@ module.exports = cdb.core.Model.extend({
       result = this._analyzeGeom(stats);
     }
 
-    if (result === this._KEEP) {
-      this._approveMessage(name);
-    }
-
     return result;
   },
 
@@ -91,12 +86,10 @@ module.exports = cdb.core.Model.extend({
     var name = this.get("column");
 
     if (this.get("geometry_type") !== 'point') {
-      this._rejectMessage(name, "geometry type is not point", this.get("geometry_type"));
       return this._REJECT;
     }
 
     if (stats.cluster_rate * stats.density < 0.1) {
-      this._rejectMessage(name, "heat factor < 10%", stats.cluster_rate  * 100);
       return this._REJECT;
     }
     return this._KEEP;
@@ -109,16 +102,13 @@ module.exports = cdb.core.Model.extend({
     if (stats.weight >= 0.8) {
       return this._KEEP;
     } else if (stats.weight < 0.1 || !stats.weight) {
-      this._rejectMessage(name, "weight is 0", stats.weight);
       return this._REJECT;
     }
 
     if (stats.null_ratio > 0.95) {
-      this._rejectMessage(name, "null_ratio > 95%", stats.null_ratio  * 100);
       return this._REJECT;
     }
 
-    this._rejectMessage(name, "weight < 0.8", stats.weight);
     return this._REJECT;
   },
 
@@ -129,7 +119,6 @@ module.exports = cdb.core.Model.extend({
     var calc_weight = (stats.weight + cdb.CartoCSS.getWeightFromShape(dist_type)) / 2;
 
     if (stats.weight < 0.1 || !stats.weight) {
-      this._rejectMessage(name, "weight is 0", stats.weight);
       return this._REJECT;
     }
 
@@ -137,20 +126,17 @@ module.exports = cdb.core.Model.extend({
       return this._KEEP;
     } else if (stats.weight > 0.5 || distinctPercentage < 25) {
       if (distinctPercentage < 1) {
-        this._redoMessage(name);
         return this._KEEP;
       }
       return this._KEEP;
     }
 
-    this._rejectMessage(name, "distinctPercentage is > 25 && weight < 0.5");
     return this._REJECT;
   },
 
   _analyzeBoolean: function(stats) {
     var name = this.get("column");
     if (stats.null_ratio > 0.75) {
-      this._rejectMessage(name, "null_ratio > 75%", stats.null_ratio  * 100);
       return this._REJECT;
     }
     return this._KEEP;
@@ -164,61 +150,9 @@ module.exports = cdb.core.Model.extend({
     }
 
     if (stats.null_ratio > 0.75) {
-      this._rejectMessage(name, "null_ratio > 75%", stats.null_ratio  * 100);
       return this._REJECT;
     }
     return this._KEEP;
-  },
-
-  _printStats: function(stats) {
-    var name        = this.get("column");
-    var type        = stats.type;
-    var weight      = stats.weight;
-    var skew        = stats.skew;
-    var distinct    = stats.distinct;
-    var count       = stats.count;
-    var null_ratio  = stats.null_ratio;
-    var dist_type   = stats.dist_type;
-    var calc_weight = (weight + cdb.CartoCSS.getWeightFromShape(dist_type)) / 2;
-
-    var distinctPercentage = (distinct / count) * 100;
-
-    cdb.log.info("%cAnalyzing %c" + name, "text-decoration:underline; font-weight:bold", "text-decoration:underline; font-weight:normal");
-
-    cdb.log.info('%c · %ctype%c = ' + type, 'color:#666;', 'color: #666; font-weight:bold;', "color: #666; font-weight:normal");
-    cdb.log.info('%c · %cdistinctPercentage%c = ' + distinctPercentage, 'color:#666;', 'color: #666; font-weight:bold;', "color: #666; font-weight:normal");
-    cdb.log.info('%c · %ccount%c = ' + count, 'color:#666;', 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
-    cdb.log.info('%c · %cnull ratio%c = ' + null_ratio, 'color:#666;', 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
-
-    if (dist_type) {
-      cdb.log.info('%c · %cdist_type%c = ' + dist_type, 'color:#666;', 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
-      cdb.log.info('%c · %ccalc_weight%c = ' + calc_weight, 'color:#666;', 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
-    }
-
-    if (skew) {
-      cdb.log.info("%c · %cskew%c: " + skew.toFixed(2), "color:#666;", 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
-    }
-
-    if (weight) {
-      cdb.log.info("%c · %cweight%c: " + weight.toFixed(2), "color: #666;", "color:#666; font-weight:bold;", "color:#666;font-weight:normal");
-    }
-
-    if (stats.density) {
-      cdb.log.info("%c · %cdensity%c: " + stats.density, "color:#666;", 'color: #666; font-weight:bold;', 'color: #666; font-weight:normal;');
-    }
-
-  },
-
-  _redoMessage: function(name, message, value) {
-    if (this._PRINT_STATS) cdb.log.info('%c > turned into category', "color:pink;");
-  },
-
-  _rejectMessage: function(name, message, value) {
-    if (this._PRINT_STATS) cdb.log.info('%c = rejected because ' + message + ": %c" + (value ? value : ""), "color:red;", "color:red; font-weight:bold");
-  },
-
-  _approveMessage: function(name) {
-    if (this._PRINT_STATS) cdb.log.info('%c = approved', "color:green;");
-  },
+  }
 
 });


### PR DESCRIPTION
This PR allows to print debugging information enabling the `pecan_debugging` flag.

Changes made:

* Moves _printStats method to the collection.
* Removes success and error debugging logs.