### PR TITLE
Close dashboard dropdowns on opening modals

### DIFF
--- a/lib/assets/javascripts/cartodb/dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/filters_view.js
@@ -38,7 +38,7 @@ module.exports = cdb.core.View.extend({
     'click .js-lock':           '_openChangeLockDialog',
     'click .js-privacy':        '_openPrivacyDialog',
     'click .js-link':           navigateThroughRouter,
-    'click':                    'killEvent'
+    'click':                    '_onClick'
   },
 
   initialize: function() {
@@ -393,6 +393,11 @@ module.exports = cdb.core.View.extend({
     } else {
       return false;
     }
+  },
+
+  _onClick: function(ev) {
+    this.killEvent(ev);
+    cdb.god.trigger('closeDialogs');
   },
 
   clean: function() {

--- a/lib/assets/javascripts/cartodb/dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/filters_view.js
@@ -37,8 +37,7 @@ module.exports = cdb.core.View.extend({
     'click .js-new_map':        '_newMap',
     'click .js-lock':           '_openChangeLockDialog',
     'click .js-privacy':        '_openPrivacyDialog',
-    'click .js-link':           navigateThroughRouter,
-    'click':                    '_onClick'
+    'click .js-link':           navigateThroughRouter
   },
 
   initialize: function() {
@@ -57,7 +56,7 @@ module.exports = cdb.core.View.extend({
   // This is due to the behaviour of the CSS animations.
   _preRender: function() {
     var $uInner = $('<div>').addClass('u-inner');
-    var $filtersInner = $('<div>').addClass('Filters-inner');
+    var $filtersInner = $('<div>').addClass('Filters-inner js-skip-unselect-all');
     this.$el.append($uInner.append($filtersInner));
   },
 
@@ -108,7 +107,7 @@ module.exports = cdb.core.View.extend({
     this.collection.bind('add remove change reset', this.render, this);
     this.user.bind('change:remaining_byte_quota', this.render, this);
     cdb.god.bind('closeDialogs', this._animate, this);
-    cdb.god.bind('closeDialogs', this._unselectAll, this);
+    cdb.god.bind('unselectAllItems', this._unselectAll, this);
     _.bindAll(this, '_onWindowScroll');
 
     this.add_related_model(this.collection);
@@ -393,11 +392,6 @@ module.exports = cdb.core.View.extend({
     } else {
       return false;
     }
-  },
-
-  _onClick: function(ev) {
-    this.killEvent(ev);
-    cdb.god.trigger('closeDialogs');
   },
 
   clean: function() {

--- a/lib/assets/javascripts/cartodb/dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/main_view.js
@@ -1,3 +1,4 @@
+var $ = require('jquery');
 var cdb = require('cartodb.js');
 cdb.admin = require('cdb.admin');
 var LocalStorage = require('../common/local_storage');
@@ -54,7 +55,7 @@ module.exports = cdb.core.View.extend({
     if (params.content_type === "maps" && order === "size") {
       order = 'updated_at'
     }
-    
+
     var types = params.content_type === "datasets" ? 'table' : 'derived';
 
     // Requesting data library items?
@@ -89,7 +90,7 @@ module.exports = cdb.core.View.extend({
       showGeocodingDatasetURLButton: true,
       geocodingsPolling: true,
       importsPolling: true
-    }, { 
+    }, {
       user: this.user
     });
 
@@ -104,7 +105,7 @@ module.exports = cdb.core.View.extend({
       this.user.fetch();
     }, this);
     this.$el.append(this._backgroundPollingView.render().el);
-    
+
     this.addView(this._backgroundPollingView);
 
     var mamufasView = new MamufasImportView({
@@ -136,7 +137,7 @@ module.exports = cdb.core.View.extend({
       el:           this.$('#content-controller'),
       // Pass the whole element for only calculating
       // the height is not "fair"
-      headerHeight: this.$('#header').height(), 
+      headerHeight: this.$('#header').height(),
       user:         this.user,
       router:       this.router,
       collection:   this.collection,
@@ -153,13 +154,20 @@ module.exports = cdb.core.View.extend({
     supportView.render();
   },
 
-  // In case user clicks out of any dialog "body" will fire
-  // a closeDialogs event
   _onClick: function(e) {
-    var $dialog = $(e.target).closest('.Dialog');
-    if ($dialog.length === 0) {
-      cdb.god.trigger("closeDialogs");
+    // Clicks outside of any dialog "body" will fire a closeDialogs event
+    if (this._closeTo(e, '.Dialog')) {
+      cdb.god.trigger('closeDialogs');
+
+      // If click outside the filters view should also unselect any selected items
+      if (this._closeTo(e, '.js-skip-unselect-all')) {
+        cdb.god.trigger('unselectAllItems');
+      }
     }
+  },
+
+  _closeTo: function(ev, selector) {
+    return $(ev.target).closest(selector).length === 0;
   }
 
 });

--- a/lib/assets/javascripts/cartodb/dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/main_view.js
@@ -156,17 +156,17 @@ module.exports = cdb.core.View.extend({
 
   _onClick: function(e) {
     // Clicks outside of any dialog "body" will fire a closeDialogs event
-    if (this._closeTo(e, '.Dialog')) {
+    if (this._isEventFromWithin(e, '.Dialog')) {
       cdb.god.trigger('closeDialogs');
 
       // If click outside the filters view should also unselect any selected items
-      if (this._closeTo(e, '.js-skip-unselect-all')) {
+      if (this._isEventFromWithin(e, '.js-skip-unselect-all')) {
         cdb.god.trigger('unselectAllItems');
       }
     }
   },
 
-  _closeTo: function(ev, selector) {
+  _isEventFromWithin: function(ev, selector) {
     return $(ev.target).closest(selector).length === 0;
   }
 

--- a/lib/assets/javascripts/cartodb/dashboard/main_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/main_view.js
@@ -156,17 +156,17 @@ module.exports = cdb.core.View.extend({
 
   _onClick: function(e) {
     // Clicks outside of any dialog "body" will fire a closeDialogs event
-    if (this._isEventFromWithin(e, '.Dialog')) {
+    if (this._isEventTriggeredOutsideOf(e, '.Dialog')) {
       cdb.god.trigger('closeDialogs');
 
       // If click outside the filters view should also unselect any selected items
-      if (this._isEventFromWithin(e, '.js-skip-unselect-all')) {
+      if (this._isEventTriggeredOutsideOf(e, '.js-skip-unselect-all')) {
         cdb.god.trigger('unselectAllItems');
       }
     }
   },
 
-  _isEventFromWithin: function(ev, selector) {
+  _isEventTriggeredOutsideOf: function(ev, selector) {
     return $(ev.target).closest(selector).length === 0;
   }
 

--- a/lib/assets/test/spec/cartodb/dashboard/filters_view.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/filters_view.spec.js
@@ -73,7 +73,13 @@ describe('dashboard/filters_view', function() {
 
   it('should deselect items when god triggers an event', function() {
     this.collection.reset({ selected: true }, { selected: true });
+
+    // old behavior, should not deselect any items
     cdb.god.trigger('closeDialogs');
+    expect(this.collection.where({ selected: true }).length).not.toBe(0);
+
+    // new, should deselect
+    cdb.god.trigger('unselectAllItems');
     expect(this.collection.where({ selected: true }).length).toBe(0);
   });
 


### PR DESCRIPTION
Fixes #5065

_(edit: changed approach since original PR, updated the desc to reflect this:)_

> The reason for the original 'click': 'killEvent' in this view is to prevent unselecting any selected item(s). The problem that comes with preventing that is that we, with maintaining current logic, would have to do explicit trigger for the closeDialogs event on each click callback in this view (or subviews).

> The root problem is that closeDialogs is used to unselect items too. I'd suggest to change that, to use another isolated event to control that behavior and not mix it with how dialogs are intended to behave.

So, changed to use another event to unselect items than mix it with the event used to control the open/closed behavior of dialogs.

ping @xavijam for review
cc @mariodelvalle for reporting

FYI @CartoDB/frontend 