### PR TITLE
Fixed gmaps double click

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.08",
+  "version": "3.23.09",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/vendor/assets/javascripts/cartodb.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.uncompressed.js
@@ -1,6 +1,6 @@
 // cartodb.js version: 3.15.8
 // uncompressed version: cartodb.uncompressed.js
-// sha: 3798323b953318576fac7ef00dede0aeec81e978
+// sha: be76b55caeeb0dfc147e3fa36628d9e215717ce5
 (function() {
   var define;  // Undefine define (require.js), see https://github.com/CartoDB/cartodb.js/issues/543
   var root = this;
@@ -37045,7 +37045,7 @@ if(typeof(google) != "undefined" && typeof(google.maps) != "undefined") {
           scrollwheel: this.map.get("scrollwheel"),
           // Allow dragging (and double click zoom)
           draggable: this.map.get("drag"),
-          disableDoubleClickZoom: this.map.get("drag"),
+          disableDoubleClickZoom: !this.map.get("drag"),
           mapTypeControl:false,
           mapTypeId: google.maps.MapTypeId.ROADMAP,
           backgroundColor: 'white',


### PR DESCRIPTION
Basically updating CartoDB.js bundle, adding the fix for GMaps double click suffered in CartoDB editor.

Reference #6216