### PR TITLE
5463 register used geocoder in geocoder logs

### DIFF
--- a/app/controllers/carto/api/geocodings_controller.rb
+++ b/app/controllers/carto/api/geocodings_controller.rb
@@ -10,7 +10,10 @@ module Carto
       def index
         # data_import_id is set for content guessing geocodes
         # TODO: agree on a more flexible API with params
-        geocodings = Carto::Geocoding.where("user_id = ? AND (state NOT IN (?)) AND (data_import_id IS NULL)", current_user.id, ['failed', 'finished', 'cancelled']).all
+        geocodings = Carto::Geocoding.where(
+          "user_id = ? AND (state NOT IN (?)) AND (data_import_id IS NULL)",
+          current_user.id, ['failed', 'finished', 'cancelled']
+        ).all
         render json: { geocodings: geocodings }, root: false
       end
 

--- a/app/models/carto/geocoding.rb
+++ b/app/models/carto/geocoding.rb
@@ -6,7 +6,10 @@ require_relative '../../../services/table-geocoder/lib/exceptions'
 module Carto
   class Geocoding < ActiveRecord::Base
 
-    PUBLIC_ATTRIBUTES = [:id, :table_id, :table_name, :state, :kind, :country_code, :region_code, :formatter, :geometry_type, :error, :processed_rows, :cache_hits, :processable_rows, :real_rows, :price, :used_credits, :remaining_quota, :country_column, :region_column, :data_import_id, :error_code]
+    PUBLIC_ATTRIBUTES = [:id, :table_id, :table_name, :state, :kind, :country_code, :region_code, :formatter,
+                        :geocoder_type, :geometry_type, :error, :processed_rows, :cache_hits, :processable_rows,
+                        :real_rows, :price, :used_credits, :remaining_quota, :country_column, :region_column,
+                        :data_import_id, :error_code]
 
     def self.processable_rows(table_service, force_all_rows=false)
       dataset = table_service.owner.in_database.select.from(table_service.sequel_qualified_table_name)
@@ -31,7 +34,7 @@ module Carto
         { title: 'Geocoding error', description: '' }
       end
     end
-    
+
     def price
       return 0 unless used_credits.to_i > 0
       (user.geocoding_block_price * used_credits) / Carto::User::GEOCODING_BLOCK_SIZE.to_f
@@ -40,8 +43,6 @@ module Carto
     def remaining_quota
       user.remaining_geocoding_quota
     end
-
-    private
 
   end
 end

--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -325,6 +325,7 @@ class Geocoding < Sequel::Model
 
     @finished_at = Time.now
     self.batched = table_geocoder.used_batch_request?
+    self.geocoder_type = table_geocoder.name
     geocoded_rows = total_geocoded_rows(rows_geocoded_before)
     self.update(state: 'finished', real_rows: geocoded_rows, used_credits: calculate_used_credits)
     send_report_mail(state, self.table_name, nil, self.processable_rows, geocoded_rows)
@@ -340,6 +341,7 @@ class Geocoding < Sequel::Model
   def handle_geocoding_failure(raised_exception, rows_geocoded_before)
     @finished_at = Time.now
     self.batched = table_geocoder.nil? ? false : table_geocoder.used_batch_request?
+    self.geocoder_type = table_geocoder.nil? ? '' : table_geocoder.name
     if raised_exception.is_a? Carto::GeocoderErrors::GeocoderBaseError
       self.error_code = raised_exception.class.additional_info.error_code
     end

--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -15,9 +15,9 @@ class Geocoding < Sequel::Model
 
 
   PUBLIC_ATTRIBUTES = [:id, :table_id, :table_name, :state, :kind, :country_code, :region_code, :formatter,
-                       :geometry_type, :error, :processed_rows, :cache_hits, :processable_rows, :real_rows,
-                       :price, :used_credits, :remaining_quota, :country_column, :region_column, :data_import_id,
-                       :error_code]
+                       :geocoder_type, :geometry_type, :error, :processed_rows, :cache_hits, :processable_rows,
+                       :real_rows, :price, :used_credits, :remaining_quota, :country_column, :region_column,
+                       :data_import_id, :error_code]
 
   # Characters in the following Unicode categories: Letter, Mark, Number and Connector_Punctuation,
   # plus spaces and single quotes

--- a/services/table-geocoder/lib/abstract_table_geocoder.rb
+++ b/services/table-geocoder/lib/abstract_table_geocoder.rb
@@ -41,6 +41,10 @@ module CartoDB
       raise 'Not implemented'
     end
 
+    def name
+      raise 'Not implemented'
+    end
+
     def used_batch_request?
       false
     end

--- a/services/table-geocoder/lib/gme/table_geocoder.rb
+++ b/services/table-geocoder/lib/gme/table_geocoder.rb
@@ -55,6 +55,9 @@ module Carto
         { processed_rows: processed_rows, state: state }
       end
 
+      def name
+        'google'
+      end
 
       private
 

