### PR TITLE
Recover from tiler errors saving privacy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -502,7 +502,7 @@ Metrics/AbcSize:
   Description: A calculated magnitude based on number of assignments, branches, and
     conditions.
   Enabled: true
-  Max: 15
+  Max: 25
 Metrics/BlockNesting:
   Description: Avoid excessive block nesting
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -8,7 +8,7 @@ module Carto
     PRIVACY_PUBLIC = 1
     PRIVACY_LINK = 2
 
-    belongs_to :visualization, primary_key: :map_id, foreign_key: :map_id, 
+    belongs_to :visualization, primary_key: :map_id, foreign_key: :map_id,
                 conditions: { type: Carto::Visualization::TYPE_CANONICAL }, inverse_of: :user_table
 
     belongs_to :user
@@ -91,8 +91,7 @@ module Carto
     end
 
     def affected_visualizations
-      affected_visualizations ||= affected_visualization_ids
-        .map  { |id| Carto::Visualization.find(id) }
+      @affected_visualizations ||= affected_visualization_ids.map { |id| Carto::Visualization.find(id) }
     end
 
     # TODO: use associations?

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -449,23 +449,12 @@ class Table
   end
 
   def after_save
-    store_previous_privacy
     manage_tags
     update_name_changes
 
-    privacy_manager = CartoDB::TablePrivacyManager.new(@user_table)
+    CartoDB::TablePrivacyManager.new(@user_table).apply_privacy_change(self, previous_privacy, privacy_changed?)
 
-    # Separate on purpose as if fails here no need to revert visualizations' privacy
-    revertable_block(privacy_manager) do
-      # Map saving actually doesn't changes privacy, but to keep on same reverting logic
-      @user_table.map.save
-      privacy_manager.set_from_table_privacy(@user_table.privacy)
-    end
-
-    revertable_block(privacy_manager, [table_visualization] + affected_visualizations) do
-      privacy_manager.propagate_to([table_visualization])
-      notify_privacy_affected_entities(privacy_manager) if privacy_changed?
-    end
+    update_cdb_tablemetadata if privacy_changed?
   end
 
   def propagate_namechange_to_table_vis
@@ -1351,43 +1340,9 @@ class Table
 
   private
 
-  def revertable_block(privacy_manager, entities = [])
-    yield
-  rescue => exception
-    CartoDB.notify_exception(exception, user_id: user_id, table_id: id)
-    revert_to_previous_privacy(privacy_manager, entities)
-    raise exception
-  end
-
-  def store_previous_privacy
+  def previous_privacy
     # INFO: @user_table.initial_value(:privacy) weirdly returns incorrect value so using changes index instead
-    @old_privacy = privacy_changed? ? @user_table.previous_changes[:privacy].first : nil
-  end
-
-  def revert_to_previous_privacy(privacy_manager, additional_revert_targets)
-    return unless @old_privacy
-
-    privacy_manager.set_from_table_privacy(@old_privacy)
-
-    errors = []
-    additional_revert_targets.each do |visualization|
-      begin
-        privacy_manager.propagate_to([visualization])
-      rescue => exception
-        # Can't do much more, just let remaining ones finish
-        errors << exception
-      end
-    end
-
-    if errors.length > 0
-      CartoDB.notify_error("Errors reverting Table privacy", user_id: user_id, table_id: id, errors: errors)
-    end
-  end
-
-  def notify_privacy_affected_entities(privacy_manager)
-    privacy_manager.propagate_to_varnish
-    update_cdb_tablemetadata
-    privacy_manager.propagate_to(affected_visualizations, true)
+    privacy_changed? ? @user_table.previous_changes[:privacy].first : nil
   end
 
   def importer_stats

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -456,6 +456,7 @@ class Table
 
     privacy_manager = CartoDB::TablePrivacyManager.new(@user_table)
     privacy_manager.set_from_table_privacy(@user_table.privacy)
+    # Propagation: Table -> Table PrivacyManager -> Visualization -> Visualization NamedMap
     privacy_manager.propagate_to([table_visualization])
 
     notify_privacy_affected_entities(privacy_manager) if privacy_changed?

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -5,30 +5,25 @@ require_relative 'user_table'
 
 module CartoDB
   class TablePrivacyManager
