### PR TITLE
Recover deleted route and index function for api/v1/synchronizations/

### DIFF
--- a/app/controllers/carto/api/synchronizations_controller.rb
+++ b/app/controllers/carto/api/synchronizations_controller.rb
@@ -16,7 +16,7 @@ module Carto
       def index
         synchronizations = Carto::Synchronization.where(user_id: current_user.id)
         representation = synchronizations.map(&:to_hash)
-        response  = {
+        response = {
           synchronizations: representation,
           total_entries: synchronizations.count
         }

--- a/app/controllers/carto/api/synchronizations_controller.rb
+++ b/app/controllers/carto/api/synchronizations_controller.rb
@@ -2,12 +2,25 @@ module Carto
   module Api
     class SynchronizationsController < ::Api::ApplicationController
 
-      ssl_required :show, :syncing?
+      ssl_required :show, :index, :syncing?
 
       before_filter :load_synchronization, only: [:show, :syncing?]
 
       def show
         render_jsonp(@synchronization)
+      rescue => exception
+        CartoDB.notify_exception(exception)
+        head(404)
+      end
+
+      def index
+        synchronizations = Carto::Synchronization.where(user_id: current_user.id)
+        representation = synchronizations.map(&:to_hash)
+        response  = {
+          synchronizations: representation,
+          total_entries: synchronizations.count
+        }
+        render_jsonp(response)
       rescue => exception
         CartoDB.notify_exception(exception)
         head(404)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -358,6 +358,7 @@ CartoDB::Application.routes.draw do
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:visualization_id/overlays'     => 'overlays#index',    as: :api_v1_visualizations_overlays_index,  constraints: { visualization_id: /[^\/]+/ }
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:visualization_id/overlays/:id' => 'overlays#show',     as: :api_v1_visualizations_overlays_show,   constraints: { visualization_id: /[^\/]+/ }
 
+    get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations'                => 'synchronizations#index',     as: :api_v1_synchronizations_index
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id'            => 'synchronizations#show',     as: :api_v1_synchronizations_show
     # INFO: sync_now is public API
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id/sync_now'   => 'synchronizations#syncing?', as: :api_v1_synchronizations_syncing

--- a/spec/requests/carto/api/synchronizations_controller_spec.rb
+++ b/spec/requests/carto/api/synchronizations_controller_spec.rb
@@ -99,7 +99,6 @@ describe Carto::Api::SynchronizationsController do
         last_response.status.should == 200
       end
     end
-
   end
 
 end

--- a/spec/requests/carto/api/synchronizations_controller_spec.rb
+++ b/spec/requests/carto/api/synchronizations_controller_spec.rb
@@ -93,6 +93,13 @@ describe Carto::Api::SynchronizationsController do
       end
     end
 
+    describe 'GET /api/v1/synchronizations/' do
+      it 'returns sync list' do
+        get "/api/v1/synchronizations?api_key=#{@api_key}", nil, @headers
+        last_response.status.should == 200
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This was removed at: https://github.com/CartoDB/cartodb/commit/6238fbaac2b3e4f3d64c1a3855c144ab195cd8bf

Fixes https://github.com/CartoDB/cartodb/issues/6313