### PR TITLE
Remove Process.wait

### DIFF
--- a/services/user-mover/utils.rb
+++ b/services/user-mover/utils.rb
@@ -45,7 +45,6 @@ module CartoDB
         p cmd
         IO.popen(cmd) do |io|
           puts io.gets while !io.eof?
-          Process.wait(io.pid)
         end
         throw "Error running #{cmd}, output code: #{$?}" if $? != 0
       end


### PR DESCRIPTION
On the user_mover, Process.wait() now changes the output of the "magic variable" $? to be nil on Ruby >2.0, causing the return code detection to fail.

This removes this Process.wait as it seems it was not needed after all