### PR TITLE
Fix terminate_database_connections on non-release versions - fixes #6321

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1087,15 +1087,12 @@ module CartoDB
         conn.run("
           DO language plpgsql $$
           DECLARE
-              ver INT[];
+              ver INT;
               sql TEXT;
           BEGIN
-              SELECT INTO ver regexp_split_to_array(
-                regexp_replace(version(), '^PostgreSQL ([^ ]*) .*', '\\1'),
-                '\\.'
-              );
+              SELECT INTO ver setting from pg_settings where name='server_version_num';
               sql := 'SELECT pg_terminate_backend(';
-              IF ver[1] > 9 OR ( ver[1] = 9 AND ver[2] > 1 ) THEN
+              IF ver > 90199 THEN
                 sql := sql || 'pid';
               ELSE
                 sql := sql || 'procpid';


### PR DESCRIPTION
Now we use `server_version_num` so we don't have to parse `VERSION()`.

