### PR TITLE
Changes permission show policy for read-permission grants

### DIFF
--- a/app/controllers/carto/api/permission_presenter.rb
+++ b/app/controllers/carto/api/permission_presenter.rb
@@ -18,7 +18,7 @@ module Carto
       end
 
       def to_poro
-        return to_public_poro unless !@options[:current_viewer].nil? && @permission.is_owner_user?(@options[:current_viewer])
+        return to_public_poro unless !@options[:current_viewer].nil? && @permission.user_has_read_permission?(@options[:current_viewer])
 
         owner = @presenter_cache.get_poro(@permission.owner) do
           Carto::Api::UserPresenter.new(@permission.owner, fetch_groups: false,


### PR DESCRIPTION
Fixes #6269

Now, the more details about the owner of a give permission are shown to users with (at least) read privileges in its acl. Before, they where only show to the owner of the permission.

Please CR @ethervoid 

cc/ @xavijam 