### PR TITLE
Showing synchronization url in the title of the sync options dialog

### DIFF
--- a/app/assets/stylesheets/table/header/table_sync.css.scss
+++ b/app/assets/stylesheets/table/header/table_sync.css.scss
@@ -45,7 +45,7 @@
 
         &.separator {
           padding:0 7px 0 10px;
-          
+
           &:before {
             content:'';
             position:absolute;
@@ -67,7 +67,7 @@
       vertical-align:top;
       width:10px;
       height:10px;
-      margin-top:3px;
+      margin-top: 5px;
 
       span.point {
         position:absolute;

--- a/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset.jst.ejs
@@ -2,8 +2,10 @@
   <div class="Dialog-headerIcon Dialog-headerIcon--neutral">
     <i class="iconFont iconFont-Alarm"></i>
   </div>
-  <p class="Dialog-headerTitle">Sync Table options</p>
-  <p class="Dialog-headerText Dialog-headerText--ellipsis Dialog-headerText--centered Dialog-headerText--small ">Your table is in sync with a <%- service %> file: <%- url %></p>
+  <h4 class="Dialog-headerTitle">Sync dataset options</h4>
+  <p class="Dialog-headerText Dialog-headerText--ellipsis Dialog-headerText--centered Dialog-headerText--small" title="<%- url %>">
+    Your dataset is in sync with a <%- service %> file: <br/><%- url %>
+  </p>
 </div>
 <div class="Dialog-body Dialog-body--small">
   <div class="Form-row">

--- a/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset_view.js
@@ -88,6 +88,7 @@ module.exports = BaseDialog.extend({
     if (this.table.synchronization.get('service_name') || this.table.synchronization.get('service_item_id')) {
       return this.table.synchronization.get('service_item_id');
     }
+    return this.table.synchronization.get('url');
   },
 
   _serviceName: function() {

--- a/lib/assets/test/spec/cartodb/common/dialogs/sync_dataset_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/sync_dataset_view.spec.js
@@ -1,7 +1,7 @@
 var cdb = require('cartodb.js');
 var SyncView = require('../../../../../javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset_view');
 
-describe('common/dialogs/sync_dataset/', function() {
+describe('common/dialogs/sync_dataset', function() {
   beforeEach(function() {
 
     this.tablemetadata = {
@@ -57,7 +57,7 @@ describe('common/dialogs/sync_dataset/', function() {
   });
 
   it('should render the loading screen to start with', function() {
-    expect(this.innerHTML()).not.toContain('Sync Table options');
+    expect(this.innerHTML()).not.toContain('Sync dataset options');
   });
 
   describe('when table fetch fails', function() {
@@ -76,13 +76,26 @@ describe('common/dialogs/sync_dataset/', function() {
     });
 
     it('should render the view as expected', function() {
-      expect(this.innerHTML()).toContain('Sync Table options');
-      expect(this.innerHTML()).toContain('Your table is in sync with a Dropbox file: /Public/citibike.csv');
+      expect(this.innerHTML()).toContain('Sync dataset options');
+      expect(this.innerHTML()).toContain('Dropbox file');
+      expect(this.innerHTML()).toContain('/Public/citibike.csv');
       expect(this.innerHTML()).toContain('Every hour');
       expect(this.innerHTML()).toContain('Every day');
       expect(this.innerHTML()).toContain('Every week');
       expect(this.innerHTML()).toContain('Never');
       expect(this.view.$(".is-checked").parent().find(".RadioButton-label").text()).toContain('Every hour');
+    });
+
+    it('should render when item is an url', function() {
+      this.table.synchronization.set({
+        service_name: '',
+        service_item_id: '',
+        url: 'http://fake.url/point.csv'
+      });
+      this.view.render();
+      expect(this.innerHTML()).not.toContain('Dropbox file');
+      expect(this.innerHTML()).toContain('Your dataset is in sync with a  file');
+      expect(this.innerHTML()).toContain('http://fake.url/point.csv');
     });
 
     describe('when select an interval', function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.09",
+  "version": "3.23.11",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- It fixes the problem with the file sync url.
- Show a tooltip for the url, just in case it is so long and is cut off.
- Changed text, no more tables, only datasets :).
- Reviewed tests.

<img width="890" alt="screen shot 2015-12-09 at 14 28 56" src="https://cloud.githubusercontent.com/assets/132146/11686685/99dffa9c-9e82-11e5-8821-b733a9c774e6.png">
<img width="765" alt="screen shot 2015-12-09 at 14 29 18" src="https://cloud.githubusercontent.com/assets/132146/11686686/99e3e6f2-9e82-11e5-98f6-4e40a9df9a07.png">


Fixes #6221.

REVIEWER: @javierarce 
cc @ernesmb 