### PR TITLE
Close database connections before drop test DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,8 @@ ifdef JENKINS_URL
 	cp .rspec_ci .rspec
 endif
 	# TODO skip this if db already exists ?
+	# Clean DB connections before drop test DB
+	psql -U postgres -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='carto_db_test'"
 	MOCHA_OPTIONS=skip_integration RAILS_ENV=test bundle exec rake cartodb:test:prepare
 
 # TODO: Ongoing removal of groups, that's the reason of holes in numbering

--- a/spec/factories/visualization_creation_helpers.rb
+++ b/spec/factories/visualization_creation_helpers.rb
@@ -96,6 +96,7 @@ shared_context 'organization with users helper' do
   end
 
   after(:all) do
+    bypass_named_maps
     delete_user_data @org_user_owner if @org_user_owner
     @organization.destroy_cascade
   end
@@ -154,6 +155,7 @@ shared_context 'users helper' do
   end
 
   after(:all) do
+    bypass_named_maps
     delete_user_data @user1 if @user1
     delete_user_data @user2 if @user2
     # User destruction is handled at spec_helper

--- a/spec/lib/central_spec.rb
+++ b/spec/lib/central_spec.rb
@@ -30,6 +30,7 @@ describe Cartodb::Central do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user && @user.destroy
   end
 

--- a/spec/lib/sql_test_spec.rb
+++ b/spec/lib/sql_test_spec.rb
@@ -7,6 +7,7 @@ describe User do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -8,6 +8,7 @@ describe AccessToken do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -9,6 +9,7 @@ describe Asset do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/carto/map.rb
+++ b/spec/models/carto/map.rb
@@ -16,6 +16,7 @@ describe Carto::Map do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/carto/user_service_spec.rb
+++ b/spec/models/carto/user_service_spec.rb
@@ -17,6 +17,7 @@ describe Carto::UserService do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/carto/user_table_spec.rb
+++ b/spec/models/carto/user_table_spec.rb
@@ -13,11 +13,12 @@ describe Carto::UserTable do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     delete_user_data(@user)
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -13,11 +13,12 @@ describe Carto::Visualization do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     delete_user_data(@user)
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/data_import_regression.rb
+++ b/spec/models/data_import_regression.rb
@@ -10,6 +10,7 @@ describe DataImport do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -9,7 +9,7 @@ describe DataImport do
   end
 
   after(:all) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/geocoding_spec.rb
+++ b/spec/models/geocoding_spec.rb
@@ -5,16 +5,16 @@ describe Geocoding do
   before(:all) do
     @user  = create_user(geocoding_quota: 200, geocoding_block_price: 1500)
 
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
     @table = FactoryGirl.create(:user_table, user_id: @user.id)
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
   end
 
   after(:all) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/layer_spec.rb
+++ b/spec/models/layer_spec.rb
@@ -9,13 +9,13 @@ describe Layer do
 
   after(:all) do
     # Using Mocha stubs until we update RSpec (@see http://gofreerange.com/mocha/docs/Mocha/ClassMethods.html)
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     delete_user_data $user_1
   end
 
   before(:each) do
     User.any_instance.stubs(:enable_remote_db_user).returns(true)
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
 
     CartoDB::Overlay::Member.any_instance.stubs(:can_store).returns(true)
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -37,7 +37,7 @@ describe Organization do
   end
 
   after(:all) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     begin
       @user.destroy
     rescue

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -18,7 +18,7 @@ describe CartoDB::Permission do
   end
 
   after(:all) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/platform-limits/user_concurrent_imports_amount_spec.rb
+++ b/spec/models/platform-limits/user_concurrent_imports_amount_spec.rb
@@ -15,6 +15,7 @@ describe CartoDB::PlatformLimits::Importer::UserConcurrentImportsAmount do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/shared_entity_spec.rb
+++ b/spec/models/shared_entity_spec.rb
@@ -12,7 +12,7 @@ describe CartoDB::SharedEntity do
   end
 
   after(:all) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/synchronization/synchronization_oauth_spec.rb
+++ b/spec/models/synchronization/synchronization_oauth_spec.rb
@@ -8,6 +8,7 @@ describe SynchronizationOauth do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -44,7 +44,7 @@ describe Table do
   before(:each) do
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
 
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
 
     CartoDB::Overlay::Member.any_instance.stubs(:can_store).returns(true)
   end

