### PR TITLE
Fixes incorrect markdown rendering

### DIFF
--- a/app/assets/stylesheets/public_map/public_map.css.scss
+++ b/app/assets/stylesheets/public_map/public_map.css.scss
@@ -57,7 +57,7 @@
   float: right;
   width: 50%;
 }
-.PublicMap-description {
+.PublicMap-description p {
   font-size: 20px;
   font-weight: $sFontWeight-lighter;
   line-height: 32px;

--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -127,7 +127,7 @@
             <div class="js-user-meta">
               <h1 class="PublicMap-title js-PublicMap-title Title Title--m"><%= @visualization.name %></h1>
               <% if @visualization.description_clean %>
-                <p class="PublicMap-description"><%= @visualization.description %></p>
+                <div class="PublicMap-description"><%= raw @visualization.description_html_safe %></div>
               <% end %>
 
               <div class="PublicMap-meta">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.16",
+  "version": "3.18.17",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes a problem with the markdown rendering of the map descriptions.

Original issue: #4811.