### PR TITLE
Improve HTTP headers handling in importer downloader

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -322,24 +322,19 @@ module CartoDB
       end
 
       def content_length_from(headers)
-        content_length = headers.fetch('Content-Length', nil)
-        content_length ||= headers.fetch('Content-length', nil)
-        content_length ||= headers.fetch('content-length', -1)
+        content_length = headers['content-length']
+        return -1 unless content_length
         content_length.to_i
       end
 
       def etag_from(headers)
-        etag  =   headers.fetch('ETag', nil)
-        etag  ||= headers.fetch('Etag', nil)
-        etag  ||= headers.fetch('etag', nil)
-        etag  = etag.delete('"').delete("'") if etag
+        etag = headers['etag']
+        etag = etag.delete('"').delete("'") if etag
         etag
       end
 
       def last_modified_from(headers)
-        last_modified =   headers.fetch('Last-Modified', nil)
-        last_modified ||= headers.fetch('Last-modified', nil)
-        last_modified ||= headers.fetch('last-modified', nil)
+        last_modified = headers['last-modified']
         last_modified = last_modified.delete('"').delete("'") if last_modified
         if last_modified
           begin
@@ -374,15 +369,13 @@ module CartoDB
       end
 
       def content_type
-        full_content_type = headers['content-type']
-        return nil unless full_content_type
-        full_content_type.split(';').first
+        media_type = headers['content-type']
+        return nil unless media_type
+        media_type.split(';').first
       end
 
       def name_from_http(headers)
-        disposition = headers.fetch('Content-Disposition', nil)
-        disposition ||= headers.fetch('Content-disposition', nil)
-        disposition ||= headers.fetch('content-disposition', nil)
+        disposition = headers['content-disposition']
         return false unless disposition
         filename = disposition.match(CONTENT_DISPOSITION_RE).to_a[1]
         return false unless filename
@@ -410,7 +403,7 @@ module CartoDB
       end
 
       def gdrive_deny_in?(headers)
-        headers.fetch('X-Frame-Options', nil) == 'DENY'
+        headers['x-frame-options'] == 'DENY'
       end
 
       def md5_command_for(name)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -324,8 +324,7 @@ module CartoDB
       end
 
       def content_length_from(headers)
