### PR TITLE
Remove non-working and invalid organization link within user settings dropdown in public pages

### DIFF
--- a/lib/assets/javascripts/cartodb/public_common/user_settings/dropdown_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/public_common/user_settings/dropdown_template.jst.ejs
@@ -10,11 +10,7 @@
   <li class="SettingsDropdown-item">
     <p><a class="SettingsDropdown-itemLink" href="<%- dashboardUrl %>">Your dashboard</a></p>
     <p><a class="SettingsDropdown-itemLink" href="<%- apiKeysUrl %>">Your API keys</a></p>
-    <p>
-      <a class="SettingsDropdown-itemLink" href="<%- accountSettingsUrl %>">
-        <%- isOrgAdmin ? 'Organization' : 'Account settings' %>
-      </a>
-    </p>
+    <p><a class="SettingsDropdown-itemLink" href="<%- accountSettingsUrl %>">Account settings</a></p>
     <p><a class="SettingsDropdown-itemLink" href="<%- logoutUrl %>">Close session</a></p>
   </li>
 </ul


### PR DESCRIPTION
Fixes #5066.

cc @mariodelvalle 