### PR TITLE
Remove custom basemaps for google users

### DIFF
--- a/lib/assets/javascripts/cartodb/table/basemap/basemap_dropdown/basemap_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/basemap/basemap_dropdown/basemap_dropdown.js
@@ -173,9 +173,11 @@ cdb.admin.DropdownBasemap = cdb.ui.common.Dropdown.extend({
       var listClassName = '.custom ul.' + category.toLowerCase();
       var $ul = this.$(listClassName);
       if (!$ul.length) {
-        $(template({
-          category: category
-        })).insertBefore(this.$('.fixed_basemaps'));
+        this.$('.js-customBasemaps').prepend(
+          template({
+            category: category
+          })
+        );
         $ul = this.$(listClassName);
       }
       $ul.append($element);
@@ -429,15 +431,24 @@ cdb.admin.DropdownBasemap = cdb.ui.common.Dropdown.extend({
    * Renders the basemap dropdown
    */
   render: function() {
-
     this.clearSubViews();
+    var googleMapsEnabled = this.googleMapsEnabled() || this.user.featureEnabled('google_maps');
 
-    this.$el.html(this.template_base(this.options));
+    this.$el.html(
+      this.template_base(
+        _.extend(this.options, {
+          googleMapsEnabled: googleMapsEnabled
+        })
+      )
+    );
 
     this._addBaseDefault();
-    this._addColorBasemap();
-    this._addBackgroundBasemap();
-    this._addAddBasemapLink();
+
+    if (!googleMapsEnabled) {
+      this._addColorBasemap();
+      this._addBackgroundBasemap();
+      this._addAddBasemapLink();
+    }
 
     return this;
   },

--- a/lib/assets/javascripts/cartodb/table/views/basemap/basemap_dropdown.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/basemap/basemap_dropdown.jst.ejs
@@ -1,4 +1,5 @@
-<div class="custom">
+<div class="custom js-customBasemaps">
+  <% if (!googleMapsEnabled) { %>
   <ul class="fixed_basemaps">
     <li>Custom</li>
     <li>
@@ -11,4 +12,5 @@
       <ul class="thumbs yours"></ul>
     </li>
   </ul>
+  <% } %>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.18",
+  "version": "3.23.19",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Don't let google users add a custom basemap.

Fixes https://github.com/CartoDB/cartodb-platform/issues/1132.
Fixes https://github.com/CartoDB/cartodb-platform/issues/1320.

cc @luisbosque @yasharora73
CR: @javierarce 