### PR TITLE
public datasets: display_name_or_name

### DIFF
--- a/app/controllers/carto/admin/visualization_public_map_adapter.rb
+++ b/app/controllers/carto/admin/visualization_public_map_adapter.rb
@@ -18,7 +18,7 @@ module Carto
       delegate [
         :type_slide?, :has_permission?, :derived?, :organization, :organization?, :id, :likes,
         :password_protected?, :varnish_key, :related_tables, :is_password_valid?, :get_auth_tokens, :table, :name,
-        :display_name, :overlays, :created_at, :updated_at, :description, :mapviews, :geometry_types, :privacy, :tags,
+        :overlays, :created_at, :updated_at, :description, :mapviews, :geometry_types, :privacy, :tags,
         :surrogate_key, :has_password?, :total_mapviews, :is_viewable_by_user?, :is_accesible_by_user?,
         :can_be_cached?, :is_privacy_private?
       ] => :visualization

--- a/app/controllers/carto/admin/visualization_public_map_adapter.rb
+++ b/app/controllers/carto/admin/visualization_public_map_adapter.rb
@@ -18,7 +18,7 @@ module Carto
       delegate [
         :type_slide?, :has_permission?, :derived?, :organization, :organization?, :id, :likes,
         :password_protected?, :varnish_key, :related_tables, :is_password_valid?, :get_auth_tokens, :table, :name,
-        :overlays, :created_at, :updated_at, :description, :mapviews, :geometry_types, :privacy, :tags,
+        :display_name, :overlays, :created_at, :updated_at, :description, :mapviews, :geometry_types, :privacy, :tags,
         :surrogate_key, :has_password?, :total_mapviews, :is_viewable_by_user?, :is_accesible_by_user?,
         :can_be_cached?, :is_privacy_private?
       ] => :visualization
@@ -102,6 +102,10 @@ module Carto
 
       def map_zoom
         map.nil? ? nil : map.zoom
+      end
+
+      def display_name_or_name
+        @visualization.display_name.nil? ? @visualization.name : @visualization.display_name
       end
 
       private

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -163,7 +163,7 @@
       <div class="PublicMap-block">
         <div class="PublicMap-leftBlock PublicMap-leftBlock--large">
           <div class="js-user-meta">
-            <h1 class="PublicMap-title js-PublicMap-title Title Title--m"><%= @visualization.name %></h1>
+            <h1 class="PublicMap-title js-PublicMap-title Title Title--m"><%= @visualization.display_name_or_name %></h1>
             <% if @visualization.description_clean %>
               <div class="PublicMap-description"><%= raw @visualization.description_html_safe %></div>
             <% end %>


### PR DESCRIPTION
close #6255

- when table has display name (mostly for data-library) it will display `display_name` instead of `name` in the public dataset view, otherwise it will default to `name`

CR @juanignaciosl 