### PR TITLE
Rake task to migrate the current cycle geocoding metrics from DB to Redis

### DIFF
--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -38,6 +38,14 @@ class Geocoding < Sequel::Model
     dataset.where(kind: 'high-resolution').where('geocodings.created_at >= ? and geocodings.created_at <= ?', date_from, date_to + 1.days).sum("processed_rows + cache_hits".lit).to_i
   end
 
+  def self.get_not_aggregated_geocoding_calls(dataset, date_from, date_to)
+    geocoding_calls_sql = "SELECT date(created_at), sum(processed_rows) as processed_rows, " \
+                          "sum(cache_hits) as cache_hits FROM geocodings WHERE kind = 'high-resolution' " \
+                          "AND geocodings.created_at >= ? and geocodings.created_at <= ?" \
+                          "GROUP BY date(created_at) ORDER BY date(created_at) DESC"
+    dataset.db.fetch(geocoding_calls_sql, date_from, date_to + 1.days).all
+  end
+
   def public_values
     Hash[PUBLIC_ATTRIBUTES.map{ |k| [k, (self.send(k) rescue self[k].to_s)] }]
   end

--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -38,12 +38,12 @@ class Geocoding < Sequel::Model
     dataset.where(kind: 'high-resolution').where('geocodings.created_at >= ? and geocodings.created_at <= ?', date_from, date_to + 1.days).sum("processed_rows + cache_hits".lit).to_i
   end
 
-  def self.get_not_aggregated_geocoding_calls(dataset, date_from, date_to)
+  def self.get_not_aggregated_user_geocoding_calls(db, user_id, date_from, date_to)
     geocoding_calls_sql = "SELECT date(created_at), sum(processed_rows) as processed_rows, " \
                           "sum(cache_hits) as cache_hits FROM geocodings WHERE kind = 'high-resolution' " \
-                          "AND geocodings.created_at >= ? and geocodings.created_at <= ?" \
+                          "AND user_id = ? AND geocodings.created_at >= ? and geocodings.created_at <= ?" \
                           "GROUP BY date(created_at) ORDER BY date(created_at) DESC"
-    dataset.db.fetch(geocoding_calls_sql, date_from, date_to + 1.days).all
+    db.fetch(geocoding_calls_sql, user_id, date_from, date_to + 1.days).all
   end
 
   def public_values

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -789,7 +789,7 @@ class User < Sequel::Model
 
   def get_not_aggregated_geocoding_calls(options = {})
     date_from, date_to = quota_dates(options)
-    Geocoding.get_not_aggregated_geocoding_calls(geocodings_dataset, date_from, date_to)
+    Geocoding.get_not_aggregated_user_geocoding_calls(geocodings_dataset.db, self.id, date_from, date_to)
   end
 
   def effective_twitter_block_price

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -784,8 +784,13 @@ class User < Sequel::Model
 
   def get_geocoding_calls(options = {})
     date_from, date_to = quota_dates(options)
-    Geocoding.get_geocoding_calls(self.geocodings_dataset, date_from, date_to)
-  end # get_geocoding_calls
+    Geocoding.get_geocoding_calls(geocodings_dataset, date_from, date_to)
+  end
+
+  def get_not_aggregated_geocoding_calls(options = {})
+    date_from, date_to = quota_dates(options)
+    Geocoding.get_not_aggregated_geocoding_calls(geocodings_dataset, date_from, date_to)
+  end
 
   def effective_twitter_block_price
     organization.present? ? organization.twitter_datasource_block_price : self.twitter_datasource_block_price

--- a/services/table-geocoder/lib/geocoder_usage_metrics.rb
+++ b/services/table-geocoder/lib/geocoder_usage_metrics.rb
@@ -27,16 +27,16 @@ module CartoDB
       @redis = redis
     end
 
-    def incr(service, metric, amount = 1)
+    def incr(service, metric, amount = 1, date = DateTime.current)
       check_valid_data(service, metric, amount)
       return if amount == 0
 
       # TODO We could add EXPIRE command to add TTL to the keys
       if !@orgname.nil?
-        @redis.zincrby("#{org_key_prefix(service, metric)}", amount, "#{current_day}")
+        @redis.zincrby("#{org_key_prefix(service, metric, date)}", amount, "#{date_day(date)}")
       end
 
-      @redis.zincrby("#{user_key_prefix(service, metric)}", amount, "#{current_day}")
+      @redis.zincrby("#{user_key_prefix(service, metric, date)}", amount, "#{date_day(date)}")
     end
 
     private
@@ -47,20 +47,20 @@ module CartoDB
       raise 'invalid amount' if amount < 0
     end
 
-    def user_key_prefix(service, metric)
-      "user:#{@username}:#{service}:#{metric}:#{current_year_month}"
+    def user_key_prefix(service, metric, date)
+      "user:#{@username}:#{service}:#{metric}:#{date_year_month(date)}"
     end
 
-    def org_key_prefix(service, metric)
-      "org:#{@orgname}:#{service}:#{metric}:#{current_year_month}"
+    def org_key_prefix(service, metric, date)
+      "org:#{@orgname}:#{service}:#{metric}:#{date_year_month(date)}"
     end
 
-    def current_day
-      DateTime.current.strftime('%d')
+    def date_day(date)
+      date.strftime('%d')
     end
 
-    def current_year_month
-      DateTime.current.strftime('%Y%m')
+    def date_year_month(date)
+      date.strftime('%Y%m')
     end
 
   end


### PR DESCRIPTION
Rake task to migrate the current cycle geocoding data from the metadata DB to the Redis database as part of the new geocoder metrics system.

This task goes through all the cloud metadata users and replicate the last geocoding uses in the new metrics system in Redis

// @rafatower take a look