### PR TITLE
6202 organization creation fail didnt clean all metadata

### DIFF
--- a/app/controllers/superadmin/organizations_controller.rb
+++ b/app/controllers/superadmin/organizations_controller.rb
@@ -28,9 +28,9 @@ class Superadmin::OrganizationsController < Superadmin::SuperadminController
   rescue => e
     begin
       @organization.delete if @organization
-    rescue => e
+    rescue => ee
       # Avoid shadowing original error
-      CartoDB.notify_error('Cleaning failed creation', error: e.inspect, organization: @organization)
+      CartoDB.notify_error('Cleaning failed creation', error: ee.inspect, organization: @organization)
     end
     CartoDB.notify_error('Error creating organization', error: e.inspect, organization: @organization)
     respond_with(:superadmin, @organization, errors: [e.inspect], status: 500)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -644,13 +644,7 @@ class User < Sequel::Model
   #       improved to skip "service" tables
   #
   def tables_effective
-    in_database do |user_database|
-      user_database.synchronize do |conn|
-        query = "select table_name::text from information_schema.tables where table_schema = 'public'"
-        tables = user_database[query].all.map { |i| i[:table_name] }
-        return tables
-      end
-    end
+    self.db_service.tables_effective('public')
   end
 
   # Gets the list of OAuth accounts the user has (currently only used for synchronization)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -644,7 +644,7 @@ class User < Sequel::Model
   #       improved to skip "service" tables
   #
   def tables_effective
-    self.db_service.tables_effective('public')
+    db_service.tables_effective('public')
   end
 
   # Gets the list of OAuth accounts the user has (currently only used for synchronization)

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -294,6 +294,16 @@ module CartoDB
         end
       end
 
+      def tables_effective(schema = 'public')
+        @user.in_database do |user_database|
+          user_database.synchronize do |conn|
+            query = "select table_name::text from information_schema.tables where table_schema = '#{schema}'"
+            tables = user_database[query].all.map { |i| i[:table_name] }
+            return tables
+          end
+        end
+      end
+
       def drop_owned_by_user(conn, role)
         conn.run("DROP OWNED BY \"#{role}\"")
       end
@@ -950,7 +960,9 @@ module CartoDB
         # Undo metadata changes if process fails
         begin
           @user.this.update database_schema: old_database_schema_name
-          if schema_exists?(new_schema_name)
+
+          # Defensive measure to avoid undesired table dropping
+          if schema_exists?(new_schema_name) && tables_effective(new_schema_name).count == 0
             drop_all_functions_from_schema(new_schema_name)
             @user.in_database.run(%{ DROP SCHEMA "#{new_schema_name}" })
           end


### PR DESCRIPTION
This is related to #6202. This doesn't actually fix the underlying problem, but there's nothing I can do yet, because I can't find the root cause. So, I've added some failing scenarios, a safety measure (not deleting non-empty schemas) and improved logging, so next time we'll have better information.

@gfiorav CR this, please.