### PR TITLE
Display annotations and use CDN in highlighted explore map

### DIFF
--- a/lib/assets/javascripts/cartodb/explore/entry.js
+++ b/lib/assets/javascripts/cartodb/explore/entry.js
@@ -60,14 +60,13 @@ $(function() {
         createVis: {
           url: visURL,
           opts: {
-            no_cdn: true
+            annotation: true
           }
         }
       });
 
       favMapView.render();
       self.$('.js-favMapTitle').removeClass('is-hidden');
-
     };
 
     this.exploreModel.fetch({ success: onSuccess });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.67",
+  "version": "3.19.68",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We should use CDN tiles instead of application tiles, and showing annotations if the map has any of those.

Fixes #5789.

REVIEWER: @javierarce 