### PR TITLE
Added country code filter for visualizations

### DIFF
--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -43,6 +43,7 @@ module Carto
           likes: @visualization.likes.count,
           prev_id: @visualization.prev_id,
           next_id: @visualization.next_id,
+          country_codes: @visualization.country_codes,
           transition_options: @visualization.transition_options,
           active_child: @visualization.active_child,
           table: Carto::Api::UserTablePresenter.new(@visualization.table, @visualization.permission, @current_viewer).to_poro,

--- a/app/controllers/carto/api/visualization_searcher.rb
+++ b/app/controllers/carto/api/visualization_searcher.rb
@@ -25,8 +25,9 @@ module Carto
         shared = compose_shared(params[:shared], only_shared, exclude_shared)
         tags = params.fetch(:tags, '').split(',')
         tags = nil if tags.empty?
-        bbox_parameter = params.fetch(:bbox,nil)
-        privacy = params.fetch(:privacy,nil)
+        bbox_parameter = params.fetch(:bbox, nil)
+        country_code = params.fetch(:country_code, nil)
+        privacy = params.fetch(:privacy, nil)
         only_with_display_name = params[:only_with_display_name] == 'true'
 
         vqb = VisualizationQueryBuilder.new
@@ -39,6 +40,10 @@ module Carto
 
         if !bbox_parameter.blank?
           vqb.with_bounding_box(BoundingBoxHelper.parse_bbox_parameters(bbox_parameter))
+        end
+
+        if !country_code.blank?
+          vqb.with_country_code(country_code)
         end
 
         # FIXME Patch to exclude legacy visualization from data-library #5097

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -82,6 +82,7 @@ module CartoDB
       attribute :prev_id,             String, default: nil
       attribute :next_id,             String, default: nil
       attribute :bbox,                String, default: nil
+      attribute :country_codes,       Array[String], default: nil
       # Don't use directly, use instead getter/setter "transition_options"
       attribute :slide_transition_options,  String, default: DEFAULT_OPTIONS_VALUE
       attribute :active_child,        String, default: nil

--- a/app/models/visualization/migrator.rb
+++ b/app/models/visualization/migrator.rb
@@ -43,6 +43,7 @@ module CartoDB
         @db.run(%Q{
           ALTER TABLE "#{relation}"
           ADD COLUMN tags text[],
+          ADD COLUMN country_codes text[],
           ADD COLUMN bbox geometry
         })
       end

--- a/app/models/visualization/presenter.rb
+++ b/app/models/visualization/presenter.rb
@@ -43,6 +43,7 @@ module CartoDB
           likes: visualization.likes_count,
           prev_id: visualization.prev_id,
           next_id: visualization.next_id,
+          country_codes: visualization.country_codes,
           transition_options: visualization.transition_options,
           active_child: visualization.active_child
         }

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -180,6 +180,11 @@ class Carto::VisualizationQueryBuilder
     self
   end
 
+  def with_country_code(country_code)
+    @country_code = country_code
+    self
+  end
+
   def build
     query = Carto::Visualization.scoped
 
@@ -282,6 +287,10 @@ class Carto::VisualizationQueryBuilder
 
     if @only_with_display_name
       query = query.where("display_name is not null")
+    end
+
+    if @country_code
+      query = query.where("ARRAY[?]::text[] <@ visualizations.country_codes", @country_code.upcase)
     end
 
     @include_associations.each { |association|

--- a/services/data-repository/spec/unit/backend/sequel_spec.rb
+++ b/services/data-repository/spec/unit/backend/sequel_spec.rb
@@ -29,6 +29,8 @@ describe DataRepository::Backend::Sequel do
       String    :kind
       String    :prev_id
       String    :next_id
+      String    :bbox
+      String    :country_codes
       String    :slide_transition_options
       String    :active_child
     end

--- a/spec/models/visualization/presenter_spec.rb
+++ b/spec/models/visualization/presenter_spec.rb
@@ -92,6 +92,7 @@ describe Visualization::Member do
       vis_mock.stubs(:related_tables).returns([])
       vis_mock.stubs(:prev_id).returns(nil)
       vis_mock.stubs(:next_id).returns(nil)
+      vis_mock.stubs(:country_codes).returns(nil)
       vis_mock.stubs(:transition_options).returns({})
       vis_mock.stubs(:active_child).returns(nil)
       vis_mock.stubs(:likes).returns([])

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -123,6 +123,7 @@ module HelperMethods
       kind:               attributes.fetch(:kind, Visualization::Member::KIND_GEOM),
       prev_id:            attributes.fetch(:prev_id, nil),
       next_id:            attributes.fetch(:next_id, nil),
+      country_codes:      attributes.fetch(:country_codes, nil),
       transition_options: attributes.fetch(:transition_options, {}),
       active_child:       attributes.fetch(:active_child, nil),
       locked:             attributes.fetch(:locked, false)


### PR DESCRIPTION
As a fix for the bounding box problem with the dateline @matallo suggested tu use ISO country codes to "tag" the visualizations so we can filter the tables based on that.

Please @rafatower check this PR