### PR TITLE
Sends the right dimensions to the advanced export dialog 

### DIFF
--- a/lib/assets/javascripts/cartodb/table/export_image_view.js
+++ b/lib/assets/javascripts/cartodb/table/export_image_view.js
@@ -57,11 +57,8 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
       _.extend(this.options, this.header.attributes);
     }
 
-    this.viewPortWidth = this.options.width;
-    this.viewPortHeight = this.options.height;
-
-    this.width  = this.viewPortWidth  - this.options.horizontalMargin;
-    this.height = this.viewPortHeight- this.options.verticalMargin;
+    this.width  = this.options.width  - this.options.horizontalMargin;
+    this.height = this.options.height - this.options.verticalMargin;
 
     this.model = new cdb.core.Model({
       format: 'png',
@@ -79,7 +76,7 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
   render: function() {
     this.template_base = cdb.templates.getTemplate(this.options.template_name);
 
-    this.$el.append(this.template_base( _.extend( this.options, { width: this.width, height: this.height })));
+    this.$el.append(this.template_base(_.extend({}, this.options, { width: this.width, height: this.height })));
 
     this._setupCanvas();
     this._hideOverlays();
@@ -288,8 +285,8 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
       enter_to_confirm: false,
       user: this.options.user,
       format: this.model.get('format'),
-      width: this.viewPortWidth,
-      height: this.viewPortHeight
+      width: this.options.width,
+      height: this.options.height
     });
 
     view.appendToBody();

--- a/lib/assets/javascripts/cartodb/table/export_image_view.js
+++ b/lib/assets/javascripts/cartodb/table/export_image_view.js
@@ -57,8 +57,11 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
       _.extend(this.options, this.header.attributes);
     }
 
-    this.width  = this.options.width  - this.options.horizontalMargin;
-    this.height = this.options.height - this.options.verticalMargin;
+    this.viewPortWidth = this.options.width;
+    this.viewPortHeight = this.options.height;
+
+    this.width  = this.viewPortWidth  - this.options.horizontalMargin;
+    this.height = this.viewPortHeight- this.options.verticalMargin;
 
     this.model = new cdb.core.Model({
       format: 'png',
@@ -285,8 +288,8 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
       enter_to_confirm: false,
       user: this.options.user,
       format: this.model.get('format'),
-      width: this.options.width,
-      height: this.options.height
+      width: this.viewPortWidth,
+      height: this.viewPortHeight
     });
 
     view.appendToBody();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.19.71",
+  "version": "3.19.72",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes a problem that prevented sending the right dimensions to the advanced dialog (the problem was that this.options.width and this.options.height was being overwritten in the extend)