### PR TITLE
Store invalidation client with unique name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2032,14 +2032,16 @@ TRIGGER
       retry = #{invalidation_retry}
       trigger_verbose = #{invalidation_trigger_verbose}
 
-      client = GD.get('invalidation', None)
+      invalidation_client_key = 'invalidation:%s:%d' % ('#{invalidation_host}', #{invalidation_port})
+
+      client = GD.get(invalidation_client_key, None)
 
       while True:
 
         if not client:
             try:
               import redis
-              client = GD['invalidation'] = redis.Redis(host='#{invalidation_host}', port=#{invalidation_port}, socket_timeout=timeout)
+              client = GD[invalidation_client_key] = redis.Redis(host='#{invalidation_host}', port=#{invalidation_port}, socket_timeout=timeout)
             except Exception as err:
               # NOTE: we won't retry on connection error
               if critical:


### PR DESCRIPTION
When the invalidation function stores the client in a python global var,
store it under a unique name based on the invalidation service host and
port

@rochoa please review