### PR TITLE
Offer dates shortcuts within dates range picker

### DIFF
--- a/app/assets/stylesheets/common/datepicker.css.scss
+++ b/app/assets/stylesheets/common/datepicker.css.scss
@@ -64,8 +64,8 @@ $sDates-defaultWidth: 434px;
   left: 0;
   right: 0;
   bottom: 55px;
-  width: 422px;
-  padding: 18px;
+  width: 458px;
+  padding: 0;
   border: 1px solid #CCC;
   background: white;
   border-radius: $border-radius;
@@ -83,7 +83,7 @@ $sDates-defaultWidth: 434px;
   margin-left: -4px;
   border-left: 8px solid transparent;
   border-right: 8px solid transparent;
-  border-top: 8px solid white;
+  border-top: 8px solid $cCard-hoverFill;
   z-index: 1;
 }
 .DatePicker-dropdown:after {
@@ -100,6 +100,7 @@ $sDates-defaultWidth: 434px;
   @include display-flex();
   @include justify-content(space-between, justify);
   @include align-items(center, center);
+  margin: 0 18px;
 }
 .DatePicker-timersFrom ,
 .DatePicker-timersTo {
@@ -117,12 +118,33 @@ $sDates-defaultWidth: 434px;
   text-transform: uppercase;
 }
 
+// Date picker shortcuts
+.DatePicker-shortcuts {
+  @include display-flex();
+  @include justify-content(space-between, justify);
+  @include align-items(center);
+  width: 422px;
+  height: 39px;
+  margin-top: 9px;
+  padding: 0 18px;
+  border-top: 1px solid $cStructure-mainLine;
+  background: $cCard-hoverFill;
+  border-bottom-left-radius: $border-radius;
+  border-bottom-right-radius: $border-radius;
+}
+.DatePicker-shortcutsText {
+  font-size: $sFontSize-smallUpperCase;
+  color: $cTypography-paragraphs;
+  @include nicer-lato-typography();
+}
+
 // Calendar :S
 
 // Default datepicker styles
 .DatePicker-calendar {
-  width: 100%;
-  height: 200px;
+  width: 422px;
+  height: 196px;
+  margin: 16px 18px 0;
   font-size: 11px;
   cursor: default;
 }

--- a/app/assets/stylesheets/common/datepicker.css.scss
+++ b/app/assets/stylesheets/common/datepicker.css.scss
@@ -63,7 +63,7 @@ $sDates-defaultWidth: 434px;
   position: absolute;
   left: 0;
   right: 0;
-  bottom: 55px;
+  bottom: 43px;
   width: 458px;
   padding: 0;
   border: 1px solid #CCC;

--- a/lib/assets/javascripts/cartodb/common/views/date_pickers/dates_range.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/date_pickers/dates_range.jst.ejs
@@ -22,4 +22,12 @@
       </div>
     </div>
   </div>
+  <div class="DatePicker-shortcuts">
+    <p class="DatePicker-shortcutsText">
+      Get last <button type="button" class="Button--link js-fourHours">4 hours</button>,
+      <button type="button" class="Button--link js-oneDay">1 day</button> or
+      <button type="button" class="Button--link js-oneWeek">1 week</button>
+    </p>
+    <p class="DatePicker-shortcutsText">Date will be converted to GMT +0</p>
+  </div>
 </div>

