### PR TITLE
Adds get_unused_port method to helper and applies it in serve_file 5909

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -26,11 +26,13 @@ module HelperMethods
   end
 
   def serve_file(file_path, options = {})
+    port = get_unused_port
+
     require 'webrick'
     server = WEBrick::HTTPServer.new(
       :AccessLog       => [],
       :Logger          => WEBrick::Log::new("/dev/null", 7), #comment this line if weird things happen
-      :Port            => 9779,
+      :Port            => port,
       :DocumentRoot    => File.dirname(file_path),
       :RequestCallback => Proc.new() { |req, res|
         options[:headers].each { |k, v| res[k] = v } if options[:headers].present?
@@ -45,7 +47,7 @@ module HelperMethods
     a = Thread.new { server.start }
 
     begin
-      yield "http://localhost:9779/#{File.basename(file_path)}" if block_given?
+      yield "http://localhost:#{port}/#{File.basename(file_path)}" if block_given?
     rescue => e
       raise e
     ensure
@@ -56,6 +58,16 @@ module HelperMethods
     end
   end
 
+  def get_unused_port
+    used_ports_command = `netstat -tln | tail -n +3 | awk '{ print $4 }' | cut -f2 -d ':'`
+    used_ports = used_ports_command.split("\n").map(&:to_i)
+
+    (10000..65535).each do |port|
+      return port if !used_ports.include?(port)
+    end
+
+    raise "No ports available on machine."
+  end
 
   def get_json(path, params = {}, headers ={}, &block)
     get path, params, headers

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -30,11 +30,11 @@ module HelperMethods
 
     require 'webrick'
     server = WEBrick::HTTPServer.new(
-      :AccessLog       => [],
-      :Logger          => WEBrick::Log::new("/dev/null", 7), #comment this line if weird things happen
-      :Port            => port,
-      :DocumentRoot    => File.dirname(file_path),
-      :RequestCallback => Proc.new() { |req, res|
+      AccessLog: [],
+      Logger: WEBrick::Log::new("/dev/null", 7), #comment this line if weird things happen
+      Port: port,
+      DocumentRoot: File.dirname(file_path),
+      RequestCallback: Proc.new() { |req, res|
         options[:headers].each { |k, v| res[k] = v } if options[:headers].present?
         if options[:headers].present? && options[:headers]['content-type'].present?
           res.content_type = options[:headers]['content-type']

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -31,7 +31,7 @@ module HelperMethods
     require 'webrick'
     server = WEBrick::HTTPServer.new(
       AccessLog: [],
-      Logger: WEBrick::Log::new("/dev/null", 7), #comment this line if weird things happen
+      Logger: WEBrick::Log::new("/dev/null", 7), # comment this line if weird things happen
       Port: port,
       DocumentRoot: File.dirname(file_path),
       RequestCallback: Proc.new() { |_req, res|

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -34,7 +34,7 @@ module HelperMethods
       Logger: WEBrick::Log::new("/dev/null", 7), #comment this line if weird things happen
       Port: port,
       DocumentRoot: File.dirname(file_path),
-      RequestCallback: Proc.new() { |req, res|
+      RequestCallback: Proc.new() { |_req, res|
         options[:headers].each { |k, v| res[k] = v } if options[:headers].present?
         if options[:headers].present? && options[:headers]['content-type'].present?
           res.content_type = options[:headers]['content-type']


### PR DESCRIPTION
Fixes #5909

Now `serve_file` method in helper uses new `get_unused_port` method to find an unused port instead of using a fix port.

This prevents `EADDRINUSE` from rising when two tests using `serve_file` are executed in parallel.

Please CR @rafatower 

cc/ @jesusvazquez 