### PR TITLE
close div tag in tooltip template

### DIFF
--- a/lib/assets/javascripts/cartodb/table/views/tooltip/templates/tooltip_light.jst.mustache
+++ b/lib/assets/javascripts/cartodb/table/views/tooltip/templates/tooltip_light.jst.mustache
@@ -7,4 +7,4 @@
     <p>{{{ value }}}</p>
   {{/fields}}
   </div>
-<div>
+</div>

--- a/spec/requests/api/json/layer_presenter_shared_examples.rb
+++ b/spec/requests/api/json/layer_presenter_shared_examples.rb
@@ -480,7 +480,7 @@ shared_examples_for "layer presenters" do |tested_klass, model_klass|
           tooltip: {
               'fields' => nil,
               'template_name' => "tooltip_light",
-              'template' => "<div><div>",
+              'template' => "<div></div>",
               'alternative_names' => { },
               'maxHeight' => 180
             }


### PR DESCRIPTION
I noticed in several viz.json files that that the tooltip template for `tooltip_light` is not properly closed.
<img width="626" alt="screen shot 2015-08-02 at 12 32 13" src="https://cloud.githubusercontent.com/assets/1041056/9027022/8a4aa800-3912-11e5-8851-2af795a54b8e.png">

Example file here: http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json

The code in `spec/requests/api/json/layer_presenter_shared_examples.rb` is the only reference I was able to find.

@juanignaciosl could you please take a look?