### PR TITLE
Google+ button fixed

### DIFF
--- a/app/assets/stylesheets/common/account_forms.css.scss
+++ b/app/assets/stylesheets/common/account_forms.css.scss
@@ -672,5 +672,5 @@ $sLabel-width: 140px;
 }
 
 .FormAccount-GooglePlus-iframe {
-  display: none
+  display: none;
 }

--- a/app/assets/stylesheets/common/account_forms.css.scss
+++ b/app/assets/stylesheets/common/account_forms.css.scss
@@ -672,5 +672,5 @@ $sLabel-width: 140px;
 }
 
 .FormAccount-GooglePlus-iframe {
-  border: 0;
+  display: none
 }

--- a/app/assets/stylesheets/common/account_forms.css.scss
+++ b/app/assets/stylesheets/common/account_forms.css.scss
@@ -670,3 +670,7 @@ $sLabel-width: 140px;
     text-decoration: underline;
   }
 }
+
+.FormAccount-GooglePlus-iframe {
+  border: 0;
+}

--- a/lib/assets/javascripts/cartodb/account/entry.js
+++ b/lib/assets/javascripts/cartodb/account/entry.js
@@ -100,7 +100,7 @@ $(function() {
       });
 
       googlePlus.hide();
-      this.$('.js-confirmPassword').after(googlePlus.render().el);
+      this.$('.js-confirmPassword').parent().after(googlePlus.render().el);
     }
 
     // Services items

--- a/lib/assets/javascripts/cartodb/common/views/google_plus.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/google_plus.jst.ejs
@@ -3,7 +3,7 @@
     <label class="FormAccount-label">Google+</label>
   </div>
   <div class="FormAccount-rowData">
-    <iframe class="GooglePlus-iframe js-googleIframe" src="<%- iframeSrc %>" width="300" height="41"></iframe>
+    <iframe class="FormAccount-GooglePlus-iframe GooglePlus-iframe js-googleIframe" src="<%- iframeSrc %>" width="300" height="41"></iframe>
 
     <div class="FormAccount-rowInfo FormAccount-rowInfo--marginLeft">
       <button type="button" class="FormAccount-link FormAccount-rowInfo--marginLeft js-googleDisconnect">Disconnect your Google+ account</button>

--- a/lib/assets/javascripts/cartodb/common/views/google_plus.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/google_plus.jst.ejs
@@ -1,13 +1,16 @@
-<div class="Form-row GooglePlus-row js-googleRow">
-  <div class="Form-rowLabel">
-    <label class="Form-label">Google +</label>
+<div class="FormAccount-row GooglePlus-row js-googleRow">
+  <div class="FormAccount-rowLabel">
+    <label class="FormAccount-label">Google+</label>
   </div>
-  <div class="Form-rowData">
+  <div class="FormAccount-rowData">
     <iframe class="GooglePlus-iframe js-googleIframe" src="<%- iframeSrc %>" width="300" height="41"></iframe>
-    <button type="button" class="Form-link js-googleDisconnect">Disconnect your Google+ account</button>
+
+    <div class="FormAccount-rowInfo FormAccount-rowInfo--marginLeft">
+      <button type="button" class="FormAccount-link FormAccount-rowInfo--marginLeft js-googleDisconnect">Disconnect your Google+ account</button>
+    </div>
   </div>
-  <div class="Form-rowInfo">
-    <p class="Form-rowInfoText js-googleText">Set a new password in order to disconnect from Google</p>
+  <div class="FormAccount-rowInfo">
+    <p class="FormAccount-rowInfoText js-googleText">Set a new password in order to disconnect from Google</p>
   </div>
 </div>
 

--- a/lib/assets/javascripts/cartodb/common/views/google_plus.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/google_plus.jst.ejs
@@ -4,9 +4,8 @@
   </div>
   <div class="FormAccount-rowData">
     <iframe class="FormAccount-GooglePlus-iframe GooglePlus-iframe js-googleIframe" src="<%- iframeSrc %>" width="300" height="41"></iframe>
-
-    <div class="FormAccount-rowInfo FormAccount-rowInfo--marginLeft">
-      <button type="button" class="FormAccount-link FormAccount-rowInfo--marginLeft js-googleDisconnect">Disconnect your Google+ account</button>
+    <div class="FormAccount-rowInfo">
+      <button type="button" class="FormAccount-link js-googleDisconnect">Disconnect your Google+ account</button>
     </div>
   </div>
   <div class="FormAccount-rowInfo">


### PR DESCRIPTION
Fixes #5727
Now users with Google+ login will see its account options correctly.

![screen shot 2015-09-28 at 17 51 44](https://cloud.githubusercontent.com/assets/2141690/10140783/9fe70d92-6609-11e5-8f68-a9d16f50a280.png)

CR @xavijam 


