### PR TITLE
Remove user_domain from login and signup urls

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,14 +13,14 @@ CartoDB::Application.routes.draw do
   get   '/(user/:user_domain)(u/:user_domain)'                 => 'admin/pages#public', as: :root
   root :to => 'admin/pages#index'
 
-  get   '(/user/:user_domain)(/u/:user_domain)/signup'           => 'signup#signup',     as: :signup
-  post  '(/user/:user_domain)(/u/:user_domain)/signup'           => 'signup#create',  as: :signup_organization_user
+  get   '/signup'           => 'signup#signup',     as: :signup
+  post  '/signup'           => 'signup#create',  as: :signup_organization_user
 
   get   '(/user/:user_domain)(/u/:user_domain)/enable_account_token/:id' => 'account_tokens#enable',     as: :enable_account_token_show
   get   '(/user/:user_domain)(/u/:user_domain)/resend_validation_mail/:user_id' => 'account_tokens#resend',     as: :resend_validation_mail
   get   '(/user/:user_domain)(/u/:user_domain)/account_token_authentication_error' => 'sessions#account_token_authentication_error',     as: :account_token_authentication_error
 
-  get   '(/user/:user_domain)(/u/:user_domain)/login'           => 'sessions#new',     as: :login
+  get   '/login'           => 'sessions#new',     as: :login
   get   '(/user/:user_domain)(/u/:user_domain)/logout'          => 'sessions#destroy', as: :logout
   match '(/user/:user_domain)(/u/:user_domain)/sessions/create' => 'sessions#create',  as: :create_session
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# rubocop:disable Metrics/LineLength, Style/ExtraSpacing
+# rubocop:disable Metrics/LineLength, Style/ExtraSpacing, Style/SingleSpaceBeforeFirstArg
 
 # NOTES:
 # (/u/:user_domain)     -> This allows support of org-urls (support != enforcement)
@@ -531,4 +531,4 @@ CartoDB::Application.routes.draw do
 
 end
 
-# rubocop:enable Metrics/LineLength, Style/ExtraSpacing
+# rubocop:enable Metrics/LineLength, Style/ExtraSpacing, Style/SingleSpaceBeforeFirstArg


### PR DESCRIPTION
This fixes #5725. @Kartones , could you CR this, please? I copied login route when I did signup. Is `user_domain` necessary in any login scenario?