### PR TITLE
Fixing user base url within public dashboard

### DIFF
--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -91,6 +91,7 @@
     <script type="text/javascript">
       var config = <%= safe_js_object frontend_config_public({https_apis: request.protocol == 'https://' }) %>;
       var account_host = '<%= CartoDB.account_host %>';
+      var base_url = '<%= @user.public_url(nil, request.protocol == "https://" ? "https" : "http") %>';
       var favMapViewAttrs = {
         el: '#<%= fav_map_target_id %>',
         <% if @most_viewed_vis_map %>


### PR DESCRIPTION
Without the base_url variable, model endpoints will not add the desired /u/:username in order to make correctly the requests.

Fixes #4903.
@matallo @juanignaciosl 