### PR TITLE
Rake task to invalidate common data users flag

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,6 +74,8 @@ class User < Sequel::Model
 
   DEFAULT_GEOCODING_QUOTA = 0
 
+  COMMON_DATA_ACTIVE_DAYS = 31
+
   self.raise_on_typecast_failure = false
   self.raise_on_save_failure = false
 
@@ -189,7 +191,7 @@ class User < Sequel::Model
   end
 
   def should_load_common_data?
-    last_common_data_update_date.nil? || last_common_data_update_date < Time.now - 1.month
+    last_common_data_update_date.nil? || last_common_data_update_date < Time.now - COMMON_DATA_ACTIVE_DAYS.day
   end
 
   def load_common_data(visualizations_api_url)

--- a/lib/tasks/remote_tables_maintenance.rake
+++ b/lib/tasks/remote_tables_maintenance.rake
@@ -67,6 +67,28 @@ namespace :cartodb do
       puts DateTime.now
     end
 
+    desc "Invalidate user's date flag and make them refresh data library"
+    task :invalidate_common_data => [:environment] do
+      require_relative '../../app/helpers/common_data_redis_cache'
+      require_relative '../../app/services/visualization/common_data_service'
+
+      invalidate_sql = %Q[
+          UPDATE users
+          SET last_common_data_update_date = null
+          WHERE last_common_data_update_date >= now() - '#{User::COMMON_DATA_ACTIVE_DAYS} day'::interval;
+        ]
+      updated_rows = Rails::Sequel.connection.fetch(invalidate_sql).update
+      CommonDataRedisCache.new.invalidate
+      puts "#{updated_rows} users invalidated"
+
+      # Now we try to add the new common-data request to the cache using the common_data user
+      common_data_user = User.where(username: Cartodb.config[:common_data]["username"]).first
+      if !common_data_user.nil?
+        vis_api_url = get_visualizations_api_url
+        CartoDB::Visualization::CommonDataService.new.load_common_data_for_user(common_data_user, vis_api_url)
+      end
+    end
+
     def get_visualizations_api_url
       common_data_config = Cartodb.config[:common_data]
       username = common_data_config["username"]


### PR DESCRIPTION
Created a task to invalidate the users common data flag so when a change is made in the common data public datasets we can invalidate that flag and the request cache and force the users to reload the new dataset.

* [x] Put the users `last_common_data_update_date` flag to null
* [x] Invalidate request cache (pending to merge #5304)
 
Closes #5301 