### PR TITLE
Fixes issue when duplicating an overlay

### DIFF
--- a/lib/assets/javascripts/cartodb/table/overlays/overlays.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/overlays.js
@@ -80,7 +80,6 @@ cdb.admin.models.Overlay = cdb.core.Model.extend({
       _.extend(resp, {
         x:            options.x,
         y:            options.y,
-        order:        options.order,
         device:       options.device,
         extra:        options.extra,
         style:        options.style,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.11",
+  "version": "3.18.12",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR removes an unused key in the overlay hash that was producing an error in the backend. 
The error was introduced when fixing a typo: https://github.com/CartoDB/cartodb/commit/be5a0ebd7469b96b52823b8f99beaf4bdb6734b1, so it's safe to remove.