-        content_length = headers['content-length']
-        return -1 unless content_length
+        content_length = headers['content-length'] || -1
         content_length.to_i
       end
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -46,7 +46,7 @@ module CartoDB
       CONTENT_TYPES_MAPPING = [
         {
           content_types: ['text/plain'],
-          extensions: ['txt']
+          extensions: ['txt', 'kml']
         },
         {
           content_types: ['text/csv'],
@@ -313,7 +313,6 @@ module CartoDB
 
         file_extension = File.extname(name).split('.').last
         name_without_extension = File.basename(name, ".*")
-
         #If there is no extension or file extension match in the content type extensions, add content type
         #extension to the file name deleting the previous extension (if exist)
         if (file_extension.nil? || file_extension.empty?) || !content_type_extensions.include?(file_extension)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -260,7 +260,6 @@ module CartoDB
           @last_modified  = last_modified_from(headers)
         end
         request.run
-
         if download_error && !error_response.nil?
           if error_response.timed_out?
             raise DownloadTimeoutError.new("TIMEOUT ERROR: Body:#{error_response.body}")
@@ -278,7 +277,6 @@ module CartoDB
         end
 
         File.rename(temp_name, filepath(name))
-
         # Just return the source file structure
         self.source_file  = SourceFile.new(filepath(name), name)
       end
@@ -376,9 +374,9 @@ module CartoDB
       end
 
       def content_type
-        headers.fetch('Content-Type', nil) ||
-          headers.fetch('Content-type', nil) ||
-          headers.fetch('content-type', nil)
+        full_content_type = headers['content-type']
+        return nil unless full_content_type
+        full_content_type.split(';').first
       end
 
       def name_from_http(headers)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -313,6 +313,7 @@ module CartoDB
 
         file_extension = File.extname(name).split('.').last
         name_without_extension = File.basename(name, ".*")
+
         #If there is no extension or file extension match in the content type extensions, add content type
         #extension to the file name deleting the previous extension (if exist)
         if (file_extension.nil? || file_extension.empty?) || !content_type_extensions.include?(file_extension)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -260,6 +260,7 @@ module CartoDB
           @last_modified  = last_modified_from(headers)
         end
         request.run
+
         if download_error && !error_response.nil?
           if error_response.timed_out?
             raise DownloadTimeoutError.new("TIMEOUT ERROR: Body:#{error_response.body}")
@@ -277,6 +278,7 @@ module CartoDB
         end
 
         File.rename(temp_name, filepath(name))
+
         # Just return the source file structure
         self.source_file  = SourceFile.new(filepath(name), name)
       end

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -254,6 +254,8 @@ module CartoDB
           end
           downloaded_file.close
 
+          # Header hash keys can take advantage of typhoeus case insensitive
+          # headers lookup (https://github.com/typhoeus/typhoeus/issues/227)
           headers = response.headers
           name            = name_from(headers, url, @custom_filename)
           @etag           = etag_from(headers)
@@ -324,18 +326,18 @@ module CartoDB
       end
 
       def content_length_from(headers)
-        content_length = headers['content-length'] || -1
+        content_length = headers['Content-Length'] || -1
         content_length.to_i
       end
 
       def etag_from(headers)
-        etag = headers['etag']
+        etag = headers['ETag']
         etag = etag.delete('"').delete("'") if etag
         etag
       end
 
       def last_modified_from(headers)
-        last_modified = headers['last-modified']
+        last_modified = headers['Last-Modified']
         last_modified = last_modified.delete('"').delete("'") if last_modified
         if last_modified
           begin
@@ -370,13 +372,13 @@ module CartoDB
       end
 
       def content_type
-        media_type = headers['content-type']
+        media_type = headers['Content-Type']
         return nil unless media_type
         media_type.split(';').first
       end
 
       def name_from_http(headers)
-        disposition = headers['content-disposition']
+        disposition = headers['Content-Disposition']
         return false unless disposition
         filename = disposition.match(CONTENT_DISPOSITION_RE).to_a[1]
         return false unless filename
@@ -404,7 +406,7 @@ module CartoDB
       end
 
       def gdrive_deny_in?(headers)
-        headers['x-frame-options'] == 'DENY'
+        headers['X-Frame-Options'] == 'DENY'
       end
 
       def md5_command_for(name)

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -214,19 +214,17 @@ describe Downloader do
 
   describe '#name_from' do
     it 'gets the file name from the Content-Disposition header if present' do
-      # header hash keys are downcased to take advantage of typhoeus case
-      # insensitive headers lookup (https://github.com/typhoeus/typhoeus/issues/227)
-      headers = { "content-disposition" => %{attachment; filename="bar.csv"} }
+      headers = { "Content-Disposition" => %{attachment; filename="bar.csv"} }
       downloader = Downloader.new(@file_url)
       downloader.send(:name_from, headers, @file_url).should eq 'bar.csv'
 
-      headers = { "content-disposition" => %{attachment; filename=bar.csv} }
+      headers = { "Content-Disposition" => %{attachment; filename=bar.csv} }
       downloader = Downloader.new(@file_url)
       downloader.send(:name_from, headers, @file_url).should eq 'bar.csv'
 
       disposition = "attachment; filename=map_gaudi3d.geojson; " +
                     'modification-date="Tue, 06 Aug 2013 15:05:35 GMT'
-      headers = { "content-disposition" => disposition }
+      headers = { "Content-Disposition" => disposition }
       downloader = Downloader.new(@file_url)
       downloader.send(:name_from, headers, @file_url).should eq 'map_gaudi3d.geojson'
     end


### PR DESCRIPTION
This started as an attempt to change the way we are retrieving the `Content-Type` header from downloads, as only exact matches would be supported later on in the code. We are supposing that the `Content-Type` would only contain the media type and not its parameters (such as  the charset: `Content-Type: text/html; charset=ISO-8859-4`).

* Content-Header definition in HTTP 1.1 - RFC 2616: https://tools.ietf.org/html/rfc2616#section-14.17
* Media types in HTTP 1.1 - RFC 2616: https://tools.ietf.org/html/rfc2616#section-3.7

In order to retrieve just the type, we are using a split with the `;` character which is the delimiter of parameters according to the RFC.

I noticed that we were commonly using different comparisons to retrieve the headers:

```ruby
      def content_type
        headers.fetch('Content-Type', nil) ||
          headers.fetch('Content-type', nil) ||
          headers.fetch('content-type', nil)
      end
```

but since Typhoeus 0.5.2 it is [downcasing the headers for easier access](https://github.com/typhoeus/typhoeus/issues/227). CartoDB uses `typhoeus 0.7.2` at the moment.

They [added a @sanitized variable](https://github.com/typhoeus/typhoeus/blob/v0.7.2/lib/typhoeus/response/header.rb#L18) that stores the downcased keys and then [set a fallback procedure](https://github.com/typhoeus/typhoeus/blob/v0.7.2/lib/typhoeus/response/header.rb#L20) for the key lookups. If the lookup doesn't find the key (`Content-Type`) then it would fallback to a downcased lookup `content-type` that will always work as they're storing this @sanitized downcase copy of the hash.

This way, if the header comes as `Content-type`, any combination as `headers.fetch('Content-type')` would work, `headers['Content-type']` would work, and the default downcased `headers['content-type']` would work. The lookup will be done with a downcased key, that will always match with the downcased key that Typhoeus stores in the sanitized header.

Therefore I edited the way that all headers are retrieved substituting them by a `headers['capitalized_key']` approach. The `content_type` function defined above ends up like:

```ruby
      def content_type
        media_type = headers['Content-Type']
        return nil unless media_type
        media_type.split(';').first
      end
``` 

**Note**: Even though lookups are case insensitive in Typhoeus Headers, I am using the capitalized header names.

### Testing

* Added new test `'ignores extra type parameters in Content-Type header' ` to test the output of the content type detection when a parameter is received
* These changes broke:
  * `'gets the file name from the Content-Disposition header if present'`: this test was generating directly the hash for the headers in a new variable, which ignores the behaviour that Typhoeus provides and the one that we are taking advantage of in this approach. I decided to downcase the key names to mimic Typhoeus' behaviour.
  * `'imports KML files from url'`: this test was working with a KML URL whose content type is  `text/plain; charset=utf-8`. Due to the charset parameter, this content type was never captured in the past and now the file was uploaded as a CSV (provoking the test to fail). I added `kml` to the mapping with `text/plain` content type, as Google says it can be used too officially. There are more details about this in the comments below.


Fixes https://github.com/CartoDB/cartodb/issues/5524