### PR TITLE
Reject empty custom attributions

### DIFF
--- a/app/controllers/carto/api/visualization_vizjson_adapter.rb
+++ b/app/controllers/carto/api/visualization_vizjson_adapter.rb
@@ -29,7 +29,7 @@ module Carto
       end
 
       def attributions_from_derived_visualizations
-        @visualization.related_visualizations.map(&:attributions).compact
+        @visualization.related_visualizations.map(&:attributions).reject {|attribution| attribution.blank?}
       end
 
       def children

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -642,7 +642,7 @@ module CartoDB
       end
 
       def attributions_from_derived_visualizations
-        related_visualizations.map(&:attributions).compact
+        related_visualizations.map(&:attributions).reject {|attribution| attribution.blank?}
       end
 
       private

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1321,7 +1321,7 @@ describe Carto::Api::VisualizationsController do
         table2_visualization = Carto::Visualization.find(table2["table_visualization"]["id"])
         table2_visualization.update_attribute(:attributions, 'attribution2')
         table3_visualization = Carto::Visualization.find(table3["table_visualization"]["id"])
-        table3_visualization.update_attribute(:attributions, 'attribution3')
+        table3_visualization.update_attribute(:attributions, '')
 
         visualization = JSON.parse(last_response.body)
 
@@ -1334,10 +1334,10 @@ describe Carto::Api::VisualizationsController do
         layer_group_layer["type"].should == 'layergroup'
 
         layer_group_attributions = layer_group_layer["options"]["attribution"].split(',').map(&:strip)
+        layer_group_layer.size.should == 2
 
         layer_group_attributions.should include('attribution1')
         layer_group_attributions.should include('attribution2')
-        layer_group_attributions.should include('attribution3')
       end
 
       it 'joins the attributions of the layers in a namedmap in the viz.json' do
@@ -1365,7 +1365,7 @@ describe Carto::Api::VisualizationsController do
         table2_visualization = Carto::Visualization.find(table2["table_visualization"]["id"])
         table2_visualization.update_attribute(:attributions, 'attribution2')
         table3_visualization = Carto::Visualization.find(table3["table_visualization"]["id"])
-        table3_visualization.update_attribute(:attributions, 'attribution3')
+        table3_visualization.update_attribute(:attributions, '')
 
         visualization = JSON.parse(last_response.body)
 
@@ -1382,9 +1382,9 @@ describe Carto::Api::VisualizationsController do
 
         named_map_attributions = named_map_layer["options"]["attribution"].split(',').map(&:strip)
 
+        named_map_attributions.size.should == 2
         named_map_attributions.should include('attribution1')
         named_map_attributions.should include('attribution2')
-        named_map_attributions.should include('attribution3')
       end
     end
 


### PR DESCRIPTION
Custom attributions are "" by default and we're joining them in the viz.json. That was causing some attributions of layers with multiple sublayers show things like: ", ". This prevents that issue.

@Kartones can you please review this? Thanks!