### PR TITLE
Detect max named map templates import error

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -198,7 +198,7 @@ class DataImport < Sequel::Model
     self
   rescue CartoDB::NamedMapsWrapper::TooManyTemplatesError
     templates_exception = CartoDB::Importer2::TooManyNamedMapTemplatesError.new
-    log.append "Exception: #{templates_exception.to_s}"
+    log.append "Exception: #{templates_exception}"
     CartoDB::notify_warning_exception(templates_exception)
     handle_failure(templates_exception)
     self

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -180,7 +180,6 @@ class DataImport < Sequel::Model
       end
     end
 
-
     log.append 'After dispatch'
     if self.results.empty?
       self.error_code = 1002

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -198,6 +198,7 @@ class DataImport < Sequel::Model
     self
   rescue CartoDB::NamedMapsWrapper::TooManyTemplatesError
     templates_exception = CartoDB::Importer2::TooManyNamedMapTemplatesError.new
+    log.append "Exception: #{templates_exception.to_s}"
     CartoDB::notify_warning_exception(templates_exception)
     handle_failure(templates_exception)
     self

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -164,6 +164,7 @@ class DataImport < Sequel::Model
     values
   end
 
+  # @throws TooManyNamedMapTemplatesError
   def run_import!
     self.resque_ppid = Process.ppid
     self.server = Socket.gethostname
@@ -179,6 +180,7 @@ class DataImport < Sequel::Model
         log.append ex2.backtrace
       end
     end
+
 
     log.append 'After dispatch'
     if self.results.empty?
@@ -201,7 +203,11 @@ class DataImport < Sequel::Model
     log.append exception.backtrace, truncate = false
     stacktrace = exception.to_s + exception.backtrace.join
     Rollbar.report_message('Import error', 'error', error_info: stacktrace)
-    handle_failure(exception)
+    if exception.is_a? CartoDB::NamedMapsWrapper::TooManyTemplatesError
+      handle_failure(CartoDB::Importer2::TooManyNamedMapTemplatesError.new)
+    else
+      handle_failure(exception)
+    end
     self
   end
 
@@ -309,6 +315,7 @@ class DataImport < Sequel::Model
   def handle_failure(supplied_exception = nil)
     self.success    = false
     self.state      = STATE_FAILURE
+    debugger
     if !supplied_exception.nil? && supplied_exception.respond_to?(:error_code)
       self.error_code = supplied_exception.error_code
     end
@@ -811,6 +818,7 @@ class DataImport < Sequel::Model
     dataimport_logger.info(import_log.to_json)
     CartoDB::Importer2::MailNotifier.new(self, results, ::Resque).notify_if_needed
     results.each { |result| CartoDB::Metrics.new.report(:import, payload_for(result)) }
+    debugger
   end
 
   def importer_stats_aggregator

--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -258,7 +258,7 @@ module CartoDB
     },
     6670 => {
       title: 'Too many named map templates',
-      what_about: "You reached the limit on the number of named map templates (4096/4096).",
+      what_about: "You reached the limit on the number of named map templates.",
       source: ERROR_SOURCE_USER
     },
     99999 => {

--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -258,7 +258,7 @@ module CartoDB
     },
     6670 => {
       title: 'Too many named map templates',
-      what_about: "You reached the limit on number of templates (4096/4096). If you need further help contact our support team at <a href='mailto:support@cartodb.com?subject=Dataset%20too%20many%20concurrent%20imports%20error'>support@cartodb.com</a>.",
+      what_about: "You reached the limit on the number of named map templates (4096/4096).",
       source: ERROR_SOURCE_USER
     },
     99999 => {

--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -256,6 +256,11 @@ module CartoDB
       what_about: "You cannot import more data until one of your active imports finishes. If you need further import slots contact our support team at <a href='mailto:support@cartodb.com?subject=Dataset%20too%20many%20concurrent%20imports%20error'>support@cartodb.com</a>.",
       source: ERROR_SOURCE_USER
     },
