### PR TITLE
data-library breadcrumb fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 -------------------
 * Update navigation in public pages.
 * New feature in organizations management: user quota slider.
+* Added `data_library_path` to the config. Usage instructions:
+  1. Configure data-library path. You can copy `data_library_path` config from `config/app_config.yml.sample` into your `config/app_config.yml`.
 
 3.12.0 (2016-01-05)
 -------------------

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -176,6 +176,8 @@ class Admin::VisualizationsController < Admin::AdminController
     # Public export API SQL url
     @export_sql_api_url = "#{ sql_api_url("SELECT * FROM #{ @table.owner.sql_safe_database_schema }.#{ @table.name }", @user) }&format=shp"
 
+    @data_library_url = CartoDB.data_library_path.nil? ? nil : "#{request.protocol}#{CartoDB.account_host}#{CartoDB.data_library_path}"
+
     respond_to do |format|
       format.html { render 'public_dataset', layout: 'application_table_public' }
     end

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -148,7 +148,7 @@ class Admin::VisualizationsController < Admin::AdminController
 
     has_data_library_username = Cartodb.config[:data_library].present? && !Cartodb.config[:data_library]['username'].blank?
 
-    if has_data_library_username && is_data_library_user?
+    if has_data_library_username && data_library_user?
       @name = "Data Library"
       @user_url = Cartodb.config[:data_library].present? && !Cartodb.config[:data_library]['path'].blank? ? "#{request.protocol}#{CartoDB.account_host}#{Cartodb.config[:data_library]['path']}" : @user_url
     end
@@ -686,7 +686,7 @@ class Admin::VisualizationsController < Admin::AdminController
     @viewed_user = ::User.where(username: username).first
   end
 
-  def is_data_library_user?
+  def data_library_user?
     Cartodb.config[:data_library] && (Cartodb.config[:data_library]['username'] == @viewed_user.username)
   end
 

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -147,8 +147,9 @@ class Admin::VisualizationsController < Admin::AdminController
     @user_url = CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user)
 
     has_data_library_username = Cartodb.config[:data_library].present? && !Cartodb.config[:data_library]['username'].blank?
+    @is_data_library = has_data_library_username && data_library_user?
 
-    if has_data_library_username && data_library_user?
+    if @is_data_library
       @name = "Data Library"
       @user_url = Cartodb.config[:data_library].present? && !Cartodb.config[:data_library]['path'].blank? ? "#{request.protocol}#{CartoDB.account_host}#{Cartodb.config[:data_library]['path']}" : @user_url
     end

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -146,12 +146,11 @@ class Admin::VisualizationsController < Admin::AdminController
     @name = @visualization.user.name.present? ? @visualization.user.name : @visualization.user.username.truncate(20)
     @user_url = CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user)
 
-    has_data_library_username = Cartodb.config[:data_library].present? && !Cartodb.config[:data_library]['username'].blank?
-    @is_data_library = has_data_library_username && data_library_user?
+    @is_data_library = data_library_user?
 
     if @is_data_library
       @name = "Data Library"
-      @user_url = Cartodb.config[:data_library].present? && !Cartodb.config[:data_library]['path'].blank? ? "#{request.protocol}#{CartoDB.account_host}#{Cartodb.config[:data_library]['path']}" : @user_url
+      @user_url = Cartodb.get_config(:data_library, 'path') ? "#{request.protocol}#{CartoDB.account_host}#{Cartodb.config[:data_library]['path']}" : @user_url
     end
 
     @avatar_url             = @visualization.user.avatar
@@ -688,7 +687,7 @@ class Admin::VisualizationsController < Admin::AdminController
   end
 
   def data_library_user?
-    Cartodb.config[:data_library] && (Cartodb.config[:data_library]['username'] == @viewed_user.username)
+    Cartodb.get_config(:data_library, 'username') && (Cartodb.config[:data_library]['username'] == @viewed_user.username)
   end
 
 end

--- a/app/controllers/data_library_controller.rb
+++ b/app/controllers/data_library_controller.rb
@@ -7,7 +7,7 @@ class DataLibraryController < ApplicationController
   before_filter :get_viewed_user
 
   def index
