### PR TITLE
Don't validate empty urls for importing

### DIFF
--- a/app/controllers/api/json/synchronizations_controller.rb
+++ b/app/controllers/api/json/synchronizations_controller.rb
@@ -199,7 +199,7 @@ class Api::Json::SynchronizationsController < Api::ApplicationController
       options.merge!( { data_source: external_source.import_url.presence } )
     else
       url = params[:url]
-      validate_url!(url) unless Rails.env.development? || Rails.env.test?
+      validate_url!(url) unless Rails.env.development? || Rails.env.test? || url.nil? || url.empty?
       options.merge!(data_source: url)
     end
 


### PR DESCRIPTION
Hotfix for syncs to work. There're services which use service_item_id instead of url, it shouldn't be mandatory.

Will check in staging and deploy.

cc @ethervoid @rafatower 