### PR TITLE
Configurable uploads folder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
   6. From now on you must run the server in multithread mode: `bundle exec thin start --threaded -p 3000 --threadpool-size 5`.
 * New visualization backups feature. Upon viz deletion a special vizjson will be stored in a new DB table. Backups live for Carto::VisualizationsExportService::DAYS_TO_KEEP_BACKUP days and can be recovered with `cartodb:vizs:import_user_visualization` rake by visualization id. Needs new feature flag `visualizations_backup`. Check https://github.com/CartoDB/cartodb/issues/5710 for additional details
 * Fully removed Layer parent_id from backend and frontend as wasn't used.
+* Added new (optional) config parameters `unp_temporal_folder` & `uploads_path` under `importer` section to allow custom UNP and file upload paths.
 
 
 3.11.0 (2015-09-09)

--- a/app/controllers/api/json/uploads_controller.rb
+++ b/app/controllers/api/json/uploads_controller.rb
@@ -22,9 +22,12 @@ class Api::Json::UploadsController < Api::ApplicationController
 
         random_token = Digest::SHA2.hexdigest("#{Time.now.utc}--#{filename.object_id.to_s}").first(20)
 
+        file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
+        file_upload_helper.get_uploads_path
+
         @stats_aggregator.timing('save') do
-          FileUtils.mkdir_p(Rails.root.join('public/uploads').join(random_token))
-          file = File.new(Rails.root.join('public/uploads').join(random_token).join(File.basename(filename)), 'w')
+          FileUtils.mkdir_p(file_upload_helper.get_uploads_path.join(random_token))
+          file = File.new(file_upload_helper.get_uploads_path.join(random_token).join(File.basename(filename)), 'w')
           file.write filedata
           file.close
         end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -78,7 +78,9 @@ class Asset < Sequel::Model
   end
 
   def save_local(filename)
-    local_path = Rails.root.join 'public', 'uploads', target_asset_path
+    file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
+
+    local_path = file_upload_helper.get_uploads_path.join(target_asset_path)
     FileUtils.mkdir_p local_path
     FileUtils.cp @file.path, local_path.join(filename)
     p = File.join('/', 'uploads', target_asset_path, filename)

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -259,7 +259,8 @@ class DataImport < Sequel::Model
   def remove_uploaded_resources
     return nil unless uploaded_file
 
-    path = Rails.root.join('public', 'uploads', uploaded_file[1])
+    file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
+    path = file_upload_helper.get_uploads_path.join(uploaded_file[1])
     FileUtils.rm_rf(path) if Dir.exists?(path)
   end
 

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -192,11 +192,11 @@ module CartoDB
                                                   downloader: downloader,
                                                   log: log,
                                                   user: user,
-                                                  unpacker: CartoDB::Importer2::Unp.new,
-                                                  post_import_handler: post_import_handler
+                                                  unpacker: CartoDB::Importer2::Unp.new(Cartodb.config[:importer]),
+                                                  post_import_handler: post_import_handler,
+                                                  importer_config: Cartodb.config[:importer]
                                                 })
         runner.loader_options = ogr2ogr_options.merge content_guessing_options
-
 
         runner.include_additional_errors_mapping(
           {
@@ -314,7 +314,8 @@ module CartoDB
                 last_modified:    modified_at,
                 checksum:         checksum,
                 verify_ssl_cert:  false
-              }
+              },
+              { importer_config: Cartodb.config[:importer] }
           )
           log.append "File will be downloaded from #{downloader.url}"
         else
@@ -323,7 +324,8 @@ module CartoDB
             datasource_provider, metadata,
             {
               http_timeout:     DataImport.http_timeout_for(user),
-              checksum: checksum
+              checksum: checksum,
+              importer_config: Cartodb.config[:importer]
             }, log
           )
         end

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -176,6 +176,7 @@ defaults: &defaults
       url_ttl:
       async_long_uploads: false
     unp_temporal_folder: '/tmp/imports/'
