### PR TITLE
Fix bug trying to change users permission

### DIFF
--- a/lib/assets/javascripts/cartodb/models/permissions.js
+++ b/lib/assets/javascripts/cartodb/models/permissions.js
@@ -69,16 +69,24 @@ cdb.admin.Permission = cdb.core.Model.extend({
   },
 
   hasWriteAccess: function(model) {
-    var access = this._maybeAccessForAclItem(this.findRepresentableAclItem(model));
-    return access === this.constructor.READ_WRITE;
+    var access = cdb.Utils.result(this.findRepresentableAclItem(model), 'get', 'access');
+    return access === cdb.admin.Permission.READ_WRITE;
   },
 
   canChangeReadAccess: function(model) {
-    return this._hasOwnAclItem(model) || !this.hasReadAccess(model);
+    return this._canChangeAccess(model);
   },
 
   canChangeWriteAccess: function(model) {
-    return this._hasOwnAclItem(model) || !this.hasWriteAccess(model);
+    return this._canChangeAccess(model, function(representableAclItem) {
+      return cdb.Utils.result(representableAclItem, 'get', 'access') !== cdb.admin.Permission.READ_WRITE;
+    })
+  },
+
+  _canChangeAccess: function(model) {
+    var representableAclItem = this.findRepresentableAclItem(model);
+    return this.isOwner(model) || !representableAclItem ||
+      representableAclItem === this._ownAclItem(model) || cdb.Utils.result(arguments, 1, representableAclItem) || false;
   },
 
   grantWriteAccess: function(model) {
@@ -141,7 +149,8 @@ cdb.admin.Permission = cdb.core.Model.extend({
     this.acl.reset(otherPermission.acl.models);
   },
 
-  // Note that this may return an inherited ACL item, use ._ownAclItem to get the model's own item, if there is any
+  // Note that this may return an inherited ACL item
+  // use ._ownAclItem instead if only model's own is wanted (if there is any)
   findRepresentableAclItem: function(model) {
     if (this.isOwner(model)) {
       return this._newAclItem(model, this.constructor.READ_WRITE);
@@ -171,7 +180,7 @@ cdb.admin.Permission = cdb.core.Model.extend({
 
   _ownAclItem: function(model) {
     if (!model || !_.isFunction(model.isNew)) {
-      throw new Error('model is required to access model');
+      cdb.log.error('model is required to find an ACL item');
     }
     if (!model.isNew()) {
       return this.acl.find(function(aclItem) {
@@ -204,15 +213,11 @@ cdb.admin.Permission = cdb.core.Model.extend({
    */
   _findMostPrivilegedAclItem: function(list, iteratee) {
     var aclItem;
-    for (var i = 0, x = list[i]; x && this._maybeAccessForAclItem(aclItem) !== cdb.admin.Permission.READ_WRITE; x = list[++i]) {
+    for (var i = 0, x = list[i]; x && cdb.Utils.result(aclItem, 'get', 'access') !== cdb.admin.Permission.READ_WRITE; x = list[++i]) {
       // Keep last ACL item if iteratee returns nothing
       aclItem = iteratee.call(this, x) || aclItem;
     }
     return aclItem;
-  },
-
-  _hasOwnAclItem: function(model) {
-    return !!this._ownAclItem(model);
   },
 
   /**
@@ -234,11 +239,6 @@ cdb.admin.Permission = cdb.core.Model.extend({
         throw new Error(access + ' is not a valid ACL access');
       }
     }
-  },
-
-  // @return {String, null} the access if given an aclItem, if ACL item is available
-  _maybeAccessForAclItem: function(aclItem) {
-    return aclItem ? aclItem.get('access') : null;
   },
 
   _newAclItem: function(model, access) {

--- a/lib/assets/javascripts/cartodb/old_common/utils.js
+++ b/lib/assets/javascripts/cartodb/old_common/utils.js
@@ -253,3 +253,25 @@
   cdb.Utils.capitalize = function(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
   };
+
+  /**
+   * Similar to _.result, but also allows passing arbitrary arguments to the property if it's function.
+   * This makes code more terse  when one just wants to use a value if it's available, no if-checks required.
+   *
+   * @example Expected output
+   *   model.set('something', 'yay');
+   *   cdb.Utils.result(model, 'get', 'something') // => 'yay'
+   *   cdb.Utils.result(model, 'nonexisting', 'else') // => undefined
+   *   cdb.Utils.result(undefinedVar, 'get') // => null
+   *
+   * @example Of usage
+   *  return cdb.Utils.result(model, 'get', 'mightNotExist') === 'OK'
+   *
+   * @param {*} maybeFn
+   * @return {*} Result from called maybeFn if a function, null otherwise
+   */
+  cdb.Utils.result = function(object, property) {
+    if (object == null) return null;
+    var value = object[property];
+    return _.isFunction(value) ? value.apply(object, Array.prototype.slice.call(arguments, 2)) : value;
+  };

--- a/lib/assets/test/spec/cartodb/models/permissions.spec.js
+++ b/lib/assets/test/spec/cartodb/models/permissions.spec.js
@@ -94,7 +94,7 @@ describe('cdb.admin.Permission', function() {
   });
 
   // Test all can/has/grant-access methods at once, since they all depend on similar setups
-  describe('accesses', function() {
+  describe('access', function() {
     beforeEach(function() {
       // Setup various group scenarios for later use
       this.groupX = new cdb.admin.Group({ id: 'gx' });
@@ -107,14 +107,14 @@ describe('cdb.admin.Permission', function() {
 
     describe('when given a model w/o any access', function() {
       it('should not have any access', function() {
-        expect(this.permission.hasAccess(user1)).toBe(false);
-        expect(this.permission.hasReadAccess(user1)).toBe(false);
-        expect(this.permission.hasWriteAccess(user1)).toBe(false);
+        expect(this.permission.hasAccess(user2)).toBe(false);
+        expect(this.permission.hasReadAccess(user2)).toBe(false);
+        expect(this.permission.hasWriteAccess(user2)).toBe(false);
       });
 
       it('should be able to set any access', function() {
-        expect(this.permission.canChangeReadAccess(user1)).toBe(true);
-        expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+        expect(this.permission.canChangeReadAccess(user2)).toBe(true);
+        expect(this.permission.canChangeWriteAccess(user2)).toBe(true);
       });
     });
 
@@ -124,42 +124,62 @@ describe('cdb.admin.Permission', function() {
         expect(this.permission.hasReadAccess(this.owner)).toBe(true);
         expect(this.permission.hasWriteAccess(this.owner)).toBe(true);
       });
+
+      it('should be able to set any access', function() {
+        expect(this.permission.canChangeReadAccess(this.owner)).toBe(true);
+        expect(this.permission.canChangeWriteAccess(this.owner)).toBe(true);
+      });
     });
 
     describe('when given an user', function() {
       describe('when user is given read access', function() {
         beforeEach(function() {
-          this.permission.grantReadAccess(user1);
+          this.permission.grantReadAccess(user2);
         });
 
         it('should have read access', function() {
-          expect(this.permission.hasAccess(user1)).toBe(true);
-          expect(this.permission.hasReadAccess(user1)).toBe(true);
-          expect(this.permission.hasWriteAccess(user1)).toBe(false);
+          expect(this.permission.hasAccess(user2)).toBe(true);
+          expect(this.permission.hasReadAccess(user2)).toBe(true);
+          expect(this.permission.hasWriteAccess(user2)).toBe(false);
+        });
+
+        it('should be able to set any access', function() {
+          expect(this.permission.canChangeReadAccess(this.owner)).toBe(true);
+          expect(this.permission.canChangeWriteAccess(this.owner)).toBe(true);
         });
       });
 
       describe('when user is given write access', function() {
         beforeEach(function() {
-          this.permission.grantWriteAccess(user1);
+          this.permission.grantWriteAccess(user2);
         });
 
         it('should have both read+write access', function() {
-          expect(this.permission.hasAccess(user1)).toBe(true);
-          expect(this.permission.hasReadAccess(user1)).toBe(true);
-          expect(this.permission.hasWriteAccess(user1)).toBe(true);
+          expect(this.permission.hasAccess(user2)).toBe(true);
+          expect(this.permission.hasReadAccess(user2)).toBe(true);
+          expect(this.permission.hasWriteAccess(user2)).toBe(true);
+        });
+
+        it('should be able to set any access', function() {
+          expect(this.permission.canChangeReadAccess(this.owner)).toBe(true);
+          expect(this.permission.canChangeWriteAccess(this.owner)).toBe(true);
         });
       });
 
-      describe('when user is part of organization with access', function() {
+      describe('when user is part of organization with read access', function() {
         beforeEach(function() {
           this.permission.grantReadAccess(this.organization);
         });
 
         it('should have read access', function() {
-          expect(this.permission.hasAccess(this.organization)).toBe(true);
-          expect(this.permission.hasReadAccess(this.organization)).toBe(true);
-          expect(this.permission.hasWriteAccess(this.organization)).toBe(false);
+          expect(this.permission.hasAccess(user2)).toBe(true);
+          expect(this.permission.hasReadAccess(user2)).toBe(true);
+          expect(this.permission.hasWriteAccess(user2)).toBe(false);
+        });
+
+        it('should only be able to set write access', function() {
+          expect(this.permission.canChangeReadAccess(user2)).toBe(false);
+          expect(this.permission.canChangeWriteAccess(user2)).toBe(true);
         });
 
         describe('when organization has write access', function() {
@@ -167,10 +187,15 @@ describe('cdb.admin.Permission', function() {
             this.permission.grantWriteAccess(this.organization);
           });
 
-          it('should have write access too', function() {
-            expect(this.permission.hasAccess(this.organization)).toBe(true);
-            expect(this.permission.hasReadAccess(this.organization)).toBe(true);
-            expect(this.permission.hasWriteAccess(this.organization)).toBe(true);
+          it('should have both read+write access', function() {
+            expect(this.permission.hasAccess(user2)).toBe(true);
+            expect(this.permission.hasReadAccess(user2)).toBe(true);
+            expect(this.permission.hasWriteAccess(user2)).toBe(true);
+          });
+
+          it('should not be able to change any access', function() {
+            expect(this.permission.canChangeReadAccess(user2)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user2)).toBe(false);
           });
         });
       });
@@ -203,24 +228,52 @@ describe('cdb.admin.Permission', function() {
             expect(this.permission.hasReadAccess(this.groupA)).toBe(true);
             expect(this.permission.hasWriteAccess(this.groupA)).toBe(true);
           });
+
+          it('should not be able to change any access', function() {
+            expect(this.permission.canChangeReadAccess(this.groupA)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(this.groupA)).toBe(false);
+          });
         });
       });
 
-      describe('when group w/o own access but is part of organization with access', function() {
+      describe('when group w/o own access but is part of organization with read access', function() {
         beforeEach(function() {
-          this.permission.grantWriteAccess(this.organization);
+          this.permission.grantReadAccess(this.organization);
           this.organization.groups.add(this.groupX);
         });
 
-        it('should have the organization access', function() {
+        it('should have the organization read access', function() {
           expect(this.permission.hasAccess(this.groupX)).toBe(true);
           expect(this.permission.hasReadAccess(this.groupX)).toBe(true);
-          expect(this.permission.hasWriteAccess(this.groupX)).toBe(true);
+          expect(this.permission.hasWriteAccess(this.groupX)).toBe(false);
+        });
+
+        it('should only be able to change write access', function() {
+          expect(this.permission.canChangeReadAccess(this.groupX)).toBe(false);
+          expect(this.permission.canChangeWriteAccess(this.groupX)).toBe(true);
+        });
+
+        describe('when organization has write access', function() {
+          beforeEach(function() {
+            this.permission.grantWriteAccess(this.organization);
+            this.organization.groups.add(this.groupX);
+          });
+
+          it('should have the organization read+write access', function() {
+            expect(this.permission.hasAccess(this.groupX)).toBe(true);
+            expect(this.permission.hasReadAccess(this.groupX)).toBe(true);
+            expect(this.permission.hasWriteAccess(this.groupX)).toBe(true);
+          });
+
+          it('should not be able to change any access', function() {
+            expect(this.permission.canChangeReadAccess(this.groupX)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(this.groupX)).toBe(false);
+          });
         });
       });
     });
 
-    describe('when given a user w/o own access but is member of group with access', function() {
+    describe('when given a user w/o own access but is member of group with read access', function() {
       beforeEach(function() {
         user1.groups.add(this.groupA)
       });
@@ -229,6 +282,11 @@ describe('cdb.admin.Permission', function() {
           expect(this.permission.hasAccess(user1)).toBe(true);
           expect(this.permission.hasReadAccess(user1)).toBe(true);
           expect(this.permission.hasWriteAccess(user1)).toBe(false);
+      });
+
+      it('should only be able to change write access', function() {
+        expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+        expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
       });
 
       describe('when user is member of multiple groups', function() {
@@ -240,6 +298,11 @@ describe('cdb.admin.Permission', function() {
           expect(this.permission.hasAccess(user1)).toBe(true);
           expect(this.permission.hasReadAccess(user1)).toBe(true);
           expect(this.permission.hasWriteAccess(user1)).toBe(true);
+        });
+
+        it('should not be able to change any access (since has write inherited)', function() {
+          expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+          expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
         });
       });
 
@@ -253,6 +316,11 @@ describe('cdb.admin.Permission', function() {
           expect(this.permission.hasAccess(user1)).toBe(true);
           expect(this.permission.hasReadAccess(user1)).toBe(true);
           expect(this.permission.hasWriteAccess(user1)).toBe(true);
+        });
+
+        it('should not be able to change any access (since has write inherited)', function() {
+          expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+          expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
         });
       });
 
@@ -269,6 +337,11 @@ describe('cdb.admin.Permission', function() {
           expect(this.permission.hasReadAccess(user1)).toBe(true);
           expect(this.permission.hasWriteAccess(user1)).toBe(true);
         });
+
+        it('should not be able to change any access (since has write inherited)', function() {
+          expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+          expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
+        });
       });
 
       describe('when user has organization read-only access', function() {
@@ -283,6 +356,11 @@ describe('cdb.admin.Permission', function() {
           expect(this.permission.hasWriteAccess(user1)).toBe(false);
         });
 
+        it('should be able to change write access only', function() {
+          expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+          expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+        });
+
         describe('when user has better access than organization', function() {
           beforeEach(function() {
             this.permission.grantWriteAccess(user1);
@@ -292,6 +370,11 @@ describe('cdb.admin.Permission', function() {
             expect(this.permission.hasAccess(user1)).toBe(true);
             expect(this.permission.hasReadAccess(user1)).toBe(true);
             expect(this.permission.hasWriteAccess(user1)).toBe(true);
+          });
+
+          it('should be able to change access', function() {
+            expect(this.permission.canChangeReadAccess(user1)).toBe(true);
+            expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
           });
         });
 
@@ -304,6 +387,11 @@ describe('cdb.admin.Permission', function() {
             expect(this.permission.hasAccess(user1)).toBe(true);
             expect(this.permission.hasReadAccess(user1)).toBe(true);
             expect(this.permission.hasWriteAccess(user1)).toBe(true);
+          });
+
+          it('should be able to change access', function() {
+            expect(this.permission.canChangeReadAccess(user1)).toBe(true);
+            expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
           });
         });
       });

--- a/lib/assets/test/spec/cartodb/old_common/utils.spec.js
+++ b/lib/assets/test/spec/cartodb/old_common/utils.spec.js
@@ -113,4 +113,26 @@ describe('Utils', function() {
 
   });
 
+  describe('.result', function() {
+    beforeEach(function() {
+      this.model = new cdb.core.Model({
+        something: 'yay'
+      });
+      this.model.myProp = 123;
+    });
+
+    it('should try to call given method', function() {
+      expect(cdb.Utils.result(this.model, 'get', 'something')).toEqual('yay');
+    });
+
+    it('should return the property if a value', function() {
+      expect(cdb.Utils.result(this.model, 'myProp')).toEqual(123);
+    });
+
+    it('should return fallback value if can not call method', function() {
+      expect(cdb.Utils.result(this.model, 'nonexisting')).toBeUndefined();
+      expect(cdb.Utils.result(undefined, 'nonexisting')).toBeNull();
+    });
+  });
+
 });


### PR DESCRIPTION
Don’t allow revoking access if it’s inherited, effectively only allow to modify the item’s access if it’s adds a more privileged access on top of the inherited one.

fixes #5676 

![screen shot 2015-09-23 at 13 10 23](https://cloud.githubusercontent.com/assets/978461/10043668/30a0b81a-61f5-11e5-94b4-f2ef84ead905.png)
![screen shot 2015-09-23 at 13 10 34](https://cloud.githubusercontent.com/assets/978461/10043672/33eb7cf8-61f5-11e5-9b3e-ec054cc7952d.png)
![screen shot 2015-09-23 at 13 11 04](https://cloud.githubusercontent.com/assets/978461/10043674/378b1e7c-61f5-11e5-8a79-e207759a227f.png)

@xavijam can you review the code?
cc @urbanphes @juanignaciosl 