### PR TITLE
Fix title if creating table from query

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/duplicate_dataset_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/duplicate_dataset_view.js
@@ -31,7 +31,7 @@ module.exports = BaseDialog.extend({
     this.addView(this._panes);
     this._panes.addTab('loading',
       ViewFactory.createByTemplate('common/templates/loading', {
-        title: 'Duplicating your dataset',
+        title: this.model.isInSQLView() ? 'Creating dataset from your query' : 'Duplicating your dataset',
         quote: randomQuote()
       })
     );

--- a/lib/assets/test/spec/cartodb/common/dialogs/duplicate_dataset_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/duplicate_dataset_view.spec.js
@@ -29,6 +29,14 @@ describe('common/dialogs/duplicate_dataset_view', function() {
     expect(this.innerHTML()).toContain('Duplicating your dataset');
   });
 
+  it('should render alternative title if creating from SQL', function() {
+    spyOn(this.table, 'isInSQLView').and.returnValue(true);
+    this.view.initialize();
+    this.view.render();
+    expect(this.innerHTML()).not.toContain('Duplicating your dataset');
+    expect(this.innerHTML()).toContain('Creating dataset from your query');
+  });
+
   describe('when duplication finishes successfully', function() {
 
     beforeEach(function() {


### PR DESCRIPTION
Fixes #4801 

Actually using the table.duplicate that internally duplicate table from the query, this changes the title depending on that state

@javierarce for code review