### PR TITLE
Autologin for just created users closes #4180

### DIFF
--- a/app/controllers/carto/api/user_creations_controller.rb
+++ b/app/controllers/carto/api/user_creations_controller.rb
@@ -12,6 +12,10 @@ module Carto
       before_filter :load_user_creation, only: :show
 
       def show
+        if @user_creation.autologin?
+          params[:username] = @user_creation.username
+          authenticate!(:user_creation, scope: @user_creation.subdomain)
+        end
         render_jsonp(UserCreationPresenter.new(@user_creation).to_poro)
       end
 

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -84,6 +84,14 @@ class Carto::UserCreation < ActiveRecord::Base
     self.google_sign_in != true && !Carto::Ldap::Manager.new.configuration_present?
   end
 
+  def autologin?
+    state == 'success' && created_at > Time.now - 1.minute && user.enable_account_token.nil? && user.enabled && user.dashboard_viewed_at.nil?
+  end
+
+  def subdomain
+    user.subdomain
+  end
+
   private
 
   def user

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -167,3 +167,21 @@ Warden::Manager.after_set_user except: :fetch do |user, auth, opts|
   end
 end
 
+Warden::Strategies.add(:user_creation) do
+
+  def authenticate!
+    username = params[:username]
+    user = User.where(username: username).first
+    return fail! unless user
+
+    user_creation = Carto::UserCreation.where(user_id: user.id).first
+    return fail! unless user_creation
+
+    if user_creation.autologin?
+      success!(user, :message => "Success")
+    else
+      fail!
+    end
+  end
+
+end

--- a/spec/factories/user_creation.rb
+++ b/spec/factories/user_creation.rb
@@ -1,0 +1,25 @@
+require 'ostruct'
+
+FactoryGirl.define do
+
+  factory :user_creation, class: Carto::UserCreation do
+    username "whatever"
+    email "whatever@cartodb.com"
+    crypted_password "rgjreogjorejgpovrjeg"
+    salt "ewefgrjwopjgow"
+    google_sign_in false
+    quota_in_bytes 10000000
+
+    factory :autologin_user_creation do
+      state 'success'
+      created_at { Time.now }
+
+      after(:build) do |model, evaluator|
+        fake_user = OpenStruct.new(enable_account_token: nil, enabled: true, dashboard_viewed_at: nil)
+        model.instance_variable_set(:@user, fake_user)
+      end
+    end
+  end
+
+end
+

--- a/spec/factories/visualization_creation_helpers.rb
+++ b/spec/factories/visualization_creation_helpers.rb
@@ -55,7 +55,7 @@ shared_context 'organization with users helper' do
     organization = Organization.new
     organization.name = org_name = "org#{rand(9999)}"
     organization.quota_in_bytes = 1234567890
-    organization.seats = 5
+    organization.seats = 50
     organization
   end
 

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -27,6 +27,13 @@ describe Carto::UserCreation do
       FactoryGirl.build(:autologin_user_creation, created_at: Time.now - 59.seconds).autologin?.should == true
     end
 
+    it 'is false for users with enable_account_token' do
+      user_creation = FactoryGirl.build(:autologin_user_creation)
+      user = user_creation.instance_variable_get(:@user)
+      user.enable_account_token = 'whatever'
+      user_creation.autologin?.should == false
+    end
+
   end
 
   describe 'validation token' do

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -41,6 +41,13 @@ describe Carto::UserCreation do
       user_creation.autologin?.should == false
     end
 
+    it 'is false for users that have seen their dashboard' do
+      user_creation = FactoryGirl.build(:autologin_user_creation)
+      user = user_creation.instance_variable_get(:@user)
+      user.dashboard_viewed_at = Time.now
+      user_creation.autologin?.should == false
+    end
+
   end
 
   describe 'validation token' do

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -5,6 +5,10 @@ describe Carto::UserCreation do
 
   describe 'autologin?' do
 
+    it 'is true for autologin_user_creation factory' do
+      FactoryGirl.build(:autologin_user_creation).autologin?.should == true
+    end
+
     it 'is false for states other than success' do
       FactoryGirl.build(:autologin_user_creation, state: 'creating_user').autologin?.should == false
       FactoryGirl.build(:autologin_user_creation, state: 'validating_user').autologin?.should == false
@@ -15,6 +19,12 @@ describe Carto::UserCreation do
       FactoryGirl.build(:autologin_user_creation, state: 'failure').autologin?.should == false
 
       FactoryGirl.build(:autologin_user_creation, state: 'success').autologin?.should == true
+    end
+
+    it 'is stops working after one minute' do
+      FactoryGirl.build(:autologin_user_creation, created_at: Time.now - 61.seconds).autologin?.should == false
+      FactoryGirl.build(:autologin_user_creation, created_at: Time.now - 60.seconds).autologin?.should == false
+      FactoryGirl.build(:autologin_user_creation, created_at: Time.now - 59.seconds).autologin?.should == true
     end
 
   end

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -34,6 +34,13 @@ describe Carto::UserCreation do
       user_creation.autologin?.should == false
     end
 
