### PR TITLE
Captures random_name return 5822

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -277,11 +277,11 @@ module CartoDB
 
       def name_from(headers, url, custom=nil)
         name =  custom || name_from_http(headers) || name_in(url)
+
         if name == nil || name == ''
-          random_name
-        else
-          name
+          name = random_name
         end
+
         name_with_extension(name, headers)
       end
 

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -236,6 +236,14 @@ describe Downloader do
       downloader.send(:name_from, headers, hard_url).should eq 'zip_file.csv.zip'
     end
 
+    it 'uses random name in no name can be found in url or http headers' do
+      headers = {}
+      empty_url = "https://manolo.escobar.es/param&myfilenameparam&nothing&otherinfo"
+
+      downloader = Downloader.new(empty_url)
+      downloader.send(:name_from, headers, empty_url).should_not eq nil
+    end
+
     it 'discards url query params' do
       headers = {}
       downloader = Downloader.new(@file_url)


### PR DESCRIPTION
Fixes #5822

Because of previous `name_in(url)` method always returning something, the following code was not ready for `random_name`'s return to be used. 

My bad for not testing a no-url-name no-http-header-name import, and not discovering this earlier.

It should now work.

Please, CR @rafatower or @ethervoid

cc/ @iriberri