### PR TITLE
Fixed image preview for subdomainless (without CDN) applications

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -110,13 +110,14 @@ module.exports = BaseDialog.extend({
     var self = this;
 
     this.$el.find('.MapCard').each(function() {
+      var username = $(this).data('visOwnerName');
       var mapCardPreview = new MapCardPreview({
         el: $(this).find('.js-header'),
         width: 298,
         height: 130,
-        mapsApiHost: cdb.config.getMapsApiHost(),
+        mapsApiResource: cdb.config.getMapsResourceName(username),
         visId: $(this).data('visId'),
-        username: $(this).data('visOwnerName')
+        username: username
       }).load();
 
       self.addView(mapCardPreview);

--- a/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
@@ -1,7 +1,12 @@
+var $ = require('jquery');
+var cdb = require('cartodb.js');
+var _ = require("underscore");
+
 /**
  *  MapCard previews
  *
  */
+
 module.exports = cdb.core.View.extend({
 
   options: {
@@ -10,17 +15,17 @@ module.exports = cdb.core.View.extend({
     privacy: 'PUBLIC',
     username: '',
     visId: '',
-    mapsApiHost: '',
+    mapsApiResource: '',
     className: ''
   },
 
   _TEMPLATES: {
-    regular: '<%- protocol %>://<%- username %>.<%- mapsApiHost %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png',
+    regular: '<%- protocol %>://<%= mapsApiResource %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png',
     cdn: '<%- protocol %>://<%- cdn %>/<%- username %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png'
   },
 
   initialize: function() {
-    _.each(['visId', 'mapsApiHost', 'username'], function(name) {
+    _.each(['visId', 'mapsApiResource', 'username'], function(name) {
       if (!this.options[name]) {
         console.log(name + ' is required for Static Map instantiation');
       }
@@ -46,7 +51,7 @@ module.exports = cdb.core.View.extend({
     var options = {
       protocol: protocol,
       username: this.options.username,
-      mapsApiHost: this.options.mapsApiHost,
+      mapsApiResource: this.options.mapsApiResource,
       tpl: this._generateImageTemplate(),
       width: this.options.width,
       height: this.options.height

--- a/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
@@ -20,6 +20,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _TEMPLATES: {
+    // Using <%= %> instead of <%- %> because if not / characters (for example) will be escaped
     regular: '<%- protocol %>://<%= mapsApiResource %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png',
     cdn: '<%- protocol %>://<%- cdn %>/<%- username %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png'
   },

--- a/lib/assets/javascripts/cartodb/config.js
+++ b/lib/assets/javascripts/cartodb/config.js
@@ -39,3 +39,15 @@ cdb.config.prefixUrlPathname = function() {
   return prefix;
 };
 
+/**
+ *  returns the maps API resource name, removing protocol.
+ *  {user}.cartodb.com:3333 || cartodb.com:3333/{user} || ...
+ */
+cdb.config.getMapsResourceName = function(username) {
+  var url;
+  var mapsApiTemplate = this.get('maps_api_template');
+  if (mapsApiTemplate) {
+    url = mapsApiTemplate.replace(/(http|https)?:\/\//, '').replace(/{user}/g, username);
+  }
+  return url;
+}

--- a/lib/assets/javascripts/cartodb/dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/maps/maps_item.js
@@ -121,13 +121,14 @@ module.exports = cdb.core.View.extend({
   _renderMapThumbnail: function() {
     var zoom = this.model.get("zoom");
     var owner = this.model.permission.owner;
+    var ownerUsername = owner.get('username');
     var previewZoom = (zoom + 2 <= this.model.map.get("maxZoom")) ? zoom + 2 : zoom;
 
     var mapCardPreview = new MapCardPreview({
       el: this.$('.js-header'),
       privacy: this.model.get("privacy"),
-      mapsApiHost: cdb.config.getMapsApiHost(),
-      username: owner.get('username'),
+      mapsApiResource: cdb.config.getMapsResourceName(ownerUsername),
+      username: ownerUsername,
       visId: this.model.get('id')
     });
 

--- a/lib/assets/javascripts/cartodb/data_library/content/list/dataset_item_view.js
+++ b/lib/assets/javascripts/cartodb/data_library/content/list/dataset_item_view.js
@@ -36,13 +36,14 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderMapThumbnail: function() {
+    var username = this.model.get('permission')['owner']['username'];
     var mapCardPreview = new MapCardPreview({
       el: this.$('.js-header'),
-      username: this.model.get('permission')['owner']['username'],
+      username: username,
       width: 298,
       height: 220,
       visId: this.model.get('id'),
-      mapsApiHost: cdb.config.getMapsApiHost()
+      mapsApiResource: cdb.config.getMapsResourceName(username)
     });
 
     if (this.imageURL) {

--- a/lib/assets/javascripts/cartodb/explore/view.js
+++ b/lib/assets/javascripts/cartodb/explore/view.js
@@ -220,7 +220,7 @@ module.exports = Feed.extend({
         username: username,
         visId: visId,
         className: className,
-        mapsApiHost: cdb.config.getMapsApiHost()
+        mapsApiResource: cdb.config.getMapsResourceName(username)
       }).load();
     }
   },

--- a/lib/assets/javascripts/cartodb/public_dashboard/entry.js
+++ b/lib/assets/javascripts/cartodb/public_dashboard/entry.js
@@ -76,12 +76,13 @@ $(function() {
     $('.MapCard').each(function() {
       var visId = $(this).data('visId');
       if (visId) {
+        var username = $(this).data('visOwnerName');
         var mapCardPreview = new MapCardPreview({
           el: $(this).find('.js-header'),
           height: 220,
           visId: $(this).data('visId'),
-          username: $(this).data('visOwnerName'),
-          mapsApiHost: cdb.config.getMapsApiHost()
+          username: username,
+          mapsApiResource: cdb.config.getMapsResourceName(username)
         });
         mapCardPreview.load();
       }

--- a/lib/assets/javascripts/cartodb/public_map/entry.js
+++ b/lib/assets/javascripts/cartodb/public_map/entry.js
@@ -110,11 +110,12 @@ $(function() {
     $('.MapCard').each(function() {
       var visId = $(this).data('visId');
       if (visId) {
+        var username = $(this).data('visOwnerName');
         var mapCardPreview = new MapCardPreview({
           el: $(this).find('.js-header'),
           visId: $(this).data('visId'),
-          username: $(this).data('visOwnerName'),
-          mapsApiHost: cdb.config.getMapsApiHost()
+          username: username,
+          mapsApiResource: cdb.config.getMapsResourceName(username)
         });
         mapCardPreview.load();
       }

--- a/lib/assets/javascripts/cartodb/public_table.js
+++ b/lib/assets/javascripts/cartodb/public_table.js
@@ -79,11 +79,12 @@ $(function() {
     $('.MapCard').each(function() {
       var visId = $(this).data('visId');
       if (visId) {
+        var username = $(this).data('visOwnerName');
         var mapCardPreview = new MapCardPreview({
           el: $(this).find('.js-header'),
           visId: $(this).data('visId'),
-          username: $(this).data('visOwnerName'),
-          mapsApiHost: cdb.config.getMapsApiHost()
+          username: username,
+          mapsApiResource: cdb.config.getMapsResourceName(username)
         });
         mapCardPreview.load();
       }

--- a/lib/assets/javascripts/cartodb/user_feed/view.js
+++ b/lib/assets/javascripts/cartodb/user_feed/view.js
@@ -233,7 +233,7 @@ module.exports = cdb.core.View.extend({
         el: $el.find('.js-header'),
         width: width,
         height: this._CARD_HEIGHT,
-        mapsApiHost: cdb.config.getMapsApiHost(),
+        mapsApiResource: cdb.config.getMapsResourceName(username),
         username: username,
         visId: visId,
         className: className

--- a/lib/assets/test/spec/cartodb/common/views/mapcard_preview.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/mapcard_preview.spec.js
@@ -14,7 +14,7 @@ describe('common/views/mapcard_preview', function() {
     this.view = new MapCardPreview({
       el: $(this.cardHTML).find(".js-header"),
       visId: 'oooo-llll-aaaa-mmmm',
-      mapsApiHost: 'hello.com',
+      mapsApiResource: 'javier.hello.com',
       username: 'javier'
     });
   });
@@ -28,7 +28,7 @@ describe('common/views/mapcard_preview', function() {
     var view = new MapCardPreview({
       el: $(this.cardHTML).find(".js-header"),
       visId: 'oooo-llll-aaaa-mmmm',
-      mapsApiHost: 'hello.com',
+      mapsApiResource: 'hello.com',
       username: 'javier',
       width: 100,
       height: 99
@@ -57,6 +57,12 @@ describe('common/views/mapcard_preview', function() {
       spyOn(this.view, '_isHTTPS').and.returnValue(true);
       this.view.load();
       expect(this.view._loadImage).toHaveBeenCalledWith(jasmine.any(Object), 'https://javier.hello.com/api/v1/map/static/named/tpl_oooo_llll_aaaa_mmmm/300/170.png');
+    });
+
+    it("should not generate the url with username + maps api host", function() {
+      this.view.options.mapsApiResource = "hello.com/user/javier"; // Subdomainless type
+      this.view.load();
+      expect(this.view._loadImage).toHaveBeenCalledWith(jasmine.any(Object), 'http://hello.com/user/javier/api/v1/map/static/named/tpl_oooo_llll_aaaa_mmmm/300/170.png');
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.16",
+  "version": "3.23.17",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Basically we tried to parse maps_api_template incorrectly. So, right now we replace username from that string and it works perfectly in any situation, w/o subdomain.

Fixes #6274.

REVIEWER: @javierarce, you was my mate changing this stuff some time ago :D.