### PR TITLE
5184 share datasets with groups backend

### DIFF
--- a/app/models/carto/permission.rb
+++ b/app/models/carto/permission.rb
@@ -60,7 +60,7 @@ class Carto::Permission < ActiveRecord::Base
 
   def acl_entries_for_user(user)
     acl.select { |entry|
-      acl_entry_is_for_user_id?(entry, user.id) || acl_entry_is_for_organization_id(entry, user.organization_id)
+      acl_entry_is_for_user_id?(entry, user.id) || acl_entry_is_for_organization_id(entry, user.organization_id) || (!user.groups.nil? && acl_entry_is_for_a_user_group(entry, user.groups.collect(&:id)))
     }
   end
 
@@ -70,6 +70,10 @@ class Carto::Permission < ActiveRecord::Base
 
   def acl_entry_is_for_organization_id(entry, organization_id)
     entry[:type] == TYPE_ORGANIZATION && entry[:id] == organization_id
+  end
+
+  def acl_entry_is_for_a_user_group(entry, group_ids)
+    entry[:type] == TYPE_GROUP && group_ids.include?(entry[:id])
   end
 
 end

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -25,6 +25,9 @@ class Carto::User < ActiveRecord::Base
   has_many :search_tweets, inverse_of: :user
   has_many :synchronizations, inverse_of: :user
 
+  has_many :users_group, dependent: :destroy, class_name: Carto::UsersGroup
+  has_many :groups, :through => :users_group
+
   delegate [ 
       :database_username, :database_password, :in_database, :load_cartodb_functions, :rebuild_quota_trigger,
       :db_size_in_bytes, :get_api_calls, :table_count, :public_visualization_count, :visualization_count,

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,4 @@
+# coding: UTF-8
+
+class Group < Sequel::Model
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -351,6 +351,13 @@ module CartoDB
         if entry[:type] == TYPE_USER && entry[:id] == subject.id
           permission = entry[:access]
         end
+
+        if entry[:type] == TYPE_GROUP && permission == nil
+          if !subject.groups.nil? && subject.groups.collect(&:id).include?(entry[:id])
+            permission = entry[:access]
+          end
+        end
+
         # Organization has lower precedence than user, if set leave as it is
         if entry[:type] == TYPE_ORGANIZATION && permission == nil
           if !subject.organization.nil? && subject.organization.id == entry[:id]

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -206,16 +206,22 @@ module CartoDB
       elsif granted_access == ACCESS_NONE
         set_subject_permission(group.id, access, TYPE_GROUP)
       else
-        acl_entry = {
-          type: TYPE_GROUP,
-          entity: {
-            id: group.id,
-            name: group.name
-          },
-          access: access
-        }
-        acl_without_this_group = self.inputable_acl.select { |entry| entry[:entity][:id] != group.id }
-        self.acl = (acl_without_this_group << acl_entry)
+        # Remove group entry from acl in order to add new (or none if ACCESS_NONE)
+        new_acl = self.inputable_acl.select { |entry| entry[:entity][:id] != group.id }
+
+        unless access == ACCESS_NONE
+          acl_entry = {
+            type: TYPE_GROUP,
+            entity: {
+              id: group.id,
+              name: group.name
+            },
+            access: access
+          }
+          new_acl << acl_entry
+        end
+
+        self.acl = new_acl
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,6 +46,9 @@ class User < Sequel::Model
 
   one_to_many :feature_flags_user
 
+  plugin :many_through_many
+  many_through_many :groups, [[:users_groups, :user_id, :group_id]]
+
   # Sequel setup & plugins
   plugin :association_dependencies, :client_application => :destroy, :synchronization_oauths => :destroy, :feature_flags_user => :destroy
   plugin :validation_helpers

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -306,7 +306,11 @@ class Carto::VisualizationQueryBuilder
   end
 
   def recipient_ids(user)
-    [ user.id, user.organization_id ].compact
+    [ user.id, user.organization_id ].compact + groups_ids(user)
+  end
+
+  def groups_ids(user)
+    user.groups.nil? ? [] : user.groups.collect(&:id)
   end
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,7 +45,7 @@ CartoDB::Application.configure do
 
   # Enable threaded mode (https://github.com/resque/resque/issues/611)
   # config.threadsafe!
-  # In order to run supporting concurrent requests, uncomment next line and run with `bundle exec thin start --threaded -p 3000`.
+  # In order to run supporting concurrent requests, uncomment next line and run with `bundle exec thin start --threaded -p 3000 --threadpool-size 5`. Check your `config/database.yml` has `pool: 50` or higher for `development`.
   # The condition excludes this from resque, since it won't work with it and it doesn't need it.
   config.threadsafe! unless $rails_rake_task
 

--- a/spec/requests/carto/api/database_groups_controller_spec.rb
+++ b/spec/requests/carto/api/database_groups_controller_spec.rb
@@ -143,16 +143,7 @@ describe Carto::Api::DatabaseGroupsController do
       put api_v1_databases_group_update_permission_url(database_name: group.database_name, name: group.name, username: @org_user_1.username, table_name: @table_user_1['name']), permission.to_json, sync_db_api_headers
       response.status.should == 200
 
-      expected_acl = [
-          {
-              type: Permission::TYPE_GROUP,
-              entity: {
-                  id:         group.id,
-                  name:       group.name
-              },
-              access: Permission::ACCESS_NONE
-          }
-      ]
+      expected_acl = []
 
       delete api_v1_databases_group_destroy_permission_url(database_name: group.database_name, name: group.name, username: @org_user_1.username, table_name: @table_user_1['name']), '', sync_db_api_headers
       response.status.should == 200


### PR DESCRIPTION
This closes #5184 and will be merged into #4924 branch.

@rafatower CR this, please.

With this you can open a readonly shared with my group dataset, and after installing [latest changes to the extension](https://github.com/CartoDB/cartodb-postgresql/commit/a4952f6a1e2b009f1e960725c332684a0c6297f3) (still under review at CartoDB/cartodb-postgresql#104) I also was able to open a RW dataset and add and delete data.