### PR TITLE
Link Synchronization to Visualizations by vis.id

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ cd lib/sql; sudo make all install
 * Properly and fully disallowing multilogins, by killing other existing sessions upon login
 * Added new Platform Limit for concurrent syncs per user. Currently 2 hours TTL, 3 syncs per user max. allowed
 * Importer now tries to import shapefile zips without .prj file, by setting 4326 projection.
+* Synchronizations model now has a new field (and FK) to visualizations.id and joins to them using that instead of by matching name to canonical visualization's table name. It also gets deleted if FK dissapears.
 
 Bugfixes:
 * Fixed deletion of layers upon disconnecting synced datasources [#3718](https://github.com/CartoDB/cartodb/pull/3718)

--- a/app/controllers/carto/api/synchronization_presenter.rb
+++ b/app/controllers/carto/api/synchronization_presenter.rb
@@ -32,7 +32,8 @@ module Carto
           etag:             @synchronization.etag,
           log_id:           @synchronization.log_id,
           quoted_fields_guessing: @synchronization.quoted_fields_guessing,
-          type_guessing:    @synchronization.type_guessing
+          type_guessing:    @synchronization.type_guessing,
+          visualization_id: @synchronization.visualization_id
         }
       end
 

--- a/app/models/carto/synchronization.rb
+++ b/app/models/carto/synchronization.rb
@@ -1,8 +1,9 @@
 require 'active_record'
 
 class Carto::Synchronization < ActiveRecord::Base
-  
+
   belongs_to :user
+  belongs_to :visualization, class_name: Carto::Visualization
 
   STATE_CREATED   = 'created'
   # Already at resque, waiting for slot

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -663,13 +663,18 @@ class DataImport < Sequel::Model
       synchronization.log_id  = log.id
 
       if importer.success?
+        imported_table = ::Table.get_by_table_id(self.table_id)
+        if !imported_table.nil? && imported_table.table_visualization
+          synchronization.visualization_id = imported_table.table_visualization.id
+        end
+
         synchronization.state = 'success'
         synchronization.error_code = nil
         synchronization.error_message = nil
       else
         synchronization.state = 'failure'
         synchronization.error_code = error_code
-        synchronization.error_message = get_error_text
+        synchronization.error_message = get_error_text[:title] + ' ' + get_error_text[:what_about]
       end
       log.append "importer.success? #{synchronization.state}"
       synchronization.store
@@ -788,7 +793,7 @@ class DataImport < Sequel::Model
     payload.merge!(
       file_url_hostname: URI.parse(public_url).hostname
     ) if public_url rescue nil
-    payload.merge!(error_title: get_error_text) if state == STATE_FAILURE
+    payload.merge!(error_title: get_error_text[:title]) if state == STATE_FAILURE
     payload
   end
 

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -59,6 +59,7 @@ module CartoDB
       attribute :type_guessing,           Boolean, default: true
       attribute :quoted_fields_guessing,  Boolean, default: true
       attribute :content_guessing,        Boolean, default: false
+      attribute :visualization_id,        String
 
       def initialize(attributes={}, repository=Synchronization.repository)
         super(attributes)
@@ -88,7 +89,7 @@ module CartoDB
         "service_name:\"#{@service_name}\" service_item_id:\"#{@service_item_id}\" checksum:\"#{@checksum}\" " \
         "url:\"#{@url}\" error_code:\"#{@error_code}\" error_message:\"#{@error_message}\" modified_at:\"#{@modified_at}\" " \
         " user_id:\"#{@user_id}\" type_guessing:\"#{@type_guessing}\" " \
-        "quoted_fields_guessing:\"#{@quoted_fields_guessing}\">"
+        "quoted_fields_guessing:\"#{@quoted_fields_guessing}\" visualization_id:\"#{@visualization_id}\">"
       end
 
       def synchronizations_logger
@@ -250,8 +251,8 @@ module CartoDB
         notify
         self
       ensure
