### PR TITLE
Take care of possible incorrect values returned by the batch geocoder

### DIFF
--- a/lib/tasks/geocoder_metrics.rake
+++ b/lib/tasks/geocoder_metrics.rake
@@ -17,10 +17,11 @@ namespace :geocoder do
         legacy_quota_value = user.get_geocoding_calls
         new_system_quota_value = user.get_new_system_geocoding_calls
         if legacy_quota_value != new_system_quota_value
-          puts "User #{user.username} has differente value between LEGACY (#{legacy_quota_value}) " \
+          puts "User #{user.username} has different values between LEGACY (#{legacy_quota_value}) " \
                "and NEW (#{new_system_quota_value}) metrics systems"
         else
-          puts "User #{user.username} OK"
+          puts "User #{user.username} OK => LEGACY (#{legacy_quota_value}) " \
+               "and NEW (#{new_system_quota_value})"
         end
       end
     end

--- a/services/geocoder/lib/hires_batch_geocoder.rb
+++ b/services/geocoder/lib/hires_batch_geocoder.rb
@@ -185,6 +185,15 @@ module CartoDB
       nil
     end
 
+    def extract_numeric_response_field(response, query)
+      value = extract_response_field(response, query)
+      return nil if value.blank?
+      Integer(value)
+    rescue ArgumentError => e
+      CartoDB.notify_error("Batch geocoder value error", error: e.message, value: value)
+      nil
+    end
+
     def handle_api_error(response)
       if response.success? == false
         @failed_processed_rows = number_of_input_file_rows
@@ -206,13 +215,13 @@ module CartoDB
 
     def update_stats(response)
       @status = extract_response_field(response.body, '//Response/Status')
-      @processed_rows = extract_response_field(response.body, '//Response/ProcessedCount')
-      @successful_processed_rows = extract_response_field(response.body, '//Response/SuccessCount')
+      @processed_rows = extract_numeric_response_field(response.body, '//Response/ProcessedCount')
+      @successful_processed_rows = extract_numeric_response_field(response.body, '//Response/SuccessCount')
       # addresses that could not be matched
-      @empty_processed_rows = extract_response_field(response.body, '//Response/ErrorCount')
+      @empty_processed_rows = extract_numeric_response_field(response.body, '//Response/ErrorCount')
       # invalid input that could not be processed
-      @failed_processed_rows = extract_response_field(response.body, '//Response/InvalidCount')
-      @total_rows = extract_response_field(response.body, '//Response/TotalCount')
+      @failed_processed_rows = extract_numeric_response_field(response.body, '//Response/InvalidCount')
+      @total_rows = extract_numeric_response_field(response.body, '//Response/TotalCount')
     end
   end
 end

--- a/services/geocoder/spec/geocoder_spec.rb
+++ b/services/geocoder/spec/geocoder_spec.rb
@@ -49,10 +49,10 @@ describe CartoDB::HiresBatchGeocoder do
       expect { geocoder.update_status }.to change(geocoder, :status).from(nil).to('completed')
     end
     it "updates processed rows" do
-      expect { geocoder.update_status }.to change(geocoder, :processed_rows).from(nil).to("2")
+      expect { geocoder.update_status }.to change(geocoder, :processed_rows).from(nil).to(2)
     end
     it "updates total rows" do
-      expect { geocoder.update_status }.to change(geocoder, :total_rows).from(nil).to("3")
+      expect { geocoder.update_status }.to change(geocoder, :total_rows).from(nil).to(3)
     end
   end
 

--- a/services/geocoder/spec/hires_batch_geocoder_spec.rb
+++ b/services/geocoder/spec/hires_batch_geocoder_spec.rb
@@ -2,6 +2,7 @@
 require 'tmpdir'
 require 'fileutils'
 require_relative '../../../spec/rspec_configuration.rb'
+require_relative '../../../spec/spec_helper.rb'
 require_relative '../lib/hires_batch_geocoder'
 
 
@@ -94,8 +95,8 @@ describe CartoDB::HiresBatchGeocoder do
       url.should match(%r'action=cancel')
 
       expected_status = 'cancelled'
-      expected_processed_rows = '20'
-      expected_total_rows = '30'
+      expected_processed_rows = 20
+      expected_total_rows = 30
 
       response_body = <<END_XML
 <Response>
@@ -123,8 +124,8 @@ END_XML
       url.should match(%r'action=status')
 
       expected_status = 'running'
-      expected_processed_rows = '20'
-      expected_total_rows = '30'
+      expected_processed_rows = 20
+      expected_total_rows = 30
 
       response_body = <<END_XML
 <Response>

--- a/services/table-geocoder/lib/geocoder_usage_metrics.rb
+++ b/services/table-geocoder/lib/geocoder_usage_metrics.rb
@@ -52,9 +52,9 @@ module CartoDB
     private
 
     def check_valid_data(service, metric, amount = 0)
-      raise 'Invalid service' unless VALID_SERVICES.include?(service)
-      raise 'invalid metric' unless VALID_METRICS.include?(metric)
-      raise 'invalid amount' if amount < 0
+      raise ArgumentError.new('Invalid service') unless VALID_SERVICES.include?(service)
+      raise ArgumentError.new('Invalid metric') unless VALID_METRICS.include?(metric)
+      raise ArgumentError.new('Invalid geocoder metric amount') if !amount.nil? and amount < 0
     end
 
     def user_key_prefix(service, metric, date)


### PR DESCRIPTION
Closes #6406

In some unknown cases the number of rows returned by the batch geocoder is a string instead of a number and the geocoder metrics usage is failing so we need to:

- Avoid to return exceptions, until we have more info
- Register this exceptions in order to take measures against this kind of problems

// please @rafatower check this out when the tests pass