### PR TITLE
Store the user geocoding requests to redis

### DIFF
--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -367,7 +367,8 @@ class Geocoding < Sequel::Model
   end
 
   def total_geocoded_rows(rows_geocoded_before)
-    rows_geocoded_after = table_service.owner.in_database.select.from(table_service.sequel_qualified_table_name).where('cartodb_georef_status is true and the_geom is not null').count rescue 0
+    rows_geocoded_after = table_service.owner.in_database.select.from(table_service.sequel_qualified_table_name).
+      where('cartodb_georef_status is true and the_geom is not null').count rescue 0
     rows_geocoded_after - rows_geocoded_before
   end
 

--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -1,17 +1,21 @@
 # encoding: UTF-8'
 require 'socket'
+require_relative './geocoding/geocoder_metrics_decorator'
 require_relative '../../services/table-geocoder/lib/table_geocoder_factory'
 require_relative '../../services/table-geocoder/lib/exceptions'
 require_relative '../../services/table-geocoder/lib/mail_geocoder'
 require_relative '../../services/geocoder/lib/geocoder_config'
+require_relative '../../services/metrics/lib/geocoder_metrics'
 require_relative '../../lib/cartodb/metrics'
 require_relative '../../app/helpers/bounding_box_helper'
 require_relative 'log'
 require_relative '../../lib/cartodb/stats/geocoding'
 
 class Geocoding < Sequel::Model
+  include CartoDB::GeocoderMetricsDecorator
 
   ALLOWED_KINDS   = %w(admin0 admin1 namedplace postalcode high-resolution ipaddress)
+  HIGH_RESOLUTION_GEOCODER = 'high-resolution'
 
 
   PUBLIC_ATTRIBUTES = [:id, :table_id, :table_name, :state, :kind, :country_code, :region_code, :formatter,
@@ -35,7 +39,7 @@ class Geocoding < Sequel::Model
   attr_reader :log
 
   def self.get_geocoding_calls(dataset, date_from, date_to)
-    dataset.where(kind: 'high-resolution').where('geocodings.created_at >= ? and geocodings.created_at <= ?', date_from, date_to + 1.days).sum("processed_rows + cache_hits".lit).to_i
+    dataset.where(kind: HIGH_RESOLUTION_GEOCODER).where('geocodings.created_at >= ? and geocodings.created_at <= ?', date_from, date_to + 1.days).sum("processed_rows + cache_hits".lit).to_i
   end
 
   def public_values
@@ -168,6 +172,10 @@ class Geocoding < Sequel::Model
   def report(error = nil)
     payload = metrics_payload(error)
     CartoDB::Metrics.new.report(:geocoding, payload)
+    if !geocoder_type.blank?
+      # We only want to store when we have geocoder defined
+      store_metrics(payload)
+    end
     payload.delete_if {|k,v| %w{distinct_id email table_id}.include?(k.to_s)}
     geocoding_logger.info(payload.to_json)
   end
@@ -181,7 +189,7 @@ class Geocoding < Sequel::Model
   end # self.processable_rows
 
   def calculate_used_credits
-    return 0 unless kind == 'high-resolution'
+    return 0 unless kind == HIGH_RESOLUTION_GEOCODER
     total_rows       = processed_rows.to_i + cache_hits.to_i
     geocoding_quota  = user.organization.present? ? user.organization.geocoding_quota.to_i : user.geocoding_quota
     # ::User#get_geocoding_calls includes this geocoding run, so we discount it
@@ -197,7 +205,7 @@ class Geocoding < Sequel::Model
   end # price
 
   def cost
-    return 0 unless kind == 'high-resolution'
+    return 0 unless kind == HIGH_RESOLUTION_GEOCODER
     processed_rows.to_i * CartoDB::GeocoderConfig.instance.get['cost_per_hit_in_cents'] rescue 0
   end
 
@@ -346,13 +354,16 @@ class Geocoding < Sequel::Model
     if raised_exception.is_a? Carto::GeocoderErrors::GeocoderBaseError
       self.error_code = raised_exception.class.additional_info.error_code
     end
-    self.update(state: 'failed', processed_rows: 0, cache_hits: 0)
+    self.state = 'failed'
     CartoDB::notify_exception(raised_exception, user: user)
     geocoded_rows = total_geocoded_rows(rows_geocoded_before)
     send_report_mail(state, self.table_name, error_code, self.processable_rows, geocoded_rows)
     log.append "Unexpected exception: #{raised_exception.to_s}"
     log.append raised_exception.backtrace
     self.report(raised_exception)
+    # We set this to 0 to not compute the non-processed rows to the user if the
+    # geocoder is a payment one
+    self.update(processed_rows: 0, cache_hits: 0)
   end
 
   def total_geocoded_rows(rows_geocoded_before)
@@ -365,5 +376,4 @@ class Geocoding < Sequel::Model
     geocoding_time = @finished_at - @started_at
     CartoDB::Geocoder::MailNotifier.new(user.id, state, table_name, error_code, processable_rows, number_geocoded_rows, geocoding_time).notify_if_needed
   end
-
 end

--- a/app/models/geocoding/geocoder_metrics_decorator.rb
+++ b/app/models/geocoding/geocoder_metrics_decorator.rb
@@ -66,7 +66,7 @@ module CartoDB
         metrics[:cache_hits]
       )
       cache_metrics.add_responses(
-        CartoDB::GeocoderMetrics::CACHE_MISSES_TYPE,
+        CartoDB::GeocoderMetrics::CACHE_MISS_TYPE,
         today,
         metrics[:cache_misses]
       )

