### PR TITLE
Fixes incorrect rendering of the HTML in the 'Unable to load data' error dialog

### DIFF
--- a/lib/assets/javascripts/cartodb/common/views/create/create_loading_error.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/create/create_loading_error.jst.ejs
@@ -18,7 +18,7 @@
   </h4>
   <p class="DefaultParagraph DefaultParagraph--short">
     <% if ((selectedDatasets && selectedDatasets.length > 0) || currentImport) { %>
-      <%- err.what_about %>
+      <%= cdb.core.sanitize.html(err.what_about) %>
     <% } else { %>
       If the problem persists contact us at <a class="js-mail-link" href="mailto:support@cartodb.com">support@cartodb.com</a>.
     <% } %>


### PR DESCRIPTION
This PR fixes a problem rendering the email address in the  'Unable to load data' error dialog.

Original ticket: #5365 
