### PR TITLE
Exclude shared visualizations from the user feed

### DIFF
--- a/lib/assets/javascripts/cartodb/user_feed/view.js
+++ b/lib/assets/javascripts/cartodb/user_feed/view.js
@@ -307,6 +307,7 @@ module.exports = cdb.core.View.extend({
     var data = _.extend({
         types: 'table,derived',
         privacy: 'public',
+        exclude_shared: 'true',
         per_page: this._ITEMS_PER_PAGE,
         order: 'updated_at'
       }, params);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.43",
+  "version": "3.19.44",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We want to exclude the shared maps and datasets from the user feed