### PR TITLE
Fixed problem with filter-view styles

### DIFF
--- a/app/assets/stylesheets/common/filters.css.scss
+++ b/app/assets/stylesheets/common/filters.css.scss
@@ -281,8 +281,7 @@ a.Filters-cleanSearch { line-height:32px }
 }
 .Filters-inner.search--enabled {
 
-  .Filters-typeItem:not(&.Filters-searchEnabler--underFilter),
-  .Filters-typeItem:not(&.Filters-searchInput--underFilter),
+  .Filters-typeItem,
   .Filters-orderItem,
   .Button--positive { display:none }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.19",
+  "version": "3.19.20",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We introduced a CSS bug with [this change](https://github.com/CartoDB/cartodb/commit/8df7583c283421747affe7af8fa8ddd2478a2d3a#diff-9eb09f24fcd61780eb56874f60092483R436) @MariaCheca and it didn't allow to hide the unnecessary elements when search was enabled. I've checked those classes in the whole project and there is no reference to them, so I went to the previous version and everything is ok.

Happening now:
  
<img width="1065" alt="screen shot 2015-09-08 at 18 42 39" src="https://cloud.githubusercontent.com/assets/132146/9741204/6aee28a6-5659-11e5-8242-6872fee22a38.png">


With the changes:

<img width="1002" alt="screen shot 2015-09-08 at 18 42 28" src="https://cloud.githubusercontent.com/assets/132146/9741207/6e26647a-5659-11e5-9535-c305a9e74ace.png">


cc @MariaCheca 
Fixes #5357 
