### PR TITLE
Remove public profile mention

### DIFF
--- a/app/views/user_mailer/trending_map.html.erb
+++ b/app/views/user_mailer/trending_map.html.erb
@@ -34,7 +34,7 @@
             <table cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #F2FAE8; border-bottom: 1px solid #dddddd; width: 100% !important;">
               <tr>
                 <td align="left" style="padding: 40px 50px 40px 50px; font-family: Helvetica, Arial, sans-serif;">
-                  <p style="margin: 0; font-size: 16px; line-height: 25px; color: #666666;"><%= @greetings.sample.capitalize %>!, Your <strong><%= @map_name %></strong> has received more than <strong><%= number_to_human(@mapviews).downcase %> mapviews</strong> from your public profile!</p>
+                  <p style="margin: 0; font-size: 16px; line-height: 25px; color: #666666;"><%= @greetings.sample.capitalize %>!, Your <strong><%= @map_name %></strong> has received more than <strong><%= number_to_human(@mapviews).downcase %> mapviews</strong>!</p>
                 </td>
               </tr>
             </table>

--- a/app/views/user_mailer/trending_map.html.erb
+++ b/app/views/user_mailer/trending_map.html.erb
@@ -34,7 +34,7 @@
             <table cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #F2FAE8; border-bottom: 1px solid #dddddd; width: 100% !important;">
               <tr>
                 <td align="left" style="padding: 40px 50px 40px 50px; font-family: Helvetica, Arial, sans-serif;">
-                  <p style="margin: 0; font-size: 16px; line-height: 25px; color: #666666;"><%= @greetings.sample.capitalize %>!, Your <strong><%= @map_name %></strong> has received more than <strong><%= number_to_human(@mapviews).downcase %> mapviews</strong>!</p>
+                  <p style="margin: 0; font-size: 16px; line-height: 25px; color: #666666;"><%= @greetings.sample.capitalize %>!, Your <strong><%= @map_name %></strong> has received more than <strong><%= number_to_human(@mapviews).downcase %> map views</strong>!</p>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
cc @ethervoid:

Any specific reason why "public profile" was mentioned here? This is not really true, as map views are measured from any source. If there's not any specific reason why the sentence is there, I would like to remove it as it can cause confusion for users with "with link" map privacies.