### PR TITLE
#5726 Spaces are valid group name characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ WORKING_SPECS_1 = \
   spec/lib/carto/http/client_spec.rb \
 	spec/helpers/uuidhelper_spec.rb \
 	spec/models/carto/template_spec.rb \
+	spec/models/carto/group_spec.rb \
 	spec/models/carto/ldap/configuration_spec.rb \
 	spec/requests/sessions_controller_spec.rb \
   $(NULL)

--- a/app/models/carto/group.rb
+++ b/app/models/carto/group.rb
@@ -124,7 +124,7 @@ module Carto
     def self.valid_group_name(display_name)
       name = display_name.squish
       name = "g_#{name}" unless name[/^[a-zA-Z_]{1}/]
-      name.gsub(/[^a-zA-Z0-9_]/, '_').gsub(/_{2,}/, '_')
+      name.gsub(/[^a-zA-Z0-9_ ]/, '_').gsub(/_{2,}/, '_')
     end
 
     def self.create_group_extension_query(conn, name)

--- a/spec/models/carto/group_spec.rb
+++ b/spec/models/carto/group_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../../spec_helper'
+require_relative '../../../app/models/carto/group'
+
+describe Carto::Group do
+
+  describe '#valid_group_name' do
+
+    it 'returns valid names' do
+      valid_names = ['A Group', 'My5Group']
+      valid_names.each do |valid_name|
+        Carto::Group.valid_group_name(valid_name).should == valid_name
+      end
+    end
+
+    it 'returns g_ prepended at the name if does not begin with a letter' do
+      not_valid_names = { '5 group' => 'g_5 group' }
+      not_valid_names.each do |name, valid|
+        Carto::Group.valid_group_name(name).should == valid
+      end
+    end
+
+    it 'changes not alphanumeric or spaces characters to underscores' do
+      not_valid_names = { '/group' => 'g_group', 'g/group' => 'g_group' }
+      not_valid_names.each do |name, valid|
+        Carto::Group.valid_group_name(name).should == valid
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This fixes #5726. @Kartones CR this, please.