### PR TITLE
Set include_all param to true in respond_to method

### DIFF
--- a/services/table-geocoder/spec/lib/gme/table_geocoder_spec.rb
+++ b/services/table-geocoder/spec/lib/gme/table_geocoder_spec.rb
@@ -30,7 +30,7 @@ describe Carto::Gme::TableGeocoder do
                            :process_results
                            ]
       interface_methods.each do |method|
-        table_geocoder.respond_to?(method).should == true
+        table_geocoder.respond_to?(method, true).should == true
       end
     end
 


### PR DESCRIPTION
Since ruby 2 the behavior of respond_to? method has changed. Now, it
only checks, by default, the public methods, but not private and
protected ones. In order to enable check of all methods, a second
parameter "include_all" must be enabled. More info in:
http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html

Please @rafatower and @juanignaciosl review