### PR TITLE
Fix: ArgGIS failed if the service returned out-of-order ids

### DIFF
--- a/services/datasources/lib/datasources/url/arcgis.rb
+++ b/services/datasources/lib/datasources/url/arcgis.rb
@@ -357,6 +357,8 @@ module CartoDB
         end
 
         # NOTE: Assumes url is valid
+        # NOTE: Returned ids are sorted so they can be chunked into blocks to
+        #       be requested by range queries: `(OBJECTID >= ... AND OBJECTID <= ... )`        
         # @param url String
         # @return Array
         # @throws DataDownloadError
@@ -368,7 +370,7 @@ module CartoDB
             if response.code != 200
 
           begin
-            data = ::JSON.parse(response.body).fetch('objectIds')
+            data = ::JSON.parse(response.body).fetch('objectIds').sort
           rescue => exception
             raise ResponseError.new("Missing data: #{exception.to_s} #{request_url} #{exception.backtrace}")
           end

--- a/services/datasources/spec/fixtures/arcgis_unordered_ids_list.json
+++ b/services/datasources/spec/fixtures/arcgis_unordered_ids_list.json
@@ -1,0 +1,1 @@
+{"objectIdFieldName":"OBJECTID","objectIds":[7,6,10,4,5,2,1,8,9,3]}

--- a/services/datasources/spec/unit/arcgis_spec.rb
+++ b/services/datasources/spec/unit/arcgis_spec.rb
@@ -294,6 +294,28 @@ describe Url::ArcGIS do
       respose_ids.should eq expected_ids
     end
 
+    it 'tests the get_ids_list() private method on out-of-order ids' do
+      arcgis = Url::ArcGIS.get_new(@user)
+
+      id = arcgis.send(:sanitize_id, @url)
+
+      Typhoeus.stub(/\/arcgis\/rest\//) do |request|
+        body = File.read(File.join(File.dirname(__FILE__), "../fixtures/arcgis_unordered_ids_list.json"))
+        Typhoeus::Response.new(
+          code: 200,
+          headers: { 'Content-Type' => 'application/json' },
+          body: body
+        )
+      end
+
+      expected_ids = [1,2,3,4,5,6,7,8,9,10]
+
+      respose_ids = arcgis.send(:get_ids_list, id)
+
+      respose_ids.nil?.should be false
+      respose_ids.should eq expected_ids
+    end
+
     it 'tests the get_by_ids() private method with error scenarios' do
       arcgis = Url::ArcGIS.get_new(@user)
 


### PR DESCRIPTION
The object ids list must be ordered so we can take chunks of it and query for the objects with between condition

Fixes #5741

Please review this commit: @rafatower @ethervoid 