### PR TITLE
Add user as error_source for URL import errors

### DIFF
--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -121,15 +121,18 @@ module CartoDB
     },
     1100 => {
       title: 'Download file not found',
-      what_about: "Provided URL doesn't return a file (error 404). Please check that URL is still valid and that you can download the file and try again."
+      what_about: "Provided URL doesn't return a file (error 404). Please check that URL is still valid and that you can download the file and try again.",
+      source: ERROR_SOURCE_USER
     },
     1101 => {
       title: 'Forbidden file URL',
-      what_about: "Provided URL returns authentication error. Maybe it's private, or requires user and password. Please provide a valid, public URL and try again."
+      what_about: "Provided URL returns authentication error. Maybe it's private, or requires user and password. Please provide a valid, public URL and try again.",
+      source: ERROR_SOURCE_USER
     },
     1102 => {
       title: 'Unknown server URL',
-      what_about: "Provided URL can't be resolved to a known server. Maybe that URL is wrong or behind a private network. Please provide a valid, public URL and try again."
+      what_about: "Provided URL can't be resolved to a known server. Maybe that URL is wrong or behind a private network. Please provide a valid, public URL and try again.",
+      source: ERROR_SOURCE_USER
     },
     2001 => {
       title: 'Unable to load data',


### PR DESCRIPTION
Sets user as the source of the error for some URL download imports whose error source was missing.

Fixes https://github.com/CartoDB/cartodb/issues/6280