### PR TITLE
Don't let google users add custom XYZ/TMZ/... basemaps

### DIFF
--- a/app/assets/stylesheets/map/dropdowns/basemap_dropdown.css.scss
+++ b/app/assets/stylesheets/map/dropdowns/basemap_dropdown.css.scss
@@ -79,7 +79,7 @@ div.dropdown.basemap {
 
       &:first-child {
         width: 60px;
-        margin: 2px 4px 0 0;
+        margin: 5px 4px 0 0;
         color: #CCCCCC;
       }
 
@@ -233,7 +233,7 @@ div.dropdown.basemap {
       @mixin google-thumbnail($name) {
         &.#{$name} .thumb {
           @include background(image-url('layout/gmaps-basemaps/#{$name}.png') no-repeat center center);
-        }        
+        }
       }
 
       @include google-thumbnail(roadmap);
@@ -253,7 +253,7 @@ div.dropdown.basemap {
 
 
 
-      &.add .thumb          { @include map-sprite(plus); } 
+      &.add .thumb          { @include map-sprite(plus); }
       &.pattern .thumb      { @include elements-sprite(image_fill, $offset-x:5px, $offset-y:7px); }
 
       span.color {

--- a/app/assets/stylesheets/old_elements/color_picker_dropdown.css.scss
+++ b/app/assets/stylesheets/old_elements/color_picker_dropdown.css.scss
@@ -261,6 +261,5 @@
     // Basemap tail
     &.basemap:before {
       left:-5px!important;
-      border-right:6px solid #EEEEEE!important;
     }
   }

--- a/lib/assets/javascripts/cartodb/table/basemap/basemap_dropdown/basemap_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/basemap/basemap_dropdown/basemap_dropdown.js
@@ -173,9 +173,11 @@ cdb.admin.DropdownBasemap = cdb.ui.common.Dropdown.extend({
       var listClassName = '.custom ul.' + category.toLowerCase();
       var $ul = this.$(listClassName);
       if (!$ul.length) {
-        $(template({
-          category: category
-        })).insertBefore(this.$('.fixed_basemaps'));
+        this.$('.js-customBasemaps').prepend(
+          template({
+            category: category
+          })
+        );
         $ul = this.$(listClassName);
       }
       $ul.append($element);
@@ -429,15 +431,24 @@ cdb.admin.DropdownBasemap = cdb.ui.common.Dropdown.extend({
    * Renders the basemap dropdown
    */
   render: function() {
-
     this.clearSubViews();
+    var googleMapsEnabled = this.googleMapsEnabled() || this.user.featureEnabled('google_maps');
 
-    this.$el.html(this.template_base(this.options));
+    this.$el.html(
+      this.template_base(
+        _.extend(this.options, {
+          googleMapsEnabled: googleMapsEnabled
+        })
+      )
+    );
 
     this._addBaseDefault();
-    this._addColorBasemap();
-    this._addBackgroundBasemap();
-    this._addAddBasemapLink();
+
+    if (!googleMapsEnabled) {
+      this._addColorBasemap();
+      this._addBackgroundBasemap();
+      this._addAddBasemapLink();
+    }
 
     return this;
   },

--- a/lib/assets/javascripts/cartodb/table/basemap/basemap_dropdown/basemap_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/basemap/basemap_dropdown/basemap_dropdown.js
@@ -443,10 +443,10 @@ cdb.admin.DropdownBasemap = cdb.ui.common.Dropdown.extend({
     );
 
     this._addBaseDefault();
+    this._addColorBasemap();
+    this._addBackgroundBasemap();
 
     if (!googleMapsEnabled) {
-      this._addColorBasemap();
-      this._addBackgroundBasemap();
       this._addAddBasemapLink();
     }
 

--- a/lib/assets/javascripts/cartodb/table/basemap/basemap_dropdown/color_basemap.js
+++ b/lib/assets/javascripts/cartodb/table/basemap/basemap_dropdown/color_basemap.js
@@ -42,9 +42,9 @@ cdb.admin.BackgroundMapColorView = cdb.admin.BaseLayerButton.extend({
 
   _changeModel: function() {
     if (this.model) {
-      this.model.unbind(null, null, this);  
+      this.model.unbind(null, null, this);
     }
-    
+
     this.model = this.map.getBaseLayer();
     this._initBinds();
     this.render();
@@ -60,11 +60,11 @@ cdb.admin.BackgroundMapColorView = cdb.admin.BaseLayerButton.extend({
     this.color_picker = new cdb.admin.ColorPicker({
       className: 'dropdown color_picker basemap border vertical_offset',
       target: this.$el,
-      vertical_position: "down",
+      vertical_position: "up",
       horizontal_position: "left",
-      vertical_offset: 40,
+      vertical_offset: -42,
       horizontal_offset: 50,
-      tick: "top",
+      tick: "bottom",
       dragUpdate: false
     }).bind("colorChosen", this.setColor, this);
 
@@ -112,7 +112,7 @@ cdb.admin.BackgroundMapColorView = cdb.admin.BaseLayerButton.extend({
 
   _openPicker: function(e) {
     this.killEvent(e);
-    
+
     if (this.color_picker) this._destroyPicker();
 
     if (!this.color_picker) {

--- a/lib/assets/javascripts/cartodb/table/views/basemap/basemap_dropdown.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/basemap/basemap_dropdown.jst.ejs
@@ -1,11 +1,11 @@
 <div class="custom js-customBasemaps">
-  <% if (!googleMapsEnabled) { %>
   <ul class="fixed_basemaps">
     <li>Custom</li>
     <li>
       <ul class="thumbs custom"></ul>
     </li>
   </ul>
+  <% if (!googleMapsEnabled) { %>
   <ul>
     <li>Yours</li>
     <li>

--- a/lib/assets/javascripts/cartodb/table/views/basemap/basemap_dropdown.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/basemap/basemap_dropdown.jst.ejs
@@ -1,4 +1,5 @@
-<div class="custom">
+<div class="custom js-customBasemaps">
+  <% if (!googleMapsEnabled) { %>
   <ul class="fixed_basemaps">
     <li>Custom</li>
     <li>
@@ -11,4 +12,5 @@
       <ul class="thumbs yours"></ul>
     </li>
   </ul>
+  <% } %>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.20",
+  "version": "3.23.22",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It comes from this merged [PR](https://github.com/CartoDB/cartodb/pull/6334) and then [reverted](https://github.com/CartoDB/cartodb/pull/6359) due to color was disabled too.

---

Standard user:
![screen shot 2016-01-11 at 16 05 42](https://cloud.githubusercontent.com/assets/132146/12237085/3c4ca8e8-b87d-11e5-97b8-8e259de663ef.png)

<img width="515" alt="screen shot 2016-01-12 at 11 58 06" src="https://cloud.githubusercontent.com/assets/132146/12261843/017d42e8-b924-11e5-9bec-d0a56552507f.png">


---
Google user (_*don't take into account small previews, they are wrong_):
<img width="425" alt="screen shot 2016-01-11 at 16 05 55" src="https://cloud.githubusercontent.com/assets/132146/12237086/3dd186ac-b87d-11e5-9f7d-a4e1145b0663.png">

<img width="399" alt="screen shot 2016-01-12 at 11 59 37" src="https://cloud.githubusercontent.com/assets/132146/12261841/fddb1908-b923-11e5-806e-67fe3a8de2a1.png">


---

cc @yasharora73 @javisantana @saleiva 