### PR TITLE
Fixed twitter details button and dialog

### DIFF
--- a/app/assets/stylesheets/common/background-polling/background-polling-result-details-dialog.css.scss
+++ b/app/assets/stylesheets/common/background-polling/background-polling-result-details-dialog.css.scss
@@ -13,14 +13,10 @@ $w: 560px;
   @include align-items(center);
   min-width: initial;
   width: $w;
-}
-.BackgroundPollingDetails-body {
-  min-width: initial;
-  width: $w;
   padding: $sMargin-group 0;
   margin: 0 auto;
   border-top: 1px solid $cStructure-mainLine;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 0;
 }
 .BackgroundPollingDetails-body--noBorderTop { border-top: 0 }
 .BackgroundPollingDetails-icon {

--- a/lib/assets/javascripts/cartodb/common/background_polling/background_polling_model.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/background_polling_model.js
@@ -13,7 +13,7 @@ module.exports = cdb.core.Model.extend({
 
   defaults: {
     showGeocodingDatasetURLButton: false,
-    showSuccessDetailsButton: false,
+    showSuccessDetailsButton: true,
     geocodingsPolling: false, // enable geocodings polling
     importsPolling: false // enable imports polling
   },

--- a/lib/assets/javascripts/cartodb/common/background_polling/views/imports/background_import_item_view.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/views/imports/background_import_item_view.js
@@ -76,7 +76,7 @@ module.exports = cdb.core.View.extend({
     }
 
     // Service
-    d.service = this.model.get('upload').service_name;
+    d.service = upload.service_name;
 
     // Progress
     if (this.model.get('step') === 'upload') {

--- a/lib/assets/javascripts/cartodb/common/background_polling/views/imports/twitter_import_details.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/background_polling/views/imports/twitter_import_details.jst.ejs
@@ -14,7 +14,7 @@
     <% } %>
   </p>
 </div>
-<div class="Dialog-body BackgroundPollingDetails-body">
+<div class="BackgroundPollingDetails-body">
   <div class="LayoutIcon BackgroundPollingDetails-icon <%- tweetsCost > 0 ? 'is-nonFree' : 'is-free' %>">
     <i class="iconFont iconFont-Dollar"></i>
   </div>

--- a/lib/assets/javascripts/cartodb/dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/main_view.js
@@ -87,6 +87,7 @@ module.exports = cdb.core.View.extend({
   _initViews: function() {
     var backgroundPollingModel = new DashboardBackgroundPollingModel({
       showGeocodingDatasetURLButton: true,
+      showSuccessDetailsButton: true,
       geocodingsPolling: true,
       importsPolling: true
     }, { 

--- a/lib/assets/javascripts/cartodb/dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/main_view.js
@@ -87,7 +87,6 @@ module.exports = cdb.core.View.extend({
   _initViews: function() {
     var backgroundPollingModel = new DashboardBackgroundPollingModel({
       showGeocodingDatasetURLButton: true,
-      showSuccessDetailsButton: true,
       geocodingsPolling: true,
       importsPolling: true
     }, { 

--- a/lib/assets/javascripts/cartodb/editor/background_polling_model.js
+++ b/lib/assets/javascripts/cartodb/editor/background_polling_model.js
@@ -20,7 +20,12 @@ module.exports = BackgroundPollingModel.extend({
         success: function() {
           // layers need to be saved because the order may changed
           self.vis.map.layers.saveLayers();
-          self.importsCollection.remove(importsModel);
+          // Don't remove import item if it is Twitter type
+          var serviceName = importsModel.get('upload').service_name;
+          var twitterImport = serviceName && serviceName === "twitter_search";
+          if (!twitterImport) {
+            self.importsCollection.remove(importsModel);  
+          }
         },
         error: function() {
           self.trigger('importLayerFail', 'Failed to add the connected dataset as a layer to this map');
@@ -39,9 +44,6 @@ module.exports = BackgroundPollingModel.extend({
     }
   },
 
-  _onAnalysisStateChange: function(mdl, collection) {
-    // console.log("model analysis state changed?");
-    // debugger;
-  }
+  _onAnalysisStateChange: function(mdl, collection) {}
 
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.25",
+  "version": "3.18.26",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] Show twitter import details button within background polling import view, in any scenario, dashboard or editor.
- [x] Let user check twitter import details when a twitter import is created within editor.
- [x] Fixed background polling success details styles.