### PR TITLE
Adds no-cache headers for browser

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,9 +1,16 @@
 class Admin::AdminController < ApplicationController
   before_filter :x_frame_options_deny
+  before_filter :invalidate_browser_cache
 
   protected
 
   def x_frame_options_deny
     response.headers['X-Frame-Options'] = 'DENY'
+  end
+
+  def invalidate_browser_cache
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 'Mon, 01 Jan 1990 00:00:00 GMT'
   end
 end

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,6 +1,5 @@
 class Admin::AdminController < ApplicationController
   before_filter :x_frame_options_deny
-  before_filter :invalidate_browser_cache
 
   protected
 

--- a/app/controllers/admin/client_applications_controller.rb
+++ b/app/controllers/admin/client_applications_controller.rb
@@ -3,6 +3,7 @@
 class Admin::ClientApplicationsController < Admin::AdminController
   ssl_required :oauth, :api_key, :regenerate_api_key, :regenerate_oauth
 
+  before_filter :invalidate_browser_cache
   before_filter :login_required
 
   layout 'application'

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -21,6 +21,7 @@ class Admin::UsersController < Admin::AdminController
 
   ssl_required  :account, :profile, :account_update, :profile_update, :delete
 
+  before_filter :invalidate_browser_cache
   before_filter :login_required
   before_filter :setup_user
   before_filter :initialize_google_plus_config, only: [:profile, :account]
@@ -185,5 +186,4 @@ class Admin::UsersController < Admin::AdminController
   def setup_user
     @user = current_user
   end
-
 end

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -40,18 +40,6 @@ class Admin::VisualizationsController < Admin::AdminController
                                                    :show_organization_embed_map, :show_protected_embed_map,
                                                    :track_embed]
 
-  skip_before_filter :invalidate_browser_cache, only: [:show_organization_embed_map,
-                                                       :show_protected_embed_map,
-                                                       :embed_map,
-                                                       :embed_protected,
-                                                       :embed_forbidden,
-                                                       :public_table,
-                                                       :public_map,
-                                                       :show_organization_public_map,
-                                                       :show_protected_public_map,
-                                                       :public_map_protected,
-                                                       :track_embed]
-
   def index
     @first_time    = !current_user.dashboard_viewed?
     @just_logged_in = !!flash['logged']

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -40,6 +40,18 @@ class Admin::VisualizationsController < Admin::AdminController
                                                    :show_organization_embed_map, :show_protected_embed_map,
                                                    :track_embed]
 
+  skip_before_filter :invalidate_browser_cache, only: [:show_organization_embed_map,
+                                                       :show_protected_embed_map,
+                                                       :embed_map,
+                                                       :embed_protected,
+                                                       :embed_forbidden,
+                                                       :public_table,
+                                                       :public_map,
+                                                       :show_organization_public_map,
+                                                       :show_protected_public_map,
+                                                       :public_map_protected,
+                                                       :track_embed]
+
   def index
     @first_time    = !current_user.dashboard_viewed?
     @just_logged_in = !!flash['logged']

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,13 +13,13 @@ class SessionsController < ApplicationController
   ssl_required :new, :create, :destroy, :show, :unauthenticated, :account_token_authentication_error,
                :ldap_user_not_at_cartodb
 
+  skip_before_filter :ensure_org_url_if_org_user # Don't force org urls
+  skip_before_filter :ensure_account_has_been_activated,
+                     only: [:account_token_authentication_error, :ldap_user_not_at_cartodb]
+
   before_filter :load_organization
   before_filter :initialize_google_plus_config
-  before_filter :api_authorization_required, :only => :show
-  # Don't force org urls
-  skip_before_filter :ensure_org_url_if_org_user
-  skip_before_filter :ensure_account_has_been_activated, :only => [ :account_token_authentication_error,
-                     :ldap_user_not_at_cartodb ]
+  before_filter :api_authorization_required, only: :show
 
   def new
     if logged_in?(CartoDB.extract_subdomain(request))


### PR DESCRIPTION
Please CR, @juanignaciosl 

This only affects client side cache and only our editor pages (which have sensible info).

This will prevent those pages showing up when clicking “back” button after logout in modern browsers.