### PR TITLE
Escaping quotes in available_geometries query

### DIFF
--- a/app/controllers/carto/api/geocodings_controller.rb
+++ b/app/controllers/carto/api/geocodings_controller.rb
@@ -66,7 +66,7 @@ module Carto
         return head(400) if input.nil? && params[:table_name].present?
         render(json: []) and return if input.nil? || input.empty?
 
-        list = input.map{ |v| "'#{ v.to_s.gsub("'", %q('')) }'" }.join(",")
+        list = input.map { |v| "'#{v.to_s.gsub("'", "''")}'" }.join(",")
 
         services = CartoDB::SQLApi.new({ username: 'geocoding', timeout: GEOCODING_SQLAPI_CALLS_TIMEOUT}).fetch("SELECT (admin0_available_services(Array[#{list}])).*")
 

--- a/app/controllers/carto/api/geocodings_controller.rb
+++ b/app/controllers/carto/api/geocodings_controller.rb
@@ -66,7 +66,7 @@ module Carto
         return head(400) if input.nil? && params[:table_name].present?
         render(json: []) and return if input.nil? || input.empty?
 
-        list = input.map{ |v| "'#{ v }'" }.join(",")
+        list = input.map{ |v| "'#{ v.downcase.gsub(/[^\p{Alnum}]/) }'" }.join(",")
 
         services = CartoDB::SQLApi.new({ username: 'geocoding', timeout: GEOCODING_SQLAPI_CALLS_TIMEOUT}).fetch("SELECT (admin0_available_services(Array[#{list}])).*")
 

--- a/app/controllers/carto/api/geocodings_controller.rb
+++ b/app/controllers/carto/api/geocodings_controller.rb
@@ -66,7 +66,7 @@ module Carto
         return head(400) if input.nil? && params[:table_name].present?
         render(json: []) and return if input.nil? || input.empty?
 
-        list = input.map{ |v| "'#{ v.gsub("'", %q('')) }'" }.join(",")
+        list = input.map{ |v| "'#{ v.to_s.gsub("'", %q('')) }'" }.join(",")
 
         services = CartoDB::SQLApi.new({ username: 'geocoding', timeout: GEOCODING_SQLAPI_CALLS_TIMEOUT}).fetch("SELECT (admin0_available_services(Array[#{list}])).*")
 

--- a/app/controllers/carto/api/geocodings_controller.rb
+++ b/app/controllers/carto/api/geocodings_controller.rb
@@ -65,9 +65,7 @@ module Carto
         input = params[:free_text].present? ? clean_free_text_input([params[:free_text]]) : select_distinct_from_table_and_column(params[:table_name], params[:column_name])
         return head(400) if input.nil? && params[:table_name].present?
         render(json: []) and return if input.nil? || input.empty?
-
-        list = input.map{ |v| "'#{ v.downcase.gsub(/[^\p{Alnum}]/) }'" }.join(",")
-
+        list = input.map{ |v| "'#{ v.gsub("'", %q(\\\')) }'" }.join(",")
         services = CartoDB::SQLApi.new({ username: 'geocoding', timeout: GEOCODING_SQLAPI_CALLS_TIMEOUT}).fetch("SELECT (admin0_available_services(Array[#{list}])).*")
 
         geometries = []

--- a/app/controllers/carto/api/geocodings_controller.rb
+++ b/app/controllers/carto/api/geocodings_controller.rb
@@ -65,7 +65,9 @@ module Carto
         input = params[:free_text].present? ? clean_free_text_input([params[:free_text]]) : select_distinct_from_table_and_column(params[:table_name], params[:column_name])
         return head(400) if input.nil? && params[:table_name].present?
         render(json: []) and return if input.nil? || input.empty?
-        list = input.map{ |v| "'#{ v.gsub("'", %q(\\\')) }'" }.join(",")
+
+        list = input.map{ |v| "'#{ v.gsub("'", %q('')) }'" }.join(",")
+
         services = CartoDB::SQLApi.new({ username: 'geocoding', timeout: GEOCODING_SQLAPI_CALLS_TIMEOUT}).fetch("SELECT (admin0_available_services(Array[#{list}])).*")
 
         geometries = []

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -181,6 +181,16 @@ describe 'legacy behaviour tests' do
       JSON.parse(last_response.body).should eq ['polygon']
     end
 
+    it 'returns point from an input column if SQLApi says there is a point service for it' do
+      table = create_table(user_id: @user1.id)
+      table.add_column!(name: 'country', type: 'string')
+      table.insert_row!(country: 'Cote d\'Ivore')
+      table.insert_row!(country: 'Spain')
+
+      get api_v1_geocodings_available_geometries_url, { kind: 'postalcode', column_name: 'country', table_name: table.name}
+      last_response.status.should == 200
+    end
+
     it 'returns 400 if table name does not exist' do
       get api_v1_geocodings_available_geometries_url, { kind: 'postalcode', column_name: 'my_column', table_name: 'my_table'}
       last_response.status.should eq 400

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -187,7 +187,7 @@ describe 'legacy behaviour tests' do
       table.insert_row!(country: 'Cote d\'Ivore')
       table.insert_row!(country: 'Spain')
 
-      get api_v1_geocodings_available_geometries_url, { kind: 'postalcode', column_name: 'country', table_name: table.name}
+      get api_v1_geocodings_available_geometries_url, { kind: 'postalcode', column_name: 'country', table_name: table.name }
       last_response.status.should == 200
     end
 

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -185,8 +185,8 @@ describe 'legacy behaviour tests' do
       table = create_table(user_id: @user1.id)
       table.add_column!(name: 'country', type: 'string')
       table.insert_row!(country: 'Cote d\'Ivore')
-      table.insert_row!(country: 'Spain')
 
+      CartoDB::SQLApi.any_instance.expects(:fetch).with("SELECT (admin0_available_services(Array['Cote d''Ivore'])).*").returns([ { 'postal_code_points' => 1, 'postal_code_polygons' => 0 }])
       get api_v1_geocodings_available_geometries_url, { kind: 'postalcode', column_name: 'country', table_name: table.name }
       last_response.status.should == 200
     end

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -188,8 +188,9 @@ describe 'legacy behaviour tests' do
 
       CartoDB::SQLApi.any_instance.expects(:fetch).
         with("SELECT (admin0_available_services(Array['Cote d''Ivore'])).*").
-        returns([ { 'postal_code_points' => 1, 'postal_code_polygons' => 0 }])
-      get api_v1_geocodings_available_geometries_url, { kind: 'postalcode', column_name: 'country', table_name: table.name }
+        returns([{ 'postal_code_points' => 1, 'postal_code_polygons' => 0 }])
+      get api_v1_geocodings_available_geometries_url,
+        { kind: 'postalcode', column_name: 'country', table_name: table.name }
       last_response.status.should == 200
     end
 

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -186,7 +186,9 @@ describe 'legacy behaviour tests' do
       table.add_column!(name: 'country', type: 'string')
       table.insert_row!(country: 'Cote d\'Ivore')
 
-      CartoDB::SQLApi.any_instance.expects(:fetch).with("SELECT (admin0_available_services(Array['Cote d''Ivore'])).*").returns([ { 'postal_code_points' => 1, 'postal_code_polygons' => 0 }])
+      CartoDB::SQLApi.any_instance.expects(:fetch).
+        with("SELECT (admin0_available_services(Array['Cote d''Ivore'])).*").
+        returns([ { 'postal_code_points' => 1, 'postal_code_polygons' => 0 }])
       get api_v1_geocodings_available_geometries_url, { kind: 'postalcode', column_name: 'country', table_name: table.name }
       last_response.status.should == 200
     end


### PR DESCRIPTION
## Description:

This issue was reported at our Data Services repo: https://github.com/CartoDB/data-services/issues/161.
The problem happens explicitly in the  `postal_code` geocoding process when the country input information is obtained from a column (a free text is correctly sanitized by the current code).

When one of the countries in that column contains a `' ` character, which happens for Cote d'Ivore, the following line crashed:

https://github.com/CartoDB/cartodb/blob/master/app/controllers/carto/api/geocodings_controller.rb#L71

as the code was generating an array with the countries in the column without escaping the values inside. This was generating something like:

````
SELECT (admin0_available_services(Array['Spain', 'Cote d'Ivore'])).*
`````

Which provokes a clear syntax error in Postgres.

## Proposed solution

The code gets the distinct values for the countries in a separate function and generated the contents of the SQL Array here:
````
 list = input.map{ |v| "'#{ v }'" }.join(",")
````

From: https://github.com/CartoDB/cartodb/blob/master/app/controllers/carto/api/geocodings_controller.rb#L69

This new code escapes single quotes inside the mapping substituting them by two single quotes, which is the way in Postgres to escape single quotes:

````
list = input.map{ |v| "'#{ v.to_s.gsub("'", "''") }'" }.join(",")
```
## Tests

I created a new test that generates a table whose content is syntactically incorrect for the SQL API and runs the available_geometries request. It expects to get a 200 response, which basically would mean that there's no syntax error in the query.

The test is running, but here's the behaviour of the test with the old code (notice the syntax error):

![image](https://cloud.githubusercontent.com/assets/1730320/11245899/800c9e36-8e15-11e5-9f02-6f3ce672860d.png)


cc @rafatower @jgoizueta 

Fixes https://github.com/CartoDB/data-services/issues/161