### PR TITLE
Adding 'duplicate map' option in the dashboard view + 'change view' in the options menu in the editor view

### DIFF
--- a/lib/assets/javascripts/cartodb/dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/filters_view.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var Utils = require('cdb.Utils');
 var navigateThroughRouter = require('../common/view_helpers/navigate_through_router');
 var pluralizeString = require('../common/view_helpers/pluralize_string');
+var DuplicateMap = require('../common/dialogs/duplicate_vis_view');
 var DeleteItemsDialog = require('../common/dialogs/delete_items_view');
 var ChangeLockDialog = require('../common/dialogs/change_lock/change_lock_view');
 var ChangeLockViewModel = require('../common/dialogs/change_lock/change_lock_view_model');
@@ -35,6 +36,7 @@ module.exports = cdb.core.View.extend({
     'click .js-import_remote':  '_importRemote',
     'click .js-new_dataset':    '_connectDataset',
     'click .js-duplicate_dataset': '_duplicateDataset',
+    'click .js-duplicate_map':  '_duplicateMap',
     'click .js-new_map':        '_newMap',
     'click .js-lock':           '_openChangeLockDialog',
     'click .js-privacy':        '_openPrivacyDialog',
@@ -305,6 +307,26 @@ module.exports = cdb.core.View.extend({
         value: tableName,
         create_vis: false
       });
+    }
+  },
+
+  _duplicateMap: function(e) {
+    if (e) {
+      this.killEvent(e);
+    }
+
+    var selectedDatasets = this._selectedItems();
+
+    if (selectedDatasets.length === 1) {
+      var m = selectedDatasets[0];
+      var table = m.tableMetadata();
+
+      new DuplicateMap({
+        model: m,
+        table: table,
+        user: this.user,
+        clean_on_hide: true
+      }).appendToBody();
     }
   },
 

--- a/lib/assets/javascripts/cartodb/dashboard/views/filters.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/filters.jst.ejs
@@ -132,6 +132,9 @@
               <li class="Filters-actionsItem">
                 <a class="Filters-actionsLink js-privacy" href="#/change-privacy">Change privacy...</a>
               </li>
+              <li class="Filters-actionsItem">
+                <a class="Filters-actionsLink js-duplicate_map" href="#/duplicate-map">Duplicate map</a>
+              </li>
             <% } %>
             <% if (!q && !tag && !liked) { %>
               <li class="Filters-actionsItem">

--- a/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
@@ -1,7 +1,7 @@
 <ul>
   <% if (!isVisualization) { %>
     <li class="<% if (table.isInSQLView() && dataLayer && !dataLayer.get('query')) { %>disabled<% } %>"><a class="small export_table" href="#/export">Export...</a></li>
-    
+
     <% if (table.isInSQLView()) { %>
       <li><a class="small duplicate_table" href="#/table-from-query">Dataset from query</a></li>
     <% } else { %>
@@ -17,14 +17,14 @@
       </li>
       <li><a class="small duplicate_table" href="#/duplicate">Duplicate dataset...</a></li>
       <li><a class="small merge_tables" href="#/merge-tables">Merge with dataset...</a></li>
-      
+
       <!-- Change privacy?  -->
       <% if (isLayerOwner) { %>
         <% if (private_tables) { %>
           <li><a class="small change_privacy" href="#/change-privacy">Change privacy</a></li>
         <% } else { %>
           <li class="disabled"><a class="small">Change privacy...</a></li>
-        <% } %>    
+        <% } %>
       <% } %>
 
     <% } %>
@@ -66,11 +66,12 @@
     <!-- Map options  -->
     <li><a class="small duplicate_vis" href="#/duplicate">Duplicate map</a></li>
     <% if (isVisOwner) { %>
+      <li><a class="small change_privacy" href="#/change-privacy">Change privacy</a></li>
       <li><a class="small lock_vis" href="#/lock-vis">Lock map</a></li>
     <% } %>
     <% if (isVisOwner) { %>
       <li><a class="small delete_vis red" href="#/delete">Delete map</a></li>
     <% } %>
-    
+
   <% } %>
 </ul>

--- a/lib/assets/test/spec/cartodb/dashboard/filters_view.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/filters_view.spec.js
@@ -500,6 +500,28 @@ describe('dashboard/filters_view', function() {
 
   });
 
