### PR TITLE
Make table factory stub named maps calls

### DIFF
--- a/spec/support/factories/tables.rb
+++ b/spec/support/factories/tables.rb
@@ -20,6 +20,7 @@ module CartoDB
     end
 
     def create_table(attributes = {})
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
       table = new_table(attributes)
       table.save
       table.reload


### PR DESCRIPTION
Tables created with the `create_table` helper factory don't stub the `NamedMapsWrapper::NamedMaps` class, causing them to fail when using due to not having a tiler running.

This class is stubbed on visualizations