--- a/app/models/geocoding/geocoder_metrics_decorator.rb
+++ b/app/models/geocoding/geocoder_metrics_decorator.rb
@@ -1,0 +1,75 @@
+module CartoDB
+  module GeocoderMetricsDecorator
+
+    HIGH_RESOLUTION_GEOCODER = 'high-resolution'
+
+    def store_metrics(payload)
+      geocoder_type = payload[:geocoder_type]
+      geocoder_kind = payload[:kind]
+      metrics = calculate_metrics(payload)
+      store_geocoder_metrics(geocoder_type, metrics)
+      store_cache_metrics(metrics) if geocoder_kind == HIGH_RESOLUTION_GEOCODER
+    end
+
+    private
+
+    def calculate_metrics(payload)
+      failed_rows = Integer(payload[:failed_rows]) rescue 0
+      cache_hits = Integer(payload[:cache_hits]) rescue 0
+      successful_responses = Integer(payload[:successful_rows]) rescue 0
+      successful_responses = successful_responses - cache_hits
+      cache_misses = successful_responses
+      empty_responses = payload[:success] ? failed_rows : 0
+      failed_responses = !payload[:success] ? failed_rows : 0
+
+      {
+        successful_responses: successful_responses,
+        empty_responses: empty_responses,
+        failed_responses: failed_responses,
+        cache_hits: cache_hits,
+        cache_misses: cache_misses,
+        total_requests: (successful_responses + empty_responses + failed_responses)
+      }
+    end
+
+    def store_geocoder_metrics(geocoder_type, metrics)
+      today = Date.today.strftime('%Y%m%d')
+      geocoder_metrics = CartoDB::GeocoderMetrics.new(user, geocoder_type)
+      geocoder_metrics.add_responses(
+        CartoDB::GeocoderMetrics::SUCCESSFUL_RESPONSE_TYPE,
+        today,
+        metrics[:successful_responses]
+      )
+      geocoder_metrics.add_responses(
+        CartoDB::GeocoderMetrics::EMPTY_RESPONSE_TYPE,
+        today,
+        metrics[:empty_responses]
+      )
+      geocoder_metrics.add_responses(
+        CartoDB::GeocoderMetrics::FAILED_RESPONSE_TYPE,
+        today,
+        metrics[:failed_responses]
+      )
+      geocoder_metrics.add_responses(
+        CartoDB::GeocoderMetrics::TOTAL_RESPONSE_TYPE,
+        today,
+        metrics[:total_requests]
+      )
+    end
+
+    def store_cache_metrics(metrics)
+      today = Date.today.strftime('%Y%m%d')
+      cache_metrics = CartoDB::GeocoderMetrics.new(user, 'cache')
+      cache_metrics.add_responses(
+        CartoDB::GeocoderMetrics::CACHE_HITS_TYPE,
+        today,
+        metrics[:cache_hits]
+      )
+      cache_metrics.add_responses(
+        CartoDB::GeocoderMetrics::CACHE_MISSES_TYPE,
+        today,
+        metrics[:cache_misses]
+      )
+    end
+  end
+end

