### PR TITLE
Basic groups management UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,12 +95,11 @@ end
 group :development, :test do
   gem 'rspec-rails',           '2.12.0'
   gem 'rb-readline'
-  gem 'byebug'
+  gem 'debugger',              '1.6.8'
   gem 'rack'
 
   # Server
   gem 'thin',                           require: false
-  gem 'pry-rails'
 end
 
 # Load optional engines

--- a/Gemfile
+++ b/Gemfile
@@ -95,11 +95,12 @@ end
 group :development, :test do
   gem 'rspec-rails',           '2.12.0'
   gem 'rb-readline'
-  gem 'debugger',              '1.6.8'
+  gem 'byebug'
   gem 'rack'
 
   # Server
   gem 'thin',                           require: false
+  gem 'pry-rails'
 end
 
 # Load optional engines

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     backports (3.6.6)
     bartt-ssl_requirement (1.4.2)
     builder (3.0.4)
+    byebug (6.0.2)
     capybara (1.1.2)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -73,10 +74,10 @@ GEM
     chunky_png (1.3.4)
     ci_reporter (1.8.4)
       builder (>= 2.1.2)
+    coderay (1.1.0)
     coercible (0.2.0)
       backports (~> 3.0, >= 3.1.0)
       descendants_tracker (~> 0.0.1)
-    columnize (0.9.0)
     compass (0.12.3)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
@@ -85,12 +86,6 @@ GEM
     db-query-matchers (0.4.0)
     dbf (2.0.6)
       fastercsv (~> 1.5.4)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.8)
     delorean (2.1.0)
       chronic
     descendants_tracker (0.0.4)
@@ -163,6 +158,7 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     metaclass (0.0.4)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
     mixpanel (4.0.2)
@@ -188,6 +184,12 @@ GEM
       http_parser.rb (~> 0.5.3)
       multi_json (~> 1.0)
     polyglot (0.3.5)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (1.4.7)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -274,6 +276,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    slop (3.6.0)
     spreadsheet (1.0.4)
       ruby-ole (>= 1.0)
     sprockets (2.2.3)
@@ -329,13 +332,13 @@ DEPENDENCIES
   aequitas (= 0.0.2)
   aws-sdk (= 1.8.5)
   bartt-ssl_requirement (~> 1.4.0)
+  byebug
   capybara (= 1.1.2)
   charlock_holmes (= 0.7.2)
   ci_reporter (= 1.8.4)
   compass (= 0.12.3)
   db-query-matchers (= 0.4.0)
   dbf (= 2.0.6)
-  debugger (= 1.6.8)
   delorean
   dropbox-sdk (= 1.6.3)
   ejs (~> 1.1.1)
@@ -355,6 +358,7 @@ DEPENDENCIES
   oauth-plugin (= 0.4.0.pre4)
   pg (= 0.13.2)
   poltergeist (>= 1.0.0)
+  pry-rails
   rack
   rack-test (= 0.6.2)
   rails (= 3.2.22)
@@ -385,6 +389,3 @@ DEPENDENCIES
   virtus (= 1.0.0.beta3)
   vizzuality-sequel-rails (= 0.3.7)!
   webrick (= 1.3.1)
-
-BUNDLED WITH
-   1.10.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,6 @@ GEM
     backports (3.6.6)
     bartt-ssl_requirement (1.4.2)
     builder (3.0.4)
-    byebug (6.0.2)
     capybara (1.1.2)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -74,10 +73,10 @@ GEM
     chunky_png (1.3.4)
     ci_reporter (1.8.4)
       builder (>= 2.1.2)
-    coderay (1.1.0)
     coercible (0.2.0)
       backports (~> 3.0, >= 3.1.0)
       descendants_tracker (~> 0.0.1)
+    columnize (0.9.0)
     compass (0.12.3)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
@@ -86,6 +85,12 @@ GEM
     db-query-matchers (0.4.0)
     dbf (2.0.6)
       fastercsv (~> 1.5.4)
+    debugger (1.6.8)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.5)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.8)
     delorean (2.1.0)
       chronic
     descendants_tracker (0.0.4)
@@ -158,7 +163,6 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     metaclass (0.0.4)
-    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
     mixpanel (4.0.2)
@@ -184,12 +188,6 @@ GEM
       http_parser.rb (~> 0.5.3)
       multi_json (~> 1.0)
     polyglot (0.3.5)
-    pry (0.10.1)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    pry-rails (0.3.4)
-      pry (>= 0.9.10)
     rack (1.4.7)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -276,7 +274,6 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    slop (3.6.0)
     spreadsheet (1.0.4)
       ruby-ole (>= 1.0)
     sprockets (2.2.3)
@@ -332,13 +329,13 @@ DEPENDENCIES
   aequitas (= 0.0.2)
   aws-sdk (= 1.8.5)
   bartt-ssl_requirement (~> 1.4.0)
-  byebug
   capybara (= 1.1.2)
   charlock_holmes (= 0.7.2)
   ci_reporter (= 1.8.4)
   compass (= 0.12.3)
   db-query-matchers (= 0.4.0)
   dbf (= 2.0.6)
+  debugger (= 1.6.8)
   delorean
   dropbox-sdk (= 1.6.3)
   ejs (~> 1.1.1)
@@ -358,7 +355,6 @@ DEPENDENCIES
   oauth-plugin (= 0.4.0.pre4)
   pg (= 0.13.2)
   poltergeist (>= 1.0.0)
-  pry-rails
   rack
   rack-test (= 0.6.2)
   rails (= 3.2.22)
@@ -389,3 +385,6 @@ DEPENDENCIES
   virtus (= 1.0.0.beta3)
   vizzuality-sequel-rails (= 0.3.7)!
   webrick (= 1.3.1)
+
+BUNDLED WITH
+   1.10.5

--- a/app/assets/stylesheets/common/nav-button.css.scss
+++ b/app/assets/stylesheets/common/nav-button.css.scss
@@ -20,6 +20,7 @@
   &:hover {
     border-color: $cNavButton-active;
     color: $cNavButton-active;
+    text-decoration: none;
   }
 
   // For safari 8 the element node inside the NavButton is not centered horizontally with the flex layout, this uses the

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 class Admin::OrganizationsController < ApplicationController
-  ssl_required :show, :settings, :settings_update, :regenerate_all_api_keys
+  ssl_required :show, :settings, :groups, :settings_update, :regenerate_all_api_keys
   before_filter :login_required, :load_organization_and_members
 
   layout 'application'
@@ -14,6 +14,12 @@ class Admin::OrganizationsController < ApplicationController
   def settings
     respond_to do |format|
       format.html { render 'settings' }
+    end
+  end
+
+  def groups
+    respond_to do |format|
+      format.html { render 'groups' }
     end
   end
 
@@ -69,7 +75,7 @@ class Admin::OrganizationsController < ApplicationController
     raise RecordNotFound unless @organization.present? && current_user.organization_owner?
 
     # INFO: Special scenario of handcrafted URL to go to organization-based signup page
-    @organization_signup_url = 
+    @organization_signup_url =
       "#{CartoDB.protocol}://#{@organization.name}.#{CartoDB.account_host}#{CartoDB.path(self, 'signup_organization_user')}"
   end
 

--- a/app/views/admin/organizations/groups.html.erb
+++ b/app/views/admin/organizations/groups.html.erb
@@ -1,0 +1,25 @@
+<% content_for(:page_title) do %>
+  <%= current_user.organization.name %> groups |
+<% end %>
+<%= content_for(:js) do %>
+  <script type="text/javascript">
+    var username = "<%= current_user.username %>";
+    var config = <%= safe_js_object frontend_config %>;
+    var user_data = <%= safe_js_object current_user.data.to_json.html_safe %>;
+  </script>
+  <%= javascript_include_tag 'cdb.js', 'models.js', 'organization_templates.js', 'organization_deps.js', 'organization_groups.js' -%>
+<% end %>
+<%= content_for(:css) do %>
+  <%= stylesheet_link_tag 'organization.css', :media => 'all' %>
+<% end %>
+
+<div>
+  <%= render :partial => 'admin/shared/org_subheader' %>
+  <div class="js-content"></div>
+</div>
+
+<% if !Cartodb.config[:cartodb_com_hosted].present? %>
+  <div class="SupportBanner" id="support-banner"></div>
+<% end %>
+
+<%= render 'admin/shared/footer' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -82,6 +82,7 @@ module CartoDB
       models.js
       organization_templates.js
       organization_deps.js
