### PR TITLE
Rake task to update canonical visualizations with metadata from external

### DIFF
--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -21,6 +21,7 @@ module Carto
         poro = {
           id: @visualization.id,
           name: @visualization.name,
+          display_name: @visualization.display_name,
           map_id: @visualization.map_id,
           active_layer_id: @visualization.active_layer_id,
           type: @visualization.type,

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -58,6 +58,7 @@ module CartoDB
       # app/models/visualization/presenter.rb
       attribute :id,                  String
       attribute :name,                String
+      attribute :display_name,        String
       attribute :map_id,              String
       attribute :active_layer_id,     String
       attribute :type,                String

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -105,6 +105,7 @@ module CartoDB
       def self.remote_member(name, user_id, privacy, description, tags, license, source, attributions)
         Member.new({
           name: name,
+          display_name: display_name,
           user_id: user_id,
           privacy: privacy,
           description: description,
@@ -120,6 +121,10 @@ module CartoDB
         if self.privacy != privacy
           changed = true
           self.privacy = privacy
+        end
+        if self.display_name != display_name
+          changed = true
+          self.display_name = display_name
         end
         if self.description != description
           changed = true

--- a/app/models/visualization/migrator.rb
+++ b/app/models/visualization/migrator.rb
@@ -14,6 +14,7 @@ module CartoDB
         @db.create_table(relation.to_sym) do
           UUID      :id, primary_key: true
           String    :name
+          String    :display_name
           String    :description
           UUID      :map_id, index: true
           String    :active_layer_id

--- a/app/models/visualization/presenter.rb
+++ b/app/models/visualization/presenter.rb
@@ -22,6 +22,7 @@ module CartoDB
         poro = {
           id: visualization.id,
           name: visualization.name,
+          display_name: visualization.display_name,
           map_id: visualization.map_id,
           active_layer_id: visualization.active_layer_id,
           type: visualization.type,
@@ -58,6 +59,7 @@ module CartoDB
         {
           id:               visualization.id,
           name:             visualization.name,
+          display_name:     visualization.display_name,
           type:             visualization.type,
           tags:             visualization.tags,
           description:      visualization.description,

--- a/db/migrate/20150814133226_add_visualizations_display_name.rb
+++ b/db/migrate/20150814133226_add_visualizations_display_name.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table :visualizations do
+      add_column :display_name, :text
+    end
+  end
+
+  down do
+    alter_table :visualizations do
+      drop_column :display_name
+    end
+  end
+end

--- a/lib/tasks/migrate_metadataset_to_visualizations.rake
+++ b/lib/tasks/migrate_metadataset_to_visualizations.rake
@@ -1,0 +1,62 @@
+require 'uri'
+require_relative '../../app/models/common_data'
+
+namespace :cartodb do
+  namespace :db do
+    desc "Populate license, source and tags fields using data from external_sources to their original imports for the common-data user"
+    task :migrate_external_sources, [:user_id, :simulation] => :environment do |t, args|
+      # We user external_sources because remote visualization don't have map or user_tables rows
+      if args[:user_id].nil?
+        puts "Use: rake cartodb:db:migrate_external_sources['user_id'[,true]]. User id should be the id for the common-data user"
+        exit 1
+      end
+      common_datasets = get_datasets
+      tabnames = common_datasets.keys.map{ |k| %Q['#{k}'] }.join(',')
+      canonical_vis_sql = %Q[select v.id, v.name
+                              FROM maps m
+                              INNER JOIN visualizations v ON v.map_id = m.id
+                              WHERE v.user_id = '#{args[:user_id]}'
+                              AND v.type = 'table'
+                              AND v.name IN (#{tabnames})]
+      canonical_vis = Rails::Sequel.connection.fetch(canonical_vis_sql).all
+      puts "Number of visualizations to update: #{canonical_vis.length}"
+      rows_updated = 0
+      error_rows = []
+      canonical_vis.each do |vis_data|
+        data = common_datasets[vis_data[:name]]
+        begin
+          vis = CartoDB::Visualization::Member.new(id: vis_data[:id]).fetch
+          if args[:simulation]
+            puts '[DATA]-----------------'
+            puts data
+            puts '[TABLE]----------------'
+            puts CartoDB::Visualization::Presenter.new(vis).to_poro
+            puts '------------------------------------------------------'
+          else
+            vis.license = data[:license]
+            vis.source = data[:source]
+            vis.tags = data[:tags]
+            vis.display_name = data[:name]
+            vis.description = data[:description]
+            vis.store
+            rows_updated += 1
+          end
+        rescue Exception => e
+          CartoDB.notify_exception(e)
+          error_rows << vis_data[:id]
+        end
+      end
+      puts "Successfully updated rows: #{rows_updated}"
+      puts "There were errors in the following rows: #{error_rows}" if !error_rows.empty?
+    end
+  end
+end
+
+def get_datasets
+  common_datasets = CommonData.new.datasets
+  datasets = {}
+  common_datasets[:datasets].each do |dataset| 
+    datasets[dataset["tabname"]] = dataset.deep_symbolize_keys
+  end
+  datasets
+end

--- a/lib/tasks/migrate_metadataset_to_visualizations.rake
+++ b/lib/tasks/migrate_metadataset_to_visualizations.rake
@@ -7,7 +7,11 @@ namespace :cartodb do
     task :migrate_external_sources, [:user_id, :simulation] => :environment do |t, args|
       # We user external_sources because remote visualization don't have map or user_tables rows
       if args[:user_id].nil?
-        puts "Use: rake cartodb:db:migrate_external_sources['user_id'[,true]]. User id should be the id for the common-data user"
+        puts %Q[
+          Usage: rake cartodb:db:migrate_external_sources['user_id'[,simulation?]]
+            ie migration without simulation: rake cartodb:db:migrate_external_sources['beacfd17-418e-4e71-b307-95b5c96105dc', false]
+            ie migration with simulation: rake cartodb:db:migrate_external_sources['beacfd17-418e-4e71-b307-95b5c96105dc', true]
+        ]
         exit 1
       end
       common_datasets = get_datasets
@@ -33,6 +37,7 @@ namespace :cartodb do
             puts CartoDB::Visualization::Presenter.new(vis).to_poro
             puts '------------------------------------------------------'
           else
+            puts %Q[Visualization data: Id #{vis.id}, name #{vis.name}]
             vis.license = data[:license]
             vis.source = data[:source]
             vis.tags = data[:tags]

--- a/services/data-repository/spec/unit/backend/sequel_spec.rb
+++ b/services/data-repository/spec/unit/backend/sequel_spec.rb
@@ -10,6 +10,7 @@ describe DataRepository::Backend::Sequel do
     db.create_table :visualizations do
       UUID      :id, primary_key: true
       String    :name
+      String    :display_name
       String    :title
       String    :description
       String    :license

--- a/spec/models/visualization/presenter_spec.rb
+++ b/spec/models/visualization/presenter_spec.rb
@@ -68,6 +68,7 @@ describe Visualization::Member do
       vis_mock = mock
       vis_mock.stubs(:id).returns(UUIDTools::UUID.timestamp_create.to_s)
       vis_mock.stubs(:name).returns('vis1')
+      vis_mock.stubs(:display_name).returns('vis1')
       vis_mock.stubs(:map_id).returns(UUIDTools::UUID.timestamp_create.to_s)
       vis_mock.stubs(:active_layer_id).returns(1)
       vis_mock.stubs(:type).returns(Visualization::Member::TYPE_CANONICAL)
@@ -100,6 +101,7 @@ describe Visualization::Member do
 
       data[:id].present?.should eq true
       data[:name].present?.should eq true
+      data[:display_name].present?.should eq true
       data[:map_id].present?.should eq true
       data[:active_layer_id].present?.should eq true
       data[:type].present?.should eq true

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -108,6 +108,7 @@ module HelperMethods
     random = UUIDTools::UUID.timestamp_create.to_s
     {
       name:               attributes.fetch(:name, "name #{random}"),
+      display_name:       attributes.fetch(:display_name, "display name #{random}"),
       description:        attributes.fetch(:description, "description #{random}"),
       privacy:            attributes.fetch(:privacy, Visualization::Member::PRIVACY_PUBLIC),
       tags:               attributes.fetch(:tags, ['tag 1']),


### PR DESCRIPTION
This is the first part of the migration from `meta_dataset` table to use `visualizations`. 

This rake task will take `license`, `source` and `tags` fields from `external_sources` and remote `visualizations` and will update the visualizations of the `common-data` user.

We have a simulation flag to only check what will be the visualizations to be updated