### PR TITLE
Platform 566 add bounding box explore

### DIFF
--- a/app/helpers/bounding_box_helper.rb
+++ b/app/helpers/bounding_box_helper.rb
@@ -104,6 +104,10 @@ module BoundingBoxHelper
     %Q{ST_Transform(ST_Envelope('SRID=4326;POLYGON((#{minx} #{miny}, #{minx} #{maxy}, #{maxx} #{maxy}, #{maxx} #{miny}, #{minx} #{miny}))'::geometry), 3857)}
   end
 
+  def self.to_point(x, y)
+    %Q[ST_GeomFromText('POINT(#{x} #{y})',3857)]
+  end
+
   def self.parse_bbox_parameters(bounding_box)
     bbox_coords = bounding_box.split(',').map { |coord| Float(coord) rescue nil }.compact
     raise CartoDB::BoundingBoxError.new('bounding box must have 4 coordinates: minx, miny, maxx, maxy') if bbox_coords.length != 4

--- a/app/helpers/explore_api.rb
+++ b/app/helpers/explore_api.rb
@@ -40,12 +40,12 @@ module Helpers
           bbox = !bbox_values[v.id].nil? ? "ST_AsText('#{bbox_values[v.id]}')" : 'NULL'
 
           # Insert values built based in the coulmn order from VISUALIZATIONS_COLUMNS
-          visualizations_values.push %Q[('#{v.id}', '#{v.name}', '#{v.description}','#{v.type}',
-          '#{!v.synchronization.is_a?(Hash)}', '#{tables}', '#{tags}', #{bbox}, #{geometry_data[:view_box_polygon]},
-          #{geometry_data[:center_geometry]}, #{geometry_data[:zoom]},
-          '#{v.created_at}', '#{v.updated_at}', '#{v.map_id}','#{v.title}',#{v.likes_count},
-          #{v.mapviews}, '#{u.id}', '#{u.username}', #{organization_id}, '#{u.twitter_username}',
-          '#{u.website}', '#{u.avatar_url}', '#{u.available_for_hire}')]
+          visualizations_values.push "('#{v.id}', '#{v.name}', '#{v.description}','#{v.type}',"\
+          "'#{!v.synchronization.is_a?(Hash)}', '#{tables}', '#{tags}', #{bbox}, #{geometry_data[:view_box_polygon]},"\
+          "#{geometry_data[:center_geometry]}, #{geometry_data[:zoom]},"\
+          "'#{v.created_at}', '#{v.updated_at}', '#{v.map_id}','#{v.title}',#{v.likes_count},"\
+          "#{v.mapviews}, '#{u.id}', '#{u.username}', #{organization_id}, '#{u.twitter_username}',"\
+          "'#{u.website}', '#{u.avatar_url}', '#{u.available_for_hire}')"
         end
         visualizations_values
       end

--- a/app/helpers/explore_api.rb
+++ b/app/helpers/explore_api.rb
@@ -37,11 +37,11 @@ module Helpers
           tables = get_visualization_tables(v)
           geometry_data = get_geometry_data(v)
           organization_id = u.organization_id.nil? ? 'NULL' : "'#{u.organization_id}'"
-          bbox = !bbox_values[v.id].nil? ? "ST_AsText('#{bbox_values[v.id]}')" : 'NULL'
+          bbox = bbox_values[v.id].nil? ? 'NULL' : "ST_AsText('#{bbox_values[v.id]}')"
 
           # Insert values built based in the coulmn order from VISUALIZATIONS_COLUMNS
           visualizations_values.push "('#{v.id}', '#{v.name}', '#{v.description}','#{v.type}',"\
-          "'#{!v.synchronization.is_a?(Hash)}', '#{tables}', '#{tags}', #{bbox}, #{geometry_data[:view_box_polygon]},"\
+          "'#{v.is_synced?}', '#{tables}', '#{tags}', #{bbox}, #{geometry_data[:view_box_polygon]},"\
           "#{geometry_data[:center_geometry]}, #{geometry_data[:zoom]},"\
           "'#{v.created_at}', '#{v.updated_at}', '#{v.map_id}','#{v.title}',#{v.likes_count},"\
           "#{v.mapviews}, '#{u.id}', '#{u.username}', #{organization_id}, '#{u.twitter_username}',"\

--- a/app/helpers/explore_api.rb
+++ b/app/helpers/explore_api.rb
@@ -3,11 +3,51 @@
 module Helpers
   class ExploreAPI
 
