### PR TITLE
JPEG image format raises invalid format error when changing avatars

### DIFF
--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -35,7 +35,7 @@ describe Asset do
     it 'validates file correct metadata' do
       asset = Asset.new user_id: @user.id, asset_file: (Rails.root + 'spec/support/data/fake_png.png').to_s
       asset.valid?.should be_false
-      asset.errors.full_messages.should include("file doesn't appears to be an image")
+      asset.errors.full_messages.should include("file doesn't appear to be an image")
     end
 
     it 'validates file size' do

--- a/spec/requests/api/assets_spec.rb
+++ b/spec/requests/api/assets_spec.rb
@@ -53,6 +53,22 @@ describe "Assets API" do
     end
   end
 
+  it "finds image file extension" do
+    asset = FactoryGirl.create(:asset, user_id: $user_1.id)
+
+    Asset::VALID_EXTENSIONS.each do |extension|
+      asset_name = "cartofante" + extension
+      asset.stubs(:asset_file).returns(asset_name)
+      asset.asset_file_extension.should == extension
+    end
+  end
+
+  it "detects incorrect image file extension" do
+    asset = FactoryGirl.create(:asset, user_id: $user_1.id)
+    asset.stubs(:asset_file).returns("cartofante.gifv")
+    asset.asset_file_extension.should == nil
+  end
+
   it "deletes an asset" do
     FactoryGirl.create(:asset, user_id: $user_1.id)
     $user_1.reload


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/6106

Hey, I gave this some more thought.

We wanted to avoid the function to consider `.gifv` a valid extension, but editing the regexp to dismiss the random characters that Rack is appending to the filename didn't seem like a nice idea to me because we were creating a specific regexp just to pass the test.

We saw that the appended suffix was following a specific pattern (timestamp + some random strings here and there) and I found from where it actually comes from [here](https://github.com/ruby/ruby/blob/33b832979b2d01a865a25c9faefe6a3cee6e5dc2/lib/tmpdir.rb#L115).

````ruby
path = "#{prefix}#{t}-#{$$}-#{rand(0x100000000).to_s(36)}".dup
````

Since we have to strip the pattern only when running the tests, I have created a new path in the code only used during testing in which the extension is cleaned before passing through the regular validation process.

````ruby
  def asset_file_extension
    filename = asset_file.respond_to?(:original_filename) ? asset_file.original_filename : asset_file
    extension = File.extname(filename).downcase

    # Filename might include a postfix hash -- Rack::Test::UploadedFile adds it
    extension.gsub!(/\d+-\w+-\w+\z/, '') if Rails.env.test?

    extension if VALID_EXTENSIONS.include?(extension)
  end
`````

Now it will not allow formats such as `.gifv` or `.jpeg2` and we will not be running production code *specifically thought* to pass the tests.

I also added two tests; one for testing the detection of all valid extensions and a second one for detecting as invalid a file with extension `.gifv`.

This commit also fixes a typo in an unrelated test.