### PR TITLE
'Edit in CartoDB' link in the public map page points to the map instead of the dataset

### DIFF
--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -119,7 +119,7 @@
 
             <ul class="Navmenu-list u-hideOnTablet">
               <li class="Navmenu-item">
-                <a class="Button Button--main Navmenu-editLink Navmenu-editLink--edit js-Navmenu-editLink" href="<%= CartoDB.url(self, 'public_visualizations_show', {id: @visualization.id }, @visualization.user) %>">Edit in cartodb</a>
+                <a class="Button Button--main Navmenu-editLink Navmenu-editLink--edit js-Navmenu-editLink" href="<%= CartoDB.url(self, 'public_visualizations_show_map', {id: @visualization.id }, @visualization.user) %>">Edit in cartodb</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
'Edit in CartoDB' link is currently linking to:

`https://wadus.cartodb.com/viz/d29f9a84-5546-11e5-815b-0e9d821ea90d/`

That link opens the visualization in the Dataset view...

This PR changes that link to point to:

`https://wadus.cartodb.com/viz/d29f9a84-5546-11e5-815b-0e9d821ea90d/map`

This way, the map is displayed and the behaviour is consistent with clicking on a map in the dashboard.

@matallo this one is for you! :)