### PR TITLE
Upload validation should check if file name is not empty

### DIFF
--- a/lib/assets/javascripts/cartodb/common/background_polling/models/upload_model.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/upload_model.js
@@ -89,8 +89,16 @@ module.exports = Backbone.Model.extend({
           msg: "Unfortunately only one file is allowed per upload"
         }
       }
-      // File extension
+      
+      // File name
       var name = attrs.value.name;
+      if (!name) {
+        return {
+          msg: "File name should be defined"
+        }
+      }
+
+      // File extension
       var ext = name.substr(name.lastIndexOf('.') + 1);
       if (ext) {
         ext = ext.toLowerCase();

--- a/lib/assets/test/spec/cartodb/common/background_importer/imports_model.spec.js
+++ b/lib/assets/test/spec/cartodb/common/background_importer/imports_model.spec.js
@@ -153,6 +153,14 @@ describe('common/background_polling/imports_model', function() {
       expect(this.upload.get('error_code')).toBe('');
     });
 
+    it("should raise an error when file name is not provided", function() {
+      this.upload.set({
+        type: 'file',
+        value: { }
+      });
+      expect(this.upload.get('state')).toBe('error');
+    });
+
     describe('.setFresh', function() {
       beforeEach(function() {
         spyOn(this.upload, 'set');

--- a/lib/assets/test/spec/cartodb/common/background_importer/imports_model.spec.js
+++ b/lib/assets/test/spec/cartodb/common/background_importer/imports_model.spec.js
@@ -159,6 +159,7 @@ describe('common/background_polling/imports_model', function() {
         value: { }
       });
       expect(this.upload.get('state')).toBe('error');
+      expect(this.upload.get('get_error_text').what_about).toBe('File name should be defined');
     });
 
     describe('.setFresh', function() {


### PR DESCRIPTION
When a user tried to drop a non valid file it didn't check if it had a valid file name and a JS error appeared (substr undefined) because file name was not defined.

![file-name](https://cloud.githubusercontent.com/assets/132146/9037540/9f2d6692-39ec-11e5-9067-7c4645d9e0e4.gif)

Fixes #4841 and  [TrackJS](https://my.trackjs.com/messages/filtered?message=Cannot+read+property+%27substr%27+of+undefined).

cc @javierarce 
REVIEWER: @matallo 
