### PR TITLE
4229 check name duplication against central user database to avoid user creation failure

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -39,7 +39,7 @@ class SignupController < ApplicationController
       @user.password_confirmation = params[:user][:password]
     end
 
-    if @user.valid?
+    if @user.valid? && @user.validate_credentials_not_taken_in_central
       @user_creation = Carto::UserCreation.new_user_signup(@user)
       @user_creation.save
       ::Resque.enqueue(::Resque::UserJobs::Signup::NewUser, @user_creation.id)

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -39,7 +39,7 @@ class SignupController < ApplicationController
       @user.password_confirmation = params[:user][:password]
     end
 
-    if @user.valid? && @user.validate_credentials_not_taken_in_central
+    if @user.valid?
       @user_creation = Carto::UserCreation.new_user_signup(@user)
       @user_creation.save
       ::Resque.enqueue(::Resque::UserJobs::Signup::NewUser, @user_creation.id)

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -4,6 +4,9 @@ class Carto::UserCreation < ActiveRecord::Base
 
   belongs_to :log, class_name: Carto::Log
 
+  validates  :username, :email, :crypted_password, :presence => true
+  validate :credentials_not_taken_in_central
+
   def self.new_user_signup(user)
     raise 'User needs an organization' unless user.organization
 
@@ -61,6 +64,12 @@ class Carto::UserCreation < ActiveRecord::Base
       end
     end
     
+  end
+
+  def credentials_not_taken_in_central
+    return unless Cartodb::Central.sync_data_with_cartodb_central?
+
+
   end
 
   private

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -68,16 +68,6 @@ class Carto::UserCreation < ActiveRecord::Base
     
   end
 
-  def validate_credentials_not_taken_in_central
-    return unless Cartodb::Central.sync_data_with_cartodb_central?
-
-    central_client = Cartodb::Central.new
-
-    errors.add(:username, "Username taken") if central_client.get_user(self.username)['username'] == self.username
-    errors.add(:email, "Email taken") if central_client.get_user(self.email)['email'] == self.email
-    errors.empty?
-  end
-
   private
 
   def user
@@ -122,8 +112,8 @@ class Carto::UserCreation < ActiveRecord::Base
 
   # Central validation
   def validate_user
-    validate_credentials_not_taken_in_central
-    raise "Credentials already used" unless errors.empty?
+    @user.validate_credentials_not_taken_in_central
+    raise "Credentials already used" unless @user.errors.empty?
   rescue => e
     handle_failure(e, mark_as_failure = true)
   end

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -3,7 +3,7 @@ module Concerns
 
     def validate_credentials_not_taken_in_central
       return true unless self.is_a?(User)
-      return unless Cartodb::Central.sync_data_with_cartodb_central?
+      return true unless Cartodb::Central.sync_data_with_cartodb_central?
 
       central_client = Cartodb::Central.new
 

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -1,6 +1,17 @@
 module Concerns
   module CartodbCentralSynchronizable
 
+    def validate_credentials_not_taken_in_central
+      return true unless self.is_a?(User)
+      return unless Cartodb::Central.sync_data_with_cartodb_central?
+
+      central_client = Cartodb::Central.new
+
+      errors.add(:username, "Username taken") if central_client.get_user(self.username)['username'] == self.username
+      errors.add(:email, "Email taken") if central_client.get_user(self.email)['email'] == self.email
+      errors.empty?
+    end
+
     def create_in_central
       return true unless sync_data_with_cartodb_central?
       if self.is_a?(User) && organization.present?

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -1,6 +1,7 @@
 module Concerns
   module CartodbCentralSynchronizable
 
+    # This validation can't be added to the model because if a user creation begins at Central we can't know if user is the same or existing
     def validate_credentials_not_taken_in_central
       return true unless self.is_a?(User)
       return true unless Cartodb::Central.sync_data_with_cartodb_central?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,8 +100,6 @@ class User < Sequel::Model
 
     validates_presence :password if new? && (crypted_password.blank? || salt.blank?)
 
-    validate_credentials_not_taken_in_central if (new? || changed_columns.include?(username) || changed_columns.include?(email))
-
     if new? || (password.present? && !@new_password.present?)
       errors.add(:password, "is not confirmed") unless password == password_confirmation
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,6 +100,8 @@ class User < Sequel::Model
 
     validates_presence :password if new? && (crypted_password.blank? || salt.blank?)
 
+    validate_credentials_not_taken_in_central if (new? || changed_columns.include?(username) || changed_columns.include?(email))
+
     if new? || (password.present? && !@new_password.present?)
       errors.add(:password, "is not confirmed") unless password == password_confirmation
     end

