### PR TITLE
Simplify groups transitions/states handling

### DIFF
--- a/app/assets/stylesheets/common/nav-button.css.scss
+++ b/app/assets/stylesheets/common/nav-button.css.scss
@@ -16,6 +16,7 @@
   font-weight: $sFontWeight-lighter;
   font-size: 18px;
   outline: none;
+  box-sizing: border-box;
 
   &:hover {
     border-color: $cNavButton-active;

--- a/app/views/admin/organizations/groups.html.erb
+++ b/app/views/admin/organizations/groups.html.erb
@@ -13,9 +13,14 @@
   <%= stylesheet_link_tag 'organization.css', :media => 'all' %>
 <% end %>
 
-<div>
-  <%= render :partial => 'admin/shared/org_subheader' %>
-  <div class="js-content"></div>
+<div class="FormAccount-Section u-inner">
+  <%= render :partial => 'admin/shared/pages_subheader' %>
+
+  <div class="FormAccount-Content">
+    <%= render :partial => 'admin/shared/org_subheader' %>
+
+    <div class="js-content"></div>
+  </div>
 </div>
 
 <% if !Cartodb.config[:cartodb_com_hosted].present? %>

--- a/app/views/admin/organizations/groups.html.erb
+++ b/app/views/admin/organizations/groups.html.erb
@@ -14,12 +14,14 @@
 <% end %>
 
 <div class="FormAccount-Section u-inner">
-  <%= render :partial => 'admin/shared/pages_subheader' %>
+  <%= render partial: 'admin/shared/pages_subheader' %>
 
   <div class="FormAccount-Content">
-    <%= render :partial => 'admin/shared/org_subheader' %>
+    <%= render partial: 'admin/shared/org_subheader' %>
 
-    <div class="js-content"></div>
+    <div class="js-content">
+      <%= render partial: 'admin/shared/loading', locals: { title: 'Loading assets' } %>
+    </div>
   </div>
 </div>
 

--- a/app/views/admin/shared/_loading.erb
+++ b/app/views/admin/shared/_loading.erb
@@ -1,0 +1,5 @@
+<div class="IntermediateInfo">
+  <div class="Spinner"></div>
+  <h4 class="IntermediateInfo-title"><%= title %></h4>
+  <div class="DefaultParagraph DefaultParagraph--short">&nbsp;</div>
+</div>

--- a/app/views/admin/shared/_org_subheader.html.erb
+++ b/app/views/admin/shared/_org_subheader.html.erb
@@ -22,6 +22,13 @@
           <% if (!Cartodb.config[:cartodb_com_hosted].present? && (!current_user.organization.present? || current_user.organization_owner?))  %>
             <li class="Filters-typeItem"><a href="<%= current_user.plan_url(request.protocol) %>" class="Filters-typeLink">Billing</a></li>
           <% end %>
+          <% if current_user.has_feature_flag?('groups') %>
+            <li class="Filters-typeItem">
+              <a href="<%= CartoDB.url(self, 'organization_groups') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_groups" %>">
+                Groups
+              </a>
+            </li>
+          <% end %>
         </ul>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ CartoDB::Application.routes.draw do
     put    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings_update', as: :organization_settings_update
     post '(/user/:user_domain)(/u/:user_domain)/organization/regenerate_api_keys'       => 'organizations#regenerate_all_api_keys', as: :regenerate_organization_users_api_key
 
-    get    '(/user/:user_domain)(/u/:user_domain)/organization/groups(/*other)' => 'organizations#groups',          as: :organization_settings
+    get    '(/user/:user_domain)(/u/:user_domain)/organization/groups(/*other)' => 'organizations#groups',          as: :organization_groups
 
     get    '(/user/:user_domain)(/u/:user_domain)/organization/auth'        => 'organizations#auth',        as: :organization_auth
     put    '(/user/:user_domain)(/u/:user_domain)/organization/auth'        => 'organizations#auth_update', as: :organization_auth_update

--- a/lib/assets/javascripts/cartodb/models/group.js
+++ b/lib/assets/javascripts/cartodb/models/group.js
@@ -9,6 +9,15 @@ cdb.admin.Group = cdb.core.Model.extend({
     display_name: '' // UI name, as given by
     // name: '', // internal alphanumeric representation, converted from display_name internally
     // organization_id: '',
+  },
+
+  initialize: function(attrs) {
+    this.parse(attrs || {}); // handle given attrs in the same way as for .fetch()
+  },
+
+  parse: function(attrs) {
+    this.users = new Backbone.Collection(attrs.members);
+    return attrs;
   }
 
 });

