### PR TITLE
fix long username issue in public pages

### DIFF
--- a/app/assets/stylesheets/common/navmenu.css.scss
+++ b/app/assets/stylesheets/common/navmenu.css.scss
@@ -136,7 +136,11 @@
 }
 .Navmenu-link.Navmenu-link--owner {
   float: left;
+  text-overflow: ellipsis;
+  max-width: 150px;
+  display: inline-block;
   white-space: nowrap;
+  overflow: hidden;
 }
 .Navmenu-link--action,
 .Navmenu-item--action {

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -110,7 +110,7 @@
 
           <ul class="Navmenu-list Navmenu-list--owner">
             <li class="Navmenu-item u-hideOnTablet last-child">
-              <a href="<%= CartoDB.url(self, 'root', {}, @visualization.user) %>" class="Navmenu-link Navmenu-link--owner"><%= @name %></a>
+              <a href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>" class="Navmenu-link Navmenu-link--owner"><%= @name %></a>
             </li>
 
             <li class="Navmenu-item">

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -109,11 +109,11 @@
           </ul>
 
           <ul class="Navmenu-list Navmenu-list--owner">
-            <li class="Navmenu-item last-child">
+            <li class="Navmenu-item u-hideOnTablet last-child">
               <a href="<%= CartoDB.url(self, 'root', {}, @visualization.user) %>" class="Navmenu-link Navmenu-link--owner"><%= @name %></a>
             </li>
 
-            <li class="Navmenu-item u-hideOnTablet">
+            <li class="Navmenu-item">
               <i class="Navmenu-rarrow iconFont iconFont-Rarrow"></i>
               <a href="<%= CartoDB.url(self, 'public_datasets_home', {}, @visualization.user) %>" class="Navmenu-link">Datasets</a>
             </li>

--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -45,11 +45,11 @@
             </ul>
 
             <ul class="Navmenu-list Navmenu-list--owner">
-              <li class="Navmenu-item last-child">
+              <li class="Navmenu-item u-hideOnTablet last-child">
                 <a href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>" class="Navmenu-link Navmenu-link--owner"><%= @name %></a>
               </li>
 
-              <li class="Navmenu-item u-hideOnTablet">
+              <li class="Navmenu-item">
                 <i class="Navmenu-rarrow iconFont iconFont-Rarrow"></i>
                 <a href="<%= CartoDB.url(self, 'public_maps_home', {}, @visualization.user) %>" class="Navmenu-link">Maps</a>
               </li>

--- a/app/views/shared/_public_dashboard_user_header.html.erb
+++ b/app/views/shared/_public_dashboard_user_header.html.erb
@@ -15,7 +15,7 @@
 
           <ul class="Navmenu-list Navmenu-list--owner">
             <li class="Navmenu-item u-hideOnMobile">
-              <a href="<%= CartoDB.url(self, 'public_user_feed_home') %>" class="Navmenu-link <%= "#{@content_type != 'maps' and @content_type != 'datasets' ? 'is-selected' : '' }" %>">
+              <a href="<%= CartoDB.url(self, 'public_user_feed_home') %>" class="Navmenu-link Navmenu-link--owner<%= "#{@content_type != 'maps' and @content_type != 'datasets' ? 'is-selected' : '' }" %>">
                 <%= @name %>
               </a>
             </li>

--- a/app/views/shared/_public_dashboard_user_header.html.erb
+++ b/app/views/shared/_public_dashboard_user_header.html.erb
@@ -15,7 +15,7 @@
 
           <ul class="Navmenu-list Navmenu-list--owner">
             <li class="Navmenu-item u-hideOnMobile">
-              <a href="<%= CartoDB.url(self, 'public_user_feed_home') %>" class="Navmenu-link Navmenu-link--owner<%= "#{@content_type != 'maps' and @content_type != 'datasets' ? 'is-selected' : '' }" %>">
+              <a href="<%= CartoDB.url(self, 'public_user_feed_home') %>" class="Navmenu-link Navmenu-link--owner <%= "#{@content_type != 'maps' and @content_type != 'datasets' ? 'is-selected' : '' }" %>">
                 <%= @name %>
               </a>
             </li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.65",
+  "version": "3.19.66",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
close #5770

find screenshots for public map/dataset/datasets

<img width="800" alt="screen shot 2015-09-28 at 14 11 45" src="https://cloud.githubusercontent.com/assets/36676/10135261/8df1e160-65ec-11e5-9062-6ebdad66f1d0.png">
<img width="800" alt="screen shot 2015-09-28 at 14 12 07" src="https://cloud.githubusercontent.com/assets/36676/10135262/8df424de-65ec-11e5-90d4-631706c7a7b4.png">
<img width="800" alt="screen shot 2015-09-28 at 14 12 46" src="https://cloud.githubusercontent.com/assets/36676/10135263/8df6506a-65ec-11e5-8984-11596496f271.png">

also, consolidated behaviour on mobile (hiding username), and link to user feed in public dataset view

CR @javierarce 