### PR TITLE
Geocoder api user creation

### DIFF
--- a/app/models/carto/user_db_service.rb
+++ b/app/models/carto/user_db_service.rb
@@ -8,6 +8,7 @@ module Carto
       SCHEMA_CARTODB = 'cartodb'
       SCHEMA_CDB_GEOCODER = 'cdb_geocoder_client'
       SCHEMA_IMPORTER = 'cdb_importer'
+      SCHEMA_CDB_GEOCODER_API = 'cdb_geocoder_client'
 
     def initialize(user)
       @user = user
@@ -26,7 +27,7 @@ module Carto
     def self.build_search_path(user_schema, quote_user_schema = true)
       #TODO Add SCHEMA_CDB_GEOCODER when we open the geocoder API to all the people
       quote_char = quote_user_schema ? "\"" : ""
-      "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_PUBLIC}"
+      "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_CDB_GEOCODER_API}, #{SCHEMA_PUBLIC}"
     end
 
 

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -80,7 +80,8 @@ module CartoDB
         create_importer_schema
         create_geocoding_schema
         load_cartodb_functions
-        install_and_configure_geocoder_api_extension
+        # TODO Activate when we launch geocoder api for all the users
+        #install_and_configure_geocoder_api_extension
         # We reset the connections to this database to be sure the change in default search_path is effective
         reset_pooled_connections
 
@@ -98,7 +99,8 @@ module CartoDB
         end.join
         create_own_schema
         setup_organization_user_schema
-        install_and_configure_geocoder_api_extension
+        # TODO Activate when we launch geocoder api for all the users
+        #install_and_configure_geocoder_api_extension
         # We reset the connections to this database to be sure the change in default search_path is effective
         reset_pooled_connections
         revoke_cdb_conf_access

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -80,6 +80,9 @@ module CartoDB
         create_importer_schema
         create_geocoding_schema
         load_cartodb_functions
+        install_and_configure_geocoder_api_extension
+        # We reset the connections to this database to be sure the change in default search_path is effective
+        reset_pooled_connections
 
         reset_database_permissions # Reset privileges
 
@@ -95,6 +98,9 @@ module CartoDB
         end.join
         create_own_schema
         setup_organization_user_schema
+        install_and_configure_geocoder_api_extension
+        # We reset the connections to this database to be sure the change in default search_path is effective
+        reset_pooled_connections
         revoke_cdb_conf_access
       end
 
@@ -146,9 +152,6 @@ module CartoDB
 
         upgrade_cartodb_postgres_extension(statement_timeout, cdb_extension_target_version)
 
-        # We reset the connections to this database to be sure the change in default search_path is effective
-        reset_pooled_connections
-
         rebuild_quota_trigger
       end
 
@@ -183,7 +186,7 @@ module CartoDB
       # Centralized method to provide the (ordered) search_path
       def self.build_search_path(user_schema, quote_user_schema = true)
         quote_char = quote_user_schema ? "\"" : ""
-        "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_PUBLIC}"
+        "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_CDB_GEOCODER_API}, #{SCHEMA_PUBLIC}"
       end
 
       def set_database_search_path
@@ -394,7 +397,23 @@ module CartoDB
         end
       end
 
