### PR TITLE
Using the wrong vis model for create-vis-first dialog

### DIFF
--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -233,7 +233,7 @@
         var createVisFirstView = new cdb.editor.CreateVisFirstView({
           clean_on_hide: true,
           enter_to_confirm: true,
-          model: this.vis,
+          model: this.master_vis,
           router: window.table_router,
           title: 'A map is required to add layers',
           explanation: 'A map is a shareable mix of layers, styles and queries. You can view all your maps in your dashboard.',

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -230,7 +230,7 @@
       if (this.vis.isVisualization()) {
         this._createAddLayerDialog();
       } else {
-        var createVisFirstView = new cdb.editor.CreateVisFirstView({
+        this.createVisDlg = new cdb.editor.CreateVisFirstView({
           clean_on_hide: true,
           enter_to_confirm: true,
           model: this.master_vis,
@@ -239,7 +239,7 @@
           explanation: 'A map is a shareable mix of layers, styles and queries. You can view all your maps in your dashboard.',
           success: this._createAddLayerDialog.bind(this)
         });
-        createVisFirstView.appendToBody();
+        this.createVisDlg.appendToBody();
       }
     },
 

--- a/lib/assets/test/spec/cartodb/table/actions_menu.spec.js
+++ b/lib/assets/test/spec/cartodb/table/actions_menu.spec.js
@@ -4,6 +4,7 @@ describe("Actions menu", function() {
 
   beforeEach(function() {
     vis = TestUtil.createVis();
+    master_vis = TestUtil.createVis();
     sqlView = new cdb.admin.SQLViewData(null, { sql: 'select * from a' });
     table = new cdb.admin.CartoDBTableMetadata({ name: 'test1' });
     user = new cdb.admin.User({
@@ -23,7 +24,7 @@ describe("Actions menu", function() {
 
     view = new cdb.admin.LayersPanel({
       vis: vis,
-      master_vis: vis,
+      master_vis: master_vis,
       user: user,
       globalError: new cdb.admin.GlobalError({ el: $('<div>') })
     });
@@ -111,9 +112,14 @@ describe("Actions menu", function() {
 
   it("should ask create vis first when vis of type", function() {
     // can't add more layers to a table
+    var masterVisId = view.master_vis.cid;
+    var visId = view.vis.cid;
     spyOn(cdb.editor.CreateVisFirstView.prototype, 'initialize').and.callThrough();
     view.$('.add_layer').click();
     expect(cdb.editor.CreateVisFirstView.prototype.initialize).toHaveBeenCalled();
+    expect(view.createVisDlg).toBeDefined();
+    expect(view.createVisDlg.model.cid).toBe(masterVisId);
+    expect(view.createVisDlg.model.cid).not.toBe(visId);
   });
 
   it("should open new layer modal when vis if of type derived (i.e. map)", function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.30",
+  "version": "3.19.31",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Being in a dataset, if you try to add a new layer, the "create a map first" dialog will appear. The model of the dialog is turned into a derived visualization, but unfortunately this model is the wrong one.

This is another example of the problems we have with ```master_vis``` and ```vis```. 
I'm really considering to remove odyssey code preventing more bugs in the future.
In any case, what would you do to prevent this error happening again?
cc @CartoDB/frontend 

REVIEWER: @viddo 
Fixes #5563