### PR TITLE
Public dataset fixes

### DIFF
--- a/app/assets/stylesheets/common/header/breadcrumbs_dropdown.css.scss
+++ b/app/assets/stylesheets/common/header/breadcrumbs_dropdown.css.scss
@@ -24,6 +24,7 @@
   vertical-align: top;
 }
 .BreadcrumbsDropdown-icon {
+  display: inline-block;
   margin-right: $sMargin-elementInline;
   width: 20px;
 }

--- a/app/assets/stylesheets/public/public_map_wrapper.css.scss
+++ b/app/assets/stylesheets/public/public_map_wrapper.css.scss
@@ -15,8 +15,8 @@
 
   .Checkbox {
     position: absolute;
-    top: 35px;
-    right: 35px;
+    top: 28px;
+    right: 28px;
     z-index: 30;
     background-color: rgba(#000, .5);
     padding: 3px 5px;

--- a/app/assets/stylesheets/public/public_table_wrapper.css.scss
+++ b/app/assets/stylesheets/public/public_table_wrapper.css.scss
@@ -111,15 +111,6 @@ body.public { /* Public table CSS */
     border-top: 1px solid #E5E5E5;
   }
 
-  div.separator_shadow {
-    position: absolute;
-    height: 20px;
-    bottom: 0;
-    width: 100%;
-    @extend .black-gradient-shadow-bottom;
-    z-index: 100;
-  }
-
   div.table.public table tbody tr td div.cell {
     cursor: default; 
   }

--- a/app/assets/stylesheets/public/public_table_wrapper.css.scss
+++ b/app/assets/stylesheets/public/public_table_wrapper.css.scss
@@ -120,6 +120,17 @@ body.public { /* Public table CSS */
     z-index: 100;
   }
 
+  div.table.public table tbody tr td div.cell {
+    cursor: default; 
+  }
+
+  div.table.public table tbody tr:hover {
+    background: inherit;
+    border-top: 1px solid #ECECEC;
+
+    & + tr { border-top: 1px solid #ECECEC; }    
+  }
+  
   div.table table thead tr th {
     > div {
       label.interactuable .coloptions {

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -103,7 +103,7 @@ class Admin::VisualizationsController < ApplicationController
     # Legacy redirect, now all public pages also with org. name
     if eligible_for_redirect?(@visualization.user)
       redirect_to CartoDB.url(self,
-                              'public_dataset',
+                              'public_table',
                               { id: "#{params[:id]}", redirected:true },
                               @visualization.user
                               ) and return

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -257,31 +257,18 @@
           </li>
         <% end %>
         <%# at most 3 cards per line, visbility is handled by CSS depending on viewport size %>
-        <% ((3 - @total_visualizations.count + 3) % 3).times.each do %>
-          <li class="MapsList-item MapsList-item--fake">
-            <div class="MapCard">
-              <div class="MapCard-header MapCard-header--fake"></div>
-              <div class="MapCard-content MapCard-content--compact"></div>
-            </div>
-          </li>
+        <% if @total_visualizations.count < 3 %>
+          <% ((3 - @total_visualizations.count + 3) % 3).times.each do %>
+            <li class="MapsList-item MapsList-item--fake">
+              <div class="MapCard">
+                <div class="MapCard-header MapCard-header--fake"></div>
+                <div class="MapCard-content MapCard-content--compact"></div>
+              </div>
+            </li>
+          <% end %>
         <% end %>
       </ul>
     <% end %>
-
-    <div class="u-inner">
-      <div class="PublicMap-block">
-        <% if @total_nonpublic_total_vis_count > 0 %>
-          <ul>
-            <li class="DatasetsList-item">
-              <div class="LayoutIcon">
-                <i class="iconFont iconFont-Lock"></i>
-              </div>
-              <div class="DefaultTitle PublicMap-privateDatasets"><%= pluralize(@total_nonpublic_total_vis_count, 'private map') %></div>
-            </li>
-          </ul>
-        <% end %>
-      </div>
-    </div>
 
     <%# DISQUS %>
     <div class="u-inner">

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -148,8 +148,8 @@
 
             <% if !Cartodb.config[:cartodb_com_hosted].present? %>
               <li class="Navmenu-item u-hideOnTablet">
-                <a class="Button Button--main Navmenu-editLink Navmenu-editLink--edit Navmenu-editLink--oneclick is-active oneclick" href="http://oneclick.cartodb.com/?file=<%= CGI.escape( @export_sql_api_url ) %>&provider=<%= URI.encode(@table.owner.username) %>&logo=<%= URI.encode(@avatar_url) %>">Create map</a>
-                <a href="<%= CartoDB.url(self, 'public_tables_show', {id: @table.name}, @table.owner.organization ? @table.owner : nil) %>" class="Button Button--main Navmenu-editLink Navmenu-editLink--edit Navmenu-editLink--oneclick edit">Edit in CartoDB</a>
+                <a class="Button Button--main Navmenu-editLink Navmenu-editLink--edit Navmenu-editLink--oneclick is-active js-oneclick" href="http://oneclick.cartodb.com/?file=<%= CGI.escape( @export_sql_api_url ) %>&provider=<%= URI.encode(@table.owner.username) %>&logo=<%= URI.encode(@avatar_url) %>">Create map</a>
+                <a href="<%= CartoDB.url(self, 'public_tables_show', {id: @table.name}, @table.owner.organization ? @table.owner : nil) %>" class="Button Button--main Navmenu-editLink Navmenu-editLink--edit Navmenu-editLink--oneclick js-edit">Edit in CartoDB</a>
               </li>
             <% end %>
           </ul>

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -234,7 +234,7 @@
 
     <% if @total_visualizations.count > 0 %>
       <ul class="MapsList PublicMap-mapsList">
-        <% @total_visualizations.each do |vis| %>
+        <% @total_visualizations.take(3).each do |vis| %>
           <li class="MapsList-item">
             <div class="MapCard" data-zoom="<%= '' %>" data-vizjson-url="<%= CartoDB.url(self, 'api_v2_visualizations_vizjson', {id: vis.id}, vis.user) %>.json">
               <a href="<%= CartoDB.url(self, 'public_visualizations_public_map', {id: vis.id}, user) %>" class="MapCard-header js-header">

--- a/lib/assets/javascripts/cartodb/common/dialogs/export/public_export_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/export/public_export_view.js
@@ -24,6 +24,7 @@ module.exports = ExportView.extend({
   initialize: function() {
     this.elder('initialize');
     this.model.set('bounds', this.options.bounds);
+    this.model.bind('change:bounds', this._setBoundsCheckbox, this);
   },
 
   _changeBounds: function() {

--- a/lib/assets/javascripts/cartodb/common/views/dashboard_header/breadcrumbs/dropdown.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/dashboard_header/breadcrumbs/dropdown.jst.ejs
@@ -1,6 +1,6 @@
 <ul class="BreadcrumbsDropdown-list">
   <li class="BreadcrumbsDropdown-listItem">
-    <span class="BreadcrumbsDropdown-icon UserAvatar">
+    <span class="BreadcrumbsDropdown-icon">
       <img class="UserAvatar-img UserAvatar-img--small" src="<%- avatarUrl %>" title="<%- userName %>" alt="<%- userName %>" />
     </span>
     <nav class="BreadcrumbsDropdown-options">

--- a/lib/assets/javascripts/cartodb/common/views/dashboard_header/breadcrumbs/dropdown.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/dashboard_header/breadcrumbs/dropdown.jst.ejs
@@ -15,4 +15,4 @@
       <a href="<%- lockedDatasetsUrl %>" class="BreadcrumbsDropdown-optionsItem has-margin <%- isDatasets && isLocked ? 'is-selected' : '' %>">Your locked datasets</a>
     </nav>
   </li>
-</ul
+</ul>

--- a/lib/assets/javascripts/cartodb/public_table.js
+++ b/lib/assets/javascripts/cartodb/public_table.js
@@ -61,8 +61,12 @@ $(function() {
         $('.js-login').hide();
         $('.js-learn').show();
 
-        $('.edit').css('display', 'inline-block');
-        $('.oneclick').css('display', 'none');
+        if (user.get('username') === window.owner_username) {
+          // Show "Edit in CartoDB" button if logged user
+          // is the map owner ;)
+          $('.js-edit').css('display', 'inline-block');
+          $('.js-oneclick').hide();
+        }
       }
     });
 

--- a/lib/assets/javascripts/cartodb/public_table/table_public.js
+++ b/lib/assets/javascripts/cartodb/public_table/table_public.js
@@ -214,9 +214,7 @@
       this.workViewMap.active('map');
       this.mapTab.enableMap();
 
-      $(".pane_table")
-      .addClass("is-active")
-      .append("<div class='separator_shadow' />");
+      $(".pane_table").addClass("is-active");
     },
 
     _updateTable: function() {

--- a/lib/assets/javascripts/cartodb/public_table/tableview_public.js
+++ b/lib/assets/javascripts/cartodb/public_table/tableview_public.js
@@ -4,10 +4,7 @@
    */
   cdb.open.PublicTableView = cdb.admin.TableView.extend({
     
-    events: {
-      'click td':     '_cellClick',
-      'dblclick td':  '_cellDblClick'
-    },
+    events: {},
 
     rowView: cdb.open.PublicRowView,
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.46",
+  "version": "3.18.47",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] One click or edit in CartoDB button appearance.
- [x] No table hover.
- [x] No table double click.
- [x] Limit maps related with public dataset to 3.
- [x] Fixed "no rows matched" with public map view problem in export view.
- [x] User breadcrumb style.
- [x] Remove public table shadow.

cc @saleiva 