### PR TITLE
Silence duplicate viz export messages

### DIFF
--- a/app/services/carto/visualizations_export_service.rb
+++ b/app/services/carto/visualizations_export_service.rb
@@ -38,14 +38,23 @@ module Carto
         Carto::Api::VisualizationVizJSONAdapter.new(visualization, $tables_metadata), vizjson_options, Cartodb.config)
                                             .to_export_poro(export_version)
                                             .to_json
-      backup_entry = Carto::VisualizationBackup.new(
-        username: visualization.user.username,
-        visualization: visualization.id,
-        export_vizjson: data
-      )
-      backup_entry.save
 
-      true
+      backup_present = Carto::VisualizationBackup.where(
+        username: visualization.user.username,
+        visualization: visualization.id).first != nil
+
+      if backup_present
+        false
+      else
+        backup_entry = Carto::VisualizationBackup.new(
+          username: visualization.user.username,
+          visualization: visualization.id,
+          export_vizjson: data
+        )
+        backup_entry.save
+
+        true
+      end
     rescue VisualizationsExportServiceError => export_error
       raise export_error
     rescue => exception

--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -67,8 +67,8 @@ namespace :cartodb do
       vis_export_service = Carto::VisualizationsExportService.new
 
       puts "Exporting visualization #{args[:vis_id]}..."
-      vis_export_service.export(args[:vis_id])
-
+      result = vis_export_service.export(args[:vis_id])
+      puts "Export result was: #{result ? 'OK' : 'NOK (export already present)'}"
       puts "Export complete"
     end
 


### PR DESCRIPTION
Upon AR patched reconnections, the transactionability replays the full viz deletion process, which includes exporting its backup. This generates noise in the error logging system, when it is actually not any critical error because the backup was commited before the error (or wouldn't be stored at the DB).

No need for new automated tests as the return value was just ignored, but I tested manually using the Rake.

@ethervoid CR please