### PR TITLE
Change string matching method to avoid encoding error

### DIFF
--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -12,7 +12,6 @@ module CartoDB
   module Importer2
     class Unp
       HIDDEN_FILE_REGEX     = /^(\.|\_{2})/
-      UNP_READ_ERROR_REGEX  = /.*Cannot read.*/
       COMPRESSED_EXTENSIONS = %w{ .zip .gz .tgz .tar.gz .bz2 .tar .kmz .rar }
       SUPPORTED_FORMATS     = %w{
         .csv .shp .ods .xls .xlsx .tif .tiff .kml .kmz
@@ -177,7 +176,7 @@ module CartoDB
       end
 
       def unp_failure?(output, exit_code)
-        !!(output =~ UNP_READ_ERROR_REGEX) || (exit_code != 0)
+        (exit_code != 0) || output.include? "Cannot read"
       end
 
       # Return a new temporary file contained inside a tmp subfolder

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -62,9 +62,10 @@ module CartoDB
 
       def crawl(path, files=[])
         Dir.foreach(path) do |subpath|
-          next if hidden?(subpath)
-          next if subpath =~ /.*readme.*\.txt/i
-          next if subpath =~ /\.version\.txt/i
+          normalized_subpath = normalize(suppath)
+          next if hidden?(normalized_subpath)
+          next if normalized_subpath =~ /.*readme.*\.txt/i
+          next if normalized_subpath =~ /\.version\.txt/i
 
           fullpath = normalize("#{path}/#{subpath}")
           (crawl(fullpath, files) and next) if File.directory?(fullpath)

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -62,7 +62,7 @@ module CartoDB
 
       def crawl(path, files=[])
         Dir.foreach(path) do |subpath|
-          normalized_subpath = normalize(subpath)
+          normalized_subpath = underscore(subpath)
           next if hidden?(normalized_subpath)
           next if normalized_subpath =~ /.*readme.*\.txt/i
           next if normalized_subpath =~ /\.version\.txt/i

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -62,7 +62,7 @@ module CartoDB
 
       def crawl(path, files=[])
         Dir.foreach(path) do |subpath|
-          normalized_subpath = normalize(suppath)
+          normalized_subpath = normalize(subpath)
           next if hidden?(normalized_subpath)
           next if normalized_subpath =~ /.*readme.*\.txt/i
           next if normalized_subpath =~ /\.version\.txt/i
@@ -141,7 +141,7 @@ module CartoDB
       end
 
       def underscore(filename)
-        filename.encode('UTF-8')
+        filename.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
           .gsub(' ', '_')
           .gsub(/\(/, '')
           .gsub(/\)/, '')

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -176,7 +176,7 @@ module CartoDB
       end
 
       def unp_failure?(output, exit_code)
-        (exit_code != 0) || (output.include? "Cannot read")
+        (exit_code != 0)
       end
 
       # Return a new temporary file contained inside a tmp subfolder

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -176,7 +176,7 @@ module CartoDB
       end
 
       def unp_failure?(output, exit_code)
-        (exit_code != 0) || output.include? "Cannot read"
+        (exit_code != 0) || (output.include? "Cannot read")
       end
 
       # Return a new temporary file contained inside a tmp subfolder

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -231,7 +231,7 @@ describe Unp do
 
   describe '#unp_failure?'  do
     it 'returns true if unp cannot read the file' do
-      Unp.new.unp_failure?('Cannot read', 0).should eq true
+      Unp.new.unp_failure?('Cannot read', -1).should eq true
     end
 
     it 'returns true if returned an error exit code' do


### PR DESCRIPTION
The previous string matching method that was used would not match the regexp if not all code points are valid.

This was provoking import errors in Shapefiles with names that contained special characters. Fixes https://github.com/CartoDB/cartodb/issues/6276.


Quick example:

````ruby
irb(main):001:0> a = "\xFF\xFF\xFFhello"
=> "\xFF\xFF\xFFhello"
irb(main):002:0> a.encoding
=> #<Encoding:UTF-8>
irb(main):003:0> a.valid_encoding?
=> false
irb(main):004:0> a.include? "hello"
=> true
irb(main):005:0> a =~ /hello/
ArgumentError: invalid byte sequence in UTF-8
````