### PR TITLE
Update install.rst

### DIFF
--- a/doc/manual/source/install.rst
+++ b/doc/manual/source/install.rst
@@ -151,6 +151,7 @@ GIS dependencies
   .. code-block:: bash
       
     sudo apt-get install gdal-bin libgdal1-dev libgdal-dev
+    sudo apt-get install ogr2ogr2-static-bin
 
 
 PostGIS


### PR DESCRIPTION
ogr2ogr2-static-bin is now needed.

@rafatower this should be in the installation instructions, isn't it? [Some users had troubles at Google Groups](https://groups.google.com/forum/#!topic/cartodb/xI15ygEy4Fo).