### PR TITLE
Add groups+groups users meta details

### DIFF
--- a/app/assets/stylesheets/common/account_forms.css.scss
+++ b/app/assets/stylesheets/common/account_forms.css.scss
@@ -11,7 +11,6 @@ $sLabel-width: 140px;
   @include display-flex();
   @include flex-direction(row);
   @include justify-content(space-between);
-  overflow: hidden;
 }
 .FormAccount-Content {
   display: block;

--- a/app/assets/stylesheets/common/dialog.css.scss
+++ b/app/assets/stylesheets/common/dialog.css.scss
@@ -244,9 +244,6 @@ body.is-inDialog {
   @include justify-content(space-between, justify);
   @include align-items(center);
 }
-.Dialog-affectedEntitiesAvatar {
-  margin-left: $sMargin-min;
-}
 
 // Styles related to expanded styles, where body--expanded is intended to be scrollable
 $sStickyHeight: 97px;

--- a/app/assets/stylesheets/common/user-avatar.css.scss
+++ b/app/assets/stylesheets/common/user-avatar.css.scss
@@ -44,8 +44,8 @@
   @include display-flex();
   @include justify-content(center);
   @include align-items(center);
-  font-size: $sFontSize-small;
   border: 1px solid $cTypography-link;
+  font-size: $sFontSize-small;
   &:hover {
     border-color: $cTypography-link;
   }

--- a/app/assets/stylesheets/common/user-avatar.css.scss
+++ b/app/assets/stylesheets/common/user-avatar.css.scss
@@ -13,6 +13,9 @@
   @include display-flex();
   @include align-items(center);
 }
