### PR TITLE
Fixes #5131: unsync synced tables when the schema changes

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1313,6 +1313,10 @@ class Table
     name.tr('_', ' ').split.map(&:capitalize).join(' ')
   end
 
+  def column_count
+    schema(reload: true).collect { |c| c[0] }.count
+  end
+
   private
 
   def previous_privacy

--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -234,6 +234,11 @@ module CartoDB
       what_about: "You can't add more layers to your map. Please upgrade your account.",
       source: ERROR_SOURCE_USER
     },
+    6665 => {
+        title: 'Schema change: Column/s dropped',
+        what_about: "Table schema has changed, dropping one or more columns. In order to solve this issue, please add a new layer with the updated dataset.",
+        source: ERROR_SOURCE_USER
+    },
     6666 => {
       title: 'Dataset too big',
       what_about: "The dataset you tried to import is too big and cannot be processed. If the dataset allows it, you can try splitting it into smaller files and then append them once imported, or contact our support team at <a href='mailto:support@cartodb.com?subject=Dataset%20too%20big%20import%20error'>support@cartodb.com</a>.",

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -2412,6 +2412,14 @@ describe Table do
 
   end
 
+  describe '#column_count' do
+    it "should return column counts" do
+      table = new_table(:user_id => $user_1.id)
+      table.stubs(:schema).returns([[:cartodb_id, "integer"], [:bed, "text"], [:the_geom, "point"]])
+      table.column_count.should == 3
+    end
+  end
+
   describe '#estimated_row_count and #actual_row_count' do
     it "should return row counts" do
       table = new_table(:user_id => $user_1.id)


### PR DESCRIPTION
Fixes CartoDB 5131

#### Proposed Solution

In order to solve the issue regarding the failing map due cartocss using a non-existing column, the proposal from me, is the following:

Firstly, getting the previous column count and the column count for the new updated/synced table. In this particular case, happening in ```Synchronization::Adapter#overwrite``` and when the schema differs, the sync is going to be allowed to go through.

This is been allowed to go through in order to display the newly synced table, so the UI can display the table, offering to the user a point to verify the new updated/synced table. (The user may not have access to the ```data_url``` or to the file itself, possibly making hard to understand which column/columns had been removed).

Once we have the column counts, the idea is to alert the user through the UI, this has been done including the new state. This new state, currently defined as modified is really the reflection of the schema losing/dropping column/s. 

This newly added state could be perfectly defined as ```modified_increased``` and ```modified_decreased```, making use just of the latter one, as right now we don't have a usage/necessity to maintain both, I just went with the simplest approach.

The idea of having ```modified_increased``` and ```modified_decreased``` is quite open still and suggestions are more than welcome. 

Once we have the viability of verifying if column/s has been dropped, we just set the newly added state in ```Synchronization::Member#run```.

The new state makes usage of the ```error_code``` and ```error_message```, in order to use the UI helper and display to issue to the user.

Furthermore, this error code and message have been added to the import_error for further investigation of inclusion as part of the importing build, possibly verifying on the fly that the import has been compromised due a column deletion. 

The error code has been chosen in the **6XXX** has seems to be related with occasional issues as too many table rows, or dataset too big. The message is trying to be as direct as possible, further refinement might be desired.

Please, reviews, opinions, points or advice are more than welcome to complete this issue.

_Note: as the not reverting the sync is a self-taken decision and alerting the user through Email still something that I was not sure to include, further inclusion of fixes and refinements would need to be included, if necessary._

