### PR TITLE
Fixed issue with date inequallity because of microseconds

### DIFF
--- a/app/models/visualization/collection.rb
+++ b/app/models/visualization/collection.rb
@@ -357,8 +357,8 @@ module CartoDB
         dataset = filter_by_tags(dataset, tags_from(filters))
         dataset = filter_by_partial_match(dataset, filters.delete(:q))
         dataset = filter_by_kind(dataset, filters.delete(:exclude_raster))
-        dataset = filter_by_min_updated_at(dataset, filters.delete(:min_updated_at))
-        dataset = filter_by_min_created_at(dataset, filters.delete(:min_created_at))
+        dataset = filter_by_min_date('updated_at', dataset, filters.delete(:min_updated_at)) if filters.has_key?(:min_updated_at)
+        dataset = filter_by_min_date('created_at', dataset, filters.delete(:min_created_at)) if filters.has_key?(:min_created_at)
         dataset = filter_by_ids(dataset, filters.delete(:ids))
         order_desc = filters.delete(:order_asc_desc)
         order(dataset, filters.delete(:order), order_desc.nil? || order_desc == :desc)
@@ -461,18 +461,11 @@ module CartoDB
         dataset.where('kind=?', Member::KIND_GEOM)
       end
 
-      def filter_by_min_created_at(dataset, min_created_at, included = false)
-        filter_by_min_date('created_at', dataset, min_created_at, included)
-      end
-
-      def filter_by_min_updated_at(dataset, min_updated_at, included = false)
-        filter_by_min_date('updated_at', dataset, min_updated_at, included)
-      end
-
-      def filter_by_min_date(column, dataset, date, included = false)
-        return dataset if !date
+      def filter_by_min_date(column, dataset, date_filter)
+        return dataset if !date_filter
+        included = date_filter.has_key?(:include) ? date_filter[:include] : false
         comparison = included ? '>=' : '>'
-        dataset.where("#{column} #{comparison} ?", date)
+        dataset.where("#{column} #{comparison} ?", date_filter[:date])
       end
 
       def filter_by_ids(dataset, ids)


### PR DESCRIPTION
The problem comes with the timestamp stored in the visualizations table of metadata.

To retrieve insertable rows as new in the explore api we get created_at value from the last visualization inserted and use that field to retrieve all the visualizations we want to import but we could have the following case:

In the visualizations table from meta data
-[ RECORD 1 ]------------------------------------ id | d3a4c192-5245-11e5-a2e9-080027880ca6 name | untitled_table created_at | 2015-09-03 14:12:36.169409+00 updated_at | 2015-09-03 14:12:38.294086+00`

In the explore api visualizations table

-[ RECORD 1 ]------------+------------------------------------- visualization_id | d3a4c192-5245-11e5-a2e9-080027880ca6 visualization_created_at | 2015-09-03 14:12:36+00 visualization_updated_at | 2015-09-03 14:12:38+00

So when we check for new rows to insert, using the condition created_at > 2015-09-03 14:12:36+00 we get the same row and the insert crash due primary key constraint