### PR TITLE
Fix layer name missalignment in Firefox

### DIFF
--- a/app/assets/stylesheets/table/table_panel/layer-info.css.scss
+++ b/app/assets/stylesheets/table/table_panel/layer-info.css.scss
@@ -38,6 +38,7 @@
       display:block;
       left:0!important;
       top:0!important;
+      width: 100%;
       text-align: left;
       padding-left: 24px;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.13",
+  "version": "3.19.14",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes a problem with the position of the layer name under Firefox.

Original ticket: #5373 

Can you review this @alonsogarciapablo, please?