### PR TITLE
Get proper website url for user feed and maps/datasets public pages

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -123,7 +123,9 @@ class Admin::PagesController < Admin::AdminController
       @name               = @viewed_user.name.blank? ? @viewed_user.username : @viewed_user.name
       @avatar_url         = @viewed_user.avatar
       @tables_num         = @viewed_user.public_table_count
-      @maps_count         = @viewed_user.public_visualization_count 
+      @maps_count         = @viewed_user.public_visualization_count
+      @website            = website_url(@viewed_user.website)
+      @website_clean      = @website ? @website.gsub(/https?:\/\//, "") : ""
 
       if eligible_for_redirect?(@viewed_user)
         # redirect username.host.ext => org-name.host.ext/u/username
@@ -347,7 +349,7 @@ class Admin::PagesController < Admin::AdminController
     @twitter_username   = model.twitter_username
     @location           = model.location
     @description        = model.description
-    @website            = !model.website.blank? && model.website[/^https?:\/\//].nil? ? "http://#{model.website}" : model.website
+    @website            = website_url(model.website)
     @website_clean      = @website ? @website.gsub(/https?:\/\//, "") : ""
     @name               = required.fetch(:name)
     @avatar_url         = required.fetch(:avatar_url)
@@ -441,6 +443,15 @@ class Admin::PagesController < Admin::AdminController
   def get_viewed_user
     username = CartoDB.extract_subdomain(request)
     @viewed_user = User.where(username: username).first
+  end
+
+
+  def website_url(url)
+    if url.blank?
+      ""
+    else
+      !url.blank? && url[/^https?:\/\//].nil? ? "http://#{url}" : url
+    end
   end
 
 end

--- a/app/views/admin/pages/user_feed.html.erb
+++ b/app/views/admin/pages/user_feed.html.erb
@@ -17,7 +17,7 @@
         <% end %>
 
         <% unless @viewed_user.website.blank? %>
-          <li class="PublicUserProfile-detail"><i class="iconFont iconFont-Anchor iconFont--with-label"></i> <a href="<%= @viewed_user.website %>"><%= @viewed_user.website %></a></li>
+          <li class="PublicUserProfile-detail"><i class="iconFont iconFont-Anchor iconFont--with-label"></i> <a href="<%= @website %>"><%= @website_clean %></a></li>
         <% end %>
 
         <% if @viewed_user.has_organization? %>
@@ -39,4 +39,3 @@
     <div class="Feed js-feed"></div>
   </div>
 </div>
-


### PR DESCRIPTION
#### Problem:
People is used to entering the url w/o http, and the url link is not working in the new user feed.
We solved in the maps/datasets page so I've decided to create a helper method, what do you think @kartones? Is it the right place (biggest doubt)?

Fixes #5775
REVIEWER:  @Kartones 
cc @piensaenpixel, thanks for spotting it.