+    it 'is false for disabled users' do
+      user_creation = FactoryGirl.build(:autologin_user_creation)
+      user = user_creation.instance_variable_get(:@user)
+      user.enabled = false
+      user_creation.autologin?.should == false
+    end
+
   end
 
   describe 'validation token' do

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -3,6 +3,22 @@ require_relative '../../../app/models/carto/user_creation'
 
 describe Carto::UserCreation do
 
+  describe 'autologin?' do
+
+    it 'is false for states other than success' do
+      FactoryGirl.build(:autologin_user_creation, state: 'creating_user').autologin?.should == false
+      FactoryGirl.build(:autologin_user_creation, state: 'validating_user').autologin?.should == false
+      FactoryGirl.build(:autologin_user_creation, state: 'saving_user').autologin?.should == false
+      FactoryGirl.build(:autologin_user_creation, state: 'promoting_user').autologin?.should == false
+      FactoryGirl.build(:autologin_user_creation, state: 'creating_user_in_central').autologin?.should == false
+      FactoryGirl.build(:autologin_user_creation, state: 'load_common_data').autologin?.should == false
+      FactoryGirl.build(:autologin_user_creation, state: 'failure').autologin?.should == false
+
+      FactoryGirl.build(:autologin_user_creation, state: 'success').autologin?.should == true
+    end
+
+  end
+
   describe 'validation token' do
     include_context 'organization with users helper'
 

--- a/spec/requests/carto/api/user_creations_controller_spec.rb
+++ b/spec/requests/carto/api/user_creations_controller_spec.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+
+require 'uuidtools'
+require_relative '../../../spec_helper'
+require_relative '../../../../app/controllers/carto/api/user_creations_controller'
+
+describe Carto::Api::UserCreationsController do
+  include_context 'organization with users helper'
+
+  describe 'show' do
+
+    it 'returns 404 for unknown user creations' do
+      get_json api_v1_user_creations_show_url(id: UUIDTools::UUID.timestamp_create.to_s), @headers do |response|
+        response.status.should == 404
+      end
+    end
+
+    it 'returns user creation data' do
+      User.any_instance.stubs(:create_in_central).returns(true)
+      User.any_instance.stubs(:enable_remote_db_user).returns(true)
+      user_data = FactoryGirl.build(:valid_user)
+      user_data.organization = @organization
+      user_data.google_sign_in = false
+
+      user_creation = Carto::UserCreation.new_user_signup(user_data)
+      user_creation.next_creation_step until user_creation.finished?
+
+      get_json api_v1_user_creations_show_url(id: user_creation.id), @headers do |response|
+        response.status.should == 200
+        response.body[:id].should == user_creation.id
+        response.body[:username].should == user_creation.username
+        response.body[:email].should == user_creation.email
+        response.body[:organization_id].should == user_creation.organization_id
+        response.body[:google_sign_in].should == user_creation.google_sign_in
+        response.body[:requires_validation_email].should == user_creation.requires_validation_email?
+        response.body[:state].should == user_creation.state
+      end
+
+    end
+
+  end
+
+end

--- a/spec/requests/carto/api/user_creations_controller_spec.rb
+++ b/spec/requests/carto/api/user_creations_controller_spec.rb
@@ -35,9 +35,26 @@ describe Carto::Api::UserCreationsController do
         response.body[:requires_validation_email].should == user_creation.requires_validation_email?
         response.body[:state].should == user_creation.state
       end
-
     end
 
+    it 'triggers user_creation authentication for google users' do
+      User.any_instance.stubs(:create_in_central).returns(true)
+      User.any_instance.stubs(:enable_remote_db_user).returns(true)
+      user_data = FactoryGirl.build(:valid_user)
+      user_data.organization = @organization
+      user_data.google_sign_in = true
+
+      Carto::Api::UserCreationsController.any_instance.expects(:authenticate!).with(:user_creation, scope: user_data.organization.name).once
+
+      user_creation = Carto::UserCreation.new_user_signup(user_data)
+      user_creation.next_creation_step until user_creation.finished?
+
+      get_json api_v1_user_creations_show_url(id: user_creation.id), @headers do |response|
+        response.body[:state].should == 'success'
+        response.body[:google_sign_in].should == user_creation.google_sign_in
+        response.body[:enable_account_token].should be_nil
+      end
+    end
   end
 
 end


### PR DESCRIPTION
@Kartones , @viddo , what do you think about this approach for autologin at organization signup?

Some context:

Normal, Central signup direct authentication works because it can authenticate before actual user creation: a Central-created user is always valid. If creation doesn't work because of whatever reason it doesn't mind, and if it works final redirection to dashboard will be authenticated thanks to Central cookie.

Box-centric signup, nevertheless, creates users that can't be authenticated in advance, because of the need for email validation (`enable_account_token `) and because box-central communication might fail, so I think the polling for user creation state might be a good place for a one-shot authentication. Since it's performed through https and based on user creation uuid it can't be intercepted, and time constraint, `enable_account_token` and `dashboard_viewed_at` checks make it safer.