+.UserAvatar.is-in-list {
+  margin-left: $sMargin-min;
+}
 .UserAvatar.is-error:before {
   @include display-flex();
   @include justify-content(center);
@@ -36,6 +39,16 @@
 }
 .UserAvatar-img--no-src {
   background-image: image-url('avatars/avatar_ghost_red.png');
+}
+.UserAvatar-img--textReplacement {
+  @include display-flex();
+  @include justify-content(center);
+  @include align-items(center);
+  font-size: $sFontSize-small;
+  border: 1px solid $cTypography-link;
+  &:hover {
+    border-color: $cTypography-link;
+  }
 }
 .UserAvatar-img.is-error {
   border-radius: $sAvatar-borderRadius;

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view_template.jst.ejs
@@ -61,7 +61,7 @@
     <p class="DefaultParagraph">Some users will lose access to your <%- pluralizedContentType %></p>
     <div>
       <% affectedEntitiesSample.forEach(function(user) { %>
-        <span class="UserAvatar Dialog-affectedEntitiesAvatar">
+        <span class="UserAvatar is-in-list">
           <% if (user.get('avatar_url')) { %>
             <img class="UserAvatar-img UserAvatar-img--medium" src="<%- user.get('avatar_url') %>" alt="<%- user.get('name') || user.get('username') %>" title="<%- user.get('name') || user.get('username') %>" />
           <% } else { %>
@@ -70,7 +70,7 @@
         </span>
       <% }); %>
       <% if (affectedEntitiesCount > affectedEntitiesSampleCount) { %>
-        <div class="UserAvatar Dialog-affectedEntitiesAvatar">
+        <div class="UserAvatar is-in-list">
           <span class="UserAvatar-img UserAvatar-img--medium UserAvatar--moreItems" />
         </div>
       <% } %>

--- a/lib/assets/javascripts/cartodb/common/view_helpers/pluralize_string.js
+++ b/lib/assets/javascripts/cartodb/common/view_helpers/pluralize_string.js
@@ -8,4 +8,12 @@ var pluralizeStr = function(singular, plural, count) {
   return count === 1 ? singular : plural;
 };
 
+pluralizeStr.includeCount = function(singular, plural, count) {
+  return pluralizeStr(
+    '1 ' + singular, // e.g. 1 item
+    count + ' ' + plural, // e.g. 123 items
+    count
+  );
+}
+
 module.exports = pluralizeStr;

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/group.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/group.jst.ejs
@@ -5,7 +5,7 @@
         <%- displayName %>
       </h3>
       <h4 class="OrganizationList-userInfoSubtitle u-ellipsLongText">
-        <%/* TODO: replace w/ meta info about group */%>&nbsp;
+        <%- sharedMapsCount %> &bull; <%- sharedDatasetsCount %>
       </h4>
     </div>
   </div>

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/group.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/group.jst.ejs
@@ -9,4 +9,18 @@
       </h4>
     </div>
   </div>
+  <div class="OrganizationList-userInfoData">
+    <% previewUsers.forEach(function(u) { %>
+        <span class="UserAvatar is-in-list">
+          <img class="UserAvatar-img UserAvatar-img--medium" src="<%- u.get('avatar_url') %>" title="<%- u.nameOrUsername() %>" />
+        </span>
+    <% }) %>
+    <% if (usersCount > 0) { %>
+      <span class="UserAvatar is-in-list">
+        <span class="UserAvatar-img UserAvatar-img--medium UserAvatar-img--textReplacement">
+          +<%- usersCount %>
+        </span>
+      </span>
+    <% } %>
+  </div>
 </a>

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/group_user.jst.ejs
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/group_user.jst.ejs
@@ -7,7 +7,19 @@
       <h3 class="OrganizationList-userInfoTitle u-ellipsLongText" title="<%- username %>">
         <%- username %>
       </h3>
-      <h4 class="OrganizationList-userInfoSubtitle u-ellipsLongText" title="<%- email %>"><%- email %></h4>
+      <h4 class="OrganizationList-userInfoSubtitle u-ellipsLongText" title="<%- email %>">
+        <%- email %>
+      </h4>
+    </div>
+    <div class="OrganizationList-userInfoData">
+      <p class="OrganizationLisr-userInfoData--paragraph">
+        <i class="iconFont iconFont-Map OrganizationLisr-userInfoData--paragraph-icon"></i>
+        <%- xMaps %>
+      </p>
+      <p class="OrganizationLisr-userInfoData--paragraph">
+        <i class="iconFont iconFont-Rows OrganizationLisr-userInfoData--paragraph-icon"></i>
+        <%- xDatasets %>
+      </p>
     </div>
   </div>
 </a>

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/group_user_view.js
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/group_user_view.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var cdb = require('cartodb.js');
 var ViewFactory = require('../../common/view_factory');
+var pluralizeStr = require('../../common/view_helpers/pluralize_string');
 
 /**
  * View of a single group user.
@@ -25,7 +26,9 @@ module.exports = cdb.core.View.extend({
       this.getTemplate('organization/groups_admin/group_user')({
         avatarUrl: this.model.get('avatar_url'),
         username: this.model.get('username'),
-        email: this.model.get('email')
+        email: this.model.get('email'),
+        xMaps: pluralizeStr.includeCount('map', 'maps', this.model.get('maps_count')),
+        xDatasets: pluralizeStr.includeCount('dataset', 'datasets', this.model.get('table_count'))
       })
     );
     return this;

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/group_view.js
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/group_view.js
@@ -9,6 +9,7 @@ module.exports = cdb.core.View.extend({
 
   tagName: 'li',
   className: 'OrganizationList-user',
+  _PREVIEW_COUNT: 3,
 
   initialize: function() {
     _.each(['model', 'url'], function(name) {
@@ -24,7 +25,9 @@ module.exports = cdb.core.View.extend({
         displayName: this.model.get('display_name'),
         sharedMapsCount: pluralizeStr('1 shared map', sharedMapsCount + ' shared maps', sharedMapsCount),
         sharedDatasetsCount: pluralizeStr('1 shared map', sharedDatasetsCount + ' shared datasets', sharedDatasetsCount),
-        url: this.options.url
+        url: this.options.url,
+        previewUsers: this.model.users.toArray().slice(0, this._PREVIEW_COUNT),
+        usersCount: Math.max(this.model.users.length - this._PREVIEW_COUNT, 0)
       })
     );
     return this;

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/group_view.js
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/group_view.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var cdb = require('cartodb.js');
+var pluralizeStr = require('../../common/view_helpers/pluralize_string');
 
 /**
  * View for an individual group.
@@ -10,16 +11,20 @@ module.exports = cdb.core.View.extend({
   className: 'OrganizationList-user',
 
   initialize: function() {
-    _.each(['model', 'newGroupUrl'], function(name) {
+    _.each(['model', 'url'], function(name) {
       if (!this.options[name]) throw new Error(name + ' is required');
     }, this);
   },
 
   render: function() {
+    var sharedMapsCount = this.model.get('shared_maps_count');
+    var sharedDatasetsCount = this.model.get('shared_tables_count');
     this.$el.html(
       this.getTemplate('organization/groups_admin/group')({
         displayName: this.model.get('display_name'),
-        url: this.options.newGroupUrl(this.model)
+        sharedMapsCount: pluralizeStr('1 shared map', sharedMapsCount + ' shared maps', sharedMapsCount),
+        sharedDatasetsCount: pluralizeStr('1 shared map', sharedDatasetsCount + ' shared datasets', sharedDatasetsCount),
+        url: this.options.url
       })
     );
     return this;

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/groups_index_view.js
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/groups_index_view.js
@@ -35,7 +35,7 @@ module.exports = cdb.core.View.extend({
     return this.options.groups.map(function(m) {
       var view = new GroupView({
         model: m,
-        newGroupUrl: this.options.newGroupUrl
+        url: this.options.newGroupUrl(m)
       });
       this.addView(view);
       return view.render().el;

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/router.js
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/router.js
@@ -52,7 +52,9 @@ module.exports = Router.extend({
     var self = this;
     this.groups.fetch({
       data: {
-        fetch_users: true
+        fetch_users: true,
+        fetch_shared_maps_count: true,
+        fetch_shared_tables_count: true
       },
       success: function() {
         self.model.set('view',

--- a/lib/assets/test/spec/cartodb/organization/groups_admin/group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization/groups_admin/group_view.spec.js
@@ -8,7 +8,11 @@ describe('organization/groups_admin/group_view', function() {
     this.group = new cdb.admin.Group({
       display_name: 'foobar',
       shared_tables_count: 42,
-      shared_maps_count: 37
+      shared_maps_count: 37,
+      users: [{
+        id: 'u1',
+        name: 'pepe'
+      }]
     })
 
     this.view = new GroupView({
@@ -33,6 +37,10 @@ describe('organization/groups_admin/group_view', function() {
   it('should render the shared maps/datasets counts', function() {
     expect(this.innerHTML()).toContain('42 shared datasets');
     expect(this.innerHTML()).toContain('37 shared maps');
+  });
+
+  it('should render a preview of the users', function() {
+    expect(this.innerHTML()).toContain('pepe');
   });
 
   afterEach(function() {

--- a/lib/assets/test/spec/cartodb/organization/groups_admin/group_view.spec.js
+++ b/lib/assets/test/spec/cartodb/organization/groups_admin/group_view.spec.js
@@ -1,0 +1,42 @@
+var $ = require('jquery');
+var cdb = require('cartodb.js');
+var GroupView = require('../../../../../javascripts/cartodb/organization/groups_admin/group_view');
+
+describe('organization/groups_admin/group_view', function() {
+
+  beforeEach(function() {
+    this.group = new cdb.admin.Group({
+      display_name: 'foobar',
+      shared_tables_count: 42,
+      shared_maps_count: 37
+    })
+
+    this.view = new GroupView({
+      model: this.group,
+      url: 'group-url'
+    });
+    this.view.render();
+  });
+
+  it('should not have leaks', function() {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should render the title', function() {
+    expect(this.innerHTML()).toContain('foobar');
+  });
+
+  it('should render the URL', function() {
+    expect(this.innerHTML()).toContain('href="group-url"');
+  });
+
+  it('should render the shared maps/datasets counts', function() {
+    expect(this.innerHTML()).toContain('42 shared datasets');
+    expect(this.innerHTML()).toContain('37 shared maps');
+  });
+
+  afterEach(function() {
+    this.view.clean();
+  });
+
+});


### PR DESCRIPTION
Solves some parts of #4883, in particular:

Organisation owner can:
- [x] see datasets/maps count for each group
- [x] see count/avatar previews of group members
- [x] see datasets/maps count for each group user

![screen shot 2015-09-21 at 17 50 00](https://cloud.githubusercontent.com/assets/978461/9997421/55cbd846-608c-11e5-9d82-4d5c04d7ce97.png)
![screen shot 2015-09-21 at 17 50 12](https://cloud.githubusercontent.com/assets/978461/9997422/55d2f78e-608c-11e5-9333-b36b2be05d41.png)
![screen shot 2015-09-21 at 18 10 05](https://cloud.githubusercontent.com/assets/978461/9997423/55e9b47e-608c-11e5-8ad0-a6ed9b05384c.png)

@xavijam pretty please review?
cc @juanignaciosl 