### PR TITLE
Fixes bottom margin of the torque torque slider

### DIFF
--- a/app/assets/stylesheets/public_map/public_map.css.scss
+++ b/app/assets/stylesheets/public_map/public_map.css.scss
@@ -261,6 +261,11 @@
   position: relative;
   top: -2px;
 }
+
+div.cartodb-timeslider {
+  margin-bottom: 0;
+}
+
 @media (min-width: $sMedia-desktop +1) {
   .PublicMap-metaList.PublicMap-metaList--mobile {
     display: inline-block !important;


### PR DESCRIPTION
This PR fixes the extra bottom margin of the torque slider in the public map pages:

Before:

![screen shot 2015-08-11 at 17 28 04](https://cloud.githubusercontent.com/assets/4933/9201626/4bbbd7c4-404e-11e5-8a2e-2663992571c1.png)

After:

![screen shot 2015-08-11 at 17 25 21](https://cloud.githubusercontent.com/assets/4933/9201544/eb0277d0-404d-11e5-97c7-a4936250a6e5.png)

Original issue: #4889 

Have a look, @matallo. I'm not sure if I placed the CSS in a convenient place. 