### PR TITLE
Insert table data (rows, size and geometry types) to explore api

### DIFF
--- a/app/helpers/explore_api.rb
+++ b/app/helpers/explore_api.rb
@@ -26,6 +26,16 @@ module Helpers
         %Q{ST_AsText('#{bbox_value}')}
       end
 
+      def get_table_data(visualization)
+        user_table = UserTable.where(user_id: visualization.user_id, name: visualization.name).first
+        return {} if user_table.nil?
+        {
+          rows: user_table.service.rows_counted,
+          size: user_table.service.table_size,
+          geometry_types: user_table.service.geometry_types
+        }
+      end
+
       private
 
       def extract_table_name(layer)

--- a/spec/factories/table_storage.rb
+++ b/spec/factories/table_storage.rb
@@ -1,6 +1,9 @@
 FactoryGirl.define do
 
-  factory :user_table do
+  factory :table, class: Table do
+  end
+
+  factory :user_table, class: UserTable do
   end
 
 end

--- a/spec/helpers/explore_api_spec.rb
+++ b/spec/helpers/explore_api_spec.rb
@@ -71,6 +71,47 @@ describe 'Helpers' do
       geometry_data.should eq expected_data
     end
 
+    it 'should return the table data properly setted' do
+      user = FactoryGirl.build(:user)
+      map = FactoryGirl.build(
+        :map, user_id: user.id, zoom: 3, center: [30, 0], view_bounds_ne: [85.0511, 179],
+        view_bounds_sw: [-85.0511, -179]
+      )
+      visualization = FactoryGirl.build(:table_visualization, :user_id => user.id, :map_id => map.id)
+      visualization.stubs(:map).returns(map)
+      table = FactoryGirl.build(:table)
+      table.stubs(:rows_counted => 10, :geometry_types => ["ST_Point"], :table_size => 100)
+      user_table = FactoryGirl.build(:user_table)
+      user_table.stubs(:service).returns(table)
+      user_table.stubs(:first).returns(user_table)
+      UserTable.stubs(:where => user_table)
+      table_data = @explore_api.get_table_data(visualization)
+      expected_data = {
+        rows: 10,
+        size: 100,
+        geometry_types: ["ST_Point"]
+      }
+      table_data.should eq expected_data
+    end
+
+    it 'should return empty if there is no user table' do
+      user = FactoryGirl.build(:user)
+      map = FactoryGirl.build(
+        :map, user_id: user.id, zoom: 3, center: [30, 0], view_bounds_ne: [85.0511, 179],
+        view_bounds_sw: [-85.0511, -179]
+      )
+      visualization = FactoryGirl.build(:table_visualization, :user_id => user.id, :map_id => map.id)
+      visualization.stubs(:map).returns(map)
+      table = FactoryGirl.build(:table)
+      table.stubs(:rows_counted => 10, :geometry_types => ["ST_Point"], :table_size => 100)
+      user_table = FactoryGirl.build(:user_table)
+      user_table.stubs(:service).returns(table)
+      user_table.stubs(:first).returns(nil)
+      UserTable.stubs(:where => user_table)
+      table_data = @explore_api.get_table_data(visualization)
+      table_data.empty?.should eq true
+    end
+
     it 'should return nil if the coordinates are out of the bounds' do
       user = FactoryGirl.build(:user)
       map = FactoryGirl.build(


### PR DESCRIPTION
We need for the explore page the following fields:

* Table rows
* Table size
* Geometry types

We should run this migration on the table

```
ALTER TABLE visualizations ADD COLUMN visualization_table_rows integer;
ALTER TABLE visualizations ADD COLUMN visualization_table_size integer;
ALTER TABLE visualizations ADD COLUMN visualization_geometry_types text[];
```