### PR TITLE
Rake to install geocoder client extension

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 * Removed config option `maps_api_cdn_template`, reusing now instead `cdn_url`
 * Allow to create sync tables with a map if setting up onw from "connect dataset" from the Maps view
 * Added [#5975 Box integration](https://github.com/CartoDB/cartodb/issues/5975).
+* New rake to install in user or organization the geocoder extension
 
 
 3.11.0 (2015-09-09)

--- a/app/models/carto/user_db_service.rb
+++ b/app/models/carto/user_db_service.rb
@@ -6,6 +6,7 @@ module Carto
       # Also default schema for new users
       SCHEMA_PUBLIC = 'public'
       SCHEMA_CARTODB = 'cartodb'
+      SCHEMA_CDB_GEOCODER = 'cdb_geocoder_client'
       SCHEMA_IMPORTER = 'cdb_importer'
 
     def initialize(user)
@@ -23,6 +24,7 @@ module Carto
 
     # Centralized method to provide the (ordered) search_path
     def self.build_search_path(user_schema, quote_user_schema = true)
+      #TODO Add SCHEMA_CDB_GEOCODER when we open the geocoder API to all the people
       quote_char = quote_user_schema ? "\"" : ""
       "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_PUBLIC}"
     end

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -168,6 +168,11 @@ defaults: &defaults
       base_url: ''
       api_key: ''
       table_name: ''
+    api:
+      host: ''
+      port: ''
+      dbname: ''
+      user: ''
   importer:
     content_guessing:        # Depends on geocoding
       enabled:         false # Disabled if false or not present


### PR DESCRIPTION
Added rake and model logic to install the geocoder extension to the passed user or organization:

- [x] Add `cdb_geocoder_client` schema to the search path
- [x] Install `plproxy` and `cdb_geocoder_extensions`
- [x] Add required geocoder server config

@rafatower pls check this out