### PR TITLE
Update CartoCSS docs reference

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/help/carto_css.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/help/carto_css.jst.ejs
@@ -20,7 +20,7 @@
   <div class="Dialog-resultsBodyTexts">
     <p class="DefaultParagraph DefaultParagraph--tertiary">
       For more help, take a look at
-      <a href="https://github.com/mapbox/carto/blob/master/docs/latest.md" target="_blank">CartoCSS reference</a>.
+      <a href="http://docs.cartodb.com/cartodb-editor.html#customizing-maps-with-cartocss" target="_blank">CartoCSS reference</a>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
I noticed that the docs ref was updated for cartodb.js, in CartoDB/cartodb.js#709, I figure we should do the same here?

@javisantana @csobier since you two were involved in the other PR