+    6670 => {
+      title: 'Too many named map templates',
+      what_about: "You reached the limit on number of templates (4096/4096). If you need further help contact our support team at <a href='mailto:support@cartodb.com?subject=Dataset%20too%20many%20concurrent%20imports%20error'>support@cartodb.com</a>.",
+      source: ERROR_SOURCE_USER
+    },
     99999 => {
       title: 'Unknown',
       what_about: "Sorry, something went wrong and we're not sure what. Try

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -36,11 +36,19 @@ module CartoDB
       end
     end
 
+    class TooManyNamedMapTemplatesError < BaseImportError
+      def initialize(message="User reached the limit on number of templates (4096/4096)")
+        super(message, 6670)
+      end
+    end
+
     class DownloadTimeoutError < BaseImportError
       def initialize(message="Data download timed out. Check the source is not running slow and/or try again.")
         super(message, 1020)
       end
     end
+
+
 
     class InstallError                          < StandardError; end
     class EmptyFileError                        < StandardError; end

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -48,8 +48,6 @@ module CartoDB
       end
     end
 
-
-
     class InstallError                          < StandardError; end
     class EmptyFileError                        < StandardError; end
     class ExtractionError                       < StandardError; end

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -37,7 +37,7 @@ module CartoDB
     end
 
     class TooManyNamedMapTemplatesError < BaseImportError
-      def initialize(message="User reached the limit on number of templates (4096/4096)")
+      def initialize(message="User reached the limit on number of templates")
         super(message, 6670)
       end
     end

--- a/services/named-maps-api-wrapper/lib/named-maps-wrapper/exceptions.rb
+++ b/services/named-maps-api-wrapper/lib/named-maps-wrapper/exceptions.rb
@@ -15,5 +15,6 @@ module CartoDB
     class NamedMapsDataError < NamedMapsGenericError; end
     class HTTPResponseError < NamedMapsGenericError; end
     class NamedMapsPresenterError < NamedMapsGenericError; end
+    class TooManyTemplatesError < NamedMapsGenericError; end
   end
 end

--- a/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
+++ b/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
@@ -31,6 +31,7 @@ module CartoDB
 
       # Create a new named map
       # @throws HTTPResponseError
+      # @throws TooManyTemplatesError
       def self.create_new(visualization, parent)
         NamedMap.stats_aggregator.timing('named-map.create') do
           template_data = NamedMap.get_template_data( visualization, parent )
@@ -44,6 +45,10 @@ module CartoDB
             connecttimeout:  HTTP_CONNECT_TIMEOUT,
             timeout:          HTTP_REQUEST_TIMEOUT
             } )
+
+          if response.body =~ /reached limit on number of templates/
+            raise TooManyTemplatesError.new("Reached limit on number of named map templates")
+          end
 
           unless response.code == 200
             raise HTTPResponseError.new("POST:#{response.code} #{response.request.url} #{response.body}", template_data)

--- a/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
+++ b/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
@@ -46,7 +46,7 @@ module CartoDB
             timeout:          HTTP_REQUEST_TIMEOUT
             } )
 
-          if response.body =~ /reached limit on number of templates/
+          if response.code == 409 && response.body =~ /reached limit on number of templates/
             raise TooManyTemplatesError.new("Reached limit on number of named map templates")
           end
 


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/6275

### Description
In its configuration, Windshaft states a maximum number of `maxUserTemplates`. This is typically set to 4096.

When a dataset is imported, CartoDB creates a named map for it. If the named maps limit has been reached, the named maps wrapper was raising an HTTP exception that was understood as an unknown import error by the platform.

### Proposed solution
In order to detect this limit, two new exceptions have been defined.

