### PR TITLE
Only filter the remotes in a mixed visualization search

### DIFF
--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -234,8 +234,13 @@ class Carto::VisualizationQueryBuilder
     end
 
     if @exclude_imported_remote_visualizations
-      # Filter legacy remotes that don't have display name
-      query = query.where('"visualizations"."display_name" IS NOT NULL')
+      # Right now only common-data public visualizations have display name setted so
+      # the data-library visualizations have it too. So if we want to filter legacy remote
+      # visualizations without display_name, we have to to this way.
+      # We take into account other types and exclude from the display_name because the search
+      # of datasets, for example, make a query with multiples types (table, remote) and we don't
+      # want to filter the table ones
+      query = query.where('("visualizations"."type" <> \'remote\' OR "visualizations"."type" = \'remote\' AND "visualizations"."display_name" IS NOT NULL)')
     end
 
     if @type

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1585,6 +1585,39 @@ describe Carto::Api::VisualizationsController do
       collection[2]['id'].should == vis_3_id
     end
 
+    it 'mixed types search should filter only remote without display name' do
+
+      post api_v1_visualizations_create_url(api_key: $user_1.api_key),
+           factory($user_1, locked: true, type: 'table').to_json, @headers
+      vis_1_id = JSON.parse(last_response.body).fetch('id')
+
+      post api_v1_visualizations_create_url(api_key: $user_1.api_key),
+           factory($user_1, locked: true, type: 'remote', name: 'visu2', display_name: 'visu2').to_json, @headers
+      vis_2_id = JSON.parse(last_response.body).fetch('id')
+      Carto::ExternalSource.new(
+        visualization_id: vis_2_id,
+        import_url: 'http://www.fake.com',
+        rows_counted: 1,
+        size: 200).save
+
+      post api_v1_visualizations_create_url(api_key: $user_1.api_key),
+           factory($user_1, locked: true, type: 'remote', name: 'visu3').to_json, @headers
+      vis_3_id = JSON.parse(last_response.body).fetch('id')
+      Carto::ExternalSource.new(
+        visualization_id: vis_3_id,
+        import_url: 'http://www.fake.com',
+        rows_counted: 1,
+        size: 200).save
+
+      get api_v1_visualizations_index_url(api_key: $user_1.api_key, types: 'remote,table'), {}, @headers
+      last_response.status.should == 200
+      response    = JSON.parse(last_response.body)
+      collection  = response.fetch('visualizations')
+      collection.length.should eq 2
+      [vis_1_id, vis_2_id].include?(collection[0]['id']).should eq true
+      [vis_1_id, vis_2_id].include?(collection[1]['id']).should eq true
+    end
+
   end
 
   describe 'index shared_only' do


### PR DESCRIPTION
Now the search is filtering all the visualizations checking for non null display name when remotes are in the search type. This PR fix it

Please @juanignaciosl check this PR when green