+      organization_groups.js
       organization.js
       table.js
       public_dashboard.js

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ CartoDB::Application.routes.draw do
     get    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings',        as: :organization_settings
     put    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings_update', as: :organization_settings_update
     post '(/user/:user_domain)(/u/:user_domain)/organization/regenerate_api_keys'       => 'organizations#regenerate_all_api_keys', as: :regenerate_organization_users_api_key
+    get    '(/user/:user_domain)(/u/:user_domain)/organization/groups'          => 'organizations#groups',          as: :organization_settings
     # Organization users management
     get    '(/user/:user_domain)(/u/:user_domain)/organization/users/:id/edit'  => 'organization_users#edit',    as: :edit_organization_user,   constraints: { id: /[0-z\.\-]+/ }
     put    '(/user/:user_domain)(/u/:user_domain)/organization/users/:id'       => 'organization_users#update',  as: :update_organization_user, constraints: { id: /[0-z\.\-]+/ }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ CartoDB::Application.routes.draw do
     get    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings',        as: :organization_settings
     put    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings_update', as: :organization_settings_update
     post '(/user/:user_domain)(/u/:user_domain)/organization/regenerate_api_keys'       => 'organizations#regenerate_all_api_keys', as: :regenerate_organization_users_api_key
-    get    '(/user/:user_domain)(/u/:user_domain)/organization/groups'          => 'organizations#groups',          as: :organization_settings
+    get    '(/user/:user_domain)(/u/:user_domain)/organization/groups(/*other)' => 'organizations#groups',          as: :organization_settings
     # Organization users management
     get    '(/user/:user_domain)(/u/:user_domain)/organization/users/:id/edit'  => 'organization_users#edit',    as: :edit_organization_user,   constraints: { id: /[0-z\.\-]+/ }
     put    '(/user/:user_domain)(/u/:user_domain)/organization/users/:id'       => 'organization_users#update',  as: :update_organization_user, constraints: { id: /[0-z\.\-]+/ }

