### PR TITLE
Use right protocol with id previews 

### DIFF
--- a/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
@@ -41,7 +41,7 @@ module.exports = cdb.core.View.extend({
 
   _loadFromVisId: function() {
 
-    var protocol = this._isHTTPS ? 'https': 'http';
+    var protocol = this._isHTTPS() ? 'https': 'http';
     var url = protocol + '://' + this.options.username + '.' + this.options.account_host + '/api/v1/map/static/named/' + this._generateImageTemplate() + '/' + this.width + '/' + this.height + '.png';
     this._loadImage({}, url);
   },

--- a/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
@@ -41,7 +41,8 @@ module.exports = cdb.core.View.extend({
 
   _loadFromVisId: function() {
 
-    var url = 'http://' + this.options.username + '.' + this.options.account_host + '/api/v1/map/static/named/' + this._generateImageTemplate() + '/' + this.width + '/' + this.height + '.png';
+    var protocol = this._isHTTPS ? 'https': 'http';
+    var url = protocol + '://' + this.options.username + '.' + this.options.account_host + '/api/v1/map/static/named/' + this._generateImageTemplate() + '/' + this.width + '/' + this.height + '.png';
     this._loadImage({}, url);
   },
 

--- a/lib/assets/test/spec/cartodb/common/views/mapcard_preview.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/mapcard_preview.spec.js
@@ -1,6 +1,5 @@
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
-var $ = require('jquery');
+var cdb = require('cartodb.js'); var $ = require('jquery');
 var MapCardPreview = require('../../../../../javascripts/cartodb/common/views/mapcard_preview');
 
 describe('common/views/mapcard_preview', function() {
@@ -172,6 +171,13 @@ describe('common/views/mapcard_preview', function() {
     it("should generate the image url", function() {
       view.load();
       expect(view._loadImage).toHaveBeenCalledWith({}, 'http://javier.cartodb.com/api/v1/map/static/named/tpl_12_34_5/300/170.png');
+    });
+
+    it("should generate the image URL with the right protocol", function() {
+      var s = sinon.stub(view, '_isHTTPS');
+      s.returns(true);
+      view.load();
+      expect(view._loadImage).toHaveBeenCalledWith({}, 'https://javier.cartodb.com/api/v1/map/static/named/tpl_12_34_5/300/170.png');
     });
 
     afterEach(function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.40",
+  "version": "3.19.41",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes the static map generation to use the right protocol depending on the page where the image is loaded.