### PR TITLE
Don't round remote datasets size when they are bigger than 1GB

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/create/listing/datasets/remote_dataset_item_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/listing/datasets/remote_dataset_item_view.js
@@ -57,7 +57,10 @@ module.exports = DatasetItem.extend({
 
     var datasetSize = table.get('size');
     if (datasetSize >= 0) {
-      d.datasetSize = Utils.readablizeBytes(datasetSize, true);
+      d.datasetSize = Utils.readablizeBytes(
+        datasetSize,
+        datasetSize.toString().length > 9 ? false : true
+      );
     }
 
     this.$el.html(this.template(d));

--- a/lib/assets/javascripts/cartodb/dashboard/datasets/remote_datasets_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/datasets/remote_datasets_item.js
@@ -65,7 +65,10 @@ module.exports = DatasetsItem.extend({
 
     var datasetSize = table.get('size');
     if (datasetSize >= 0) {
-      d.datasetSize = Utils.readablizeBytes(datasetSize, true);
+      d.datasetSize = Utils.readablizeBytes(
+        datasetSize,
+        datasetSize.toString().length > 9 ? false : true
+      );
     }
 
     this.$el.html(this.template(d));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.20",
+  "version": "3.23.21",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<img width="1002" alt="screen shot 2016-01-11 at 15 41 53" src="https://cloud.githubusercontent.com/assets/132146/12236409/dc0f34bc-b879-11e5-9993-9a7548d11527.png">

Fixes #6340.

cc @ztephm 