### PR TITLE
GPX multilayer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Fix for #5477 bug moving users with non-cartodbfied tables
 * Added a rake task to notify trendy maps to the map owner when reach a certain mapviews amount (500, 1000, 2000 and so on). This task takes into account the day before so it should be exectuded daily
 * Fixed negative geocoding quota in georeference modal [#5622](https://github.com/CartoDB/cartodb/pull/5622)
+* Now create a map from a GPX multilayer file is going to create a multilayer map
 * Group support for organizations. Usage instructions:
   1. Update CartoDB PostgreSQL extension to the latest version ([instructions](https://github.com/CartoDB/cartodb/blob/master/UPGRADE#L43)).
   2. Configure metadata api credentials and timeout. You can copy `org_metadata_api` config from `config/app_config.yml.sample` into your `config/app_config.yml`.

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -100,6 +100,7 @@ module CartoDB
 
         @http_options = http_options
         @importer_config = options[:importer_config]
+        @ogr2ogr_config = options[:ogr2ogr]
         @seed         = seed
         @repository   = repository || DataRepository::Filesystem::Local.new(temporary_directory)
         @datasource = nil
@@ -133,7 +134,7 @@ module CartoDB
 
       def clean_up
         if defined?(@temporary_directory) &&
-           @temporary_directory =~ /^#{Unp.new(@importer_config).get_temporal_subfolder_path}/ &&
+           @temporary_directory =~ /^#{Unp.new(@importer_config, @ogr2ogr_config).get_temporal_subfolder_path}/ &&
            !(@temporary_directory =~ /\.\./)
           FileUtils.rm_rf @temporary_directory
         end

--- a/services/importer/lib/importer/gpx_splitter.rb
+++ b/services/importer/lib/importer/gpx_splitter.rb
@@ -1,0 +1,78 @@
+# encoding: utf-8
+require 'open3'
+require_relative './source_file'
+require_relative './unp'
+require_relative './exceptions'
+
+module CartoDB
+  module Importer2
+    class GpxSplitter
+      MAX_LAYERS = 50
+      GPX_LAYERS = ['waypoints','routes','tracks','route_points','track_points']
+      ITEM_COUNT_REGEX = 'Feature Count:\s'
+      def self.support?(source_file)
+        source_file.extension == '.gpx'
+      end
+
+      def initialize(source_file, temporary_directory)
+        @source_file          = source_file
+        @temporary_directory  = temporary_directory
+      end
+
+      def run
+        n_layers = layers_in(source_file).length
+        return self if n_layers <= 1
+        raise CartoDB::Importer2::TooManyLayersError.new("File has too many layers (#{n_layers}). Maximum number of layers: #{MAX_LAYERS}") if n_layers > MAX_LAYERS
+        @source_files = source_files_for(source_file, layers_in(source_file))
+        self
+      end
+
+      def source_files
+        return [source_file] unless multiple_layers?(source_file)
+        @source_files
+      end
+
+      def source_files_for(source_file, layer_names=[])
+        layer_names.map { |layer_name|
+          extract(path_for(layer_name), source_file, layer_name)
+          SourceFile.new(path_for(layer_name), nil, layer_name)
+        }
+      end
+
+      def extract(extracted_file_path, source_file, layer_name)
+        `ogr2ogr2 -f 'GPX' -dsco GPX_USE_EXTENSIONS=YES #{extracted_file_path} #{source_file.fullpath} #{layer_name}`
+      end
+
+      def multiple_layers?(source_file)
+        layers_in(source_file).length > 1
+      end
+
+      def layers_in(source_file)
+        layers = []
+        GPX_LAYERS.each do |layer|
+          stdout, stderr, status = Open3.capture3("ogrinfo -so #{source_file.fullpath} #{layer}")
+          number_rows = stdout.split("\n")
+            .select { |line| line =~ /^#{ITEM_COUNT_REGEX}/}
+            .map{ |line| line.gsub(/#{ITEM_COUNT_REGEX}/, '') }.first
+          number_rows = Integer(number_rows) rescue nil
+          layers << layer if !number_rows.nil? && number_rows > 0
+        end
+        layers
+      end
+
+      def path_for(layer_name)
+        File.join(
+          temporary_directory,
+          Unp.new.underscore(layer_name) + '.gpx'
+        )
+      end
+
+      attr_reader :source_file
+
+      private
+
+      attr_reader :temporary_directory
+      attr_writer :source_file
+    end
+  end
+end

--- a/services/importer/lib/importer/gpx_splitter.rb
+++ b/services/importer/lib/importer/gpx_splitter.rb
@@ -60,10 +60,11 @@ module CartoDB
         layers
       end
 
-      def path_for(layer_name)
+      def path_for(source_file, layer_name)
+        file_layer_name = "#{source_file.name}_#{layer_name}"
         File.join(
           temporary_directory,
-          Unp.new.underscore(layer_name) + '.gpx'
+          Unp.new.underscore(file_layer_name) + '.gpx'
         )
       end
 

--- a/services/importer/lib/importer/gpx_splitter.rb
+++ b/services/importer/lib/importer/gpx_splitter.rb
@@ -8,7 +8,7 @@ module CartoDB
   module Importer2
     class GpxSplitter
       MAX_LAYERS = 50
-      GPX_LAYERS = ['waypoints','routes','tracks','route_points','track_points']
+      GPX_LAYERS = ['waypoints', 'routes', 'tracks', 'route_points', 'track_points']
       ITEM_COUNT_REGEX = 'Feature Count:\s'
       OGRINFO_BINARY = 'ogrinfo'
       DEFAULT_OGR2OGR_BINARY = 'ogr2ogr2'
@@ -26,7 +26,9 @@ module CartoDB
       def run
         n_layers = layers_in(source_file).length
         return self if n_layers <= 1
-        raise CartoDB::Importer2::TooManyLayersError.new("File has too many layers (#{n_layers}). Maximum number of layers: #{MAX_LAYERS}") if n_layers > MAX_LAYERS
+        raise CartoDB::Importer2::TooManyLayersError.new(
+          "File has too many layers (#{n_layers}). Maximum number of layers: #{MAX_LAYERS}"
+        ) if n_layers > MAX_LAYERS
         @source_files = source_files_for(source_file, layers_in(source_file))
         self
       end
@@ -36,12 +38,12 @@ module CartoDB
         @source_files
       end
 
-      def source_files_for(source_file, layer_names=[])
-        layer_names.map { |layer_name|
+      def source_files_for(source_file, layer_names = [])
+        layer_names.map do |layer_name|
           layer_file_name = path_for(source_file, layer_name)
           extract(layer_file_name, source_file, layer_name)
           SourceFile.new(layer_file_name, nil, layer_name)
-        }
+        end
       end
 
       def extract(extracted_file_path, source_file, layer_name)
@@ -57,8 +59,8 @@ module CartoDB
         GPX_LAYERS.each do |layer|
           stdout, stderr, status = Open3.capture3("#{OGRINFO_BINARY} -so #{source_file.fullpath} #{layer}")
           number_rows = stdout.split("\n")
-            .select { |line| line =~ /^#{ITEM_COUNT_REGEX}/}
-            .map{ |line| line.gsub(/#{ITEM_COUNT_REGEX}/, '') }.first
+                        .select { |line| line =~ /^#{ITEM_COUNT_REGEX}/ }
+                        .map { |line| line.gsub(/#{ITEM_COUNT_REGEX}/, '') }.first
           number_rows = Integer(number_rows) rescue nil
           layers << layer if !number_rows.nil? && number_rows > 0
         end

--- a/services/importer/lib/importer/kml_splitter.rb
+++ b/services/importer/lib/importer/kml_splitter.rb
@@ -8,13 +8,17 @@ module CartoDB
   module Importer2
     class KmlSplitter
       MAX_LAYERS = 50
+      OGRINFO_BINARY = 'ogrinfo'
+      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr2'
+
       def self.support?(source_file)
         source_file.extension == '.kml'
       end
 
-      def initialize(source_file, temporary_directory)
+      def initialize(source_file, temporary_directory, ogr2ogr_config = nil)
         @source_file          = source_file
         @temporary_directory  = temporary_directory
+        @ogr2ogr_binary = @ogr2ogr_config.nil? ? DEFAULT_OGR2OGR_BINARY : ogr2ogr_config['binary']
       end
 
       def run
@@ -38,7 +42,7 @@ module CartoDB
       end
 
       def extract(extracted_file_path, source_file, layer_name)
-        `ogr2ogr2 -f 'KML' #{extracted_file_path} #{source_file.fullpath} "#{layer_name}"`
+        `#{@ogr2ogr_binary} -f 'KML' #{extracted_file_path} #{source_file.fullpath} "#{layer_name}"`
       end
 
       def multiple_layers?(source_file)
@@ -47,7 +51,7 @@ module CartoDB
 
       def layers_in(source_file)
         stdout, stderr, status =
-          Open3.capture3("ogrinfo #{source_file.fullpath}")
+          Open3.capture3("#{OGRINFO_BINARY} #{source_file.fullpath}")
         stdout.split("\n")
           .select { |line| line =~ /\A\d/ }
           .map { |line| line.gsub(/\A\d+:\s/, '') }

--- a/services/importer/lib/importer/loader.rb
+++ b/services/importer/lib/importer/loader.rb
@@ -35,7 +35,7 @@ module CartoDB
       def initialize(job, source_file, layer = nil, ogr2ogr = nil, georeferencer = nil)
         self.job            = job
         self.source_file    = source_file
-        self.layer          = 'track_points' if source_file.extension =~ /\.gpx/
+        self.layer          = layer
         self.ogr2ogr        = ogr2ogr
         self.georeferencer  = georeferencer
         self.options        = {}

--- a/services/importer/lib/importer/osm_splitter.rb
+++ b/services/importer/lib/importer/osm_splitter.rb
@@ -10,7 +10,7 @@ module CartoDB
         source_file.extension == '.osm'
       end
 
-      def initialize(source_file, temporary_directory=nil)
+      def initialize(source_file, temporary_directory=nil, ogr2ogr_config = nil)
         @source_file = source_file
       end
 

--- a/services/importer/lib/importer/osm_splitter.rb
+++ b/services/importer/lib/importer/osm_splitter.rb
@@ -10,7 +10,7 @@ module CartoDB
         source_file.extension == '.osm'
       end
 
-      def initialize(source_file, temporary_directory=nil, ogr2ogr_config = nil)
+      def initialize(source_file, temporary_directory = nil, ogr2ogr_config = nil)
         @source_file = source_file
       end
 
@@ -19,14 +19,14 @@ module CartoDB
       end
 
       def source_files
-        LAYER_NAMES.map { |layer_name|
+        LAYER_NAMES.map do |layer_name|
           file = SourceFile.new(
             source_file.send(:filepath),
             "#{source_file.name}_#{layer_name}"
           )
           file.layer = layer_name
           file
-        }
+        end
       end
 
       attr_reader :source_file

--- a/services/importer/lib/importer/source_file.rb
+++ b/services/importer/lib/importer/source_file.rb
@@ -4,11 +4,12 @@ module CartoDB
     class SourceFile
       ENCODING_RE = /_encoding_([\w|-]+)_encoding_.*\./
 
-      def initialize(filepath, filename=nil, http_opts={})
+      def initialize(filepath, filename=nil, layer=nil, http_opts={})
         @filepath       = filepath
         @filename       = filename
         @etag           = http_opts.fetch(:etag, nil)
         @last_modified  = http_opts.fetch(:last_modified, nil)
+        @layer          = layer
         @checksum       = nil
       end
 

--- a/services/importer/lib/importer/source_file.rb
+++ b/services/importer/lib/importer/source_file.rb
@@ -4,7 +4,7 @@ module CartoDB
     class SourceFile
       ENCODING_RE = /_encoding_([\w|-]+)_encoding_.*\./
 
-      def initialize(filepath, filename=nil, layer=nil, http_opts={})
+      def initialize(filepath, filename = nil, layer = nil, http_opts = {})
         @filepath       = filepath
         @filename       = filename
         @etag           = http_opts.fetch(:etag, nil)
@@ -24,7 +24,7 @@ module CartoDB
       def fullpath
         File.join(
           File.dirname(filepath),
-          File.basename(filepath, extension) +  extension
+          File.basename(filepath, extension) + extension
         )
       end
 
@@ -51,11 +51,10 @@ module CartoDB
 
       attr_accessor :layer
       attr_reader :filename, :etag, :last_modified, :checksum
-      
+
       private
 
       attr_reader :filepath
     end
   end
 end
-

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -25,8 +25,9 @@ module CartoDB
 
       attr_reader :source_files, :temporary_directory
 
-      def initialize(importer_config = nil)
+      def initialize(importer_config = nil, ogr2ogr_config = nil)
         @source_files = []
+        @ogr2ogr_config = ogr2ogr_config
         if !importer_config.nil? && !importer_config['unp_temporal_folder'].nil?
           @temporal_subfolder_path = importer_config['unp_temporal_folder']
         end
@@ -194,7 +195,7 @@ module CartoDB
         source_files.flat_map { |source_file|
           splitter = splitter_for(source_file)
           if splitter
-            splitter.new(source_file, temporary_directory)
+            splitter.new(source_file, temporary_directory, @ogr2ogr_config)
               .run.source_files
           else
             source_file

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -5,6 +5,7 @@ require 'open3'
 require_relative './exceptions'
 require_relative './source_file'
 require_relative './kml_splitter'
+require_relative './gpx_splitter'
 require_relative './osm_splitter'
 
 module CartoDB
@@ -18,7 +19,7 @@ module CartoDB
         .js .json .tar .gz .tgz .osm .bz2 .geojson
         .gpx .sql .tab .tsv .txt
       }
-      SPLITTERS = [KmlSplitter, OsmSplitter]
+      SPLITTERS = [KmlSplitter, OsmSplitter, GpxSplitter]
 
       DEFAULT_IMPORTER_TMP_SUBFOLDER = '/tmp/imports/'
 

--- a/services/importer/spec/acceptance/gpx_spec.rb
+++ b/services/importer/spec/acceptance/gpx_spec.rb
@@ -29,4 +29,33 @@ describe 'GPX regression tests' do
     geometry_type_for(runner).should be
   end
 
+  it 'imports a multi layer GPX file' do
+    filepath    = path_to('multiple_layer.gpx')
+    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    runner      = CartoDB::Importer2::Runner.new({
+                               pg: @pg_options,
+                               downloader: downloader,
+                               log: CartoDB::Importer2::Doubles::Log.new,
+                               user: CartoDB::Importer2::Doubles::User.new
+                             })
+    runner.run
+
+    runner.results.each { |result| result.success.should eq true }
+    runner.results.length.should eq 4
+  end
+
+  it 'imports a single layer GPX file that becomes two layer dataset' do
+    filepath    = path_to('one_layer.gpx')
+    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    runner      = CartoDB::Importer2::Runner.new({
+                               pg: @pg_options,
+                               downloader: downloader,
+                               log: CartoDB::Importer2::Doubles::Log.new,
+                               user: CartoDB::Importer2::Doubles::User.new
+                             })
+    runner.run
+
+    runner.results.each { |result| result.success.should eq true }
+    runner.results.length.should eq 2
+  end
 end

--- a/services/importer/spec/acceptance/gpx_spec.rb
+++ b/services/importer/spec/acceptance/gpx_spec.rb
@@ -18,12 +18,10 @@ describe 'GPX regression tests' do
   it 'imports GPX files' do
     filepath    = path_to('route2.gpx')
     downloader  = CartoDB::Importer2::Downloader.new(filepath)
-    runner      = CartoDB::Importer2::Runner.new({
-                               pg: @pg_options,
-                               downloader: downloader,
-                               log: CartoDB::Importer2::Doubles::Log.new,
-                               user: CartoDB::Importer2::Doubles::User.new
-                             })
+    runner      = CartoDB::Importer2::Runner.new(pg: @pg_options,
+                                                 downloader: downloader,
+                                                 log: CartoDB::Importer2::Doubles::Log.new,
+                                                 user: CartoDB::Importer2::Doubles::User.new)
     runner.run
 
     geometry_type_for(runner).should be
@@ -32,12 +30,10 @@ describe 'GPX regression tests' do
   it 'imports a multi layer GPX file' do
     filepath    = path_to('multiple_layer.gpx')
     downloader  = CartoDB::Importer2::Downloader.new(filepath)
-    runner      = CartoDB::Importer2::Runner.new({
-                               pg: @pg_options,
-                               downloader: downloader,
-                               log: CartoDB::Importer2::Doubles::Log.new,
-                               user: CartoDB::Importer2::Doubles::User.new
-                             })
+    runner      = CartoDB::Importer2::Runner.new(pg: @pg_options,
+                                                 downloader: downloader,
+                                                 log: CartoDB::Importer2::Doubles::Log.new,
+                                                 user: CartoDB::Importer2::Doubles::User.new)
     runner.run
 
     runner.results.each { |result| result.success.should eq true }
@@ -47,12 +43,10 @@ describe 'GPX regression tests' do
   it 'imports a single layer GPX file that becomes two layer dataset' do
     filepath    = path_to('one_layer.gpx')
     downloader  = CartoDB::Importer2::Downloader.new(filepath)
-    runner      = CartoDB::Importer2::Runner.new({
-                               pg: @pg_options,
-                               downloader: downloader,
-                               log: CartoDB::Importer2::Doubles::Log.new,
-                               user: CartoDB::Importer2::Doubles::User.new
-                             })
+    runner      = CartoDB::Importer2::Runner.new(pg: @pg_options,
+                                                 downloader: downloader,
+                                                 log: CartoDB::Importer2::Doubles::Log.new,
+                                                 user: CartoDB::Importer2::Doubles::User.new)
     runner.run
 
     runner.results.each { |result| result.success.should eq true }

--- a/services/importer/spec/fixtures/multiple_layer.gpx
+++ b/services/importer/spec/fixtures/multiple_layer.gpx
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">
+    <metadata>
+        <name>Multi layer Test file</name>
+    </metadata>
+    <rte>
+        <name>Example Route</name>
+        <rtept lon="9.860624216140083" lat="54.9328621088893">
+            <ele>0.0</ele>
+            <name>Route 1</name>
+        </rtept>
+        <rtept lon="9.86092208681491" lat="54.93293237320851">
+            <ele>0.0</ele>
+            <name>Route 2</name>
+        </rtept>
+        <rtept lon="9.86187816543752" lat="54.93327743521187">
+            <ele>0.0</ele>
+            <name>Route 3</name>
+        </rtept>
+        <rtept lon="9.862439849679859" lat="54.93342326167919">
+            <ele>0.0</ele>
+            <name>Route 4</name>
+        </rtept>
+    </rte>
+    <trk>
+        <name>Example Track</name>
+        <trkseg>
+            <trkpt lon="9.860624216140083" lat="54.9328621088893">
+                <ele>0.0</ele>
+                <name>Position 1</name>
+            </trkpt>
+            <trkpt lon="9.86092208681491" lat="54.93293237320851">
+                <ele>0.0</ele>
+                <name>Position 2</name>
+            </trkpt>
+            <trkpt lon="9.86187816543752" lat="54.93327743521187">
+                <ele>0.0</ele>
+                <name>Position 3</name>
+            </trkpt>
+            <trkpt lon="9.862439849679859" lat="54.93342326167919">
+                <ele>0.0</ele>
+                <name>Position 4</name>
+            </trkpt>
+        </trkseg>
+    </trk>
+</gpx>

--- a/services/importer/spec/fixtures/one_layer.gpx
+++ b/services/importer/spec/fixtures/one_layer.gpx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1">
+    <metadata>
+        <name>One Layer Test file</name>
+    </metadata>
+    <trk>
+        <name>Example Track</name>
+        <trkseg>
+            <trkpt lon="9.860624216140083" lat="54.9328621088893">
+                <ele>0.0</ele>
+                <name>Position 1</name>
+            </trkpt>
+            <trkpt lon="9.86092208681491" lat="54.93293237320851">
+                <ele>0.0</ele>
+                <name>Position 2</name>
+            </trkpt>
+            <trkpt lon="9.86187816543752" lat="54.93327743521187">
+                <ele>0.0</ele>
+                <name>Position 3</name>
+            </trkpt>
+            <trkpt lon="9.862439849679859" lat="54.93342326167919">
+                <ele>0.0</ele>
+                <name>Position 4</name>
+            </trkpt>
+        </trkseg>
+    </trk>
+</gpx>

--- a/services/importer/spec/unit/gpx_splitter_spec.rb
+++ b/services/importer/spec/unit/gpx_splitter_spec.rb
@@ -11,7 +11,7 @@ describe CartoDB::Importer2::GpxSplitter do
     @one_layer_filepath       = path_to('one_layer.gpx')
     @multiple_layer_filepath  = path_to('multiple_layer.gpx')
     @temporary_directory      = '/var/tmp'
-    @ogr2ogr_config = {'binary' => 'which ogr2ogr2'}
+    @ogr2ogr_config = { 'binary' => 'which ogr2ogr2' }
   end
 
   describe '#run' do
@@ -26,7 +26,7 @@ describe CartoDB::Importer2::GpxSplitter do
       source_file = CartoDB::Importer2::SourceFile.new(@one_layer_filepath)
       splitter    = CartoDB::Importer2::GpxSplitter.new(source_file, @temporary_directory, @ogr2ogr_config)
       splitter.run
-      #route and track with the points layer too (track and track_points)
+      # route and track with the points layer too (track and track_points)
       splitter.source_files.length.should eq 2
     end
   end
@@ -49,4 +49,3 @@ describe CartoDB::Importer2::GpxSplitter do
     )
   end
 end
-

--- a/services/importer/spec/unit/gpx_splitter_spec.rb
+++ b/services/importer/spec/unit/gpx_splitter_spec.rb
@@ -1,0 +1,52 @@
+# encoding: utf-8
+require 'rspec/core'
+require 'rspec/expectations'
+require 'rspec/mocks'
+
+# Unp includes reference to kml_splitter
+require_relative '../../lib/importer/unp'
+
+describe CartoDB::Importer2::GpxSplitter do
+  before do
+    @one_layer_filepath       = path_to('one_layer.gpx')
+    @multiple_layer_filepath  = path_to('multiple_layer.gpx')
+    @temporary_directory      = '/var/tmp'
+    @ogr2ogr_config = {'binary' => 'which ogr2ogr2'}
+  end
+
+  describe '#run' do
+    it 'splits a multilayer GPX into single-layer GPX' do
+      source_file = CartoDB::Importer2::SourceFile.new(@multiple_layer_filepath)
+      splitter    = CartoDB::Importer2::GpxSplitter.new(source_file, @temporary_directory, @ogr2ogr_config)
+      splitter.run
+      splitter.source_files.length.should eq 4
+    end
+
+    it 'splits a single-layer GPX into multiple-layer GPX' do
+      source_file = CartoDB::Importer2::SourceFile.new(@one_layer_filepath)
+      splitter    = CartoDB::Importer2::GpxSplitter.new(source_file, @temporary_directory, @ogr2ogr_config)
+      splitter.run
+      #route and track with the points layer too (track and track_points)
+      splitter.source_files.length.should eq 2
+    end
+  end
+
+  describe '#layers_in' do
+    it 'returns all layers name in the file' do
+      source_file = CartoDB::Importer2::SourceFile.new(@one_layer_filepath)
+      splitter    = CartoDB::Importer2::GpxSplitter.new(source_file, @temporary_directory, @ogr2ogr_config)
+      splitter.layers_in(source_file).should eq ["tracks", "track_points"]
+
+      source_file = CartoDB::Importer2::SourceFile.new(@multiple_layer_filepath)
+      splitter    = CartoDB::Importer2::GpxSplitter.new(source_file, @temporary_directory, @ogr2ogr_config)
+      splitter.layers_in(source_file).length.should eq 4
+    end
+  end
+
+  def path_to(filepath)
+    File.expand_path(
+      File.join(File.dirname(__FILE__), "../fixtures/#{filepath}")
+    )
+  end
+end
+

--- a/services/importer/spec/unit/kml_splitter_spec.rb
+++ b/services/importer/spec/unit/kml_splitter_spec.rb
@@ -11,7 +11,7 @@ describe CartoDB::Importer2::KmlSplitter do
     @one_layer_filepath       = path_to('one_layer.kml')
     @multiple_layer_filepath  = path_to('multiple_layer.kml')
     @temporary_directory      = '/var/tmp'
-    @ogr2ogr_config = {'binary' => 'which ogr2ogr2'}
+    @ogr2ogr_config = { 'binary' => 'which ogr2ogr2' }
   end
 
   describe '#run' do
@@ -36,9 +36,6 @@ describe CartoDB::Importer2::KmlSplitter do
   end
 
   def path_to(filepath)
-    File.expand_path(
-      File.join(File.dirname(__FILE__), "../fixtures/#{filepath}")
-    )
+    File.expand_path(File.join(File.dirname(__FILE__), "../fixtures/#{filepath}"))
   end
 end
-

--- a/services/importer/spec/unit/kml_splitter_spec.rb
+++ b/services/importer/spec/unit/kml_splitter_spec.rb
@@ -11,12 +11,13 @@ describe CartoDB::Importer2::KmlSplitter do
     @one_layer_filepath       = path_to('one_layer.kml')
     @multiple_layer_filepath  = path_to('multiple_layer.kml')
     @temporary_directory      = '/var/tmp'
+    @ogr2ogr_config = {'binary' => 'which ogr2ogr2'}
   end
 
   describe '#run' do
     it 'splits a multilayer KML into single-layer KML' do
       source_file = CartoDB::Importer2::SourceFile.new(@multiple_layer_filepath)
-      splitter    = CartoDB::Importer2::KmlSplitter.new(source_file, @temporary_directory)
+      splitter    = CartoDB::Importer2::KmlSplitter.new(source_file, @temporary_directory, @ogr2ogr_config)
       splitter.run
       splitter.source_files.length.should eq 10
     end
@@ -25,11 +26,11 @@ describe CartoDB::Importer2::KmlSplitter do
   describe '#layers_in' do
     it 'returns all layers name in the file' do
       source_file = CartoDB::Importer2::SourceFile.new(@one_layer_filepath)
-      splitter    = CartoDB::Importer2::KmlSplitter.new(source_file, @temporary_directory)
+      splitter    = CartoDB::Importer2::KmlSplitter.new(source_file, @temporary_directory, @ogr2ogr_config)
       splitter.layers_in(source_file).should eq ["Absolute_and_Relative"]
 
       source_file = CartoDB::Importer2::SourceFile.new(@multiple_layer_filepath)
-      splitter    = CartoDB::Importer2::KmlSplitter.new(source_file, @temporary_directory)
+      splitter    = CartoDB::Importer2::KmlSplitter.new(source_file, @temporary_directory, @ogr2ogr_config)
       splitter.layers_in(source_file).length.should eq 10
     end
   end


### PR DESCRIPTION
Closes #5974 

GPX Splitter to import multi layer GPX files to create multilayer maps with it. 

If you import one file with "one layer" its going to create a two layer map or two datasets. For example if you have a file with a `<trk>` block, **ogr2ogr** create two layers with data: **track** and **track_points**. `track` have the the `multilinestring` for the points and `track_points` all the points gathered by the GPS