### PR TITLE
Fixing problems with Firefox and IE with the double click behaviour over layer name

### DIFF
--- a/lib/assets/javascripts/cartodb/table/views/right_panel.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/right_panel.jst.ejs
@@ -1,10 +1,10 @@
 <div class="layer-info">
   <div class="left">
-    <button class="info">
+    <span class="info">
       <span class="order"></span>
       <span class="name"></span>
       <span class="name_info"></span>
-    </button>
+    </span>
     <input type="text" value="" class="alias" />
   </div>
   <div class="right">


### PR DESCRIPTION
Seems like Firefox doesn't allow (correctly) add a ```<a>``` tag within a ```<button>``` tag, so it provoked undesired behaviours, like double click not working and so on.

Fixes #5390.