### PR TITLE
Migrate user metadata config to redis

### DIFF
--- a/app/models/carto/organization.rb
+++ b/app/models/carto/organization.rb
@@ -31,6 +31,10 @@ module Carto
       end
     end
 
+    def period_end_date
+      owner.period_end_date
+    end
+
     def get_new_system_geocoding_calls(options = {})
       date_to = (options[:to] ? options[:to].to_date : Date.current)
       date_from = (options[:from] ? options[:from].to_date : owner.last_billing_cycle)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -340,7 +340,7 @@ class Organization < Sequel::Model
   end
 
   def period_end_date
-    owner.period_end_date
+    owner ? owner.period_end_date : nil
   end
 
   def public_vis_count_by_type(type)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -80,12 +80,23 @@ class Organization < Sequel::Model
 
   def before_save
     super
+    @geocoding_quota_modified = changed_columns.include?(:geocoding_quota)
     self.updated_at = Time.now
     raise errors.join('; ') unless valid?
   end
 
   def before_destroy
     destroy_groups
+  end
+
+  def after_create
+    super
+    save_metadata
+  end
+
+  def after_save
+    super
+    save_metadata
   end
 
   # INFO: replacement for destroy because destroying owner triggers
@@ -282,6 +293,22 @@ class Organization < Sequel::Model
     display_name.nil? ? name : display_name
   end
 
+  # create the key that is used in redis
+  def key
+    "rails:orgs:#{name}"
+  end
+
+  # save orgs basic metadata to redis for other services (node sql api, geocoder api, etc)
+  # to use
+  def save_metadata
+    $users_metadata.HMSET key,
+      'id', id,
+      'geocoding_quota', geocoding_quota,
+      'google_maps_client_id', google_maps_key,
+      'google_maps_api_key', google_maps_private_key,
+      'period_end_date', period_end_date
+  end
+
   private
 
   def destroy_groups
@@ -310,6 +337,10 @@ class Organization < Sequel::Model
 
   def last_billing_cycle
     owner ? owner.last_billing_cycle : Date.today
+  end
+
+  def period_end_date
+    owner.period_end_date
   end
 
   def public_vis_count_by_type(type)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# encoding: UTF-8
 require 'cartodb/per_request_sequel_cache'
 require_relative './user/user_decorator'
 require_relative './user/oauths'
@@ -736,12 +736,17 @@ class User < Sequel::Model
     !!dashboard_viewed_at
   end
 
+  def geocoder_type
+    google_maps_geocoder_enabled? ? "google" : "heremaps"
+  end
+
   # create the core user_metadata key that is used in redis
   def key
     "rails:users:#{username}"
   end
 
-  # save users basic metadata to redis for node sql api to use
+  # save users basic metadata to redis for other services (node sql api, geocoder api, etc)
+  # to use
   def save_metadata
     $users_metadata.HMSET key,
       'id', id,
@@ -749,7 +754,13 @@ class User < Sequel::Model
       'database_password', database_password,
       'database_host', database_host,
       'database_publicuser', database_public_username,
-      'map_key', api_key
+      'map_key', api_key,
+      'geocoder_type', geocoder_type,
+      'geocoding_quota', geocoding_quota,
+      'soft_geocoding_limit', soft_geocoding_limit,
+      'google_maps_client_id', google_maps_key,
+      'google_maps_api_key', google_maps_private_key,
+      'period_end_date', period_end_date
   end
 
   def get_auth_tokens

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -41,6 +41,7 @@ $tables_metadata     = Redis.new(redis_conf.merge(db: databases[:tables_metadata
 $api_credentials     = Redis.new(redis_conf.merge(db: databases[:api_credentials]))
 $users_metadata      = Redis.new(redis_conf.merge(db: databases[:users_metadata]))
 $redis_migrator_logs = Redis.new(redis_conf.merge(db: databases[:redis_migrator_logs]))
+$geocoder_metrics    = Redis.new(redis_conf.merge(db: databases[:users_metadata]))
 
 # When in the "test" environment we don't expect a Redis
 # server to be up and running at this point. Later code
@@ -51,6 +52,7 @@ unless Rails.env.test?
     $api_credentials.ping
     $users_metadata.ping
     $redis_migrator_logs.ping
+    $geocoder_metrics.ping
   rescue => e
     raise "Error connecting to Redis databases: #{e}" 
   end

--- a/services/importer/lib/importer/georeferencer.rb
+++ b/services/importer/lib/importer/georeferencer.rb
@@ -211,7 +211,7 @@ module CartoDB
           @tracker.call('geocoding')
           create_the_geom_in(table_name)
           orgname = user.organization.nil? ? nil : user.organization.name
-          usage_metrics = CartoDB::GeocoderUsageMetrics.new($users_metadata, user.username, orgname)
+          usage_metrics = CartoDB::GeocoderUsageMetrics.new($geocoder_metrics, user.username, orgname)
           config = @options[:geocoder].merge(
             table_schema: schema,
             table_name: table_name,

--- a/services/table-geocoder/lib/table_geocoder_factory.rb
+++ b/services/table-geocoder/lib/table_geocoder_factory.rb
@@ -64,7 +64,7 @@ module Carto
 
     def self.get_geocoder_metrics_instance(user)
       orgname = user.organization.nil? ? nil : user.organization.name
-      CartoDB::GeocoderUsageMetrics.new($users_metadata, user.username, orgname)
+      CartoDB::GeocoderUsageMetrics.new($geocoder_metrics, user.username, orgname)
     end
   end
 end


### PR DESCRIPTION
Closes #6415 

In order to use metadata config in the geocode API we need to store and synchronize some metadata fields in redis either for users and for organizations.

Also we have a new rake task to update all the existing users and organizations to have all this new fields available.

And finally there is a new redis database object in the editor that is going to be used to store the geocoder metrics although now is pointing to the same redis db than users_metadata.