### PR TITLE
Allow org owner adding oneself to a group

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/add_group_users/add_group_users_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/add_group_users/add_group_users_view.js
@@ -3,7 +3,8 @@ var _ = require('underscore');
 var cdb = require('cartodb.js');
 var BaseDialog = require('../../views/base_dialog/view.js');
 var PagedSearchView = require('../../views/paged_search/paged_search_view');
-var randomQuote = require('../../view_helpers/random_quote.js');
+var PagedSearchModel = require('../../paged_search_model');
+var randomQuote = require('../../view_helpers/random_quote');
 var GroupUsersView = require('../../../organization/groups_admin/group_users_view');
 
 /**
@@ -80,6 +81,10 @@ module.exports = BaseDialog.extend({
   _initViews: function() {
     var self = this;
     this._PagedSearchView = new PagedSearchView({
+      pagedSearchModel: new PagedSearchModel({
+        per_page: 50,
+        order: 'username'
+      }),
       collection: this.options.orgUsers,
       createListView: function() {
         return new GroupUsersView({

--- a/lib/assets/javascripts/cartodb/common/dialogs/add_group_users/add_group_users_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/add_group_users/add_group_users_view.js
@@ -19,8 +19,18 @@ module.exports = BaseDialog.extend({
 
     this.elder('initialize');
     this.model = new cdb.core.Model();
+
+    // Include current user in fetch results
+    this.options.orgUsers.excludeCurrentUser(false);
+
     this._initBinds();
     this._initViews();
+  },
+
+  clean: function() {
+    // restore org users
+    this.options.orgUsers.restoreExcludeCurrentUser();
+    this.elder('clean');
   },
 
   /**

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/grantables_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/grantables_view.js
@@ -8,10 +8,17 @@ var ViewFactory = require('../../../view_factory');
 
 /**
  * Content view of the share dialog, lists of users to share item with.
+ * - model: {Object} the share view model
+ * - collection: {cdb.admin.Grantables}
+ * - hasSearch: {Boolean}
  */
 module.exports = cdb.core.View.extend({
 
   initialize: function() {
+    _.each(['model', 'collection', 'pagedSearchModel'], function(name) {
+      if (_.isUndefined(this.options[name])) throw new Error(name + ' is required');
+    }, this);
+
     this._initBinds();
   },
 
@@ -19,7 +26,7 @@ module.exports = cdb.core.View.extend({
     this.clearSubViews();
     this.$el.empty();
 
-    if (!this.collection.get('q')) {
+    if (!this.options.pagedSearchModel.get('q')) {
       this._renderOrganizationPermissionView()
     }
     this._renderGrantablesViews();
@@ -29,6 +36,9 @@ module.exports = cdb.core.View.extend({
   _initBinds: function() {
     this.collection.bind('reset', this.render, this);
     this.add_related_model(this.collection);
+
+    this.options.pagedSearchModel.on('change:q', this.render, this);
+    this.add_related_model(this.options.pagedSearchModel);
   },
 
   _renderGrantablesViews: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/share_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/share_view.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var BaseDialog = require('../../../views/base_dialog/view');
 var randomQuote = require('../../../view_helpers/random_quote');
 var ViewFactory = require('../../../view_factory');
+var PagedSearchModel = require('../../../paged_search_model');
 var PagedSearchView = require('../../../views/paged_search/paged_search_view');
 var ShareModel = require('./share_model');
 var GrantablesView = require('./grantables_view');
@@ -75,12 +76,18 @@ module.exports = BaseDialog.extend({
   _initViews: function() {
     var model = this.model;
     var grantables = this.organization.grantables;
+    var pagedSearchModel = new PagedSearchModel({
+      per_page: 50,
+      order: 'name',
+    });
     this._grantablesView = new PagedSearchView({
+      pagedSearchModel: pagedSearchModel,
       collection: grantables,
       createListView: function() {
         return new GrantablesView({
           model: model,
-          collection: grantables
+          collection: grantables,
+          pagedSearchModel: pagedSearchModel
         })
       }
     });

--- a/lib/assets/javascripts/cartodb/common/paged_search_model.js
+++ b/lib/assets/javascripts/cartodb/common/paged_search_model.js
@@ -1,17 +1,14 @@
-var _ = require('underscore');
-var queryString = require('query-string');
 var cdb = require('cartodb.js');
 
 /**
  * Model representing the query string params for a "paged search" of a collection (matching the server-side APIs).
+ *
  * @example usage
  *   var PagedSearch = require('common/paged_search_model');
- *   PagedSearch.setupCollection(collection)
- *   collection.params.get('page'); // => 1
- *   collection.params.get('per_page'); // => 20
- *   collection.params.set({ page: 2, per_page: 10, q: 'test' });
- *   collection.fetch() // => GET /collection/123?page=2&per_page10&q=test
- *   collection.total_entries // => 123 count of search results with current search
+ *   pagedSearch = new PagedSearch({ … })
+ *   pagedSearch.fetch(collection) // => jqXHR, GET /collection/123?page=1&per_page20
+ *   pagedSearch.set({ page: 2, per_page: 10, q: 'test' });
+ *   pagedSearch.fetch(collection) // => GET /collection/123?page=2&per_page10&q=test
  */
 module.exports = cdb.core.Model.extend({
 
@@ -20,29 +17,12 @@ module.exports = cdb.core.Model.extend({
     page: 1
     // order: 'name'
     // q: '',
-  }
+  },
 
-}, {
-
-  /**
-   * @param {Backbone.Collection} collection
-   * @param {Object} defaultParams hash of default params to set
-   */
-  setupCollection: function(collection, defaultParams) {
-    collection.params = new this(defaultParams);
-
-    collection.parse = _.wrap(collection.parse, function(originalFn, response) {
-      collection.total_entries = response.total_entries; // Total entries for current params (e.g. query)
-      return originalFn.call(collection, response);
-    });
-
-    collection.url = _.wrap(collection.url, function(originalFn) {
-      return originalFn.call(collection) + '?' + queryString.stringify(collection.params.attributes);
-    });
-
-    collection.fetch = _.wrap(collection.fetch, function(originalFetch) {
-      this.trigger('loading');
-      originalFetch.apply(collection, Array.prototype.slice.call(arguments, 1));
+  fetch: function(collection) {
+    collection.trigger('fetching');
+    return collection.fetch({
+      data: this.attributes
     });
   }
 

--- a/lib/assets/javascripts/cartodb/common/views/paged_search/paged_search_view.js
+++ b/lib/assets/javascripts/cartodb/common/views/paged_search/paged_search_view.js
@@ -24,12 +24,12 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function() {
-    _.each(['collection', 'createListView'], function(name) {
+    _.each(['collection', 'pagedSearchModel', 'createListView'], function(name) {
       if (!this.options[name]) throw new Error(name + ' is required');
     }, this);
     this.collection = this.options.collection;
 
-    var params = this.collection.params;
+    var params = this.options.pagedSearchModel;
     this.paginationModel = new PaginationModel({
       current_page: params.get('page'),
       total_count: this.collection.total_entries || 0,
@@ -38,7 +38,7 @@ module.exports = cdb.core.View.extend({
 
     this.elder('initialize');
     this._initBinds();
-    this.collection.fetch();
+    this.options.pagedSearchModel.fetch(this.collection);
   },
 
   render: function() {
@@ -46,19 +46,19 @@ module.exports = cdb.core.View.extend({
 
     this.$el.html(
       this.getTemplate('common/views/paged_search/paged_search')({
-        q: this.collection.params.get('q')
+        q: this.options.pagedSearchModel.get('q')
       })
     );
 
     this._initViews();
-    // Hide clean search button from the beginning
-    this.$('.js-clean-search').hide();
+    this._$cleanSearchBtn().hide();
 
     return this;
   },
 
   _initBinds: function() {
-    this.collection.bind('loading', function() {
+    this.collection.bind('fetching', function() {
+      this._toggleCleanSearchBtn();
       this._activatePane('loading');
     }, this);
 
@@ -68,31 +68,33 @@ module.exports = cdb.core.View.extend({
       if (!e || (e && e.statusText !== "abort")) {
         this._activatePane('error');
       }
+      this._toggleCleanSearchBtn();
     }, this);
 
     this.collection.bind('reset', function(collection) {
       this.paginationModel.set({
         total_count: collection.total_entries,
-        current_page: collection.params.get('page')
+        current_page: this.options.pagedSearchModel.get('page')
       });
       this._activatePane(collection.total_entries > 0 ? 'users' : 'no_results');
-    }, this);
-
-    this.collection.bind('reset error loading', function() {
-      this.$('.js-clean-search').toggle(!!this.collection.params.get('q'))
+      this._toggleCleanSearchBtn();
     }, this);
 
     this.paginationModel.bind('change:current_page', function(mdl, newPage) {
-      this.collection.params.set('page', newPage);
-      this.collection.fetch();
+      this.options.pagedSearchModel.set('page', newPage);
+      this.options.pagedSearchModel.fetch(this.collection);
     }, this);
 
+    this.add_related_model(this.options.pagedSearchModel);
     this.add_related_model(this.collection);
     this.add_related_model(this.paginationModel);
   },
 
+  _toggleCleanSearchBtn: function() {
+    this._$cleanSearchBtn().toggle(!!this.options.pagedSearchModel.get('q'))
+  },
+
   _initViews: function() {
-    // Panes
     this._panes = new cdb.ui.common.TabPane({
       el: this.$('.js-tab-pane')
     });
@@ -129,7 +131,7 @@ module.exports = cdb.core.View.extend({
       })
     );
 
-    if (this.collection.params.get('q')) {
+    if (this.options.pagedSearchModel.get('q')) {
       this._focusSearchInput();
     }
 
@@ -151,13 +153,13 @@ module.exports = cdb.core.View.extend({
   },
 
   _focusSearchInput: function() {
-    var $searchInput = this.$('.js-search-input');
-    $searchInput.focus().val($searchInput.val());
+    // also selects the current search str on the focus
+    this._$searchInput().focus().val(this._$searchInput().val());
   },
 
-  _onSearchClick: function(e) {
-    if (e) this.killEvent(e);
-    this.$('.js-search-input').focus();
+  _onSearchClick: function(ev) {
+    this.killEvent(ev);
+    this._$searchInput().focus();
   },
 
   _onCleanSearchClick: function(ev) {
@@ -173,29 +175,35 @@ module.exports = cdb.core.View.extend({
       this._submitSearch();
     } else if (escapePressed) {
       this.killEvent(ev);
-      if (this.collection.params.get('q')) {
+      if (this.options.pagedSearchModel.get('q')) {
         this._cleanSearch();
       }
     }
   },
 
   _submitSearch: function(e) {
-    var search = this.$('.js-search-input').val().trim();
-    this.collection
-      .setParameters({
-        q: Utils.stripHTML(search),
-        page: 1
-      })
-      .fetch();
+    this._makeNewSearch(Utils.stripHTML(this._$searchInput().val().trim()));
   },
 
   _cleanSearch: function() {
-    this.$('.js-search-input').val('');
-    this.collection
-      .setParameters({
-        q: '',
-        page: 1
-      })
-      .fetch();
+    this._$searchInput().val('');
+    this._makeNewSearch();
+  },
+
+  _makeNewSearch: function(query) {
+    this.options.pagedSearchModel.set({
+      q: query,
+      page: 1
+    });
+    this.options.pagedSearchModel.fetch(this.collection);
+  },
+
+  _$searchInput: function() {
+    return this.$('.js-search-input');
+  },
+
+  _$cleanSearchBtn: function() {
+    return this.$('.js-clean-search');
   }
+
 });

--- a/lib/assets/javascripts/cartodb/models/grantables.js
+++ b/lib/assets/javascripts/cartodb/models/grantables.js
@@ -24,12 +24,10 @@ cdb.admin.Grantables = Backbone.Collection.extend({
     this.organization = opts.organization;
     this.currentUserId = opts.currentUserId;
     this.sync = Backbone.syncAbort; // adds abort behaviour
-    PagedSearchModel.setupCollection(this, {
-      order: 'name'
-    });
   },
 
   parse: function(response) {
+    this.total_entries = response.total_entries;
     return _.reduce(response.grantables, function(memo, m) {
       if (m.id === this.currentUserId) {
         this.total_entries--;

--- a/lib/assets/javascripts/cartodb/models/organization.js
+++ b/lib/assets/javascripts/cartodb/models/organization.js
@@ -58,6 +58,7 @@ cdb.admin.Organization = cdb.core.Model.extend({
 cdb.admin.Organization.Users = Backbone.Collection.extend({
 
   model: cdb.admin.User,
+  _DEFAULT_EXCLUDE_CURRENT_USER: true,
 
   url: function() {
     return '/api/v1/organization/' + this.organization.id + '/users';
@@ -70,6 +71,7 @@ cdb.admin.Organization.Users = Backbone.Collection.extend({
     this.elder('initialize');
     this.organization = opts.organization;
     this.currentUserId = opts.currentUserId;
+    this._excludeCurrentUser = this._DEFAULT_EXCLUDE_CURRENT_USER;
 
     // Let's add abort behaviour
     this.sync = Backbone.syncAbort;
@@ -79,12 +81,24 @@ cdb.admin.Organization.Users = Backbone.Collection.extend({
     return mdl.get('username');
   },
 
+  excludeCurrentUser: function(exclude) {
+    exclude = !!exclude;
+    this._excludeCurrentUser = exclude;
+    if (exclude && !this.currentUserId) {
+      cdb.log.error('set excludeCurrentUser to true, but there is no current user id set to exclude!');
+    }
+  },
+
+  restoreExcludeCurrentUser: function() {
+    this.excludeCurrentUser(this._DEFAULT_EXCLUDE_CURRENT_USER);
+  },
+
   parse: function(r) {
     this.total_entries = r.total_entries;
     this.total_user_entries = r.total_user_entries;
 
     return _.reduce(r.users, function(memo, user) {
-      if (user.id === this.currentUserId) {
+      if (this._excludeCurrentUser && user.id === this.currentUserId) {
         this.total_user_entries--;
         this.total_entries--;
       } else {

--- a/lib/assets/javascripts/cartodb/models/organization.js
+++ b/lib/assets/javascripts/cartodb/models/organization.js
@@ -1,5 +1,3 @@
-var PagedSearchModel = require('../common/paged_search_model');
-
 if (typeof module !== 'undefined') {
   module.exports = {};
 }
@@ -9,12 +7,8 @@ if (typeof module !== 'undefined') {
  * the current user and the users who are inside the organizacion.
  *
  * Attributes:
- *
  * - users: collection with user instances whithin the organization (see cdb.admin.Organization.Users
- *
- *
  */
-
 cdb.admin.Organization = cdb.core.Model.extend({
 
   url: '/api/v1/org/',
@@ -76,11 +70,6 @@ cdb.admin.Organization.Users = Backbone.Collection.extend({
     this.elder('initialize');
     this.organization = opts.organization;
     this.currentUserId = opts.currentUserId;
-    PagedSearchModel.setupCollection(this, {
-      per_page: 50,
-      order: 'username',
-      q: ''
-    });
 
     // Let's add abort behaviour
     this.sync = Backbone.syncAbort;
@@ -91,6 +80,7 @@ cdb.admin.Organization.Users = Backbone.Collection.extend({
   },
 
   parse: function(r) {
+    this.total_entries = r.total_entries;
     this.total_user_entries = r.total_user_entries;
 
     return _.reduce(r.users, function(memo, user) {
@@ -102,27 +92,6 @@ cdb.admin.Organization.Users = Backbone.Collection.extend({
       }
       return memo;
     }, [], this);
-  },
-
-  // @deprecated use .pagedSearch.set(data)
-  setParameters: function(data) {
-    this.params.set(data);
-    return this;
-  },
-
-  // @deprecated use .pagedSearch.get(key)
-  getParameter: function(key) {
-    return this.params.get(key);
-  },
-
-  // @deprecated use .total_entries
-  getTotalUsers: function() {
-    return this.total_user_entries
-  },
-
-  // @deprecated use .pagedSearch.get('q')
-  getSearch: function() {
-    return this.getParameter('q');
   }
 
 });

--- a/lib/assets/javascripts/cartodb/organization/organization_users/organization_users_view.js
+++ b/lib/assets/javascripts/cartodb/organization/organization_users/organization_users_view.js
@@ -2,13 +2,14 @@ var cdb = require('cartodb.js');
 var _ = require('underscore');
 var $ = require('jquery');
 var Utils = require('cdb.Utils');
-var OrganizationUsersListView = require('./organization_users_list_view'); 
+var OrganizationUsersListView = require('./organization_users_list_view');
 var OrganizationUsersFooterView = require('./organization_users_footer_view');
+var PagedSearchModel = require('../../common/paged_search_model');
 var PaginationModel = require('../../common/views/pagination/model');
 var randomQuote = require('../../common/view_helpers/random_quote');
 var ViewFactory = require('../../common/view_factory');
 
-/** 
+/**
  *  Organization users content, list, pagination,
  *  form footer,...
  *
@@ -26,14 +27,18 @@ module.exports = cdb.core.View.extend({
   initialize: function() {
     this.organization = this.options.organization;
     this.organizationUsers = this.options.organizationUsers;
+    this.pagedSearchModel = new PagedSearchModel({
+      per_page: 50,
+      order: 'username'
+    });
     this.paginationModel = new PaginationModel({
-      current_page: this.organizationUsers.getParameter('page'),
-      total_count: this.organizationUsers.getTotalUsers(),
-      per_page: this.organizationUsers.getParameter('per_page')
+      current_page: this.pagedSearchModel.get('page'),
+      total_count: this.organizationUsers.total_entries,
+      per_page: this.pagedSearchModel.get('per_page')
     });
     this.template = cdb.templates.getTemplate('organization/organization_users/organization_users');
     this._initBinds();
-    this.organizationUsers.fetch(); // Fetch fetch fetch!
+    this.pagedSearchModel.fetch(this.organizationUsers);
   },
 
   render: function() {
@@ -48,7 +53,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _initBinds: function() {
-    this.organizationUsers.bind('loading', function() {
+    this.organizationUsers.bind('fetching', function() {
       this._panes && this._panes.active('loading');
     }, this);
 
@@ -61,46 +66,42 @@ module.exports = cdb.core.View.extend({
     }, this);
 
     this.organizationUsers.bind('reset', function(coll) {
-      var total = coll.getTotalUsers();
+      var total = coll.total_entries;
       this.paginationModel.set({
         total_count: total,
-        current_page: coll.getParameter('page')
+        current_page: this.pagedSearchModel.get('page')
       });
       this._panes && this._panes.active(total > 0 ? 'users' : 'no_results');
     }, this);
 
     this.organizationUsers.bind('reset error loading', function(coll) {
-      this[ this.organizationUsers.getSearch() ? '_showCleanSearchButton' : '_hideCleanSearchButton' ]();
+      this[ this.pagedSearchModel.get('q') ? '_showCleanSearchButton' : '_hideCleanSearchButton' ]();
     }, this);
 
     this.paginationModel.bind('change:current_page', function(mdl) {
       var newPage = mdl.get('current_page');
-      this.organizationUsers
-        .setParameters({
-          page: newPage
-        })
-        .fetch();
+      this.pagedSearchModel.set('page', newPage);
+      this.pagedSearchModel.fetch(this.organizationUsers);
     }, this);
 
     // Bind for getting all users from the first request
     this.organizationUsers.bind('reset', this._setTotalUsers, this);
-    
+
     this.add_related_model(this.organizationUsers);
     this.add_related_model(this.paginationModel);
   },
 
   _setTotalUsers: function() {
-    this.organization.set('total_users', this.organizationUsers.getTotalUsers());
+    this.organization.set('total_users', this.organizationUsers.total_entries);
     this.organizationUsers.unbind('reset', this._setTotalUsers, this);
   },
 
   _initViews: function() {
-    // Panes
     this._panes = new cdb.ui.common.TabPane({
       el: this.$('.js-organizationUsersPanes')
     });
     this.addView(this._panes);
-    
+
     this._panes.addTab('users',
       new OrganizationUsersListView({
         organization: this.organization,
@@ -137,12 +138,12 @@ module.exports = cdb.core.View.extend({
     this.$el.append(footer.render().el);
 
     var activePane = 'loading';
-    if (this.organizationUsers.getTotalUsers() === 0) {
+    if (this.organizationUsers.total_entries === 0) {
       activePane = 'no_results';
-    } else if (this.organizationUsers.getTotalUsers() > 0) {
+    } else if (this.organizationUsers.total_entries > 0) {
       activePane = 'users';
     }
-    
+
     this._panes.active(activePane);
   },
 
@@ -177,30 +178,28 @@ module.exports = cdb.core.View.extend({
       this._submitSearch();
     } else if (escapePressed) {
       this.killEvent(ev);
-      if (this.organizationUsers.getSearch()) {
-        this._cleanSearch();  
+      if (this.pagedSearchModel.get('q')) {
+        this._cleanSearch();
       }
     }
   },
 
   _submitSearch: function(e) {
     var search = this.$('.js-search-input').val().trim();
-    this.organizationUsers
-      .setParameters({
-        q: Utils.stripHTML(search),
-        page: 1
-      })
-      .fetch();
+    this.pagedSearchModel.set({
+      q: Utils.stripHTML(search),
+      page: 1
+    })
+    this.pagedSearchModel.fetch(this.organizationUsers);
   },
 
   _cleanSearch: function() {
     this.$('.js-search-input').val('');
-    this.organizationUsers
-      .setParameters({
-        q: '',
-        page: 1
-      })
-      .fetch();
+    this.pagedSearchModel.set({
+      q: '',
+      page: 1
+    })
+    this.pagedSearchModel.fetch(this.organizationUsers);
   }
 
 });

--- a/lib/assets/test/spec/cartodb/common/dialogs/add_group_users/add_group_users_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/add_group_users/add_group_users_view.spec.js
@@ -16,6 +16,7 @@ describe('common/dialogs/add_group_users/add_group_users_view', function() {
       }
     });
     this.orgUsers = this.user.organization.users;
+    spyOn(this.orgUsers, 'excludeCurrentUser').and.callThrough();
     spyOn(this.orgUsers, 'fetch').and.callThrough();
     this.orgUsers.sync = function(a,b,opts) {
       opts.success && opts.success({
@@ -56,6 +57,26 @@ describe('common/dialogs/add_group_users/add_group_users_view', function() {
 
   it('should not have leaks', function() {
     expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should include current user', function() {
+    expect(this.orgUsers.excludeCurrentUser).toHaveBeenCalledWith(false);
+  });
+
+  describe('when view is cleaned', function() {
+    beforeEach(function() {
+      spyOn(this.orgUsers, 'restoreExcludeCurrentUser').and.callThrough();
+      spyOn(this.view, 'elder');
+      this.view.clean();
+    });
+
+    it('should restore orgUsers', function() {
+      expect(this.orgUsers.restoreExcludeCurrentUser).toHaveBeenCalled();
+    });
+
+    it('should call parent clean', function() {
+      expect(this.view.elder).toHaveBeenCalledWith('clean');
+    });
   });
 
   it('should fetch org users', function() {

--- a/lib/assets/test/spec/cartodb/common/dialogs/change_privacy/share/grantables_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/change_privacy/share/grantables_view.spec.js
@@ -1,6 +1,7 @@
 var cdb = require('cartodb.js');
-var GrantablesView = require('../../../../../../../javascripts/cartodb/common/dialogs/change_privacy/share/grantables_view.js');
+var GrantablesView = require('../../../../../../../javascripts/cartodb/common/dialogs/change_privacy/share/grantables_view');
 var ShareModel = require('../../../../../../../javascripts/cartodb/common/dialogs/change_privacy/share/share_model');
+var PagedSearchModel = require('../../../../../../../javascripts/cartodb/common/paged_search_model');
 
 /**
  * Most high-fidelity details are covered in underlying collection/model, so no need to re-test that here.
@@ -66,10 +67,13 @@ describe('common/dialogs/change_privacy/share/grantables_view', function() {
       organization: this.user.organization
     });
 
+    this.pagedSearchModel = new PagedSearchModel();
+
     this.view = new GrantablesView({
       model: this.viewModel,
       collection: this.grantables,
-      organization: this.user.organization
+      hasSearch: false,
+      pagedSearchModel: this.pagedSearchModel
     });
 
     spyOn(this.view, 'killEvent');
@@ -80,10 +84,19 @@ describe('common/dialogs/change_privacy/share/grantables_view', function() {
     expect(this.view).toHaveNoLeaks();
   });
 
+  describe('when has search applied', function() {
+    beforeEach(function() {
+      this.pagedSearchModel.set('q', 'foo');
+    });
+
+    it('should not render the organization permission view', function() {
+      expect(this.innerHTML()).not.toContain('Organization');
+    });
+  });
+
   describe('given there is at least one dependant visualization', function() {
     beforeEach(function() {
       this.dependantUser = { id: 'abc-123' };
-      this.grantables.params.set('q', '');
       spyOn(this.vis.tableMetadata(), 'dependentVisualizations').and.returnValue([{permission: {owner: this.dependantUser}}]);
     });
 

--- a/lib/assets/test/spec/cartodb/common/paged_search_model.spec.js
+++ b/lib/assets/test/spec/cartodb/common/paged_search_model.spec.js
@@ -2,77 +2,44 @@ var Backbone = require('backbone');
 var PagedSearchModel = require('../../../../javascripts/cartodb/common/paged_search_model');
 
 describe('common/paged_search_model', function() {
-  describe('.setupCollection', function() {
+  beforeEach(function() {
+    this.model = new PagedSearchModel();
+  });
+
+  it('should have some default params', function() {
+    expect(this.model.get('per_page')).toMatch(/\d+/);
+    expect(this.model.get('page')).toEqual(1);
+  });
+
+  describe('.fetch', function() {
     beforeEach(function() {
       this.collection = new Backbone.Collection();
-      this.collection.url = function() {
-        return '/some/path/123';
-      };
-      this.collection.parse = function(response) {
-        return response.items;
-      };
-      PagedSearchModel.setupCollection(this.collection);
+
+      this.fetchingSpy = jasmine.createSpy('fetching');
+      this.collection.on('fetching', this.fetchingSpy);
+
+      this.jqXHR = $.Deferred();
+      spyOn(this.collection, 'fetch').and.returnValue(this.jqXHR);
+
+      this.results = this.model.fetch(this.collection);
     });
 
-    it('should attached a pagedSearch model to the collection', function() {
-      expect(this.collection.params).toBeDefined();
+    it('should call fetch on collection', function() {
+      expect(this.collection.fetch).toHaveBeenCalledWith(jasmine.any(Object));
     });
 
-    it('should have reasonable defaults', function() {
-      expect(this.collection.params.get('page')).toEqual(1);
-      expect(this.collection.params.get('per_page')).toEqual(20);
+    it('should trigger a loading event on collection', function() {
+      expect(this.fetchingSpy).toHaveBeenCalled();
     });
 
-    it('should set custom defaults if provided', function() {
-      PagedSearchModel.setupCollection(this.collection, {
-        page: 3,
-        per_page: 42
-      });
-      expect(this.collection.params.get('page')).toEqual(3);
-      expect(this.collection.params.get('per_page')).toEqual(42);
+    it('should have data params set', function() {
+      expect(this.collection.fetch.calls.argsFor(0)[0].data).toEqual(jasmine.any(Object));
+      expect(this.collection.fetch.calls.argsFor(0)[0].data.per_page).toMatch(/\d+/);
+      expect(this.collection.fetch.calls.argsFor(0)[0].data.page).toMatch(/\d+/);
     });
 
-    describe('should wrap collection.parse', function() {
-      beforeEach(function() {
-        this.items = [{}, {}];
-        this.results = this.collection.parse({
-          items: this.items,
-          total_entries: 42,
-        });
-      });
-
-      it('should extract total entries', function() {
-        expect(this.collection.total_entries).toEqual(42);
-      });
-
-      it('should still execute original parse', function() {
-        expect(this.results).toBe(this.items);
-      });
-    });
-
-    describe('should wrap collection.url', function() {
-      beforeEach(function() {
-        this.url = this.collection.url();
-      });
-
-      it('should append params to the query string', function() {
-        expect(this.url).toContain('?');
-        expect(this.url).toMatch(/page=\d/);
-        expect(this.url).toMatch(/per_page=\d+/);
-      });
-    });
-
-    describe('should wrap collection.fetch', function() {
-      beforeEach(function() {
-        this.args = {};
-        this.loadingSpy = jasmine.createSpy('loading');
-        this.collection.on('loading', this.loadingSpy);
-        this.jqXHR = this.collection.fetch(this.args);
-      });
-
-      it('should trigger a loading event', function() {
-        expect(this.loadingSpy).toHaveBeenCalled();
-      });
+    it('should return a deferred object', function() {
+      expect(this.results).toBe(this.jqXHR);
     });
   });
 });

--- a/lib/assets/test/spec/cartodb/common/views/paged_search/paged_search_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/paged_search/paged_search_view.spec.js
@@ -2,6 +2,7 @@ var $ = require('jquery');
 var _ = require('underscore');
 var cdb = require('cartodb.js');
 var PagedSearchView = require('../../../../../../javascripts/cartodb/common/views/paged_search/paged_search_view');
+var PagedSearchModel = require('../../../../../../javascripts/cartodb/common/paged_search_model.js');
 
 function keyPressEvent(key, metaKey) {
   var event = $.Event('keydown');
@@ -38,21 +39,6 @@ describe('common/views/paged_search/paged_search_view', function() {
     });
 
     this.organizationUsers = this.user.organization.users;
-    this.organizationUsers.sync = function(a,b,opts) {
-      opts.success && opts.success({
-        users: [
-          {
-            id: 'abc-123',
-            username: 'paco'
-          },
-          {
-            id: 'abc-456',
-            username: 'pepe'
-          }
-        ],
-        total_entries: 2
-      })
-    };
 
     var self = this;
     this.fakeUsersView = new cdb.core.View();
@@ -68,13 +54,22 @@ describe('common/views/paged_search/paged_search_view', function() {
       return self.fakeUsersView;
     });
 
+    this.pagedSearchModel = new PagedSearchModel();
+    spyOn(this.pagedSearchModel, 'fetch');
+
     this.view = new PagedSearchView({
+      pagedSearchModel: this.pagedSearchModel,
       collection: this.organizationUsers,
       createListView: this.createListViewSpy
     });
 
     spyOn(this.view, 'killEvent');
     this.view.render();
+
+    // Custom innerHTML helper, since all panes are rendered but hidden
+    this.innerHTML = function() {
+      return this.view._panes.getActivePane().$el.html();
+    }
   });
 
   it('should have no leaks', function() {
@@ -86,86 +81,127 @@ describe('common/views/paged_search/paged_search_view', function() {
     expect(_.size(this.view._panes._subviews)).toBe(4);
   });
 
-  it('should create list view', function() {
-    expect(this.createListViewSpy).toHaveBeenCalled();
+  it('should fetch users', function() {
+    expect(this.pagedSearchModel.fetch).toHaveBeenCalled();
   });
 
-  describe('searching users', function() {
-    it("should show results when search is done", function() {
+  describe('when users are fetched', function() {
+    beforeEach(function() {
+      this.organizationUsers.sync = function(a,b,opts) {
+        opts.success && opts.success({
+          users: [{
+            id: 'p1',
+            username: 'pierre'
+          }],
+          total_entries: 1
+        })
+      };
       this.organizationUsers.fetch();
-      expect(this.innerHTML()).toContain('pepe');
-      expect(this.innerHTML()).toContain('paco');
     });
 
-    it("should show clean search button when search is done", function() {
-      expect(this.view.$('.js-clean-search').css('display')).toBe('none');
-      this.organizationUsers
-        .setParameters({ q: 'hello' })
-        .reset([]);
-      expect(this.view.$('.js-clean-search').css('display')).not.toBe('none');
+    it('should create list view', function() {
+      expect(this.createListViewSpy).toHaveBeenCalled();
+      expect(this.innerHTML()).toContain('pierre');
+    });
+  });
+
+  describe('when a search is initialized', function() {
+    beforeEach(function() {
+      this.pagedSearchModel.fetch.calls.reset();
+      this.view._$searchInput().val('str');
+      this.view.$('.js-search-input').trigger(keyPressEvent($.ui.keyCode.ENTER));
     });
 
-    it("should change between panes when organization users collection is fetched", function() {
-      var states = [];
-      this.view._panes.bind('tabEnabled', function(name){
-        states.push(name);
+    it('should call fetch on paged search model', function() {
+      expect(this.pagedSearchModel.fetch).toHaveBeenCalledWith(this.organizationUsers);
+    });
+
+    it('should show searching', function() {
+      expect(this.innerHTML()).toContain('Searching');
+    });
+
+    describe('when search returns an empty result', function() {
+      beforeEach(function() {
+        this.organizationUsers.sync = function(a,b,opts) {
+          opts.success && opts.success({
+            users: [],
+            total_entries: 0
+          })
+        };
+        this.organizationUsers.fetch();
       });
-      this.organizationUsers.fetch();
-      expect(_.contains(states, 'loading')).toBeTruthy();
-      expect(_.contains(states, 'users')).toBeTruthy();
+
+      it('should show no-results block', function() {
+        expect(this.innerHTML()).toContain('No results');
+      });
     });
 
-    it("should change pagination model when organization users collection is fetched", function() {
-      this.view.paginationModel.set({
-        total_entries: 2,
-        current_page: 1
-      })
-      this.organizationUsers.fetch();
-      expect(this.view.paginationModel.get('total_entries')).toBe(2);
-    });
+    describe('when search is successfully done', function() {
+      beforeEach(function() {
+        this.createListViewSpy.calls.reset();
+        this.organizationUsers.sync = function(a,b,opts) {
+          opts.success && opts.success({
+            users: [{
+              id: 'abc-123',
+              username: 'paco'
+            }, {
+              id: 'abc-456',
+              username: 'pepe'
+            }],
+            total_entries: 2
+          })
+        };
+        this.organizationUsers.fetch();
+      });
 
-    it("should fetch a new page of organization users when pagination model changes its current_page", function() {
-      expect(this.organizationUsers.getParameter('page')).toBe(1);
+      it('should show results', function() {
+        expect(this.innerHTML()).toContain('pepe');
+        expect(this.innerHTML()).toContain('paco');
+      });
+
+      it('should show clean search button', function() {
+        expect(this.view.$('.js-clean-search').css('display')).not.toBe('none');
+      });
+
+      it('should update pagination model', function() {
+        expect(this.view.paginationModel.get('total_count')).toEqual(2);
+      });
+
+      describe('when click clean search', function() {
+        beforeEach(function() {
+          this.view.$('.js-clean-search').click();
+        });
+
+        it('should reset search', function() {
+          expect(this.view.$('.js-search-input').val()).toEqual('');
+          expect(this.view.$('.js-clean-search').css('display')).not.toBe('none');
+        });
+      });
+
+      describe('when click ESC on search input', function() {
+        beforeEach(function() {
+          this.view.$('.js-search-input').trigger(keyPressEvent($.ui.keyCode.ESCAPE));
+        });
+
+        it('should clear the search when user hits ESCAPE', function() {
+          expect(this.view.$('.js-search-input').val()).toEqual('');
+          expect(this.view.$('.js-clean-search').css('display')).not.toBe('none');
+        });
+      });
+    });
+  });
+
+  describe('when pagination is changed', function() {
+    beforeEach(function() {
       var states = [];
-      spyOn(this.organizationUsers,'fetch');
       this.view.paginationModel.set({
         current_page: 2
       });
-      expect(this.organizationUsers.fetch).toHaveBeenCalled();
-      expect(this.organizationUsers.getParameter('page')).toBe(2);
     });
 
-    it("should hide 'default for organization' view when a search is run", function() {
-      this.organizationUsers.setParameters({
-        q: 'hello'
-      }).fetch();
-      expect(this.view.$el.html()).not.toContain('Default settings for your Organization');
+    it('should fetch a new page of organization users', function() {
+      expect(this.pagedSearchModel.get('page')).toBe(2);
+      expect(this.pagedSearchModel.fetch).toHaveBeenCalled();
     });
-
-    it("should show no-results block when search is empty", function() {
-      this.organizationUsers.total_entries = 0;
-      this.organizationUsers.reset([]);
-      var activePane = this.view._panes.getActivePane();
-      expect(activePane.$el.html()).toContain('No results');
-    });
-
-    it('should update the search value when a search is submitted', function() {
-      this.view.$('.js-search-input').val('pepe');
-      this.view.$('.js-search-input').trigger(keyPressEvent($.ui.keyCode.ENTER));
-      expect(this.organizationUsers.getSearch()).toEqual('pepe');
-    });
-
-    it('should clear the search when users clicks X', function() {
-      this.organizationUsers.setParameters({ q: 'pepe' });
-      this.view.$('.js-clean-search').click();
-      expect(this.organizationUsers.getSearch()).toEqual('');
-    });
-
-    it('should clear the search when user hits ESCAPE', function() {
-      this.organizationUsers.setParameters({ q: 'pepe' });
-      this.view.$('.js-search-input').trigger(keyPressEvent($.ui.keyCode.ESCAPE));
-      expect(this.organizationUsers.getSearch()).toEqual('');
-    });
-
   });
 });

--- a/lib/assets/test/spec/cartodb/models/organization.spec.js
+++ b/lib/assets/test/spec/cartodb/models/organization.spec.js
@@ -63,11 +63,6 @@ describe('cdb.admin.Organization.Users', function() {
     this.orgUsers.sync = function(a, b, opts) {}
   });
 
-  it("should have several parameters by default", function() {
-    expect(this.orgUsers.params.get('per_page')).toEqual(50);
-    expect(this.orgUsers.params.get('order')).toEqual('username');
-  });
-
   it("should include sync abort", function() {
     expect(this.orgUsers.sync).not.toBeUndefined();
   });
@@ -103,28 +98,6 @@ describe('cdb.admin.Organization.Users', function() {
     expect(this.orgUsers.length).toBe(1);
     expect(this.orgUsers.total_user_entries).toBe(1);
     expect(this.orgUsers.total_entries).toBe(1);
-  });
-
-  it("should trigger loading event when collection is fetched", function() {
-    var count = 0;
-    this.orgUsers.bind('loading', function() {
-      ++count
-    });
-    this.orgUsers.fetch();
-    expect(count).toBe(1);
-  });
-
-  it("should have several helper functions", function() {
-    this.orgUsers.setParameters({ page: 1000 });
-    expect(this.orgUsers.getParameter('page')).toBe(1000);
-    this.orgUsers.setParameters({ q: 'hello' });
-    expect(this.orgUsers.getSearch()).toBe('hello');
-    expect(this.orgUsers.getParameter('q')).toBe('hello');
-  });
-
-  it("should return total of users", function() {
-    this.orgUsers.total_user_entries = 5;
-    expect(this.orgUsers.getTotalUsers()).toBe(5);
   });
 
   function generateUser(id) {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "load-grunt-tasks": "3.2.0",
     "moment": "2.10.6",
     "open": "0.0.5",
-    "query-string": "2.4.x",
     "queue-async": "^1.0.7",
     "shelljs": "0.5.3",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
Fixes #5655 and #5658 

Refactored the collections to have a simpler setup (composition over adding a mixin' onto the collections). The query string handling is a solved problem by Backbone actually, while one adheres to `.fetch({ data: {…} })` convention.

@xavijam can you review please?