### PR TITLE
Fixes blurry patterns + updates copy

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/map/image_picker/navigation_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/image_picker/navigation_template.jst.ejs
@@ -22,7 +22,7 @@
       <% if (kind == 'pattern') { %>
       <li class="Filters-typeItem">
         <button data-type="patterns" class="Filters-typeLink js-item<%- pane === 'patterns' ? ' is-selected' : '' %>">
-          Patterns
+          CartoDB Patterns Library
         </button>
       </li>
       <% } %>

--- a/lib/assets/javascripts/cartodb/table/asset_manager/asset_item.js
+++ b/lib/assets/javascripts/cartodb/table/asset_manager/asset_item.js
@@ -11,7 +11,7 @@
 
   cdb.admin.AssetsItem = cdb.core.View.extend({
 
-    _SIZE: 42, // Thumbnail size (same cm for width and height)
+    _SIZE: 60, // Thumbnail size (same cm for width and height)
     _MIN_SIZE: 32, // Minimal thumbnail size (same cm for width and height)
 
     tagName: 'li',
@@ -72,7 +72,7 @@
             });
           }
         } else {
-          if((w || h) > self._SIZE) {
+          if ((w || h) > self._SIZE) {
             $thumbnail.css({
               "background-size":  "cover",
               "background-origin": "content-box"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.20",
+  "version": "3.18.21",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR removes the blurriness from the patter thumbnails (caused by a difference between the default size of the thumbnails and the actual one). It also updates the title of the pattern library.

Original issue: https://github.com/CartoDB/cartodb/issues/3761

![screen shot 2015-08-03 at 17 16 02](https://cloud.githubusercontent.com/assets/4933/9040606/8ef73aac-3a03-11e5-80e3-cf1d1ad298e9.png)

/cc: @xavijam 