--- a/services/table-geocoder/lib/internal_geocoder.rb
+++ b/services/table-geocoder/lib/internal_geocoder.rb
@@ -122,6 +122,10 @@ module CartoDB
         @temp_table_name ||= %Q{"#{@table_schema}".internal_geocoding_#{Time.now.to_i}}
       end # temp_table_name
 
+      def name
+        'internal'
+      end
+
     end # Geocoder
 
   end # InternalGeocoder

--- a/services/table-geocoder/lib/table_geocoder.rb
+++ b/services/table-geocoder/lib/table_geocoder.rb
@@ -77,6 +77,9 @@ module CartoDB
       return geocoder.used_batch_request?
     end
 
+    def name
+      'heremaps'
+    end
 
     private
 

--- a/services/table-geocoder/lib/table_geocoder_factory.rb
+++ b/services/table-geocoder/lib/table_geocoder_factory.rb
@@ -54,7 +54,9 @@ module Carto
       end
 
       log.append "geocoder_class = #{geocoder_class.to_s}"
-      return geocoder_class.new(instance_config)
+      instance = geocoder_class.new(instance_config)
+      log.append "geocoder_type = #{instance.name}"
+      instance
     end
 
   end

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -243,14 +243,25 @@ describe 'legacy behaviour tests' do
     end
 
     it 'returns started geocodings but not finished' do
-      geocoding1 = FactoryGirl.create(:geocoding, user: @user1, kind: 'high-resolution', created_at: Time.now, processed_rows: 1, state: 'started')
-      FactoryGirl.create(:geocoding, user: @user1, kind: 'high-resolution', created_at: Time.now, processed_rows: 1, state: 'finished')
+      geocoding1 = FactoryGirl.create(:geocoding, user: @user1, kind: 'high-resolution', created_at: Time.now,
+                                      processed_rows: 1, state: 'started')
+      FactoryGirl.create(:geocoding, user: @user1, kind: 'high-resolution', created_at: Time.now,
+                         processed_rows: 1, state: 'finished')
 
       get api_v1_geocodings_index_url
       last_response.status.should eq 200
 
-      expected = {"geocodings"=>[{"table_name"=>nil, "processed_rows"=>1, "remote_id"=>nil, "formatter"=>nil, "geocoder_type"=>nil, "state"=>"started", "cache_hits"=>0, "id"=>geocoding1.id, "user_id"=>@user1.id,"table_id"=>nil, "automatic_geocoding_id"=>nil, "kind"=>"high-resolution", "country_code"=>nil, "geometry_type"=>nil, "processable_rows"=>nil, "real_rows"=>nil, "used_credits"=>nil, "country_column"=>nil, "data_import_id"=>nil, "region_code"=>nil, "region_column"=>nil, "batched"=>nil, "error_code"=>nil, "force_all_rows"=>false, "log_id"=>nil}]}
-      received_without_dates = { 'geocodings' => JSON.parse(last_response.body)['geocodings'].map { |g| remove_dates(g) } }
+      expected = {"geocodings"=>[{"table_name" => nil, "processed_rows" => 1, "remote_id" => nil, "formatter" => nil,
+                                  "geocoder_type" => nil, "state" => "started", "cache_hits" => 0,
+                                  "id" => geocoding1.id, "user_id" => @user1.id,"table_id" => nil,
+                                  "automatic_geocoding_id" => nil, "kind" => "high-resolution", "country_code" => nil,
+                                  "geometry_type" => nil, "processable_rows" => nil, "real_rows" => nil,
+                                  "used_credits" => nil, "country_column" => nil, "data_import_id" => nil,
+                                  "region_code" => nil, "region_column" => nil, "batched" => nil, "error_code" => nil,
+                                  "force_all_rows" => false, "log_id" => nil}]}
+      received_without_dates = {
+        'geocodings' => JSON.parse(last_response.body)['geocodings'].map { |g| remove_dates(g) }
+      }
       received_without_dates.should == expected
     end
 
@@ -264,12 +275,24 @@ describe 'legacy behaviour tests' do
     end
 
     it 'returns requested geocoding' do
-      geocoding = FactoryGirl.create(:geocoding, user: @user1, kind: 'high-resolution', created_at: Time.now, processed_rows: 1, state: 'started')
+      geocoding = FactoryGirl.create(
+        :geocoding,
+        user: @user1,
+        kind: 'high-resolution',
+        created_at: Time.now,
+        processed_rows: 1,
+        state: 'started'
+      )
 
       get api_v1_geocodings_show_url(id: geocoding.id)
       last_response.status.should eq 200
 
-      expected = {"id"=>geocoding.id, "table_id"=>nil, "table_name"=>nil, "state"=>"started", "kind"=>"high-resolution", "country_code"=>nil, "region_code"=>nil, "formatter"=>nil, "geometry_type"=>nil, "error"=>{"title"=>"Geocoding error", "description"=>""}, "processed_rows"=>1, "cache_hits"=>0, "processable_rows"=>nil, "real_rows"=>nil, "price"=>0, "used_credits"=>nil, "remaining_quota"=>999, "country_column"=>nil, "region_column"=>nil, "data_import_id"=>nil, "error_code"=>nil}
+      expected = {"id" => geocoding.id, "table_id" => nil, "table_name" => nil, "state" => "started",
+                  "kind" => "high-resolution", "country_code" => nil, "region_code" => nil, "formatter" => nil,
+                  "geocoder_type" => nil, "geometry_type" => nil, "error" => {"title" => "Geocoding error",
+                  "description" => ""}, "processed_rows" => 1, "cache_hits" => 0, "processable_rows" => nil,
+                  "real_rows" => nil, "price" => 0, "used_credits" => nil, "remaining_quota" => 999,
+                  "country_column" => nil, "region_column" => nil, "data_import_id" => nil, "error_code" => nil}
       received_without_dates = remove_dates(JSON.parse(last_response.body))
       received_without_dates.should == expected
     end


### PR DESCRIPTION
Closes #5463 

**Deploy first the migration**

Added geoder type info in:

- Geocoding logs
- Geocoding table with the field `geocoder_type`

Please @rafatower check this out