### PR TITLE
Improve empty CSV files handling

### DIFF
--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -40,8 +40,8 @@ module CartoDB
       source: ERROR_SOURCE_USER
     },
     1005 => {
-      title: 'Zero byte file',
-      what_about: "The file appears to have no information. Double check using a local tool such as QGIS that the file is indeed correct. If everything appears fine, try uploading it again or <a href='mailto:support@cartodb.com?subject=Zero byte file'>contact us</a>.",
+      title: 'Empty file',
+      what_about: "The file appears to have no processable information. Double check that the file is indeed correct and it contains supported data. If everything appears fine, try uploading it again or <a href='mailto:support@cartodb.com?subject=Empty file'>contact us</a>.",
       source: ERROR_SOURCE_USER
     },
     1006 => {

--- a/services/importer/lib/importer/csv_normalizer.rb
+++ b/services/importer/lib/importer/csv_normalizer.rb
@@ -170,11 +170,8 @@ module CartoDB
 
       def single_column?
         columns = ::CSV.parse(first_line, csv_options)
-        if !columns.any?
-          raise EmptyFileError.new
-        else
-          columns.first.length < 2
-        end
+        raise EmptyFileError.new if !columns.any?
+        columns.first.length < 2
       end
 
       def multiple_column(row)

--- a/services/importer/lib/importer/csv_normalizer.rb
+++ b/services/importer/lib/importer/csv_normalizer.rb
@@ -169,7 +169,12 @@ module CartoDB
       end
 
       def single_column?
-        ::CSV.parse(first_line, csv_options).first.to_s.length < 2
+        columns = ::CSV.parse(first_line, csv_options)
+        if !columns.any?
+          raise EmptyFileError.new
+        else
+          columns.first.length < 2
+        end
       end
 
       def multiple_column(row)

--- a/services/importer/lib/importer/csv_normalizer.rb
+++ b/services/importer/lib/importer/csv_normalizer.rb
@@ -169,7 +169,7 @@ module CartoDB
       end
 
       def single_column?
-        ::CSV.parse(first_line, csv_options).first.length < 2
+        ::CSV.parse(first_line, csv_options).first.to_s.length < 2
       end
 
       def multiple_column(row)
@@ -208,8 +208,9 @@ module CartoDB
       def first_line
         return @first_line if @first_line
         stream.rewind
-        @first_line ||= stream.gets
+        @first_line ||= stream.gets || ''
         stream.rewind
+        @first_line
       end
 
       def release

--- a/services/importer/spec/unit/csv_normalizer_spec.rb
+++ b/services/importer/spec/unit/csv_normalizer_spec.rb
@@ -9,7 +9,7 @@ include CartoDB::Importer2::Doubles
 describe CartoDB::Importer2::CsvNormalizer do
 
   BUG_COLUMNS_WRONG_SPLIT_FIXTURE_FILE = "#{File.dirname(__FILE__)}/bug_columns_wrong_split.csv"
-  
+
   describe '#run' do
     it 'transforms the file using a proper comma delimiter' do
       fixture = tab_delimiter_factory
@@ -20,6 +20,16 @@ describe CartoDB::Importer2::CsvNormalizer do
       csv.delimiter.should eq "\t"
       csv.run
       csv.delimiter.should eq ','
+    end
+    it 'raise if detects an empty file' do
+      fixture = empty_file_factory
+
+      csv     = CartoDB::Importer2::CsvNormalizer.new(fixture, Log.new)
+      expect {
+        csv.run
+      }.to raise_exception CartoDB::Importer2::EmptyFileError
+
+      FileUtils.rm(fixture)
     end
   end
 
@@ -211,6 +221,14 @@ describe CartoDB::Importer2::CsvNormalizer do
       csv << ['header_1']
       csv << ['row 1']
     end
+
+    filepath
+  end
+
+  def empty_file_factory
+    filepath = get_temp_csv_fullpath
+
+    FileUtils.touch(filepath)
 
     filepath
   end


### PR DESCRIPTION
For empty CSVs, which usually came from unsupported Excel files, such
as sheets with graphs, the normalization was crashing.

The first_line method was returning the `stream.rewind` value in case
that the file was empty, and therefore the first_line would be nil.

This commit also edits the CSV column number checking in order to
be able to admit empty files (otherwise, nil.length would raise an
exception).

* [x] Before merging, update docs.

Fixes https://github.com/CartoDB/cartodb/issues/6403