### PR TITLE
Sync message edit for sync errors

### DIFF
--- a/lib/assets/javascripts/cartodb/common/views/create/listing/dataset_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/create/listing/dataset_item.jst.ejs
@@ -2,7 +2,7 @@
   <% if (syncStatus) { %>
     <i
     <% if (syncStatus === "failure") { %>
-      data-title="Synced failed, last attempt was <%- syncRanAt %>"
+      data-title="Sync failed, last attempt was <%- syncRanAt %>"
     <% } else if (syncStatus === "syncing") { %>
       data-title="Syncing"
     <% } else { %>

--- a/lib/assets/javascripts/cartodb/dashboard/views/datasets_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/datasets_item.jst.ejs
@@ -3,7 +3,7 @@
   <% if (syncStatus) { %>
     <i
     <% if (syncStatus === "failure") { %>
-      data-title="Synced failed, last attempt was <%- syncRanAt %>"
+      data-title="Sync failed, last attempt was <%- syncRanAt %>"
     <% } else if (syncStatus === "syncing") { %>
       data-title="Syncing"
     <% } else { %>

--- a/lib/assets/javascripts/cartodb/table/header/views/sync_info_content.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/sync_info_content.jst.ejs
@@ -12,7 +12,7 @@
       <% } else if (state === "syncing") { %>
         Syncing...
       <% } else if (state === "failure") { %>
-        Synced failed.
+        Sync failed.
       <% } %>
       
       <% if (state === "success") { %>


### PR DESCRIPTION
Using "sync failed" instead of "synced failed" in the copies that contained it.


cc @xavijam @viddo 