### PR TITLE
Several raster enhancementes

### DIFF
--- a/app/assets/stylesheets/common/datasets-list.css.scss
+++ b/app/assets/stylesheets/common/datasets-list.css.scss
@@ -152,7 +152,10 @@ $bannedColor: #E1A7A5;
   @include display-flex();
   @include align-items(center);
 }
-.DatasetsList-itemTitle.is--disabled { color: $cTypography-help }
+.DatasetsList-itemTitle.is-disabled {
+  color: $cTypography-help;
+  font-weight: normal;
+}
 .DatasetsList-itemTitlePermission {
   margin-left: $sMargin-elementInline;
   background: white;

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/create_dataset_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/create_dataset_model.js
@@ -169,16 +169,17 @@ module.exports = cdb.core.Model.extend({
     var params = this.visFetchModel.attributes;
 
     this.collection.options.set({
-      locked:         '',
-      q:              params.q,
-      page:           params.page || 1,
-      tags:           params.tag,
-      per_page:       this.collection['_TABLES_PER_PAGE'],
-      shared:         params.shared,
-      only_liked:     params.liked,
-      order:          'updated_at',
-      type:           '',
-      types:          params.library ? 'remote' : 'table'
+      locked: '',
+      q: params.q,
+      page: params.page || 1,
+      tags: params.tag,
+      per_page: this.collection['_TABLES_PER_PAGE'],
+      shared: params.shared,
+      only_liked: params.liked,
+      order: 'updated_at',
+      type: '',
+      types: params.library ? 'remote' : 'table',
+      exclude_raster: true
     });
 
     this.collection.fetch();

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
@@ -216,16 +216,17 @@ module.exports = cdb.core.Model.extend({
     }
 
     this.collection.options.set({
-      locked:         '',
-      q:              params.q,
-      page:           params.page || 1,
-      tags:           params.tag,
-      per_page:       this.collection['_TABLES_PER_PAGE'],
-      shared:         params.shared,
-      only_liked:     params.liked,
-      order:          'updated_at',
-      type:           '',
-      types:          types
+      locked: '',
+      q: params.q,
+      page: params.page || 1,
+      tags: params.tag,
+      per_page: this.collection['_TABLES_PER_PAGE'],
+      shared: params.shared,
+      only_liked: params.liked,
+      order: 'updated_at',
+      type: '',
+      types: types,
+      exclude_raster: true
     });
 
     this.collection.fetch();

--- a/lib/assets/javascripts/cartodb/common/dialogs/map/add_layer_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/add_layer_model.js
@@ -158,16 +158,17 @@ module.exports = cdb.core.Model.extend({
     }
 
     this.collection.options.set({
-      locked:     '',
-      q:          params.q,
-      page:       params.page || 1,
-      tags:       params.tag,
-      per_page:   this.collection['_TABLES_PER_PAGE'],
-      shared:     params.shared,
+      locked: '',
+      q: params.q,
+      page: params.page || 1,
+      tags: params.tag,
+      per_page: this.collection['_TABLES_PER_PAGE'],
+      shared: params.shared,
       only_liked: params.liked,
-      order:      'updated_at',
-      type:       '',
-      types:      types
+      order: 'updated_at',
+      type: '',
+      types: types,
+      exclude_raster: true
     });
 
     this.collection.fetch();

--- a/lib/assets/javascripts/cartodb/dashboard/views/datasets_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/datasets_item.jst.ejs
@@ -19,7 +19,7 @@
   <div class="DatasetsList-itemPrimaryInfo">
     <h3 class="DatasetsList-itemTitle">
       <% if (isRaster) { %>
-        <p title="<%- title %>" class="DatasetsList-itemTitle is--disabled u-ellipsLongText"><%- title %></p>
+        <p title="<%- title %>" class="DatasetsList-itemTitle is-disabled u-ellipsLongText"><%- title %></p>
       <% } else { %>
         <a href="<%- datasetUrl %>" title="<%- title %>" class="DefaultTitle-link u-ellipsLongText"><%- title %></a>
       <% } %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.22",
+  "version": "3.23.23",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fix style problem over raster datasets.

Before:

<img width="1055" alt="screen shot 2016-01-12 at 17 09 18" src="https://cloud.githubusercontent.com/assets/132146/12268936/456dc808-b94f-11e5-8d29-17f86d9c45e0.png">

After:

<img width="1042" alt="screen shot 2016-01-12 at 17 06 44" src="https://cloud.githubusercontent.com/assets/132146/12268942/4999a24e-b94f-11e5-883b-6343cdda1805.png">

---

- Exclude raster datasets from import datasets list.


Fixes part of #6377 bug.

cc @gfiorav 