### PR TITLE
Skips email verification if user is created through API

### DIFF
--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -20,6 +20,8 @@ module Carto
       def create
         account_creator = CartoDB::UserAccountCreator.new.with_organization(@organization)
 
+        account_creator.with_api
+
         account_creator.with_username(create_params[:username]) if create_params[:username].present?
         account_creator.with_email(create_params[:email]) if create_params[:email].present?
         account_creator.with_password(create_params[:password]) if create_params[:password].present?

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -101,17 +101,13 @@ class Carto::UserCreation < ActiveRecord::Base
     self
   end
 
-  def with_options(options)
-    self.options = load_options.merge!(options).to_json
+  def with_api
+    self.created_via_api = true
     self
   end
 
-  def load_options
-    options.blank? ? {} : JSON.load(options).symbolize_keys
-  end
-
-  def created_through_api?
-    load_options[:created_through_api]
+  def created_via_api?
+    self.created_via_api
   end
 
   def has_valid_invitation?
@@ -179,7 +175,7 @@ class Carto::UserCreation < ActiveRecord::Base
     @cartodb_user.soft_geocoding_limit = soft_geocoding_limit unless soft_geocoding_limit.nil?
     @cartodb_user.google_sign_in = google_sign_in
     @cartodb_user.invitation_token = invitation_token
-    @cartodb_user.enable_account_token = ::User.make_token if requires_validation_email? && !created_through_api?
+    @cartodb_user.enable_account_token = ::User.make_token if requires_validation_email? && !created_via_api?
     unless @promote_to_organization_owner
       organization = ::Organization.where(id: organization_id).first
       raise "Trying to copy organization settings from one without owner" if organization.owner.nil?
@@ -210,7 +206,7 @@ class Carto::UserCreation < ActiveRecord::Base
   end
 
   def use_invitation
-    return if created_through_api?
+    return if created_via_api?
     return unless invitation_token
     invitation = unused_invitation
     return unless invitation
@@ -245,7 +241,7 @@ class Carto::UserCreation < ActiveRecord::Base
 
   def close_creation
     clean_password
-    cartodb_user.notify_new_organization_user unless has_valid_invitation? || created_through_api?
+    cartodb_user.notify_new_organization_user unless has_valid_invitation? || created_via_api?
     cartodb_user.organization.notify_if_disk_quota_limit_reached if cartodb_user.organization
     cartodb_user.organization.notify_if_seat_limit_reached if cartodb_user.organization
   rescue => e

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -111,7 +111,7 @@ class Carto::UserCreation < ActiveRecord::Base
   end
 
   def load_options
-    self.options.blank? ? {} : JSON.load(self.options).symbolize_keys
+    options.blank? ? {} : JSON.load(options).symbolize_keys
   end
 
   def has_valid_invitation?

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -175,7 +175,7 @@ class Carto::UserCreation < ActiveRecord::Base
     @cartodb_user.soft_geocoding_limit = soft_geocoding_limit unless soft_geocoding_limit.nil?
     @cartodb_user.google_sign_in = google_sign_in
     @cartodb_user.invitation_token = invitation_token
-    @cartodb_user.enable_account_token = ::User.make_token if requires_validation_email? && !created_via_api?
+    @cartodb_user.enable_account_token = ::User.make_token if requires_validation_email?
     unless @promote_to_organization_owner
       organization = ::Organization.where(id: organization_id).first
       raise "Trying to copy organization settings from one without owner" if organization.owner.nil?

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -106,12 +106,12 @@ class Carto::UserCreation < ActiveRecord::Base
     self
   end
 
-  def created_through_api?
-    load_options[:created_through_api]
-  end
-
   def load_options
     options.blank? ? {} : JSON.load(options).symbolize_keys
+  end
+
+  def created_through_api?
+    load_options[:created_through_api]
   end
 
   def has_valid_invitation?

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -85,7 +85,7 @@ class Carto::UserCreation < ActiveRecord::Base
 
   # TODO: Shorcut, search for a better solution to detect requirement
   def requires_validation_email?
-    google_sign_in != true && !has_valid_invitation? && !Carto::Ldap::Manager.new.configuration_present?
+    google_sign_in != true && !has_valid_invitation? && !Carto::Ldap::Manager.new.configuration_present? && !created_via_api?
   end
 
   def autologin?
@@ -206,7 +206,6 @@ class Carto::UserCreation < ActiveRecord::Base
   end
 
   def use_invitation
-    return if created_via_api?
     return unless invitation_token
     invitation = unused_invitation
     return unless invitation
@@ -241,7 +240,7 @@ class Carto::UserCreation < ActiveRecord::Base
 
   def close_creation
     clean_password
-    cartodb_user.notify_new_organization_user unless has_valid_invitation? || created_via_api?
+    cartodb_user.notify_new_organization_user unless has_valid_invitation?
     cartodb_user.organization.notify_if_disk_quota_limit_reached if cartodb_user.organization
     cartodb_user.organization.notify_if_seat_limit_reached if cartodb_user.organization
   rescue => e

--- a/db/migrate/20160107133358_add_options_to_user_creations.rb
+++ b/db/migrate/20160107133358_add_options_to_user_creations.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    add_column :user_creations, :options, :text
+  end
+
+  down do
+    drop_column :user_creations, :options
+  end
+end

--- a/db/migrate/20160107133358_add_options_to_user_creations.rb
+++ b/db/migrate/20160107133358_add_options_to_user_creations.rb
@@ -1,9 +1,0 @@
-Sequel.migration do
-  up do
-    add_column :user_creations, :options, :text
-  end
-
-  down do
-    drop_column :user_creations, :options
-  end
-end

