### PR TITLE
Remove duplicates from explore api table names

### DIFF
--- a/app/helpers/explore_api.rb
+++ b/app/helpers/explore_api.rb
@@ -6,7 +6,7 @@ module Helpers
       def get_visualization_tables(visualization)
         # We are using layers instead of related tables because with related tables we are connecting
         # to the users databases and we are reaching the connections limit
-        table_names = visualization.layers(:carto_and_torque).map { |layer| extract_table_name(layer) }
+        table_names = visualization.layers(:carto_and_torque).map { |layer| extract_table_name(layer) }.uniq
         %Q{{#{table_names.compact.join(",")}}}
       end
 

--- a/spec/helpers/explore_api_spec.rb
+++ b/spec/helpers/explore_api_spec.rb
@@ -33,6 +33,18 @@ describe 'Helpers' do
       tables.should eq '{\"user_name_1\".table_1,\"user_name_2\".table_2}'
     end
 
+    it 'should return the visualizations tables with multiple layers without duplicates' do
+      user = FactoryGirl.build(:user)
+      map = FactoryGirl.build(:map, :user_id => user.id)
+      visualization = FactoryGirl.build(:derived_visualization, :user_id => user.id, :map_id => map.id)
+      layer_1 = create_layer('table_1', 'user_name_1', 1)
+      layer_2 = create_layer('table_1', 'user_name_1', 2)
+      visualization.stubs(:map).returns(map)
+      visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1, layer_2])
+      tables = @explore_api.get_visualization_tables(visualization)
+      tables.should eq '{\"user_name_1\".table_1}'
+    end
+
     it 'should empty if the is no user name or table name in the layer' do
       user = FactoryGirl.build(:user)
       map = FactoryGirl.build(:map, :user_id => user.id)


### PR DESCRIPTION
This PR removes duplicates in the table names. This duplicates are caused because the layers could be using the same table N times