### PR TITLE
Enable forbid_reuse option for downloader connections

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -226,7 +226,7 @@ module CartoDB
           ssl_verifypeer:   verify_ssl,
           ssl_verifyhost:   (verify_ssl ? 2 : 0),
           forbid_reuse:     true,
-          connecttimeout:  HTTP_CONNECT_TIMEOUT,
+          connecttimeout:   HTTP_CONNECT_TIMEOUT,
           timeout:          http_options.fetch(:http_timeout, DEFAULT_HTTP_REQUEST_TIMEOUT)
         }
       end

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -225,6 +225,7 @@ module CartoDB
           followlocation:   true,
           ssl_verifypeer:   verify_ssl,
           ssl_verifyhost:   (verify_ssl ? 2 : 0),
+          forbid_reuse:     true,
           connecttimeout:  HTTP_CONNECT_TIMEOUT,
           timeout:          http_options.fetch(:http_timeout, DEFAULT_HTTP_REQUEST_TIMEOUT)
         }


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb/issues/6419