### PR TITLE
Rescue dataset generation on public pages fixes #5061

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -183,11 +183,17 @@ class Admin::PagesController < ApplicationController
         geometry_type = table_geometry_types.first.present? ? geometry_mapping.fetch(table_geometry_types.first.downcase, '') : ''
       end
 
-      @datasets << vis_item(vis).merge({
-          rows_count:    vis.table.rows_counted,
-          size_in_bytes: vis.table.table_size,
-          geometry_type: geometry_type,
-        })
+      begin
+        @datasets << vis_item(vis).merge({
+            rows_count:    vis.table.rows_counted,
+            size_in_bytes: vis.table.table_size,
+            geometry_type: geometry_type,
+          })
+      rescue => e
+        # A dataset might be invalid. For example, having the table deleted and not yet cleaned.
+        # We don't want public page to be broken, but error must be traced.
+        CartoDB.notify_exception(e, { vis: vis })
+      end
     end
 
     description = "#{@name} has"


### PR DESCRIPTION
This fixes #5061 . @javisantana , @Kartones , what do you think about this? Since some inconsistency is currently allowed (a user deletes a table with the SQL API but doesn't enter the dashboard and tables are not cleaned) I think the only thing we can do is excluding those datasets from public pages. The actual fix will be triggering ghost tables from the database, but meanwhile...