### PR TITLE
Reuse `cdn_url` config param for Static Map URL helper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * Added new (optional) config parameters `unp_temporal_folder` & `uploads_path` under `importer` section to allow custom UNP and file upload paths.
 * Added new (optional) config parameters `unp_temporal_folder` & `uploads_path` under `importer` section to allow custom UNP and file upload paths.
 * Data-library page for common-data and accounts with data_library feature flag [#5712](https://github.com/CartoDB/cartodb/pull/5712)
+* Removed config option `maps_api_cdn_template`, reusing now instead `cdn_url`
 
 
 3.11.0 (2015-09-09)

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -1,4 +1,8 @@
 defaults: &defaults
+  # If uncommented, most images like static map previews and twitter card image urls will use this CDN urls
+  #cdn_url:
+  #  http:             "http.cdn.host"
+  #  https:            "https.cdn.host"
   http_client_logs: true
   ogr2ogr:
     binary:           'which ogr2ogr2'

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -10,7 +10,6 @@ defaults: &defaults
   subdomainless_urls: false
   http_port:           3000 # nil|integer. HTTP port to use when building urls. Leave empty to use default (80)
   https_port:          # nil|integer. HTTPS port to use when building urls. Leave empty to use default (443)
-  maps_api_cdn_template: # nil|string. E.g. '{protocol}://{zone}.cartocdn/{user}' (`/api/v1/...` fragment added via code)
   secret_token:       '71c2b25921b84a1cb21c71503ab8fb23'
   account_host:       'localhost.lan:3000'
   account_path:       '/account'

--- a/lib/static_maps_url_helper.rb
+++ b/lib/static_maps_url_helper.rb
@@ -18,26 +18,19 @@ module Carto
 
     # INFO: Assumes no trailing '/' comes inside, so returned string doesn't has it either
     def static_maps_base_url(username, request_protocol)
-      config = get_static_maps_api_cdn_config
-
+      config = get_cdn_config
       if !config.nil? && !config.empty?
-        # Sample formats:
-        # {protocol}://{user}.cartodb.com
-        # {protocol}://zone.cartocdn.com/{user}
-        base_url = config
+        "#{request_protocol}://#{config[request_protocol]}/#{username}"
       else
-        # Typical format (but all parameters except {user} come already replaced):
-        # {protocol}://{user}.{maps_domain}:{port}/
-        base_url = ApplicationHelper.maps_api_template('public')
+        # sample format: {protocol}://{user}.{maps_domain}:{port}/
+        # All parameters except {user} come already replaced
+        ApplicationHelper.maps_api_template('public').sub('{user}', username)
       end
-
-      base_url.sub('{protocol}', CartoDB.protocol(request_protocol))
-              .sub('{user}', username)
     end
 
     # INFO: To ease testing while we keep the config in a global array...
-    def get_static_maps_api_cdn_config
-      Cartodb.config[:maps_api_cdn_template]
+    def get_cdn_config
+      Cartodb.config[:cdn_url]
     end
 
     def static_maps_image_url_fragment(visualization_id, width, height)

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -84,7 +84,7 @@ describe Carto::Api::VisualizationsController do
       table1 = create_random_table($user_1)
 
       Carto::StaticMapsURLHelper.any_instance
-                                .stubs(:get_static_maps_api_cdn_config)
+                                .stubs(:get_cdn_config)
                                 .returns(nil)
       ApplicationHelper.stubs(:maps_api_template)
                        .returns("http://#{$user_1.username}.localhost.lan:8181")
@@ -109,16 +109,15 @@ describe Carto::Api::VisualizationsController do
       table1 = create_random_table($user_1)
 
       Carto::StaticMapsURLHelper.any_instance
-                                .stubs(:get_static_maps_api_cdn_config)
-                                .returns("{protocol}://cdn.local.lan/{user}")
+                                .stubs(:get_cdn_config)
+                                .returns("http" => "cdn.local.lan")
 
-      get api_v2_visualizations_static_map_url({
+      get api_v2_visualizations_static_map_url(
           user_domain: $user_1.username,
-          #api_key: $user_1.api_key,
           id: table1.table_visualization.id,
           width: width,
           height: height
-        }),
+        ),
         @headers
       last_response.status.should == 302
 
@@ -141,7 +140,7 @@ describe Carto::Api::VisualizationsController do
       private_table = create_random_table($user_1)
 
       Carto::StaticMapsURLHelper.any_instance
-                                     .stubs(:get_static_maps_api_cdn_config)
+                                     .stubs(:get_cdn_config)
                                      .returns(nil)
       ApplicationHelper.stubs(:maps_api_template)
                        .returns("http://#{$user_1.username}.localhost.lan:8181")
@@ -186,8 +185,8 @@ describe Carto::Api::VisualizationsController do
       table1 = create_random_table($user_1)
 
       Carto::StaticMapsURLHelper.any_instance
-                                     .stubs(:get_static_maps_api_cdn_config)
-                                     .returns("{protocol}://cdn.local.lan/{user}")
+                                     .stubs(:get_cdn_config)
+                                     .returns("http" => "cdn.local.lan")
 
       get api_v2_visualizations_static_map_url({
           user_domain: $user_1.username,


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb/issues/5926