### PR TITLE
Adds exclude raster to VQB

### DIFF
--- a/app/controllers/carto/api/visualization_searcher.rb
+++ b/app/controllers/carto/api/visualization_searcher.rb
@@ -21,6 +21,7 @@ module Carto
         only_liked = params[:only_liked] == 'true'
         only_shared = params[:only_shared] == 'true'
         exclude_shared = params[:exclude_shared] == 'true'
+        exclude_raster = params[:exclude_raster] == 'true'
         locked = params[:locked]
         shared = compose_shared(params[:shared], only_shared, exclude_shared)
         tags = params.fetch(:tags, '').split(',')
@@ -59,6 +60,10 @@ module Carto
           when FILTER_SHARED_ONLY
             vqb.with_shared_with_user_id(current_user.id)
                 .with_user_id_not(current_user.id)
+          end
+
+          if exclude_raster
+            vqb.without_raster
           end
 
           if locked == 'true'

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -44,7 +44,7 @@ class Carto::VisualizationQueryBuilder
     @off_database_order = {}
     @exclude_synced_external_sources = false
     @exclude_imported_remote_visualizations = false
-    @exclude_raster = false
+    @excluded_kinds = []
   end
 
   def with_id_or_name(id_or_name)
@@ -76,7 +76,7 @@ class Carto::VisualizationQueryBuilder
   end
 
   def without_raster
-    @exclude_raster = true
+    @excluded_kinds << CartoDB::Visualization::Member::KIND_RASTER
     self
   end
 
@@ -258,8 +258,8 @@ class Carto::VisualizationQueryBuilder
       query = query.where('("visualizations"."type" <> \'remote\' OR "visualizations"."type" = \'remote\' AND "visualizations"."display_name" IS NOT NULL)')
     end
 
-    if @exclude_raster
-      query = query.where("\"visualizations\".\"kind\" != '#{CartoDB::Visualization::Member::KIND_RASTER}'")
+    @excluded_kinds.each do |kind|
+      query = query.where("\"visualizations\".\"kind\" != '#{kind}'")
     end
 
     if @type

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -44,6 +44,7 @@ class Carto::VisualizationQueryBuilder
     @off_database_order = {}
     @exclude_synced_external_sources = false
     @exclude_imported_remote_visualizations = false
+    @exclude_raster = false
   end
 
   def with_id_or_name(id_or_name)
@@ -71,6 +72,11 @@ class Carto::VisualizationQueryBuilder
 
   def without_imported_remote_visualizations
     @exclude_imported_remote_visualizations = true
+    self
+  end
+
+  def without_raster
+    @exclude_raster = true
     self
   end
 
@@ -250,6 +256,10 @@ class Carto::VisualizationQueryBuilder
       # of datasets, for example, make a query with multiples types (table, remote) and we don't
       # want to filter the table ones
       query = query.where('("visualizations"."type" <> \'remote\' OR "visualizations"."type" = \'remote\' AND "visualizations"."display_name" IS NOT NULL)')
+    end
+
+    if @exclude_raster
+      query = query.where("\"visualizations\".\"kind\" != '#{CartoDB::Visualization::Member::KIND_RASTER}'")
     end
 
     if @type

--- a/spec/queries/carto/visualization_query_builder_spec.rb
+++ b/spec/queries/carto/visualization_query_builder_spec.rb
@@ -303,7 +303,7 @@ describe Carto::VisualizationQueryBuilder do
         .all.map(&:id)
     ids.should == [ remote_vis_2.id, remote_vis_1.id, table.table_visualization.id]
 
-    ExternalDataImport.all { |edi| edi.destroy } # Clean up to avoid forgein key not null violation
+    ExternalDataImport.all { |edi| edi.destroy } # Clean up to avoid foreign key not null violation
   end
 
   it 'filters raster tables' do

--- a/spec/queries/carto/visualization_query_builder_spec.rb
+++ b/spec/queries/carto/visualization_query_builder_spec.rb
@@ -303,7 +303,7 @@ describe Carto::VisualizationQueryBuilder do
         .all.map(&:id)
     ids.should == [ remote_vis_2.id, remote_vis_1.id, table.table_visualization.id]
 
-
+    ExternalDataImport.all do |edi| edi.destroy end # Clean up to avoid forgein key not null violation
   end
 
   it 'filters raster tables' do

--- a/spec/queries/carto/visualization_query_builder_spec.rb
+++ b/spec/queries/carto/visualization_query_builder_spec.rb
@@ -306,4 +306,21 @@ describe Carto::VisualizationQueryBuilder do
 
   end
 
+  it 'filters raster tables' do
+    stub_named_maps_calls
+
+    table = create_random_table(@user1)
+    table_visualization = table.table_visualization
+    table_visualization.store
+
+    raster_table = create_random_table(@user1)
+    raster_table_visualization = raster_table.table_visualization
+    raster_table_visualization.kind = CartoDB::Visualization::Member::KIND_RASTER
+    raster_table_visualization.store
+
+    visualizations = @vqb.without_raster.build
+
+    visualizations.map(&:id).should include table_visualization.id
+    visualizations.map(&:id).should_not include raster_table_visualization.id
+  end
 end

--- a/spec/queries/carto/visualization_query_builder_spec.rb
+++ b/spec/queries/carto/visualization_query_builder_spec.rb
@@ -303,7 +303,7 @@ describe Carto::VisualizationQueryBuilder do
         .all.map(&:id)
     ids.should == [ remote_vis_2.id, remote_vis_1.id, table.table_visualization.id]
 
-    ExternalDataImport.all do |edi| edi.destroy end # Clean up to avoid forgein key not null violation
+    ExternalDataImport.all { |edi| edi.destroy } # Clean up to avoid forgein key not null violation
   end
 
   it 'filters raster tables' do


### PR DESCRIPTION
Pipes `exclude_raster` param to the `VisualizationQueryBuilder` to get the raster exclusion feature back into the `api/v1/viz` endpoint.

Part of #6377 

cc/ @xavijam 