### PR TITLE
Fix revoking access to a 3rd party service modal loading state is wrong 

### DIFF
--- a/lib/assets/javascripts/cartodb/account/service_disconnect_dialog_view.js
+++ b/lib/assets/javascripts/cartodb/account/service_disconnect_dialog_view.js
@@ -1,22 +1,17 @@
-var cdb = require('cartodb.js');
 var BaseDialog = require('../common/views/base_dialog/view');
-var _ = require('underscore');
 var randomQuote = require('../common/view_helpers/random_quote');
 var ServiceInvalidate = require('../common/service_models/service_invalidate_model');
 
 /**
  *  Disconnect service or help user to disconnect it
- *  
+ *
  *  - It needs the service model
  */
-
 module.exports = BaseDialog.extend({
 
-  events: function() {
-    return _.extend({}, BaseDialog.prototype.events, {
-      'click .js-revoke': '_revokeAccess'
-    });
-  },
+  events: BaseDialog.extendEvents({
+    'click .js-revoke': '_revokeAccess'
+  }),
 
   initialize: function() {
     this.elder('initialize');
@@ -24,26 +19,31 @@ module.exports = BaseDialog.extend({
   },
 
   render_content: function() {
-    return cdb.templates.getTemplate('account/views/service_disconnect_dialog')(
-      _.extend({
+    if (this.model.get('state') === 'loading') {
+      return this.getTemplate('common/templates/loading')({
+        title: 'Revoking access',
         quote: randomQuote()
-      }, this.model.attributes)
-    );
+      });
+    } else {
+      return this.getTemplate('account/views/service_disconnect_dialog')(this.model.attributes);
+    }
   },
 
   _initBinds: function() {
-    this.model.bind('change:state', this._appendContent, this);
+    this.model.bind('change:state', this._maybeReplaceContent, this);
   },
 
-  _appendContent: function() {
-    this.$('.Dialog-content').html(this.render_content());
+  _maybeReplaceContent: function() {
+    if (this.model.get('state') !== 'error') {
+      this.$('.Dialog-content').html(this.render_content());
+    }
   },
 
   _revokeAccess: function() {
     this.model.set('state', 'loading');
     var self = this;
     var invalidateModel = new ServiceInvalidate({ datasource: this.model.get('name') });
-    
+
     invalidateModel.destroy({
       success: function(mdl, r) {
         if (r.success) {

--- a/lib/assets/javascripts/cartodb/account/views/service_disconnect_dialog.jst.ejs
+++ b/lib/assets/javascripts/cartodb/account/views/service_disconnect_dialog.jst.ejs
@@ -32,19 +32,11 @@
       <span>go to <%- title %></span>
     </a>
   <% } else { %>
-    <% if (state !== "loading") { %>
-      <button class="Button Button--secondary Dialog-footerBtn Button--inline cancel">
-        <span>cancel</span>
-      </button>
-      <button class="js-revoke Button Button--negative Button--inline">
-        <span>Revoke access</span>
-      </button>
-    <% } else { %>
-      <div class="Spinner"></div>
-      <h4 class="IntermediateInfo-title">Revoking access</h4>
-      <div class="DefaultParagraph DefaultParagraph--short DefaultParagraph--centered">
-        <%= quote %>
-      </div>
-    <% } %>
+    <button class="Button Button--secondary Dialog-footerBtn Button--inline cancel">
+      <span>cancel</span>
+    </button>
+    <button class="js-revoke Button Button--negative Button--inline">
+      <span>Revoke access</span>
+    </button>
   <% } %>
 </div>

--- a/lib/assets/test/spec/cartodb/account/service_disconnect_dialog_view.spec.js
+++ b/lib/assets/test/spec/cartodb/account/service_disconnect_dialog_view.spec.js
@@ -1,3 +1,4 @@
+var cdb = require('cartodb.js');
 var ServiceInvalidate = require('../../../../javascripts/cartodb/common/service_models/service_invalidate_model');
 var ServiceDisconnectDialog = require('../../../../javascripts/cartodb/account/service_disconnect_dialog_view');
 
@@ -8,7 +9,7 @@ describe('account/service_disconnect_dialog_view', function() {
     ServiceInvalidate.prototype.destroy = function(a) {
       a.success(null, {
         success: true
-      })
+      });
     };
     view = new ServiceDisconnectDialog({
       model: new cdb.core.Model({
@@ -22,7 +23,6 @@ describe('account/service_disconnect_dialog_view', function() {
       enter_to_confirm: false
     });
 
-    spyOn(view, '_appendContent');
     spyOn(view, '_reloadWindow');
     view.render();
   });
@@ -48,32 +48,50 @@ describe('account/service_disconnect_dialog_view', function() {
       expect(view.$('.Button[href]').length).toBe(1);
     });
 
+    it('should not display the loading', function() {
+      expect(this.innerHTML(view)).not.toContain('Revoking access');
+    });
   });
 
-  describe('revoke', function() {
-
-    it("should change state when user clicks over button", function() {
+  describe('when click revoke', function() {
+    beforeEach(function() {
+      spyOn(ServiceInvalidate.prototype, 'destroy');
       view.$('.js-revoke').click();
-      expect(view.model.get('state')).not.toBe('idle');
     });
 
-    it("should reload if everything goes well", function() {
-      view.$('.js-revoke').click();
-      expect(view._reloadWindow).toHaveBeenCalled();
+    it("should change to loading state", function() {
+      expect(this.innerHTML(view)).toContain('Revoking access');
     });
 
-    it("should close the dialog if the process fails", function() {
-      ServiceInvalidate.prototype.destroy = function(a) {
-        a.success(null, {
+    describe('when revoking goes well', function() {
+      beforeEach(function() {
+        ServiceInvalidate.prototype.destroy.calls.argsFor(0)[0].success(null, {
+          success: true
+        });
+      });
+
+      it("should reload if everything goes well", function() {
+        expect(view._reloadWindow).toHaveBeenCalled();
+      });
+    });
+
+    describe('when revoking fails', function() {
+      beforeEach(function() {
+        spyOn(view, 'close');
+        ServiceInvalidate.prototype.destroy.calls.argsFor(0)[0].success(null, {
           success: false
-        })
-      };
-      spyOn(view, 'close');
-      view.$('.js-revoke').click();
-      expect(view.close).toHaveBeenCalled();
-      expect(view.model.get('state')).toBe('error');
-    });
+        });
+      });
 
+      it("should close the dialog", function() {
+        expect(view.close).toHaveBeenCalled();
+      });
+
+      it('should set the model state to error', function() {
+        // error displayed outside of the scope of this modal though
+        expect(view.model.get('state')).toBe('error');
+      });
+    });
   });
 
   it("should not have leaks", function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.18.48",
+  "version": "3.18.49",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #4749 

Loading state now being proper like in the rest of the modals (rendered w/o header):
![disconnect-loading](https://cloud.githubusercontent.com/assets/978461/9330579/8af4f7ba-45ba-11e5-8178-2ae64dfd0fd2.gif)
_here demo'ed using an already disconnected account, so it closes the modal and displays the error next to the box (that was from before)_.

@xavijam pretty please review? cc @saleiva 