### PR TITLE
Allows charset parameter in content type for utf-8 cases

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -45,15 +45,15 @@ module CartoDB
 
       CONTENT_TYPES_MAPPING = [
         {
-          content_types: ['text/plain', 'text/plain;charset=utf-8'],
+          content_types: ['text/plain'],
           extensions: ['txt']
         },
         {
-          content_types: ['text/csv', 'text/csv;charset=utf-8'],
+          content_types: ['text/csv'],
           extensions: ['csv']
         },
         {
-          content_types: ['application/vnd.ms-excel', 'application/vnd.ms-excel;charset=utf-8'],
+          content_types: ['application/vnd.ms-excel'],
           extensions: ['xls']
         },
         {
@@ -286,7 +286,7 @@ module CartoDB
       end
 
       def extensions_by_content_type(content_type)
-        downcased_content_type = content_type.downcase.gsub('; ', ';')
+        downcased_content_type = content_type.downcase.gsub('charset=utf-8', '')
         CONTENT_TYPES_MAPPING.each do |item|
           if item[:content_types].include?(downcased_content_type)
             return item[:extensions]

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -45,15 +45,15 @@ module CartoDB
 
       CONTENT_TYPES_MAPPING = [
         {
-          content_types: ['text/plain'],
+          content_types: ['text/plain', 'text/plain;charset=utf-8'],
           extensions: ['txt']
         },
         {
-          content_types: ['text/csv'],
+          content_types: ['text/csv', 'text/csv;charset=utf-8'],
           extensions: ['csv']
         },
         {
-          content_types: ['application/vnd.ms-excel'],
+          content_types: ['application/vnd.ms-excel', 'application/vnd.ms-excel;charset=utf-8'],
           extensions: ['xls']
         },
         {
@@ -286,7 +286,7 @@ module CartoDB
       end
 
       def extensions_by_content_type(content_type)
-        downcased_content_type = content_type.downcase
+        downcased_content_type = content_type.downcase.delete(' ')
         CONTENT_TYPES_MAPPING.each do |item|
           if item[:content_types].include?(downcased_content_type)
             return item[:extensions]

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -286,7 +286,7 @@ module CartoDB
       end
 
       def extensions_by_content_type(content_type)
-        downcased_content_type = content_type.downcase.delete(' ')
+        downcased_content_type = content_type.downcase.gsub('; ', ';')
         CONTENT_TYPES_MAPPING.each do |item|
           if item[:content_types].include?(downcased_content_type)
             return item[:extensions]


### PR DESCRIPTION
and trims empty spaces to compare the Content-Type header, as according to [RFC 2068](http://www.w3.org/Protocols/rfc2068/rfc2068.txt) it could present spaces. 

Sample URL which is suffering this issue: http://geoportalgasolineras.es/descargarPreciosTodasEstaciones.do?tipoBusqueda=0

Fixes  https://github.com/CartoDB/cartodb/issues/5524
cc @Kartones :-)