### PR TITLE
Enabled invalidation duration log in python

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1270,7 +1270,9 @@ module CartoDB
                 current_time = time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime())
                 session_user = plpy.execute("SELECT session_user", 1)[0]["session_user"]
                 invalidation_result = {'timestamp': current_time, 'duration': round(invalidation_duration, 8), 'termination_state': termination_state, 'retries': retries, 'error': error, 'database': '#{@user.database_name}', 'table_name': table_name, 'dbuser': session_user}
-                syslog.syslog(syslog.LOG_INFO, "invalidation: %s" % invalidation_result)
+                
+                if trigger_verbose:
+                  syslog.syslog(syslog.LOG_INFO, "invalidation: %s" % invalidation_result)
 
             $$
             LANGUAGE 'plpythonu' VOLATILE;

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1218,6 +1218,23 @@ module CartoDB
 
                 client = GD.get('invalidation', None)
 
+                if 'syslog' not in GD:
+                  import syslog
+                  GD['syslog'] = syslog
+                else:  
+                  syslog = GD['syslog']
+               
+                if 'time' not in GD:
+                  import time
+                  GD['time'] = time
+                else:  
+                  time = GD['time']
+ 
+                start = time.time()
+                retries = 0
+                termination_state = 1
+                error = ''          
+
                 while True:
 
                   if not client:
@@ -1225,6 +1242,7 @@ module CartoDB
                         import redis
                         client = GD['invalidation'] = redis.Redis(host='#{invalidation_host}', port=#{invalidation_port}, socket_timeout=timeout)
                       except Exception as err:
+                        error = "client_error - %s" % str(err)
                         # NOTE: we won't retry on connection error
                         if critical:
                           plpy.error('Invalidation Service connection error: ' +  str(err))
@@ -1232,8 +1250,11 @@ module CartoDB
 
                   try:
                     client.execute_command('TCH', '#{@user.database_name}', table_name)
+                    termination_state = 0
+                    error = ''
                     break
                   except Exception as err:
+                    error = "request_error - %s" % str(err)
                     if trigger_verbose:
                       plpy.warning('Invalidation Service warning: ' + str(err))
                     client = GD['invalidation'] = None # force reconnect
@@ -1241,7 +1262,15 @@ module CartoDB
                       if critical:
                         plpy.error('Invalidation Service error: ' +  str(err))
                       break
+                    retries = retries + 1
                     retry -= 1 # try reconnecting
+                  
+                end = time.time()
+                invalidation_duration = (end - start)
+                current_time = time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime())
+                invalidation_result = {'timestamp': current_time, 'duration': round(invalidation_duration, 8), 'termination_state': termination_state, 'retries': retries, 'error': error, 'database': '#{@user.database_name}', 'table_name': table_name}
+                syslog.syslog(syslog.LOG_INFO, "invalidation: %s" % invalidation_result)
+
             $$
             LANGUAGE 'plpythonu' VOLATILE;
             REVOKE ALL ON FUNCTION public.cdb_invalidate_varnish(TEXT) FROM PUBLIC;

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1268,7 +1268,8 @@ module CartoDB
                 end = time.time()
                 invalidation_duration = (end - start)
                 current_time = time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime())
-                invalidation_result = {'timestamp': current_time, 'duration': round(invalidation_duration, 8), 'termination_state': termination_state, 'retries': retries, 'error': error, 'database': '#{@user.database_name}', 'table_name': table_name}
+                session_user = plpy.execute("SELECT session_user", 1)[0]["session_user"]
+                invalidation_result = {'timestamp': current_time, 'duration': round(invalidation_duration, 8), 'termination_state': termination_state, 'retries': retries, 'error': error, 'database': '#{@user.database_name}', 'table_name': table_name, 'dbuser': session_user}
                 syslog.syslog(syslog.LOG_INFO, "invalidation: %s" % invalidation_result)
 
             $$


### PR DESCRIPTION
Enable invalidation log inside the invalidation service plpython trigger. The logging is done through syslog. It's a more natural way to do it if postgresql is already configured to log through syslog.

Note that the format is just a string representation of a python dict. Not sure how expensive can be converting a dict to json to string every time a invalidation occurs.

I've taken the chance to write some more info that may help to debug in case of problems like the number of retries and error string.

/cc @rochoa @javisantana @rafatower @zenitraM 