The first one, `TooManyTemplatesError` is created [in the wrapper side](https://github.com/CartoDB/cartodb/blob/8c4ea94398cbda7af93fda603d5464aae8e76cb7/services/named-maps-api-wrapper/lib/named-maps-wrapper/exceptions.rb#L18) and it's raised [when it detects the limit error in the response of the named map creation](https://github.com/CartoDB/cartodb/blob/8c4ea94398cbda7af93fda603d5464aae8e76cb7/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb#L49). In the near future, this part should be re-done and we should  take care of comparing the status code `409: Conflict` which will be added in the Named Maps API. (More info about the open issue in CartoDB-Windshaft [here](https://github.com/CartoDB/Windshaft-cartodb/issues/346)).

In the import side, I have defined a new exception `TooManyNamedMapTemplatesError` [here](https://github.com/CartoDB/cartodb/blob/8c4ea94398cbda7af93fda603d5464aae8e76cb7/services/importer/lib/importer/exceptions.rb#L39), that will be responding to the import error code `6670` (the next number, following the already existent list of import codes related to limits).

A rescue will recover the `CartoDB::NamedMapsWrapper::TooManyTemplatesError` from Windshaft, and the import process will then handle the error by using the  `CartoDB::Importer2::TooManyNamedMapTemplatesError` exception, as can be seen [here](https://github.com/CartoDB/cartodb/blob/8c4ea94398cbda7af93fda603d5464aae8e76cb7/app/models/data_import.rb#L199).

I tested the solution by forcing the exception in the wrapper at first. Then in staging I reached the maximum number of templates by creating them programatically with the named maps API, and the result was as follows:

![image](https://cloud.githubusercontent.com/assets/1730320/11979101/cfb99f4c-a990-11e5-91e2-9f502ff51cda.png)


````
irb(main):001:0> DataImport['85fe4f0a-51c8-4064-9349-f6279f836547'].log
=> #<CartoDB::Log @values={:id=>"5ce2002e-9fb7-438f-a29b-2b8cc7ef0f9f", :type=>"import", :user_id=>"367c0edc-b2ad-4bab-ad43-3d58a6179a93", :created_at=>2015-12-23 15:25:03 +0000, :updated_at=>2015-12-23 15:25:06 +0000, :entries=>"2015-12-23 15:25:04 UTC: Running on server cdb with PID: 2570\n2015-12-23 15:25:04 UTC: new_importer()
2015-12-23 15:25:04 UTC: Fetching datasource public_url metadata for item id /home/ubuntu/www/production.cartodb.com/current/public/uploads/37f53b29756028fdb325/cositis.csv
2015-12-23 15:25:04 UTC: File will be downloaded from /home/ubuntu/www/production.cartodb.com/current/public/uploads/37f53b29756028fdb325/cositis.csv
2015-12-23 15:25:04 UTC: Before importer run\n2015-12-23 15:25:04 UTC: Starting import for /home/ubuntu/www/production.cartodb.com/current/public/uploads/37f53b29756028fdb325/cositis.csv
2015-12-23 15:25:04 UTC: Unpacking /home/ubuntu/www/production.cartodb.com/current/public/uploads/37f53b29756028fdb325/cositis.csv
2015-12-23 15:25:04 UTC: Filename: /tmp/imports/20151223-2570-19ta0p4/cositis.csv Size (bytes): 25
true: Importing data from /tmp/imports/20151223-2570-19ta0p4/cositis.csv
true: File-based import load\ntrue: Detected encoding ISO-8859-1
true: Using database connection with {:adapter=>\"postgres\", :encoding=>\"unicode\", :host=>\"localhost\", :port=>5432, :database=>\"cartodb_dev_user_367c0edc-b2ad-4bab-ad43-3d58a6179a93_db\", :username=>\"postgres\", :conn_validator_timeout=>900, :user=>\"development_cartodb_user_367c0edc-b2ad-4bab-ad43-3d58a6179a93\"}\nfalse: ogr2ogr call:            OSM_USE_CUSTOM_INDEXING=NO PG_USE_COPY=YES PGCLIENTENCODING=ISO-8859-1  /usr/bin/ogr2ogr -f PostgreSQL   PG:\"host=localhost port=5432 user=development_cartodb_user_367c0edc-b2ad-4bab-ad43-3d58a6179a93 dbname=cartodb_dev_user_367c0edc-b2ad-4bab-ad43-3d58a6179a93_db password=-b2ad-4bab-ad43-3d58a6179a93\"  -lco DIM=2 -lco PRECISION=NO /tmp/imports/20151223-2570-19ta0p4/cositis.csv  -nln cdb_importer.importer_57588876a98911e5b085080027880ca6 -nlt PROMOTE_TO_MULTI  
true: ogr2ogr output:          
true: ogr2ogr exit code:       0
true: Georeferencing...
true: Disabling autovacuum for \"cdb_importer\".\"importer_57588876a98911e5b085080027880ca6\"
true: Trying ip guessing...
true: Trying country guessing...
true: country_proportion(carla) = 0.0
true: country_proportion(pepe) = 0.0
true: Creating the_geom column
true: Enabling autovacuum for \"cdb_importer\".\"importer_57588876a98911e5b085080027880ca6\"
true: Georeferenced\ntrue: Finished importing data from /tmp/imports/20151223-2570-19ta0p4/cositis.csv
2015-12-23 15:25:06 UTC: Proceeding to register
2015-12-23 15:25:06 UTC: Before renaming from importer_57588876a98911e5b085080027880ca6 to cositis
2015-12-23 15:25:06 UTC: Before moving schema 'cositis_1' from cdb_importer to public
2015-12-23 15:25:06 UTC: Before persisting metadata 'cositis_1' data_import_id: 85fe4f0a-51c8-4064-9349-f6279f836547
2015-12-23 15:25:06 UTC: Exception: User reached the limit on number of templates
2015-12-23 15:25:06 UTC: ERROR!

"}>
````