+
     def initialize(table)
       @table = table
     end
 
-    def set_public
-      self.privacy = ::UserTable::PRIVACY_PUBLIC
-      set_database_permissions(grant_query)
-      self
-    end
+    def apply_privacy_change(metadata_table, old_privacy, privacy_changed = false)
+      @table.map.save
 
-    def set_private
-      self.privacy = ::UserTable::PRIVACY_PRIVATE
-      set_database_permissions(revoke_query)
-      self
-    end
+      # Separate on purpose as if fails here no need to revert visualizations' privacy
+      revertable_privacy_change(metadata_table, old_privacy) do
+        # Map saving actually doesn't changes privacy, but to keep on same reverting logic
+        @table.map.save
+        set_from_table_privacy(@table.privacy)
+      end
 
-    def set_from_table_privacy(table_privacy)
-      case table_privacy
-      when ::UserTable::PRIVACY_PUBLIC
-        set_public
-      when ::UserTable::PRIVACY_LINK
-        set_public_with_link_only
-      else
-        set_private
+      revertable_privacy_change(metadata_table, old_privacy,
+                                [metadata_table.table_visualization] + metadata_table.affected_visualizations) do
+        propagate_to([metadata_table.table_visualization])
+        notify_privacy_affected_entities(metadata_table) if privacy_changed
       end
     end
 
@@ -37,18 +32,6 @@ module CartoDB
       set_public_with_link_only if visualization.public_with_link?
       set_private               if visualization.private? or visualization.organization?
       table.update(privacy: privacy)
-      self
-    end
-
-    # Propagation flow: Table -> Table PrivacyManager -> Visualization -> Visualization NamedMap
-    def propagate_to(visualizations, table_privacy_changed = false)
-      visualizations.each do |visualization|
-        visualization.store_using_table({
-                                          privacy_text: ::UserTable::PRIVACY_VALUES_TO_TEXTS[privacy],
-                                          map_id: visualization.map_id
-                                        }, table_privacy_changed)
-      end
-
       self
     end
 
@@ -63,6 +46,41 @@ module CartoDB
 
     attr_reader :table
     attr_accessor :privacy
+
+    def set_from_table_privacy(table_privacy)
+      case table_privacy
+      when ::UserTable::PRIVACY_PUBLIC
+        set_public
+      when ::UserTable::PRIVACY_LINK
+        set_public_with_link_only
+      else
+        set_private
+      end
+    end
+
+    # Propagation flow: Table -> Table PrivacyManager -> Visualization -> Visualization NamedMap
+    def propagate_to(visualizations, table_privacy_changed = false)
+      visualizations.each do |visualization|
+        visualization.store_using_table({
+                                          privacy_text: ::UserTable::PRIVACY_VALUES_TO_TEXTS[privacy],
+                                          map_id: visualization.map_id
+                                        }, table_privacy_changed)
+      end
+
+      self
+    end
+
+    def set_public
+      self.privacy = ::UserTable::PRIVACY_PUBLIC
+      set_database_permissions(grant_query)
+      self
+    end
+
+    def set_private
+      self.privacy = ::UserTable::PRIVACY_PRIVATE
+      set_database_permissions(revoke_query)
+      self
+    end
 
     def set_public_with_link_only
       self.privacy = ::UserTable::PRIVACY_LINK
@@ -93,6 +111,41 @@ module CartoDB
 
     def invalidate_varnish_cache
       table.invalidate_varnish_cache(false)