--- a/services/metrics/lib/geocoder_metrics.rb
+++ b/services/metrics/lib/geocoder_metrics.rb
@@ -1,0 +1,40 @@
+require_relative './metrics_redis_repository'
+
+module CartoDB
+  class GeocoderMetrics
+
+    SUCCESSFUL_RESPONSE_TYPE = "successful_response"
+    FAILED_RESPONSE_TYPE = "failed_response"
+    EMPTY_RESPONSE_TYPE = "empty_response"
+    TOTAL_RESPONSE_TYPE = "total_requests"
+    CACHE_HITS_TYPE = "cache_hits"
+    CACHE_MISS_TYPE = "cache_miss"
+
+    def initialize(user, geocoder_type)
+      @user = user
+      @geocoder_type = geocoder_type
+      @metrics_repository = CartoDB::MetricsRedisRepository.instance
+    end
+
+    def add_responses(type, key, value)
+      prefix = build_key_prefix(type)
+      @metrics_repository.store(prefix, key, value)
+    end
+
+    def get_responses(type, key)
+      raise NotImplementedError, "Not working yet"
+    end
+
+    private
+
+    def build_key_prefix(type)
+      if @user.organization_user?
+        orgname = @user.organization.name
+        %{org:#{orgname}:#{@user.username}:#{@geocoder_type}:#{type}}
+      else
+        %{user:#{@user.username}:#{@geocoder_type}:#{type}}
+      end
+    end
+
+  end
+end

--- a/services/metrics/lib/metrics_redis_repository.rb
+++ b/services/metrics/lib/metrics_redis_repository.rb
@@ -1,0 +1,25 @@
+module CartoDB
+  class MetricsRedisRepository
+
+    include Singleton
+
+    def initialize(redis_conn = $users_metadata)
+      @redis_conn = redis_conn
+    end
+
+    def store(prefix, key, value)
+      @redis_conn.zincrby(prefix, value, key)
+    rescue Redis::BaseError => exception
+      CartoDB.notify_error('Error trying to store a metric in redis', { key: key, exception: exception.inspect })
+      false
+    end
+
+    def get(key, value)
+      @redis_conn.get()
+    rescue Redis::BaseError => exception
+      CartoDB.notify_error('Error trying to get a metric from redis', { key: key, exception: exception.inspect })
+      false
+    end
+
+  end
+end

--- a/services/metrics/lib/metrics_redis_repository.rb
+++ b/services/metrics/lib/metrics_redis_repository.rb
@@ -1,10 +1,15 @@
 module CartoDB
   class MetricsRedisRepository
 
-    include Singleton
+    @@instance = nil
 
     def initialize(redis_conn = $users_metadata)
       @redis_conn = redis_conn
+    end
+
+    def self.instance
+      @@instance = MetricsRedisRepository.new if @@instance.nil?
+      @@instance
     end
 
     def store(prefix, key, value)


### PR DESCRIPTION
Closes #6286 

- [x] Store the geocoding metrics in Redis
- [x] When there is no rows to proccess don't store the results without service. Ie. "user:ethervoid-ded04::total_requests"
- [ ] When there is cache_hits in the payload, don't add it to geocoder. Add it to the cache keys

//cc @rafatower 