--- a/db/migrate/20160108122849_add_created_via_api_to_user_creations.rb
+++ b/db/migrate/20160108122849_add_created_via_api_to_user_creations.rb
@@ -1,6 +1,6 @@
 Sequel.migration do
   up do
-    add_column :user_creations, :created_via_api, :boolean
+    add_column :user_creations, :created_via_api, :boolean, null: false, default: false
   end
 
   down do

--- a/db/migrate/20160108122849_add_created_via_api_to_user_creations.rb
+++ b/db/migrate/20160108122849_add_created_via_api_to_user_creations.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    add_column :user_creations, :created_via_api, :boolean
+  end
+
+  down do
+    drop_column :user_creations, :created_via_api
+  end
+end

--- a/lib/user_account_creator.rb
+++ b/lib/user_account_creator.rb
@@ -54,6 +54,11 @@ module CartoDB
       self
     end
 
+    def with_api
+      @created_through_api = true
+      self
+    end
+
     def user
       @user
     end
@@ -83,7 +88,10 @@ module CartoDB
       build
 
       user_creation = Carto::UserCreation.new_user_signup(@user).
-                      with_invitation_token(@invitation_token)
+                                          with_invitation_token(@invitation_token)
+
+      user_creation = user_creation.with_options(created_through_api: true) if @created_through_api
+
       user_creation.save
 
       common_data_url = CartoDB::Visualization::CommonDataService.build_url(current_controller)

--- a/lib/user_account_creator.rb
+++ b/lib/user_account_creator.rb
@@ -55,7 +55,7 @@ module CartoDB
     end
 
     def with_api
-      @created_through_api = true
+      @created_via_api = true
       self
     end
 
@@ -89,7 +89,7 @@ module CartoDB
 
       user_creation = Carto::UserCreation.new_user_signup(@user).with_invitation_token(@invitation_token)
 
-      user_creation = user_creation.with_options(created_through_api: true) if @created_through_api
+      user_creation = user_creation.with_api if @created_via_api
 
       user_creation.save
 

--- a/lib/user_account_creator.rb
+++ b/lib/user_account_creator.rb
@@ -87,8 +87,7 @@ module CartoDB
     def enqueue_creation(current_controller)
       build
 
-      user_creation = Carto::UserCreation.new_user_signup(@user).
-                                          with_invitation_token(@invitation_token)
+      user_creation = Carto::UserCreation.new_user_signup(@user).with_invitation_token(@invitation_token)
 
       user_creation = user_creation.with_options(created_through_api: true) if @created_through_api
 

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -258,6 +258,18 @@ describe Carto::UserCreation do
       user_creation.next_creation_step until user_creation.finished?
     end
 
+    it 'should not send validation email if user is created via API' do
+      ::User.any_instance.stubs(:create_in_central).returns(true)
+      CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
+      ::Resque.expects(:enqueue).with(Resque::UserJobs::Mail::NewOrganizationUser, instance_of(String)).never
+
+      user_data = FactoryGirl.build(:valid_user)
+      user_data.organization = @organization
+
+      user_creation = Carto::UserCreation.new_user_signup(user_data).with_options(created_through_api: true)
+      user_creation.next_creation_step until user_creation.finished?
+    end
+
   end
 
   describe 'organization overquota email' do

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -266,7 +266,7 @@ describe Carto::UserCreation do
       user_data = FactoryGirl.build(:valid_user)
       user_data.organization = @organization
 
-      user_creation = Carto::UserCreation.new_user_signup(user_data).with_options(created_through_api: true)
+      user_creation = Carto::UserCreation.new_user_signup(user_data).with_api
       user_creation.next_creation_step until user_creation.finished?
     end
   end

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -258,7 +258,7 @@ describe Carto::UserCreation do
       user_creation.next_creation_step until user_creation.finished?
     end
 
-    it 'should send invitation emial but not validation email if user is created via API' do
+    it 'should send invitation email but not validation email if user is created via API' do
       ::User.any_instance.stubs(:create_in_central).returns(true)
       CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
       ::Resque.expects(:enqueue).with(Resque::OrganizationJobs::Mail::Invitation, instance_of(String)).never

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -258,10 +258,11 @@ describe Carto::UserCreation do
       user_creation.next_creation_step until user_creation.finished?
     end
 
-    it 'should not send validation email if user is created via API' do
+    it 'should send invitation emial but not validation email if user is created via API' do
       ::User.any_instance.stubs(:create_in_central).returns(true)
       CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
-      ::Resque.expects(:enqueue).with(Resque::UserJobs::Mail::NewOrganizationUser, instance_of(String)).never
+      ::Resque.expects(:enqueue).with(Resque::OrganizationJobs::Mail::Invitation, instance_of(String)).never
+      ::Resque.expects(:enqueue).with(Resque::UserJobs::Mail::NewOrganizationUser, instance_of(String)).once
 
       user_data = FactoryGirl.build(:valid_user)
       user_data.organization = @organization

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -269,7 +269,6 @@ describe Carto::UserCreation do
       user_creation = Carto::UserCreation.new_user_signup(user_data).with_options(created_through_api: true)
       user_creation.next_creation_step until user_creation.finished?
     end
-
   end
 
   describe 'organization overquota email' do


### PR DESCRIPTION
Fixes #6311

The migration will be deployed separately.

This PR adds an `options` JSON array to the `UserCreation`. This is meant to be reused in the future, but for now its purpose is to store info about the use or not of the EUMAPI in the users creation, so the right decision can be made on whether the email should be verified or not.

I think a migration is inevitable for this and tried to mitigate it by making it reusable. If you come up with a way of avoiding it please propose. The less clutter, the best!

Please review @juanignaciosl 