+    end
+
+    def revertable_privacy_change(metadata_table, old_privacy = nil, entities = [])
+      yield
+    rescue => exception
+      CartoDB.notify_exception(exception, user_id: metadata_table.user_id, table_id: metadata_table.id)
+      revert_to_previous_privacy(metadata_table, old_privacy, entities)
+      raise exception
+    end
+
+    def revert_to_previous_privacy(metadata_table, old_privacy, additional_revert_targets = [])
+      return unless old_privacy
+
+      set_from_table_privacy(old_privacy)
+
+      errors = []
+      additional_revert_targets.each do |visualization|
+        begin
+          propagate_to([visualization])
+        rescue => exception
+          # Can't do much more, just let remaining ones finish
+          errors << exception
+        end
+      end
+
+      if errors.length > 0
+        CartoDB.notify_error("Errors reverting Table privacy", user_id: metadata_table.user_id,
+                                                               table_id: metadata_table.id,
+                                                               errors: errors)
+      end
+    end
+
+    def notify_privacy_affected_entities(metadata_table)
+      propagate_to_varnish
+      propagate_to(metadata_table.affected_visualizations, true)
     end
 
   end

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -6,7 +6,7 @@ require_relative 'user_table'
 module CartoDB
   class TablePrivacyManager
     def initialize(table)
-      @table  = table
+      @table = table
     end
 
     def set_public
@@ -23,16 +23,16 @@ module CartoDB
 
     def set_from_table_privacy(table_privacy)
       case table_privacy
-        when ::UserTable::PRIVACY_PUBLIC
-          set_public
-        when ::UserTable::PRIVACY_LINK
-          set_public_with_link_only
-        else
-          set_private
+      when ::UserTable::PRIVACY_PUBLIC
+        set_public
+      when ::UserTable::PRIVACY_LINK
+        set_public_with_link_only
+      else
+        set_private
       end
     end
 
-    def set_from(visualization)
+    def set_from_visualization(visualization)
       set_public                if visualization.public?
       set_public_with_link_only if visualization.public_with_link?
       set_private               if visualization.private? or visualization.organization?
@@ -40,11 +40,14 @@ module CartoDB
       self
     end
 
-    def propagate_to(visualization, table_privacy_changed=false)
-      visualization.store_using_table({
-                                        privacy_text: ::UserTable::PRIVACY_VALUES_TO_TEXTS[privacy],
-                                        map_id: visualization.map_id
-                                      }, table_privacy_changed)
+    def propagate_to(visualizations, table_privacy_changed = false)
+      visualizations.each do |visualization|
+        visualization.store_using_table({
+                                          privacy_text: ::UserTable::PRIVACY_VALUES_TO_TEXTS[privacy],
+                                          map_id: visualization.map_id
+                                        }, table_privacy_changed)
+      end
+
       self
     end
 
@@ -57,7 +60,7 @@ module CartoDB
 
     private
 
-    attr_reader   :table
+    attr_reader :table
     attr_accessor :privacy
 
     def set_public_with_link_only
@@ -93,4 +96,3 @@ module CartoDB
 
   end
 end
-

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -40,6 +40,7 @@ module CartoDB
       self
     end
 
