### PR TITLE
Checks authorization when running sync tables process

### DIFF
--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -242,6 +242,8 @@ module CartoDB
           elsif exception.kind_of?(CartoDB::Importer2::FileTooBigError)
             set_general_failure_state_from(exception, exception.error_code,
                                            CartoDB::IMPORTER_ERROR_CODES[exception.error_code][:title])
+          elsif exception.kind_of?(AuthError)
+            set_general_failure_state_from(exception, 1011, 'Unauthorized')
           else
             set_general_failure_state_from(exception)
           end

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -174,6 +174,7 @@ module CartoDB
         if user.nil?
           raise "Couldn't instantiate synchronization user. Data: #{to_s}"
         end
+
         if !authorize?(user)
           raise CartoDB::Datasources::AuthError.new('User is not authorized to sync tables')
         end

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -174,6 +174,9 @@ module CartoDB
         if user.nil?
           raise "Couldn't instantiate synchronization user. Data: #{to_s}"
         end
+        if !authorize?(user)
+          raise CartoDB::Datasources::AuthError.new('User is not authorized to sync tables')
+        end
 
         downloader    = get_downloader
 

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -237,12 +237,12 @@ module CartoDB
         log.append exception.backtrace.join('\n'), truncate = false
 
         if importer.nil?
-          if exception.kind_of?(NotFoundDownloadError)
+          if exception.is_a?(NotFoundDownloadError)
             set_general_failure_state_from(exception, 1017, 'File not found, you must import it again')
-          elsif exception.kind_of?(CartoDB::Importer2::FileTooBigError)
+          elsif exception.is_a?(CartoDB::Importer2::FileTooBigError)
             set_general_failure_state_from(exception, exception.error_code,
                                            CartoDB::IMPORTER_ERROR_CODES[exception.error_code][:title])
-          elsif exception.kind_of?(AuthError)
+          elsif exception.is_a?(AuthError)
             set_general_failure_state_from(exception, 1011, 'Unauthorized')
           else
             set_general_failure_state_from(exception)
@@ -253,7 +253,7 @@ module CartoDB
 
         store
 
-        if exception.kind_of?(TokenExpiredOrInvalidError)
+        if exception.is_a?(TokenExpiredOrInvalidError)
           begin
             user.oauths.remove(exception.service_name)
           rescue => ex


### PR DESCRIPTION
Although the `sync_now` process checks if the user is authorized, the regular sync was not including this check. Any existent sync table would work automatically (not by manually syncing, though) as the sync_table feature was not being checked at any moment during the regular process.

Now, it shows:

![image](https://cloud.githubusercontent.com/assets/1730320/12022742/0b6e536a-ad93-11e5-9183-9c75674c0660.png)

The sync error code is set as 1011, and the error_message as "Unauthorized". An example from local data:

````
{  
  "item":{  
    "data":{  
      "id":"9b2dd65c-ad79-11e5-9170-040146752f01",
      "name":"one_layer_2",
      "interval":3600,
      "url":"https://raw.githubusercontent.com/CartoDB/cartodb/master/services/importer/spec/fixtures/one_layer.kml",
      "state":"failure",
      "created_at":"2015-12-28T15:42:31+00:00",
      "updated_at":"2015-12-28T17:44:12+00:00",
      "run_at":"2015-12-28T18:44:12+00:00",
      "retried_times":2,
      "log_id":"4cce214d-3016-4845-9dc6-1cc60e048c4a",
      "error_code":1011,
      "error_message":"Unauthorized",
      "ran_at":"2015-12-28T16:43:15+00:00",
      "modified_at":null,
      "etag":"8e9fd2586d73a2d32749c26ccbab1e1e4e3b74d9",
      "checksum":"8e9fd2586d73a2d32749c26ccbab1e1e4e3b74d9",
      "user_id":"62584b48-18d0-4ed7-b018-749fe46009e7",
      "service_name":null,
      "service_item_id":"https://raw.githubusercontent.com/CartoDB/cartodb/master/services/importer/spec/fixtures/one_layer.kml",
      "type_guessing":true,
      "quoted_fields_guessing":true,
      "content_guessing":true,
      "visualization_id":"9dd42334-ad79-11e5-92b1-040146752f01",
      "from_external_source":false
    }
````
Fixes https://github.com/CartoDB/cartodb-management/issues/4344