+      VISUALIZATIONS_COLUMNS = ['visualization_id', 'visualization_name', 'visualization_description', 'visualization_type', 'visualization_synced',
+                              'visualization_table_names', 'visualization_tags', 'visualization_bbox', 'visualization_view_box',
+                              'visualization_view_box_center', 'visualization_zoom', 'visualization_created_at', 'visualization_updated_at',
+                              'visualization_map_id', 'visualization_title', 'visualization_likes', 'visualization_mapviews', 'user_id',
+                              'user_username', 'user_organization_id', 'user_twitter_username', 'user_website', 'user_avatar_url',
+                              'user_available_for_hire']
+
       def get_visualization_tables(visualization)
         # We are using layers instead of related tables because with related tables we are connecting
         # to the users databases and we are reaching the connections limit
         table_names = visualization.layers(:carto_and_torque).map { |layer| extract_table_name(layer) }
         %Q{{#{table_names.compact.join(",")}}}
+      end
+
+      def get_geometry_data(visualization)
+        map = visualization.map
+        view_box = map.view_bounds_data
+        center_coordinates = map.center_data.reverse
+        {
+          zoom: map.zoom,
+          view_box_polygon: BoundingBoxHelper.to_polygon(view_box[:west], view_box[:south], view_box[:east], view_box[:north]),
+          center_geometry: BoundingBoxHelper.to_point(center_coordinates[0], center_coordinates[1])
+        }
+      end
+
+      def get_visualizations_values_for_insert(visualizations, bbox_values)
+        visualizations_values = []
+        visualizations.each do |v|
+          u = v.user
+
+          tags = %Q[{#{v.tags.join(",")}}]
+          tables = get_visualization_tables(v)
+          geometry_data = get_geometry_data(v)
+          organization_id = u.organization_id.nil? ? 'NULL' : "'#{u.organization_id}'"
+          bbox = !bbox_values[v.id].nil? ? "ST_AsText('#{bbox_values[v.id]}')" : 'NULL'
+
+          # Insert values built based in the coulmn order from VISUALIZATIONS_COLUMNS
+          visualizations_values.push %Q[('#{v.id}', '#{v.name}', '#{v.description}','#{v.type}',
+          '#{!v.synchronization.is_a?(Hash)}', '#{tables}', '#{tags}', #{bbox}, #{geometry_data[:view_box_polygon]},
+          #{geometry_data[:center_geometry]}, #{geometry_data[:zoom]},
+          '#{v.created_at}', '#{v.updated_at}', '#{v.map_id}','#{v.title}',#{v.likes_count},
+          #{v.mapviews}, '#{u.id}', '#{u.username}', #{organization_id}, '#{u.twitter_username}',
+          '#{u.website}', '#{u.avatar_url}', '#{u.available_for_hire}')]
+        end
+        visualizations_values
       end
 
       private

--- a/app/helpers/explore_api.rb
+++ b/app/helpers/explore_api.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+
+module Helpers
+  class ExploreAPI
+
+      def get_visualization_tables(visualization)
+        # We are using layers instead of related tables because with related tables we are connecting
+        # to the users databases and we are reaching the connections limit
+        table_names = visualization.layers(:carto_and_torque).map { |layer| extract_table_name(layer) }
+        %Q{{#{table_names.compact.join(",")}}}
+      end
+
+      private
+
+      def extract_table_name(layer)
+        table_username = layer.options['user_name']
+        table_name = layer.options['table_name'].gsub(/"/,'\"').split('.')
+        # Here we check for:
+        #   a) return as comes, but escaping quotes, if the table_name have a . this means an old format username.tablename
+        #   b) return username.table_name with the username escaped to avoid problems with non-alphanumeric characters like '-'
+        if table_name.length > 1
+          %Q[#{layer.options['table_name'].gsub(/"/,'\"')}]
+        elsif table_name.length == 1 && !table_username.blank?
+          %Q[\\"#{table_username}\\".#{table_name[0]}]
+        else
+          nil
+        end
+      end
+
+  end
+end

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -18,7 +18,7 @@ module CartoDB
                       }
 
       INTERFACE     = %w{ overlays map user table related_templates related_tables related_visualizations layers
-                          stats mapviews total_mapviews single_data_layer? synchronization permission parent
+                          stats mapviews total_mapviews single_data_layer? synchronization is_synced? permission parent
                           children support_tables prev_list_item next_list_item likes likes_count reload_likes
                           estimated_row_count actual_row_count }
 
@@ -118,6 +118,10 @@ module CartoDB
         CartoDB::Synchronization::Member.new(visualization_id: @id).fetch_by_visualization_id
       rescue KeyError
         {}
+      end
+
+      def is_synced?
+        !synchronization.is_a?(Hash)
       end
 
       def stats(user=nil)

--- a/lib/tasks/explore_api.rake
+++ b/lib/tasks/explore_api.rake
@@ -47,6 +47,7 @@ namespace :cartodb do
                 visualization_map_id,
                 visualization_title,
                 visualization_likes,
+                visualization_mapviews::numeric/(1.0 + (now()::date - visualization_created_at::date)::numeric)^2 AS popularity
                 user_id,
                 user_username,
                 user_organization_id,

--- a/lib/tasks/explore_api.rake
+++ b/lib/tasks/explore_api.rake
@@ -88,8 +88,11 @@ namespace :cartodb do
     end
 
     task :setup_public_view => [:environment] do
-      user = target_user
-      user.in_database.run CREATE_PUBLIC_VIEW
+      target_user.in_database.run CREATE_PUBLIC_VIEW
+    end
+
+    task :drop_public_view => [:environment] do
+      target_user.in_database.run DROP_PUBLIC_VIEW_SQL
     end
 
     desc "Deletes the #{VISUALIZATIONS_TABLE} table"

--- a/spec/factories/layers.rb
+++ b/spec/factories/layers.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+
+  factory :carto_layer, class: Layer do
+    kind 'carto'
+    order 1
+  end
+
+end

--- a/spec/factories/maps.rb
+++ b/spec/factories/maps.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+
+  factory :map, class: Map do
+  end
+
+end

--- a/spec/factories/visualizations.rb
+++ b/spec/factories/visualizations.rb
@@ -1,0 +1,17 @@
+FactoryGirl.define do
+
+  random = UUIDTools::UUID.timestamp_create.to_s
+
+  factory :derived_visualization, class: CartoDB::Visualization::Member do
+    type 'derived'
+    name "visualization #{random}"
+    privacy 'public'
+  end
+
+  factory :table_visualization, class: CartoDB::Visualization::Member do
+    type 'table'
+    name "visualization_#{random}"
+    privacy 'public'
+  end
+
+end

--- a/spec/helpers/explore_api_spec.rb
+++ b/spec/helpers/explore_api_spec.rb
@@ -82,8 +82,8 @@ describe 'Helpers' do
         :map_id => map.id,
         :name => 'vis_name',
         :description => 'vis_description',
-        :created_at => '',
-        :updated_at => '',
+        :created_at => '2015-08-13 06:13:15+00',
+        :updated_at => '2015-09-03 06:12:15+00',
         :title => 'vis_title',
         :tags => ['lala', 'lele']
       }
@@ -97,7 +97,7 @@ describe 'Helpers' do
       visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1])
       bbox_values = {visualization.id => '0103000000010000000500000069B6E1BBD0FD69C17200D8285370474169B6E1BBD0FD69C1E6DDC1415E6B574120FFD8C8C1365FC1E6DDC1415E6B574120FFD8C8C1365FC17200D8285370474169B6E1BBD0FD69C17200D82853704741'}
       insert_values = @explore_api.get_visualizations_values_for_insert([visualization],bbox_values)
-      insert_values[0].should eq "('ffb16d4e-e74a-4764-b509-1b5f682238b5', 'vis_name', 'vis_description','derived','true', '{\\\"user_name_1\\\".table_1}', '{lala,lele}', ST_AsText('0103000000010000000500000069B6E1BBD0FD69C17200D8285370474169B6E1BBD0FD69C1E6DDC1415E6B574120FFD8C8C1365FC1E6DDC1415E6B574120FFD8C8C1365FC17200D8285370474169B6E1BBD0FD69C17200D82853704741'), ST_Transform(ST_Envelope('SRID=4326;POLYGON((-179.0 -85.0511, -179.0 85.0511, 179.0 85.0511, 179.0 -85.0511, -179.0 -85.0511))'::geometry), 3857),ST_GeomFromText('POINT(0 30)',3857), 3,'', '', '','vis_title',1,0, 'dcb16d4e-e74a-4764-b509-1b5f682238b5', 'user_test', NULL, 'twitter_user_test','website_test', 'avatar_url_test', 'true')"
+      insert_values[0].should eq "('ffb16d4e-e74a-4764-b509-1b5f682238b5', 'vis_name', 'vis_description','derived','false', '{\\\"user_name_1\\\".table_1}', '{lala,lele}', ST_AsText('0103000000010000000500000069B6E1BBD0FD69C17200D8285370474169B6E1BBD0FD69C1E6DDC1415E6B574120FFD8C8C1365FC1E6DDC1415E6B574120FFD8C8C1365FC17200D8285370474169B6E1BBD0FD69C17200D82853704741'), ST_Transform(ST_Envelope('SRID=4326;POLYGON((-179.0 -85.0511, -179.0 85.0511, 179.0 85.0511, 179.0 -85.0511, -179.0 -85.0511))'::geometry), 3857),ST_GeomFromText('POINT(0 30)',3857), 3,'2015-08-13 06:13:15 +0000', '2015-09-03 06:12:15 +0000', '','vis_title',1,0, 'dcb16d4e-e74a-4764-b509-1b5f682238b5', 'user_test', NULL, 'twitter_user_test','website_test', 'avatar_url_test', 'true')"
     end
   end
 

--- a/spec/helpers/explore_api_spec.rb
+++ b/spec/helpers/explore_api_spec.rb
@@ -1,0 +1,111 @@
+#encoding: UTF-8
+require_relative '../spec_helper'
+
+CARTO_OPTIONS = '{"query":"","opacity":0.99,"auto_bound":false,"interactivity":"cartodb_id","debug":false,"visible":true,"tiler_domain":"localhost.lan","tiler_port":"80","tiler_protocol":"http","sql_domain":"localhost.lan","sql_port":"80","sql_protocol":"http","extra_params":{"cache_policy":"persist"},"cdn_url":"","tile_style_history":[],"style_version":"2.1.1","table_name":"districtes_barcelona","user_name":"ethervoid-common","tile_style":"#districtes_barcelona {\n  polygon-fill:#FF6600;\n  polygon-opacity: 0.7;\n  line-opacity:1;\n  line-color: #FFFFFF;\n}"}'
+
+describe 'Helpers' do
+  describe 'ExploreAPI' do
+
+    before(:each) do
+      @explore_api = Helpers::ExploreAPI.new
+    end
+
+    it 'should return the visualization table' do
+      user = FactoryGirl.build(:user)
+      map = FactoryGirl.build(:map, :user_id => user.id)
+      visualization = FactoryGirl.build(:table_visualization, :user_id => user.id, :map_id => map.id)
+      layer_1 = create_layer('table_1', 'user_name_1', 1)
+      visualization.stubs(:map).returns(map)
+      visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1])
+      tables = @explore_api.get_visualization_tables(visualization)
+      tables.should eq '{\"user_name_1\".table_1}'
+    end
+
+    it 'should return the visualizations tables with multiple layers' do
+      user = FactoryGirl.build(:user)
+      map = FactoryGirl.build(:map, :user_id => user.id)
+      visualization = FactoryGirl.build(:derived_visualization, :user_id => user.id, :map_id => map.id)
+      layer_1 = create_layer('table_1', 'user_name_1', 1)
+      layer_2 = create_layer('table_2', 'user_name_2', 2)
+      visualization.stubs(:map).returns(map)
+      visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1, layer_2])
+      tables = @explore_api.get_visualization_tables(visualization)
+      tables.should eq '{\"user_name_1\".table_1,\"user_name_2\".table_2}'
+    end
+
+    it 'should empty if the is no user name or table name in the layer' do
+      user = FactoryGirl.build(:user)
+      map = FactoryGirl.build(:map, :user_id => user.id)
+      visualization = FactoryGirl.build(:table_visualization, :user_id => user.id, :map_id => map.id)
+      layer_1 = create_layer('table_1', '', 1)
+      layer_2 = create_layer('', 'user_name_2', 1)
+      visualization.stubs(:map).returns(map)
+      visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1, layer_2])
+      tables = @explore_api.get_visualization_tables(visualization)
+      tables.should eq '{}'
+    end
+
+    it 'should return the geometry data properly setted' do
+      user = FactoryGirl.build(:user)
+      map = FactoryGirl.build(
+        :map, user_id: user.id, zoom: 3, center: [30, 0], view_bounds_ne: [85.0511, 179],
+        view_bounds_sw: [-85.0511, -179]
+      )
+      visualization = FactoryGirl.build(:derived_visualization, :user_id => user.id, :map_id => map.id)
+      visualization.stubs(:map).returns(map)
+      geometry_data = @explore_api.get_geometry_data(visualization)
+      expected_data = {
+        :zoom=>3,
+        :view_box_polygon=>%Q[ST_Transform(ST_Envelope('SRID=4326;POLYGON((-179.0 -85.0511, -179.0 85.0511, 179.0 85.0511, 179.0 -85.0511, -179.0 -85.0511))'::geometry), 3857)],
+        :center_geometry=>"ST_GeomFromText('POINT(0 30)',3857)"
+      }
+      geometry_data.should eq expected_data
+    end
+
+    it 'should return the visualization insertion values in order with the table columns' do
+      user_options = {
+        id: 'dcb16d4e-e74a-4764-b509-1b5f682238b5',
+        username: 'user_test',
+        twitter_username: 'twitter_user_test',
+        website: 'website_test',
+        avatar_url: 'avatar_url_test',
+        available_for_hire: true
+      }
+      user = FactoryGirl.build(:user, user_options)
+      map = FactoryGirl.build(
+        :map, user_id: user.id, zoom: 3, center: [30, 0], view_bounds_ne: [85.0511, 179],
+        view_bounds_sw: [-85.0511, -179]
+      )
+      visualization_options = {
+        :id => 'ffb16d4e-e74a-4764-b509-1b5f682238b5',
+        :user_id => user.id,
+        :map_id => map.id,
+        :name => 'vis_name',
+        :description => 'vis_description',
+        :created_at => '',
+        :updated_at => '',
+        :title => 'vis_title',
+        :tags => ['lala', 'lele']
+      }
+      visualization = FactoryGirl.build(:derived_visualization, visualization_options)
+      visualization.stubs(:map).returns(map)
+      visualization.stubs(:user).returns(user)
+      visualization.stubs(:synchronization).returns(Object.new)
+      visualization.stubs(:likes_count).returns(1)
+      visualization.stubs(:map_views).returns(10)
+      layer_1 = create_layer('table_1', 'user_name_1', 1)
+      visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1])
+      bbox_values = {visualization.id => '0103000000010000000500000069B6E1BBD0FD69C17200D8285370474169B6E1BBD0FD69C1E6DDC1415E6B574120FFD8C8C1365FC1E6DDC1415E6B574120FFD8C8C1365FC17200D8285370474169B6E1BBD0FD69C17200D82853704741'}
+      insert_values = @explore_api.get_visualizations_values_for_insert([visualization],bbox_values)
+      insert_values[0].should eq "('ffb16d4e-e74a-4764-b509-1b5f682238b5', 'vis_name', 'vis_description','derived','true', '{\\\"user_name_1\\\".table_1}', '{lala,lele}', ST_AsText('0103000000010000000500000069B6E1BBD0FD69C17200D8285370474169B6E1BBD0FD69C1E6DDC1415E6B574120FFD8C8C1365FC1E6DDC1415E6B574120FFD8C8C1365FC17200D8285370474169B6E1BBD0FD69C17200D82853704741'), ST_Transform(ST_Envelope('SRID=4326;POLYGON((-179.0 -85.0511, -179.0 85.0511, 179.0 85.0511, 179.0 -85.0511, -179.0 -85.0511))'::geometry), 3857),ST_GeomFromText('POINT(0 30)',3857), 3,'', '', '','vis_title',1,0, 'dcb16d4e-e74a-4764-b509-1b5f682238b5', 'user_test', NULL, 'twitter_user_test','website_test', 'avatar_url_test', 'true')"
+    end
+  end
+
+  def create_layer(table_name, user_name, order = 1)
+    options = JSON.parse(CARTO_OPTIONS)
+    options["table_name"] = table_name
+    options["user_name"] = user_name
+    FactoryGirl.build(:carto_layer, :options => options, :order => order)
+  end
+
+end


### PR DESCRIPTION
This PR change a few thing in Explore API:

* [x] Extract methods to a helper (this class is becoming more than a rake)
* [x] Add geometry fields (bbox, view_box, etc) to the table
* [x] Added GIST index for bbox and visual box to the table
* [x] Change insertion method to be able to insert geometries
* [x] Add test

We have to run the following SQL to the table `visualizations`:

```
ALTER TABLE visualizations ADD COLUMN visualization_bbox geometry;
ALTER TABLE visualizations ADD COLUMN visualization_view_box geometry;
ALTER TABLE visualizations ADD COLUMN visualization_view_box_center geometry;
ALTER TABLE visualizations ADD COLUMN visualization_zoom integer;
CREATE INDEX visualizations_visualization_bbox_geom_idx ON visualizations USING GIST (visualization_bbox);
CREATE INDEX visualizations_visualization_view_box_geom_idx ON visualizations USING GIST (visualization_view_box);
```