### PR TITLE
Remove DB object from notify_debug

### DIFF
--- a/services/importer/lib/importer/job.rb
+++ b/services/importer/lib/importer/job.rb
@@ -64,7 +64,7 @@ module CartoDB
       end
 
       def delete_job_table
-        CartoDB.notify_debug('Dropping temp table', schema: @schema, table: table_name, database: @db)
+        CartoDB.notify_debug('Dropping temp table', schema: @schema, table: table_name)
         delete_temp_table(table_name)
       end
 


### PR DESCRIPTION
It seems to be provoking a "PG::Error: ERROR: SELECT * with no tables specified is not valid" error on some notify processes.

[Sequel::DatabaseError: PG::Error: ERROR: SELECT * with no tables specified is not valid](https://rollbar.com/vizzuality/CartoDB/items/13470/?item_page=0&#traceback)


```
... 66 non-project frames 
67
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/config/initializers/error_notifier.rb", line 40 in notify_debug
68
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/job.rb", line 67 in delete_job_table
69
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 202 in rescue in import
70
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 154 in import
71
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 335 in execute_import
72
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 264 in block (3 levels) in single_resource_import
73
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 258 in each
74
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 258 in each_with_index
75
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 258 in block (2 levels) in single_resource_import
76
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/cartodb/stats/aggregator.rb", line 45 in block in timing
... 1 non-project frame 
78
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/cartodb/stats/aggregator.rb", line 43 in timing
79
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 253 in block in single_resource_import
80
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/cartodb/stats/aggregator.rb", line 45 in block in timing
... 1 non-project frame 
82
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/cartodb/stats/aggregator.rb", line 43 in timing
83
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 231 in single_resource_import
84
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 97 in run_import
85
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 90 in block in run
86
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/cartodb/stats/aggregator.rb", line 45 in block in timing
... 1 non-project frame 
88
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/cartodb/stats/aggregator.rb", line 43 in timing
89
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/services/importer/lib/importer/runner.rb", line 89 in run
90
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/app/connectors/importer.rb", line 41 in run
91
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/app/models/data_import.rb", line 638 in new_importer
92
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/app/models/data_import.rb", line 372 in dispatch
93
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/app/models/data_import.rb", line 172 in run_import!
94
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/resque/importer_jobs.rb", line 9 in block in perform
95
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/resque/base_job.rb", line 21 in call
96
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/resque/base_job.rb", line 21 in run_action
97
File "/home/ubuntu/www/production.cartodb.com/releases/20160115112718/lib/resque/importer_jobs.rb", line 9 in perform
````
