### PR TITLE
Adds rake tasks to delete users by username or email

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -5,7 +5,9 @@ namespace :user do
       raise 'Please specify the username of the user to be deleted' if args[:username].blank?
       
       user = User.find(username: args[:username])
-      raise "The username '#{args[:username]}' does not correspond to any user"
+      raise "The username '#{args[:username]}' does not correspond to any user" if user.nil?
+
+      raise 'Deletion aborted due to bad confirmation' if !deletion_confirmed?(user)
 
       user.destroy
     end
@@ -15,9 +17,28 @@ namespace :user do
       raise 'Please specify the email of the user to be deleted' if args[:email].blank?
       
       user = User.find(email: args[:email])
-      raise "The email '#{args[:email]}' does not correspond to any user"
+      raise "The email '#{args[:email]}' does not correspond to any user" if user.nil?
+
+      raise 'Deletion aborted due to bad confirmation' if !deletion_confirmed?(user)
 
       user.destroy
+    end
+
+    def deletion_confirmed?(user)
+      puts ""
+      puts "You are about to delete the following user:"
+      puts "\t> username: #{user.username}"
+      puts "\t> email: #{user.email}"
+      puts ""
+      puts "Alongside '#{user.username}', the following will be deleted:"
+      puts "\t> #{user.maps.length} maps"
+      puts "\t> #{user.tables.count} datasets"
+      puts ""
+      puts "Type in the user's username (#{user.username}) to confirm:"
+
+      confirm = STDIN.gets.strip
+      
+      confirm == user.username
     end
   end
 end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,13 @@
+namespace :user do
+  namespace :deletion do
+    desc 'Delete a user given a username'
+    task :by_username, [:username] => [:environment] do |task, args|
+      User.find(username: args[:username]).destroy
+    end
+
+    desc 'Delete a user given an email'
+    task :by_email, [:email] => [:environment] do |task, args|
+      User.find(email: args[:email]).destroy
+    end
+  end
+end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -2,12 +2,22 @@ namespace :user do
   namespace :deletion do
     desc 'Delete a user given a username'
     task :by_username, [:username] => [:environment] do |task, args|
-      User.find(username: args[:username]).destroy
+      raise 'Please specify the username of the user to be deleted' if args[:username].blank?
+      
+      user = User.find(username: args[:username])
+      raise "The username '#{args[:username]}' does not correspond to any user"
+
+      user.destroy
     end
 
     desc 'Delete a user given an email'
     task :by_email, [:email] => [:environment] do |task, args|
-      User.find(email: args[:email]).destroy
+      raise 'Please specify the email of the user to be deleted' if args[:email].blank?
+      
+      user = User.find(email: args[:email])
+      raise "The email '#{args[:email]}' does not correspond to any user"
+
+      user.destroy
     end
   end
 end


### PR DESCRIPTION
Fixes #5587

Now available:

```
bundle exec rake user:deletion:by_username[‘manolo']
bundle exec rake user:deletion:by_email['manolo@cartodb.com']
```

Please CR @rafatower :)

cc @javisantana 