--- a/config/app_config.yml.testing
+++ b/config/app_config.yml.testing
@@ -159,12 +159,13 @@ defaults: &defaults
       options: { color: '#ffffff' }
       options:
   cartodb_com_hosted: true
-  cartodb_central_domain_name: 'cartodb.com'
-  cartodb_central_api:
-    host: 'admin.localhost.lan'
-    port: 4000
-    username: 'api'
-    password: 'test'
+  # Test don't have Central
+  #cartodb_central_domain_name: 'cartodb.com'
+  #cartodb_central_api:
+  #  host: 'admin.localhost.lan'
+  #  port: 4000
+  #  username: 'api'
+  #  password: 'test'
   aws:
     s3:
       access_key_id: "test"

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -48,6 +48,10 @@ module Cartodb
       end
     end
 
+    def get_user(username_or_email)
+      return send_request("api/users/#{username_or_email}", nil, :get, [200,404])
+    end # get_organization_users
+
     def get_organization_users(organization_name)
       return send_request("api/organizations/#{ organization_name }/users", nil, :get, [200], 600)
     end # get_organization_users

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -76,25 +76,67 @@ describe Carto::UserCreation do
     end
 
     it 'neither creates a new User nor sends the mail and marks creation as failure if Central has a registered user matching username' do
-      Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(true)
-      user = FactoryGirl.build(:valid_user)
-      user_data = JSON.parse(user.to_json)
-      # Central doesn't return exactly the same attributes, but this is good enough for testing
-      Cartodb::Central.any_instance.stubs(:get_user).returns(user_data)
+      user = prepare_fake_central_user
+      # This tests only matching usernames
+      user.email = 'other@whatever.com'
 
       ::Resque.expects(:enqueue).with(::Resque::UserJobs::Mail::NewOrganizationUser).never
 
-      user_data.organization = @organization
-      user_data.google_sign_in = true
+      user.organization = @organization
 
-      user_creation = Carto::UserCreation.new_user_signup(user_data)
+      user_creation = Carto::UserCreation.new_user_signup(user)
       user_creation.next_creation_step until user_creation.finished?
 
-      saved_user = Carto::User.where(username: user_data.username).first
-      saved_user.should == nil
+      Carto::User.where(username: user.username).first.should == nil
 
       user_creation.reload
       user_creation.state.should == 'failure'
+    end
+
+    it 'neither creates a new User nor sends the mail and marks creation as failure if Central has a registered user matching email' do
+      user = prepare_fake_central_user
+      # This tests only matching emails
+      user.username = 'other_whatever'
+
+      ::Resque.expects(:enqueue).with(::Resque::UserJobs::Mail::NewOrganizationUser).never
+
+      user.organization = @organization
+
+      user_creation = Carto::UserCreation.new_user_signup(user)
+      user_creation.next_creation_step until user_creation.finished?
+
+      Carto::User.where(username: user.username).first.should == nil
+
+      user_creation.reload
+      user_creation.state.should == 'failure'
+    end
+
+    it 'neither creates a new User nor sends the mail and marks creation as failure if username es empty' do
+      user = prepare_fake_central_user
+      # This tests only matching emails
+      user.username = nil
+
+      ::Resque.expects(:enqueue).with(::Resque::UserJobs::Mail::NewOrganizationUser).never
+
+      user.organization = @organization
+
+      expect {
+        user_creation = Carto::UserCreation.new_user_signup(user)
+      }.to raise_error
+    end
+
+    def prepare_fake_central_user
+      Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(true)
+      fake_central_client = {}
+      fake_central_client.stubs(:create_organization_user).returns(true)
+      User.any_instance.stubs(:cartodb_central_client).returns(fake_central_client)
+      Cartodb::Central.stubs(:new).returns(fake_central_client)
+      user = FactoryGirl.build(:valid_user)
+      central_user_data = JSON.parse(user.to_json)
+      # Central doesn't return exactly the same attributes, but this is good enough for testing
+      Cartodb::Central.any_instance.stubs(:get_user).returns(central_user_data)
+      fake_central_client.stubs(:get_user).returns(central_user_data)
+      user
     end
   end
 

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -55,6 +55,10 @@ describe Carto::UserCreation do
       user_creation.state.should == 'failure'
     end
 
+    after(:each) do
+      Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(false)
+    end
+
     it 'neither creates a new User nor sends the mail and marks creation as failure if Central fails' do
       Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(true)
       User.any_instance.stubs(:create_in_central).raises('Error on state creating_user_in_central, mark_as_failure: false. Error: Application server responded with http 422: {"errors":["Existing username."]}')


### PR DESCRIPTION
This closes #4229. @Kartones CR this, please.