### PR TITLE
Avoid division by zero

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -772,6 +772,7 @@ class DataImport < Sequel::Model
     importer_stats_aggregator.update_counter('total_size', total_size)
 
     import_time = self.updated_at - self.created_at
+    cartodbfy_throughtput = self.cartodbfy_time == 0 ? 0 : (total_size / self.cartodbfy_time)
 
     import_log = {'user'                   => owner.username,
                   'state'                  => self.state,
@@ -794,7 +795,7 @@ class DataImport < Sequel::Model
                   'total_size'             => total_size,
                   'cartodbfy_time'         => self.cartodbfy_time,
                   'import_throughput'      => (total_size / import_time),
-                  'cartodbfy_throughtput'  => (total_size / self.cartodbfy_time),
+                  'cartodbfy_throughtput'  => cartodbfy_throughtput,
                   'cartodbfy_import_ratio' => (self.cartodbfy_time / import_time)
                  }
     if !self.extra_options.nil?

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -772,7 +772,7 @@ class DataImport < Sequel::Model
     importer_stats_aggregator.update_counter('total_size', total_size)
 
     import_time = self.updated_at - self.created_at
-    cartodbfy_throughtput = self.cartodbfy_time == 0 ? 0 : (total_size / self.cartodbfy_time)
+    cartodbfy_throughtput = (cartodbfy_time == 0.0 ? nil : (total_size / cartodbfy_time))
 
     import_log = {'user'                   => owner.username,
                   'state'                  => self.state,


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/6212

When the CartoDBfy time was equal to 0, the throughput metric was computed as NaN, which provoked some issues in metrics.

Now, if the time is equal to 0, the `cartodbfy_throughput` value is set to 0 as well.

Sample output from a log with `cartodbfy_time == 0`

````json
{  
  "user":"cdb",
  "state":"failure",
  "tables":1,
  "imported_tables":0,
  "failed_tables":1,
  "error_code":2004,
  "import_timestamp":"2015-12-10T16:33:48+00:00",
  "queue_server":"cdb",
  "database_host":"localhost",
  "service_name":"public_url",
  "data_type":"file",
  "is_sync_import":false,
  "import_time":48.550614875,
  "file_stats":[  
    {  
      "type":".xlsx",
      "size":10856745,
      "file_rows":null,
      "imported_rows":86,
      "error_percent":null,
      "fallback_executed":null
    }
  ],
  "resque_ppid":5854,
  "user_timeout":13981,
  "error_source":"user",
  "id":"X",
  "total_size":10856745,
  "cartodbfy_time":0.0,
  "import_throughput":223617.04435571271,
  "cartodbfy_throughtput":0,
  "cartodbfy_import_ratio":0.0,
  "extra_options":{  

  },
  "retrieved_items":0
}
````