--- a/spec/models/user_organization_spec.rb
+++ b/spec/models/user_organization_spec.rb
@@ -6,6 +6,7 @@ describe UserOrganization do
     include_context 'visualization creation helpers'
 
     after(:all) do
+      stub_named_maps_calls
       @organization.destroy_cascade if @organization
       @owner = User.where(id: @owner.id).first
       @owner.destroy if @owner

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,7 @@ describe User do
   end
 
   before(:all) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
 
     @user_password = 'admin123'
     puts "\n[rspec][user_spec] Creating test user databases..."
@@ -36,12 +36,13 @@ describe User do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
     User.any_instance.stubs(:enable_remote_db_user).returns(true)
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
     @user2.destroy
   end

--- a/spec/models/user_table_spec.rb
+++ b/spec/models/user_table_spec.rb
@@ -13,11 +13,12 @@ describe UserTable do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     delete_user_data(@user)
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/models/visualization/relator_spec.rb
+++ b/spec/models/visualization/relator_spec.rb
@@ -25,11 +25,12 @@ describe Visualization::Relator do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     delete_user_data(@user)
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/admin/tables_spec.rb
+++ b/spec/requests/admin/tables_spec.rb
@@ -19,7 +19,7 @@ describe Admin::TablesController do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
     @db = Rails::Sequel.connection
     delete_user_data $user_1
@@ -30,8 +30,9 @@ describe Admin::TablesController do
   end
 
   after(:all) do
-    $user_1.destroy
+    stub_named_maps_calls
     delete_user_data($user_1)
+    $user_1.destroy
   end
 
   describe 'GET /dashboard' do

--- a/spec/requests/api/geocodings_spec.rb
+++ b/spec/requests/api/geocodings_spec.rb
@@ -8,12 +8,13 @@ describe "Geocodings API" do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
     delete_user_data $user_1
     host! "#{$user_1.username}.localhost.lan"
   end
 
   after(:all) do
+    stub_named_maps_calls
     delete_user_data($user_1)
   end
 

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -9,12 +9,13 @@ describe "Imports API" do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
     delete_user_data $user_1
     host! "#{$user_1.username}.localhost.lan"
   end
 
   after(:all) do
+    stub_named_maps_calls
     delete_user_data $user_1
     $user_1.update table_quota: 500
   end

--- a/spec/requests/api/json/assets_controller_shared_examples.rb
+++ b/spec/requests/api/json/assets_controller_shared_examples.rb
@@ -10,11 +10,13 @@ shared_examples_for "assets controllers" do
     end
 
     before(:each) do
+      stub_named_maps_calls
       delete_user_data @user
       host! 'test.localhost.lan'
     end
 
     after(:all) do
+      stub_named_maps_calls
       @user.destroy
     end
 

--- a/spec/requests/api/json/columns_controller_shared_examples.rb
+++ b/spec/requests/api/json/columns_controller_shared_examples.rb
@@ -10,12 +10,13 @@ shared_examples_for "columns controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      stub_named_maps_calls
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end
 
     after(:all) do
+      stub_named_maps_calls
       @user.destroy
     end
 

--- a/spec/requests/api/json/geocodings_controller_shared_examples.rb
+++ b/spec/requests/api/json/geocodings_controller_shared_examples.rb
@@ -12,13 +12,14 @@ shared_examples_for "geocoding controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      stub_named_maps_calls
       delete_user_data @user
       host! "#{@user.username}.localhost.lan"
       login_as(@user, scope: @user.username)
     end
 
     after(:all) do
+      stub_named_maps_calls
       @user.destroy
     end
 

--- a/spec/requests/api/json/geocodings_controller_spec.rb
+++ b/spec/requests/api/json/geocodings_controller_spec.rb
@@ -19,13 +19,14 @@ describe Api::Json::GeocodingsController do
     end
 
     after(:all) do
+      stub_named_maps_calls
       @user.destroy
     end
 
     let(:params) { { api_key: @user.api_key, kind: 'ipaddress', formatter: '{some_column}' } }
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      stub_named_maps_calls
       delete_user_data @user
       host! "#{@user.username}.localhost.lan"
       login_as(@user, scope: @user.username)