-    render_404 and return if @viewed_user.nil? || (Cartodb.config[:data_library] && Cartodb.config[:data_library]['path'].blank?)
+    render_404 and return if @viewed_user.nil? || (Cartodb.config[:data_library] && Cartodb.config[:data_library]['username'] != @viewed_user.username)
 
     @dataset_base_url = (Rails.env.production? || Rails.env.staging?) ? "#{request.protocol}#{CartoDB.account_host}/dataset/" : "#{@viewed_user.public_url(nil, request.protocol == "https://" ? "https" : "http")}/tables/"
 

--- a/app/controllers/data_library_controller.rb
+++ b/app/controllers/data_library_controller.rb
@@ -7,7 +7,7 @@ class DataLibraryController < ApplicationController
   before_filter :get_viewed_user
 
   def index
-    render_404 and return if @viewed_user.nil? || (Cartodb.config[:data_library] && Cartodb.config[:data_library]['username'] != @viewed_user.username)
+    render_404 and return if @viewed_user.nil? || (Cartodb.get_config(:data_library, 'username') && (Cartodb.config[:data_library]['username'] != @viewed_user.username))
 
     @dataset_base_url = (Rails.env.production? || Rails.env.staging?) ? "#{request.protocol}#{CartoDB.account_host}/dataset/" : "#{@viewed_user.public_url(nil, request.protocol == "https://" ? "https" : "http")}/tables/"
 

--- a/app/controllers/data_library_controller.rb
+++ b/app/controllers/data_library_controller.rb
@@ -7,7 +7,7 @@ class DataLibraryController < ApplicationController
   before_filter :get_viewed_user
 
   def index
-    render_404 and return if @viewed_user.nil? || !@viewed_user.has_feature_flag?("data_library")
+    render_404 and return if @viewed_user.nil? || (Cartodb.config[:data_library] && Cartodb.config[:data_library]['path'].blank?)
 
     @dataset_base_url = (Rails.env.production? || Rails.env.staging?) ? "#{request.protocol}#{CartoDB.account_host}/dataset/" : "#{@viewed_user.public_url(nil, request.protocol == "https://" ? "https" : "http")}/tables/"
 

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -100,24 +100,40 @@
         <div class="PublicMap-gradient"></div>
 
         <div class="PublicMap-leftBlock PublicMap-leftBlock--owner">
-          <ul class="Navmenu-list Navmenu-list--owner Navmenu-list--avatar">
-            <li class="Navmenu-item">
-              <a href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>" target="_blank" class="UserAvatar">
-                <img class="UserAvatar-img--medium" src="<%= @visualization.user.avatar %>" alt="<%= @name %>" title="<%= @name %>" />
-              </a>
-            </li>
-          </ul>
+          <% if @viewed_user.has_feature_flag?("data_library") && @data_library_url %>
+            <ul class="Navmenu-list Navmenu-list--owner Navmenu-list--avatar">
+              <li class="Navmenu-item">
+                <a href="<%= @data_library_url %>" class="UserAvatar">
+                  <img class="UserAvatar-img--medium" src="<%= @visualization.user.avatar %>" alt="Data Library" title="Data Library" />
+                </a>
+              </li>
+            </ul>
 
-          <ul class="Navmenu-list Navmenu-list--owner">
-            <li class="Navmenu-item u-hideOnTablet last-child">
-              <a href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>" class="Navmenu-link Navmenu-link--owner" title="<%= @name %>"><%= @name %></a>
-            </li>
+            <ul class="Navmenu-list Navmenu-list--owner">
+              <li class="Navmenu-item u-hideOnTablet last-child">
+                <a href="<%= @data_library_url %>" class="Navmenu-link Navmenu-link--owner" title="Data Library">Data Library</a>
+              </li>
+            </ul>
+          <% else %>
+            <ul class="Navmenu-list Navmenu-list--owner Navmenu-list--avatar">
+              <li class="Navmenu-item">
+                <a href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>" class="UserAvatar">
+                  <img class="UserAvatar-img--medium" src="<%= @visualization.user.avatar %>" alt="<%= @name %>" title="<%= @name %>" />
+                </a>
+              </li>
+            </ul>
 