-        CartoDB::PlatformLimits::Importer::UserConcurrentSyncsAmount.new({ 
-              user: user, redis: { db: $users_metadata } 
+        CartoDB::PlatformLimits::Importer::UserConcurrentSyncsAmount.new({
+              user: user, redis: { db: $users_metadata }
             }).decrement!
       end
 
@@ -416,6 +417,12 @@ module CartoDB
           @table = ::Table.new(name: name, user_id: user.id)
         end
         @table
+      end
+
+      def visualization
+        @visualization ||= CartoDB::Visualization::Member.new(id: @visualization_id).fetch
+      rescue KeyErrror
+        @visualization = nil
       end
 
       def authorize?(user)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -155,7 +155,7 @@ class Table
                 # Handy for rakes and custom ghost table registers, won't delete user table in case of error
                 :keep_user_database_table
 
-  # Getter by table uuid or table name using canonical visualizations
+  # Getter by table uuid osing canonical visualizations
   # @param table_id String
   # @param viewer_user User
   def self.get_by_id(table_id, viewer_user)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -174,6 +174,13 @@ class Table
     table
   end
 
+  # Getter by table uuid using canonical visualizations. No privacy checks
+  # @param table_id String
+  def self.get_by_table_id(table_id)
+    table_temp = UserTable.where(id: table_id).first
+    table_temp.service unless table_temp.nil?
+  end
+
   # Get a list of tables given an array with the names
   # (can be fully qualified).
   # it also needs the user used to search a table when the

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -155,7 +155,7 @@ class Table
                 # Handy for rakes and custom ghost table registers, won't delete user table in case of error
                 :keep_user_database_table
 
-  # Getter by table uuid osing canonical visualizations
+  # Getter by table uuid using canonical visualizations
   # @param table_id String
   # @param viewer_user User
   def self.get_by_id(table_id, viewer_user)

--- a/db/migrate/20150812120815_add_visualization_id_to_synchronizations.rb
+++ b/db/migrate/20150812120815_add_visualization_id_to_synchronizations.rb
@@ -1,0 +1,21 @@
+Sequel.migration do
+  up do
+    alter_table :synchronizations do
+      add_column :visualization_id, 'uuid'
+    end
+
+    Rails::Sequel.connection.run(%Q{
+      ALTER TABLE "synchronizations"
+        ADD CONSTRAINT  visualization_id_fkey
+        FOREIGN KEY (visualization_id)
+        REFERENCES visualizations(id)
+        ON DELETE CASCADE
+    })
+  end
+
+  down do
+    alter_table :synchronizations do
+      drop_column :visualization_id
+    end
+  end
+end

--- a/lib/tasks/sync_tables.rake
+++ b/lib/tasks/sync_tables.rake
@@ -18,7 +18,7 @@ namespace :cartodb do
 
 
   desc 'Adds visualization_id to every Synchronization'
-  task :populate_visualization_ids => [:environment] do |task, args|
+  task :populate_synchronization_visualization_ids => [:environment] do |task, args|
     require_relative '../../services/synchronizer/lib/synchronizer/collection'
     collection = CartoDB::Synchronizer::Collection.new
 

--- a/lib/tasks/sync_tables.rake
+++ b/lib/tasks/sync_tables.rake
@@ -1,19 +1,62 @@
 # encoding: utf-8
 
-# This rake retrieves all sync tables that should get synchronized, and puts the synchronization tasks at Resque
-# NOTE: This version does not mark the tables as "enqueued", should be done if planning to run multiple instances
 namespace :cartodb do
+  # This rake retrieves all sync tables that should get synchronized, and puts the synchronization tasks at Resque
+  # NOTE: This version does not mark the tables as "enqueued", should be done if planning to run multiple instances
   desc 'Runs the sync tables process'
   task :sync_tables, [:force_all_arg] => [:environment] do |task, args|
     puts '> Sync tables started' if ENV['VERBOSE']
 
     require_relative '../../services/synchronizer/lib/synchronizer/collection'
-
     collection = CartoDB::Synchronizer::Collection.new
 
     # This fetches and enqueues
     collection.fetch_and_enqueue(args[:force_all_arg].present? ? args[:force_all_arg] : false)
 
     puts '> Sync tables finished' if ENV['VERBOSE']
+  end
+
+
+  desc 'Adds visualization_id to every Synchronization'
+  task :populate_visualization_ids => [:environment] do |task, args|
+    require_relative '../../services/synchronizer/lib/synchronizer/collection'
+    collection = CartoDB::Synchronizer::Collection.new
+
+    collection.fetch_all.each { |record|
+      begin
+        synchronization = CartoDB::Synchronization::Member.new(id: record[:id]).fetch
+      rescue KeyError
+        synchronization = nil
+      end
+      if synchronization
+        begin
+          table = UserTable.where({
+              name: synchronization.name,
+              user_id: synchronization.user_id
+            }).first.service
+        rescue => exception
+          table = nil
+          puts "\nSync id '#{record[:id]}' errored: #{exception.inspect}"
+        end
+        unless table.nil?
+          if synchronization.visualization_id.nil?
+            synchronization.visualization_id = table.table_visualization.id
+            begin
+              synchronization.store
+              printf '.'
+            rescue => exception
+              puts "\nSync id '#{record[:id]}' errored: #{exception.inspect}"
+            end
+          else
+            printf 'S'
+          end
+      end
+      else
+        puts "\nSync id '#{record[:id]}' errored: missing synchronization entry"
+      end
+    }
+
+
+
   end
 end

--- a/services/synchronizer/lib/synchronizer/collection.rb
+++ b/services/synchronizer/lib/synchronizer/collection.rb
@@ -34,6 +34,12 @@ module CartoDB
         print_log 'Pass finished'
       end
 
+      def fetch_all
+        query = db.fetch(%Q(
+            SELECT id FROM #{relation}
+          ))
+      end
+
       # Fetches and enqueues all syncs that should run
       # @param force_all_syncs bool
       def fetch_and_enqueue(force_all_syncs=false)
@@ -96,8 +102,8 @@ module CartoDB
           user = Carto::User.where(id: record[:user_id]).first
           next if user.nil?
 
-          platform_limit = CartoDB::PlatformLimits::Importer::UserConcurrentSyncsAmount.new({ 
-              user: user, redis: { db: $users_metadata } 
+          platform_limit = CartoDB::PlatformLimits::Importer::UserConcurrentSyncsAmount.new({
+              user: user, redis: { db: $users_metadata }
             })
           if platform_limit.is_within_limit?
             enqueue_record(record)


### PR DESCRIPTION
Relates to https://github.com/CartoDB/cartodb/issues/4996

After running manually the rake and all existing (and new) syncs have a visualization.id we can think about deprecating the visualization <- table_name -> synchronization link