### PR TITLE
Update metadata for visualizations that has likes or mapviews yesterday

### DIFF
--- a/lib/explore_api.rb
+++ b/lib/explore_api.rb
@@ -4,156 +4,159 @@ require 'cartodb/stats/api_calls'
 
 class ExploreAPI
 
-    def initialize
-      @stats_manager = CartoDB::Stats::APICalls.new
-    end
+  def initialize
+    @stats_manager = CartoDB::Stats::APICalls.new
+  end
 
-    def get_visualization_tables(visualization)
-      # We are using layers instead of related tables because with related tables we are connecting
-      # to the users databases and we are reaching the connections limit
-      table_names = visualization.layers(:carto_and_torque).map { |layer| extract_table_name(layer) }.uniq
-      %Q{{#{table_names.compact.join(",")}}}
-    end
+  def get_visualization_tables(visualization)
+    # We are using layers instead of related tables because with related tables we are connecting
+    # to the users databases and we are reaching the connections limit
+    table_names = visualization.layers(:carto_and_torque).map { |layer| extract_table_name(layer) }.uniq
+    %[{#{table_names.compact.join(',')}}]
+  end
 
-    def get_geometry_data(visualization)
-      map = visualization.map
-      return {} if map.nil?
-      view_box = map.view_bounds_data
-      center_coordinates = map.center_data.reverse
-      {
-        zoom: map.zoom,
-        view_box_polygon: BoundingBoxHelper.to_polygon(view_box[:west], view_box[:south], view_box[:east], view_box[:north]),
-        center_geometry: BoundingBoxHelper.to_point(center_coordinates[0], center_coordinates[1])
-      }
-    end
+  def get_geometry_data(visualization)
+    map = visualization.map
+    return {} if map.nil?
+    view_box = map.view_bounds_data
+    center_coordinates = map.center_data.reverse
+    {
+      zoom: map.zoom,
+      view_box_polygon: BoundingBoxHelper.to_polygon(
+        view_box[:west], view_box[:south], view_box[:east], view_box[:north]
+      ),
+      center_geometry: BoundingBoxHelper.to_point(center_coordinates[0], center_coordinates[1])
+    }
+  end
 
-    def bbox_from_value(bbox_value)
-      %Q{ST_AsText('#{bbox_value}')}
-    end
+  def bbox_from_value(bbox_value)
+    %{ST_AsText('#{bbox_value}')}
+  end
 
-    def get_visualizations_table_data(visualizations)
-      return {} if visualizations.blank?
-      data = {}
-      tables_by_user = get_tables_by_user(visualizations)
-      tables_by_user.each do |user_id, tables|
-        user = User.find(id: user_id)
-        data.merge!(table_data_by_user(user, tables)) unless user.nil?
+  def get_visualizations_table_data(visualizations)
+    return {} if visualizations.blank?
+    data = {}
+    tables_by_user = get_tables_by_user(visualizations)
+    tables_by_user.each do |user_id, tables|
+      user = User.find(id: user_id)
+      data.merge!(table_data_by_user(user, tables)) unless user.nil?
+    end
+    data
+  end
+
+  def visualization_likes_since(date_since)
+    data = {}
+    liked_visualizations = CartoDB::Like.where('created_at >= ?', date_since).group_and_count(:subject).all
+    liked_visualizations.each do |liked_vis|
+      data[liked_vis[:subject]] = CartoDB::Like.where(subject: liked_vis[:subject]).count
+    end
+    data
+  end
+
+  def visualization_mapviews_since(date_since)
+    data = {}
+    $users_metadata.scan_each(match: "user:*") do |key|
+      next if key =~ /global/
+      date_formatted = date_since.strftime("%Y%m%d")
+      key_splitted = key.split(':')
+      username = key_splitted[1]
+      visualization_id = key_splitted[4]
+      vis_mapviews = @stats_manager.get_api_calls_from_redis(
+        username,
+        from: date_formatted, to: date_formatted, stat_tag: visualization_id
+      )[date_formatted]
+      data[visualization_id] = @stats_manager.get_total_api_calls(username, visualization_id) unless vis_mapviews == 0
+    end
+    data
+  end
+
+  private
+
+  def table_data_by_user(user, tables)
+    data = {}
+    begin
+      # INFO If we use the model connection we hit the max number of connections due the pooler so we create a
+      # direct connection with the user database and close it after use
+      conn = PG::Connection.open(dbname: user.database_name, host: user.database_host, user: 'postgres')
+      geometry_types = tables_geometry_types(user.id, tables)
+      data = compose_tables_data(conn, user.id, user.database_schema, tables, geometry_types)
+    rescue => e
+      CartoDB.notify_error(
+        "Error generating table data for explorer api",
+        user: user.id, tables: tables, error: e.inspect
+      )
+    ensure
+      conn.close unless conn.nil?
+    end
+    data
+  end
+
+  def get_tables_by_user(visualizations)
+    tables_by_user = {}
+    visualizations.each do |vis|
+      if vis.type == CartoDB::Visualization::Member::TYPE_CANONICAL
+        tables_by_user[vis.user_id] = [] unless tables_by_user.has_key?(vis.user_id)
+        tables_by_user[vis.user_id] << vis.name
+        tables_by_user[vis.user_id].uniq
       end
-      data
     end
+    tables_by_user
+  end
 
-    def visualization_likes_since(date_since)
-      data = {}
-      liked_visualizations = CartoDB::Like.where('created_at >= ?', date_since).group_and_count(:subject).all
-      liked_visualizations.each do |liked_vis|
-        data[liked_vis[:subject]] = CartoDB::Like.where(subject: liked_vis[:subject]).count
-      end
-      data
+  def tables_geometry_types(user_id, tables)
+    geometry_types = {}
+    tables.each do |table|
+      user_table = UserTable.where(user_id: user_id, name: table).first
+      geometry_types[table] = user_table.service.geometry_types
     end
+    geometry_types
+  end
 
-    def visualization_mapviews_since(date_since)
-      data = {}
-      $users_metadata.scan_each(:match => "user:*") do |key|
-        next if key =~/global/
-        date_formatted = date_since.strftime("%Y%m%d")
-        key_splitted = key.split(':')
-        username = key_splitted[1]
-        visualization_id = key_splitted[4]
-        vis_mapviews = @stats_manager.get_api_calls_from_redis(username, { from: date_formatted, to: date_formatted, stat_tag: visualization_id })[date_formatted]
-        data[visualization_id] = @stats_manager.get_total_api_calls(username, visualization_id) unless vis_mapviews == 0
-      end
-      data
-    end
-
-    private
-
-    def table_data_by_user(user, tables)
-      data = {}
-      begin
-        # INFO If we use the model connection we hit the max number of connections due the pooler so we create a
-        # direct connection with the user database and close it after use
-        conn = PG::Connection.open(:dbname => user.database_name, :host => user.database_host, :user => 'postgres')
-        geometry_types = tables_geometry_types(user.id, tables)
-        data = compose_tables_data(conn, user.id, user.database_schema, tables, geometry_types)
-      rescue => e
-        CartoDB.notify_error(
-          "Error generating table data for explorer api",
-          { user: user.id, tables: tables, error: e.inspect }
-        )
-      ensure
-        conn.close unless conn.nil?
-      end
-      data
-    end
-
-    def get_tables_by_user(visualizations)
-      tables_by_user = {}
-      visualizations.each do |vis|
-        if vis.type == CartoDB::Visualization::Member::TYPE_CANONICAL
-          tables_by_user[vis.user_id] = [] unless tables_by_user.has_key?(vis.user_id)
-          tables_by_user[vis.user_id] << vis.name
-          tables_by_user[vis.user_id].uniq
-        end
-      end
-      tables_by_user
-    end
-
-    def tables_geometry_types(user_id, tables)
-      geometry_types = {}
-      tables.each do |table|
-        user_table = UserTable.where(user_id: user_id, name: table).first
-        geometry_types[table] = user_table.service.geometry_types
-      end
-      geometry_types
-    end
-
-    def compose_tables_data(conn, user_id, database_schema, tables, geometry_types)
-      begin
-        data = {user_id => {}}
-        result = get_rows_and_size_from_tables(conn, database_schema, tables)
-        result.each do |row|
-          data[user_id][row['table_name']] = {
-            rows: row['row_count'],
-            size: row['size'],
-            geometry_types: geometry_types[row['table_name']]
-          }
-        end
-        data
-      rescue => e
-        data = {}
-        CartoDB.notify_error(
-          "Error composing table data user",
-          { user: user_id, tables: tables, error: e.inspect }
-        )
-      end
-      data
-    end
-
-    def get_rows_and_size_from_tables(conn, database_schema, tables)
-      size_calc = "pg_total_relation_size('\"#{database_schema}\".\"' || relname || '\"') / 2"
-      table_names = %Q['#{tables.join('\',\'')}']
-      conn.exec(%Q{
-          SELECT #{size_calc} AS size,
-            reltuples::integer AS row_count,
-            relname as table_name
-          FROM pg_class
-          WHERE relname IN (#{table_names})
+  def compose_tables_data(conn, user_id, database_schema, tables, geometry_types)
+    begin
+      data = { user_id => {} }
+      result = get_rows_and_size_from_tables(conn, database_schema, tables)
+      result.each do |row|
+        data[user_id][row['table_name']] = {
+          rows: row['row_count'],
+          size: row['size'],
+          geometry_types: geometry_types[row['table_name']]
         }
+      end
+      data
+    rescue => e
+      data = {}
+      CartoDB.notify_error(
+        "Error composing table data user",
+        user: user_id, tables: tables, error: e.inspect
       )
     end
+    data
+  end
 
-    def extract_table_name(layer)
-      table_username = layer.options['user_name']
-      table_name = layer.options['table_name'].gsub(/"/,'\"').split('.')
-      # Here we check for:
-      #   a) return as comes, but escaping quotes, if the table_name have a . this means an old format username.tablename
-      #   b) return username.table_name with the username escaped to avoid problems with non-alphanumeric characters like '-'
-      if table_name.length > 1
-        %Q[#{layer.options['table_name'].gsub(/"/,'\"')}]
-      elsif table_name.length == 1 && !table_username.blank?
-        %Q[\\"#{table_username}\\".#{table_name[0]}]
-      else
-        nil
-      end
+  def get_rows_and_size_from_tables(conn, database_schema, tables)
+    size_calc = "pg_total_relation_size('\"#{database_schema}\".\"' || relname || '\"') / 2"
+    table_names = %['#{tables.join('\',\'')}']
+    conn.exec(%{SELECT #{size_calc} AS size,
+                  reltuples::integer AS row_count,
+                  relname as table_name
+                FROM pg_class
+                WHERE relname IN (#{table_names})
+              }
+             )
+  end
+
+  def extract_table_name(layer)
+    table_username = layer.options['user_name']
+    table_name = layer.options['table_name'].gsub(/"/, '\"').split('.')
+    # Here we check for:
+    #   a) return as comes, but escaping quotes, if the table_name have a . this means an old format username.tablename
+    #   b) return username.table_name with the username escaped to avoid problems
+    #      with non-alphanumeric characters like '-'
+    if table_name.length > 1
+      %[#{layer.options['table_name'].gsub(/"/, '\"')}]
+    elsif table_name.length == 1 && !table_username.blank?
+      %[\\"#{table_username}\\".#{table_name[0]}]
     end
+  end
 end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :like, class: CartoDB::Like do
+  end
+end

--- a/spec/lib/explore_api_spec.rb
+++ b/spec/lib/explore_api_spec.rb
@@ -1,19 +1,24 @@
-#encoding: UTF-8
+# encoding: UTF-8
 require_relative '../spec_helper'
 require_relative '../../lib/explore_api'
 
-CARTO_OPTIONS = '{"query":"","opacity":0.99,"auto_bound":false,"interactivity":"cartodb_id","debug":false,"visible":true,"tiler_domain":"localhost.lan","tiler_port":"80","tiler_protocol":"http","sql_domain":"localhost.lan","sql_port":"80","sql_protocol":"http","extra_params":{"cache_policy":"persist"},"cdn_url":"","tile_style_history":[],"style_version":"2.1.1","table_name":"districtes_barcelona","user_name":"ethervoid-common","tile_style":"#districtes_barcelona {\n  polygon-fill:#FF6600;\n  polygon-opacity: 0.7;\n  line-opacity:1;\n  line-color: #FFFFFF;\n}"}'
+CARTO_OPTIONS = '{"query":"","opacity":0.99,"auto_bound":false,"interactivity":"cartodb_id","debug":false,' \
+                '"visible":true,"tiler_domain":"localhost.lan","tiler_port":"80","tiler_protocol":"http",' \
+                '"sql_domain":"localhost.lan","sql_port":"80","sql_protocol":"http","extra_params":{' \
+                '"cache_policy":"persist"},"cdn_url":"","tile_style_history":[],"style_version":"2.1.1",' \
+                '"table_name":"districtes_barcelona","user_name":"ethervoid-common",' \
+                '"tile_style":"#districtes_barcelona {\n  polygon-fill:#FF6600;\n  polygon-opacity: 0.7;\n  ' \
+                'line-opacity:1;\n  line-color: #FFFFFF;\n}"}'
 
 describe 'ExploreAPI' do
-
   before(:each) do
     @explore_api = ExploreAPI.new
   end
 
   it 'should return the visualization table' do
     user = FactoryGirl.build(:user)
-    map = FactoryGirl.build(:map, :user_id => user.id)
-    visualization = FactoryGirl.build(:table_visualization, :user_id => user.id, :map_id => map.id)
+    map = FactoryGirl.build(:map, user_id: user.id)
+    visualization = FactoryGirl.build(:table_visualization, user_id: user.id, map_id: map.id)
     layer_1 = create_layer('table_1', 'user_name_1', 1)
     visualization.stubs(:map).returns(map)
     visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1])
@@ -23,8 +28,8 @@ describe 'ExploreAPI' do
 
   it 'should return the visualizations tables with multiple layers' do
     user = FactoryGirl.build(:user)
-    map = FactoryGirl.build(:map, :user_id => user.id)
-    visualization = FactoryGirl.build(:derived_visualization, :user_id => user.id, :map_id => map.id)
+    map = FactoryGirl.build(:map, user_id: user.id)
+    visualization = FactoryGirl.build(:derived_visualization, user_id: user.id, map_id: map.id)
     layer_1 = create_layer('table_1', 'user_name_1', 1)
     layer_2 = create_layer('table_2', 'user_name_2', 2)
     visualization.stubs(:map).returns(map)
@@ -35,8 +40,8 @@ describe 'ExploreAPI' do
 
   it 'should return the visualizations tables with multiple layers without duplicates' do
     user = FactoryGirl.build(:user)
-    map = FactoryGirl.build(:map, :user_id => user.id)
-    visualization = FactoryGirl.build(:derived_visualization, :user_id => user.id, :map_id => map.id)
+    map = FactoryGirl.build(:map, user_id: user.id)
+    visualization = FactoryGirl.build(:derived_visualization, user_id: user.id, map_id: map.id)
     layer_1 = create_layer('table_1', 'user_name_1', 1)
     layer_2 = create_layer('table_1', 'user_name_1', 2)
     visualization.stubs(:map).returns(map)
@@ -47,8 +52,8 @@ describe 'ExploreAPI' do
 
   it 'should empty if the is no user name or table name in the layer' do
     user = FactoryGirl.build(:user)
-    map = FactoryGirl.build(:map, :user_id => user.id)
-    visualization = FactoryGirl.build(:table_visualization, :user_id => user.id, :map_id => map.id)
+    map = FactoryGirl.build(:map, user_id: user.id)
+    visualization = FactoryGirl.build(:table_visualization, user_id: user.id, map_id: map.id)
     layer_1 = create_layer('table_1', '', 1)
     layer_2 = create_layer('', 'user_name_2', 1)
     visualization.stubs(:map).returns(map)
@@ -59,24 +64,28 @@ describe 'ExploreAPI' do
 
   it 'should return the geometry data properly setted' do
     user = FactoryGirl.build(:user)
-    map = FactoryGirl.build(
-      :map, user_id: user.id, zoom: 3, center: [30, 0], view_bounds_ne: [85.0511, 179],
-      view_bounds_sw: [-85.0511, -179]
-    )
-    visualization = FactoryGirl.build(:derived_visualization, :user_id => user.id, :map_id => map.id)
+    map = FactoryGirl.build(:map,
+                            user_id: user.id,
+                            zoom: 3,
+                            center: [30, 0],
+                            view_bounds_ne: [85.0511, 179],
+                            view_bounds_sw: [-85.0511, -179]
+                           )
+    visualization = FactoryGirl.build(:derived_visualization, user_id: user.id, map_id: map.id)
     visualization.stubs(:map).returns(map)
     geometry_data = @explore_api.get_geometry_data(visualization)
     expected_data = {
-      :zoom=>3,
-      :view_box_polygon=>%Q[ST_Transform(ST_Envelope('SRID=4326;POLYGON((-179.0 -85.0511, -179.0 85.0511, 179.0 85.0511, 179.0 -85.0511, -179.0 -85.0511))'::geometry), 3857)],
-      :center_geometry=>"ST_GeomFromText('POINT(0 30)',3857)"
+      zoom: 3,
+      view_box_polygon: "ST_Transform(ST_Envelope('SRID=4326;POLYGON((-179.0 -85.0511, -179.0 85.0511, " \
+                        "179.0 85.0511, 179.0 -85.0511, -179.0 -85.0511))'::geometry), 3857)",
+      center_geometry: "ST_GeomFromText('POINT(0 30)',3857)"
     }
     geometry_data.should eq expected_data
   end
 
   it 'should return empty if there is no map associated to the visualization' do
     user = FactoryGirl.build(:user)
-    visualization = FactoryGirl.build(:derived_visualization, :user_id => user.id)
+    visualization = FactoryGirl.build(:derived_visualization, user_id: user.id)
     visualization.stubs(:map).returns(nil)
     geometry_data = @explore_api.get_geometry_data(visualization)
     expected_data = {}
@@ -84,31 +93,31 @@ describe 'ExploreAPI' do
   end
 
   it 'should return the table data properly setted for two vis of the same user' do
-    user = FactoryGirl.build(:user, :database_name => 'cartodb_user_1', :database_host => '127.0.0.1')
+    user = FactoryGirl.build(:user, database_name: 'cartodb_user_1', database_host: '127.0.0.1')
     User.stubs(:find).with(id: user.id).returns(user)
-    visualization = FactoryGirl.build(:table_visualization, :user_id => user.id)
-    visualization_2 = FactoryGirl.build(:table_visualization, :user_id => user.id)
+    visualization = FactoryGirl.build(:table_visualization, user_id: user.id)
+    visualization_2 = FactoryGirl.build(:table_visualization, user_id: user.id)
     result = [
-      {"row_count" => 10, "size" => 100, "table_name" => visualization.name}, 
-      {"row_count" => 20, "size" => 200, "table_name" => visualization_2.name}
+      { "row_count" => 10, "size" => 100, "table_name" => visualization.name },
+      { "row_count" => 20, "size" => 200, "table_name" => visualization_2.name }
     ]
     conn = Object.new
-    conn.stubs(:close => true, :exec => result)
-    PG::Connection.stubs(:open => conn)
+    conn.stubs(close: true, exec: result)
+    PG::Connection.stubs(open: conn)
     table = FactoryGirl.build(:table)
-    table.stubs(:geometry_types => ["ST_Point"])
+    table.stubs(geometry_types: ["ST_Point"])
     user_table = FactoryGirl.build(:user_table)
     user_table.stubs(:service).returns(table)
     user_table.stubs(:first).returns(user_table)
-    UserTable.stubs(:where => user_table)
+    UserTable.stubs(where: user_table)
     table_data = @explore_api.get_visualizations_table_data([visualization, visualization_2])
-    expected_data = { 
+    expected_data = {
       user.id => {
         visualization.name => {
-          :rows=>10, :size=>100, :geometry_types=>["ST_Point"]
+          rows: 10, size: 100, geometry_types: ["ST_Point"]
         },
         visualization_2.name => {
-          :rows=>20, :size=>200, :geometry_types=>["ST_Point"]
+          rows: 20, size: 200, geometry_types: ["ST_Point"]
         }
       }
     }
@@ -116,36 +125,40 @@ describe 'ExploreAPI' do
   end
 
   it 'should return the table data properly setted for two vis of the different users' do
-    user = FactoryGirl.build(:user, :database_name => 'cartodb_user_1', :database_host => '127.0.0.1')
-    user_2 = FactoryGirl.build(:user, :database_name => 'cartodb_user_2', :database_host => '127.0.0.1')
+    user = FactoryGirl.build(:user, database_name: 'cartodb_user_1', database_host: '127.0.0.1')
+    user_2 = FactoryGirl.build(:user, database_name: 'cartodb_user_2', database_host: '127.0.0.1')
     User.stubs(:find).with(id: user.id).returns(user)
     User.stubs(:find).with(id: user_2.id).returns(user_2)
-    visualization = FactoryGirl.build(:table_visualization, :user_id => user.id)
-    visualization_2 = FactoryGirl.build(:table_visualization, :user_id => user_2.id)
-    result_1 = [{"row_count" => 10, "size" => 100, "table_name" => visualization.name}]
-    result_2 = [{"row_count" => 20, "size" => 200, "table_name" => visualization_2.name}]
+    visualization = FactoryGirl.build(:table_visualization, user_id: user.id)
+    visualization_2 = FactoryGirl.build(:table_visualization, user_id: user_2.id)
+    result_1 = [{ "row_count" => 10, "size" => 100, "table_name" => visualization.name }]
+    result_2 = [{ "row_count" => 20, "size" => 200, "table_name" => visualization_2.name }]
     conn = Object.new
-    conn.stubs(:close => true, :exec => result_1)
+    conn.stubs(close: true, exec: result_1)
     conn_2 = Object.new
-    conn_2.stubs(:close => true, :exec => result_2)
-    PG::Connection.stubs(:open).with(:dbname => user.database_name, :host => user.database_host, :user => 'postgres').returns(conn)
-    PG::Connection.stubs(:open).with(:dbname => user_2.database_name, :host => user_2.database_host, :user => 'postgres').returns(conn_2)
+    conn_2.stubs(close: true, exec: result_2)
+    PG::Connection.stubs(:open).
+      with(dbname: user.database_name, host: user.database_host, user: 'postgres').
+      returns(conn)
+    PG::Connection.stubs(:open).
+      with(dbname: user_2.database_name, host: user_2.database_host, user: 'postgres').
+      returns(conn_2)
     table = FactoryGirl.build(:table)
-    table.stubs(:geometry_types => ["ST_Point"])
+    table.stubs(geometry_types: ["ST_Point"])
     user_table = FactoryGirl.build(:user_table)
     user_table.stubs(:service).returns(table)
     user_table.stubs(:first).returns(user_table)
-    UserTable.stubs(:where => user_table)
+    UserTable.stubs(where: user_table)
     table_data = @explore_api.get_visualizations_table_data([visualization, visualization_2])
-    expected_data = { 
+    expected_data = {
       user.id => {
         visualization.name => {
-          :rows=>10, :size=>100, :geometry_types=>["ST_Point"]
+          rows: 10, size: 100, geometry_types: ["ST_Point"]
         }
       },
       user_2.id => {
         visualization_2.name => {
-          :rows=>20, :size=>200, :geometry_types=>["ST_Point"]
+          rows: 20, size: 200, geometry_types: ["ST_Point"]
         }
       }
     }
@@ -155,16 +168,20 @@ describe 'ExploreAPI' do
   it 'should return nil if the coordinates are out of the bounds' do
     user = FactoryGirl.build(:user)
     map = FactoryGirl.build(
-      :map, user_id: user.id, zoom: 3, center: [45.706179285330855, 1439.12109375], view_bounds_ne: [-13.2399454992863, 1251.2109374999998],
+      :map,
+      user_id: user.id,
+      zoom: 3,
+      center: [45.706179285330855, 1439.12109375],
+      view_bounds_ne: [-13.2399454992863, 1251.2109374999998],
       view_bounds_sw: [75.05035357407698, 1627.03125]
     )
-    visualization = FactoryGirl.build(:derived_visualization, :user_id => user.id, :map_id => map.id)
+    visualization = FactoryGirl.build(:derived_visualization, user_id: user.id, map_id: map.id)
     visualization.stubs(:map).returns(map)
     geometry_data = @explore_api.get_geometry_data(visualization)
     expected_data = {
-      :zoom=>3,
-      :view_box_polygon=> nil,
-      :center_geometry=> nil
+      zoom: 3,
+      view_box_polygon: nil,
+      center_geometry: nil
     }
     geometry_data.should eq expected_data
   end
@@ -173,7 +190,7 @@ describe 'ExploreAPI' do
     it 'should return 0 elements if dont have likes' do
       date = Date.today - 1.days
       user = FactoryGirl.build(:user)
-      FactoryGirl.build(:derived_visualization, :user_id => user.id)
+      FactoryGirl.build(:derived_visualization, user_id: user.id)
 
       likes = @explore_api.visualization_likes_since(date)
       likes.length.should eq 0
@@ -182,7 +199,7 @@ describe 'ExploreAPI' do
     it 'should return 10 likes the visualization' do
       date = Date.today - 1.days
       user = FactoryGirl.build(:user)
-      visualization_1 = FactoryGirl.build(:derived_visualization, :user_id => user.id)
+      visualization_1 = FactoryGirl.build(:derived_visualization, user_id: user.id)
       like = { subject: visualization_1.id, count: 1 }
       like.stubs(:group_and_count).returns(like)
       like.stubs(:all).returns([like])
@@ -201,7 +218,7 @@ describe 'ExploreAPI' do
       date = Date.today - 1.days
       date_key = date.strftime("%Y%m%d")
       user = FactoryGirl.build(:user)
-      visualization_1 = FactoryGirl.build(:derived_visualization, :user_id => user.id)
+      visualization_1 = FactoryGirl.build(:derived_visualization, user_id: user.id)
       add_total_data(visualization_1.id, user.username, 490)
       add_date_data(visualization_1.id, user.username, date_key, 0)
 
@@ -213,16 +230,16 @@ describe 'ExploreAPI' do
       date = Date.today - 1.days
       date_key = date.strftime("%Y%m%d")
       user = FactoryGirl.build(:user)
-      visualization_1 = FactoryGirl.build(:derived_visualization, :user_id => user.id)
+      visualization_1 = FactoryGirl.build(:derived_visualization, user_id: user.id)
       add_total_data(visualization_1.id, user.username, 490)
       add_date_data(visualization_1.id, user.username, date_key, 1)
-      visualization_2 = FactoryGirl.build(:derived_visualization, :user_id => user.id)
+      visualization_2 = FactoryGirl.build(:derived_visualization, user_id: user.id)
       add_total_data(visualization_2.id, user.username, 0)
       add_date_data(visualization_2.id, user.username, date_key, 0)
-      visualization_3 = FactoryGirl.build(:derived_visualization, :user_id => user.id)
+      visualization_3 = FactoryGirl.build(:derived_visualization, user_id: user.id)
       add_total_data(visualization_3.id, user.username, 0)
       add_date_data(visualization_3.id, user.username, date_key, 0)
-      visualization_4 = FactoryGirl.build(:derived_visualization, :user_id => user.id)
+      visualization_4 = FactoryGirl.build(:derived_visualization, user_id: user.id)
       add_total_data(visualization_4.id, user.username, 490)
       add_date_data(visualization_4.id, user.username, (Date.today - 10.days).strftime("%Y%m%d"), 10)
 
@@ -232,14 +249,13 @@ describe 'ExploreAPI' do
       mapviews[visualization_1.id].should eq 491
     end
   end
-
 end
 
 def create_layer(table_name, user_name, order = 1)
   options = JSON.parse(CARTO_OPTIONS)
   options["table_name"] = table_name
   options["user_name"] = user_name
-  FactoryGirl.build(:carto_layer, :options => options, :order => order)
+  FactoryGirl.build(:carto_layer, options: options, order: order)
 end
 
 def add_date_data(visualization_id, username, date, value)


### PR DESCRIPTION
Another try to improve the speed of Explore API and be more efficient.

* I've been doing some measures:
  * Time to get the visualizations that have mapviews for yesterday ~= 552 seconds
  * Amount of visualizations 12970 of 263326

As a result of this data, I've decided to change how the metadata is updated and update for the visualizations that has likes or mapviews for the day before. This way we are going to cover all this cases in one round:
* New
* Updated
* Modified privacy (delete private visualizations)
* Liked visualizations since last day
* View visualizations since last day

We could avoid to update some visualizations but I think that with all this cases covered should me minimum.

This should improve the current state in two ways:

* We don't have to have two rake tasks to update explore API daily
* I've to run in production but a priori avoiding to connect every time against Redis (to get `likes` and `mapviews` for every visualization to be updated) we should have improved a lot the time to access that data.

This to do:

* If this change is satisfactory, activate the update for the table metadata (row count, size and geometry type) for this subset of visualizations.

// @juanignaciosl please check this PR :)