-            <li class="Navmenu-item">
-              <i class="Navmenu-rarrow iconFont iconFont-Rarrow"></i>
-              <a href="<%= CartoDB.url(self, 'public_datasets_home', {}, @visualization.user) %>" class="Navmenu-link">Datasets</a>
-            </li>
-          </ul>
+            <ul class="Navmenu-list Navmenu-list--owner">
+              <li class="Navmenu-item u-hideOnTablet last-child">
+                <a href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>" class="Navmenu-link Navmenu-link--owner" title="<%= @name %>"><%= @name %></a>
+              </li>
+
+              <li class="Navmenu-item">
+                <i class="Navmenu-rarrow iconFont iconFont-Rarrow"></i>
+                <a href="<%= CartoDB.url(self, 'public_datasets_home', {}, @visualization.user) %>" class="Navmenu-link">Datasets</a>
+              </li>
+            </ul>
+          <% end %>
         </div>
 
         <div class="PublicMap-rightBlock PublicMap-rightBlock--owner u-txt-right">

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -100,40 +100,26 @@
         <div class="PublicMap-gradient"></div>
 
         <div class="PublicMap-leftBlock PublicMap-leftBlock--owner">
-          <% if @viewed_user.has_feature_flag?("data_library") && @data_library_url %>
-            <ul class="Navmenu-list Navmenu-list--owner Navmenu-list--avatar">
-              <li class="Navmenu-item">
-                <a href="<%= @data_library_url %>" class="UserAvatar">
-                  <img class="UserAvatar-img--medium" src="<%= @visualization.user.avatar %>" alt="Data Library" title="Data Library" />
-                </a>
-              </li>
-            </ul>
+          <ul class="Navmenu-list Navmenu-list--owner Navmenu-list--avatar">
+            <li class="Navmenu-item">
+              <a href="<%= @data_library_url_or_url %>" class="UserAvatar">
+                <img class="UserAvatar-img--medium" src="<%= @visualization.user.avatar %>" alt="<%= @data_library_name_or_name %>" title="<%= @data_library_name_or_name %>" />
+              </a>
+            </li>
+          </ul>
 
-            <ul class="Navmenu-list Navmenu-list--owner">
-              <li class="Navmenu-item u-hideOnTablet last-child">
-                <a href="<%= @data_library_url %>" class="Navmenu-link Navmenu-link--owner" title="Data Library">Data Library</a>
-              </li>
-            </ul>
-          <% else %>
-            <ul class="Navmenu-list Navmenu-list--owner Navmenu-list--avatar">
-              <li class="Navmenu-item">
-                <a href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>" class="UserAvatar">
-                  <img class="UserAvatar-img--medium" src="<%= @visualization.user.avatar %>" alt="<%= @name %>" title="<%= @name %>" />
-                </a>
-              </li>
-            </ul>
+          <ul class="Navmenu-list Navmenu-list--owner">
+            <li class="Navmenu-item u-hideOnTablet last-child">
+              <a href="<%= @data_library_url_or_url %>" class="Navmenu-link Navmenu-link--owner" title="<%= @data_library_name_or_name %>"><%= @data_library_name_or_name %></a>
+            </li>
 
-            <ul class="Navmenu-list Navmenu-list--owner">
-              <li class="Navmenu-item u-hideOnTablet last-child">
-                <a href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>" class="Navmenu-link Navmenu-link--owner" title="<%= @name %>"><%= @name %></a>
-              </li>
-
+            <% unless @data_library_username %>
               <li class="Navmenu-item">
                 <i class="Navmenu-rarrow iconFont iconFont-Rarrow"></i>
                 <a href="<%= CartoDB.url(self, 'public_datasets_home', {}, @visualization.user) %>" class="Navmenu-link">Datasets</a>
               </li>
-            </ul>
-          <% end %>
+            <% end %>
+          </ul>
         </div>
 
         <div class="PublicMap-rightBlock PublicMap-rightBlock--owner u-txt-right">

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -102,15 +102,15 @@
         <div class="PublicMap-leftBlock PublicMap-leftBlock--owner">
           <ul class="Navmenu-list Navmenu-list--owner Navmenu-list--avatar">
             <li class="Navmenu-item">
-              <a href="<%= @data_library_url_or_url %>" class="UserAvatar">
-                <img class="UserAvatar-img--medium" src="<%= @visualization.user.avatar %>" alt="<%= @data_library_name_or_name %>" title="<%= @data_library_name_or_name %>" />
+              <a href="<%= @user_url %>" class="UserAvatar">
+                <img class="UserAvatar-img--medium" src="<%= @visualization.user.avatar %>" alt="<%= @name %>" title="<%= @name %>" />
               </a>
             </li>
           </ul>
 
           <ul class="Navmenu-list Navmenu-list--owner">
             <li class="Navmenu-item u-hideOnTablet last-child">
