### PR TITLE
5290 cache common data request

### DIFF
--- a/app/helpers/common_data_redis_cache.rb
+++ b/app/helpers/common_data_redis_cache.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+class CommonDataRedisCache
+
+  # This needs to be changed whenever there're changes in the code that require invalidation of old keys
+  VERSION = '1'
+
+  def initialize(redis_cache = $tables_metadata)
+    @redis = redis_cache
+  end
+
+  def get(is_https_request)
+    key = key(is_https_request)
+    value = redis.get(key)
+    if value.present?
+      return JSON.parse(value, symbolize_names: true)
+    else
+      return nil
+    end
+  rescue Redis::BaseError => exception
+    CartoDB.notify_exception(exception, { key: key })
+    nil
+  end
+
+  def set(is_https_request, response_headers, response_body)
+    serialized = JSON.generate({headers: response_headers,
+                                body: response_body
+                               })
+    redis.setex(key(is_https_request), 6.hours.to_i, serialized)
+  rescue Redis::BaseError => exception
+    CartoDB.notify_exception(exception, { key: key, headers: response_headers, body: response_body })
+    nil
+  end
+
+  def invalidate
+    redis.del [key(is_https_request=true), key(is_https_request=false)]
+  rescue Redis::BaseError => exception
+    CartoDB.notify_exception(exception)
+    nil
+  end
+
+  def key(is_https_request=false)
+    protocol = is_https_request ? 'https' : 'http'
+    "common_data:request:#{protocol}:#{VERSION}"
+  end
+
+  private
+
+  def redis
+    @redis
+  end
+
+end

--- a/spec/models/common_data_spec.rb
+++ b/spec/models/common_data_spec.rb
@@ -11,6 +11,7 @@ describe CommonData do
     @common_data.stubs(:config).with('base_url').returns(nil)
     @common_data.stubs(:config).with('api_key').returns('wadus')
     @common_data.stubs(:config).with('format', 'shp').returns('shp')
+    CommonDataRedisCache.new.invalidate
   end
 
   after(:all) do


### PR DESCRIPTION
* [X] Added a 6 hours cache to the common data request.
* [X] Fixed infinite loop bug when the org. user have no quota so the update_date flag is never setted.

Closes #5290 