### PR TITLE
Fixes color border around export image dialog icon

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.jst.ejs
@@ -1,6 +1,6 @@
 <div class="u-inner">
   <div class="Dialog-header">
-    <div class="Dialog-headerIcon Dialog-headerIcon--main">
+    <div class="Dialog-headerIcon Dialog-headerIcon--neutral">
       <i class="iconFont iconFont-Ray"></i>
     </div>
     <p class="Dialog-headerTitle">Your image has been generated correctly</p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.34",
+  "version": "3.18.35",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The original border was too light. This PR sets the right color for the border:

![screen shot 2015-08-07 at 10 51 10](https://cloud.githubusercontent.com/assets/4933/9132229/36a8c73e-3cf2-11e5-9e12-acd7bc7da257.png)

Original issue: #4925
