### PR TITLE
Adds test to check 'Common Data' library datasets can be imported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ PENDING_SPECS = \
   spec/lib/varnish_spec.rb (#321) \
   $(NULL)
 
+WORKING_SPECS_INTEGRATIONS = \
+  spec/integrations/common_data_integration.rb \
+  $(NULL)
+
 WORKING_SPECS_1 = \
   spec/rspec_configuration.rb \
   spec/models/table_spec.rb \
@@ -204,6 +208,10 @@ check-9:
 	RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_9)
 check-carto-db-class:
 	RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_carto_db_class)
+check-integrations:
+	RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_INTEGRATIONS)	
+
+check-external: prepare-test-db check-integrations
 
 check-prepared: check-1 check-2 check-4 check-5 check-7 check-9 check-carto-db-class
 

--- a/spec/integrations/common_data_integration.rb
+++ b/spec/integrations/common_data_integration.rb
@@ -1,0 +1,35 @@
+# coding: UTF-8
+require_relative '../spec_helper'
+
+describe CommonData do
+  before(:each) do
+    @common_data = CommonData.new
+    stub_named_maps_calls
+  end
+
+  after(:all) do
+    Typhoeus::Expectation.clear
+  end
+
+  it 'should import correctly Common Data datasets' do
+    datasets = @common_data.datasets[:datasets]
+
+    user = create_user(
+      :quota_in_bytes => 1000000000, 
+      :table_quota => 10000, 
+      :private_tables_enabled => true
+      )
+    
+    datasets.each do |dataset|
+      data_import = DataImport.create(
+        :user_id => user.id,
+        :data_source => dataset["url"]
+        )
+      
+      data_import.run_import!
+      data_import.success.should(eq(true), "Dataset '#{dataset['name']}' failed to be imported")
+    end   
+
+    user.destroy 
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,10 @@ require 'rspec/rails'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join('spec/support/**/*.rb')].each {|f| require f}
 
+def stub_named_maps_calls 
+  CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+end
+
 # Inline Resque for queue handling
 Resque.inline = true
 


### PR DESCRIPTION
Fixes #4209 

Adds test to check 'Common Data' library datasets can be imported, modifies Makefile to run appropiate tests 'bundle exec make check-external' and adds method to properly stub 'named maps' calls.

cc @juanignaciosl 