### PR TITLE
Bump version of EmbedRedisCache to invalidate embeds

### DIFF
--- a/app/helpers/embed_redis_cache.rb
+++ b/app/helpers/embed_redis_cache.rb
@@ -3,7 +3,7 @@
 class EmbedRedisCache
 
   # This needs to be changed whenever there're changes in the code that require invalidation of old keys
-  VERSION = '2'
+  VERSION = '3'
 
 
   def initialize(redis_cache = $tables_metadata)


### PR DESCRIPTION
I just updated cartodb.js in the editor and bumped the version of assets, and I need cached embeds to pickup them up.

@rafatower: looks good to you? thanks!