### PR TITLE
Use counter for importer.total_size #5208

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -737,7 +737,7 @@ class DataImport < Sequel::Model
     # Calculate total size out of stats
     total_size = 0
     ::JSON.parse(self.stats).each {|stat| total_size += stat['size']}
-    importer_stats_aggregator.gauge('total_size', total_size)
+    importer_stats_aggregator.update_counter('total_size', total_size)
 
     import_time = self.updated_at - self.created_at
 

--- a/lib/cartodb/stats/aggregator.rb
+++ b/lib/cartodb/stats/aggregator.rb
@@ -68,6 +68,10 @@ module CartoDB
         Statsd.decrement("#{fully_qualified_prefix}.#{key}")
       end
 
+      def update_counter(key, delta)
+        Statsd.update_counter("#{fully_qualified_prefix}.#{key}", delta)
+      end
+
       protected
 
       def self.read_config


### PR DESCRIPTION
Use a counter instead of a gauge for total_size metrics. Gauges are only
appropriate if sending periodic data. Otherwise counters are better to
aggregate size information, especially if there are not many events.

See http://statsd.readthedocs.org/en/latest/types.html

@Kartones can you please review?