### PR TITLE
Avoid erroneous XLS format detection for XLSX files

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -26,6 +26,11 @@ module CartoDB
 
       SUPPORTED_EXTENSIONS = CartoDB::Importer2::Unp::SUPPORTED_FORMATS
                               .concat(CartoDB::Importer2::Unp::COMPRESSED_EXTENSIONS)
+                              .sort_by { |s| s.length }.reverse
+
+      URL_FILENAME_REGEX = Regexp.new(
+                              "[[:word:]]+(#{ SUPPORTED_EXTENSIONS.map{ |s| s.sub(/\./, "\\.")}.join("|") })+",
+                              true)
 
       DEFAULT_FILENAME        = 'importer'
       CONTENT_DISPOSITION_RE  = %r{;\s*filename=(.*;|.*)}
@@ -389,13 +394,9 @@ module CartoDB
       end
 
       def name_in(url)
-        parsed_filepath = URI.parse(url).path.to_s
-        url_basename = File.basename(parsed_filepath)
-        extension = File.extname(url_basename)
+        url_name = URL_FILENAME_REGEX.match(url).to_s
 
-        if (!url_basename.empty? && SUPPORTED_EXTENSIONS.include?(extension))
-          url_basename
-        end
+        url_name if !url_name.empty?
       end
 
       def random_name

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -26,9 +26,6 @@ module CartoDB
 
       SUPPORTED_EXTENSIONS = CartoDB::Importer2::Unp::SUPPORTED_FORMATS
                               .concat(CartoDB::Importer2::Unp::COMPRESSED_EXTENSIONS)
-      URL_FILENAME_REGEX = Regexp.new(
-                              "[[:word:]]+(#{ SUPPORTED_EXTENSIONS.map{ |s| s.sub(/\./, "\\.")}.join("|") })+",
-                              true)
 
       DEFAULT_FILENAME        = 'importer'
       CONTENT_DISPOSITION_RE  = %r{;\s*filename=(.*;|.*)}
@@ -392,9 +389,13 @@ module CartoDB
       end
 
       def name_in(url)
-        url_name = URL_FILENAME_REGEX.match(url).to_s
+        parsed_filepath = URI.parse(url).path.to_s
+        url_basename = File.basename(parsed_path)
+        extension = File.extname(url_basename)
 
-        url_name if !url_name.empty?
+        if (!url_basename.empty? && SUPPORTED_EXTENSIONS.include?(extension))
+          url_basename
+        end
       end
 
       def random_name

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -96,7 +96,7 @@ module CartoDB
 
       def self.url_filename_regex
         @url_filename_regex ||= Regexp.new(
-                                "[[:word:]]+" + Regexp.union(supported_extensions).to_s,
+                                "[[:word:]]+#{Regexp.union(supported_extensions)}+",
                                 true)
       end
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -390,7 +390,7 @@ module CartoDB
 
       def name_in(url)
         parsed_filepath = URI.parse(url).path.to_s
-        url_basename = File.basename(parsed_path)
+        url_basename = File.basename(parsed_filepath)
         extension = File.extname(url_basename)
 
         if (!url_basename.empty? && SUPPORTED_EXTENSIONS.include?(extension))

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -24,14 +24,6 @@ module CartoDB
       DEFAULT_HTTP_REQUEST_TIMEOUT = 600
       URL_ESCAPED_CHARACTERS = 'áéíóúÁÉÍÓÚñÑçÇàèìòùÀÈÌÒÙ'
 
-      SUPPORTED_EXTENSIONS = CartoDB::Importer2::Unp::SUPPORTED_FORMATS
-                              .concat(CartoDB::Importer2::Unp::COMPRESSED_EXTENSIONS)
-                              .sort_by { |s| s.length }.reverse
-
-      URL_FILENAME_REGEX = Regexp.new(
-                              "[[:word:]]+(#{ SUPPORTED_EXTENSIONS.map{ |s| s.sub(/\./, "\\.")}.join("|") })+",
-                              true)
-
       DEFAULT_FILENAME        = 'importer'
       CONTENT_DISPOSITION_RE  = %r{;\s*filename=(.*;|.*)}
       URL_RE                  = %r{://}
@@ -95,6 +87,18 @@ module CartoDB
           extensions: ['json']
         }
       ]
+
+      def self.supported_extensions
+        @supported_extensions ||= CartoDB::Importer2::Unp::SUPPORTED_FORMATS
+                                  .concat(CartoDB::Importer2::Unp::COMPRESSED_EXTENSIONS)
+                                  .sort_by { |s| s.length }.reverse
+      end
+
+      def self.url_filename_regex
+        @url_filename_regex ||= Regexp.new(
+                                "[[:word:]]+" + Regexp.union(supported_extensions).to_s,
+                                true)
+      end
 
       def initialize(url, http_options = {}, options = {}, seed = nil, repository = nil)
         @url = url
@@ -394,7 +398,7 @@ module CartoDB
       end
 
       def name_in(url)
-        url_name = URL_FILENAME_REGEX.match(url).to_s
+        url_name = Downloader.url_filename_regex.match(url).to_s
 
         url_name if !url_name.empty?
       end

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -91,13 +91,13 @@ module CartoDB
       def self.supported_extensions
         @supported_extensions ||= CartoDB::Importer2::Unp::SUPPORTED_FORMATS
                                   .concat(CartoDB::Importer2::Unp::COMPRESSED_EXTENSIONS)
-                                  .sort_by { |s| s.length }.reverse
+                                  .sort_by(&:length).reverse
       end
 
       def self.url_filename_regex
         @url_filename_regex ||= Regexp.new(
-                                "[[:word:]]+#{Regexp.union(supported_extensions)}+",
-                                true)
+                                 "[[:word:]]+#{Regexp.union(supported_extensions)}+",
+                                 true)
       end
 
       def initialize(url, http_options = {}, options = {}, seed = nil, repository = nil)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -398,7 +398,7 @@ module CartoDB
       end
 
       def name_in(url)
-        url_name = Downloader.url_filename_regex.match(url).to_s
+        url_name = self.class.url_filename_regex.match(url).to_s
 
         url_name if !url_name.empty?
       end

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -250,6 +250,14 @@ describe Downloader do
       downloader.send(:name_from, headers, "#{@file_url}?foo=bar&woo=wee")
         .should eq 'ne_110m_lakes.zip'
     end
+
+    it 'matches longer extension available from filename' do
+      headers = {}
+      hard_url = "https://cartofante.net/my_file.xlsx"
+
+      downloader = Downloader.new(hard_url)
+      downloader.send(:name_from, headers, hard_url).should eq 'my_file.xlsx'
+    end
   end #name_from
 
   def stub_download(options)


### PR DESCRIPTION
Fixes #6361 

In previous versions of the code, the order of the arrays in which we were storing the supported extensions was not taken into account.

This was causing that the format XLS was being considered for some XLSX files, as it was the first match of the `URL_FILENAME_REGEX`. This happened in a specific scenario in which the Content-Type for the file was empty.

Now the supported extensions array gets ordered by length of the extensions name so that the regex is greedy:

```ruby
CartoDB::Importer2::Unp::SUPPORTED_FORMATS
                                  .concat(CartoDB::Importer2::Unp::COMPRESSED_EXTENSIONS)
                                  .sort_by { |s| s.length }.reverse
````

This PR also contains code changes to move the regex related constants to class methods.

Finally, a new test has been added to ensure that the XSLX extension is being detected correctly in the scenario where it wasn't previously. The old version of the code makes this test to fail.