+    # It must end in `/uploads` and be accessible via HTTP, if relative will default to Rails.Root/#{uploads_path}
     uploads_path: 'public/uploads'
   error_track:
     url: 'https://viz2.cartodb.com/api/v1/sql'

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -175,6 +175,8 @@ defaults: &defaults
       bucket_name:
       url_ttl:
       async_long_uploads: false
+    unp_temporal_folder: '/tmp/imports/'
+    uploads_path: 'public/uploads'
   error_track:
     url: 'https://viz2.cartodb.com/api/v1/sql'
     percent_users: 10

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,14 +1,14 @@
 # encoding: utf-8
 require 'fileutils'
 
-require_relative '../../app/helpers/file_upload_helper'
+require_relative '../../app/helpers/file_upload'
 
 namespace :cartodb do
   desc 'Import a file to CartoDB'
   task :import, [:username, :filepath] => [:environment] do |task, args|
     user        = User.where(username: args[:username]).first
     filepath    = File.expand_path(args[:filepath])
-    
+
     data_import = DataImport.create(
       :user_id       => user.id,
       :data_source   => filepath,
@@ -29,6 +29,8 @@ namespace :cartodb do
                                  .order(:created_at)
                                  .first
 
+    file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
+
     unless data_import_item.nil?
       begin
         puts "Retrieved #{data_import_item.id}"
@@ -36,21 +38,21 @@ namespace :cartodb do
         data_import_item.state = DataImport::STATE_PENDING
         data_import_item.save
 
-
         filepath = data_import_item.data_source
-
         filename = data_import_item.data_source.slice(data_import_item.data_source.rindex('/')+1,
                                                       data_import_item.data_source.length)
 
-        token = data_import_item.data_source.slice(/#{FileUploadHelper::UPLOADS_PATH}\/(.)+\//)
-                                            .sub("#{FileUploadHelper::UPLOADS_PATH}/",'')
+        uploads_path = file_upload_helper.get_uploads_path
+
+        token = data_import_item.data_source.slice(/#{uploads_path}\/(.)+\//)
+                                            .sub("#{uploads_path}/",'')
                                             .sub('/','')
 
-        file_uri = FileUploadHelper.upload_file_to_s3(filepath, filename, token, Cartodb.config[:importer]['s3'])
+        file_uri = file_upload_helper.upload_file_to_s3(filepath, filename, token, Cartodb.config[:importer]['s3'])
         begin
           File.delete(filepath)
-          folder = filepath.slice(0, filepath.rindex('/')).gsub('..','')
-          FileUtils.rm_rf(folder) unless folder.length < FileUploadHelper::UPLOADS_PATH.length
+          folder = filepath.slice(0, filepath.rindex('/')).gsub('..' , '')
+          FileUtils.rm_rf(folder) unless folder.length < uploads_path.to_s.length
         rescue => exception
           puts "Errored #{data_import_item.id} : #{exception}"
           CartoDB::notify_exception(exception, {
@@ -78,7 +80,7 @@ namespace :cartodb do
 
         File.delete(filepath)
         folder = filepath.slice(0, filepath.rindex('/')).gsub('..','')
-        FileUtils.rm_rf(folder) unless folder.length < FileUploadHelper::UPLOADS_PATH.length
+        FileUtils.rm_rf(folder) unless folder.length < file_upload_helper.get_uploads_path.to_s.length
       end
     end
   end

--- a/services/importer/lib/importer/csv_normalizer.rb
+++ b/services/importer/lib/importer/csv_normalizer.rb
@@ -25,12 +25,13 @@ module CartoDB
       REVERSE_LINE_FEED     = "\x8D"
 
 
-      def initialize(filepath, job=nil)
+      def initialize(filepath, job = nil, importer_config = nil)
         @filepath = filepath
         @job      = job || Job.new
         @delimiter = nil
         @force_normalize = false
         @encoding = nil
+        @importer_config = importer_config
       end
 
       def force_normalize
@@ -83,9 +84,9 @@ module CartoDB
         end
 
         occurrences = Hash[
-          COMMON_DELIMITERS.map { |delimiter| 
-            [delimiter, lines_for_detection.map { |line| 
-              line.count(delimiter) }] 
+          COMMON_DELIMITERS.map { |delimiter|
+            [delimiter, lines_for_detection.map { |line|
+              line.count(delimiter) }]
           }
         ]
 
@@ -93,9 +94,9 @@ module CartoDB
 
         variances = Hash.new
         @delimiter = DEFAULT_DELIMITER
-        
+
         use_variance = true
-        occurrences.each { |key, values| 
+        occurrences.each { |key, values|
           if values.length > 1
             variances[key] = sample_variance(values) unless values.first == 0
           elsif values.length == 1
@@ -235,7 +236,7 @@ module CartoDB
       private
 
       def generate_temporary_directory
-        self.temporary_directory = Unp.new.generate_temporary_directory.temporary_directory
+        self.temporary_directory = Unp.new(@importer_config).generate_temporary_directory.temporary_directory
         self
       end
 

--- a/services/importer/lib/importer/datasource_downloader.rb
+++ b/services/importer/lib/importer/datasource_downloader.rb
@@ -9,13 +9,14 @@ module CartoDB
   module Importer2
     class DatasourceDownloader
 
-      def initialize(datasource, item_metadata, options={}, logger = nil, repository=nil)
+      def initialize(datasource, item_metadata, options = {}, logger = nil, repository = nil)
         @checksum = nil
 
         @source_file = nil
         @datasource = datasource
         @item_metadata = item_metadata
         @options = options
+        @importer_config = options[:importer_config]
         raise UploadError if datasource.nil?
 
         @logger = logger
@@ -46,7 +47,7 @@ module CartoDB
 
       def clean_up
         if defined?(@temporary_directory) \
-           && @temporary_directory =~ /^#{CartoDB::Importer2::Unp::IMPORTER_TMP_SUBFOLDER}/ \
+           && @temporary_directory =~ /^#{Unp.new(@importer_config).get_temporal_subfolder_path}/ \
            && !(@temporary_directory =~ /\.\./)
           FileUtils.rm_rf @temporary_directory
         end
@@ -70,7 +71,7 @@ module CartoDB
       attr_reader  :source_file, :item_metadata, :datasource, :options, :logger, :repository
 
       private
-      
+
       attr_writer :source_file
 
       # In the case of DirectStream datasources, this will store a sample to trigger DB creation.
@@ -138,7 +139,7 @@ module CartoDB
 
       def temporary_directory
         return @temporary_directory if @temporary_directory
-        @temporary_directory = Unp.new.generate_temporary_directory.temporary_directory
+        @temporary_directory = Unp.new(@importer_config).generate_temporary_directory.temporary_directory
       end
     end
   end

--- a/services/importer/lib/importer/excel2csv.rb
+++ b/services/importer/lib/importer/excel2csv.rb
@@ -18,14 +18,15 @@ module CartoDB
 
       def self.supported?(extension)
         extension == ".#{@format}"
-      end #self.supported?
+      end
 
-      def initialize(supported_format, filepath, job=nil, csv_normalizer=nil)
+      def initialize(supported_format, filepath, job=nil, csv_normalizer=nil, importer_config = nil)
         @format = "#{supported_format.downcase}"
         @filepath = filepath
         @job      = job || Job.new
-        @csv_normalizer = csv_normalizer || CsvNormalizer.new(converted_filepath, @job)
-      end #initialize
+        @importer_config = importer_config
+        @csv_normalizer = csv_normalizer || CsvNormalizer.new(converted_filepath, @job, @importer_config)
+      end
 
       def run
         job.log "Converting #{@format.upcase} to CSV"
@@ -44,21 +45,20 @@ module CartoDB
           job.log "done executing in2csv."
         end
 
-
         # Can be check locally using wc -l ... (converted_filepath)
         job.log "Orig file: #{filepath}\nTemp destination: #{converted_filepath}"
         # Roo gem is not exporting always correctly when source Excel has atypical UTF-8 characters
         @csv_normalizer.force_normalize
         @csv_normalizer.run
         self
-      end #run
+      end
 
       def converted_filepath
         File.join(
           File.dirname(filepath),
           File.basename(filepath, File.extname(filepath))
         ) + '.csv'
-      end #converted_filepath
+      end
 
       protected
 
@@ -71,6 +71,6 @@ module CartoDB
       end
 
       attr_reader :filepath, :job
-    end #Excel2Csv
-  end # Importer2
-end # CartoDB
+    end
+  end
+end

--- a/services/importer/lib/importer/format_linter.rb
+++ b/services/importer/lib/importer/format_linter.rb
@@ -10,7 +10,8 @@ module CartoDB
         extension == '.kml'
       end
 
-      def initialize(filepath, job=nil)
+      # INFO: importer_config not used but needed for compatibility with other normalizers
+      def initialize(filepath, job = nil, importer_config = nil)
         @filepath = filepath
         @job      = job || Job.new
       end
@@ -30,7 +31,7 @@ module CartoDB
 
       private
 
-      attr_reader :filepath, :job 
+      attr_reader :filepath, :job
     end # FormatLinter
   end # Importer2
 end # CartoDB

--- a/services/importer/lib/importer/kml_splitter.rb
+++ b/services/importer/lib/importer/kml_splitter.rb
@@ -46,7 +46,7 @@ module CartoDB
       end
 
       def layers_in(source_file)
-        stdout, stderr, status = 
+        stdout, stderr, status =
           Open3.capture3("ogrinfo #{source_file.fullpath}")
         stdout.split("\n")
           .select { |line| line =~ /\A\d/ }
@@ -66,7 +66,6 @@ module CartoDB
 
       attr_reader :temporary_directory
       attr_writer :source_file
-    end # KmlSplitter
-  end # Importer2
-end # CartoDB
-  
+    end
+  end
+end

--- a/services/importer/lib/importer/loader.rb
+++ b/services/importer/lib/importer/loader.rb
@@ -32,7 +32,7 @@ module CartoDB
         !(%w{ .tif .tiff .sql }.include?(extension))
       end
 
-      def initialize(job, source_file, layer=nil, ogr2ogr=nil, georeferencer=nil)
+      def initialize(job, source_file, layer = nil, ogr2ogr = nil, georeferencer = nil)
         self.job            = job
         self.source_file    = source_file
         self.layer          = 'track_points' if source_file.extension =~ /\.gpx/
@@ -115,7 +115,7 @@ module CartoDB
           .inject(source_file.fullpath) { |filepath, normalizer_klass|
 
             @importer_stats.timing(normalizer_klass.to_s.split('::').last) do
-              normalizer = normalizer_klass.new(filepath, job)
+              normalizer = normalizer_klass.new(filepath, job, options[:importer_config])
 
               FORCE_NORMALIZER_REGEX.each { |regex|
                 normalizer.force_normalize if regex =~ source_file.path
@@ -165,7 +165,7 @@ module CartoDB
           normalizer.supported?(source_file.extension)
         }
         return DEFAULT_ENCODING unless normalizer
-        normalizer.new(source_file.fullpath, job).encoding
+        normalizer.new(source_file.fullpath, job, options[:importer_config]).encoding
       end
 
       def shapefile_without_prj?

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -53,6 +53,7 @@ module CartoDB
           !@user.nil? && @user.respond_to?(:remaining_quota) ? @user.remaining_quota : DEFAULT_AVAILABLE_QUOTA
         @unpacker            = options.fetch(:unpacker, nil) || Unp.new
         @post_import_handler = options.fetch(:post_import_handler, nil)
+        @importer_config = options.fetch(:importer_config, nil)
         @importer_stats = CartoDB::Stats::Importer.instance
         limit_instances = options.fetch(:limits, {})
         @import_file_limit = limit_instances.fetch(:import_file_size_instance, input_file_size_limit_instance(@user))
@@ -154,7 +155,7 @@ module CartoDB
         raise EmptyFileError if source_file.empty?
 
         loader.set_importer_stats(@importer_stats) if loader.respond_to?(:set_importer_stats)
-        loader.options = @loader_options.merge(tracker: tracker)
+        loader.options = @loader_options.merge(tracker: tracker, importer_config: @importer_config)
 
         tracker.call('importing')
         @job.log "Importing data from #{source_file.fullpath}"

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -149,7 +149,7 @@ module CartoDB
       attr_reader :pg_options, :unpacker, :available_quota, :job
       attr_writer :results, :tracker
 
-      def import(source_file, downloader, loader_object=nil)
+      def import(source_file, downloader, loader_object = nil)
         loader = loader_object || loader_for(source_file).new(@job, source_file)
 
         raise EmptyFileError if source_file.empty?

--- a/services/importer/lib/importer/shp_normalizer.rb
+++ b/services/importer/lib/importer/shp_normalizer.rb
@@ -61,7 +61,8 @@ module CartoDB
         %w{ .shp .tab }.include?(extension)
       end
 
-      def initialize(filepath, job)
+      # INFO: importer_config not used but needed for compatibility with other normalizers
+      def initialize(filepath, job, importer_config = nil)
         @job      = job
         @filepath = filepath
         @helper = ShpHelper.new(filepath)

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -15,17 +15,24 @@ module CartoDB
       COMPRESSED_EXTENSIONS = %w{ .zip .gz .tgz .tar.gz .bz2 .tar .kmz }
       SUPPORTED_FORMATS     = %w{
         .csv .shp .ods .xls .xlsx .tif .tiff .kml .kmz
-        .js .json .tar .gz .tgz .osm .bz2 .geojson 
+        .js .json .tar .gz .tgz .osm .bz2 .geojson
         .gpx .sql .tab .tsv .txt
       }
-      SPLITTERS             = [KmlSplitter, OsmSplitter]
+      SPLITTERS = [KmlSplitter, OsmSplitter]
 
-      IMPORTER_TMP_SUBFOLDER = '/tmp/imports/'
+      DEFAULT_IMPORTER_TMP_SUBFOLDER = '/tmp/imports/'
 
       attr_reader :source_files, :temporary_directory
 
-      def initialize
+      def initialize(importer_config = nil)
         @source_files = []
+        if !importer_config.nil? && !importer_config['unp_temporal_folder'].nil?
+          @temporal_subfolder_path = importer_config['unp_temporal_folder']
+        end
+      end
+
+      def get_temporal_subfolder_path
+        @temporal_subfolder_path ||= DEFAULT_IMPORTER_TMP_SUBFOLDER
       end
 
       def run(path)
@@ -173,8 +180,8 @@ module CartoDB
 
       # Return a new temporary file contained inside a tmp subfolder
       def temporary_file
-        FileUtils.mkdir_p(IMPORTER_TMP_SUBFOLDER) unless File.directory?(IMPORTER_TMP_SUBFOLDER)
-        Tempfile.new('', IMPORTER_TMP_SUBFOLDER)
+        FileUtils.mkdir_p(get_temporal_subfolder_path) unless File.directory?(get_temporal_subfolder_path)
+        Tempfile.new('', get_temporal_subfolder_path)
       end
 
       def temporary_directory
@@ -198,7 +205,7 @@ module CartoDB
         SPLITTERS.select { |splitter| splitter.support?(source_file) }
           .first
       end
-      
+
       private
 
       attr_reader :job

--- a/services/importer/lib/importer/xls2csv.rb
+++ b/services/importer/lib/importer/xls2csv.rb
@@ -4,17 +4,17 @@ require_relative './excel2csv'
 module CartoDB
   module Importer2
     class Xls2Csv < Excel2Csv
-      
+
       SUPPORTED_EXTENSION = 'xls'
 
       def self.supported?(extension)
         extension == ".#{SUPPORTED_EXTENSION}"
-      end #self.supported?
+      end
 
-      def initialize(filepath, job=nil)
-        super(SUPPORTED_EXTENSION, filepath, job)
-      end #initialize
+      def initialize(filepath, job = nil, importer_config = nil)
+        super(SUPPORTED_EXTENSION, filepath, job, importer_config)
+      end
 
-    end #Xls2Csv
-  end # Importer2
-end # CartoDB
+    end
+  end
+end

--- a/services/importer/lib/importer/xlsx2csv.rb
+++ b/services/importer/lib/importer/xlsx2csv.rb
@@ -4,17 +4,17 @@ require_relative './excel2csv'
 module CartoDB
   module Importer2
     class Xlsx2Csv < Excel2Csv
-      
+
       SUPPORTED_EXTENSION = 'xlsx'
 
       def self.supported?(extension)
         extension == ".#{SUPPORTED_EXTENSION}"
-      end #self.supported?
+      end
 
-      def initialize(filepath, job=nil)
-        super(SUPPORTED_EXTENSION, filepath, job)
-      end #initialize
+      def initialize(filepath, job = nil, importer_config = nil)
+        super(SUPPORTED_EXTENSION, filepath, job, importer_config)
+      end
 
-    end #Xlsx2Csv
-  end # Importer2
-end # CartoDB
+    end
+  end
+end

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -33,15 +33,15 @@ describe Downloader do
 
   describe '#run' do
     it 'downloads a file from a url' do
-      stub_download(url: @file_url, filepath: @file_filepath) 
+      stub_download(url: @file_url, filepath: @file_filepath)
 
-      downloader = Downloader.new(@file_url, {}, nil, @repository)
+      downloader = Downloader.new(@file_url, {}, {}, nil, @repository)
       downloader.run
       File.exists?(downloader.source_file.fullpath).should eq true
     end
 
     it 'extracts the source_file name from the URL' do
-      stub_download(url: @file_url, filepath: @file_filepath) 
+      stub_download(url: @file_url, filepath: @file_filepath)
 
       downloader = Downloader.new(@file_url)
       downloader.run
@@ -57,8 +57,8 @@ describe Downloader do
 
     it 'uses file name for file without extension and with unknown Content-Type header' do
       stub_download(
-          url: @file_url_without_extension, 
-          filepath: @file_filepath_without_extension, 
+          url: @file_url_without_extension,
+          filepath: @file_filepath_without_extension,
           headers: { 'Content-Type' => 'application/octet-stream' }
       )
       downloader = Downloader.new(@file_url_without_extension)
@@ -70,8 +70,8 @@ describe Downloader do
       url_csv_with_extension = "http://www.example.com/ngos.csv"
       csv_filepath_with_extension  = path_to('ngos.csv')
       stub_download(
-          url: url_csv_with_extension, 
-          filepath: csv_filepath_with_extension, 
+          url: url_csv_with_extension,
+          filepath: csv_filepath_with_extension,
           headers: { 'Content-Type' => 'application/octet-stream' }
       )
       downloader = Downloader.new(url_csv_with_extension)
@@ -81,8 +81,8 @@ describe Downloader do
 
     it 'uses Content-Type header extension for files with different extension' do
       stub_download(
-          url: @file_url_with_wrong_extension, 
-          filepath: @file_filepath_with_wrong_extension, 
+          url: @file_url_with_wrong_extension,
+          filepath: @file_filepath_with_wrong_extension,
           headers: { 'Content-Type' => 'text/csv' }
       )
       downloader = Downloader.new(@file_url_with_wrong_extension)
@@ -94,8 +94,8 @@ describe Downloader do
       url_tgz_without_extension = "http://www.example.com/csvwithwrongextension.xml"
       tgz_filepath_without_extension  = path_to('csvwithwrongextension.xml')
       stub_download(
-          url: url_tgz_without_extension, 
-          filepath: tgz_filepath_without_extension, 
+          url: url_tgz_without_extension,
+          filepath: tgz_filepath_without_extension,
           headers: { 'Content-Type' => 'text/csv' }
       )
       downloader = Downloader.new(url_tgz_without_extension)
@@ -107,8 +107,8 @@ describe Downloader do
       url_tgz_without_extension = "http://www.example.com/ok_data.csv.gz"
       tgz_filepath_without_extension  = path_to('ok_data.csv.gz')
       stub_download(
-          url: url_tgz_without_extension, 
-          filepath: tgz_filepath_without_extension, 
+          url: url_tgz_without_extension,
+          filepath: tgz_filepath_without_extension,
           headers: { 'Content-Type' => 'application/x-gzip' }
       )
       downloader = Downloader.new(url_tgz_without_extension)
@@ -126,9 +126,9 @@ describe Downloader do
       downloader.run
       downloader.source_file.name.should eq 'forest_change'
     end
-    
+
     it 'supports FTP urls' do
-      stub_download(url: @ftp_url, filepath: @ftp_filepath) 
+      stub_download(url: @ftp_url, filepath: @ftp_filepath)
 
       downloader = Downloader.new(@ftp_url)
       downloader.run
@@ -163,7 +163,7 @@ describe Downloader do
         headers:  { "ETag" => etag }
       )
 
-      downloader = Downloader.new(@file_url, etag: etag)
+      downloader = Downloader.new(@file_url, {etag: etag})
       downloader.run
       downloader.modified?.should eq false
     end
@@ -174,7 +174,7 @@ describe Downloader do
         filepath: @file_filepath,
         headers:  {}
       )
-      
+
       downloader = Downloader.new(@file_url)
       lambda { downloader.run }.should raise_error DownloadError
     end
@@ -215,7 +215,7 @@ describe Downloader do
       downloader = Downloader.new(@file_url)
       downloader.send(:name_from, headers, @file_url).should eq 'bar.csv'
 
-      disposition = "attachment; filename=map_gaudi3d.geojson; " + 
+      disposition = "attachment; filename=map_gaudi3d.geojson; " +
                     'modification-date="Tue, 06 Aug 2013 15:05:35 GMT'
       headers = { "Content-Disposition" => disposition }
       downloader = Downloader.new(@file_url)

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -18,7 +18,7 @@ describe Unp do
     it 'populates a list of source files' do
       zipfile   = zipfile_factory
       unp       = Unp.new
-      
+
       unp.source_files.should be_empty
       unp.run(zipfile)
       unp.source_files.should_not be_empty
@@ -238,6 +238,15 @@ describe Unp do
       Unp.new.unp_failure?('', 999).should eq true
     end
   end #unp_failure?
+
+  describe "configuration" do
+    it "Uses a different configuration path if specified" do
+      new_config_path = "/fake/uploads"
+
+      Unp.new("unp_temporal_folder" => new_config_path).get_temporal_subfolder_path.should eq new_config_path
+      Unp.new.get_temporal_subfolder_path.should eq Unp::DEFAULT_IMPORTER_TMP_SUBFOLDER
+    end
+  end
 
   def zipfile_factory(dir='/var/tmp/bogus')
     filename = 'bogus.zip'


### PR DESCRIPTION
Makes configurable both the public uploads folder (althoug h see app_config.yml.sample as there are some limitations) and the UNP temporal folder.

Both default to current hardcoded constant values if config is not present