### PR TITLE
Don't launch Pecan if the table is not georeferenced

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_card.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_card.js
@@ -67,45 +67,6 @@ module.exports = cdb.core.View.extend({
     this.trigger("click", this.model, this);
   },
 
-  _generateLayerDefinition: function(type, sql, css) {
-    var template = this.options.urlTemplate;
-    var apiKey  = this.options.api_key;
-    var mapsApiTemplate = cdb.config.get('maps_api_template');
-
-    var layerDefinition = {
-      user_name: user_data.username,
-      maps_api_template: mapsApiTemplate,
-      api_key: apiKey,
-      layers: [{
-        type: "http",
-        options: {
-          urlTemplate: template,
-          subdomains: [ "a", "b", "c" ]
-        }
-      }, {
-        type: "cartodb",
-        options: {
-          sql: sql,
-          cartocss: css,
-          cartocss_version: "2.1.1"
-        }
-      }]
-    };
-
-    if (type === "torque"){
-      layerDefinition.layers[1] = {
-        type: "torque",
-        options: {
-          sql: sql,
-          cartocss: css,
-          cartocss_version: "2.1.1"
-        }
-      }
-    }
-
-    return layerDefinition;
-  },
-
   _addHistogram: function() {
 
     var self = this;

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_view.js
@@ -30,6 +30,8 @@ module.exports = cdb.core.View.extend({
 
   _check: function() {
 
+    var isGeoreferenced = this.options.table.isGeoreferenced();
+
     var tableData     = this.options.table.data();
     var geometryTypes = tableData.table && tableData.table.get("geometry_types");
     var hasGeometries = geometryTypes && geometryTypes.length > 0 ? true : false;
@@ -40,7 +42,7 @@ module.exports = cdb.core.View.extend({
     var col_count = _(this.query_schema).size();
     var hasColumns = col_count > 0 && col_count < this._MAX_COLS;
 
-    if (hasGeometries && hasRows && hasColumns) {
+    if (isGeoreferenced && hasGeometries && hasRows && hasColumns) {
       return true;
     } else {
       return false;

--- a/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/pecan/pecan_view.js
@@ -42,11 +42,7 @@ module.exports = cdb.core.View.extend({
     var col_count = _(this.query_schema).size();
     var hasColumns = col_count > 0 && col_count < this._MAX_COLS;
 
-    if (isGeoreferenced && hasGeometries && hasRows && hasColumns) {
-      return true;
-    } else {
-      return false;
-    }
+    return isGeoreferenced && hasGeometries && hasRows && hasColumns;
   },
 
   _initModels: function() {

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
@@ -9,6 +9,12 @@ describe("PecanView", function() {
   function stubTable(table, opts) {
     var fakeData = sinon.stub(table, 'data');
 
+    var isGeoreferenced = sinon.stub(table, "isGeoreferenced");
+
+    isGeoreferenced.return(function() {
+      return (!opts || opts.isGeoreferenced === undefined) ? true : opts.isGeoreferenced
+    });
+
     var query_schema = (opts && opts.query_schema) ? opts.query_schema : {
       cartodb_id: "number",
       the_geom: "geometry",
@@ -75,6 +81,17 @@ describe("PecanView", function() {
       });
 
       expect(view.backgroundPollingModel.addAnalysis).toHaveBeenCalled();
+    });
+
+    it("should not create an analysis if the table is not georeferenced", function() {
+      stubTable(this.table, { row_count: 100, isGeoreferenced: false });
+
+      var view = new PecanView({
+        table: this.table,
+        backgroundPollingModel: this.backgroundPollingModel
+      });
+
+      expect(view.backgroundPollingModel.addAnalysis).not.toHaveBeenCalled();
     });
 
     it("should not create an analysis if the numer of rows is > _MAX_ROWS", function() {

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
@@ -11,9 +11,7 @@ describe("PecanView", function() {
 
     var isGeoreferenced = sinon.stub(table, "isGeoreferenced");
 
-    isGeoreferenced.returns(function() {
-      return (!opts || (opts && opts.isGeoreferenced === undefined)) ? true : opts.isGeoreferenced
-    });
+    isGeoreferenced.returns(!opts || (opts && opts.isGeoreferenced === undefined) ? true : opts.isGeoreferenced);
 
     var query_schema = (opts && opts.query_schema) ? opts.query_schema : {
       cartodb_id: "number",

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
@@ -12,7 +12,7 @@ describe("PecanView", function() {
     var isGeoreferenced = sinon.stub(table, "isGeoreferenced");
 
     isGeoreferenced.return(function() {
-      return (!opts || opts.isGeoreferenced === undefined) ? true : opts.isGeoreferenced
+      return (!opts || opts && opts.isGeoreferenced === undefined) ? true : opts.isGeoreferenced
     });
 
     var query_schema = (opts && opts.query_schema) ? opts.query_schema : {

--- a/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/pecan_view.spec.js
@@ -11,8 +11,8 @@ describe("PecanView", function() {
 
     var isGeoreferenced = sinon.stub(table, "isGeoreferenced");
 
-    isGeoreferenced.return(function() {
-      return (!opts || opts && opts.isGeoreferenced === undefined) ? true : opts.isGeoreferenced
+    isGeoreferenced.returns(function() {
+      return (!opts || (opts && opts.isGeoreferenced === undefined)) ? true : opts.isGeoreferenced
     });
 
     var query_schema = (opts && opts.query_schema) ? opts.query_schema : {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.40",
+  "version": "3.18.41",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a new check in Pecan to disable the analysis if the table is not georeferenced.

Original ticket: #5005