### PR TITLE
5264 fix ghost tables deletion take2

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -20,11 +20,8 @@ class Admin::VisualizationsController < ApplicationController
   ssl_required :index, :show, :protected_embed_map, :protected_public_map, :show_protected_public_map
   before_filter :login_required, only: [:index]
   before_filter :table_and_schema_from_params, only: [:show, :public_table, :public_map, :show_protected_public_map,
-
                                                       :show_protected_embed_map, :embed_map]
-  # Commented out until fixing #5264
-  #before_filter :link_ghost_tables, only: [:index]
-
+  before_filter :link_ghost_tables, only: [:index]
   before_filter :load_common_data, only: [:index]
 
   before_filter :resolve_visualization_and_table, only: [:show, :public_table, :public_map,

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -422,7 +422,7 @@ class Admin::VisualizationsController < ApplicationController
   def link_ghost_tables
     return true unless current_user.present?
 
-    if current_user.search_for_modified_table_names
+    if current_user.search_for_modified_table_names && current_user.has_feature_flag?('ghost_tables')
       # this should be removed from there once we have the table triggers enabled in cartodb-postgres extension
       # test if there is a job already for this
       if !current_user.link_ghost_tables_working

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -77,10 +77,10 @@ module CartoDB
         table.schema(reload: true)
         table.send :set_the_geom_column!
         table.import_cleanup
+        table.send :cartodbfy
         table.schema(reload: true)
         table.reload
         table.send :update_table_pg_stats
-        table.send :cartodbfy
         table.save
         table.send(:invalidate_varnish_cache)
         update_cdb_tablemetadata(table.name)

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -86,9 +86,12 @@ describe Table do
       table.valid?.should == true
     end
 
-    it "should set a table_id value" do
+    it "should set a valid table_id value (OID)" do
       table = create_table(name: 'this_is_a_table', user_id: $user_1.id)
       table.table_id.should be_a(Integer)
+
+      oid = table.owner.in_database.fetch(%Q{SELECT '#{table.qualified_table_name}'::regclass::oid}).first[:oid].to_i
+      table.table_id.should == oid
     end
 
     it "should return nil on get_table_id when the physical table doesn't exist" do

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1886,6 +1886,8 @@ describe Table do
       ::Table.any_instance.stubs(:set_the_geom_column!).returns(true)
       ::Table.any_instance.stubs(:after_create)
       ::Table.any_instance.stubs(:after_save)
+      ::Table.any_instance.stubs(:cartodbfy)
+      ::Table.any_instance.stubs(:schema)
       CartoDB::TablePrivacyManager.any_instance.stubs(:owner).returns(user_mock)
       table = Table.new
 

--- a/spec/models/visualization/organization_visualization_spec.rb
+++ b/spec/models/visualization/organization_visualization_spec.rb
@@ -85,7 +85,8 @@ describe Visualization::Member do
         :grant_select_to_tiler_user => nil,
         :cartodbfy => nil,
         :set_the_geom_column! => nil,
-        :is_raster? => false
+        :is_raster? => false,
+        :schema => nil
     )
   end
 


### PR DESCRIPTION
I hope this is the good one.
- Reenable ghost tables with through feature flag
- Regression test (modified an existing one to extend its expectations and cover the ghost tables case)
- Changes in `Table`:
  - `import_cleanup` is no longer responsible for cartodbfy nor schema reload.
  - `before_create` executes always 2 steps at the end: reload schema and `set_table_id` <- this is the important thing
  - `cartodbfy` is no longer responsible for reloading schema.
  - `after_create` does no longer call cartodbfy.
- Call `cartodbfy` explicitly and just once from `Synchronization::Adapter#cartodbfy`. Looking into the code it basically violates the encapsulation of `Table` but that's for another iteration.
- Fixes for tests

@Kartones and/or @juanignaciosl can you please review?