### PR TITLE
Layer attribution override example

### DIFF
--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -205,6 +205,7 @@ defaults: &defaults
     data:
       kind: "carto"
       options:
+        # attribution:        'CartoDB attribution'
         query:              ""
         opacity:            0.99
         auto_bound:         false


### PR DESCRIPTION
Layer attribution can be overriden at app_config.yml, layer_opts --> data --> attribution. @javisantana, :eyes:, please.