### PR TITLE
Disable country codes column prior to removal

### DIFF
--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -270,6 +270,10 @@ class Carto::Visualization < ActiveRecord::Base
     !is_privacy_private?
   end
 
+  def self.columns
+    super.reject { |c| c.name == "country_codes" }
+  end
+
   private
 
   def get_named_map


### PR DESCRIPTION
First step to delete the `country_codes` column