### PR TITLE
changed rules for hex colors linter

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -65,7 +65,7 @@ linters:
     severity: warning
   LeadingZero:
     enabled: true
-    style: exclude_zero
+    style: include_zero
   MergeableSelector:
     enabled: true
     force_nesting: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -42,11 +42,11 @@ linters:
     enabled: true
     present: true
   HexLength:
-    enabled: false
-    style: long
+    enabled: true
+    style: short
   HexNotation:
     enabled: true
-    style: uppercase
+    style: lowercase
   HexValidation:
     enabled: true
   IdSelector:

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -46,7 +46,7 @@ linters:
     style: short
   HexNotation:
     enabled: true
-    style: lowercase
+    style: uppercase
   HexValidation:
     enabled: true
   IdSelector:

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -65,7 +65,7 @@ linters:
     severity: warning
   LeadingZero:
     enabled: true
-    style: include_zero
+    style: exclude_zero
   MergeableSelector:
     enabled: true
     force_nesting: false
@@ -164,7 +164,7 @@ linters:
     enabled: true
     severity: warning
   TrailingZero:
-    enabled: false
+    enabled: true
   UnnecessaryMantissa:
     enabled: true
   UnnecessaryParentReference:


### PR DESCRIPTION
- lowercase
- short

so

```
color: #FF22EE;
```

wouldn't be valid, but would

```
color: #f2e;
```

based on personal preference, but serve this PR as a call for discussion, I can stick to other style though

@CartoDB/frontend 