--- a/lib/assets/javascripts/cartodb/common/views/date_pickers/dates_range_picker.js
+++ b/lib/assets/javascripts/cartodb/common/views/date_pickers/dates_range_picker.js
@@ -110,17 +110,12 @@ module.exports = cdb.core.View.extend({
   },
 
   _setToday: function() {
-    var utc = new Date().getTimezoneOffset();
-    var today = moment(new Date()).utcOffset(utc).format("YYYY-MM-DD");
-    var first = moment(new Date()).utcOffset(utc).subtract((this._MAX_RANGE - 1), 'days').format("YYYY-MM-DD");
-
-    this.options.date = [first, today];
-    this.options.current = today;
-
-    this.model.set({
-      fromDate: first,
-      toDate: today
-    });
+    var datesUTC = this.model.get('user_timezone');
+    var today = moment().utc(datesUTC);
+    var previous = moment().utc(datesUTC).subtract((this._MAX_RANGE - 1), 'days');
+    this.options.date = [previous.format("YYYY-MM-DD"), today.format("YYYY-MM-DD")];
+    this.options.current = today.format("YYYY-MM-DD");
+    this._setModelFromPrevious(previous);
   },
 
   _initCalendar: function() {
@@ -175,18 +170,42 @@ module.exports = cdb.core.View.extend({
   },
 
   _setLastFourHours: function() {
-    console.log("last four hours");
+    var previous = moment().utc(0).subtract(4, 'hours');
+    this._setModelFromPrevious(previous);
+    this._setDatepickerFromPrevious(previous);
     this.closeCalendar();
   },
 
   _setLastDay: function() {
-    console.log("last day");
+    var previous = moment().utc(0).subtract(1, 'day');
+    this._setModelFromPrevious(previous);
+    this._setDatepickerFromPrevious(previous);
     this.closeCalendar();
   },
 
   _setLastWeek: function() {
-    console.log("last week");
+    var previous = moment().utc(0).subtract(1, 'week');
+    this._setModelFromPrevious(previous);
+    this._setDatepickerFromPrevious(previous);
     this.closeCalendar();
+  },
+
+  _setModelFromPrevious: function(previous) {
+    var today = moment().utc(0);
+
+    this.model.set({
+      fromDate: previous.format('YYYY-MM-DD'),
+      fromHour: parseInt(previous.format('H')),
+      fromMin:  parseInt(previous.format('m')),
+      toDate: today.format('YYYY-MM-DD'),
+      toHour: parseInt(today.format('H')),
+      toMin:  parseInt(today.format('m'))
+    });
+  },
+
+  _setDatepickerFromPrevious: function(previous) {
+    var today = moment().utc(0);    
+    this.$('.DatePicker-calendar').DatePickerSetDate([ previous.format('YYYY-MM-DD') , today.format('YYYY-MM-DD') ]);
   },
 
   _initTimers: function() {

--- a/lib/assets/javascripts/cartodb/common/views/date_pickers/dates_range_picker.js
+++ b/lib/assets/javascripts/cartodb/common/views/date_pickers/dates_range_picker.js
@@ -23,7 +23,10 @@ module.exports = cdb.core.View.extend({
   },
 
   events: {
-    'click .js-dates': '_toggleCalendar'
+    'click .js-dates': '_toggleCalendar',
+    'click .js-fourHours': '_setLastFourHours',
+    'click .js-oneDay': '_setLastDay',
+    'click .js-oneWeek': '_setLastWeek'
   },
 
   initialize: function() {
@@ -171,6 +174,20 @@ module.exports = cdb.core.View.extend({
     this.$('.DatePicker-dropdown').toggle();
   },
 
+  _setLastFourHours: function() {
+    console.log("last four hours");
+    this.closeCalendar();
+  },
+
+  _setLastDay: function() {
+    console.log("last day");
+    this.closeCalendar();
+  },
+
+  _setLastWeek: function() {
+    console.log("last week");
+    this.closeCalendar();
+  },
 
   _initTimers: function() {
     // 'From' div

--- a/lib/assets/test/spec/cartodb/common/edit_fields/date_picker_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/edit_fields/date_picker_view.spec.js
@@ -1,0 +1,75 @@
+var cdb = require('cartodb.js');
+var moment = require('moment');
+var DateRangeView = require('../../../../../javascripts/cartodb/common/views/date_pickers/dates_range_picker');
+
+
+describe('Date picker', function() {
+
+  beforeEach(function() {
+    this.view = new DateRangeView();
+    this.view.render();
+  });
+
+  it("should render properly", function() {
+    expect(this.view.$('.js-dates').length).toBe(1);
+    expect(this.view.$('.DatePicker-dropdown').length).toBe(1);
+  });
+
+  it("should set date properly when range is set", function() {
+    var today = moment().utc(0);
+    var previous = moment().utc(0).subtract(29, 'days');
+
+    expect(this.view.model.get('fromDate')).toBe(previous.format('YYYY-MM-DD'));
+    expect(this.view.model.get('fromHour')).toBe(parseInt(previous.format('H')));
+    expect(this.view.model.get('fromMin')).toBe(parseInt(previous.format('m')));
+    expect(this.view.model.get('toDate')).toBe(today.format('YYYY-MM-DD'));
+    expect(this.view.model.get('toHour')).toBe(parseInt(today.format('H')));
+    expect(this.view.model.get('toMin')).toBe(parseInt(today.format('m')));
+
+    expect(this.view.$('.js-dates').text()).toContain(
+      'From ' + previous.format('YYYY-MM-DD') + ' ' + previous.format('HH:mm') + ' to ' + today.format('YYYY-MM-DD') + ' ' + today.format('HH:mm')
+    );
+  });
+
+  describe('date shortcuts', function() {
+
+    beforeEach(function() {
+
+      this.generateDateText = function(previous, today) {
+        return 'From ' + previous.format('YYYY-MM-DD') + ' ' + previous.format('HH:mm') + ' to ' + today.format('YYYY-MM-DD') + ' ' + today.format('HH:mm')
+      }
+    });
+
+    it("should set last 4 hours as date", function() {
+      this.view.$('.js-fourHours').click();
+
+      var today = moment().utc(0);
+      var previous = moment().utc(0).subtract(4, 'hours');
+
+      expect(this.view.model.get('fromDate')).toBe(previous.format('YYYY-MM-DD'));
+      expect(this.view.model.get('fromHour')).toBe(parseInt(previous.format('H')));
+      expect(this.view.model.get('fromMin')).toBe(parseInt(previous.format('m')));
+      expect(this.view.model.get('toDate')).toBe(today.format('YYYY-MM-DD'));
+      expect(this.view.model.get('toHour')).toBe(parseInt(today.format('H')));
+      expect(this.view.model.get('toMin')).toBe(parseInt(today.format('m')));
+
+      expect(this.view.$('.js-dates').text()).toContain(this.generateDateText(previous, today));
+    });
+
+    it("should set last day as date", function() {
+      this.view.$('.js-oneDay').click();
+      var today = moment().utc(0);
+      var previous = moment().utc(0).subtract(1, 'day');
+      expect(this.view.$('.js-dates').text()).toContain(this.generateDateText(previous, today));
+    });
+
+    it("should set last week as date", function() {
+      this.view.$('.js-oneWeek').click();
+      var today = moment().utc(0);
+      var previous = moment().utc(0).subtract(1, 'week');
+      expect(this.view.$('.js-dates').text()).toContain(this.generateDateText(previous, today));
+    });
+
+  });
+  
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.21",
+  "version": "3.18.23",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION

![screen shot 2015-08-04 at 21 41 16](https://cloud.githubusercontent.com/assets/132146/9070723/91f57f04-3af1-11e5-867c-e9d5797732e9.png)

Apart from adding those news fast dates shortcuts, we set the initial date ranges checking user timezone and setting them with UTC 0, trying to avoid the confusion with the GMT conversions.

Fixes #3952.

REVIEWER: @javierarce 
cc @javisantana @saleiva 