+  describe('duplicate map', function() {
+    beforeEach(function() {
+      this.router.model.set('content_type', 'maps');
+      this.collection.reset([{ selected: true }]);
+    });
+
+    it("should offer duplicate map", function() {
+      expect(this.view.$('.js-duplicate_map').length).toBe(1);
+    });
+
+    it("shouldn't offer duplicate map when there are several maps selected", function() {
+      this.collection.reset([{ selected: true }, { selected: true }]);
+      expect(this.view.$('.js-duplicate_map').length).toBe(0);
+    });
+
+    it("should not offer duplicate map when it is a liked map", function() {
+      this.router.model.set('liked', true);
+      this.view.render();
+      expect(this.view.$('.js-duplicate_map').length).toBe(0);
+    });
+  });
+
   it('shouldn\'t offer select all option when it is viewing liked items', function() {
     this.router.model.set({
       content_type: 'datasets',

--- a/lib/assets/test/spec/cartodb/table/header/options_menu.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/options_menu.spec.js
@@ -18,7 +18,7 @@ describe("Header options menu", function() {
     });
 
     cartodb_layer = new cdb.admin.CartoDBLayer({ table_name: 'test_table' });
-    
+
     // Set permissions for last visualization layer
     cartodb_layer.table.permission = new cdb.admin.Permission({
       owner:  { username: 'staging20', avatar_url: 'http://test.com', id: 2 },
@@ -55,7 +55,7 @@ describe("Header options menu", function() {
 
   it("should create geocoding progress bar correctly", function() {
     options_menu.render();
-    
+
     // Normal
     expect(Math.floor(options_menu.$el.find("div.progress-bar .bar-2").width())).toEqual(20);
     expect(options_menu.$el.find("div.progress-bar .bar-2").hasClass('danger')).toBeFalsy();
@@ -103,11 +103,12 @@ describe("Header options menu", function() {
   it("should open the menu options with visualization mode", function() {
     this.vis.set('type', 'derived');
     options_menu.render();
-    expect(options_menu.$el.find("li").size()).toEqual(5);
+    expect(options_menu.$el.find("li").size()).toEqual(6);
     expect(options_menu.$el.find("li:contains('Export layer')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Georeference layer')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Duplicate map')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Lock map')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Change privacy')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Delete map')").size()).toEqual(1);
   });
 
@@ -117,11 +118,12 @@ describe("Header options menu", function() {
     cartodb_layer.set('query', 'select * from test');
     this.vis.map.layers.last().table.useSQLView(sqlView);
     options_menu.render();
-    expect(options_menu.$el.find("li").size()).toEqual(5);
+    expect(options_menu.$el.find("li").size()).toEqual(6);
     expect(options_menu.$el.find("li:contains('Export layer')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Dataset from query')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Duplicate map')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Lock map')").size()).toEqual(1);
+    expect(options_menu.$el.find("li:contains('Change privacy')").size()).toEqual(1);
     expect(options_menu.$el.find("li:contains('Delete map')").size()).toEqual(1);
   });
 
@@ -152,14 +154,14 @@ describe("Header options menu", function() {
     expect(options_menu.$("li a:contains('Delete this dataset')").length).toBe(0);
   });
 
-  it("shouldn't offer 'delete visualization' if user is not the owner", function() {
+  it("shouldn't offer 'delete map' or 'change privacy' if user is not the owner", function() {
     this.vis.set('type', 'derived');
     this.vis.permission = new cdb.admin.Permission({
       owner:  { username: 'test', avatar_url: 'http://test.com', id: 10 }
     });
-    
     options_menu.render();
-    expect(options_menu.$("li a:contains('Delete visualization')").length).toBe(0);
+    expect(options_menu.$("li a:contains('Delete map')").length).toBe(0);
+    expect(options_menu.$("li a:contains('Change privacy')").length).toBe(0);
   });
 
   it("shouldn't have disabled any option if a query is applied in visualization mode", function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.25",
+  "version": "3.19.26",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] Duplicate map in dashboard view: just using the same element we already have in the editor view.

<img width="1033" alt="screen shot 2015-09-11 at 13 35 48" src="https://cloud.githubusercontent.com/assets/132146/9813916/11a85fea-588a-11e5-9d44-52ebe008c172.png">


- [x] Change privacy under options-menu in editor view: we are already using that dialog for changing the privacy of the datasets, so super easy, enabled for maps too.

<img width="425" alt="screen shot 2015-09-11 at 13 00 10" src="https://cloud.githubusercontent.com/assets/132146/9813915/11a5ec92-588a-11e5-9fc2-a31fc6b26a2f.png">

---

Fixes #5178 
cc @csobier 
REVIEWER: @alonsogarciapablo 