### PR TITLE
Fix groups-warning for revoking access

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/grantables_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/grantables_view.js
@@ -42,13 +42,17 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderGrantablesViews: function() {
+    var dependentVisualizations = this.model.get('vis').tableMetadata().dependentVisualizations();
     this.collection.each(function(grantable) {
       this._appendView(
         new PermissionView({
           model: grantable.entity,
           permission: this.model.get('permission'),
           isWriteAccessTogglerAvailable: this.model.isWriteAccessTogglerAvailable(),
-          detailsView: this._createDetailsView(grantable)
+          detailsView: this._createDetailsView(
+            this._detailsViewOpts.bind(this, dependentVisualizations, grantable.entity),
+            grantable
+          )
         })
       )
     }, this);
@@ -77,37 +81,45 @@ module.exports = cdb.core.View.extend({
     this.addView(view);
   },
 
-  _createDetailsView: function(grantable) {
+  _createDetailsView: function(detailsViewOpts, grantable) {
     var type = grantable.get('type');
-    var opts = this._detailsViewOpts.bind(this, grantable.entity, this.model.get('vis').tableMetadata().dependentVisualizations());
     switch(type) {
       case 'user':
         return new UserDetailsView(
-          opts([grantable.id])
+          detailsViewOpts([grantable.id])
         );
         break;
       case 'group':
         return new GroupDetailsView(
-          opts(grantable.entity.users.models)
+          detailsViewOpts(
+            grantable.entity.users.chain()
+              .reject(this._isCurrentUser)
+              .pluck('id')
+              .value()
+          )
         );
         break;
       default:
         cdb.log.error('No details view for grantable model of type ' + type);
-        return new cdb.core.View(opts());
+        return new cdb.core.View(detailsViewOpts());
     }
   },
 
-  _detailsViewOpts: function(grantableEntity, dependentVisualizations, dependentUsers) {
+  _detailsViewOpts: function(dependentVisualizations, grantableEntity, userIds) {
     return {
       className: 'ChangePrivacy-shareListItemInfo',
       model: grantableEntity,
       permission: this.model.get('permission'),
       isUsingVis: _.any(dependentVisualizations, function(vis) {
-        return _.any(dependentUsers, function(u) {
-          return vis.permission.owner.id === u.id;
-        });
+        return _.any(userIds, function(userId) {
+          return userId === vis.permission.owner.id;
+        })
       })
     };
-  }
+  },
+
+  _isCurrentUser: function(user) {
+    return user.id === cdb.config.get('user').id;
+  },
 
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/group_details_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/group_details_view.js
@@ -23,12 +23,13 @@ module.exports = cdb.core.View.extend({
   },
 
   _desc: function() {
-    var xMembers = pluralizeString.prefixWithCount('member', 'members', this.model.users.length);
+    var usersCount = this.model.users.length;
+    var xMembers = pluralizeString.prefixWithCount('member', 'members', usersCount);
 
     if (this._willRevokeAccess()) {
-      return xMembers + ". Members' maps will be affected";
+      return xMembers + '. ' + pluralizeString("Member's", "Members'", usersCount) + ' maps will be affected';
     } else if (this.options.isUsingVis) {
-      return xMembers + '. Members are using this dataset';
+      return xMembers + '. ' + pluralizeString('Member is', 'Members are', usersCount) + ' using this dataset';
     } else {
       return xMembers;
     }

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/group_details_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/group_details_view.js
@@ -26,9 +26,9 @@ module.exports = cdb.core.View.extend({
     var xMembers = pluralizeString.prefixWithCount('member', 'members', this.model.users.length);
 
     if (this._willRevokeAccess()) {
-      return xMembers + '. At least one member map will be affected';
+      return xMembers + ". Members' maps will be affected";
     } else if (this.options.isUsingVis) {
-      return xMembers + '. At least one member is using this dataset';
+      return xMembers + '. Members are using this dataset';
     } else {
       return xMembers;
     }

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/group_details_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/group_details_view.js
@@ -23,13 +23,12 @@ module.exports = cdb.core.View.extend({
   },
 
   _desc: function() {
-    var usersCount = this.model.users.length;
-    var xMembers = pluralizeString('1 member', usersCount + ' members', usersCount);
+    var xMembers = pluralizeString.prefixWithCount('member', 'members', this.model.users.length);
 
     if (this._willRevokeAccess()) {
-      return xMembers + pluralizeString("'s", "'", usersCount) + ' maps will be affected';
+      return xMembers + '. At least one member map will be affected';
     } else if (this.options.isUsingVis) {
-      return xMembers + ' ' + pluralizeString('is', 'are', usersCount) + ' using this dataset';
+      return xMembers + '. At least one member is using this dataset';
     } else {
       return xMembers;
     }

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/user_details_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/user_details_view.js
@@ -25,20 +25,15 @@ module.exports = cdb.core.View.extend({
   },
 
   _desc: function() {
-    var consequencesStr;
+    var email = this.model.get('email')
+
     if (this._willRevokeAccess()) {
-      consequencesStr = "'s maps will be affected";
+      return email + ". User's maps will be affected";
     } else if (this.options.isUsingVis) {
-      consequencesStr = ' is using this dataset';
+      return email + ". User is this dataset";
+    } else {
+      return email;
     }
-
-    var desc = this.model.get('email')
-    if (consequencesStr) {
-      var nameOrThisUser = this.model.get('name') || 'this user';
-      desc += '. ' + nameOrThisUser + consequencesStr;
-    }
-
-    return desc;
   },
 
   _willRevokeAccess: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/user_details_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/user_details_view.js
@@ -35,7 +35,7 @@ module.exports = cdb.core.View.extend({
     var desc = this.model.get('email')
     if (consequencesStr) {
       var nameOrThisUser = this.model.get('name') || 'this user';
-      desc += '.' + nameOrThisUser + consequencesStr;
+      desc += '. ' + nameOrThisUser + consequencesStr;
     }
 
     return desc;

--- a/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/user_details_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/change_privacy/share/user_details_view.js
@@ -30,7 +30,7 @@ module.exports = cdb.core.View.extend({
     if (this._willRevokeAccess()) {
       return email + ". User's maps will be affected";
     } else if (this.options.isUsingVis) {
-      return email + ". User is this dataset";
+      return email + ". User is using this dataset";
     } else {
       return email;
     }

--- a/lib/assets/javascripts/cartodb/common/view_helpers/pluralize_string.js
+++ b/lib/assets/javascripts/cartodb/common/view_helpers/pluralize_string.js
@@ -8,7 +8,7 @@ var pluralizeStr = function(singular, plural, count) {
   return count === 1 ? singular : plural;
 };
 
-pluralizeStr.includeCount = function(singular, plural, count) {
+pluralizeStr.prefixWithCount = function(singular, plural, count) {
   return pluralizeStr(
     '1 ' + singular, // e.g. 1 item
     count + ' ' + plural, // e.g. 123 items

--- a/lib/assets/javascripts/cartodb/organization/groups_admin/group_user_view.js
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/group_user_view.js
@@ -27,8 +27,8 @@ module.exports = cdb.core.View.extend({
         avatarUrl: this.model.get('avatar_url'),
         username: this.model.get('username'),
         email: this.model.get('email'),
-        xMaps: pluralizeStr.includeCount('map', 'maps', this.model.get('maps_count')),
-        xDatasets: pluralizeStr.includeCount('dataset', 'datasets', this.model.get('table_count'))
+        xMaps: pluralizeStr.prefixWithCount('map', 'maps', this.model.get('maps_count')),
+        xDatasets: pluralizeStr.prefixWithCount('dataset', 'datasets', this.model.get('table_count'))
       })
     );
     return this;

--- a/lib/assets/test/spec/cartodb/common/dialogs/change_privacy/share/user_details_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/change_privacy/share/user_details_view.spec.js
@@ -63,7 +63,7 @@ describe('common/dialogs/change_privacy/share/user_details_view', function() {
       });
 
       it('should render the info text about usage', function() {
-        expect(this.innerHTML()).toContain('Pepe is using this dataset');
+        expect(this.innerHTML()).toContain('using');
       });
     });
 
@@ -75,7 +75,7 @@ describe('common/dialogs/change_privacy/share/user_details_view', function() {
       });
 
       it('should warn about destructive change', function() {
-        expect(this.innerHTML()).toContain("Pepe's maps will be affected");
+        expect(this.innerHTML()).toContain('will be affected');
       });
     });
   });


### PR DESCRIPTION
The check for dependent visualizations was including the current user/owner of the dataset, which ofc doesn't make sense. With fix it now shows the default view properly (not warnings):
![screen shot 2015-09-22 at 19 49 09](https://cloud.githubusercontent.com/assets/978461/10026600/04e883f2-6163-11e5-8ade-8153936e66f6.png)

Only show warnings if there exists any user that will be affected by revoking the access:
![screen shot 2015-09-22 at 19 42 15](https://cloud.githubusercontent.com/assets/978461/10026500/68a07ab8-6162-11e5-8fdd-7678cc321027.png)

@xavijam can you review the code?
cc @juanignaciosl (since you found it while testing on staging)