### PR TITLE
#5638 drop groups through extension on organization deletion

### DIFF
--- a/app/models/carto/organization.rb
+++ b/app/models/carto/organization.rb
@@ -7,6 +7,8 @@ module Carto
     belongs_to :owner, class_name: Carto::User
     has_many :groups, inverse_of: :organization, order: :display_name
 
+    before_destroy :destroy_groups_with_extension
+
     def self.find_by_database_name(database_name)
       Carto::Organization.
         joins('INNER JOIN users ON organizations.owner_id = users.id').
@@ -44,6 +46,16 @@ module Carto
 
     def create_group(display_name)
       Carto::Group.create_group_with_extension(self, display_name)
+    end
+
+    private
+
+    def destroy_groups_with_extension
+      return unless groups
+
+      groups.map { |g| g.destroy_group_with_extension }
+
+      reload
     end
 
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,7 @@
 # coding: UTF-8
 
 class Group < Sequel::Model
+
+  many_to_one :organization
+
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,16 +75,13 @@ class Organization < Sequel::Model
   end
 
   def before_destroy
-    return unless groups
-
-    groups.map { |g| Carto::Group.find(g.id).destroy_group_with_extension }
-
-    reload
+    destroy_groups
   end
 
   # INFO: replacement for destroy because destroying owner triggers
   # organization destroy
   def destroy_cascade
+    destroy_groups
     destroy_permissions
     destroy_non_owner_users
     if self.owner
@@ -248,6 +245,14 @@ class Organization < Sequel::Model
   end
 
   private
+
+  def destroy_groups
+    return unless groups
+
+    groups.map { |g| Carto::Group.find(g.id).destroy_group_with_extension }
+
+    reload
+  end
 
   # Returns true if disk quota won't allow new signups with existing defaults
   def disk_quota_limit_reached?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -34,6 +34,7 @@ class Organization < Sequel::Model
   # @param map_view_block_price Integer
 
   one_to_many :users
+  one_to_many :groups
   many_to_one :owner, class_name: 'User', key: 'owner_id'
 
   plugin :validation_helpers
@@ -71,6 +72,14 @@ class Organization < Sequel::Model
     super
     self.updated_at = Time.now
     raise errors.join('; ') unless valid?
+  end
+
+  def before_destroy
+    return unless groups
+
+    groups.map { |g| Carto::Group.find(g.id).destroy_group_with_extension }
+
+    reload
   end
 
   # INFO: replacement for destroy because destroying owner triggers

--- a/spec/models/carto/organization_spec.rb
+++ b/spec/models/carto/organization_spec.rb
@@ -30,5 +30,16 @@ describe Carto::Organization do
 
   end
 
+  describe 'deletion' do
+
+    it 'destroys its groups through the extension' do
+      Carto::Group.any_instance.expects(:destroy_group_with_extension).once
+      organization = Carto::Organization.find(FactoryGirl.create(:organization).id)
+      group = FactoryGirl.create(:carto_group, organization: organization)
+      organization.destroy
+    end
+
+  end
+
 end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -46,6 +46,11 @@ describe Organization do
   end
 
   describe '#destroy_cascade' do
+
+    after(:each) do
+      @organization.delete if @organization
+    end
+
     it 'Destroys users and owner as well' do
       User.any_instance.stubs(:create_in_central).returns(true)
       User.any_instance.stubs(:update_in_central).returns(true)
@@ -69,6 +74,15 @@ describe Organization do
       User.where(id: user.id).first.should be nil
       User.where(id: owner.id).first.should be nil
     end
+
+    it 'destroys its groups through the extension' do
+      Carto::Group.any_instance.expects(:destroy_group_with_extension).once
+      @organization = FactoryGirl.create(:organization)
+      group = FactoryGirl.create(:carto_group, organization: Carto::Organization.find(@organization.id))
+      @organization.destroy
+      @organization = nil
+    end
+
   end
 
 


### PR DESCRIPTION
This closes #5638. @ethervoid CR this, please. This is needed for database cleanup, since roles are PostgreSQL installation-wide.