### PR TITLE
Fixing vertical align for privacy toggler when element is a link

### DIFF
--- a/app/assets/stylesheets/common/privacy_toggler.css.scss
+++ b/app/assets/stylesheets/common/privacy_toggler.css.scss
@@ -12,6 +12,7 @@
   border: 1px solid $cStructure-softLine;
   border-radius: 40px;
   font-size: 16px;
+  line-height: 40px;
   text-align: center;
   vertical-align: middle;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #5824 