-              <a href="<%= @data_library_url_or_url %>" class="Navmenu-link Navmenu-link--owner" title="<%= @data_library_name_or_name %>"><%= @data_library_name_or_name %></a>
+              <a href="<%= @user_url %>" class="Navmenu-link Navmenu-link--owner" title="<%= @name %>"><%= @name %></a>
             </li>
 
             <% unless @data_library_username %>

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -113,7 +113,7 @@
               <a href="<%= @user_url %>" class="Navmenu-link Navmenu-link--owner" title="<%= @name %>"><%= @name %></a>
             </li>
 
-            <% unless @data_library_username %>
+            <% unless @is_data_library %>
               <li class="Navmenu-item">
                 <i class="Navmenu-rarrow iconFont iconFont-Rarrow"></i>
                 <a href="<%= CartoDB.url(self, 'public_datasets_home', {}, @visualization.user) %>" class="Navmenu-link">Datasets</a>

--- a/app/views/data_library/index.html.erb
+++ b/app/views/data_library/index.html.erb
@@ -1,7 +1,6 @@
 <%= content_for(:title) do %>CartoDB · Data Library<% end %>
 
-<%# TODO: Description for data library %>
-<%= content_for(:description) do %><% end %>
+<%= content_for(:description) do %>This is the data library of CartoDB. Here you will find open resources to help you populate your maps.<% end %>
 
 <div class="DataLibrary">
   <div class="DataLibrary-inner js-data_library">

--- a/app/views/data_library/index.html.erb
+++ b/app/views/data_library/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title) do %>CartoDB · Data Library<% end %>
 
-<%= content_for(:description) do %>This is the data library of CartoDB. Here you will find open resources to help you populate your maps.<% end %>
+<%= content_for(:description) do %>Incorporate your data with datasets from CartoDB and create insightful visualizations that leverage big data and location intelligence.<% end %>
 
 <div class="DataLibrary">
   <div class="DataLibrary-inner js-data_library">

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -17,6 +17,7 @@ defaults: &defaults
   secret_token:       '71c2b25921b84a1cb21c71503ab8fb23'
   account_host:       'localhost.lan:3000'
   account_path:       '/account'
+  data_library_path:  '/data-library'
   disable_file:       '~/disable'
   watcher:
     ttl:              60

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -17,7 +17,9 @@ defaults: &defaults
   secret_token:       '71c2b25921b84a1cb21c71503ab8fb23'
   account_host:       'localhost.lan:3000'
   account_path:       '/account'
-  data_library_path:  '/data-library'
+  data_library:
+    username:         'common-data'
+    path:             '/data-library'
   disable_file:       '~/disable'
   watcher:
     ttl:              60

--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -230,7 +230,7 @@ module CartoDB
   end
 
   def self.get_data_library_path
-    Cartodb.config[:data_library_path]
+    Cartodb.config[:data_library] && Cartodb.config[:data_library]['path']
   end
 
 end

--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -119,6 +119,10 @@ module CartoDB
     @@account_path ||= self.get_account_path
   end
 
+  def self.data_library_path
+    @@data_library_path ||= self.get_data_library_path
+  end
+
   def self.request_host=(value)
     @@request_host=value
   end
@@ -223,6 +227,10 @@ module CartoDB
 
   def self.get_account_path
     Cartodb.config[:account_path]
+  end
+
+  def self.get_data_library_path
+    Cartodb.config[:data_library_path]
   end
 
 end

--- a/spec/lib/initializers/carto_db_spec.rb
+++ b/spec/lib/initializers/carto_db_spec.rb
@@ -14,6 +14,7 @@ module CartoDB
     remove_class_variable(:@@subdomainless_urls) if defined?(@@subdomainless_urls)
     remove_class_variable(:@@account_host) if defined?(@@account_host)
     remove_class_variable(:@@account_path) if defined?(@@account_path)
+    remove_class_variable(:@@data_library_path) if defined?(@@data_library_path)
   end
 end
 


### PR DESCRIPTION
close #6256

when a `data_library_path` is set in the `app_config.yml` and the user has the `data_library` feature flag, breadcrumb changes from that for uses to one linking to data-library home

obv, this would need updating `app_config.yml`

CR @juanignaciosl @xavijam 