### PR TITLE
Form account row margin fixed

### DIFF
--- a/app/assets/stylesheets/common/account_forms.css.scss
+++ b/app/assets/stylesheets/common/account_forms.css.scss
@@ -60,7 +60,7 @@ $sLabel-width: 140px;
   @include display-flex();
   @include flex-direction(column);
   @include justify-content(flex-start, start);
-  margin: 0 0 30px;
+  margin: 0 0 20px;
 }
 .FormAccount-row--wideMarginBottom {
   margin-bottom: 100px;


### PR DESCRIPTION
Fixes #5681 
Now `.FormAccount-row` selector has 20px of bottom margin instead 30px.

![screen shot 2015-09-29 at 23 40 09](https://cloud.githubusercontent.com/assets/2141690/10179022/a109ce62-6703-11e5-89eb-3646f377cafb.png)

CR @xavijam CC @saleiva 
