### PR TITLE
Log the invalidation time in postgresql

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1939,8 +1939,17 @@ TRIGGER
         retry = #{varnish_retry}
         trigger_verbose = #{varnish_trigger_verbose}
 
-        import httplib
-        import time
+        if 'httplib' not in GD:
+          import httplib
+          GD['httplib'] = httplib
+        else:  
+          httplib = GD['httplib']
+        
+        if 'time' not in GD:
+          import time
+          GD['time'] = time
+        else:  
+          time = GD['time']
 
         start = time.time()
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1940,6 +1940,9 @@ TRIGGER
         trigger_verbose = #{varnish_trigger_verbose}
 
         import httplib
+        import time
+
+        start = time.time()
 
         while True:
 
@@ -1964,6 +1967,12 @@ TRIGGER
                 plpy.error('Varnish purge error: ' +  str(err))
               break
             retry -= 1 # try reconnecting
+
+        end = time.time()
+        log_error_verbosity = plpy.execute("SHOW log_error_verbosity")[0]["log_error_verbosity"]
+        plpy.execute("SET log_error_verbosity=TERSE")
+        plpy.log("Invalidation: %f" % (end - start))
+        plpy.execute("SET log_error_verbosity=%s" % log_error_verbosity)
     $$
     LANGUAGE 'plpythonu' VOLATILE;
     REVOKE ALL ON FUNCTION public.cdb_invalidate_varnish(TEXT) FROM PUBLIC;


### PR DESCRIPTION
This allows writing to postgresql log the time to run the invalidation against varnish.

Using log raise level with plpy is the more appropiate since LOG level is much lower in log_min_messages (http://www.postgresql.org/docs/9.3/static/runtime-config-logging.html#GUC-LOG-MIN-MESSAGES) than in client_min_messages (http://www.postgresql.org/docs/9.3/static/runtime-config-logging.html#GUC-CLIENT-MIN-MESSAGES).
With a proper logging configuration the invalidation time should not bother in the client responses but it will appear in the postgresql log.

By default when a RAISE is executed, the context of the execution is shown in the log. Getting the value before the raise and setting it after does the trick.

/cc @rochoa @javisantana @pramsey 