+    # Propagation flow: Table -> Table PrivacyManager -> Visualization -> Visualization NamedMap
     def propagate_to(visualizations, table_privacy_changed = false)
       visualizations.each do |visualization|
         visualization.store_using_table({

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -803,7 +803,7 @@ module CartoDB
       def propagate_privacy_to(table)
         if type == TYPE_CANONICAL
           CartoDB::TablePrivacyManager.new(table)
-                                      .set_from(self)
+                                      .set_from_visualization(self)
                                       .propagate_to_varnish
         end
         self

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -738,7 +738,7 @@ module CartoDB
         begin
           save_named_map
         rescue => exception
-          CartoDB.notify_exception(exception, "Error saving visualization named map")
+          CartoDB.notify_exception(exception, user: user, message: "Error saving visualization named map")
           restore_previous_privacy
           raise exception
         end
@@ -758,7 +758,7 @@ module CartoDB
           repository.store(id, attributes.to_hash)
         end
       rescue => exception
-        CartoDB.notify_exception(exception, "Error restoring previous visualization privacy")
+        CartoDB.notify_exception(exception, user: user, message: "Error restoring previous visualization privacy")
         raise exception
       end
 

--- a/services/named-maps-api-wrapper/lib/named-maps-wrapper/exceptions.rb
+++ b/services/named-maps-api-wrapper/lib/named-maps-wrapper/exceptions.rb
@@ -2,22 +2,18 @@
 
 module CartoDB
   module NamedMapsWrapper
-
-    class NamedMapsGenericError   < StandardError
-
-      def initialize(message, template_data={})
+    class NamedMapsGenericError < StandardError
+      def initialize(message = "Named maps generic error", template_data = {})
         @template_data = template_data
         super(message)
       end
 
       attr_reader :template_data
-
     end
 
-    class NamedMapDataError       < NamedMapsGenericError; end
-    class NamedMapsDataError      < NamedMapsGenericError; end
-    class HTTPResponseError       < NamedMapsGenericError; end
+    class NamedMapDataError < NamedMapsGenericError; end
+    class NamedMapsDataError < NamedMapsGenericError; end
+    class HTTPResponseError < NamedMapsGenericError; end
     class NamedMapsPresenterError < NamedMapsGenericError; end
-
-  end #NamedMapsWrapper
-end #CartoDB
+  end
+end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -683,7 +683,7 @@ describe Table do
   end
 
   it "should remove varnish cache when updating the table privacy" do
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true)
 
     $user_1.private_tables_enabled = true
     $user_1.save
@@ -691,12 +691,11 @@ describe Table do
 
     id = table.table_visualization.id
     CartoDB::Varnish.any_instance.expects(:purge)
-      .times(3)
-      .with(".*#{id}:vizjson")
-      .returns(true)
+                                 .times(4)
+                                 .with(".*#{id}:vizjson")
+                                 .returns(true)
 
-    CartoDB::TablePrivacyManager.any_instance
-      .expects(:propagate_to_varnish)
+    CartoDB::TablePrivacyManager.any_instance.expects(:propagate_to_varnish)
     table.privacy = UserTable::PRIVACY_PUBLIC
     table.save
   end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -2275,7 +2275,7 @@ describe Table do
       table.save
 
       CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true)
-      source  = table.table_visualization
+      source = table.table_visualization
       derived = CartoDB::Visualization::Copier.new($user_1, source).copy
       derived.store
       derived.type.should eq(CartoDB::Visualization::Member::TYPE_DERIVED)

--- a/spec/requests/api/json/visualizations_controller_spec.rb
+++ b/spec/requests/api/json/visualizations_controller_spec.rb
@@ -33,6 +33,40 @@ describe Api::Json::VisualizationsController do
     delete_user_data @user
   end
 
+  describe "#update" do
+    before(:each) do
+      login(@user)
+    end
+
+    it "Reverts privacy changes if named maps communitacion fails" do
+
+      @user.private_tables_enabled = true
+      @user.save
+
+      table = new_table(user_id: @user.id, privacy: ::UserTable::PRIVACY_PUBLIC).save.reload
+
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance
+                                          .stubs(:create)
+                                          .raises(CartoDB::NamedMapsWrapper::HTTPResponseError)
+
+      put_json api_v1_visualizations_update_url(id: table.table_visualization.id),
+      {
+        visualization_id: table.table_visualization.id,
+        privacy: Carto::Visualization::PRIVACY_PRIVATE
+      }.to_json do |response|
+        response.status.should_not be_success
+        response.status.should eq 400
+      end
+
+      table.reload
+      table.privacy.should eq ::UserTable::PRIVACY_PUBLIC
+
+      @user.private_tables_enabled = false
+      @user.save
+    end
+
+  end
+
   describe '#likes' do
 
     before(:each) do


### PR DESCRIPTION
Fixes #4992

Scope and fix only reverts privacy change so is not a full transaction-like rollback. Just reapplies old privacy. Also when reverting the change tries a best effort: if something fails will continue try to revert as many as possible then report the error.

This basically covers 2 found scenarios:
- Tiler down when saving a table privacy change. This is done through a `Visualization` model update affecting the privacy (first commits).
- Named map errors when propagating the privacy change either to the canonical visualization or to any affected visualization (vis that has a layer or query using the table). This is done through a `Table` model update affecting the privacy (latest commits).

Bonus: covers also unlikely scenarios of `UserTable privacy` change failing and `Map.save` failing.