-      def configure_geocoder_extension(organization=nil)
+      def install_and_configure_geocoder_api_extension
+        begin
+          install_geocoder_api_extension
+
+          search_path = build_search_path
+          @user.in_database(as: :superuser).run("ALTER USER \"#{@user.database_username}\"
+              SET search_path TO #{search_path}")
+          if @user.organization_user?
+            @user.in_database(as: :superuser).run("ALTER USER \"#{@user.database_public_username}\"
+              SET search_path TO #{search_path}")
+          end
+        rescue => e
+          CartoDB.notify_error('Error installing an configuring geocoder api extension', error: e.inspect, user: @user)
+        end
+      end
+
+      def install_geocoder_api_extension
         config = Cartodb.config[:geocoder]['api']
         raise("Geocoder API config missing") if config.blank?
         host = config['host']
@@ -403,6 +422,7 @@ module CartoDB
         dbname = config['dbname']
         raise("Geocoder API config incomplete, some fields are missing") if host.blank? || port.blank? || user.blank? || dbname.blank?
 
+        # Geocoder server connection config (not user related)
         geocoder_server_config_sql = %{
           SELECT cartodb.CDB_Conf_SetConf('geocoder_server_config',
             '{ \"connection_str\": \"host=#{host} port=#{port} dbname=#{dbname} user=#{user}\"}'::json
@@ -416,27 +436,6 @@ module CartoDB
             db.run(geocoder_server_config_sql)
           end
         end
-
-        if !organization.nil?
-          org_users = organization.users
-          org_users.each do |u|
-            # TODO This part is a copy of the build_search_path method to avoid put the geocoder schema path
-            # until we open this to all the users
-            search_path = "\"#{u.database_schema}\", #{SCHEMA_CARTODB}, #{SCHEMA_CDB_GEOCODER_API}, #{SCHEMA_PUBLIC}"
-            @user.in_database(as: :superuser).run("ALTER USER \"#{u.database_username}\"
-              SET search_path TO #{search_path}")
-            # We have to set the search_path to the publicuser too
-            @user.in_database(as: :superuser).run("ALTER USER \"#{u.database_public_username}\"
-              SET search_path TO #{search_path}")
-          end
-        else
-          # TODO This part is a copy of the build_search_path method to avoid put the geocoder schema path
-          # until we open this to all the users
-          search_path = "\"#{@user.database_schema}\", #{SCHEMA_CARTODB}, #{SCHEMA_CDB_GEOCODER_API}, #{SCHEMA_PUBLIC}"
-          @user.in_database(as: :superuser).run("ALTER USER \"#{@user.database_username}\"
-            SET search_path TO #{search_path}")
-        end
-        reset_pooled_connections
       end
 
       def setup_organization_owner
@@ -1268,25 +1267,25 @@ module CartoDB
                 if 'syslog' not in GD:
                   import syslog
                   GD['syslog'] = syslog
-                else:  
+                else:
                   syslog = GD['syslog']
-               
+
                 if 'time' not in GD:
                   import time
                   GD['time'] = time
-                else:  
+                else:
                   time = GD['time']
-                
+
                 if 'json' not in GD:
                   import json
                   GD['json'] = json
-                else:  
+                else:
                   json = GD['json']
- 
+
                 start = time.time()
                 retries = 0
                 termination_state = 1
-                error = ''          
+                error = ''
 
                 while True:
 
@@ -1317,13 +1316,13 @@ module CartoDB
                       break
                     retries = retries + 1
                     retry -= 1 # try reconnecting
-                  
+
                 end = time.time()
                 invalidation_duration = (end - start)
                 current_time = time.strftime("%Y-%m-%d %H:%M:%S %Z", time.localtime())
                 session_user = plpy.execute("SELECT session_user", 1)[0]["session_user"]
                 invalidation_result = {"timestamp": current_time, "duration": round(invalidation_duration, 8), "termination_state": termination_state, "retries": retries, "error": error, "database": "#{@user.database_name}", "table_name": table_name, "dbuser": session_user}
-                
+
                 if trigger_verbose:
                   syslog.syslog(syslog.LOG_INFO, "invalidation: %s" % json.dumps(invalidation_result))
 

--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -1196,28 +1196,62 @@ namespace :cartodb do
       end
     end
 
-    desc "Configure geocoder extension configuration for user or organization"
-    task :configure_geocoder_extension_configuration, [:entity_name, :is_organization] => :environment do |t, args|
-      args.with_defaults(:entity_name => nil, :is_organization => false)
-      puts "ERROR: You have to provide an username or organization name as first parameter" if args[:entity_name].blank?
-      if args[:is_organization]
-        organizations = Organization.where(name: args[:entity_name]).all
-        raise "ERROR: Organization #{args[:entity_name]} don't exists" if organizations.blank?
-        run_for_organizations_owner(organizations) do |owner|
-          begin
-            owner.db_service.configure_geocoder_extension(owner.organization)
-          rescue => e
-            puts "Error trying to configure geocoder extension for org #{owner.organization.name}: #{e.message}"
-          end
-        end
-      else
-        user = User.where(username: args[:entity_name]).first
-        raise  "ERROR: User #{args[:entity_name]} don't exists" if user.nil?
+    # e.g. bundle exec rake cartodb:db:configure_geocoder_extension_for_organizations[org-name]
+    #      bundle exec rake cartodb:db:configure_geocoder_extension_for_organizations['',true]
+    desc "Configure geocoder extension configuration for organizations"
+    task :configure_geocoder_extension_for_organizations, [:organization_name, :all_organizations] => :environment do |t, args|
+      args.with_defaults(:organization_name => nil, :all_organizations => false)
+      if args[:organization_name].blank? and args[:all_organizations] != 'true'
+        # Double check before launch an update to all the orgs
+        raise "ERROR: You haven't passed an organization name and/or put the :all_organizations flag to true"
+      end
+      organizations = args[:organization_name].blank? ? ::Organization.all : ::Organization.where(name: args[:organization_name]).all
+      raise "ERROR: Organization #{args[:organization_name]} don't exists" if organizations.blank? and not args[:all_organizations]
+      run_for_organizations_owner(organizations) do |owner|
         begin
-          user.db_service.configure_geocoder_extension()
+          owner.db_service.install_and_configure_geocoder_api_extension
+          puts "Owner #{owner.username}: OK"
+          # TODO Improved using the execute_on_users_with_index when orgs have a lot more users
+          owner.organization.users.each do |u|
+            if not u.organization_owner?
+              u.db_service.install_and_configure_geocoder_api_extension
+              puts "Organization user #{u.username}: OK"
+            end
+          end
         rescue => e
-          puts "ERROR trying to configure geocoder extension for user #{user.username}: #{e.message}"
+          puts "Error trying to configure geocoder extension for org #{owner.organization.name}: #{e.message}"
         end
+      end
+    end
+
+    # e.g. bundle exec rake cartodb:db:configure_geocoder_extension_for_non_org_users[username]
+    #      bundle exec rake cartodb:db:configure_geocoder_extension_for_non_org_users['',true]
+    desc "Configure geocoder extension configuration for non-organization users"
+    task :configure_geocoder_extension_for_non_org_users, [:username, :all_users] => :environment do |t, args|
+      args.with_defaults(:username => nil, :all_users => false)
+      if args[:username].blank? and args[:all_users] != 'true'
+        # Double check before launch an update to all the orgs
+        raise "ERROR: You haven't passed an username and/or put the :all_users flag to true"
+      end
+      if not args[:username].blank?
+        user = ::User.where(username: args[:username]).first
+        raise  "ERROR: User #{args[:username]} don't exists" if user.nil?
+        begin
+          user.db_service.install_and_configure_geocoder_api_extension unless user.organization_user?
+          puts "OK #{user.username}"
+        rescue => e
+          puts "Error trying to configure geocoder extension for user #{u.name}: #{e.message}"
+        end
+      elsif args[:all_users]
+        # TODO Could be improved passing the query to execute_on_users_with_index function to filter by non-org-users
+        execute_on_users_with_index(:configure_geocoder_extension_for_non_org_users.to_s, Proc.new { |user, i|
+          begin
+            user.db_service.install_and_configure_geocoder_api_extension
+            puts "OK #{user.username}"
+          rescue => e
+            puts "Error trying to configure geocoder extension for user #{u.name}: #{e.message}"
+          end
+        }, 1, 0.3)
       end
     end
   end

--- a/spec/models/carto/user_service_spec.rb
+++ b/spec/models/carto/user_service_spec.rb
@@ -4,8 +4,8 @@ require_relative '../../spec_helper'
 describe Carto::UserService do
   before(:all) do
     @user = create_user({
-        email: 'admin@cartotest.com', 
-        username: 'admin', 
+        email: 'admin@cartotest.com',
+        username: 'admin',
         password: '123456'
       })
 
@@ -73,7 +73,7 @@ describe Carto::UserService do
   end
 
   it "Tests search_path correctly set" do
-    expected_returned_normal_search_path = { search_path: "#{@user.database_schema}, cartodb, public" }
+    expected_returned_normal_search_path = { search_path: "#{@user.database_schema}, cartodb, cdb_geocoder_client, public" }
 
     @normal_search_path = nil
     @normal_search_path_new = nil


### PR DESCRIPTION
Added rake and model logic to install the geocoder extension to the passed user or organization:

- [x] Install and configure geocoder extension to a user when is created
- [x] Rakes to install the geocoder api extension to all the users and / or organization
- [x] Add the `entity_config` configuration (v2 but no harm is done to add here now)
- [x] Add the `_cdb_username()` function to get the username based on the schema (org users) or the config (non-org users)
- [x] Change the config part to fulfill the new config requeriments