### PR TITLE
Unicorn workers restart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'net-ldap',                '0.11'
 
 group :production, :staging do
   gem 'unicorn',               '4.8.2'
+  gem 'unicorn-worker-killer'
   gem 'raindrops',             '0.12.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
       eventmachine (>= 0.12.0)
     ffi (1.9.10)
     fssm (0.2.10)
+    get_process_mem (0.2.0)
     gibbon (1.1.4)
       httparty
       multi_json (>= 1.3.4)
@@ -314,6 +315,9 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    unicorn-worker-killer (0.4.3)
+      get_process_mem (~> 0)
+      unicorn (~> 4)
     uuidtools (2.1.5)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -395,10 +399,8 @@ DEPENDENCIES
   thin
   typhoeus (= 0.7.2)
   unicorn (= 4.8.2)
+  unicorn-worker-killer
   uuidtools (= 2.1.5)
   virtus (= 1.0.0.beta3)
   vizzuality-sequel-rails (= 0.3.7)!
   webrick (= 1.3.1)
-
-BUNDLED WITH
-   1.10.6

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,20 @@
 # This file is used by Rack-based servers to start the application.
 
+# ---------------------
+# Unicorn unicorn-worker-killer gem config (must be before the environment require)
+# @see https://github.com/kzk/unicorn-worker-killer
+
+#require 'unicorn/worker_killer'
+
+# Max requests per worker. Uncomment last parameter for verbosity (at unicorn log)
+
+#use Unicorn::WorkerKiller::MaxRequests, 3072, 4096 #, true
+
+# Max memory size (RSS) per worker. Uncomment last parameter for verbosity (at unicorn log)
+
+#use Unicorn::WorkerKiller::Oom, (500*(1024**2)), (600*(1024**2)) #, true
+
+# ---------------------
+
 require ::File.expand_path('../config/environment',  __FILE__)
 run CartoDB::Application
-
-# For specifics about Unicorn worker killer config to set here, check https://github.com/kzk/unicorn-worker-killer

--- a/config.ru
+++ b/config.ru
@@ -2,3 +2,5 @@
 
 require ::File.expand_path('../config/environment',  __FILE__)
 run CartoDB::Application
+
+# For specifics about Unicorn worker killer config to set here, check https://github.com/kzk/unicorn-worker-killer


### PR DESCRIPTION
Relates to https://github.com/CartoDB/cartodb-platform/issues/1214

As there are really few options for the combo Ruby 1.9.3 + Unicorn other than upgrading to Ruby 2.0 or higher (where the GC is better and there are a lot of memory profilers), using the unicorn-worker-killer avoids memory high memory usage (and possible memory leaks). 

It is a patch for the problem, not an answer, but considering the soon-to-be-made upgrade to Ruby 2.2 this is a quick way towards that.

It's been tested at staging and works fine, gracefully killing and restarting the workers without interfering with requests and without any loss of them.