--- a/lib/assets/javascripts/cartodb/common/router.js
+++ b/lib/assets/javascripts/cartodb/common/router.js
@@ -33,7 +33,7 @@ module.exports = Backbone.Router.extend({
   },
 
   rootPath: function() {
-    throw new Error('implement rootPath in child router');
+    throw new Error('implement rootPath in child router (no trailing slash)');
   },
 
   /**

--- a/lib/assets/javascripts/cartodb/common/view_helpers/navigate_through_router.js
+++ b/lib/assets/javascripts/cartodb/common/view_helpers/navigate_through_router.js
@@ -67,7 +67,7 @@ module.exports = function(ev) {
   }
 
   if (!isLinuxMiddleOrRightClick(ev) && !isMacCmdKeyPressed(ev)) {
-    this.router.navigate(url, { trigger: true });
+    (this.router || this.options.router).navigate(url, { trigger: true });
   } else if (isCtrlKeyPressed(ev) || isMacCmdKeyPressed(ev)) {
     window.open(url, '_blank');
   }

--- a/lib/assets/javascripts/cartodb/models/group.js
+++ b/lib/assets/javascripts/cartodb/models/group.js
@@ -1,0 +1,14 @@
+/**
+ * Model representing a group.
+ * Expected to be used in the context of a groups collection (e.g. cdb.admin.OrganizationGroups),
+ * which defines its API endpoint path.
+ */
+cdb.admin.Group = cdb.core.Model.extend({
+
+  defaults: {
+    display_name: '' // UI name, as given by
+    // name: '', // internal alphanumeric representation, converted from display_name internally
+    // organization_id: '',
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/models/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/models/organization_groups.js
@@ -18,7 +18,6 @@ cdb.admin.OrganizationGroups = Backbone.Collection.extend({
   parse: function(response) {
     // response also holds the following keys (not used yet):
     //   total_entries: {Number} total entries for current fetch (may be filtered)
-    //   total_org_entries: {Number} total entries for no filters applied
     return response.groups;
   },
 
@@ -30,7 +29,7 @@ cdb.admin.OrganizationGroups = Backbone.Collection.extend({
       group = new this.model({
         id: id
       });
-      // collection set on model, but not added to collectio yet
+      // collection set on model, but not added to collection yet
       group.collection = this;
     }
     return group;

--- a/lib/assets/javascripts/cartodb/models/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/models/organization_groups.js
@@ -20,6 +20,20 @@ cdb.admin.OrganizationGroups = Backbone.Collection.extend({
     //   total_entries: {Number} total entries for current fetch (may be filtered)
     //   total_org_entries: {Number} total entries for no filters applied
     return response.groups;
+  },
+
+  // @return {Object} A instance of cdb.admin.Group. If group wasn't already present a new model with id and collection
+  //  set will be returned, i.e. group.fetch() will be required to get the data or handle the err case (e.g. non-existing)
+  fetchGroup: function(id) {
+    var group = this.get(id);
+    if (!group) {
+      group = new this.model({
+        id: id
+      });
+      // collection set on model, but not added to collectio yet
+      group.collection = this;
+    }
+    return group;
   }
 
 });

--- a/lib/assets/javascripts/cartodb/models/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/models/organization_groups.js
@@ -1,0 +1,25 @@
+/**
+ * A collection that holds a set of organization groups
+ */
+cdb.admin.OrganizationGroups = Backbone.Collection.extend({
+
+  model: cdb.admin.Group,
+
+  url: function(method) {
+    var version = cdb.config.urlVersion('organizationGroups', method);
+    return '/api/' + version + '/organization/' + this.organization.id + '/groups';
+  },
+
+  initialize: function(models, opts) {
+    if (!opts.organization) throw new Error('organization is required');
+    this.organization = opts.organization;
+  },
+
+  parse: function(response) {
+    // response also holds the following keys (not used yet):
+    //   total_entries: {Number} total entries for current fetch (may be filtered)
+    //   total_org_entries: {Number} total entries for no filters applied
+    return response.groups;
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/old_common/urls/organization_url.js
+++ b/lib/assets/javascripts/cartodb/old_common/urls/organization_url.js
@@ -12,6 +12,10 @@ cdb.common.OrganizationUrl = cdb.common.Url.extend({
 
   create: function() {
     return this.urlToPath('new');
+  },
+
+  groups: function() {
+    return this.urlToPath('groups');
   }
 
 });

--- a/lib/assets/javascripts/cartodb/old_common/urls/user_url.js
+++ b/lib/assets/javascripts/cartodb/old_common/urls/user_url.js
@@ -12,7 +12,9 @@ cdb.common.UserUrl = cdb.common.Url.extend({
 
   organization: function() {
     if (this.get('is_org_admin')) {
-      return this.urlToPath('organization');
+      return new cdb.common.OrganizationUrl({
+        base_url: this.urlToPath('organization')
+      });
     } else {
       return this.urlToPath('account');
     }

--- a/lib/assets/javascripts/cartodb/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/organization_groups.js
@@ -1,17 +1,35 @@
 var $ = require('jquery');
 var cdb = require('cartodb.js');
+var Router = require('./organization_groups/router');
+var GroupsMainView = require('./organization_groups/groups_main_view');
 
 $(function() {
   cdb.init(function() {
     cdb.templates.namespace = 'cartodb/';
     cdb.config.set('url_prefix', window.user_data.base_url);
+    var user = new cdb.admin.User(window.user_data);
+    if (!user.isOrgAdmin()) {
+      window.location = user.viewUrl().accountSettings();
+      return false;
+    }
 
-    $(document.body).bind('click', function() {
-      cdb.god.trigger('closeDialogs');
+    var router = new Router({
+      rootUrl: user.viewUrl().organization().groups()
     });
 
-    // TODO: implement groups UI
-    var user = new cdb.admin.User(window.user_data);
-    window.u = user; // TODO: remove
+    var groups = new cdb.admin.OrganizationGroups([], {
+      organization: user.organization
+    });
+
+    var groupsMainView = new GroupsMainView({
+      el: document.body,
+      router: router,
+      user: user,
+      groups: groups
+    });
+    groupsMainView.render();
+    window.groups = groupsMainView;
+
+    router.enableAfterMainView();
   });
 });

--- a/lib/assets/javascripts/cartodb/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/organization_groups.js
@@ -1,0 +1,17 @@
+var $ = require('jquery');
+var cdb = require('cartodb.js');
+
+$(function() {
+  cdb.init(function() {
+    cdb.templates.namespace = 'cartodb/';
+    cdb.config.set('url_prefix', window.user_data.base_url);
+
+    $(document.body).bind('click', function() {
+      cdb.god.trigger('closeDialogs');
+    });
+
+    // TODO: implement groups UI
+    var user = new cdb.admin.User(window.user_data);
+    window.u = user; // TODO: remove
+  });
+});

--- a/lib/assets/javascripts/cartodb/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/organization_groups.js
@@ -13,12 +13,12 @@ $(function() {
       return false;
     }
 
-    var router = new Router({
-      rootUrl: user.viewUrl().organization().groups()
-    });
-
     var groups = new cdb.admin.OrganizationGroups([], {
       organization: user.organization
+    });
+    var router = new Router({
+      rootUrl: user.viewUrl().organization().groups(),
+      groups: groups
     });
 
     var groupsMainView = new GroupsMainView({

--- a/lib/assets/javascripts/cartodb/organization_groups/create_group.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization_groups/create_group.jst.ejs
@@ -1,0 +1,10 @@
+<div>
+  <a href="<%- backHref %>" class="js-back">back</a>
+  <div>Group name</div>
+  <div>
+    <input type="text" class="js-name" />
+  </div>
+  <button class="Button Button--main is-disabled js-create">
+    <span>Create group</span>
+  </button>
+</div>

--- a/lib/assets/javascripts/cartodb/organization_groups/create_group.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization_groups/create_group.jst.ejs
@@ -1,5 +1,4 @@
 <div>
-  <a href="<%- backHref %>" class="js-back">back</a>
   <div>Group name</div>
   <div>
     <input type="text" class="js-name" placeholder="Enter a name of group" />

--- a/lib/assets/javascripts/cartodb/organization_groups/create_group.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization_groups/create_group.jst.ejs
@@ -2,7 +2,7 @@
   <a href="<%- backHref %>" class="js-back">back</a>
   <div>Group name</div>
   <div>
-    <input type="text" class="js-name" />
+    <input type="text" class="js-name" placeholder="Enter a name of group" />
   </div>
   <button class="Button Button--main is-disabled js-create">
     <span>Create group</span>

--- a/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
@@ -1,5 +1,4 @@
 var cdb = require('cartodb.js');
-var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
 var randomQuote = require('../common/view_helpers/random_quote');
 
 /**
@@ -8,7 +7,6 @@ var randomQuote = require('../common/view_helpers/random_quote');
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-back': navigateThroughRouter,
     'click .js-create': '_onClickCreate',
     'keyup .js-name': '_onChangeName'
   },
@@ -28,7 +26,6 @@ module.exports = cdb.core.View.extend({
       });
     } else {
       html = this.getTemplate('organization_groups/create_group')({
-        backHref: this.options.router.rootUrl
       });
     }
     this.$el.html(html);

--- a/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
@@ -1,0 +1,26 @@
+var cdb = require('cartodb.js');
+var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
+
+/**
+ * View to create a new group for an organization.
+ */
+module.exports = cdb.core.View.extend({
+
+  events: {
+    'click .js-back': navigateThroughRouter
+  },
+
+  initialize: function() {
+    if (!this.options.groups) throw new Error('groups is required');
+  },
+
+  render: function() {
+    this.$el.html('').append(
+      this.make('a', {
+        href: this.options.router.rootUrl,
+        class: 'js-back'
+      }, 'back')
+    );
+    return this;
+  }
+});

--- a/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
@@ -1,5 +1,6 @@
 var cdb = require('cartodb.js');
 var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
+var randomQuote = require('../common/view_helpers/random_quote');
 
 /**
  * View to create a new group for an organization.
@@ -7,20 +8,69 @@ var navigateThroughRouter = require('../common/view_helpers/navigate_through_rou
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-back': navigateThroughRouter
+    'click .js-back': navigateThroughRouter,
+    'click .js-create': '_onClickCreate',
+    'keyup .js-name': '_onChangeName'
   },
 
   initialize: function() {
     if (!this.options.groups) throw new Error('groups is required');
+    this.model = new cdb.core.Model();
+    this._initBinds();
   },
 
   render: function() {
-    this.$el.html('').append(
-      this.make('a', {
-        href: this.options.router.rootUrl,
-        class: 'js-back'
-      }, 'back')
-    );
+    var html;
+    if (this.model.get('isLoading')) {
+      html = this.getTemplate('common/templates/loading')({
+        title: 'Creating group',
+        quote: randomQuote()
+      });
+    } else {
+      html = this.getTemplate('organization_groups/create_group')({
+        backHref: this.options.router.rootUrl
+      });
+    }
+    this.$el.html(html);
     return this;
+  },
+
+  _initBinds: function() {
+    this.model.on('change:isLoading', this.render, this);
+  },
+
+  _onClickCreate: function(ev) {
+    this.killEvent(ev);
+    var name = this._name();
+    if (name) {
+      this.model.set('isLoading', true);
+      this.options.groups.create({
+        display_name: name
+      }, {
+        wait: true,
+        success: this._redirectToGroupsIndex.bind(this),
+        error: this._showErrors.bind(this)
+      });
+    }
+  },
+
+  _redirectToGroupsIndex: function() {
+    // Redirect back to list
+    this.options.router.navigate(this.options.router.rootUrl, { trigger: true });
+  },
+
+  _showErrors: function() {
+    this.model.set({
+      isLoading: false
+    });
+  },
+
+  _onChangeName: function() {
+    this.$('.js-create').toggleClass('is-disabled', this._name().length === 0);
+  },
+
+  _name: function() {
+    return this.$('.js-name').val();
   }
+
 });

--- a/lib/assets/javascripts/cartodb/organization_groups/edit_group.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization_groups/edit_group.jst.ejs
@@ -1,0 +1,12 @@
+<div>
+  <a href="<%- backHref %>" class="js-back">back</a>
+  <h3><%- displayName %></h3>
+  <div>Group name</div>
+  <div>
+    <input type="text" class="js-name" value="<%- displayName %>" placeholder="Enter a name of group" />
+  </div>
+  <button class="Button--link js-delete">Delete this group</button>
+  <button class="Button Button--main is-disabled js-save">
+    <span>Save changes</span>
+  </button>
+</div>

--- a/lib/assets/javascripts/cartodb/organization_groups/edit_group.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization_groups/edit_group.jst.ejs
@@ -1,6 +1,4 @@
 <div>
-  <a href="<%- backHref %>" class="js-back">back</a>
-  <h3><%- displayName %></h3>
   <div>Group name</div>
   <div>
     <input type="text" class="js-name" value="<%- displayName %>" placeholder="Enter a name of group" />

--- a/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
@@ -1,0 +1,104 @@
+var cdb = require('cartodb.js');
+var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
+var randomQuote = require('../common/view_helpers/random_quote');
+
+/**
+ * View to create a new group for an organization.
+ */
+module.exports = cdb.core.View.extend({
+
+  events: {
+    'click .js-back': navigateThroughRouter,
+    'click .js-delete': '_onClickDelete',
+    'click .js-save': '_onClickSave',
+    'keyup .js-name': '_onChangeName'
+  },
+
+  initialize: function() {
+    if (!this.options.group) throw new Error('group is required');
+
+    this.model = new cdb.core.Model();
+
+    // No display name? Not fetched yet (e.g. on a full page request)
+    if (!this.options.group.get('display_name')) {
+      this._setLoading('Loading details');
+      this.options.group.fetch({
+        success: this._setLoading.bind(this, false),
+        error: this._redirectToGroupsIndex.bind(this)
+      });
+    }
+    this._initBinds();
+  },
+
+  render: function() {
+    var html;
+    if (this.model.get('isLoading')) {
+      html = this.getTemplate('common/templates/loading')({
+        title: this.model.get('loadingText'),
+        quote: randomQuote()
+      });
+    } else {
+      html = this.getTemplate('organization_groups/edit_group')({
+        backHref: this.options.router.rootUrl,
+        displayName: this.options.group.get('display_name')
+      });
+    }
+    this.$el.html(html);
+    return this;
+  },
+
+  _initBinds: function() {
+    this.model.on('change:isLoading', this.render, this);
+  },
+
+  _setLoading: function(msg) {
+    this.model.set({
+      isLoading: !!msg,
+      loadingText: msg
+    });
+  },
+
+  _onClickSave: function(ev) {
+    this.killEvent(ev);
+    var name = this._name();
+    if (name && name !== this.options.group.get('display_name')) {
+      this._setLoading('Saving changes');
+      this.options.group.save({
+        display_name: name
+      }, {
+        wait: true,
+        success: this._redirectToGroupsIndex.bind(this),
+        error: this._showErrors.bind(this)
+      });
+    }
+  },
+
+  _onClickDelete: function() {
+    this._setLoading('Deleting group');
+    this.options.group.destroy({
+      wait: true,
+      success: this._redirectToGroupsIndex.bind(this),
+      error: this._showErrors.bind(this)
+    });
+  },
+
+  _redirectToGroupsIndex: function() {
+    // Redirect back to list
+    this.options.router.navigate(this.options.router.rootUrl, { trigger: true });
+  },
+
+  _showErrors: function() {
+    this.model.set({
+      isLoading: false
+    });
+  },
+
+  _onChangeName: function() {
+    this.$('.js-save').toggleClass('is-disabled', this._name().length === 0);
+  },
+
+  _name: function() {
+    return this.$('.js-name').val();
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
@@ -1,5 +1,4 @@
 var cdb = require('cartodb.js');
-var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
 var randomQuote = require('../common/view_helpers/random_quote');
 
 /**
@@ -8,7 +7,6 @@ var randomQuote = require('../common/view_helpers/random_quote');
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-back': navigateThroughRouter,
     'click .js-delete': '_onClickDelete',
     'click .js-save': '_onClickSave',
     'keyup .js-name': '_onChangeName'
@@ -39,7 +37,6 @@ module.exports = cdb.core.View.extend({
       });
     } else {
       html = this.getTemplate('organization_groups/edit_group')({
-        backHref: this.options.router.rootUrl,
         displayName: this.options.group.get('display_name')
       });
     }

--- a/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
@@ -2,7 +2,7 @@ var cdb = require('cartodb.js');
 var randomQuote = require('../common/view_helpers/random_quote');
 
 /**
- * View to create a new group for an organization.
+ * View to edit an organization group.
  */
 module.exports = cdb.core.View.extend({
 

--- a/lib/assets/javascripts/cartodb/organization_groups/group_header.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization_groups/group_header.jst.ejs
@@ -1,0 +1,8 @@
+<div>
+  <a href="<%- backHref %>" class="NavButton NavButton--back js-back">
+    <i class="iconFont iconFont-ArrowPrev"></i>
+  </a>
+
+  <h3><%- title %></h3>
+  <div class="js-tabs"></div>
+</div>

--- a/lib/assets/javascripts/cartodb/organization_groups/group_header_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/group_header_view.js
@@ -1,0 +1,35 @@
+var cdb = require('cartodb.js');
+var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
+
+/**
+ * Header view when looking at details of a specific group.
+ */
+module.exports = cdb.core.View.extend({
+
+  events: {
+    'click .js-back': navigateThroughRouter
+  },
+
+  initialize: function() {
+    _.each(['group', 'router'], function(name) {
+      if (!this.options[name]) throw new Error(name + ' is required');
+    }, this);
+    this._initBinds();
+  },
+
+  render: function() {
+    this.$el.html(
+      this.getTemplate('organization_groups/group_header')({
+        backHref: this.options.router.rootUrl,
+        title: this.options.group.get('display_name')
+      })
+    );
+    return this;
+  },
+
+  _initBinds: function() {
+    this.options.group.on('change:display_name', this.render, this);
+    this.add_related_model(this.options.group);
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
@@ -1,0 +1,28 @@
+var cdb = require('cartodb.js');
+var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
+
+/**
+ * Index view of groups to list groups of an organization
+ */
+module.exports = cdb.core.View.extend({
+
+  events: {
+    'click .js-new-group': navigateThroughRouter
+  },
+
+  initialize: function() {
+    if (!this.options.groups) throw new Error('groups is required');
+    if (!this.options.router) throw new Error('router is required');
+  },
+
+  render: function() {
+    this.$el.html('').append(
+      this.make('h3', {}, 'Groups'),
+      this.make('a', {
+        class: 'js-new-group',
+        href: this.options.router.rootUrl.urlToPath('new')
+      }, 'Create new group')
+    );
+    return this;
+  }
+});

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
@@ -7,26 +7,40 @@ var navigateThroughRouter = require('../common/view_helpers/navigate_through_rou
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-new-group': navigateThroughRouter
+    'click a': navigateThroughRouter
   },
 
   initialize: function() {
     if (!this.options.groups) throw new Error('groups is required');
     if (!this.options.router) throw new Error('router is required');
+    this._initBinds();
   },
 
   render: function() {
-    this.options.groups.fetch();
     this.$el.html('').append(
       this.make('h3', {}, 'Groups'),
-      this.options.groups.map(function(m) {
-        return this.make('div', {}, m.get('display_name'));
-      }, this),
+
+      this.options.groups.map(this._makeGroupItem, this),
+
       this.make('a', {
         class: 'js-new-group',
         href: this.options.router.rootUrl.urlToPath('new')
       }, 'Create new group')
     );
     return this;
+  },
+
+  _initBinds: function() {
+    this.options.groups.bind('reset', this.render, this);
+  },
+
+  _makeGroupItem: function(m) {
+    return this.make('div', {},
+      this.make('a', { href: this._editUrl(m) }, m.get('display_name'))
+    );
+  },
+
+  _editUrl: function(group) {
+    return this.options.router.rootUrl.urlToPath('edit/' + group.get('id'));
   }
 });

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
@@ -16,8 +16,12 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function() {
+    this.options.groups.fetch();
     this.$el.html('').append(
       this.make('h3', {}, 'Groups'),
+      this.options.groups.map(function(m) {
+        return this.make('div', {}, m.get('display_name'));
+      }, this),
       this.make('a', {
         class: 'js-new-group',
         href: this.options.router.rootUrl.urlToPath('new')

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
@@ -1,0 +1,53 @@
+var _ = require('underscore');
+var cdb = require('cartodb.js');
+var GroupsIndexView = require('./groups_index_view');
+var CreateGroupView = require('./create_group_view');
+
+/**
+ * Controller view, managing view state of the groups entry point
+ */
+module.exports = cdb.core.View.extend({
+
+  events: {
+    'click': '_onClick'
+  },
+
+  initialize: function() {
+    _.each(['user', 'groups', 'router'], function(name) {
+      if (!this.options[name]) throw new Error(name + ' is required');
+    }, this);
+
+    this._initBinds();
+  },
+
+  render: function() {
+    this.clearSubViews();
+    this.$('.js-content').html(this._renderContent());
+    return this;
+  },
+  
+  _initBinds: function() {
+    this.options.router.model.bind('change:view', this.render, this);
+    this.add_related_model(this.options.router.model);
+  },
+
+  _renderContent: function() {
+    var view;
+    var opts = _.omit(this.options, 'el');
+
+    switch (this.options.router.model.get('view')) {
+      case 'groupsIndex':
+        view = new GroupsIndexView(opts);
+        break;
+      case 'createGroup':
+        view = new CreateGroupView(opts);
+        break;
+    }
+
+    return view.render().$el;
+  },
+
+  _onClick: function() {
+    cdb.god.trigger('closeDialogs');
+  }
+});

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var cdb = require('cartodb.js');
 var GroupsIndexView = require('./groups_index_view');
 var CreateGroupView = require('./create_group_view');
+var EditGroupView = require('./edit_group_view');
 
 /**
  * Controller view, managing view state of the groups entry point
@@ -25,7 +26,7 @@ module.exports = cdb.core.View.extend({
     this.$('.js-content').html(this._renderContent());
     return this;
   },
-  
+
   _initBinds: function() {
     this.options.router.model.bind('change:view', this.render, this);
     this.add_related_model(this.options.router.model);
@@ -34,16 +35,28 @@ module.exports = cdb.core.View.extend({
   _renderContent: function() {
     var view;
     var opts = _.omit(this.options, 'el');
+    var routerModel = this.options.router.model;
 
-    switch (this.options.router.model.get('view')) {
+    var viewName = routerModel.get('view');
+    switch (viewName) {
       case 'groupsIndex':
         view = new GroupsIndexView(opts);
         break;
       case 'createGroup':
         view = new CreateGroupView(opts);
         break;
+      case 'editGroup':
+        var groupId = this.options.router.model.get('groupId');
+        view = new EditGroupView(_.extend(opts, {
+          group: this.options.groups.fetchGroup(groupId)
+        }));
+        break;
+      default:
+        cdb.log.debug('no view for ' + viewName);
+        return '';
     }
 
+    this.addView(view);
     return view.render().$el;
   },
 

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var cdb = require('cartodb.js');
+var GroupHeaderView = require('./group_header_view');
 var GroupsIndexView = require('./groups_index_view');
 var CreateGroupView = require('./create_group_view');
 var EditGroupView = require('./edit_group_view');
@@ -23,7 +24,10 @@ module.exports = cdb.core.View.extend({
 
   render: function() {
     this.clearSubViews();
-    this.$('.js-content').html(this._renderContent());
+    var $content = this.$('.js-content');
+    var els = this._renderContent();
+    console.log(els);
+    $content.html('').append(els);
     return this;
   },
 
@@ -33,31 +37,54 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderContent: function() {
-    var view;
+    var views = [];
     var opts = _.omit(this.options, 'el');
     var routerModel = this.options.router.model;
 
     var viewName = routerModel.get('view');
     switch (viewName) {
       case 'groupsIndex':
-        view = new GroupsIndexView(opts);
+        views = [
+          new GroupsIndexView(opts)
+        ];
         break;
       case 'createGroup':
-        view = new CreateGroupView(opts);
+        views = [
+          this._createGroupHeader(),
+          new CreateGroupView(opts)
+        ];
         break;
       case 'editGroup':
         var groupId = this.options.router.model.get('groupId');
-        view = new EditGroupView(_.extend(opts, {
-          group: this.options.groups.fetchGroup(groupId)
-        }));
+        var group = this.options.groups.fetchGroup(groupId);
+        views = [
+          this._createGroupHeader(group),
+          new EditGroupView(_.extend(opts, {
+            group: group
+          }))
+        ];
         break;
       default:
         cdb.log.debug('no view for ' + viewName);
         return '';
     }
 
-    this.addView(view);
-    return view.render().$el;
+    return _.map(views, function(view) {
+      this.addView(view);
+      return view.render().el;
+    }, this);
+  },
+
+  _createGroupHeader: function(group) {
+    if (!group && !this._groupNullObj) {
+      this._groupNullObj = new cdb.core.Model({
+        display_name: 'Create new group'
+      });
+    }
+    return new GroupHeaderView({
+      router: this.options.router,
+      group: group || this._groupNullObj
+    });
   },
 
   _onClick: function() {

--- a/lib/assets/javascripts/cartodb/organization_groups/router.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/router.js
@@ -9,18 +9,18 @@ module.exports = Router.extend({
   routes: {
 
     // Groups index
-    '': '_routeToGroupsIndex',
+    '': 'routeToGroupsIndex',
     // If URL is lacking the trailing slash (e.g. 'http://username.cartodb.com/organization/groups'), treat it like index
-    'groups': '_routeToGroupsIndex',
-    '*prefix/groups': '_routeToGroupsIndex',
+    'groups': 'routeToGroupsIndex',
+    '*prefix/groups': 'routeToGroupsIndex',
 
     // Create a new group
-    'new': '_routeToCreateGroup',
-    'new/': '_routeToCreateGroup',
+    'new': 'routeToCreateGroup',
+    'new/': 'routeToCreateGroup',
 
     // Edit settings for a group
-    'edit/:id': '_routeToEditGroup',
-    'edit/:id/': '_routeToEditGroup'
+    'edit/:id': 'routeToEditGroup',
+    'edit/:id/': 'routeToEditGroup'
   },
 
   initialize: function(opts) {
@@ -40,16 +40,16 @@ module.exports = Router.extend({
     return fragmentOrUrl ? fragmentOrUrl.toString().replace(this.rootUrl.toString(), '') : '';
   },
 
-  _routeToGroupsIndex: function() {
+  routeToGroupsIndex: function() {
     this._groups.fetch();
     this.model.set('view', 'groupsIndex');
   },
 
-  _routeToCreateGroup: function() {
+  routeToCreateGroup: function() {
     this.model.set('view', 'createGroup');
   },
 
-  _routeToEditGroup: function(id) {
+  routeToEditGroup: function(id) {
     if (id) {
       this.model.set({
         view: 'editGroup',

--- a/lib/assets/javascripts/cartodb/organization_groups/router.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/router.js
@@ -10,6 +10,7 @@ module.exports = Router.extend({
 
     // Groups index
     '': 'routeToGroupsIndex',
+
     // If URL is lacking the trailing slash (e.g. 'http://username.cartodb.com/organization/groups'), treat it like index
     'groups': 'routeToGroupsIndex',
     '*prefix/groups': 'routeToGroupsIndex',

--- a/lib/assets/javascripts/cartodb/organization_groups/router.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/router.js
@@ -1,0 +1,45 @@
+var cdb = require('cartodb.js');
+var Router = require('../common/router');
+
+/**
+ *  Backbone router for organization groups urls.
+ */
+module.exports = Router.extend({
+
+  routes: {
+
+    // Groups index
+    '': '_routeToGroupsIndex',
+    // If URL is lacking the trailing slash (e.g. 'http://username.cartodb.com/organization/groups'), treat it like index
+    'groups': '_routeToGroupsIndex',
+    '*prefix/groups': '_routeToGroupsIndex',
+
+    // Create a new group
+    'new': '_routeToCreateGroup',
+    'new/': '_routeToCreateGroup'
+  },
+
+  initialize: function(opts) {
+    if (!opts.rootUrl) throw new Error('rootUrl is required');
+
+    this.model = new cdb.core.Model({
+      view: 'groupsIndex'
+    });
+
+    this.rootUrl = opts.rootUrl;
+    this.rootPath = this.rootUrl.pathname.bind(this.rootUrl);
+  },
+
+  normalizeFragmentOrUrl: function(fragmentOrUrl) {
+    return fragmentOrUrl ? fragmentOrUrl.toString().replace(this.rootUrl.toString(), '') : '';
+  },
+
+  _routeToGroupsIndex: function() {
+    this.model.set('view', 'groupsIndex');
+  },
+
+  _routeToCreateGroup: function() {
+    this.model.set('view', 'createGroup');
+  }
+
+});

--- a/lib/assets/javascripts/cartodb/organization_groups/router.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/router.js
@@ -16,16 +16,22 @@ module.exports = Router.extend({
 
     // Create a new group
     'new': '_routeToCreateGroup',
-    'new/': '_routeToCreateGroup'
+    'new/': '_routeToCreateGroup',
+
+    // Edit settings for a group
+    'edit/:id': '_routeToEditGroup',
+    'edit/:id/': '_routeToEditGroup'
   },
 
   initialize: function(opts) {
-    if (!opts.rootUrl) throw new Error('rootUrl is required');
+    _.each(['rootUrl', 'groups'], function(name) {
+      if (!opts[name]) throw new Error(name + ' is required');
+    }, this);
 
     this.model = new cdb.core.Model({
       view: 'groupsIndex'
     });
-
+    this._groups = opts.groups;
     this.rootUrl = opts.rootUrl;
     this.rootPath = this.rootUrl.pathname.bind(this.rootUrl);
   },
@@ -35,11 +41,23 @@ module.exports = Router.extend({
   },
 
   _routeToGroupsIndex: function() {
+    this._groups.fetch();
     this.model.set('view', 'groupsIndex');
   },
 
   _routeToCreateGroup: function() {
     this.model.set('view', 'createGroup');
+  },
+
+  _routeToEditGroup: function(id) {
+    if (id) {
+      this.model.set({
+        view: 'editGroup',
+        groupId: id
+      });
+    } else {
+      this.navigate(''); // redirect to index if there's no id
+    }
   }
 
 });

--- a/lib/assets/test/spec/cartodb/models/organization_groups.spec.js
+++ b/lib/assets/test/spec/cartodb/models/organization_groups.spec.js
@@ -1,0 +1,52 @@
+describe('cdb.admin.OrganizationGroups', function() {
+  beforeEach(function() {
+    var user = new cdb.admin.User({
+      id: 123,
+      base_url: 'http://cartodb.com/user/paco',
+      username: 'paco',
+      organization: {
+        id: 'myorg42',
+        owner: {
+          id: 123
+        }
+      }
+    });
+
+    this.groups = new cdb.admin.OrganizationGroups([], {
+      organization: user.organization
+    });
+  });
+
+  describe('.fetchGroup', function() {
+    describe('when the group with the given id is not yet loaded', function() {
+      beforeEach(function() {
+        this.group = this.groups.fetchGroup('g1');
+      });
+
+      it('should return a group with the given id set', function() {
+        expect(this.group.id).toEqual('g1');
+      });
+
+      it('should have a valid url under the organization', function() {
+        // required to be able to fetch the group from the expected correct location
+        var url = this.group.url();
+        expect(url).toBeTruthy();
+        expect(url).toMatch('organization/myorg42/groups/g1');
+      });
+    });
+
+    describe('when group with given id already exists in collection', function() {
+      beforeEach(function() {
+        this.groups.add({
+          id: 'g2',
+          display_name: 'foobar'
+        });
+        this.group = this.groups.fetchGroup('g2');
+      });
+
+      it('should return existing group', function() {
+        expect(this.group).toBe(this.groups.first());
+      });
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb/old_common/urls/user_url.spec.js
+++ b/lib/assets/test/spec/cartodb/old_common/urls/user_url.spec.js
@@ -20,7 +20,7 @@ describe('cdb.common.UserUrl', function() {
 
       it('should return a new url point to the organization settings page', function() {
         expect(this.newUrl).not.toBe(this.url);
-        expect(this.newUrl.get('base_url')).toEqual('http://team.cartodb.com/u/pepe/organization');
+        expect(this.newUrl.get('base_url').toString()).toEqual('http://team.cartodb.com/u/pepe/organization');
       });
     });
 

--- a/lib/assets/test/spec/cartodb/organization_groups/create_group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/create_group_view.spec.js
@@ -1,0 +1,102 @@
+var cdb = require('cartodb.js');
+var CreateGroupView = require('../../../../javascripts/cartodb/organization_groups/create_group_view');
+var Router = require('../../../../javascripts/cartodb/organization_groups/router');
+
+describe('organization_groups/create_group_view', function() {
+
+  beforeEach(function() {
+    var user = new cdb.admin.User({
+      id: 123,
+      base_url: 'http://cartodb.com/user/paco',
+      username: 'paco',
+      organization: {
+        owner: {
+          id: 123
+        }
+      }
+    });
+
+    var groups = new cdb.admin.OrganizationGroups([], {
+      organization: user.organization
+    });
+
+    this.router = new Router({
+      rootUrl: new cdb.common.Url({
+        base_url: 'http://cartodb.com/user/paco/organization/groups'
+      }),
+      groups: groups
+    });
+
+    this.view = new CreateGroupView({
+      router: this.router,
+      groups: groups
+    });
+    this.view.render();
+  });
+
+  it('should render input', function() {
+    expect(this.view.$('input').length > 0).toBe(true);
+  });
+
+  describe('when click create group', function() {
+    beforeEach(function() {
+      spyOn(cdb.admin.OrganizationGroups.prototype, 'create');
+    });
+
+    it('should not try to save group if has no name', function() {
+      this.view.$('.js-create').click();
+      expect(cdb.admin.OrganizationGroups.prototype.create).not.toHaveBeenCalled();
+    });
+
+    describe('when has written a name', function() {
+      beforeEach(function() {
+        this.view.$('.js-name').val('foobar');
+        this.view.$('.js-create').click();
+      });
+
+      it('should try to create group', function() {
+        expect(cdb.admin.OrganizationGroups.prototype.create).toHaveBeenCalled();
+      });
+
+      it('should show loading meanwhile', function() {
+        expect(this.innerHTML()).toContain('Creating group');
+      });
+
+      it('should not add to collection until got response', function() {
+        expect(cdb.admin.OrganizationGroups.prototype.create.calls.argsFor(0)[1].wait).toBe(true);
+      });
+
+      describe('when create succeeds', function() {
+        beforeEach(function() {
+          spyOn(this.router, 'navigate');
+          cdb.admin.OrganizationGroups.prototype.create.calls.argsFor(0)[1].success();
+        });
+
+        it('should navigate to groups root', function() {
+          expect(this.router.navigate).toHaveBeenCalled();
+          expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups');
+        });
+      });
+
+      describe('when create fails', function() {
+        beforeEach(function() {
+          cdb.admin.OrganizationGroups.prototype.create.calls.argsFor(0)[1].error();
+        });
+
+        it('should show form again with errors', function() {
+          expect(this.innerHTML()).not.toContain('Creating group');
+        });
+      });
+    });
+
+  });
+
+  it("should not have leaks", function() {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+
+});

--- a/lib/assets/test/spec/cartodb/organization_groups/edit_group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/edit_group_view.spec.js
@@ -101,12 +101,15 @@ describe('organization_groups/edit_group_view', function() {
 
     describe('when has changed name', function() {
       beforeEach(function() {
-        this.view.$('.js-name').val('foobar');
+        this.view.$('.js-name').val('new name');
         this.view.$('.js-save').click();
       });
 
       it('should try to save group', function() {
         expect(this.group.save).toHaveBeenCalled();
+        expect(this.group.save).toHaveBeenCalledWith({
+          display_name: 'new name'
+        }, jasmine.any(Object));
       });
 
       it('should show loading meanwhile', function() {

--- a/lib/assets/test/spec/cartodb/organization_groups/edit_group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/edit_group_view.spec.js
@@ -1,0 +1,189 @@
+var cdb = require('cartodb.js');
+var EditGroupView = require('../../../../javascripts/cartodb/organization_groups/edit_group_view');
+var Router = require('../../../../javascripts/cartodb/organization_groups/router');
+
+describe('organization_groups/edit_group_view', function() {
+
+  beforeEach(function() {
+    var user = new cdb.admin.User({
+      id: 123,
+      base_url: 'http://cartodb.com/user/paco',
+      username: 'paco',
+      organization: {
+        owner: {
+          id: 123
+        }
+      }
+    });
+
+    var groups = new cdb.admin.OrganizationGroups([{
+      id: 'g1',
+      display_name: 'my group'
+    }], {
+      organization: user.organization
+    });
+
+    this.router = new Router({
+      rootUrl: new cdb.common.Url({
+        base_url: 'http://cartodb.com/user/paco/organization/groups'
+      }),
+      groups: groups
+    });
+
+    this.group = groups.fetchGroup('g1');
+    spyOn(this.group, 'fetch');
+
+    spyOn(EditGroupView.prototype, 'initialize').and.callThrough();
+    this.view = new EditGroupView({
+      router: this.router,
+      group: this.group
+    });
+    this.view.render();
+  });
+
+  describe('when group is not yet fetched', function() {
+    beforeEach(function() {
+      this.group.clear();
+      this.group.set({
+        id: 'has_only_fake_id'
+      });
+      this.view.initialize(EditGroupView.prototype.initialize.calls.argsFor(0)[0]);
+      this.view.render();
+    });
+
+    it('should show loading until fetched', function() {
+      expect(this.innerHTML()).toContain('Loading');
+    });
+
+    describe('when fetched successfully', function() {
+      beforeEach(function() {
+        // fake set response
+        this.group.set({
+          display_name: 'my group'
+        });
+        this.group.fetch.calls.argsFor(0)[0].success();
+      });
+
+      it('should show form', function() {
+        expect(this.view.$('input').length > 0).toBe(true);
+      });
+    });
+
+    describe('when fetched fails (e.g. non-existing)', function() {
+      beforeEach(function() {
+        spyOn(this.router, 'navigate');
+        this.group.fetch.calls.argsFor(0)[0].error();
+      });
+
+      it('should redirect back to groups index', function() {
+        expect(this.router.navigate).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when group is already fetched', function() {
+    it('should render input', function() {
+      expect(this.innerHTML()).not.toContain('Loading');
+      expect(this.view.$('input').length > 0).toBe(true);
+    });
+  });
+
+  describe('when click save', function() {
+    beforeEach(function() {
+      spyOn(this.group, 'save');
+    });
+
+    it('should not try to save group if has no name', function() {
+      this.view.$('.js-name').val('');
+      this.view.$('.js-save').click();
+      expect(this.group.save).not.toHaveBeenCalled();
+    });
+
+    describe('when has changed name', function() {
+      beforeEach(function() {
+        this.view.$('.js-name').val('foobar');
+        this.view.$('.js-save').click();
+      });
+
+      it('should try to save group', function() {
+        expect(this.group.save).toHaveBeenCalled();
+      });
+
+      it('should show loading meanwhile', function() {
+        expect(this.innerHTML()).toContain('Saving');
+      });
+
+      it('should not add to collection until got succesful response', function() {
+        expect(this.group.save.calls.argsFor(0)[1].wait).toBe(true);
+      });
+
+      describe('when save succeeds', function() {
+        beforeEach(function() {
+          spyOn(this.router, 'navigate');
+          this.group.save.calls.argsFor(0)[1].success();
+        });
+
+        it('should navigate to groups root', function() {
+          expect(this.router.navigate).toHaveBeenCalled();
+          expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups');
+        });
+      });
+
+      describe('when save fails', function() {
+        beforeEach(function() {
+          this.group.save.calls.argsFor(0)[1].error();
+        });
+
+        it('should show form again', function() {
+          expect(this.view.$('input').length > 0).toBe(true);
+        });
+      });
+    });
+  });
+
+  describe('when click delete group', function() {
+    beforeEach(function() {
+      spyOn(this.group, 'destroy');
+      this.view.$('.js-delete').click();
+    });
+
+    it('should change to loading while destroying', function() {
+      expect(this.innerHTML()).toContain('Deleting');
+    });
+
+    it('should not remove from collection until response confirms it deleteted', function() {
+      expect(this.group.destroy.calls.argsFor(0)[0].wait).toBe(true);
+    });
+
+    describe('when deleted', function() {
+      beforeEach(function() {
+        spyOn(this.router, 'navigate');
+        this.group.destroy.calls.argsFor(0)[0].success();
+      });
+
+      it('should redirect to groups index', function() {
+        expect(this.router.navigate).toHaveBeenCalled();
+        expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups');
+      });
+    });
+
+    describe('when deletion fails', function() {
+      beforeEach(function() {
+        this.group.destroy.calls.argsFor(0)[0].error();
+      });
+
+      it('should show form again', function() {
+        expect(this.view.$('input').length > 0).toBe(true);
+      });
+    });
+  });
+
+  it("should not have leaks", function() {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+
+});

--- a/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
@@ -16,14 +16,15 @@ describe('organization_groups/groups_main_view', function() {
         }
       }
     });
-    var router = new Router({
-      rootUrl: new cdb.common.Url({
-        base_url: 'http://cartodb.com/user/paco/organization/groups'
-      })
-    });
 
     var groups = new cdb.admin.OrganizationGroups([], {
       organization: user.organization
+    });
+    var router = new Router({
+      rootUrl: new cdb.common.Url({
+        base_url: 'http://cartodb.com/user/paco/organization/groups'
+      }),
+      groups: groups
     });
 
     this.view = new GroupsMainView({

--- a/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
@@ -41,7 +41,7 @@ describe('organization_groups/groups_main_view', function() {
   });
 
   it('should change view when router model changes', function() {
-    this.view.options.router.model.set('view', 'createGroup');
+    this.view.options.router.model.set('view', 'editGroup');
     expect(this.innerHTML()).not.toContain('Create new group');
   });
 

--- a/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
@@ -17,21 +17,21 @@ describe('organization_groups/groups_main_view', function() {
       }
     });
 
-    var groups = new cdb.admin.OrganizationGroups([], {
+    this.groups = new cdb.admin.OrganizationGroups([], {
       organization: user.organization
     });
-    var router = new Router({
+    this.router = new Router({
       rootUrl: new cdb.common.Url({
         base_url: 'http://cartodb.com/user/paco/organization/groups'
       }),
-      groups: groups
+      groups: this.groups
     });
 
     this.view = new GroupsMainView({
       el: $('<div><div class="js-content"></div></div>'),
       user: user,
-      router: router,
-      groups: groups
+      router: this.router,
+      groups: this.groups
     });
     this.view.render();
   });
@@ -40,9 +40,51 @@ describe('organization_groups/groups_main_view', function() {
     expect(this.innerHTML()).toContain('Create new group');
   });
 
-  it('should change view when router model changes', function() {
-    this.view.options.router.model.set('view', 'editGroup');
-    expect(this.innerHTML()).not.toContain('Create new group');
+  describe('when router calls routeToGroupsIndex', function() {
+    beforeEach(function() {
+      spyOn(this.groups, 'fetch');
+      this.router.routeToGroupsIndex();
+    });
+
+    it('should fetch groups', function() {
+      expect(this.groups.fetch).toHaveBeenCalled();
+    });
+
+    it('should render groups index', function() {
+      expect(this.innerHTML()).toContain('Groups');
+    });
+  });
+
+  describe('when router calls routeToCreateGroup', function() {
+    beforeEach(function() {
+      this.router.routeToCreateGroup();
+    });
+
+    it('should render create form', function() {
+      var $input = this.view.$('input');
+      expect(this.view.$('input').length).toBeGreaterThan(0);
+      expect($input.val().length).toEqual(0);
+    });
+  });
+
+  describe('when router calls routeToEditGroup', function() {
+    beforeEach(function() {
+      this.groups.add({
+        id: 'g1',
+        display_name: 'bampadam'
+      });
+      this.router.routeToEditGroup('g1');
+    });
+
+    it('should set group id on router model', function() {
+      expect(this.router.model.get('groupId')).toEqual('g1');
+    });
+
+    it('should render edit form', function() {
+      var $input = this.view.$('input');
+      expect($input.length).toBeGreaterThan(0);
+      expect($input.val().length).toBeGreaterThan(0);
+    });
   });
 
   it("should not have leaks", function() {

--- a/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
@@ -1,0 +1,55 @@
+var $ = require('jquery');
+var cdb = require('cartodb.js');
+var GroupsMainView = require('../../../../javascripts/cartodb/organization_groups/groups_main_view');
+var Router = require('../../../../javascripts/cartodb/organization_groups/router');
+
+describe('organization_groups/groups_main_view', function() {
+
+  beforeEach(function() {
+    var user = new cdb.admin.User({
+      id: 123,
+      base_url: 'http://cartodb.com/user/paco',
+      username: 'paco',
+      organization: {
+        owner: {
+          id: 123
+        }
+      }
+    });
+    var router = new Router({
+      rootUrl: new cdb.common.Url({
+        base_url: 'http://cartodb.com/user/paco/organization/groups'
+      })
+    });
+
+    var groups = new cdb.admin.OrganizationGroups([], {
+      organization: user.organization
+    });
+
+    this.view = new GroupsMainView({
+      el: $('<div><div class="js-content"></div></div>'),
+      user: user,
+      router: router,
+      groups: groups
+    });
+    this.view.render();
+  });
+
+  it('should render the default view', function() {
+    expect(this.innerHTML()).toContain('Create new group');
+  });
+
+  it('should change view when router model changes', function() {
+    this.view.options.router.model.set('view', 'createGroup');
+    expect(this.innerHTML()).not.toContain('Create new group');
+  });
+
+  it("should not have leaks", function() {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+
+});

--- a/lib/assets/test/spec/cartodb/organization_groups/router.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/router.spec.js
@@ -13,8 +13,12 @@ describe("organization_groups/router", function() {
         }
       }
     });
+    this.groups = new cdb.admin.OrganizationGroups([], {
+      organization: user.organization
+    });
     this.router = new Router({
-      rootUrl: user.viewUrl().organization().groups()
+      rootUrl: user.viewUrl().organization().groups(),
+      groups: this.groups
     });
   });
 

--- a/lib/assets/test/spec/cartodb/organization_groups/router.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/router.spec.js
@@ -1,0 +1,31 @@
+var cdb = require('cartodb.js');
+var Router = require('../../../../javascripts/cartodb/organization_groups/router');
+
+describe("organization_groups/router", function() {
+  beforeEach(function() {
+    var user = new cdb.admin.User({
+      id: 123,
+      base_url: 'http://cartodb.com/user/paco',
+      username: 'paco',
+      organization: {
+        owner: {
+          id: 123
+        }
+      }
+    });
+    this.router = new Router({
+      rootUrl: user.viewUrl().organization().groups()
+    });
+  });
+
+  describe('.normalizeFragmentOrUrl', function() {
+    it('should return the normalized pathname for URLs matching current scope', function() {
+      expect(this.router.normalizeFragmentOrUrl('http://cartodb.com/user/paco/organization/groups/new')).toEqual('/new');
+      expect(this.router.normalizeFragmentOrUrl('http://cartodb.com/user/paco/organization/groups/edit/123')).toEqual('/edit/123');
+    });
+
+    it('should return full URL for non-matching URLs', function() {
+      expect(this.router.normalizeFragmentOrUrl('http://cartodb.com/user/paco/somewhere/else')).toEqual('http://cartodb.com/user/paco/somewhere/else');
+    });
+  });
+});

--- a/lib/build/files/browserify_files.js
+++ b/lib/build/files/browserify_files.js
@@ -18,6 +18,11 @@ module.exports = {
       'lib/assets/javascripts/cartodb/account/entry.js'
     ]
   },
+  confirmation: {
+    src: [
+      'lib/assets/javascripts/cartodb/confirmation/entry.js'
+    ]
+  },
   editor: {
     src: [
       'lib/assets/javascripts/cartodb/editor.js'
@@ -33,9 +38,19 @@ module.exports = {
       'lib/assets/javascripts/cartodb/keys/entry.js'
     ]
   },
+  new_public_table: {
+    src: [
+      'lib/assets/javascripts/cartodb/public_table.js'
+    ]
+  },
   organization: {
     src: [
       'lib/assets/javascripts/cartodb/organization/entry.js'
+    ]
+  },
+  organization_groups: {
+    src: [
+      'lib/assets/javascripts/cartodb/organization_groups.js'
     ]
   },
   public_dashboard: {
@@ -51,16 +66,6 @@ module.exports = {
   public_map: {
     src: [
       'lib/assets/javascripts/cartodb/public_map/entry.js'
-    ]
-  },
-  new_public_table: {
-    src: [
-      'lib/assets/javascripts/cartodb/public_table.js',
-    ]
-  },
-  confirmation: {
-    src: [
-      'lib/assets/javascripts/cartodb/confirmation/entry.js'
     ]
   },
   test_specs_for_browserify_modules: {

--- a/lib/build/files/browserify_files.js
+++ b/lib/build/files/browserify_files.js
@@ -76,13 +76,13 @@ module.exports = {
       'lib/assets/javascripts/cartodb/editor.js',
 
       // Add specs for browserify module code here:
-      'lib/assets/test/spec/cartodb/common/**/*.spec.js',
-      'lib/assets/test/spec/cartodb/organization/**/*.spec.js',
-      'lib/assets/test/spec/cartodb/dashboard/**/*.spec.js',
-      'lib/assets/test/spec/cartodb/keys/**/*.spec.js',
-      'lib/assets/test/spec/cartodb/public_dashboard/**/*.spec.js',
       'lib/assets/test/spec/cartodb/account/**/*.spec.js',
-      'lib/assets/test/spec/cartodb/editor/**/*.spec.js'
+      'lib/assets/test/spec/cartodb/common/**/*.spec.js',
+      'lib/assets/test/spec/cartodb/dashboard/**/*.spec.js',
+      'lib/assets/test/spec/cartodb/editor/**/*.spec.js',
+      'lib/assets/test/spec/cartodb/keys/**/*.spec.js',
+      'lib/assets/test/spec/cartodb/organization*/**/*.spec.js',
+      'lib/assets/test/spec/cartodb/public_dashboard/**/*.spec.js'
     ],
     dest: '<%= browserify_modules.tests.dest %>'
   }

--- a/lib/build/files/js_files.js
+++ b/lib/build/files/js_files.js
@@ -148,7 +148,7 @@ module.exports = files = {
 
     // Test files that use browserify should be added in the tests bundle defined in lib/build/tasks/browserify.js
     '!lib/assets/test/spec/cartodb/common/**/*.js',
-    '!lib/assets/test/spec/cartodb/organization/**/*.js',
+    '!lib/assets/test/spec/cartodb/organization*/**/*.js',
     '!lib/assets/test/spec/cartodb/dashboard/**/*.js',
     '!lib/assets/test/spec/cartodb/public_dashboard/**/*.js',
     '!lib/assets/test/spec/cartodb/keys/**/*.js',
@@ -328,7 +328,7 @@ module.exports = files = {
   _organization_templates: [
     'lib/assets/javascripts/cartodb/common/**/*.jst.ejs',
     'lib/assets/javascripts/cartodb/old_common/views/color_picker.jst.ejs',
-    'lib/assets/javascripts/cartodb/organization/**/*.jst.ejs',
+    'lib/assets/javascripts/cartodb/organization*/**/*.jst.ejs',
     'lib/assets/javascripts/cartodb/keys/**/*.jst.ejs'
   ],
 


### PR DESCRIPTION
First basic use-cases for [groups management UI #4883](https://github.com/CartoDB/cartodb/issues/4883), obviously a half-done version of the UI that obviously lacks a lot of stuff, but I want to avoid epic PRs for review. Note that this merges to `4924-Group_metadata_API_endpoints` branch which acts as "master" for this project. Once merged will branch of from there again and continue to iterate on this.

This implements the some of the first, basic use-cases for groups.
- Organisation owner can:
  - [x] create a new group
  - [x] see groups belonging to organization
  - [x] delete a group
  - [x] edit group name

Technical details (mostly for code-review):
- Routing starts at ../organization/groups and is handled all client-side from there (using the a Backbone.Router instance)
- The Main view interacts with the Router to render one view or another (index, create, edit)
- There's some incidental duplication in create and edit views, not convinced that it's worth to extract to some common view at this point
- File names suffer little of the [smurf naming convention](http://blog.codinghorror.com/new-programming-jargon/), but based on experience it makes it easier to browse/find desired code (both in IDEs and w/ source maps)

@alonsogarciapablo can you please review? This way you'll get some insights to how the client-side is mounted for an entry point too
cc @juanignaciosl FYI