--- a/spec/requests/api/json/maps_controller_shared_examples.rb
+++ b/spec/requests/api/json/maps_controller_shared_examples.rb
@@ -15,12 +15,13 @@ shared_examples_for "maps controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      stub_named_maps_calls
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end
 
     after(:all) do
+      stub_named_maps_calls
       @user.destroy
     end
 

--- a/spec/requests/api/json/records_controller_shared_examples.rb
+++ b/spec/requests/api/json/records_controller_shared_examples.rb
@@ -16,12 +16,13 @@ shared_examples_for "records controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      stub_named_maps_calls
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end
 
     after(:all) do
+      stub_named_maps_calls
       @user.destroy
     end
 

--- a/spec/requests/api/json/synchronizations_controller_shared_examples.rb
+++ b/spec/requests/api/json/synchronizations_controller_shared_examples.rb
@@ -24,6 +24,7 @@ shared_examples_for 'synchronization controllers' do
 
     CartoDB::Synchronization.repository  = DataRepository::Backend::Sequel.new(@db, :synchronizations)
 
+    stub_named_maps_calls
     delete_user_data @user
     @headers = {
       'CONTENT_TYPE'  => 'application/json',
@@ -32,6 +33,7 @@ shared_examples_for 'synchronization controllers' do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/api/json/tables_controller_shared_examples.rb
+++ b/spec/requests/api/json/tables_controller_shared_examples.rb
@@ -10,11 +10,12 @@ shared_examples_for "tables controllers" do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      stub_named_maps_calls
       delete_user_data $user_1
     end
 
     after(:all) do
+      stub_named_maps_calls
       delete_user_data $user_1
     end
 

--- a/spec/requests/api/json/visualizations_controller_spec.rb
+++ b/spec/requests/api/json/visualizations_controller_spec.rb
@@ -17,17 +17,19 @@ describe Api::Json::VisualizationsController do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 
   # let(:params) { { api_key: @user.api_key } }
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+    stub_named_maps_calls
     host! "#{@user.username}.localhost.lan"
   end
 
   after(:each) do
+    stub_named_maps_calls
     delete_user_data @user
   end
 

--- a/spec/requests/api/map_layers_spec.rb
+++ b/spec/requests/api/map_layers_spec.rb
@@ -9,8 +9,7 @@ feature "API 1.0 map layers management" do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
-    
+    stub_named_maps_calls
     delete_user_data @user
     host! 'test.localhost.lan'
     @table = create_table(user_id: @user.id)
@@ -19,6 +18,7 @@ feature "API 1.0 map layers management" do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/api/maps_spec.rb
+++ b/spec/requests/api/maps_spec.rb
@@ -9,10 +9,12 @@ feature  "API 1.0 maps management" do
   end
 
   before(:each) do
+    stub_named_maps_calls
     delete_user_data @user
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/api/permissions_controller_spec.rb
+++ b/spec/requests/api/permissions_controller_spec.rb
@@ -39,6 +39,7 @@ describe Api::Json::PermissionsController do
   end
 
   before(:each) do
+    stub_named_maps_calls
     delete_user_data @user
     delete_user_data @user2
     delete_user_data @user3
@@ -55,6 +56,7 @@ describe Api::Json::PermissionsController do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
     @user2.destroy
     @user3.destroy

--- a/spec/requests/api/queries_spec.rb
+++ b/spec/requests/api/queries_spec.rb
@@ -8,11 +8,13 @@ feature "API 1.0 queries management" do
   end
 
   before(:each) do
+    stub_named_maps_calls
     delete_user_data @user
     @table = create_table :user_id => @user.id
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/api/synchronizations_spec.rb
+++ b/spec/requests/api/synchronizations_spec.rb
@@ -34,6 +34,7 @@ describe Api::Json::SynchronizationsController do
 
     CartoDB::Synchronization.repository  = DataRepository::Backend::Sequel.new(@db, :synchronizations)
 
+    stub_named_maps_calls
     delete_user_data @user
     @headers = {
       'CONTENT_TYPE'  => 'application/json',
@@ -42,6 +43,7 @@ describe Api::Json::SynchronizationsController do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/api/user_layers_spec.rb
+++ b/spec/requests/api/user_layers_spec.rb
@@ -9,14 +9,14 @@ feature "API 1.0 user layers management" do
   end
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
-
+    stub_named_maps_calls
     delete_user_data @user
     host! 'test.localhost.lan'
     @table = create_table(:user_id => @user.id)
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -9,6 +9,7 @@ feature "API 1.0 users management" do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/api/visualizations_spec.rb
+++ b/spec/requests/api/visualizations_spec.rb
@@ -35,6 +35,7 @@ describe Api::Json::VisualizationsController do
 
   before(:each) do
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
+    stub_named_maps_calls
     @db = Rails::Sequel.connection
     Sequel.extension(:pagination)
 
@@ -55,6 +56,7 @@ describe Api::Json::VisualizationsController do
   end
 
   after(:all) do
+    stub_named_maps_calls
     @user.destroy
   end
 

--- a/spec/requests/carto/api/imports_controller_spec.rb
+++ b/spec/requests/carto/api/imports_controller_spec.rb
@@ -11,12 +11,13 @@ describe Carto::Api::ImportsController do
   @headers = { 'CONTENT_TYPE'  => 'application/json' }
 
   before(:each) do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    stub_named_maps_calls
     delete_user_data $user_1
     host! "#{$user_1.username}.localhost.lan"
   end
 
   after(:all) do
+    stub_named_maps_calls
     Resque.inline = false
     delete_user_data $user_1
   end

--- a/spec/requests/carto/api/layers_controller_spec.rb
+++ b/spec/requests/carto/api/layers_controller_spec.rb
@@ -135,12 +135,13 @@ describe Carto::Api::LayersController do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      stub_named_maps_calls
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end
 
     after(:all) do
+      stub_named_maps_calls
       @user.destroy
     end
 

--- a/spec/requests/carto/api/organizations_controller_spec.rb
+++ b/spec/requests/carto/api/organizations_controller_spec.rb
@@ -23,8 +23,9 @@ describe Carto::Api::OrganizationsController do
     end
 
     after(:all) do
-     delete_user_data(@org_user_3)
-     @org_user_3.destroy
+      stub_named_maps_calls
+      delete_user_data(@org_user_3)
+      @org_user_3.destroy
     end
 
     before(:each) do
@@ -41,7 +42,7 @@ describe Carto::Api::OrganizationsController do
       get api_v1_organization_users_url(id: @organization.id, api_key: @org_user_1.api_key), @headers
       last_response.status.should == 200
       json_body = JSON.parse(last_response.body)
-      ids = json_body['users'].map { |u| u['id'] } 
+      ids = json_body['users'].map { |u| u['id'] }
       ids[0].should == @org_user_1.id
       ids[1].should == @org_user_2.id
       ids[2].should == @org_user_3.id

--- a/spec/requests/carto/api/overlays_controller_spec.rb
+++ b/spec/requests/carto/api/overlays_controller_spec.rb
@@ -24,12 +24,13 @@ describe Carto::Api::OverlaysController do
     end
 
     before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+      stub_named_maps_calls
       delete_user_data @user
       @table = create_table :user_id => @user.id
     end
 
     after(:all) do
+      stub_named_maps_calls
       @user.destroy
     end
 

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -123,6 +123,8 @@ module CartoDB
       user.assets_dataset.destroy
       user.data_imports_dataset.destroy
       user.geocodings_dataset.destroy
+      user.delete_external_data_imports
+      user.delete_external_sources
       CartoDB::Visualization::Collection.new.fetch(user_id: user.id).each { |v|
         # INFO: no need for explicit children deletion, parent will delete it
         v.delete unless v.parent_id


### PR DESCRIPTION
We have some leaks in the test database that makes jekins been stuck trying to drop the test database

Trace
```
15:50:05 dropdb: database removal failed: ERROR:  database "carto_db_test" is being accessed by other users
15:50:05 DETAIL:  There are 6 other sessions using the database.
15:50:05 [sequel] Dropped database 'carto_db_test'
15:50:06 createdb: database creation failed: ERROR:  database "carto_db_test" already exists
15:50:06 [sequel] Created database 'carto_db_test'
```