### PR TITLE
Support proxy for S3 uploads

### DIFF
--- a/app/helpers/file_upload.rb
+++ b/app/helpers/file_upload.rb
@@ -85,7 +85,9 @@ module CartoDB
     def upload_file_to_s3(filepath, filename, token, s3_config)
       AWS.config(
         access_key_id: s3_config['access_key_id'],
-        secret_access_key: s3_config['secret_access_key']
+        secret_access_key: s3_config['secret_access_key'],
+        proxy_uri: (s3_config['proxy_uri'].present? ?  s3_config['proxy_uri'] : nil),
+        use_ssl: s3_config['use_ssl']
       )
       s3_bucket = AWS::S3.new.buckets[s3_config['bucket_name']]
 

--- a/app/helpers/file_upload.rb
+++ b/app/helpers/file_upload.rb
@@ -86,7 +86,7 @@ module CartoDB
       AWS.config(
         access_key_id: s3_config['access_key_id'],
         secret_access_key: s3_config['secret_access_key'],
-        proxy_uri: (s3_config['proxy_uri'].present? ?  s3_config['proxy_uri'] : nil),
+        proxy_uri: (s3_config['proxy_uri'].present? ? s3_config['proxy_uri'] : nil),
         use_ssl: s3_config['use_ssl']
       )
       s3_bucket = AWS::S3.new.buckets[s3_config['bucket_name']]

--- a/app/helpers/file_upload.rb
+++ b/app/helpers/file_upload.rb
@@ -86,7 +86,7 @@ module CartoDB
       AWS.config(
         access_key_id: s3_config['access_key_id'],
         secret_access_key: s3_config['secret_access_key'],
-        proxy_uri: s3_config['proxy_uri'],
+        proxy_uri: (s3_config['proxy_uri'].present? ?  s3_config['proxy_uri'] : nil),
         use_ssl: s3_config['use_ssl']
       )
       s3_bucket = AWS::S3.new.buckets[s3_config['bucket_name']]

--- a/app/helpers/file_upload.rb
+++ b/app/helpers/file_upload.rb
@@ -86,7 +86,7 @@ module CartoDB
       AWS.config(
         access_key_id: s3_config['access_key_id'],
         secret_access_key: s3_config['secret_access_key'],
-        proxy_uri: (s3_config['proxy_uri'].present? ? s3_config['proxy_uri'] : nil),
+        proxy_uri: s3_config['proxy_uri'],
         use_ssl: s3_config['use_ssl']
       )
       s3_bucket = AWS::S3.new.buckets[s3_config['bucket_name']]

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -177,6 +177,9 @@ defaults: &defaults
       bucket_name:
       url_ttl:
       async_long_uploads: false
+      proxy_uri:
+      use_ssl: False
+
     unp_temporal_folder: '/tmp/imports/'
     # It must end in `/uploads` and be accessible via HTTP, if relative will default to Rails.Root/#{uploads_path}
     uploads_path: 'public/uploads'

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -178,7 +178,7 @@ defaults: &defaults
       url_ttl:
       async_long_uploads: false
       proxy_uri:
-      use_ssl: False
+      use_ssl: True
 
     unp_temporal_folder: '/tmp/imports/'
     # It must end in `/uploads` and be accessible via HTTP, if relative will default to Rails.Root/#{uploads_path}


### PR DESCRIPTION
I have made code changes to support proxy servers while uploading to s3 so that you can use s3 like systems with s3 compatible api. the code just adds two configuration prams to AWS.config
proxy_uri: nil(default)/any proxy server
use_ssl: to enable or disable ssl