### PR TITLE
Avoid change privacy when a layer is added or removed

### DIFF
--- a/lib/assets/javascripts/cartodb/models/vis.js
+++ b/lib/assets/javascripts/cartodb/models/vis.js
@@ -104,6 +104,7 @@ cdb.admin.Visualization = cdb.core.Model.extend({
       if (c.type) self.set('type', master_vis.get('type'));
       self.set('description', master_vis.get('description'));
       if (c.name) self.set('name', master_vis.get('name'));
+      if (c.privacy) self.set('privacy', master_vis.get('privacy'));
     });
 
   },

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -182,7 +182,7 @@
       var tabBind = function(dataLayerCid) {
         var view = self.getPane(dataLayerCid);
         self.trigger('switch', view);
-        self.vis.save('active_layer_id', view.dataLayer.id);
+        self.master_vis.save('active_layer_id', view.dataLayer.id);
         self.show(view.panels.activeTab);
         self.unbind('tabEnabled', tabBind);
       }
@@ -730,8 +730,8 @@
       if (this.activePane != l) {
         this._hideLayerTooltip(l);
         this.active(l.dataLayer.cid);
-        if (l.dataLayer.id && this.vis.get('active_layer_id') != l.dataLayer.id) {
-          this.vis.save('active_layer_id', l.dataLayer.id);
+        if (l.dataLayer.id && this.master_vis.get('active_layer_id') != l.dataLayer.id) {
+          this.master_vis.save('active_layer_id', l.dataLayer.id);
         }
         if (open === undefined) this.show(l.panels.activeTab);
       }

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -182,7 +182,7 @@
       var tabBind = function(dataLayerCid) {
         var view = self.getPane(dataLayerCid);
         self.trigger('switch', view);
-        self.master_vis.save('active_layer_id', view.dataLayer.id);
+        self.vis.save('active_layer_id', view.dataLayer.id);
         self.show(view.panels.activeTab);
         self.unbind('tabEnabled', tabBind);
       }
@@ -730,8 +730,8 @@
       if (this.activePane != l) {
         this._hideLayerTooltip(l);
         this.active(l.dataLayer.cid);
-        if (l.dataLayer.id && this.master_vis.get('active_layer_id') != l.dataLayer.id) {
-          this.master_vis.save('active_layer_id', l.dataLayer.id);
+        if (l.dataLayer.id && this.vis.get('active_layer_id') != l.dataLayer.id) {
+          this.vis.save('active_layer_id', l.dataLayer.id);
         }
         if (open === undefined) this.show(l.panels.activeTab);
       }

--- a/lib/assets/test/spec/cartodb/models/vis.spec.js
+++ b/lib/assets/test/spec/cartodb/models/vis.spec.js
@@ -76,27 +76,31 @@
     });
 
     describe('slides', function() {
-      it("should change name on master change", function() {
-        master = new cdb.admin.Visualization({
+      beforeEach(function() {
+        this.master = new cdb.admin.Visualization({
           id: 'test',
           type: 'derived',
           children: [{id: 'slide_1'},{ id: 'slide_2' }]
-        })
-        vis.setMaster(master);
-        master.set('name', 'testing');
+        });
+      });
+
+      it("should change name on master change", function() {
+        vis.setMaster(this.master);
+        this.master.set('name', 'testing');
         expect(vis.get('name')).toEqual('testing');
       });
 
       it("should change id on master change", function() {
-        master = new cdb.admin.Visualization({
-          id: 'test',
-          type: 'derived',
-          children: [{id: 'slide_1'},{ id: 'slide_2' }]
-        })
-        vis.setMaster(master);
-        master.set('id', 'id_testing');
+        vis.setMaster(this.master);
+        this.master.set('id', 'id_testing');
         expect(vis.get('id')).toEqual('id_testing');
         expect(vis.slides.master_visualization_id).toEqual('id_testing');
+      });
+
+      it("should change privacy on master change", function() {
+        vis.setMaster(this.master);
+        this.master.set('privacy', 'PASSWORD');
+        expect(vis.get('privacy')).toEqual('PASSWORD');
       });
 
       it("should load slides", function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.24",
+  "version": "3.18.25",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I had the problem described in the title (and in [issue](https://github.com/CartoDB/cartodb/issues/3057) too) yesterday creating a visualization in production so I've decided to check it today finally.

Seems like we didn't set the new privacy when in master_vis was changed.

REVIEWERS: @javisantana @javierarce 
Fixes #3057 