### PR TITLE
Stop fetching geocodings when first request fails

### DIFF
--- a/lib/assets/javascripts/cartodb/common/background_polling/models/geocodings_collection.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/geocodings_collection.js
@@ -74,16 +74,25 @@ module.exports = Backbone.Collection.extend({
     });
   },
 
+  fetchGeocodings: function() {
+    var self = this;
+    // Start doing a fetch
+    this.fetch({
+      error: function(e) {
+        self.destroyCheck();
+      }
+    });
+  },
+
   pollCheck: function(i) {
     if (this.pollTimer) return;
 
     var self = this;
     this.pollTimer = setInterval(function() {
-      self.fetch();
+      self.fetchGeocodings();
     }, pollTimer);
 
-    // Start doing a fetch
-    this.fetch();
+    this.fetchGeocodings();
   },
 
   destroyCheck: function() {

--- a/lib/assets/javascripts/cartodb/common/background_polling/models/geocodings_collection.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/geocodings_collection.js
@@ -76,7 +76,6 @@ module.exports = Backbone.Collection.extend({
 
   fetchGeocodings: function() {
     var self = this;
-    // Start doing a fetch
     this.fetch({
       error: function(e) {
         self.destroyCheck();

--- a/lib/assets/test/spec/cartodb/common/background_importer/geocoding_collection.spec.js
+++ b/lib/assets/test/spec/cartodb/common/background_importer/geocoding_collection.spec.js
@@ -50,6 +50,18 @@ describe('common/background_polling/geocodings_collection', function() {
       this.collection.parse({ geocodings: [ { id: 1, table_name: 'hello' } ]});
       expect(this.collection.add).not.toHaveBeenCalled();
     });
+
+    it('should stop polling if there is an error in the poll checker request', function(done) {
+      var self = this;
+      this.collection.sync = function(a,b,opts) {
+        opts.error()
+      };
+      this.collection.pollCheck();
+      setTimeout(function() {
+        expect(self.collection.pollTimer).not.toBeDefined();
+        done();
+      }, 100);
+    });
   });
 
   it('should determine if a new geocoding could be possible', function() {

--- a/lib/assets/test/spec/cartodb/common/background_importer/geocoding_collection.spec.js
+++ b/lib/assets/test/spec/cartodb/common/background_importer/geocoding_collection.spec.js
@@ -51,16 +51,12 @@ describe('common/background_polling/geocodings_collection', function() {
       expect(this.collection.add).not.toHaveBeenCalled();
     });
 
-    it('should stop polling if there is an error in the poll checker request', function(done) {
-      var self = this;
+    it('should stop polling if there is an error in the poll checker request', function() {
       this.collection.sync = function(a,b,opts) {
         opts.error()
       };
       this.collection.pollCheck();
-      setTimeout(function() {
-        expect(self.collection.pollTimer).not.toBeDefined();
-        done();
-      }, 100);
+      expect(this.collection.pollTimer).not.toBeDefined();
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.18",
+  "version": "3.18.19",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We didn't check if geocodings request failed, so basically we have this amount of errors because polling kept requesting the endpoint.

https://my.trackjs.com/messages/filtered?message=401+Unauthorized%3a+GET+https%3a%2f%2fbdavidson.cartodb.com%2fapi%2fv1_1%2fgeocodings
https://my.trackjs.com/messages/filtered?message=401+Unauthorized%3a+GET+https%3a%2f%2fcarloscrhz.cartodb.com%2fapi%2fv1_1%2fgeocodings
https://my.trackjs.com/messages/filtered?message=401+Unauthorized%3a+GET+https%3a%2f%2fmancha.cartodb.com%2fapi%2fv1_1%2fgeocodings

REVIEWER: @javierarce 
Fixes #4834.