### PR TITLE
Fixing several styles for map card

### DIFF
--- a/app/assets/stylesheets/common/map-card.css.scss
+++ b/app/assets/stylesheets/common/map-card.css.scss
@@ -54,6 +54,7 @@ $sEditButtonSize: 50px;
   margin-bottom: $sMargin-element;
 }
 .MapCard-tags {
+  position: relative;
   @include line-clamp(1);
 }
 .MapCard--selectable{

--- a/app/assets/stylesheets/common/maps-list.css.scss
+++ b/app/assets/stylesheets/common/maps-list.css.scss
@@ -29,7 +29,7 @@
 .MapsList-item {
   position: relative;
   width: 300px;
-  margin: 10px;
+  margin: 20px 10px 0 10px;
 }
 .MapsList-item--woTopBottomMargins {
   margin-top: 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.19",
+  "version": "3.18.20",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] Margin top 20px for each map card item.

![screen shot 2015-08-03 at 16 18 25](https://cloud.githubusercontent.com/assets/132146/9039379/4f3bf7ac-39fb-11e5-8d89-a4f8de91ff54.png)

---

- [x] Map card tags line-clam positioned correctly.

· Before:
![screen shot 2015-08-03 at 16 15 22](https://cloud.githubusercontent.com/assets/132146/9039390/61b192ac-39fb-11e5-88dc-b2d31a12e8fa.png)

· After:
![screen shot 2015-08-03 at 16 15 31](https://cloud.githubusercontent.com/assets/132146/9039401/7253f104-39fb-11e5-8616-b7abea852b83.png)

---

Fixes #4754.
REVIEWER: @javierarce.