### PR TITLE
Payload consistency check

### DIFF
--- a/app/controllers/api/json/visualizations_controller.rb
+++ b/app/controllers/api/json/visualizations_controller.rb
@@ -148,7 +148,6 @@ class Api::Json::VisualizationsController < Api::ApplicationController
         end
 
         return head(404) unless vis
-        return head(403) unless payload[:id] == vis.id
         return head(403) unless vis.is_owner?(current_user)
 
         track_event(vis, 'Deleted')
@@ -157,7 +156,7 @@ class Api::Json::VisualizationsController < Api::ApplicationController
             # Remove dependent visualizations as well, if any
             track_event(dependent_vis, 'Deleted')
           }
-        end 
+        end
 
         @stats_aggregator.timing('delete') do
           vis.delete


### PR DESCRIPTION
An uncommitted change to remove this check for deletion (not needed as no inference is made from the payload) was pending through staging tests (which were obviously not correctly conducted). A a result, map deletion was broken and this mornings deploys was reverted.

Please, CR this uncommitted change so I can redeploy, @juanignaciosl 
