### PR TITLE
5537 move host and port for groups api inside org metadata api config section

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2618,12 +2618,16 @@ TRIGGER
     timeout = config.fetch('timeout', 10)
 
     if host.present? && port.present? && username.present? && password.present?
+      conf_sql = %{
+        SELECT cartodb.CDB_Conf_SetConf('groups_api',
+          '{ \"host\": \"#{host}\", \"port\": #{port}, \"timeout\": #{timeout}, \"username\": \"#{username}\", \"password\": \"#{password}\"}'::json
+        )
+      }
       in_database(as: :superuser) do |database|
-        result = database.fetch("SELECT cartodb.CDB_Conf_SetConf('groups_api', '{ \"host\": \"#{host}\", \"port\": #{port}, \"timeout\": #{timeout}, \"username\": \"#{username}\", \"password\": \"#{password}\"}'::json);").first
-        result
+        database.fetch(conf_sql).first
       end
     else
-      CartoDB.notify_debug("org_metadata_api configuration missing", { user_id: id, config: config })
+      CartoDB.notify_debug("org_metadata_api configuration missing", user_id: id, config: config)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2607,13 +2607,12 @@ TRIGGER
   end
 
   def configure_extension_org_metadata_api_endpoint
-    # TODO: remove the check after extension install
+    # TODO: remove the check after extension install (#4924 merge)
     return if Rails.env.test?
 
-    port = Cartodb.config[:http_port]
-    # INFO: account_host includes port in development
-    host = Cartodb.config[:account_host].split(':')[0]
     config = Cartodb.config[:org_metadata_api]
+    host = config['host']
+    port = config['port']
     username = config['username']
     password = config['password']
     timeout = config.fetch('timeout', 10)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2617,9 +2617,13 @@ TRIGGER
     password = config['password']
     timeout = config.fetch('timeout', 10)
 
-    in_database(as: :superuser) do |database|
-      result = database.fetch("SELECT cartodb.CDB_Conf_SetConf('groups_api', '{ \"host\": \"#{host}\", \"port\": #{port}, \"timeout\": #{timeout}, \"username\": \"#{username}\", \"password\": \"#{password}\"}'::json);").first
-      result
+    if host.present? && port.present? && username.present? && password.present?
+      in_database(as: :superuser) do |database|
+        result = database.fetch("SELECT cartodb.CDB_Conf_SetConf('groups_api', '{ \"host\": \"#{host}\", \"port\": #{port}, \"timeout\": #{timeout}, \"username\": \"#{username}\", \"password\": \"#{password}\"}'::json);").first
+        result
+      end
+    else
+      CartoDB.notify_debug("org_metadata_api configuration missing", { user_id: id, config: config })
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1651,7 +1651,7 @@ class User < Sequel::Model
     return if Rails.env.test?
 
     self.in_database(as: :superuser) do |database|
-      database.run(%Q{ SELECT cartodb.CDB_Organization_AddAdmin('#{self.username}') })
+      database.run(%{ SELECT cartodb.CDB_Organization_AddAdmin('#{username}') })
     end
   end
 

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -127,6 +127,8 @@ defaults: &defaults
       users_metadata:      5
       redis_migrator_logs: 6
   org_metadata_api:
+    host: 'localhost.lan'
+    port: '3000'
     username: "extension"
     password: "elephant"
     timeout: 10


### PR DESCRIPTION
This closes #5537.

@azamorano CR this, please.

@viddo add host and port params to org_metadata_api as you can see in the example if you want organization creation to work as expected :-)