### PR TITLE
execute_on_users_with_index for revoke_cdb_conf_access closes CartoDB/cartodb-platform#1149

### DIFF
--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -1159,7 +1159,7 @@ namespace :cartodb do
         else
           puts "ERROR #{user.username}: #{errors.join(';')}"
         end
-      })
+      }, 1, 0.3)
     end
 
     desc "Assign organization owner admin role at database. See CartoDB/cartodb-postgresql#104 and #5187"

--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -1152,14 +1152,14 @@ namespace :cartodb do
 
     desc "Revokes access to cdb_conf"
     task :revoke_cdb_conf_access => :environment do |t, args|
-      User.all.each_with_index do |user, i|
+      execute_on_users_with_index(:revoke_cdb_conf_access.to_s, Proc.new { |user, i|
         errors = user.revoke_cdb_conf_access
         if errors.empty?
           puts "OK #{user.username}"
         else
           puts "ERROR #{user.username}: #{errors.join(';')}"
         end
-      end
+      })
     end
 
     desc "Assign organization owner admin role at database. See CartoDB/cartodb-postgresql#104 and #5187"


### PR DESCRIPTION
This closes CartoDB/cartodb-platform#1149. @Kartones @azamorano CR this, please. I've used default parameters for `execute_on_users_with_index`.

I've tested it in ded02, with 3452 users and it has taken 12 minutes.