### PR TITLE
Fixes problem hiding an empty map description

### DIFF
--- a/lib/assets/javascripts/cartodb/models/vis.js
+++ b/lib/assets/javascripts/cartodb/models/vis.js
@@ -102,7 +102,7 @@ cdb.admin.Visualization = cdb.core.Model.extend({
     master_vis.bind('change', function() {
       var c = master_vis.changedAttributes();
       if (c.type) self.set('type', master_vis.get('type'));
-      if (c.description) self.set('description', master_vis.get('description'));
+      self.set('description', master_vis.get('description'));
       if (c.name) self.set('name', master_vis.get('name'));
     });
 

--- a/lib/assets/javascripts/cartodb/table/map/map_options_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/map/map_options_dropdown.js
@@ -21,6 +21,7 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
     _.defaults(this.options, this.defaults);
 
     this.collection.on("reset", this._setupOptions, this);
+    this.collection.on("change:description", this._setupOptions, this);
 
     this.mapOptions = new cdb.core.Model({
       title:            false,
@@ -111,7 +112,6 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
   },
 
   _setupOptions: function() {
-
     var self = this;
 
     var overlays = this.collection.models;
@@ -138,8 +138,15 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
 
         self.mapOptions.set({ title: show_title, description: show_description });
 
-        if (show_title)       self.$el.find(".title").removeClass("disabled");
-        if (show_description) self.$el.find(".description").removeClass("disabled");
+        if (show_title) {
+          self.$el.find(".title").removeClass("disabled");
+        }
+
+        if (show_description) {
+          self.$el.find(".description").removeClass("disabled");
+        } else {
+          self.$el.find(".description").addClass("disabled");
+        }
 
       } else if (_.contains(simpleOverlays, type)) {
 
@@ -148,10 +155,9 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
 
         if (display) self.$el.find("." + type).removeClass("disabled");
 
-      } 
+      }
 
     });
-
   },
 
   /* Check if the dropdown is visible to hiding with the click on the target */

--- a/lib/assets/javascripts/cartodb/table/map/map_options_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/map/map_options_dropdown.js
@@ -139,13 +139,13 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
         self.mapOptions.set({ title: show_title, description: show_description });
 
         if (show_title) {
-          self.$el.find(".title").removeClass("disabled");
+          self.$(".title").removeClass("disabled");
         }
 
         if (show_description) {
-          self.$el.find(".description").removeClass("disabled");
+          self.$(".description").removeClass("disabled");
         } else {
-          self.$el.find(".description").addClass("disabled");
+          self.$(".description").addClass("disabled");
         }
 
       } else if (_.contains(simpleOverlays, type)) {
@@ -153,7 +153,7 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
         var display = overlay.get("display");
         self.mapOptions.set(type, display);
 
-        if (display) self.$el.find("." + type).removeClass("disabled");
+        if (display) self.$("." + type).removeClass("disabled");
 
       }
 

--- a/lib/assets/javascripts/cartodb/table/map/map_options_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/map/map_options_dropdown.js
@@ -153,7 +153,9 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
         var display = overlay.get("display");
         self.mapOptions.set(type, display);
 
-        if (display) self.$("." + type).removeClass("disabled");
+        if (display) {
+          self.$("." + type).removeClass("disabled");
+        }
 
       }
 

