### PR TITLE
5981 missing event

### DIFF
--- a/app/controllers/api/json/visualizations_controller.rb
+++ b/app/controllers/api/json/visualizations_controller.rb
@@ -149,10 +149,12 @@ class Api::Json::VisualizationsController < Api::ApplicationController
         return(head 403) unless vis.is_owner?(current_user)
 
         track_event(vis, 'Deleted')
-        vis.table.dependent_visualizations.each { |dependent_vis|
-          # Remove dependent visualizations as well, if any
-          track_event(dependent_vis, 'Deleted')
-        } 
+        unless vis.table.nil?
+          vis.table.dependent_visualizations.each { |dependent_vis|
+            # Remove dependent visualizations as well, if any
+            track_event(dependent_vis, 'Deleted')
+          }
+        end 
 
         @stats_aggregator.timing('delete') do
           vis.delete

--- a/lib/cartodb/event_tracker.rb
+++ b/lib/cartodb/event_tracker.rb
@@ -4,11 +4,7 @@ module Cartodb
 
     def send_event(user, event_name, custom_properties = {})
       return unless is_tracking_active?
-
-      if user.nil?
-        Rollbar.report_message('Segment error tracking: User is null', 'Warning', { event: event_name,
-                                                                                    custom_properties: custom_properties })
-        return
+      return unless user_valid?(user, event_name, custom_properties)
 
       # Some events register custom properties
       # Monitary values associated with the event should use 'revenue' reserved key	
@@ -31,6 +27,17 @@ module Cartodb
 
     def is_tracking_active?
       !Cartodb.config[:segment].blank? and !Cartodb.config[:segment]['api_key'].blank?
+    end
+
+    def user_valid?(user, event_name, custom_properties)
+      if user.nil?
+        Rollbar.report_message('EventTracker: null user error', 'Error', { event: event_name,
+                                                                           custom_properties: custom_properties,
+                                                                           error_message: 'Provided user is null'})
+        false
+      else
+        true
+      end
     end
 
   end

--- a/lib/cartodb/event_tracker.rb
+++ b/lib/cartodb/event_tracker.rb
@@ -5,6 +5,11 @@ module Cartodb
     def send_event(user, event_name, custom_properties = {})
       return unless is_tracking_active?
 
+      if user.nil?
+        Rollbar.report_message('Segment error tracking: User is null', 'Warning', { event: event_name,
+                                                                                    custom_properties: custom_properties })
+        return
+
       # Some events register custom properties
       # Monitary values associated with the event should use 'revenue' reserved key	
       properties = generate_event_properties(user).merge(custom_properties)

--- a/lib/cartodb/segment_tracker.rb
+++ b/lib/cartodb/segment_tracker.rb
@@ -10,11 +10,12 @@ module Cartodb
     end
 
     def enabled?
-      !@api_key.nil?
+      !@api_key.blank?
     end
 
     def track_event(user_id, event, properties)
       return unless enabled?
+      return if user_id.blank?
 
       begin
         @analytics.track(
@@ -23,7 +24,9 @@ module Cartodb
           properties: properties
         )
       rescue => e
-      Rollbar.report_message('Segment error tracking event', 'error', { user: user_id, event: event })
+      Rollbar.report_message('Segment error tracking event', 'error', { user_id: user_id, 
+                                                                        event: event, 
+                                                                        error_message: e.inspect })
       end
     end
 
@@ -31,7 +34,7 @@ module Cartodb
       begin
         @analytics.flush
       rescue => e
-        Rollbar.report_message('Segment error flush', 'error')
+        Rollbar.report_message('Segment error flush', 'error', { error_message: e.inspect })
       end
     end
   end

--- a/lib/cartodb/segment_tracker.rb
+++ b/lib/cartodb/segment_tracker.rb
@@ -24,9 +24,10 @@ module Cartodb
           properties: properties
         )
       rescue => e
-      Rollbar.report_message('Segment error tracking event', 'error', { user_id: user_id, 
-                                                                        event: event, 
-                                                                        error_message: e.inspect })
+        Rollbar.report_message('EventTracker: segment event tracking error', 'error', { user_id: user_id, 
+                                                                                        event: event,
+                                                                                        properties: properties, 
+                                                                                        error_message: e.inspect })
       end
     end
 
@@ -34,7 +35,7 @@ module Cartodb
       begin
         @analytics.flush
       rescue => e
-        Rollbar.report_message('Segment error flush', 'error', { error_message: e.inspect })
+        Rollbar.report_message('EventTracker: segment flushing error', 'error', { error_message: e.inspect })
       end
     end
   end


### PR DESCRIPTION
Fixes:
 - it generates a 'Delete map' events in case a deleted dataset has dependent visualizations.

Improves:
 - check if provided user is valid before queuing a new event
 - add exception message to Rollbar call properties

@Kartones 