### PR TITLE
Changes the "close" button for a "view image" link

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
@@ -7,7 +7,7 @@ module.exports = BaseDialog.extend({
 
   events: BaseDialog.extendEvents({
     'click .js-input': '_onInputClick',
-    'click .js-open-image': '_onOpenImage'
+    'click .js-open-image': 'close'
   }),
 
   initialize: function() {
@@ -61,9 +61,5 @@ module.exports = BaseDialog.extend({
 
   _onInputClick: function(e) {
     $(e.target).focus().select();
-  },
-
-  _onOpenImage: function(e) {
-    this.close();
   }
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
@@ -6,7 +6,8 @@ var randomQuote = require('../../view_helpers/random_quote');
 module.exports = BaseDialog.extend({
 
   events: BaseDialog.extendEvents({
-    'click .js-input': '_onInputClick'
+    'click .js-input': '_onInputClick',
+    'click .js-open-image': '_onOpenImage'
   }),
 
   initialize: function() {
@@ -62,4 +63,7 @@ module.exports = BaseDialog.extend({
     $(e.target).focus().select();
   },
 
+  _onOpenImage: function(e) {
+    this.close();
+  }
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.jst.ejs
@@ -29,8 +29,15 @@
     <% } %>
   </div>
   <div class="Dialog-footer Dialog-footer--simple">
+
+    <% if (response.type === 'url') {%>
+    <a href="<%- response.content %>" target="_blank" class="Button Button--secondary Dialog-footerBtn js-open-image">
+      <span>view image</span>
+    </a>
+    <% } else { %>
     <button class="Button Button--secondary Dialog-footerBtn cancel">
       <span>close</span>
     </button>
+    <% } %>
   </div>
 </div>

--- a/lib/assets/test/spec/cartodb/table/map/export_image_result_view.spec.js
+++ b/lib/assets/test/spec/cartodb/table/map/export_image_result_view.spec.js
@@ -1,10 +1,11 @@
 describe("export_image_result_view", function() {
   beforeEach(function() {
+    this.url = "http://www.cartodb.com";
 
     this.view = new cdb.editor.ExportImageResultView({
       clean_on_hide: true,
       enter_to_confirm: false,
-      response: { type: "url", content: "http://www.cartodb.com" }
+      response: { type: "url", content: this.url }
     });
 
     this.view.render();
@@ -17,7 +18,7 @@ describe("export_image_result_view", function() {
   it("should render", function() {
     expect(this.view.$(".js-open-image").length).toBe(1);
     expect(this.innerHTML()).toContain("Your image has been generated correctly");
-    expect(this.innerHTML()).toContain('<p class="Dialog-headerText">It\'s now available in: <a href="http://www.cartodb.com" target="_blank" class="ExportImageResult--url">http://www.cartodb.com</a></p>');
+    expect(this.innerHTML()).toContain('<p class="Dialog-headerText">It\'s now available in: <a href="http://www.cartodb.com" target="_blank" class="ExportImageResult--url">' + this.url + '</a></p>');
   });
 
   it("should close the dialog when clicking on the view image link", function() {
@@ -28,5 +29,4 @@ describe("export_image_result_view", function() {
     this.view.$(".js-open-image").click();
     expect(hidden).toBe(true);
   });
-
 });

--- a/lib/assets/test/spec/cartodb/table/map/export_image_result_view.spec.js
+++ b/lib/assets/test/spec/cartodb/table/map/export_image_result_view.spec.js
@@ -1,0 +1,32 @@
+describe("export_image_result_view", function() {
+  beforeEach(function() {
+
+    this.view = new cdb.editor.ExportImageResultView({
+      clean_on_hide: true,
+      enter_to_confirm: false,
+      response: { type: "url", content: "http://www.cartodb.com" }
+    });
+
+    this.view.render();
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  })
+
+  it("should render", function() {
+    expect(this.view.$(".js-open-image").length).toBe(1);
+    expect(this.innerHTML()).toContain("Your image has been generated correctly");
+    expect(this.innerHTML()).toContain('<p class="Dialog-headerText">It\'s now available in: <a href="http://www.cartodb.com" target="_blank" class="ExportImageResult--url">http://www.cartodb.com</a></p>');
+  });
+
+  it("should close the dialog when clicking on the view image link", function() {
+    var hidden = false;
+    this.view.bind("hide", function() {
+      hidden = true;
+    });
+    this.view.$(".js-open-image").click();
+    expect(hidden).toBe(true);
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.36",
+  "version": "3.18.37",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR changes the "close" button for a "view image" link. Clicking on the link opens the image in a new window and closes the dialog.

Original ticket: #4937