### PR TITLE
Fix dependency bundles due to new groups models

### DIFF
--- a/lib/assets/javascripts/cartodb/models/assets.js
+++ b/lib/assets/javascripts/cartodb/models/assets.js
@@ -1,13 +1,11 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
+
 
   /*
    *  User asset Model
    */
 
   cdb.admin.Asset = cdb.core.Model.extend({
-
+    
     defaults: {
       state:  'idle',
       name:   ''
@@ -63,7 +61,7 @@ if (typeof module !== 'undefined') {
       c['public_url'] = this.get("host") + '/' + this.get("folder") + '/' + c['icon'] + (this.get("size") ? '-' + this.get("size") : '') + '.' + this.get("ext");
       return c;
     },
-
+    
     get: function(attr) {
       var r = this.attributes[attr];
 

--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -1,6 +1,4 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
+
 
 carto_quotables = [
   'text-face-name'
@@ -23,7 +21,7 @@ DEFAULT_QFUNCTION = 'Quantile';
  *  Manage some carto properties depending on
  *  type (line, polygon or point), for choropleth.
  */
-window.manage_choropleth_props = function manage_choropleth_props(type, props) {
+function manage_choropleth_props(type, props) {
   var carto_props = {
     'marker-width': props['marker-width'],
     'marker-fill-opacity': props['marker-opacity'],
@@ -56,7 +54,7 @@ window.manage_choropleth_props = function manage_choropleth_props(type, props) {
   return carto_props;
 }
 
-window.getProp = function getProp(obj, prop) {
+function getProp(obj, prop) {
   var p = [];
   for(var k in obj) {
     var v = obj[k];
@@ -75,7 +73,7 @@ var _cartocss_spec_props = getProp(carto.default_reference.version.latest, 'css'
  * some carto properties depends on others, this function
  * remove or add properties needed to carto works
  */
-window.manage_carto_properies = function manage_carto_properies(props) {
+function manage_carto_properies(props) {
 
   if(/none/i.test(props['text-name']) || !props['text-name']) {
     // remove all text-* properties
@@ -110,11 +108,11 @@ window.manage_carto_properies = function manage_carto_properies(props) {
 
 }
 
-window.isTextProperty = function isTextProperty(p) {
+function isTextProperty(p) {
   return /^text-/.test(p);
 }
 
-window.generate_carto_properties = function generate_carto_properties(props) {
+function generate_carto_properties(props) {
   return _(props).map(function(v, k) {
     if(_.include(carto_quotables, k)) {
       v = "'" + v + "'";
@@ -126,7 +124,7 @@ window.generate_carto_properties = function generate_carto_properties(props) {
   });
 }
 
-window.filter_props = function filter_props(props, fn) {
+function filter_props(props, fn) {
   var p = {};
   for(var k in props) {
     var v = props[k];
@@ -137,7 +135,7 @@ window.filter_props = function filter_props(props, fn) {
   return p;
 }
 
-window.translate_carto_properties = function translate_carto_properties(props) {
+function translate_carto_properties(props) {
   if ('marker-opacity' in props) {
     props['marker-fill-opacity'] = props['marker-opacity'];
     delete props['marker-opacity'];
@@ -145,7 +143,7 @@ window.translate_carto_properties = function translate_carto_properties(props) {
   return props;
 }
 
-window.simple_polygon_generator = function simple_polygon_generator(table, props, changed, callback) {
+function simple_polygon_generator(table, props, changed, callback) {
 
   // remove unnecesary properties, for example
   // if the text-name is not present remove all the
@@ -172,7 +170,7 @@ window.simple_polygon_generator = function simple_polygon_generator(table, props
   callback(generalLayer + textLayer);
 }
 
-window.intensity_generator = function intensity_generator(table, props, changed, callback) {
+function intensity_generator(table, props, changed, callback) {
 
   // remove unnecesary properties, for example
   // if the text-name is not present remove all the
@@ -206,7 +204,7 @@ window.intensity_generator = function intensity_generator(table, props, changed,
 
 }
 
-window.cluster_sql = function cluster_sql(table, zoom, props, nquartiles) {
+function cluster_sql(table, zoom, props, nquartiles) {
 
   var grids = ["A", "B", "C", "D", "E"];
   var bucket = "bucket" + grids[0];
@@ -288,7 +286,7 @@ window.cluster_sql = function cluster_sql(table, zoom, props, nquartiles) {
   });
 }
 
-window.cluster_generator = function cluster_generator(table, props, changed, callback) {
+function cluster_generator(table, props, changed, callback) {
 
   var methodMap = {
     '2 Buckets': 2,
@@ -362,7 +360,7 @@ window.cluster_generator = function cluster_generator(table, props, changed, cal
 
 }
 
-window.bubble_generator = function bubble_generator(table, props, changed, callback) {
+function bubble_generator(table, props, changed, callback) {
   var carto_props = {
    'marker-fill': props['marker-fill'],
    'marker-line-color': props['marker-line-color'],
@@ -420,7 +418,7 @@ window.bubble_generator = function bubble_generator(table, props, changed, callb
  * at the end. If you append only .0 it is casted to int and it
  * does not work
  */
-window.normalizeQuartiles = function normalizeQuartiles(quartiles) {
+function normalizeQuartiles(quartiles) {
   var maxNumber = 2147483648; // unsigned (1<<31);
   var normalized = [];
   for(var i = 0;  i < quartiles.length; ++i) {
@@ -433,7 +431,7 @@ window.normalizeQuartiles = function normalizeQuartiles(quartiles) {
   return normalized;
 }
 
-window.choropleth_generator = function choropleth_generator(table, props, changed, callback) {
+function choropleth_generator(table, props, changed, callback) {
   var type = table.geomColumnTypes() && table.geomColumnTypes()[0] || "polygon";
 
   var carto_props = manage_choropleth_props(type,props);
@@ -501,7 +499,7 @@ window.choropleth_generator = function choropleth_generator(table, props, change
 }
 
 
-window.density_sql = function density_sql(table, zoom, props) {
+function density_sql(table, zoom, props) {
     var prop = 'cartodb_id';
     var sql;
 
@@ -525,7 +523,7 @@ window.density_sql = function density_sql(table, zoom, props) {
 /*
  *
  */
-window.density_generator = function density_generator(table, props, changed, callback) {
+function density_generator(table, props, changed, callback) {
   var carto_props = {
    'line-color': props['line-color'],
    'line-opacity': props['line-opacity'],
@@ -842,7 +840,7 @@ cdb.admin.CartoParser.prototype = {
     }
     else if (type === "string"){
       return e.value !== "undefined" && typeof e.value === "string";
-    }
+    } 
     else if (type.constructor === Array){
       return type.indexOf(e.value) > -1 || e.value === "linear";
     }
@@ -1045,3 +1043,4 @@ cdb.admin.CartoParser.prototype = {
 
 
 };
+

--- a/lib/assets/javascripts/cartodb/models/carto/category.js
+++ b/lib/assets/javascripts/cartodb/models/carto/category.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.carto = cdb.admin.carto || {};
 
 cdb.admin.carto.category = {
@@ -86,7 +82,7 @@ cdb.admin.carto.category = {
     });
   },
 
-  // Generate categories css
+  // Generate categories css 
   generate_categories: function(props, table, metadata, property_name) {
     property_name = property_name || props['property'];
 

--- a/lib/assets/javascripts/cartodb/models/carto/torque.js
+++ b/lib/assets/javascripts/cartodb/models/carto/torque.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.carto = cdb.admin.carto || {};
 
 cdb.admin.carto.torque = {

--- a/lib/assets/javascripts/cartodb/models/carto/torque_cat.js
+++ b/lib/assets/javascripts/cartodb/models/carto/torque_cat.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.carto = cdb.admin.carto || {};
 
 cdb.admin.carto.torque_cat = {

--- a/lib/assets/javascripts/cartodb/models/cartodb_layer.js
+++ b/lib/assets/javascripts/cartodb/models/cartodb_layer.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.CartoDBLayer = cdb.geo.CartoDBLayer.extend({
   MAX_HISTORY: 5,
   MAX_HISTORY_QUERY: 5,

--- a/lib/assets/javascripts/cartodb/models/color_ramps.js
+++ b/lib/assets/javascripts/cartodb/models/color_ramps.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * color ramps for choroplet visualization
  */

--- a/lib/assets/javascripts/cartodb/models/common_tables.js
+++ b/lib/assets/javascripts/cartodb/models/common_tables.js
@@ -1,6 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
 
   /**
    *  Collection for common data

--- a/lib/assets/javascripts/cartodb/models/filter.js
+++ b/lib/assets/javascripts/cartodb/models/filter.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.models = cdb.admin.models || {};
 
 //===================================================

--- a/lib/assets/javascripts/cartodb/models/geocodings.js
+++ b/lib/assets/javascripts/cartodb/models/geocodings.js
@@ -1,6 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
 
   /**
    *  Geocoding endpoint by id

--- a/lib/assets/javascripts/cartodb/models/grantable.js
+++ b/lib/assets/javascripts/cartodb/models/grantable.js
@@ -1,9 +1,3 @@
-var cdb = require('cartodb.js');
-
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * Model representing an entity (user, group, etc.) that may share a Visualization.
  * Actual model is wrapped with additional metadata for the grantable context.

--- a/lib/assets/javascripts/cartodb/models/grantables.js
+++ b/lib/assets/javascripts/cartodb/models/grantables.js
@@ -1,12 +1,3 @@
-var _ = require('underscore');
-var cdb = require('cartodb.js');
-var Backbone = require('backbone');
-var PagedSearchModel = require('../common/paged_search_model');
-
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * A collection of Grantable objects.
  */

--- a/lib/assets/javascripts/cartodb/models/group.js
+++ b/lib/assets/javascripts/cartodb/models/group.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * Model representing a group.
  * Expected to be used in the context of a groups collection (e.g. cdb.admin.OrganizationGroups),

--- a/lib/assets/javascripts/cartodb/models/group_users.js
+++ b/lib/assets/javascripts/cartodb/models/group_users.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * A collection representing a set of users in a group.
  */

--- a/lib/assets/javascripts/cartodb/models/import.js
+++ b/lib/assets/javascripts/cartodb/models/import.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.Import = cdb.core.Model.extend({
 
   idAttribute: 'item_queue_id',

--- a/lib/assets/javascripts/cartodb/models/like.js
+++ b/lib/assets/javascripts/cartodb/models/like.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.Like = cdb.core.Model.extend({
 
   defaults: {

--- a/lib/assets/javascripts/cartodb/models/map.js
+++ b/lib/assets/javascripts/cartodb/models/map.js
@@ -1,6 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
 
 /*
  * extend infowindow to serialize only the data we need
@@ -453,7 +450,7 @@ cdb.admin.Layers = cdb.geo.Layers.extend({
   toJSON: function(options) {
     // We can't use the default toJSON because it uses this.map(function(){...})
     // function within it but we override it using map containing all map stuff there.
-    // And we have to send all layers data within a variable called layers.
+    // And we have to send all layers data within a variable called layers. 
     var array = _.map(this.models, function(model) {
       return model.toJSON(options);
     });

--- a/lib/assets/javascripts/cartodb/models/organization.js
+++ b/lib/assets/javascripts/cartodb/models/organization.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * this model contains information about the organization for
  * the current user and the users who are inside the organizacion.
@@ -70,6 +66,7 @@ cdb.admin.Organization.Users = Backbone.Collection.extend({
     }
     this.elder('initialize');
     this.organization = opts.organization;
+
     this.currentUserId = opts.currentUserId;
     this._excludeCurrentUser = this._DEFAULT_EXCLUDE_CURRENT_USER;
 

--- a/lib/assets/javascripts/cartodb/models/organization_groups.js
+++ b/lib/assets/javascripts/cartodb/models/organization_groups.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * A collection that holds a set of organization groups
  */

--- a/lib/assets/javascripts/cartodb/models/permissions.js
+++ b/lib/assets/javascripts/cartodb/models/permissions.js
@@ -1,6 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
 
 /**
  * manages a cartodb permission object, it contains:

--- a/lib/assets/javascripts/cartodb/models/slide.js
+++ b/lib/assets/javascripts/cartodb/models/slide.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.SlideTransition = cdb.core.Model.extend({
   defaults: {
     time: 0
@@ -15,7 +11,7 @@ cdb.admin.Slide = cdb.core.Model.extend({
 
   initialize: function() {
     var self = this;
-    this._tracked = [];
+    this._tracked = []; 
     this.visualization = null;
     this.bind('change:active', function _active() {
       if (self.isActive() && self.master && self.visualization) {
@@ -80,7 +76,7 @@ cdb.admin.Slide = cdb.core.Model.extend({
     this.visualization.destroy.apply(this.visualization, arguments);
     this.trigger('destroy', this, this.collection);
     return this;
-  },
+  }, 
 
   setNext: function(next_visualization_id, opt) {
     var v = new cdb.admin.Visualization({ id: this.id });
@@ -137,7 +133,7 @@ cdb.admin.Slides = Backbone.Collection.extend({
 
     var self = this;
 
-    var _setMaster = function(m) {
+    var _setMaster = function(m) { 
       m.setMaster(self.visualization);
     };
 
@@ -146,7 +142,7 @@ cdb.admin.Slides = Backbone.Collection.extend({
       this.setActive(slide);
     }, this);
 
-    this.bind('reset', function() {
+    this.bind('reset', function() { 
       this.each(_setMaster);
       this.setActive(this.at(0));
     }, this);

--- a/lib/assets/javascripts/cartodb/models/sqlview.js
+++ b/lib/assets/javascripts/cartodb/models/sqlview.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * contains data for a sql view
  * var s = new cdb.admin.SQLViewData({ sql : "select...." });

--- a/lib/assets/javascripts/cartodb/models/synchronization.js
+++ b/lib/assets/javascripts/cartodb/models/synchronization.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 
 
   /**
@@ -91,7 +87,7 @@ if (typeof module !== 'undefined') {
 
       this.pollTimer = setInterval(request , interval);
 
-      function request() {
+      function request() { 
         self.destroyCheck();
 
         self.fetch({

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 
 /**
  * models for cartodb admin

--- a/lib/assets/javascripts/cartodb/models/tabledata.js
+++ b/lib/assets/javascripts/cartodb/models/tabledata.js
@@ -1,6 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
 
 cdb.admin.CartoDBTableData = cdb.ui.common.TableData.extend({
   _ADDED_ROW_TEXT: 'Row added correctly',
@@ -390,7 +387,7 @@ cdb.admin.CartoDBTableData = cdb.ui.common.TableData.extend({
       var values = [];
 
       for (var i = 1, l = nslots; i < l; i++) {
-        values.push((range*i) + min);
+        values.push((range*i) + min); 
       }
 
       // Add last value
@@ -827,3 +824,4 @@ cdb.admin.CartoDBTableData = cdb.ui.common.TableData.extend({
   },
 
 });
+

--- a/lib/assets/javascripts/cartodb/models/tile_json.js
+++ b/lib/assets/javascripts/cartodb/models/tile_json.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 /**
  * Model to representing a TileJSON endpoint
  * See https://github.com/mapbox/tilejson-spec/tree/master/2.1.0 for details

--- a/lib/assets/javascripts/cartodb/models/user.js
+++ b/lib/assets/javascripts/cartodb/models/user.js
@@ -1,6 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
 
 /**
  * the user has some base layers saved

--- a/lib/assets/javascripts/cartodb/models/user_groups.js
+++ b/lib/assets/javascripts/cartodb/models/user_groups.js
@@ -1,7 +1,6 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
+/**
+ * Collection of a User's groups.
+ */
 cdb.admin.UserGroups = Backbone.Collection.extend({
 
   model: cdb.admin.Group,

--- a/lib/assets/javascripts/cartodb/models/vis.js
+++ b/lib/assets/javascripts/cartodb/models/vis.js
@@ -1,6 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
 
 /*
  * this model is created to manage the visualization order. In order to simplify API

--- a/lib/assets/javascripts/cartodb/models/wizard.js
+++ b/lib/assets/javascripts/cartodb/models/wizard.js
@@ -1,11 +1,8 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 // form validation
+
 var alwaysTrueValidator = function(form) { return true };
 
-window.columnExistsValidatorFor = function columnExistsValidatorFor(column_name) {
+function columnExistsValidatorFor(column_name) {
   return function(form) {
     var field = form[column_name];
     return field.form.property.extra.length > 0;
@@ -566,7 +563,7 @@ cdb.admin.WizardProperties = cdb.core.Model.extend({
     }
     else {
       return this.get('type');
-    }
+    } 
   },
 
   // returns true if current wizard supports user

--- a/lib/assets/javascripts/cartodb/models/wkt.js
+++ b/lib/assets/javascripts/cartodb/models/wkt.js
@@ -1,6 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
 
 cdb.admin.WKT = {
   types: [

--- a/lib/assets/javascripts/cartodb/models/wms_service_model.js
+++ b/lib/assets/javascripts/cartodb/models/wms_service_model.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.WMSService = Backbone.Model.extend({
 
   _PROXY_URL:   '//cartodb-wms.global.ssl.fastly.net/api',

--- a/lib/assets/javascripts/cartodb/table/overlays/overlays.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/overlays.js
@@ -1,7 +1,3 @@
-if (typeof module !== 'undefined') {
-  module.exports = {};
-}
-
 cdb.admin.overlays = cdb.admin.overlays || {};
 
 /*
@@ -74,7 +70,7 @@ cdb.admin.models.Overlay = cdb.core.Model.extend({
         extra:   this.get("extra")
       }
     }
-  },
+  }, 
 
   parse: function(resp) {
     resp.display = resp.options.display;
@@ -146,7 +142,7 @@ cdb.admin.Overlays = Backbone.Collection.extend({
 
     }, this);
 
-
+  
   },
 
   createOverlayByType: function(overlay_type, property) {

--- a/lib/build/files/browserify_files.js
+++ b/lib/build/files/browserify_files.js
@@ -48,26 +48,6 @@ module.exports = {
       'lib/assets/javascripts/cartodb/keys/entry.js'
     ]
   },
-  models: {
-    src: [
-      'lib/assets/javascripts/cartodb/models/table.js',
-      'lib/assets/javascripts/cartodb/models/tabledata.js',
-      'lib/assets/javascripts/cartodb/models/sqlview.js',
-      'lib/assets/javascripts/cartodb/models/cartodb_layer.js',
-      'lib/assets/javascripts/cartodb/models/map.js',
-      'lib/assets/javascripts/cartodb/models/user.js',
-      'lib/assets/javascripts/cartodb/models/organization.js',
-      'lib/assets/javascripts/cartodb/models/like.js',
-      'lib/assets/javascripts/cartodb/models/carto/*.js',
-      'lib/assets/javascripts/cartodb/models/**/*.js',
-      'lib/assets/javascripts/cartodb/table/overlays/overlays.js'
-    ]
-  },
-  organizationModel: {
-    src: [
-      'lib/assets/javascripts/cartodb/models/organization.js',
-    ]
-  },
   new_public_table: {
     src: [
       'lib/assets/javascripts/cartodb/public_table.js'

--- a/lib/build/files/js_files.js
+++ b/lib/build/files/js_files.js
@@ -119,6 +119,27 @@ module.exports = files = {
     'lib/assets/javascripts/cartodb/old_common/urls/**/*.js'
   ],
 
+  models: [
+    'lib/assets/javascripts/cartodb/models/table.js',
+    'lib/assets/javascripts/cartodb/models/tabledata.js',
+    'lib/assets/javascripts/cartodb/models/sqlview.js',
+    'lib/assets/javascripts/cartodb/models/cartodb_layer.js',
+    'lib/assets/javascripts/cartodb/models/map.js',
+    'lib/assets/javascripts/cartodb/models/group.js',
+    'lib/assets/javascripts/cartodb/models/user_groups.js',
+    'lib/assets/javascripts/cartodb/models/organization_groups.js',
+    'lib/assets/javascripts/cartodb/models/user.js',
+    'lib/assets/javascripts/cartodb/models/permissions.js',
+    'lib/assets/javascripts/cartodb/models/group_users.js',
+    'lib/assets/javascripts/cartodb/models/grantable.js',
+    'lib/assets/javascripts/cartodb/models/grantables.js',
+    'lib/assets/javascripts/cartodb/models/organization.js',
+    'lib/assets/javascripts/cartodb/models/like.js',
+    'lib/assets/javascripts/cartodb/models/carto/*.js',
+    'lib/assets/javascripts/cartodb/models/**/*.js',
+    'lib/assets/javascripts/cartodb/table/overlays/overlays.js'
+  ],
+
   specs: [
   /*'test/lib/jasmine-1.3.1/jasmine.js',
   'test/lib/jasmine-1.3.1/jasmine-html.js',*/
@@ -176,6 +197,7 @@ module.exports = files = {
   'lib/assets/javascripts/utils/draggable.js',
   'lib/assets/javascripts/utils/carto.codemirror.js',
   'lib/assets/javascripts/utils/color.keywords.js',
+  'vendor/assets/javascripts/models.js',
   'lib/assets/javascripts/cartodb/old_common/utils.js',
   'lib/assets/javascripts/cartodb/old_common/dropdown_menu.js',
   'lib/assets/javascripts/cartodb/old_common/forms/string_field.js',
@@ -199,8 +221,15 @@ module.exports = files = {
     'lib/assets/javascripts/cartodb/public/authenticated_user.js',
     'lib/assets/javascripts/cartodb/models/cartodb_layer.js',
     'lib/assets/javascripts/cartodb/models/map.js',
+    'lib/assets/javascripts/cartodb/models/group.js',
+    'lib/assets/javascripts/cartodb/models/user_groups.js',
+    'lib/assets/javascripts/cartodb/models/organization_groups.js',
     'lib/assets/javascripts/cartodb/models/user.js',
-    '<%= assets_dir %>/javascripts/organizationModel.js', // bundled through browserify, just here for tests
+    'lib/assets/javascripts/cartodb/models/permissions.js',
+    'lib/assets/javascripts/cartodb/models/group_users.js',
+    'lib/assets/javascripts/cartodb/models/grantable.js',
+    'lib/assets/javascripts/cartodb/models/grantables.js',
+    'lib/assets/javascripts/cartodb/models/organization.js',
     'lib/assets/javascripts/cartodb/models/like.js',
     'lib/assets/javascripts/cartodb/fonts/lato_loader.js',
     'lib/assets/javascripts/cartodb/old_common/dropdown_menu.js',
@@ -216,7 +245,14 @@ module.exports = files = {
     'lib/assets/javascripts/cartodb/public/authenticated_user.js',
     'lib/assets/javascripts/cartodb/models/cartodb_layer.js',
     'lib/assets/javascripts/cartodb/models/map.js',
+    'lib/assets/javascripts/cartodb/models/group.js',
+    'lib/assets/javascripts/cartodb/models/user_groups.js',
+    'lib/assets/javascripts/cartodb/models/organization_groups.js',
     'lib/assets/javascripts/cartodb/models/user.js',
+    'lib/assets/javascripts/cartodb/models/permissions.js',
+    'lib/assets/javascripts/cartodb/models/group_users.js',
+    'lib/assets/javascripts/cartodb/models/grantable.js',
+    'lib/assets/javascripts/cartodb/models/grantables.js',
     'lib/assets/javascripts/cartodb/models/organization.js',
     'lib/assets/javascripts/cartodb/models/like.js',
     'lib/assets/javascripts/cartodb/fonts/lato_loader.js',
@@ -234,7 +270,14 @@ module.exports = files = {
     'lib/assets/javascripts/cartodb/public/authenticated_user.js',
     'lib/assets/javascripts/cartodb/models/cartodb_layer.js',
     'lib/assets/javascripts/cartodb/models/map.js',
+    'lib/assets/javascripts/cartodb/models/group.js',
+    'lib/assets/javascripts/cartodb/models/user_groups.js',
+    'lib/assets/javascripts/cartodb/models/organization_groups.js',
     'lib/assets/javascripts/cartodb/models/user.js',
+    'lib/assets/javascripts/cartodb/models/permissions.js',
+    'lib/assets/javascripts/cartodb/models/group_users.js',
+    'lib/assets/javascripts/cartodb/models/grantable.js',
+    'lib/assets/javascripts/cartodb/models/grantables.js',
     'lib/assets/javascripts/cartodb/models/organization.js',
     'lib/assets/javascripts/cartodb/models/like.js',
     'lib/assets/javascripts/cartodb/fonts/lato_loader.js',
@@ -257,10 +300,15 @@ module.exports = files = {
     'lib/assets/javascripts/cartodb/models/sqlview.js',
     'lib/assets/javascripts/cartodb/models/cartodb_layer.js',
     'lib/assets/javascripts/cartodb/models/map.js',
+    'lib/assets/javascripts/cartodb/models/group.js',
+    'lib/assets/javascripts/cartodb/models/user_groups.js',
+    'lib/assets/javascripts/cartodb/models/organization_groups.js',
     'lib/assets/javascripts/cartodb/models/user.js',
     'lib/assets/javascripts/cartodb/models/permissions.js',
-    '<%= assets_dir %>/javascripts/organizationModel.js', // bundled through browserify, just here for tests
-    'lib/assets/javascripts/cartodb/models/like.js',
+    'lib/assets/javascripts/cartodb/models/group_users.js',
+    'lib/assets/javascripts/cartodb/models/grantable.js',
+    'lib/assets/javascripts/cartodb/models/grantables.js',
+    'lib/assets/javascripts/cartodb/models/organization.js',
     'lib/assets/javascripts/cartodb/models/like.js',
     'lib/assets/javascripts/cartodb/models/synchronization.js',
     'lib/assets/javascripts/cartodb/models/wkt.js',
@@ -298,8 +346,15 @@ module.exports = files = {
     'lib/assets/javascripts/cartodb/public/authenticated_user.js',
     'lib/assets/javascripts/cartodb/models/cartodb_layer.js',
     'lib/assets/javascripts/cartodb/models/map.js',
+    'lib/assets/javascripts/cartodb/models/group.js',
+    'lib/assets/javascripts/cartodb/models/user_groups.js',
+    'lib/assets/javascripts/cartodb/models/organization_groups.js',
     'lib/assets/javascripts/cartodb/models/user.js',
-    '<%= assets_dir %>/javascripts/organizationModel.js', // bundled through browserify
+    'lib/assets/javascripts/cartodb/models/permissions.js',
+    'lib/assets/javascripts/cartodb/models/group_users.js',
+    'lib/assets/javascripts/cartodb/models/grantable.js',
+    'lib/assets/javascripts/cartodb/models/grantables.js',
+    'lib/assets/javascripts/cartodb/models/organization.js',
     'lib/assets/javascripts/cartodb/models/like.js',
     'lib/assets/javascripts/cartodb/fonts/lato_loader.js',
     'lib/assets/javascripts/cartodb/old_common/dropdown_menu.js',
@@ -357,11 +412,7 @@ module.exports = files = {
 
   _templates_mustache: [
     'lib/assets/javascripts/cartodb/**/*.jst.mustache'
-  ],
-
-  _models: [
-    '<%= assets_dir %>/javascripts/models.js', // bundled through browserify, just here for tests
-  ],
+  ]
 
 };
 
@@ -371,7 +422,7 @@ module.exports = files = {
 var _all = [
   'cdb',
   'app',
-  '_models',
+  'models',
   'dashboard_deps',
   'keys_deps',
   'account_deps',


### PR DESCRIPTION
Reverts the models-bundle-through-browserify in a0ffc723edde48476ca69bedcecea38fce18e480, since models are not motivated to be browserified anymore. 

Also add new files that were missing in dependency bundles that broke public pages (cc @juanignaciosl for spotting this one).

@xavijam can you please review? Added the missing dependencies for user and organization models that have special bundles on public pages. 
Considering the amount of duplicated files on the public bundles there I'd recommend we DRY these ones up to have a common bundle, it doesn't make sense to have a separate bundle per page if the files are basically the same.