### PR TITLE
5464 fix quoting ghost tables

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1209,7 +1209,7 @@ class User < Sequel::Model
     sql += %Q{
           column_name IN (#{cartodb_columns}) AND
 
-          tg.tgrelid = (t.schemaname || '.' || t.tablename)::regclass::oid AND
+          tg.tgrelid = (quote_ident(t.schemaname) || '.' || quote_ident(t.tablename))::regclass::oid AND
           tg.tgname = 'test_quota_per_row'
 
           GROUP BY 1


### PR DESCRIPTION
@Kartones and @juanignaciosl please review. Fully related to the conversation we had about identifiers, quoting and standardizing names.

I though about renaming the table, but prefer not to decide that automatically for the user as it can break support tables.