### PR TITLE
Improve the update metadata task

### DIFF
--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -81,6 +81,7 @@ module CartoDB
       attribute :kind,                String, default: KIND_GEOM
       attribute :prev_id,             String, default: nil
       attribute :next_id,             String, default: nil
+      attribute :bbox,                String, default: nil
       # Don't use directly, use instead getter/setter "transition_options"
       attribute :slide_transition_options,  String, default: DEFAULT_OPTIONS_VALUE
       attribute :active_child,        String, default: nil

--- a/lib/explore_api.rb
+++ b/lib/explore_api.rb
@@ -42,14 +42,6 @@ class ExploreAPI
       liked_visualizations.map { |liked_vis| liked_vis.subject }
     end
 
-    def get_visualizations_bbox(visualization_ids)
-      return {} if visualization_ids.nil? || visualization_ids.empty?
-      bbox_dataset = Rails::Sequel.connection.fetch(
-        %Q[SELECT id, bbox FROM visualizations WHERE id in ('#{visualization_ids.join("','")}') AND type = '#{CartoDB::Visualization::Member::TYPE_CANONICAL}']
-      ).all
-      Hash[bbox_dataset.map {|row| [row[:id], row[:bbox]] }]
-    end
-
     private
 
     def table_data_by_user(user, tables)


### PR DESCRIPTION
Make some improvements in the update of explore api data:

* [x] Removed duplicate queries for visualizations
* [x] Removed bbox query that is unnecessary
* [x] Visualizations retrieved order by user_id in order to reduce the number of connections to user database