### PR TITLE
4730 ogr xy possible names

### DIFF
--- a/services/importer/lib/importer/geometry_fixer.rb
+++ b/services/importer/lib/importer/geometry_fixer.rb
@@ -41,9 +41,6 @@ module CartoDB
         })
       end
 
-      def populate_the_geom_from_latlon(qualified_table_name, latitude_column_name, longitude_column_name)
-        CartoDB::InternalGeocoder::LatitudeLongitude.new(db, job).geocode(schema, table_name, latitude_column_name, longitude_column_name)
-      end
 
       private
 

--- a/services/importer/lib/importer/ogr2ogr.rb
+++ b/services/importer/lib/importer/ogr2ogr.rb
@@ -16,6 +16,12 @@ module CartoDB
 
       DEFAULT_BINARY = 'which ogr2ogr2'
 
+      LATITUDE_POSSIBLE_NAMES   = %w{ latitude lat latitudedecimal
+        latitud lati decimallatitude decimallat point_latitude }
+      LONGITUDE_POSSIBLE_NAMES  = %w{ longitude lon lng
+        longitudedecimal longitud long decimallongitude decimallong point_longitude }
+
+
       def initialize(table_name, filepath, pg_options, layer=nil, options={})
         self.filepath   = filepath
         self.pg_options = pg_options
@@ -40,7 +46,8 @@ module CartoDB
 
       def command_for_import
         "#{OSM_INDEXING_OPTION} #{PG_COPY_OPTION} #{client_encoding_option} #{shape_encoding_option} " +
-        "#{executable_path} #{OUTPUT_FORMAT_OPTION} #{overwrite_option} #{guessing_option} #{postgres_options} #{projection_option} " +
+        "#{executable_path} #{OUTPUT_FORMAT_OPTION} #{overwrite_option} #{guessing_option} #{x_y_possible_names_option} " +
+        "#{postgres_options} #{projection_option} " +
         "#{layer_creation_options} #{filepath} #{layer} #{layer_name_option} #{NEW_LAYER_TYPE_OPTION}" +
         " #{shape_coordinate_option} "
       end
@@ -48,6 +55,7 @@ module CartoDB
       def command_for_append
         "#{OSM_INDEXING_OPTION} #{PG_COPY_OPTION} #{client_encoding_option} " +
         "#{executable_path} #{APPEND_MODE_OPTION} #{OUTPUT_FORMAT_OPTION} #{postgres_options} " +
+        "#{x_y_possible_names_option} " +
         "#{projection_option} #{filepath} #{layer} #{layer_name_option} #{NEW_LAYER_TYPE_OPTION}"
       end
 
@@ -144,6 +152,10 @@ module CartoDB
         else
           ''
         end
+      end
+
+      def x_y_possible_names_option
+        "-oo X_POSSIBLE_NAMES=#{LONGITUDE_POSSIBLE_NAMES.join(',')} -oo Y_POSSIBLE_NAMES=#{LATITUDE_POSSIBLE_NAMES.join(',')}"
       end
 
       def overwrite_option

--- a/services/importer/spec/unit/georeferencer_spec.rb
+++ b/services/importer/spec/unit/georeferencer_spec.rb
@@ -81,34 +81,6 @@ describe Importer2::Georeferencer do
     end
   end #run
 
-  describe '#populate_the_geom_from_latlon' do
-    it 'populates the_geom from lat / lon values' do
-      lat = Importer2::Georeferencer::LATITUDE_POSSIBLE_NAMES.sample
-      lon = Importer2::Georeferencer::LONGITUDE_POSSIBLE_NAMES.sample
-
-      table_name = create_table(
-        @db,
-        latitude_column:  lat,
-        longitude_column: lon
-      )
-
-      georeferencer = georeferencer_instance(@db, table_name)
-      dataset       = @db[table_name.to_sym]
-
-      georeferencer.create_the_geom_in(table_name)
-      dataset.insert(
-        :name         => 'bogus',
-        :description  => 'bogus',
-        :"#{lat}"     => rand(90),
-        :"#{lon}"     => rand(180)
-      )
-
-      dataset.first.fetch(:the_geom).should be_nil
-      georeferencer.populate_the_geom_from_latlon(table_name, lat, lon)
-      dataset.first.fetch(:the_geom).should_not be_nil
-    end
-  end
-
   describe '#create_the_geom_in' do
     before do
       @table_name = create_table(@db)

--- a/services/importer/spec/unit/georeferencer_spec.rb
+++ b/services/importer/spec/unit/georeferencer_spec.rb
@@ -1,7 +1,8 @@
 # encoding: utf-8
-require_relative '../../lib/importer/georeferencer.rb'
+require_relative '../../lib/importer/georeferencer'
 require_relative '../factories/pg_connection'
 require_relative '../../../../services/importer/spec/doubles/log'
+require_relative '../../../../spec/rspec_configuration'
 
 include CartoDB
 
@@ -48,18 +49,6 @@ describe Importer2::Georeferencer do
   end #initialize
 
   describe '#run' do
-    it 'generates the_geom from lat / lon columns' do
-      dataset     = @db[@table_name.to_sym]
-
-      10.times { dataset.insert(random_record) }
-
-      georeferencer = georeferencer_instance
-      georeferencer.run
-
-      dataset.first.fetch(:the_geom).should_not be_nil
-      dataset.first.fetch(:the_geom).should_not be_empty
-    end
-
     it 'returns self if no lat / lon columns in the table' do
       table_name  = create_table(@db,
                       latitude_column: 'bogus_1',
@@ -122,22 +111,6 @@ describe Importer2::Georeferencer do
       georeferencer.columns_in(@table_name).should include :lon
     end
   end #columns_in
-
-  describe '#latitude_column_name_in' do
-    it 'returns the name of a latitude column within a set of candidates, if
-    existing' do
-      georeferencer = georeferencer_instance
-      georeferencer.latitude_column_name_in.should eq 'lat'
-    end
-  end
-
-  describe '#longitude_column_name_in' do
-    it 'returns the name of a longitude column within a set of candidates, if
-    existing' do
-      georeferencer = georeferencer_instance
-      georeferencer.longitude_column_name_in.should eq 'lon'
-    end
-  end
 
   describe '#find_column_in' do
     it 'returns the name of a column in a set of possible names if one of them

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -92,6 +92,15 @@ describe "Imports API" do
     import_table.should have_required_indexes_and_triggers
   end
 
+  it 'detects lat/long columns and produces a the_geom column from them' do
+    post api_v1_imports_create_url,
+      params.merge(:filename => upload_file('spec/support/data/csv_with_lat_lon.csv', 'application/octet-stream'))
+    @table_from_import = UserTable.all.last.service
+
+    @table_from_import.geometry_types.should == ["ST_Point"]
+    @table_from_import.record(1)[:the_geom].should == '{"type":"Point","coordinates":[16.5607329,48.1199611]}'
+  end
+
   it 'duplicates a table without geometries' do
     post api_v1_imports_create_url,
       params.merge(:filename => upload_file('spec/support/data/csv_with_number_columns.csv', 'application/octet-stream'))


### PR DESCRIPTION
What this does:
- Moves `[LAT|LONG]_POSSIBLE_NAMES` to the `Ogr2ogr` class, removing it from the `Georeferencer`
- Removes georeferencer tests related to that feature, no longer the responsibility of rails code but ogr2ogr2
- Adds a specific integration test to check that the table is indeed imported correctly with the new ogr2ogr2 binary.

@Kartones can you please review?