### PR TITLE
Fix API Call and Download buttons not working on public datasets

### DIFF
--- a/lib/assets/javascripts/cartodb/public_table/table_public.js
+++ b/lib/assets/javascripts/cartodb/public_table/table_public.js
@@ -7,9 +7,8 @@
   cdb.open.TablePublic = cdb.core.View.extend({
 
     events: {
-      'click .extra_options .clone': '_copyTableToYourAccount',
       'click .js-Navmenu-link--download': '_exportTable',
-      'click .js-Navmenu-link--api': '_apiCallTable',
+      'click .js-Navmenu-link--api': '_apiCallTable'
     },
 
     initialize: function() {
@@ -218,9 +217,9 @@
 
     _fetchData: function(sql) {
       if (sql) {
-        this.sqlView.setSQL(sql);  
+        this.sqlView.setSQL(sql);
       }
-      
+
       this.sqlView.fetch({
         success: function() {
           self.$('.js-spinner').remove();


### PR DESCRIPTION
Fixes #5260
This event definition was causing a JS error that prevented the view from even work.

ping @javierarce 