### PR TITLE
Add geocoder type column to geocodings table

### DIFF
--- a/db/migrate/20151211103229_add_geocoding_type_to_geocodings.rb
+++ b/db/migrate/20151211103229_add_geocoding_type_to_geocodings.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    alter_table(:geocodings) do
+      add_column :geocoder_type, :text
+    end
+  end
+
+  down do
+    alter_table(:geocodings) do
+      drop_column :geocoder_type
+    end
+  end
+end

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -249,7 +249,7 @@ describe 'legacy behaviour tests' do
       get api_v1_geocodings_index_url
       last_response.status.should eq 200
 
-      expected = {"geocodings"=>[{"table_name"=>nil, "processed_rows"=>1, "remote_id"=>nil, "formatter"=>nil, "state"=>"started", "cache_hits"=>0, "id"=>geocoding1.id, "user_id"=>@user1.id,"table_id"=>nil, "automatic_geocoding_id"=>nil, "kind"=>"high-resolution", "country_code"=>nil, "geometry_type"=>nil, "processable_rows"=>nil, "real_rows"=>nil, "used_credits"=>nil, "country_column"=>nil, "data_import_id"=>nil, "region_code"=>nil, "region_column"=>nil, "batched"=>nil, "error_code"=>nil, "force_all_rows"=>false, "log_id"=>nil}]}
+      expected = {"geocodings"=>[{"table_name"=>nil, "processed_rows"=>1, "remote_id"=>nil, "formatter"=>nil, "geocoder_type"=>nil, "state"=>"started", "cache_hits"=>0, "id"=>geocoding1.id, "user_id"=>@user1.id,"table_id"=>nil, "automatic_geocoding_id"=>nil, "kind"=>"high-resolution", "country_code"=>nil, "geometry_type"=>nil, "processable_rows"=>nil, "real_rows"=>nil, "used_credits"=>nil, "country_column"=>nil, "data_import_id"=>nil, "region_code"=>nil, "region_column"=>nil, "batched"=>nil, "error_code"=>nil, "force_all_rows"=>false, "log_id"=>nil}]}
       received_without_dates = { 'geocodings' => JSON.parse(last_response.body)['geocodings'].map { |g| remove_dates(g) } }
       received_without_dates.should == expected
     end


### PR DESCRIPTION
**Deploy this PR first, then deploy #6242**

Add new `geocoder_type` column to the `geocodings` table to store the type of used geocoder.