--- a/lib/assets/javascripts/cartodb/models/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/models/organization_groups.js
@@ -23,7 +23,7 @@ cdb.admin.OrganizationGroups = Backbone.Collection.extend({
 
   // @return {Object} A instance of cdb.admin.Group. If group wasn't already present a new model with id and collection
   //  set will be returned, i.e. group.fetch() will be required to get the data or handle the err case (e.g. non-existing)
-  fetchGroup: function(id) {
+  newGroupById: function(id) {
     var group = this.get(id);
     if (!group) {
       group = new this.model({

--- a/lib/assets/javascripts/cartodb/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/organization_groups.js
@@ -23,9 +23,9 @@ $(function() {
 
     var groupsMainView = new GroupsMainView({
       el: document.body,
+      groups: groups,
       router: router,
-      user: user,
-      groups: groups
+      user: user
     });
     groupsMainView.render();
     window.groups = groupsMainView;

--- a/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
@@ -52,8 +52,8 @@ module.exports = cdb.core.View.extend({
   },
 
   _redirectToGroupsIndex: function() {
-    // Redirect back to list
-    this.options.router.navigate(this.options.router.rootUrl, { trigger: true });
+    // Redirect back to show group
+    this.options.router.navigate(this.options.router.rootUrl.urlToPath(this.options.groups.last().id), { trigger: true });
   },
 
   _showErrors: function() {

--- a/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/create_group_view.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var cdb = require('cartodb.js');
 var randomQuote = require('../common/view_helpers/random_quote');
 
@@ -12,7 +13,10 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function() {
-    if (!this.options.groups) throw new Error('groups is required');
+    _.each(['group', 'onCreated'], function(name) {
+      if (!this.options[name]) throw new Error(name + ' is required');
+    }, this);
+
     this.model = new cdb.core.Model();
     this._initBinds();
   },
@@ -41,25 +45,18 @@ module.exports = cdb.core.View.extend({
     var name = this._name();
     if (name) {
       this.model.set('isLoading', true);
-      this.options.groups.create({
+      this.options.group.save({
         display_name: name
       }, {
         wait: true,
-        success: this._redirectToGroupsIndex.bind(this),
+        success: this.options.onCreated,
         error: this._showErrors.bind(this)
       });
     }
   },
 
-  _redirectToGroupsIndex: function() {
-    // Redirect back to show group
-    this.options.router.navigate(this.options.router.rootUrl.urlToPath(this.options.groups.last().id), { trigger: true });
-  },
-
   _showErrors: function() {
-    this.model.set({
-      isLoading: false
-    });
+    this.model.set('isLoading', false);
   },
 
   _onChangeName: function() {

--- a/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var cdb = require('cartodb.js');
 var randomQuote = require('../common/view_helpers/random_quote');
 
@@ -13,18 +14,10 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function() {
-    if (!this.options.group) throw new Error('group is required');
-
+    _.each(['group', 'onSaved', 'onDeleted'], function(name) {
+      if (!this.options[name]) throw new Error(name + ' is required');
+    }, this);
     this.model = new cdb.core.Model();
-
-    // No display name? Not fetched yet (e.g. on a full page request)
-    if (!this.options.group.get('display_name')) {
-      this._setLoading('Loading details');
-      this.options.group.fetch({
-        success: this._setLoading.bind(this, false),
-        error: this._redirectToGroupsIndex.bind(this)
-      });
-    }
     this._initBinds();
   },
 
@@ -48,13 +41,6 @@ module.exports = cdb.core.View.extend({
     this.model.on('change:isLoading', this.render, this);
   },
 
-  _setLoading: function(msg) {
-    this.model.set({
-      isLoading: !!msg,
-      loadingText: msg
-    });
-  },
-
   _onClickSave: function(ev) {
     this.killEvent(ev);
     var name = this._name();
@@ -64,7 +50,7 @@ module.exports = cdb.core.View.extend({
         display_name: name
       }, {
         wait: true,
-        success: this._redirectToGroupsIndex.bind(this),
+        success: this.options.onSaved,
         error: this._showErrors.bind(this)
       });
     }
@@ -74,20 +60,20 @@ module.exports = cdb.core.View.extend({
     this._setLoading('Deleting group');
     this.options.group.destroy({
       wait: true,
-      success: this._redirectToGroupsIndex.bind(this),
+      success: this.options.onDeleted,
       error: this._showErrors.bind(this)
     });
   },
 
-  _redirectToGroupsIndex: function() {
-    // Redirect back to show group
-    this.options.router.navigate(this.options.router.rootUrl.urlToPath(this.options.group.id), { trigger: true });
+  _setLoading: function(msg) {
+    this.model.set({
+      isLoading: !!msg,
+      loadingText: msg
+    });
   },
 
   _showErrors: function() {
-    this.model.set({
-      isLoading: false
-    });
+    this._setLoading('');
   },
 
   _onChangeName: function() {

--- a/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/edit_group_view.js
@@ -80,8 +80,8 @@ module.exports = cdb.core.View.extend({
   },
 
   _redirectToGroupsIndex: function() {
-    // Redirect back to list
-    this.options.router.navigate(this.options.router.rootUrl, { trigger: true });
+    // Redirect back to show group
+    this.options.router.navigate(this.options.router.rootUrl.urlToPath(this.options.group.id), { trigger: true });
   },
 
   _showErrors: function() {

--- a/lib/assets/javascripts/cartodb/organization_groups/group_header.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization_groups/group_header.jst.ejs
@@ -6,7 +6,7 @@
   <h3><%- title %></h3>
   <% if (!isNewGroup) { %>
     <div>
-      <a href="<%- showUrl %>" class="<%- viewName === 'showGroup' ? 'is-selected' : '' %>"><%- usersCount > 0 ? usersCount + ' ' : '' %>Users</a>
+      <a href="<%- showUrl %>" class="<%- viewName === 'showGroup' ? 'is-selected' : '' %>"><%- usersCount > 0 ? usersCount + ' ' : '' %><%- pluralizeString('User', 'Users', usersCount) %></a>
       <a href="<%- editUrl %>" class="<%- viewName === 'editGroup' ? 'is-selected' : '' %>">Settings</a>
     </div>
   <% } %>

--- a/lib/assets/javascripts/cartodb/organization_groups/group_header.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization_groups/group_header.jst.ejs
@@ -1,8 +1,13 @@
 <div>
-  <a href="<%- backHref %>" class="NavButton NavButton--back js-back">
+  <a href="<%- backUrl %>" class="NavButton NavButton--back">
     <i class="iconFont iconFont-ArrowPrev"></i>
   </a>
 
   <h3><%- title %></h3>
-  <div class="js-tabs"></div>
+  <% if (!isNewGroup) { %>
+    <div>
+      <a href="<%- showUrl %>" class="<%- viewName === 'showGroup' ? 'is-selected' : '' %>"><%- usersCount > 0 ? usersCount + ' ' : '' %>Users</a>
+      <a href="<%- editUrl %>" class="<%- viewName === 'editGroup' ? 'is-selected' : '' %>">Settings</a>
+    </div>
+  <% } %>
 </div>

--- a/lib/assets/javascripts/cartodb/organization_groups/group_header_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/group_header_view.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var cdb = require('cartodb.js');
+var pluralizeString = require('../common/view_helpers/pluralize_string');
 
 /**
  * Header view when looking at details of a specific group.
@@ -28,6 +29,7 @@ module.exports = cdb.core.View.extend({
       d.showUrl = groupRootUrl;
       d.editUrl = groupRootUrl.urlToPath('edit');
       d.usersCount = group.users.length;
+      d.pluralizeString = pluralizeString
 
       if (!this._isOnShowGroupView(groupRootUrl)) {
         d.backUrl = groupRootUrl;

--- a/lib/assets/javascripts/cartodb/organization_groups/group_header_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/group_header_view.js
@@ -1,14 +1,10 @@
+var _ = require('underscore');
 var cdb = require('cartodb.js');
-var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
 
 /**
  * Header view when looking at details of a specific group.
  */
 module.exports = cdb.core.View.extend({
-
-  events: {
-    'click .js-back': navigateThroughRouter
-  },
 
   initialize: function() {
     _.each(['group', 'router'], function(name) {

--- a/lib/assets/javascripts/cartodb/organization_groups/group_header_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/group_header_view.js
@@ -14,18 +14,43 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function() {
+    var group = this.options.group;
+    var isNewGroup = group.isNew();
+    var d = {
+      backUrl: this.options.router.rootUrl,
+      title: group.get('display_name') || 'Create new group',
+      isNewGroup: isNewGroup
+    };
+
+    if (!isNewGroup) {
+      var groupRootUrl = this.options.router.rootUrl.urlToPath(group.id);
+      d.viewName = this.options.router.model.get('viewName');
+      d.showUrl = groupRootUrl;
+      d.editUrl = groupRootUrl.urlToPath('edit');
+      d.usersCount = group.users.length;
+
+      if (!this._isOnShowGroupView(groupRootUrl)) {
+        d.backUrl = groupRootUrl;
+      }
+    }
+
     this.$el.html(
-      this.getTemplate('organization_groups/group_header')({
-        backHref: this.options.router.rootUrl,
-        title: this.options.group.get('display_name')
-      })
+      this.getTemplate('organization_groups/group_header')(d)
     );
     return this;
   },
 
   _initBinds: function() {
-    this.options.group.on('change:display_name', this.render, this);
-    this.add_related_model(this.options.group);
+    var group = this.options.group;
+    group.on('change:display_name', this.render, this);
+    this.add_related_model(group);
+
+    group.users.on('reset', this.render, this);
+    this.add_related_model(group.users);
+  },
+
+  _isOnShowGroupView: function(groupRootUrl) {
+    return window.location.pathname.length === groupRootUrl.pathname().length;
   }
 
 });

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
@@ -1,14 +1,9 @@
 var cdb = require('cartodb.js');
-var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
 
 /**
  * Index view of groups to list groups of an organization
  */
 module.exports = cdb.core.View.extend({
-
-  events: {
-    'click a': navigateThroughRouter
-  },
 
   initialize: function() {
     if (!this.options.groups) throw new Error('groups is required');

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_index_view.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var cdb = require('cartodb.js');
 
 /**
@@ -6,8 +7,9 @@ var cdb = require('cartodb.js');
 module.exports = cdb.core.View.extend({
 
   initialize: function() {
-    if (!this.options.groups) throw new Error('groups is required');
-    if (!this.options.router) throw new Error('router is required');
+    _.each(['groups', 'router'], function(name) {
+      if (!this.options[name]) throw new Error(name + ' is required');
+    }, this);
     this._initBinds();
   },
 
@@ -26,16 +28,16 @@ module.exports = cdb.core.View.extend({
   },
 
   _initBinds: function() {
-    this.options.groups.bind('reset', this.render, this);
+    this.options.groups.on('reset', this.render, this);
   },
 
   _makeGroupItem: function(m) {
     return this.make('div', {},
-      this.make('a', { href: this._editUrl(m) }, m.get('display_name'))
+      this.make('a', { href: this._groupUrl(m) }, m.get('display_name'))
     );
   },
 
-  _editUrl: function(group) {
-    return this.options.router.rootUrl.urlToPath('edit/' + group.get('id'));
+  _groupUrl: function(group) {
+    return this.options.router.rootUrl.urlToPath(group.get('id'));
   }
 });

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
@@ -94,6 +94,7 @@ module.exports = cdb.core.View.extend({
     }
 
     if (!this._isEventTriggeredOutsideOf(e, 'a')) {
+      navigateThroughRouter.apply(this, arguments);
     }
   },
 

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
@@ -4,6 +4,7 @@ var GroupHeaderView = require('./group_header_view');
 var GroupsIndexView = require('./groups_index_view');
 var CreateGroupView = require('./create_group_view');
 var EditGroupView = require('./edit_group_view');
+var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
 
 /**
  * Controller view, managing view state of the groups entry point
@@ -86,7 +87,17 @@ module.exports = cdb.core.View.extend({
     });
   },
 
-  _onClick: function() {
-    cdb.god.trigger('closeDialogs');
+  _onClick: function(e) {
+    if (this._isEventTriggeredOutsideOf(e, '.Dialog')) {
+      // Clicks outside of any dialog "body" will fire a closeDialogs event
+      cdb.god.trigger('closeDialogs');
+    }
+
+    if (!this._isEventTriggeredOutsideOf(e, 'a')) {
+    }
+  },
+
+  _isEventTriggeredOutsideOf: function(ev, selector) {
+    return $(ev.target).closest(selector).length === 0;
   }
 });

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
@@ -3,6 +3,7 @@ var cdb = require('cartodb.js');
 var GroupHeaderView = require('./group_header_view');
 var GroupsIndexView = require('./groups_index_view');
 var CreateGroupView = require('./create_group_view');
+var ShowGroupView = require('./show_group_view');
 var EditGroupView = require('./edit_group_view');
 var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
 
@@ -32,7 +33,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _initBinds: function() {
-    this.options.router.model.bind('change:view', this.render, this);
+    this.options.router.model.bind('change:viewName', this.render, this);
     this.add_related_model(this.options.router.model);
   },
 
@@ -40,8 +41,10 @@ module.exports = cdb.core.View.extend({
     var views = [];
     var opts = _.omit(this.options, 'el');
     var routerModel = this.options.router.model;
+    var groupId = routerModel.get('groupId');
+    var group = this.options.groups.newGroupById(groupId);
 
-    var viewName = routerModel.get('view');
+    var viewName = routerModel.get('viewName');
     switch (viewName) {
       case 'groupsIndex':
         views = [
@@ -50,16 +53,24 @@ module.exports = cdb.core.View.extend({
         break;
       case 'createGroup':
         views = [
-          this._createGroupHeader(),
-          new CreateGroupView(opts)
+          this._createGroupHeader(group),
+          new CreateGroupView(_.extend(opts, {
+            group: group
+          }))
         ];
         break;
       case 'editGroup':
-        var groupId = this.options.router.model.get('groupId');
-        var group = this.options.groups.fetchGroup(groupId);
         views = [
           this._createGroupHeader(group),
           new EditGroupView(_.extend(opts, {
+            group: group
+          }))
+        ];
+        break;
+      case 'showGroup':
+        views = [
+          this._createGroupHeader(group),
+          new ShowGroupView(_.extend(opts, {
             group: group
           }))
         ];
@@ -76,14 +87,9 @@ module.exports = cdb.core.View.extend({
   },
 
   _createGroupHeader: function(group) {
-    if (!group && !this._groupNullObj) {
-      this._groupNullObj = new cdb.core.Model({
-        display_name: 'Create new group'
-      });
-    }
     return new GroupHeaderView({
       router: this.options.router,
-      group: group || this._groupNullObj
+      group: group
     });
   },
 

--- a/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/groups_main_view.js
@@ -1,10 +1,5 @@
 var _ = require('underscore');
 var cdb = require('cartodb.js');
-var GroupHeaderView = require('./group_header_view');
-var GroupsIndexView = require('./groups_index_view');
-var CreateGroupView = require('./create_group_view');
-var ShowGroupView = require('./show_group_view');
-var EditGroupView = require('./edit_group_view');
 var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
 
 /**
@@ -17,7 +12,7 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function() {
-    _.each(['user', 'groups', 'router'], function(name) {
+    _.each(['router'], function(name) {
       if (!this.options[name]) throw new Error(name + ' is required');
     }, this);
 
@@ -26,71 +21,17 @@ module.exports = cdb.core.View.extend({
 
   render: function() {
     this.clearSubViews();
-    var $content = this.$('.js-content');
-    var els = this._renderContent();
-    $content.html('').append(els);
+    this.$('.js-content').html(this._contentView().render().el);
     return this;
   },
 
   _initBinds: function() {
-    this.options.router.model.bind('change:viewName', this.render, this);
+    this.options.router.model.bind('change:view', this.render, this);
     this.add_related_model(this.options.router.model);
   },
 
-  _renderContent: function() {
-    var views = [];
-    var opts = _.omit(this.options, 'el');
-    var routerModel = this.options.router.model;
-    var groupId = routerModel.get('groupId');
-    var group = this.options.groups.newGroupById(groupId);
-
-    var viewName = routerModel.get('viewName');
-    switch (viewName) {
-      case 'groupsIndex':
-        views = [
-          new GroupsIndexView(opts)
-        ];
-        break;
-      case 'createGroup':
-        views = [
-          this._createGroupHeader(group),
-          new CreateGroupView(_.extend(opts, {
-            group: group
-          }))
-        ];
-        break;
-      case 'editGroup':
-        views = [
-          this._createGroupHeader(group),
-          new EditGroupView(_.extend(opts, {
-            group: group
-          }))
-        ];
-        break;
-      case 'showGroup':
-        views = [
-          this._createGroupHeader(group),
-          new ShowGroupView(_.extend(opts, {
-            group: group
-          }))
-        ];
-        break;
-      default:
-        cdb.log.debug('no view for ' + viewName);
-        return '';
-    }
-
-    return _.map(views, function(view) {
-      this.addView(view);
-      return view.render().el;
-    }, this);
-  },
-
-  _createGroupHeader: function(group) {
-    return new GroupHeaderView({
-      router: this.options.router,
-      group: group
-    });
+  _contentView: function() {
+    return this.options.router.model.get('view');
   },
 
   _onClick: function(e) {

--- a/lib/assets/javascripts/cartodb/organization_groups/router.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/router.js
@@ -19,9 +19,13 @@ module.exports = Router.extend({
     'new': 'routeToCreateGroup',
     'new/': 'routeToCreateGroup',
 
+    // Show group details
+    ':id': 'routeToShowGroup',
+    ':id/': 'routeToShowGroup',
+
     // Edit settings for a group
-    'edit/:id': 'routeToEditGroup',
-    'edit/:id/': 'routeToEditGroup'
+    ':id/edit': 'routeToEditGroup',
+    ':id/edit/': 'routeToEditGroup'
   },
 
   initialize: function(opts) {
@@ -30,7 +34,7 @@ module.exports = Router.extend({
     }, this);
 
     this.model = new cdb.core.Model({
-      view: 'groupsIndex'
+      viewName: 'groupsIndex'
     });
     this._groups = opts.groups;
     this.rootUrl = opts.rootUrl;
@@ -42,18 +46,30 @@ module.exports = Router.extend({
   },
 
   routeToGroupsIndex: function() {
-    this._groups.fetch();
-    this.model.set('view', 'groupsIndex');
+    this._groups.fetch({
+      data: {
+        fetch_members: true
+      }
+    });
+    this.model.set('viewName', 'groupsIndex');
   },
 
   routeToCreateGroup: function() {
-    this.model.set('view', 'createGroup');
+    this.model.set('viewName', 'createGroup');
+  },
+
+  routeToShowGroup: function(id) {
+    this._setGroupView('showGroup', id);
   },
 
   routeToEditGroup: function(id) {
+    this._setGroupView('editGroup', id);
+  },
+
+  _setGroupView: function(viewName, id) {
     if (id) {
       this.model.set({
-        view: 'editGroup',
+        viewName: viewName,
         groupId: id
       });
     } else {

--- a/lib/assets/javascripts/cartodb/organization_groups/router.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/router.js
@@ -1,5 +1,12 @@
 var cdb = require('cartodb.js');
 var Router = require('../common/router');
+var RouterModel = require('./router_model');
+var GroupHeaderView = require('./group_header_view');
+var GroupsIndexView = require('./groups_index_view');
+var CreateGroupView = require('./create_group_view');
+var ShowGroupView = require('./show_group_view');
+var EditGroupView = require('./edit_group_view');
+var ViewFactory = require('../common/view_factory');
 
 /**
  *  Backbone router for organization groups urls.
@@ -33,12 +40,12 @@ module.exports = Router.extend({
       if (!opts[name]) throw new Error(name + ' is required');
     }, this);
 
-    this.model = new cdb.core.Model({
-      viewName: 'groupsIndex'
+    this.model = new RouterModel({
+      groups: opts.groups
     });
-    this._groups = opts.groups;
     this.rootUrl = opts.rootUrl;
     this.rootPath = this.rootUrl.pathname.bind(this.rootUrl);
+    this.model.createLoadingView('Loading view'); // Until router's history is started
   },
 
   normalizeFragmentOrUrl: function(fragmentOrUrl) {
@@ -46,35 +53,75 @@ module.exports = Router.extend({
   },
 
   routeToGroupsIndex: function() {
-    this._groups.fetch({
+    this.model.createLoadingView('Loading groups');
+
+    var self = this;
+    var groups = this.model.get('groups');
+    groups.fetch({
       data: {
         fetch_members: true
-      }
+      },
+      success: function() {
+        self.model.set('view',
+          new GroupsIndexView({
+            groups: groups,
+            router: self
+          })
+        );
+      },
+      error: this.model.createErrorView.bind(this.model)
     });
-    this.model.set('viewName', 'groupsIndex');
   },
 
   routeToCreateGroup: function() {
-    this.model.set('viewName', 'createGroup');
+    var group = this.model.getOrNewGroup();
+    var self = this;
+    this.model.set('view',
+      ViewFactory.createByList([
+        self._createGroupHeader(group),
+        new CreateGroupView({
+          group: group,
+          onCreated: self.routeToGroupsIndex.bind(self)
+        })
+      ])
+    );
   },
 
   routeToShowGroup: function(id) {
-    this._setGroupView('showGroup', id);
+    var self = this;
+    this.model.createGroupView(id, function(group) {
+      self.model.set('view',
+        ViewFactory.createByList([
+          self._createGroupHeader(group),
+          new ShowGroupView({
+            group: group
+          })
+        ])
+      );
+    });
   },
 
   routeToEditGroup: function(id) {
-    this._setGroupView('editGroup', id);
+    var self = this;
+    this.model.createGroupView(id, function(group) {
+      self.model.set('view',
+        ViewFactory.createByList([
+          self._createGroupHeader(group),
+          new EditGroupView({
+            group: group,
+            onSaved: self.routeToShowGroup.bind(self, id),
+            onDeleted: self.routeToGroupsIndex.bind(self)
+          })
+        ])
+      );
+    });
   },
 
-  _setGroupView: function(viewName, id) {
-    if (id) {
-      this.model.set({
-        viewName: viewName,
-        groupId: id
-      });
-    } else {
-      this.navigate(''); // redirect to index if there's no id
-    }
+  _createGroupHeader: function(group) {
+    return new GroupHeaderView({
+      group: group,
+      router: this
+    });
   }
 
 });

--- a/lib/assets/javascripts/cartodb/organization_groups/router.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/router.js
@@ -81,7 +81,7 @@ module.exports = Router.extend({
         self._createGroupHeader(group),
         new CreateGroupView({
           group: group,
-          onCreated: self.routeToGroupsIndex.bind(self)
+          onCreated: self._navigateToGroup.bind(self, group)
         })
       ])
     );
@@ -109,12 +109,16 @@ module.exports = Router.extend({
           self._createGroupHeader(group),
           new EditGroupView({
             group: group,
-            onSaved: self.routeToShowGroup.bind(self, id),
-            onDeleted: self.routeToGroupsIndex.bind(self)
+            onSaved: self._navigateToGroup.bind(self, group),
+            onDeleted: self.navigate.bind(self, self.rootUrl.toString())
           })
         ])
       );
     });
+  },
+
+  _navigateToGroup: function(group) {
+    this.navigate(this.rootUrl.urlToPath(group.id), { trigger: true });
   },
 
   _createGroupHeader: function(group) {

--- a/lib/assets/javascripts/cartodb/organization_groups/router_model.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/router_model.js
@@ -1,0 +1,59 @@
+var cdb = require('cartodb.js');
+var ViewFactory = require('../common/view_factory');
+var randomQuote = require('../common/view_helpers/random_quote');
+
+/**
+ * Model representing the router state
+ */
+module.exports = cdb.core.Model.extend({
+
+  defaults: {
+    view: ''
+  },
+
+  initialize: function(attrs) {
+    _.each(['groups'], function(name) {
+      if (!attrs[name]) throw new Error(name + ' is required');
+    }, this);
+  },
+
+  getOrNewGroup: function(id) {
+    return this.get('groups').newGroupById(id);
+  },
+
+  createGroupView: function(id, fetchedCallback) {
+    var group = this.getOrNewGroup(id);
+    fetchedCallback = fetchedCallback.bind(this, group);
+
+    if (group.get('display_name')) {
+      fetchedCallback();
+    } else {
+      // No display name == model not fetched yet, so show loading msg meanwhile
+      this.createLoadingView('Loading group details');
+      var self = this;
+      group.fetch({
+        success: function() {
+          self.get('groups').add(group);
+          fetchedCallback();
+        },
+        error: this.createErrorView.bind(this)
+      });
+    }
+  },
+
+  createLoadingView: function(msg) {
+    this.set('view', ViewFactory.createByTemplate('common/templates/loading', {
+      title: msg,
+      quote: randomQuote()
+    }));
+  },
+
+  createErrorView: function() {
+    // Generic error view for now
+    this.set('view', ViewFactory.createByTemplate('common/templates/fail', {
+      msg: ''
+    }));
+  }
+
+
+});

--- a/lib/assets/javascripts/cartodb/organization_groups/show_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/show_group_view.js
@@ -1,5 +1,8 @@
 var cdb = require('cartodb.js');
 
+/**
+ * View representing the default "show" defailts of a group.
+ */
 module.exports = cdb.core.View.extend({
 
   initialize: function() {

--- a/lib/assets/javascripts/cartodb/organization_groups/show_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/show_group_view.js
@@ -1,0 +1,18 @@
+var cdb = require('cartodb.js');
+
+module.exports = cdb.core.View.extend({
+
+  initialize: function() {
+    this._initBinds();
+  },
+
+  render: function() {
+    this.$el.html(
+      this.make('div', {}, 'TBD')
+    );
+    return this;
+  },
+
+  _initBinds: function() {
+  }
+});

--- a/lib/assets/javascripts/cartodb/organization_groups/show_group_view.js
+++ b/lib/assets/javascripts/cartodb/organization_groups/show_group_view.js
@@ -1,7 +1,7 @@
 var cdb = require('cartodb.js');
 
 /**
- * View representing the default "show" defailts of a group.
+ * View representing the default "show" defaults of a group.
  */
 module.exports = cdb.core.View.extend({
 

--- a/lib/assets/test/spec/cartodb/models/group.spec.js
+++ b/lib/assets/test/spec/cartodb/models/group.spec.js
@@ -1,0 +1,32 @@
+describe('cdb.admin.Group', function() {
+  describe('when given no attrs', function() {
+    beforeEach(function() {
+      this.group = new cdb.admin.Group();
+    });
+
+    it('should create an empty users collection', function() {
+      expect(this.group.users).toBeDefined();
+      expect(this.group.users.length).toEqual(0);
+    });
+  });
+
+  describe('when given some attrs', function() {
+    beforeEach(function() {
+      this.group = new cdb.admin.Group({
+        id: 'g1',
+        display_name: 'My Group',
+        name: 'my_group',
+        members: [{
+          id: 'u1',
+          username: 'pepe'
+        }]
+      });
+    });
+
+    it('should create a users collection from given members collection', function() {
+      expect(this.group.users).toBeDefined();
+      expect(this.group.users.length).toEqual(1);
+      expect(this.group.users.first().get('username')).toEqual('pepe');
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb/models/organization_groups.spec.js
+++ b/lib/assets/test/spec/cartodb/models/organization_groups.spec.js
@@ -17,10 +17,10 @@ describe('cdb.admin.OrganizationGroups', function() {
     });
   });
 
-  describe('.fetchGroup', function() {
+  describe('.newGroupById', function() {
     describe('when the group with the given id is not yet loaded', function() {
       beforeEach(function() {
-        this.group = this.groups.fetchGroup('g1');
+        this.group = this.groups.newGroupById('g1');
       });
 
       it('should return a group with the given id set', function() {
@@ -41,7 +41,7 @@ describe('cdb.admin.OrganizationGroups', function() {
           id: 'g2',
           display_name: 'foobar'
         });
-        this.group = this.groups.fetchGroup('g2');
+        this.group = this.groups.newGroupById('g2');
       });
 
       it('should return existing group', function() {

--- a/lib/assets/test/spec/cartodb/organization_groups/create_group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/create_group_view.spec.js
@@ -16,7 +16,7 @@ describe('organization_groups/create_group_view', function() {
       }
     });
 
-    var groups = new cdb.admin.OrganizationGroups([], {
+    this.groups = new cdb.admin.OrganizationGroups([], {
       organization: user.organization
     });
 
@@ -24,12 +24,12 @@ describe('organization_groups/create_group_view', function() {
       rootUrl: new cdb.common.Url({
         base_url: 'http://cartodb.com/user/paco/organization/groups'
       }),
-      groups: groups
+      groups: this.groups
     });
 
     this.view = new CreateGroupView({
       router: this.router,
-      groups: groups
+      groups: this.groups
     });
     this.view.render();
   });
@@ -69,12 +69,17 @@ describe('organization_groups/create_group_view', function() {
       describe('when create succeeds', function() {
         beforeEach(function() {
           spyOn(this.router, 'navigate');
+           // side-effect of create being done successfully, fake for the purpose of testing
+          this.groups.add({
+            id: 'abc123',
+            display_name: 'my group'
+          });
           cdb.admin.OrganizationGroups.prototype.create.calls.argsFor(0)[1].success();
         });
 
         it('should navigate to groups root', function() {
           expect(this.router.navigate).toHaveBeenCalled();
-          expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups');
+          expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups/abc123');
         });
       });
 

--- a/lib/assets/test/spec/cartodb/organization_groups/create_group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/create_group_view.spec.js
@@ -3,33 +3,13 @@ var CreateGroupView = require('../../../../javascripts/cartodb/organization_grou
 var Router = require('../../../../javascripts/cartodb/organization_groups/router');
 
 describe('organization_groups/create_group_view', function() {
-
   beforeEach(function() {
-    var user = new cdb.admin.User({
-      id: 123,
-      base_url: 'http://cartodb.com/user/paco',
-      username: 'paco',
-      organization: {
-        owner: {
-          id: 123
-        }
-      }
-    });
-
-    this.groups = new cdb.admin.OrganizationGroups([], {
-      organization: user.organization
-    });
-
-    this.router = new Router({
-      rootUrl: new cdb.common.Url({
-        base_url: 'http://cartodb.com/user/paco/organization/groups'
-      }),
-      groups: this.groups
-    });
-
+    this.group = new cdb.admin.Group();
+    spyOn(this.group, 'save');
+    this.onCreatedSpy = jasmine.createSpy('onCreated callback');
     this.view = new CreateGroupView({
-      router: this.router,
-      groups: this.groups
+      group: this.group,
+      onCreated: this.onCreatedSpy
     });
     this.view.render();
   });
@@ -39,13 +19,9 @@ describe('organization_groups/create_group_view', function() {
   });
 
   describe('when click create group', function() {
-    beforeEach(function() {
-      spyOn(cdb.admin.OrganizationGroups.prototype, 'create');
-    });
-
     it('should not try to save group if has no name', function() {
       this.view.$('.js-create').click();
-      expect(cdb.admin.OrganizationGroups.prototype.create).not.toHaveBeenCalled();
+      expect(this.group.save).not.toHaveBeenCalled();
     });
 
     describe('when has written a name', function() {
@@ -55,7 +31,7 @@ describe('organization_groups/create_group_view', function() {
       });
 
       it('should try to create group', function() {
-        expect(cdb.admin.OrganizationGroups.prototype.create).toHaveBeenCalled();
+        expect(this.group.save).toHaveBeenCalled();
       });
 
       it('should show loading meanwhile', function() {
@@ -63,37 +39,29 @@ describe('organization_groups/create_group_view', function() {
       });
 
       it('should not add to collection until got response', function() {
-        expect(cdb.admin.OrganizationGroups.prototype.create.calls.argsFor(0)[1].wait).toBe(true);
+        expect(this.group.save.calls.argsFor(0)[1].wait).toBe(true);
       });
 
       describe('when create succeeds', function() {
         beforeEach(function() {
-          spyOn(this.router, 'navigate');
-           // side-effect of create being done successfully, fake for the purpose of testing
-          this.groups.add({
-            id: 'abc123',
-            display_name: 'my group'
-          });
-          cdb.admin.OrganizationGroups.prototype.create.calls.argsFor(0)[1].success();
+          this.group.save.calls.argsFor(0)[1].success();
         });
 
-        it('should navigate to groups root', function() {
-          expect(this.router.navigate).toHaveBeenCalled();
-          expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups/abc123');
+        it('should call onCreated callback', function() {
+          expect(this.onCreatedSpy).toHaveBeenCalled();
         });
       });
 
       describe('when create fails', function() {
         beforeEach(function() {
-          cdb.admin.OrganizationGroups.prototype.create.calls.argsFor(0)[1].error();
+          this.group.save.calls.argsFor(0)[1].error();
         });
 
-        it('should show form again with errors', function() {
+        it('should show form again', function() {
           expect(this.innerHTML()).not.toContain('Creating group');
         });
       });
     });
-
   });
 
   it("should not have leaks", function() {

--- a/lib/assets/test/spec/cartodb/organization_groups/edit_group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/edit_group_view.spec.js
@@ -3,96 +3,28 @@ var EditGroupView = require('../../../../javascripts/cartodb/organization_groups
 var Router = require('../../../../javascripts/cartodb/organization_groups/router');
 
 describe('organization_groups/edit_group_view', function() {
-
   beforeEach(function() {
-    var user = new cdb.admin.User({
-      id: 123,
-      base_url: 'http://cartodb.com/user/paco',
-      username: 'paco',
-      organization: {
-        owner: {
-          id: 123
-        }
-      }
-    });
-
-    var groups = new cdb.admin.OrganizationGroups([{
+    this.group = new cdb.admin.Group({
       id: 'g1',
       display_name: 'my group'
-    }], {
-      organization: user.organization
     });
+    spyOn(this.group, 'save');
 
-    this.router = new Router({
-      rootUrl: new cdb.common.Url({
-        base_url: 'http://cartodb.com/user/paco/organization/groups'
-      }),
-      groups: groups
-    });
-
-    this.group = groups.newGroupById('g1');
-    spyOn(this.group, 'fetch');
-
-    spyOn(EditGroupView.prototype, 'initialize').and.callThrough();
+    this.onSavedSpy = jasmine.createSpy('onSaved callback');
+    this.onDeletedSpy = jasmine.createSpy('onDeleted callback');
     this.view = new EditGroupView({
-      router: this.router,
-      group: this.group
+      group: this.group,
+      onSaved: this.onSavedSpy,
+      onDeleted: this.onDeletedSpy
     });
     this.view.render();
   });
 
-  describe('when group is not yet fetched', function() {
-    beforeEach(function() {
-      this.group.clear();
-      this.group.set({
-        id: 'has_only_fake_id'
-      });
-      this.view.initialize(EditGroupView.prototype.initialize.calls.argsFor(0)[0]);
-      this.view.render();
-    });
-
-    it('should show loading until fetched', function() {
-      expect(this.innerHTML()).toContain('Loading');
-    });
-
-    describe('when fetched successfully', function() {
-      beforeEach(function() {
-        // fake set response
-        this.group.set({
-          display_name: 'my group'
-        });
-        this.group.fetch.calls.argsFor(0)[0].success();
-      });
-
-      it('should show form', function() {
-        expect(this.view.$('input').length > 0).toBe(true);
-      });
-    });
-
-    describe('when fetched fails (e.g. non-existing)', function() {
-      beforeEach(function() {
-        spyOn(this.router, 'navigate');
-        this.group.fetch.calls.argsFor(0)[0].error();
-      });
-
-      it('should redirect back to groups index', function() {
-        expect(this.router.navigate).toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('when group is already fetched', function() {
-    it('should render input', function() {
-      expect(this.innerHTML()).not.toContain('Loading');
-      expect(this.view.$('input').length > 0).toBe(true);
-    });
+  it("should not have leaks", function() {
+    expect(this.view).toHaveNoLeaks();
   });
 
   describe('when click save', function() {
-    beforeEach(function() {
-      spyOn(this.group, 'save');
-    });
-
     it('should not try to save group if has no name', function() {
       this.view.$('.js-name').val('');
       this.view.$('.js-save').click();
@@ -116,7 +48,7 @@ describe('organization_groups/edit_group_view', function() {
         expect(this.innerHTML()).toContain('Saving');
       });
 
-      it('should not add to collection until got succesful response', function() {
+      it('should not update model until got response back', function() {
         expect(this.group.save.calls.argsFor(0)[1].wait).toBe(true);
       });
 
@@ -125,13 +57,11 @@ describe('organization_groups/edit_group_view', function() {
           this.group.set({
             id: 'g1'
           });
-          spyOn(this.router, 'navigate');
           this.group.save.calls.argsFor(0)[1].success();
         });
 
-        it('should navigate to groups root', function() {
-          expect(this.router.navigate).toHaveBeenCalled();
-          expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups/g1');
+        it('should call onSaved callback', function() {
+          expect(this.onSavedSpy).toHaveBeenCalled();
         });
       });
 
@@ -163,13 +93,11 @@ describe('organization_groups/edit_group_view', function() {
 
     describe('when deleted', function() {
       beforeEach(function() {
-        spyOn(this.router, 'navigate');
         this.group.destroy.calls.argsFor(0)[0].success();
       });
 
-      it('should redirect to groups index', function() {
-        expect(this.router.navigate).toHaveBeenCalled();
-        expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups');
+      it('should call onDeleted callback', function() {
+        expect(this.onDeletedSpy).toHaveBeenCalled();
       });
     });
 
@@ -184,12 +112,7 @@ describe('organization_groups/edit_group_view', function() {
     });
   });
 
-  it("should not have leaks", function() {
-    expect(this.view).toHaveNoLeaks();
-  });
-
   afterEach(function() {
     this.view.clean();
   });
-
 });

--- a/lib/assets/test/spec/cartodb/organization_groups/edit_group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/edit_group_view.spec.js
@@ -30,7 +30,7 @@ describe('organization_groups/edit_group_view', function() {
       groups: groups
     });
 
-    this.group = groups.fetchGroup('g1');
+    this.group = groups.newGroupById('g1');
     spyOn(this.group, 'fetch');
 
     spyOn(EditGroupView.prototype, 'initialize').and.callThrough();
@@ -122,13 +122,16 @@ describe('organization_groups/edit_group_view', function() {
 
       describe('when save succeeds', function() {
         beforeEach(function() {
+          this.group.set({
+            id: 'g1'
+          });
           spyOn(this.router, 'navigate');
           this.group.save.calls.argsFor(0)[1].success();
         });
 
         it('should navigate to groups root', function() {
           expect(this.router.navigate).toHaveBeenCalled();
-          expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups');
+          expect(this.router.navigate.calls.argsFor(0)[0]).toMatch('/groups/g1');
         });
       });
 

--- a/lib/assets/test/spec/cartodb/organization_groups/group_header_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/group_header_view.spec.js
@@ -1,0 +1,94 @@
+var cdb = require('cartodb.js');
+var GroupHeaderView = require('../../../../javascripts/cartodb/organization_groups/group_header_view');
+var Router = require('../../../../javascripts/cartodb/organization_groups/router');
+
+describe('organization_groups/group_header_view', function() {
+
+  beforeEach(function() {
+    var user = new cdb.admin.User({
+      id: 123,
+      base_url: 'http://cartodb.com/user/paco',
+      username: 'paco',
+      organization: {
+        owner: {
+          id: 123
+        }
+      }
+    });
+
+    var groups = new cdb.admin.OrganizationGroups([], {
+      organization: user.organization
+    });
+
+    this.router = new Router({
+      rootUrl: new cdb.common.Url({
+        base_url: 'http://cartodb.com/user/paco/organization/groups'
+      }),
+      groups: groups
+    });
+
+    this.setupView = function() {
+      this.group = groups.fetchGroup();
+
+      spyOn(GroupHeaderView.prototype, 'initialize').and.callThrough();
+      this.view = new GroupHeaderView({
+        router: this.router,
+        group: this.group
+      });
+      this.view.render();
+    };
+  });
+
+  describe('when group is new', function() {
+    beforeEach(function() {
+      this.setupView();
+    });
+
+    it('should render the fallback text as title', function() {
+      expect(this.view.$('h3').text()).toEqual('Create new group');
+    });
+
+    it('should not render the menu', function() {
+      expect(this.innerHTML()).not.toContain('Users');
+      expect(this.innerHTML()).not.toContain('Settings');
+    });
+
+    it("should not have leaks", function() {
+      expect(this.view).toHaveNoLeaks();
+    });
+  });
+
+  describe('when group already exist', function() {
+    beforeEach(function() {
+      this.setupView();
+      this.group.set({
+        id: 'g1',
+        display_name: 'my group'
+      });
+    });
+
+    it('should render the group display name as title', function() {
+      expect(this.view.$('h3').text()).toEqual('my group');
+    });
+
+    it('should render the menu', function() {
+      expect(this.innerHTML()).toContain('Users');
+      expect(this.innerHTML()).toContain('Settings');
+    });
+
+    it('should only render users count if has any', function() {
+      expect(this.innerHTML()).not.toContain('0 Users');
+      this.group.users.reset([{}, {}, {}]);
+      expect(this.innerHTML()).toContain('3 Users');
+    });
+
+    it("should not have leaks", function() {
+      expect(this.view).toHaveNoLeaks();
+    });
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+
+});

--- a/lib/assets/test/spec/cartodb/organization_groups/group_header_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/group_header_view.spec.js
@@ -78,6 +78,8 @@ describe('organization_groups/group_header_view', function() {
 
     it('should only render users count if has any', function() {
       expect(this.innerHTML()).not.toContain('0 Users');
+      this.group.users.reset([{}]);
+      expect(this.innerHTML()).toContain('1 User');
       this.group.users.reset([{}, {}, {}]);
       expect(this.innerHTML()).toContain('3 Users');
     });

--- a/lib/assets/test/spec/cartodb/organization_groups/group_header_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/group_header_view.spec.js
@@ -28,7 +28,7 @@ describe('organization_groups/group_header_view', function() {
     });
 
     this.setupView = function() {
-      this.group = groups.fetchGroup();
+      this.group = groups.newGroupById();
 
       spyOn(GroupHeaderView.prototype, 'initialize').and.callThrough();
       this.view = new GroupHeaderView({

--- a/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/groups_main_view.spec.js
@@ -1,94 +1,32 @@
 var $ = require('jquery');
 var cdb = require('cartodb.js');
 var GroupsMainView = require('../../../../javascripts/cartodb/organization_groups/groups_main_view');
-var Router = require('../../../../javascripts/cartodb/organization_groups/router');
 
 describe('organization_groups/groups_main_view', function() {
 
-  beforeEach(function() {
-    var user = new cdb.admin.User({
-      id: 123,
-      base_url: 'http://cartodb.com/user/paco',
-      username: 'paco',
-      organization: {
-        owner: {
-          id: 123
-        }
-      }
+  beforeEach(function() { this.contentView = new cdb.core.View();
+    spyOn(this.contentView, 'render').and.callThrough();
+    this.routerModel = new cdb.core.Model({
+      view: this.contentView
     });
-
-    this.groups = new cdb.admin.OrganizationGroups([], {
-      organization: user.organization
-    });
-    this.router = new Router({
-      rootUrl: new cdb.common.Url({
-        base_url: 'http://cartodb.com/user/paco/organization/groups'
-      }),
-      groups: this.groups
-    });
+    this.router = new cdb.core.Model();
+    this.router.model = this.routerModel;
 
     this.view = new GroupsMainView({
       el: $('<div><div class="js-content"></div></div>'),
-      user: user,
       router: this.router,
       groups: this.groups
     });
     this.view.render();
   });
 
-  it('should render the default view', function() {
-    expect(this.innerHTML()).toContain('Create new group');
-  });
-
-  describe('when router calls routeToGroupsIndex', function() {
-    beforeEach(function() {
-      spyOn(this.groups, 'fetch');
-      this.router.routeToGroupsIndex();
-    });
-
-    it('should fetch groups', function() {
-      expect(this.groups.fetch).toHaveBeenCalled();
-    });
-
-    it('should render groups index', function() {
-      expect(this.innerHTML()).toContain('Groups');
-    });
-  });
-
-  describe('when router calls routeToCreateGroup', function() {
-    beforeEach(function() {
-      this.router.routeToCreateGroup();
-    });
-
-    it('should render create form', function() {
-      var $input = this.view.$('input');
-      expect(this.view.$('input').length).toBeGreaterThan(0);
-      expect($input.val().length).toEqual(0);
-    });
-  });
-
-  describe('when router calls routeToEditGroup', function() {
-    beforeEach(function() {
-      this.groups.add({
-        id: 'g1',
-        display_name: 'bampadam'
-      });
-      this.router.routeToEditGroup('g1');
-    });
-
-    it('should set group id on router model', function() {
-      expect(this.router.model.get('groupId')).toEqual('g1');
-    });
-
-    it('should render edit form', function() {
-      var $input = this.view.$('input');
-      expect($input.length).toBeGreaterThan(0);
-      expect($input.val().length).toBeGreaterThan(0);
-    });
-  });
-
   it("should not have leaks", function() {
     expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should render the view given by router model', function() {
+    expect(this.contentView.render).toHaveBeenCalled();
+    expect(this.view.$('.js-content')[0]).toEqual(this.contentView.el.parentNode);
   });
 
   afterEach(function() {

--- a/lib/assets/test/spec/cartodb/organization_groups/router.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/router.spec.js
@@ -32,4 +32,10 @@ describe("organization_groups/router", function() {
       expect(this.router.normalizeFragmentOrUrl('http://cartodb.com/user/paco/somewhere/else')).toEqual('http://cartodb.com/user/paco/somewhere/else');
     });
   });
+
+  it('should render a generic loading view for starters', function() {
+    var view = this.router.model.get('view');
+    view.render();
+    expect(this.innerHTML(view)).toContain('Loading view');
+  });
 });

--- a/lib/assets/test/spec/cartodb/organization_groups/router_model.spec.js
+++ b/lib/assets/test/spec/cartodb/organization_groups/router_model.spec.js
@@ -1,0 +1,95 @@
+var cdb = require('cartodb.js');
+var RouterModel = require('../../../../javascripts/cartodb/organization_groups/router_model');
+
+describe("organization_groups/router", function() {
+  beforeEach(function() {
+    var user = new cdb.admin.User({
+      id: 123,
+      base_url: 'http://cartodb.com/user/paco',
+      username: 'paco',
+      organization: {
+        owner: {
+          id: 123
+        }
+      }
+    });
+    this.groups = new cdb.admin.OrganizationGroups([], {
+      organization: user.organization
+    });
+    this.model = new RouterModel({
+      groups: this.groups
+    });
+  });
+
+  describe('.createGroupView', function() {
+    beforeEach(function() {
+      this.groups.add({
+        id: 'g1',
+        display_name: 'group that i already fetched'
+      });
+      this.fetchedCallbackSpy = jasmine.createSpy('fetchedCallback');
+    });
+
+    describe('when given a id of a group that already is fetched', function() {
+      beforeEach(function() {
+        this.model.createGroupView('g1', this.fetchedCallbackSpy);
+      });
+
+      it('should call the fetched callback right away with the corresponding group', function() {
+        expect(this.fetchedCallbackSpy).toHaveBeenCalled();
+        expect(this.fetchedCallbackSpy).toHaveBeenCalledWith(this.groups.first());
+      });
+    });
+
+    describe('when given a id of a group that is not yet fetched', function() {
+      beforeEach(function() {
+        spyOn(cdb.admin.Group.prototype, 'fetch');
+        this.model.createGroupView('other', this.fetchedCallbackSpy);
+      });
+
+      it('should fetch the group first', function() {
+        expect(cdb.admin.Group.prototype.fetch).toHaveBeenCalled();
+        expect(this.fetchedCallbackSpy).not.toHaveBeenCalled();
+      });
+
+      describe('when fetch succeeds', function() {
+        beforeEach(function() {
+          cdb.admin.Group.prototype.fetch.calls.argsFor(0)[0].success();
+        });
+
+        it('should add the group to the collection', function() {
+          expect(this.groups.get('other')).toBeDefined();
+        });
+
+        it('should call the fetched callback with the new group', function() {
+          expect(this.fetchedCallbackSpy).toHaveBeenCalled();
+          expect(this.fetchedCallbackSpy).toHaveBeenCalledWith(this.groups.get('other'));
+        });
+      });
+
+      describe('when fetch fails', function() {
+        beforeEach(function() {
+          cdb.admin.Group.prototype.fetch.calls.argsFor(0)[0].error();
+        });
+
+        it('should create a generic error view', function() {
+          var view = this.model.get('view');
+          view.render();
+          expect(this.innerHTML(view)).toContain('error');
+        });
+      });
+    });
+  });
+
+  describe('.createLoadingView', function() {
+    beforeEach(function() {
+      this.model.createLoadingView('Loading something');
+    });
+
+    it('should create a loading view', function() {
+      var view = this.model.get('view');
+      view.render();
+      expect(this.innerHTML(view)).toContain('Loading something');
+    });
+  });
+});


### PR DESCRIPTION
This is a pre-step refactoring for the add-groups-users use-case.

While I started to work on this feature I realized that the current rendering was becoming too complicated, especially to handle the different pre-steps (creating, saving, deleting, prefetching etc.), so pushed that logic "up" (e.g. the `group.fetch()` call).

Both router and the main view should be both easier to understand and change now (e.g. can actually be unit-tested), as well as handling the preloading-state at the top-level instead of complicating individual child views (and get rid of that smelly switch-case in the main view).

Also: 
- [x] Header menu + back button to navigate between different views/"levels" in the view hierarchy
- [x] Changed the URL path to the group to be more proper "REST" (i.e. `/groups/:id/edit`)
- [x] Moved navigate-through-router up to main view
- [x] Using new layout container for groups (+add tab)

@alonsogarciapablo Can you review please?
cc @juanignaciosl FYI