### PR TITLE
Fixes maps an datasets URLs in the user feed page

### DIFF
--- a/lib/assets/javascripts/cartodb/explore/view.js
+++ b/lib/assets/javascripts/cartodb/explore/view.js
@@ -170,8 +170,7 @@ module.exports = Feed.extend({
         date: this.model.get('order_by') === 'updated_at' ? item.get('updated_at') : item.get('created_at'),
         datasetSize: this._getDatasetSize(item),
         geomType: this._getGeometryType(item.get('geom_types')),
-        account_host: cdb.config.get('account_host'),
-        base_url: cdb.config.get('base_url')
+        account_host: cdb.config.get('account_host')
       });
 
       this.$('.js-items').append(el);

--- a/lib/assets/javascripts/cartodb/explore/view.js
+++ b/lib/assets/javascripts/cartodb/explore/view.js
@@ -121,7 +121,6 @@ module.exports = Feed.extend({
 
     this.collection = new Visualizations();
 
-
     this.collection.bind('reset', this._renderVisualizations, this);
   },
 
@@ -171,7 +170,8 @@ module.exports = Feed.extend({
         date: this.model.get('order_by') === 'updated_at' ? item.get('updated_at') : item.get('created_at'),
         datasetSize: this._getDatasetSize(item),
         geomType: this._getGeometryType(item.get('geom_types')),
-        account_host: cdb.config.get('account_host')
+        account_host: cdb.config.get('account_host'),
+        base_url: cdb.config.get('base_url')
       });
 
       this.$('.js-items').append(el);

--- a/lib/assets/javascripts/cartodb/user_feed/dataset_item_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/user_feed/dataset_item_template.jst.ejs
@@ -11,7 +11,7 @@
         </div>
         <div class="DatasetCard-contentBodyDetails--right u-ellipsLongText">
           <h3 class="DatasetCard-title DefaultTitle">
-            <a href="/tables/<%- vis.name %>/public" class="DefaultTitle-link u-ellipsLongText" title="<%- vis.name %>"><%- vis.name %></a>
+            <a href="<%- base_url %>/tables/<%- vis.name %>/public" class="DefaultTitle-link u-ellipsLongText" title="<%- vis.name %>"><%- vis.name %></a>
           </h3>
 
           <div class="DatasetCard-contentFooter">

--- a/lib/assets/javascripts/cartodb/user_feed/map_item_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/user_feed/map_item_template.jst.ejs
@@ -4,7 +4,7 @@
   </a>
 
   <div class="MapCard MapCard--borderless MapCard--long js-card" data-vis-id="<%- vis.id %>">
-    <a href="/viz/<%- vis.id %>/public_map" class="MapCard-header js-header">
+    <a href="<%- base_url %>/viz/<%- vis.id %>/public_map" class="MapCard-header js-header">
       <div class="MapCard-loader js-loader"></div>
     </a>
 
@@ -12,7 +12,7 @@
       <div class="MapCard-contentBody">
         <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
           <h3 class="MapCard-title DefaultTitle">
-            <a href="/viz/<%- vis.id %>/public_map" class="DefaultTitle-link u-ellipsLongText" title="<%- vis.name %>"><%- vis.name %></a>
+            <a href="<%- base_url %>/viz/<%- vis.id %>/public_map" class="DefaultTitle-link u-ellipsLongText" title="<%- vis.name %>"><%- vis.name %></a>
           </h3>
         </div>
       </div>

--- a/lib/assets/javascripts/cartodb/user_feed/view.js
+++ b/lib/assets/javascripts/cartodb/user_feed/view.js
@@ -185,7 +185,8 @@ module.exports = cdb.core.View.extend({
         table_count: owner.table_count,
         maps_count: owner.maps_count,
         geomType: geomType,
-        account_host: config.account_host
+        account_host: config.account_host,
+        base_url: cdb.config.get('base_url')
       });
 
       this.$('.js-items').append(el);

--- a/lib/assets/javascripts/cartodb/user_feed/view.js
+++ b/lib/assets/javascripts/cartodb/user_feed/view.js
@@ -186,7 +186,7 @@ module.exports = cdb.core.View.extend({
         maps_count: owner.maps_count,
         geomType: geomType,
         account_host: config.account_host,
-        base_url: cdb.config.get('base_url')
+        base_url: cdb.config.get('url_prefix')
       });
 
       this.$('.js-items').append(el);

--- a/lib/assets/test/spec/cartodb/common/views/feed/feed.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/feed/feed.spec.js
@@ -57,7 +57,8 @@ describe('common/views/feed/view', function() {
 
     this.view = new Feed({
       el: $('.js-feed'),
-      authenticatedUser: this.authenticatedUser
+      authenticatedUser: this.authenticatedUser,
+      base_url: 'base_url'
     });
 
     spyOn(this.view, '_fetchLike');

--- a/lib/assets/test/spec/cartodb/common/views/feed/feed.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/feed/feed.spec.js
@@ -13,6 +13,8 @@ describe('common/views/feed/view', function() {
 
   beforeEach(function() {
 
+    cdb.config.set('url_prefix', 'base_url');
+
     Visualizations.prototype.sync = function(a, b, opts) {
       var c = [];
       c.push({
@@ -57,8 +59,7 @@ describe('common/views/feed/view', function() {
 
     this.view = new Feed({
       el: $('.js-feed'),
-      authenticatedUser: this.authenticatedUser,
-      base_url: 'base_url'
+      authenticatedUser: this.authenticatedUser
     });
 
     spyOn(this.view, '_fetchLike');
@@ -70,6 +71,11 @@ describe('common/views/feed/view', function() {
     expect(this.view.el.innerHTML).toContain('vis_name');
     expect(this.view.el.innerHTML).toContain('vis_name_2');
   });
+
+  it('should prepend the base_url to the links', function() {
+    expect(this.view.$('.DefaultTitle-link:first').attr('href')).toContain('base_url');
+  });
+
 
   it('should hide the load more button when the limit is reached', function() {
     this.view.$el.find(".js-more").click();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.64",
+  "version": "3.19.65",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes the malformed URLs for maps and datasets that appear in the user feed. Prepending the `base_url` part adds the `/u/username` part that was missing in the links from organization users.