### PR TITLE
Show display_name in the background import item when it is available

### DIFF
--- a/lib/assets/javascripts/cartodb/common/background_polling/views/imports/background_import_item_view.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/views/imports/background_import_item_view.js
@@ -72,7 +72,7 @@ module.exports = cdb.core.View.extend({
         d.name = 'Twitter import';
       }
     } else {
-      d.name = imp.item_queue_id || 'import';
+      d.name = imp.display_name || imp.item_queue_id || 'import';
     }
 
     // Service

--- a/lib/assets/test/spec/cartodb/common/background_importer/background_import_item_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/background_importer/background_import_item_view.spec.js
@@ -39,6 +39,16 @@ describe('common/background_polling/background_import_item_view', function() {
     expect(this.view.clean).toHaveBeenCalled();
   });
 
+  it('should show display_name when it is available from import model', function() {
+    this.model.imp.set({ item_queue_id: 'hello-id', type: '' });
+    this.model.set('state', 'importing');
+    expect(this.view.$('.ImportItem-text').text()).toContain('hello-id');
+    this.model.imp.set('display_name', 'table_name_test');
+    this.model.set('state', 'geocoding');
+    expect(this.view.$('.ImportItem-text').text()).toContain('table_name_test');
+    expect(this.view.$('.ImportItem-text').text()).not.toContain('hello-id');
+  });
+
   it('should have no leaks', function() {
     this.view.render();
     expect(this.view).toHaveNoLeaks();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.17",
+  "version": "3.18.18",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
No matter if page is reloaded, if display_name is available it will be shown

![screen shot 2015-08-03 at 11 47 25](https://cloud.githubusercontent.com/assets/132146/9035143/720ec44c-39d5-11e5-8866-acba800247cd.png)


cc @juanignaciosl 
REVIEWER: @javierarce 

Closes #4591