### PR TITLE
Generate logs for created import in after_create callback

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -116,6 +116,12 @@ class DataImport < Sequel::Model
     self.updated_at = Time.now
   end
 
+  # The objective of this after_create method is to track in the logs every started
+  # import process.
+  def after_create
+    notify(results)
+  end
+
   def from_common_data?
     if Cartodb.config[:common_data] &&
        !Cartodb.config[:common_data]['username'].blank? &&


### PR DESCRIPTION
This code forces the generation of a log when the import has been created (whose corresponding status is `pending`).

