### PR TITLE
Now we can set the user agent for a request

### DIFF
--- a/lib/carto/http/request.rb
+++ b/lib/carto/http/request.rb
@@ -8,8 +8,14 @@ module Carto
     #Wraps a typhoeus request and logs it
     class Request
 
+      # Used to avoid blocks to the default Typhoeus User-Agent
+      # http://www.ispcolohost.com/2015/08/05/amazon-ec2-ddos-from-typhoeus-user-agent/
+      DEFAULT_USER_AGENT = 'Mozilla/5.0 (CartoDB) Gecko/20100101 Firefox/40.0'
+
       def initialize(logger, url, options = {})
         @logger = logger
+        @options = options
+        set_user_agent
         @typhoeus_request = Typhoeus::Request.new(url, options)
       end
 
@@ -37,6 +43,14 @@ module Carto
 
       def on_complete(&block)
         @typhoeus_request.on_complete(&block)
+      end
+
+      def set_user_agent(user_agent = DEFAULT_USER_AGENT)
+        if @options.has_key?(:headers)
+          @options[:headers] = @options[:headers].merge({"User-Agent"=>user_agent})
+        else
+          @options = @options.merge({:headers => {"User-Agent"=>user_agent}})
+        end
       end
     end
 

--- a/spec/lib/carto/http/client_spec.rb
+++ b/spec/lib/carto/http/client_spec.rb
@@ -7,6 +7,7 @@ require 'rspec/expectations'
 require 'rspec/mocks'
 require 'mocha'
 require_relative '../../../../lib/carto/http/client'
+require_relative '../../../../lib/carto/http/request'
 
 describe Carto::Http::Client do
 
@@ -23,7 +24,9 @@ describe Carto::Http::Client do
         method: :post,
         body: "this is a request body",
         params: { field1: "a field" },
-        headers: { Accept: "text/html" }
+        headers: { Accept: "text/html", 
+                  "User-Agent" => Carto::Http::Request::DEFAULT_USER_AGENT 
+                }
       }
       Typhoeus::Request.expects(:new).once.with(expected_url, expected_options)
       @client.request(
@@ -31,7 +34,7 @@ describe Carto::Http::Client do
                      method: :post,
                      body: "this is a request body",
                      params: { field1: "a field" },
-                     headers: { Accept: "text/html" }
+                     headers: { Accept: "text/html", "User-Agent" => Carto::Http::Request::DEFAULT_USER_AGENT}
                      )
     end
   end
@@ -45,7 +48,7 @@ describe Carto::Http::Client do
                                method: :post,
                                body: "this is a request body",
                                params: { field1: "a field" },
-                               headers: { Accept: "text/html" }
+                               headers: { Accept: "text/html", "User-Agent" => Carto::Http::Request::DEFAULT_USER_AGENT}
                                )
       request.run.should eq expected_response
     end


### PR DESCRIPTION
Some people are doing DDoS using Typhoeus (our ruby http client) and some servers are blocking requests coming with the `User-Agent` of Typhoeus so we have to put a more common User Agent. We have thought to use the Mozilla one with CartoDB inside:

```Mozilla/5.0 (CartoDB) Gecko/20100101 Firefox/40.0```

Closes #5218 

Please @juanignaciosl check this PR