### PR TITLE
Migrate Synchronizations.id from TEXT to UUID

### DIFF
--- a/db/migrate/20150915141325_change_synchronization_id_to_uuid.rb
+++ b/db/migrate/20150915141325_change_synchronization_id_to_uuid.rb
@@ -1,0 +1,25 @@
+Sequel.migration do
+  up do
+    # INFO: Careful, order matters!
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE data_imports ALTER COLUMN synchronization_id TYPE uuid USING synchronization_id ::uuid;
+    })
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE external_data_imports DROP CONSTRAINT synchronization_id_fkey;
+    })
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE external_data_imports ALTER COLUMN synchronization_id TYPE uuid USING synchronization_id ::uuid;
+    })
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE synchronizations ALTER COLUMN id TYPE uuid USING id ::uuid;
+    })
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE external_data_imports
+        ADD CONSTRAINT synchronization_id_fkey FOREIGN KEY (synchronization_id)
+          REFERENCES synchronizations (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE CASCADE;
+    })
+  end
+
+  down do
+  end
+end


### PR DESCRIPTION
Closes #4997

Seems to not have any required dependency and no specific test double so initially only the migration is needed