### PR TITLE
Add more ArcGIS valid URLs

### DIFF
--- a/services/datasources/lib/datasources/url/arcgis.rb
+++ b/services/datasources/lib/datasources/url/arcgis.rb
@@ -14,7 +14,9 @@ module CartoDB
         # Required for all datasources
         DATASOURCE_NAME = 'arcgis'
 
-        ARCGIS_API_LIKE_URL_RE = /\/(arcgis|gis)\/rest/i
+        VALID_ARCGIS_WEBSERVERS = %w{ arcgis gis arcgiswebadaptor arcgis_web_adaptor }
+
+        ARCGIS_API_LIKE_URL_RE = /\/(#{VALID_ARCGIS_WEBSERVERS.join('|')})\/rest/i
 
         METADATA_URL     = '%s?f=json'
         FEATURE_IDS_URL  = '%s/query?where=1%%3D1&returnIdsOnly=true&f=json'


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/2300

Allows more ArcGIS server URLs, specifically ArcGIS Web Adaptors: http://server.arcgis.com/en/web-adaptor/latest/install/iis/about-the-arcgis-web-adaptor-server-.htm