--- a/lib/assets/javascripts/cartodb/table/overlays/header.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/header.js
@@ -151,14 +151,22 @@ cdb.admin.overlays.Header = cdb.admin.overlays.Text.extend({
 
   _onChangeDescription: function() {
 
+    var description = this.model.get("description");
+    var show_description = true;
+
+    if(!description || !description.trim().length) {
+      show_description = false;
+    }
+
     this.$el.find(".description").html(
-      this._getMarkdown(this.model.get("description"))
+      this._getMarkdown(description)
     );
 
     var extra = this.model.get("extra")
 
-    extra.description = this.model.get("description");
-    this.model.set({ extra: extra }, { silent: true });
+    extra.description = description;
+
+    this.model.save({ extra: extra, show_description: show_description });
 
     this.show();
 

--- a/lib/assets/javascripts/cartodb/table/overlays/header.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/header.js
@@ -158,7 +158,7 @@ cdb.admin.overlays.Header = cdb.admin.overlays.Text.extend({
       show_description = false;
     }
 
-    this.$el.find(".description").html(
+    this.$(".description").html(
       this._getMarkdown(description)
     );
 

--- a/lib/assets/javascripts/cartodb/table/overlays/header.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/header.js
@@ -154,7 +154,7 @@ cdb.admin.overlays.Header = cdb.admin.overlays.Text.extend({
     var description = this.model.get("description");
     var show_description = true;
 
-    if(!description || !description.trim().length) {
+    if (!description || !description.trim().length) {
       show_description = false;
     }
 

--- a/lib/assets/test/spec/cartodb/table/map_options_dropdown.spec.js
+++ b/lib/assets/test/spec/cartodb/table/map_options_dropdown.spec.js
@@ -84,15 +84,6 @@ describe("map_options_dropdown", function() {
     });
   });
 
-  afterEach(function() {
-    //if (view.options.geocoder.dlg) view.options.geocoder.dlg.hide();
-    //if (view.noGeoRefDialog) view.noGeoRefDialog.clean();
-    //if (view.pecanDialog) view.pecanDialog.clean();
-    //localStorage.clear();
-    //view.$el.html('').remove();
-    //$('.dropdown').remove();
-  });
-
   it("should render the dropdown", function() {
     this.view.render();
     expect(this.view.$('.switches li').length).toEqual(9);

--- a/lib/assets/test/spec/cartodb/table/map_options_dropdown.spec.js
+++ b/lib/assets/test/spec/cartodb/table/map_options_dropdown.spec.js
@@ -103,7 +103,7 @@ describe("map_options_dropdown", function() {
     expect(this.view.$('.switches li.description').hasClass("active")).toBe(true);
     var extra = this.header.get("extra");
     extra.show_description = false;
-    this.header.set({ extra: extra, description: false });
+    this.header.set({ extra: extra, description: "" });
     expect(this.view.$('.switches li.description').hasClass("active")).toBe(false);
   });
 });

--- a/lib/assets/test/spec/cartodb/table/map_options_dropdown.spec.js
+++ b/lib/assets/test/spec/cartodb/table/map_options_dropdown.spec.js
@@ -1,0 +1,109 @@
+describe("map_options_dropdown", function() {
+
+  beforeEach(function() {
+    var table = TestUtil.createTable('test');
+    var vis = TestUtil.createVis("jam");
+    this.user = TestUtil.createUser('jamon');
+    master_vis = TestUtil.createVis("jam");
+    var map = new cdb.admin.Map();
+    var layer = new cdb.admin.CartoDBLayer({
+      table_name: 'test',
+      tile_style: 'test',
+      user_name: 'test'
+    });
+    map.layers.add(layer);
+    map.layers.add(new cdb.admin.CartoDBLayer({
+      table_name: 'test2',
+      tile_style: 'style',
+      user_name: 'test'
+    }));
+    var element = $('<div><div class="cartodb-map"></div></div>');
+    element.appendTo($('body'));
+
+    view = new cdb.admin.MapTab({
+      user: this.user,
+      model: map,
+      vis: vis,
+      master_vis: master_vis,
+      menu: new cdb.admin.RightMenu({}),
+      geocoder: new cdb.admin.Geocoding('', table),
+      el: element,
+      baseLayers: new cdb.admin.Layers([ new cdb.admin.TileLayer({ urlTemplate: 'rabos'}) ])
+    });
+
+    this.header = new cdb.core.Model({
+      order: 1,
+      shareable: false,
+      description: "Description",
+      title: "Hello!",
+      type: "header",
+      url: null,
+      extra: {
+        description: "Description",
+        title: "Hello!",
+        show_title: true,
+        show_description: true
+      }
+    });
+
+    this.overlays = new Backbone.Collection([
+      this.header,
+      new cdb.core.Model({
+        device: "screen",
+        type: "text",
+        style: {
+          "z-index": 9
+        }
+      }),
+      new cdb.core.Model({
+        type: "text",
+        device: "screen",
+        style: {
+          "z-index": 2
+        }
+      })
+    ]);
+
+    var canvas  = new cdb.core.Model({ mode: "desktop" });
+
+    this.view = new cdb.admin.MapOptionsDropdown({
+      target:              $('.show-table-options'),
+      template_base:       "table/views/map_options_dropdown",
+      table:               table,
+      model:               map,
+      mapview:             this.mapView,
+      collection:          this.overlays,
+      user:                this.user,
+      vis:                 vis,
+      canvas:              canvas,
+      position:            "position",
+      tick:                "left",
+      vertical_position:   "up",
+      horizontal_position: "left",
+      horizontal_offset:   "-3px"
+    });
+  });
+
+  afterEach(function() {
+    //if (view.options.geocoder.dlg) view.options.geocoder.dlg.hide();
+    //if (view.noGeoRefDialog) view.noGeoRefDialog.clean();
+    //if (view.pecanDialog) view.pecanDialog.clean();
+    //localStorage.clear();
+    //view.$el.html('').remove();
+    //$('.dropdown').remove();
+  });
+
+  it("should render the dropdown", function() {
+    this.view.render();
+    expect(this.view.$('.switches li').length).toEqual(9);
+  });
+
+  it("should change disabled the description option when show_description is false ", function() {
+    this.view.render();
+    expect(this.view.$('.switches li.description').hasClass("active")).toBe(true);
+    var extra = this.header.get("extra");
+    extra.show_description = false;
+    this.header.set({ extra: extra, description: false });
+    expect(this.view.$('.switches li.description').hasClass("active")).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR fixes an issue with the map description. Currently if you enable the description in a map, and then edit the metadata to set it to an empty string, the description remains visible. This PR fixes that bug and add missing specs for the map dropdown. 

Original issue: https://github.com/CartoDB/cartodb/issues/3941