### PR TITLE
Added geocoder type to the geocodings log

### DIFF
--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -254,6 +254,7 @@ class Geocoding < Sequel::Model
       kind:             kind,
       country_code:     country_code,
       formatter:        formatter,
+      geocoder_type:    geocoder_type,
       geometry_type:    geometry_type,
       processed_rows:   processed_rows,
       cache_hits:       cache_hits,


### PR DESCRIPTION
We need to add the geocoder type to the geocodings metrics in order to use it in Kibana