### PR TITLE
5264 fix ghost tables deletion

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -20,11 +20,8 @@ class Admin::VisualizationsController < ApplicationController
   ssl_required :index, :show, :protected_embed_map, :protected_public_map, :show_protected_public_map
   before_filter :login_required, only: [:index]
   before_filter :table_and_schema_from_params, only: [:show, :public_table, :public_map, :show_protected_public_map,
-
                                                       :show_protected_embed_map, :embed_map]
-  # Commented out until fixing #5264
-  #before_filter :link_ghost_tables, only: [:index]
-
+  before_filter :link_ghost_tables, only: [:index]
   before_filter :load_common_data, only: [:index]
 
   before_filter :resolve_visualization_and_table, only: [:show, :public_table, :public_map,

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -422,7 +422,7 @@ class Admin::VisualizationsController < ApplicationController
   def link_ghost_tables
     return true unless current_user.present?
 
-    if current_user.search_for_modified_table_names
+    if current_user.search_for_modified_table_names && current_user.has_feature_flag?('ghost_tables')
       # this should be removed from there once we have the table triggers enabled in cartodb-postgres extension
       # test if there is a job already for this
       if !current_user.link_ghost_tables_working

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -77,10 +77,10 @@ module CartoDB
         table.schema(reload: true)
         table.send :set_the_geom_column!
         table.import_cleanup
-        table.schema(reload: true)
         table.reload
         table.send :update_table_pg_stats
         table.send :cartodbfy
+        table.schema(reload: true)
         table.save
         table.send(:invalidate_varnish_cache)
         update_cdb_tablemetadata(table.name)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -393,6 +393,7 @@ class Table
       else
         create_table_in_database!
         set_table_id
+        set_the_geom_column!(DEFAULT_THE_GEOM_TYPE)
       end
     end
   rescue => e

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1184,6 +1184,12 @@ class Table
       end
     end
 
+    # There might be a rewrite during cartodbfy. Get the OID and store it in Table metadata.
+    # This is needed in order to prevent ghost tables from dropping the table and metadata associated (vizs).
+    oid = owner.in_database.fetch(%Q{SELECT '#{qualified_table_name}'::regclass::oid}).first[:oid].to_i
+    self.table_id = oid
+    self.save
+
     elapsed = Time.now - start
     if @data_import
       CartoDB::Importer2::CartodbfyTime::instance(@data_import.id).add(elapsed)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1188,7 +1188,6 @@ class Table
     # This is needed in order to prevent ghost tables from dropping the table and metadata associated (vizs).
     oid = owner.in_database.fetch(%Q{SELECT '#{qualified_table_name}'::regclass::oid}).first[:oid].to_i
     self.table_id = oid
-    self.save
 
     elapsed = Time.now - start
     if @data_import
@@ -1608,6 +1607,7 @@ class Table
         )
       end
     end
+    self.cartodbfy
   end
 
   def update_the_geom!(attributes, primary_key)


### PR DESCRIPTION
A bit of explanation about this fix:
- Table.create_table_in_database! is a private method
- It is invoked from Table.before_create when it is not a migration nor
  a register of the table, that is, only when creating empty tables.
  E.g: from TablesController.create
- cartodbfy will be called a bit later, but it will be idempotent (no
  further changes).
- If you look into Table.before_create, it will invoke
  Table.set_table_id which is the right place to edit such a thing (the
  OID of the just created use rtable).

So this is not the perfect solution, but is the one that solves the
problem at hand minimizing side effects.

@Kartones or @juanignaciosl can you please review?