### PR TITLE
Remove outdated GDrive exception

### DIFF
--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -64,11 +64,6 @@ module CartoDB
       what_about: "There was an error connecting to Twitter service to retrieve your tweets. The server might be temporally unavaliable, please try again later.",
       source: ERROR_SOURCE_EXTERNAL
     },
-    1010 => {
-      title: 'Private Google Spreadsheet',
-      what_about: "This spreadsheet seems to be private. Please check in Google Spreadsheet sharing options that the file is public or accessible for those who know the link.",
-      source: ERROR_SOURCE_USER
-    },
     1011 => {
       title: 'Error retrieving data from datasource',
       what_about: "There was an error retrieving data from the datasource. Check that the file/data is still present.",

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -74,7 +74,6 @@ module CartoDB
     class CouldntResolveDownloadError           < DownloadError; end
 
     class TooManyNodesError                     < StandardError; end
-    class GDriveNotPublicError                  < StandardError; end
     class EncodingDetectionError                < StandardError; end
     class MalformedXLSException                 < StandardError; end
     class XLSXFormatError                       < StandardError; end
@@ -103,7 +102,6 @@ module CartoDB
       EmptyFileError                        => 1005,
       InvalidShpError                       => 1006,
       TooManyNodesError                     => 1007,
-      GDriveNotPublicError                  => 1010,
       InvalidNameError                      => 1014,
       PasswordNeededForExtractionError      => 1018,
       TooManyLayersError                    => 1019,


### PR DESCRIPTION
As CartoDB uses OAuth and doesn't rely anymore on the public sharing from GDrive (or Dropbox) this exception is outdated.

Closes https://github.com/CartoDB/cartodb/issues/6249