### PR TITLE
Removes unsupported file extension and unclickable link

### DIFF
--- a/lib/assets/javascripts/cartodb/common/mamufas_import/mamufas_import_dialog.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/mamufas_import/mamufas_import_dialog.jst.ejs
@@ -13,6 +13,6 @@
 <div class="Dialog-footer Dialog-footer--expanded MamufasDialog-footer">
   <p class="MamufasDialog-footerInfo">
     <i class="iconFont iconFont-Info MamufasDialog-footerInfoIcon"></i>
-    Files like docx, csv, gpx, xls and <a href="http://developers.cartodb.com/documentation/using-cartodb.html#formats_accepted">many more</a> are supported
+    Files like CSV, GPX, XLS and many more are supported
   </p>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.39",
+  "version": "3.18.40",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR removes the .docx extension from the list of supported file formats in the drag and drop pane and a link to the docs that can't be clicked.

Before:

![one](https://cloud.githubusercontent.com/assets/4933/9199344/30a9bd40-4042-11e5-8214-4bcfc6658bed.png)

After:

![screen shot 2015-08-11 at 16 01 59](https://cloud.githubusercontent.com/assets/4933/9199362/4776d882-4042-11e5-8c06-3e9e19021783.png)

Review: @josecruz (@saleiva)

Original ticket: https://github.com/CartoDB/cartodb/issues/4482

