### PR TITLE
Delete cdb_importer stale tables after import error

### DIFF
--- a/services/importer/lib/importer/job.rb
+++ b/services/importer/lib/importer/job.rb
@@ -64,12 +64,12 @@ module CartoDB
       end
 
       def delete_job_table
-        CartoDB.notify_debug('Dropping temp table', { schema: @schema, table: table_name, database: @db })
+        CartoDB.notify_debug('Dropping temp table', schema: @schema, table: table_name, database: @db)
         delete_temp_table(table_name)
       end
 
       def delete_temp_table(table_name)
-        db.run(%Q{DROP TABLE IF EXISTS #{@schema}.#{table_name}})
+        db.run(%{DROP TABLE IF EXISTS #{@schema}.#{table_name}})
       end
 
       attr_reader :id, :logger, :pg_options, :schema

--- a/services/importer/lib/importer/job.rb
+++ b/services/importer/lib/importer/job.rb
@@ -64,11 +64,12 @@ module CartoDB
       end
 
       def delete_job_table
+        CartoDB.notify_debug('Dropping temp table', { schema: @schema, table: table_name, database: @db })
         delete_temp_table(table_name)
       end
 
       def delete_temp_table(table_name)
-        db.run(%Q{DROP TABLE #{@schema}.#{table_name}})
+        db.run(%Q{DROP TABLE IF EXISTS #{@schema}.#{table_name}})
       end
 
       attr_reader :id, :logger, :pg_options, :schema

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -196,8 +196,10 @@ module CartoDB
         else
           valid_table_names = loader.valid_table_names
           additional_support_tables = loader.additional_support_tables
-          clean_importer_tables(@job.db, @job.schema, valid_table_names)
         end
+
+        # Delete job temporary table from cdb_importer schema
+        @job.delete_job_table
 
         @job.log "Errored importing data from #{source_file.fullpath}:"
         @job.log "#{exception.class.to_s}: #{exception.to_s}", truncate=false
@@ -389,17 +391,6 @@ module CartoDB
                                                                user: user,
                                                                db: db
                                                              })
-      end
-
-      # This function cleans any stale cdb_importer.importer_* table
-      # related with the running process which should be discarded
-      def clean_importer_tables(database, schema, table_names)
-        table_names.each do |table|
-          CartoDB.notify_debug('Dropping cdb_importer table', { schema: schema, table: table, database: database })
-          database.execute(%Q{
-            DROP TABLE IF EXISTS "#{schema}"."#{table}"
-         })
-        end
       end
 
       def add_warning(warning)

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -395,6 +395,7 @@ module CartoDB
       # related with the running process which should be discarded
       def clean_importer_tables(database, schema, table_names)
         table_names.each do |table|
+          CartoDB.notify_debug('Dropping cdb_importer table', { schema: schema, table: table, database: database })
           database.execute(%Q{
             DROP TABLE IF EXISTS "#{schema}"."#{table}"
          })

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -196,6 +196,7 @@ module CartoDB
         else
           valid_table_names = loader.valid_table_names
           additional_support_tables = loader.additional_support_tables
+          clean_stale_importer_tables(@job.db, @job.schema, valid_table_names)
         end
 
         @job.log "Errored importing data from #{source_file.fullpath}:"
@@ -388,6 +389,16 @@ module CartoDB
                                                                user: user,
                                                                db: db
                                                              })
+      end
+
+      # This function cleans any stale cdb_importer.importer_* table
+      # related with the running process which should be discarded
+      def clean_stale_importer_tables(database, schema, table_names)
+        table_names.each do |table|
+          database.execute(%Q{
+            DROP TABLE IF EXISTS "#{schema}"."#{table}"
+         })
+        end
       end
 
       def add_warning(warning)

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -196,7 +196,7 @@ module CartoDB
         else
           valid_table_names = loader.valid_table_names
           additional_support_tables = loader.additional_support_tables
-          clean_stale_importer_tables(@job.db, @job.schema, valid_table_names)
+          clean_importer_tables(@job.db, @job.schema, valid_table_names)
         end
 
         @job.log "Errored importing data from #{source_file.fullpath}:"

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -393,7 +393,7 @@ module CartoDB
 
       # This function cleans any stale cdb_importer.importer_* table
       # related with the running process which should be discarded
-      def clean_stale_importer_tables(database, schema, table_names)
+      def clean_importer_tables(database, schema, table_names)
         table_names.each do |table|
           database.execute(%Q{
             DROP TABLE IF EXISTS "#{schema}"."#{table}"

--- a/services/importer/spec/acceptance/geojson_spec.rb
+++ b/services/importer/spec/acceptance/geojson_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require_relative '../../../../spec/rspec_configuration'
+require_relative '../../../../spec/spec_helper'
 require 'rspec/core'
 require 'rspec/expectations'
 require 'rspec/mocks'
@@ -15,20 +16,19 @@ require_relative 'acceptance_helpers'
 require_relative 'no_stats_context'
 
 
-include CartoDB::Importer2
 
 describe 'geojson regression tests' do
   include AcceptanceHelpers
   include_context "no stats"
 
   before do
-    @pg_options  = Factories::PGConnection.new.pg_options
+    @pg_options  = ::CartoDB::Importer2::Factories::PGConnection.new.pg_options
   end
 
   it 'imports a file exported from CartoDB' do
     filepath    = path_to('tm_world_borders_simpl_0_8.geojson')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -40,8 +40,8 @@ describe 'geojson regression tests' do
   it 'imports a file from a url with params' do
     filepath    = 'https://raw.github.com/benbalter/dc-wifi-social/master' +
                   '/bars.geojson?foo=bar'
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -52,8 +52,8 @@ describe 'geojson regression tests' do
 
   it "raises if GeoJSON isn't valid" do
     filepath    = path_to('invalid.geojson')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,

--- a/services/importer/spec/acceptance/gz_tgz_spec.rb
+++ b/services/importer/spec/acceptance/gz_tgz_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require_relative '../../../../spec/rspec_configuration'
+require_relative '../../../../spec/spec_helper'
 require_relative '../../lib/importer/runner'
 require_relative '../../lib/importer/job'
 require_relative '../../lib/importer/downloader'
@@ -11,21 +12,19 @@ require_relative 'cdb_importer_context'
 require_relative '../../../../spec/rspec_configuration'
 require_relative 'no_stats_context'
 
-include CartoDB::Importer2
-
 describe 'gz and tgz regression tests' do
   include AcceptanceHelpers
   include_context "cdb_importer schema"
   include_context "no stats"
 
   before do
-    @pg_options  = Factories::PGConnection.new.pg_options
+    @pg_options  = ::CartoDB::Importer2::Factories::PGConnection.new.pg_options
   end
 
   it 'returns ok with supported gzip file' do
     filepath    = path_to('ok_data.csv.gz')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -37,8 +36,8 @@ describe 'gz and tgz regression tests' do
 
   it 'returns ok with supported tgz file' do
     filepath    = path_to('ok_data.tgz')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -50,8 +49,8 @@ describe 'gz and tgz regression tests' do
 
   it 'process one of the two files inside TGZ' do
     filepath    = path_to('ok_and_wrong_data.tgz')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -65,8 +64,8 @@ describe 'gz and tgz regression tests' do
 
   it 'returns error if csv is invalid with supported gzip file' do
     filepath    = path_to('wrong_data.csv.gz')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,

--- a/services/importer/spec/acceptance/zip_spec.rb
+++ b/services/importer/spec/acceptance/zip_spec.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 require_relative '../../../../spec/rspec_configuration'
+require_relative '../../../../spec/spec_helper'
+require_relative '../../../../spec/spec_helper'
 require_relative '../../lib/importer/runner'
 require_relative '../../lib/importer/job'
 require_relative '../../lib/importer/downloader'
@@ -10,21 +12,19 @@ require_relative 'acceptance_helpers'
 require_relative 'cdb_importer_context'
 require_relative 'no_stats_context'
 
-include CartoDB::Importer2
-
 describe 'zip regression tests' do
   include AcceptanceHelpers
   include_context "cdb_importer schema"
   include_context "no stats"
 
   before do
-    @pg_options  = Factories::PGConnection.new.pg_options
+    @pg_options  = ::CartoDB::Importer2::Factories::PGConnection.new.pg_options
   end
 
   it 'returns empty results if no supported files in the bundle' do
     filepath    = path_to('one_unsupported.zip')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -37,8 +37,8 @@ describe 'zip regression tests' do
 
   it 'ignores unsupported files in the bundle' do
     filepath    = path_to('one_unsupported_one_valid.zip')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -51,8 +51,8 @@ describe 'zip regression tests' do
 
   it 'imports a zip with >1 file successfully' do
     filepath    = path_to('multiple_csvs.zip')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -70,8 +70,8 @@ describe 'zip regression tests' do
 
   it 'imports a maximum of Runner::MAX_TABLES_PER_IMPORT files from a zip, but doesnt errors' do
     filepath    = path_to('more_than_10_files.zip')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -90,8 +90,8 @@ describe 'zip regression tests' do
   it 'imports a shapefile that includes a xxx.VERSION.txt file skipping it' do
     # http://www.naturalearthdata.com/downloads/
     filepath    = path_to('shapefile_with_version_txt.zip')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,
@@ -109,8 +109,8 @@ describe 'zip regression tests' do
 
     it 'imports all non-failing items from a zip without failing the whole import' do
     filepath    = path_to('file_ok_and_file_ko.zip')
-    downloader  = Downloader.new(filepath)
-    runner      = Runner.new({
+    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @pg_options,
                                downloader: downloader,
                                log: CartoDB::Importer2::Doubles::Log.new,


### PR DESCRIPTION
Whenever there's an exception in an import, `cdb_importer.importer_*` tables do never get moved to the user schema, so they remain at `cdb_importer`.

This code is aimed to find those and delete them if they exist, so that the databases don't keep storing useless data.