### PR TITLE
Handle RangeError from sequel: too many columns for content guessing

### DIFF
--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -153,7 +153,7 @@ module CartoDB
     },
     2004 => {
       title: 'Too many columns',
-      what_about: "Data has too many columns. You can only import up to 1600 columns. You can delete the columns you're not interested in, or split the file into smaller ones.",
+      what_about: "Data has too many columns. You can only import up to 250 columns. You can delete the columns you're not interested in, or split the file into smaller ones.",
       source: ERROR_SOURCE_USER
     },
     2005 => {
@@ -179,11 +179,6 @@ module CartoDB
     2009 => {
       title: 'KML without style Id',
       what_about: "The KML file you tried to import failed because a style element doesn't have an ID attribute. To fix this error, please open the file and add an ID to all the style tags.",
-      source: ERROR_SOURCE_USER
-    },
-    2010 => {
-      title: 'Too many columns for guessing',
-      what_about: "Data has too many columns to be guessed. The guessing process can only support up to 256 columns. Please, disable content guessing on import or reduce the number of columns in the file.",
       source: ERROR_SOURCE_USER
     },
     3007 => {

--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -181,6 +181,11 @@ module CartoDB
       what_about: "The KML file you tried to import failed because a style element doesn't have an ID attribute. To fix this error, please open the file and add an ID to all the style tags.",
       source: ERROR_SOURCE_USER
     },
+    2010 => {
+      title: 'Too many columns for guessing',
+      what_about: "Data has too many columns to be guessed. The guessing process can only support up to 256 columns. Please, disable content guessing on import or reduce the number of columns in the file.",
+      source: ERROR_SOURCE_USER
+    },
     3007 => {
       title: 'JSON may not be valid GeoJSON',
       what_about: "We can only import GeoJSON formated JSON files. See if the source of this data supports GeoJSON or another file format for download.",

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -80,7 +80,7 @@ module CartoDB
     class XLSXFormatError                       < StandardError; end
     class MalformedCSVException                 < GenericImportError; end
     class TooManyColumnsError                   < GenericImportError; end
-    class TooManyColumnsGuessedError            < GenericImportError; end
+    class TooManyColumnsProcessingError         < GenericImportError; end
     class DuplicatedColumnError                 < GenericImportError; end
     class RowsEncodingColumnError               < GenericImportError; end
     class EncodingError                         < StandardError; end
@@ -113,12 +113,12 @@ module CartoDB
       EncodingDetectionError                => 2002,
       MalformedCSVException                 => 2003,
       TooManyColumnsError                   => 2004,
+      TooManyColumnsProcessingError         => 2004,
       DuplicatedColumnError                 => 2005,
       EncodingError                         => 2006,
       RowsEncodingColumnError               => 2007,
       MalformedXLSException                 => 2008,
       KmlWithoutStyleIdError                => 2009,
-      TooManyColumnsGuessedError            => 2010,
       InvalidGeoJSONError                   => 3007,
       UnknownSridError                      => 3008,
       ShpNormalizationError                 => 3009,

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -80,6 +80,7 @@ module CartoDB
     class XLSXFormatError                       < StandardError; end
     class MalformedCSVException                 < GenericImportError; end
     class TooManyColumnsError                   < GenericImportError; end
+    class TooManyColumnsGuessedError            < GenericImportError; end
     class DuplicatedColumnError                 < GenericImportError; end
     class RowsEncodingColumnError               < GenericImportError; end
     class EncodingError                         < StandardError; end
@@ -117,6 +118,7 @@ module CartoDB
       RowsEncodingColumnError               => 2007,
       MalformedXLSException                 => 2008,
       KmlWithoutStyleIdError                => 2009,
+      TooManyColumnsGuessedError            => 2010,
       InvalidGeoJSONError                   => 3007,
       UnknownSridError                      => 3008,
       ShpNormalizationError                 => 3009,

--- a/services/importer/lib/importer/table_sampler.rb
+++ b/services/importer/lib/importer/table_sampler.rb
@@ -25,7 +25,7 @@ module CartoDB
       def sample
         db[sample_query].all
       rescue RangeError
-          raise CartoDB::Importer2::TooManyColumnsGuessedError.new
+        raise CartoDB::Importer2::TooManyColumnsGuessedError.new
       end
 
 

--- a/services/importer/lib/importer/table_sampler.rb
+++ b/services/importer/lib/importer/table_sampler.rb
@@ -23,11 +23,9 @@ module CartoDB
 
       # @throws TooManyColumnsGuessedError
       def sample
-        begin
-          db[sample_query].all
-        rescue RangeError=> e
+        db[sample_query].all
+      rescue RangeError
           raise CartoDB::Importer2::TooManyColumnsGuessedError.new
-        end
       end
 
 

--- a/services/importer/lib/importer/table_sampler.rb
+++ b/services/importer/lib/importer/table_sampler.rb
@@ -21,11 +21,11 @@ module CartoDB
         @sample_size = sample_size
       end
 
-      # @throws TooManyColumnsGuessedError
+      # @throws TooManyColumnsProcessingError
       def sample
         db[sample_query].all
       rescue RangeError
-        raise CartoDB::Importer2::TooManyColumnsGuessedError.new
+        raise CartoDB::Importer2::TooManyColumnsProcessingError.new
       end
 
 

--- a/services/importer/lib/importer/table_sampler.rb
+++ b/services/importer/lib/importer/table_sampler.rb
@@ -21,8 +21,13 @@ module CartoDB
         @sample_size = sample_size
       end
 
+      # @throws TooManyColumnsGuessedError
       def sample
-        db[sample_query].all
+        begin
+          db[sample_query].all
+        rescue RangeError=> e
+          raise CartoDB::Importer2::TooManyColumnsGuessedError.new
+        end
       end
 
 


### PR DESCRIPTION
Although Postgres and therefore [OGR2OGR allow up to 1600](https://github.com/CartoDB/cartodb/blob/86c42a7306a8198d61ceb1fe6b7c3497e4ce3ce4/services/importer/lib/importer/ogr2ogr.rb#L96) columns in a dataset (depending on type), `sequel_pg` [sets the maximum number to 256](https://github.com/jeremyevans/sequel_pg/blob/79c768d9508c55f55db3f20331b9631b85ff97f0/ext/sequel_pg/sequel_pg.c#L16) in `SPG_MAX_FIELDS = 256`. (More info: https://github.com/CartoDB/cartodb/issues/3975)

The `table_sampler` file used in content guessing was crashing when getting a sample from the table whenever the dataset contained more than 256 columns. This is now rescued by raising a new exception `TooManyColumnsGuessedError` (other naming suggestions are welcome!).

With guessing disables, the old `TooManyColumnsError` would take care of the number of columns to be inserted in the dataset.

Fixes https://github.com/CartoDB/cartodb/issues/6263

