### PR TITLE
Add note for 'no such file python_requirements.txt' error

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,13 @@ pip install --no-use-wheel -r python_requirements.txt
 exit
 ```
 
-If the previous step fails, try this alternative:
+If you are told 'no such file python_requirements.txt', then check that submodules are updated for your `cartodb` repo:
+```bash
+git submodule init
+git submodule update
+```
+
+For other failures, try this alternative:
 ```bash
 export CPLUS_INCLUDE_PATH=/usr/include/gdal
 export C_INCLUDE_PATH=/usr/include/gdal


### PR DESCRIPTION
Adding a 'try this...' note based on https://github.com/CartoDB/cartodb/issues/335#issuecomment-33131622 and my own experiences. These submodule commands were needed even though I initially cloned the repo with the --recursive option on Git 1.9.x. Maybe the submodule(s) where initially added to a branch other than master? http://stackoverflow.com/a/9610153/23566 ... Either way, updating them immediately fixed the 'no such file' error.