### PR TITLE
Logs ghost table linking

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1038,7 +1038,7 @@ class User < Sequel::Model
     renamed_tables.each do |t|
       table = Table.new(:user_table => ::UserTable.find(:table_id => t[:oid], :user_id => self.id))
       begin
-        CartoDB::Logger.info('link_renamed_tables', "User[id: '#{self.id}'], Table[name: '#{t[:relname]}']")
+        CartoDB::Logger.info('link_renamed_tables', "User[id: '#{id}'], Table[name: '#{t[:relname]}']")
         Rollbar.report_message('ghost tables', 'debug', {
           :action => 'rename',
           :new_table => t[:relname]
@@ -1057,7 +1057,7 @@ class User < Sequel::Model
     created_tables = real_tables.select {|t| table_names.include?(t[:relname]) }
     created_tables.each do |t|
       begin
-        CartoDB::Logger.info('link_created_table:', "User[id: '#{self.id}'], Table[name: '#{t[:relname]}']")
+        CartoDB::Logger.info('link_created_table:', "User[id: '#{id}'], Table[name: '#{t[:relname]}']")
         Rollbar.report_message('ghost tables', 'debug', {
           :action => 'registering table',
           :new_table => t[:relname]
@@ -1089,7 +1089,7 @@ class User < Sequel::Model
 
     # Remove tables with oids that don't exist on the db
     self.tables.where(table_id: dropped_tables).all.each do |user_table|
-      CartoDB::Logger.info('link_deleted_tables', "User[id: '#{self.id}'], Table[name: '#{user_table.name}']")
+      CartoDB::Logger.info('link_deleted_tables', "User[id: '#{id}'], Table[name: '#{user_table.name}']")
       Rollbar.report_message('ghost tables', 'debug', {
         :action => 'dropping table',
         :new_table => user_table.name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1038,6 +1038,7 @@ class User < Sequel::Model
     renamed_tables.each do |t|
       table = Table.new(:user_table => ::UserTable.find(:table_id => t[:oid], :user_id => self.id))
       begin
+        CartoDB::Logger.info('link_renamed_tables', "User[id: '#{self.id}'], Table[name: '#{t[:relname]}']")
         Rollbar.report_message('ghost tables', 'debug', {
           :action => 'rename',
           :new_table => t[:relname]
@@ -1056,6 +1057,7 @@ class User < Sequel::Model
     created_tables = real_tables.select {|t| table_names.include?(t[:relname]) }
     created_tables.each do |t|
       begin
+        CartoDB::Logger.info('link_created_table:', "User[id: '#{self.id}'], Table[name: '#{t[:relname]}']")
         Rollbar.report_message('ghost tables', 'debug', {
           :action => 'registering table',
           :new_table => t[:relname]
@@ -1087,6 +1089,7 @@ class User < Sequel::Model
 
     # Remove tables with oids that don't exist on the db
     self.tables.where(table_id: dropped_tables).all.each do |user_table|
+      CartoDB::Logger.info('link_deleted_tables', "User[id: '#{self.id}'], Table[name: '#{user_table.name}']")
       Rollbar.report_message('ghost tables', 'debug', {
         :action => 'dropping table',
         :new_table => user_table.name


### PR DESCRIPTION
Fixes #5581

The output would be something like this:

```
[link_created_tables:] === User[id: '5f183b2b-f51c-4274-8ca0-d3fd07f0ad34'], Table[name: 'patata_pocha']
[link_deleted_tables] === User[id: '5f183b2b-f51c-4274-8ca0-d3fd07f0ad34'], Table[name: 'patata_pochisima']
```

What that suffice? Suggestions?

@juanignaciosl 