### PR TITLE
fixing links and adding new ones

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/help/postgres_sql.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/help/postgres_sql.jst.ejs
@@ -10,7 +10,7 @@
   <span class="Dialog-resultsBodyIcon NavButton ">1</span>
   <div class="Dialog-resultsBodyTexts">
     <p class="DefaultParagraph DefaultParagraph--tertiary">
-      To see your <strong>data in the Map</strong>, CartoDB requires that <strong>the_geom_webmercator</strong> column is in your results (<a href="http://developers.cartodb.com/documentation/advanced_concepts.html#basic_geospatial" target="_blank">CartoDB basic geospatial</a>).
+      To see your <strong>data on the map</strong>, CartoDB requires that <strong>the_geom_webmercator</strong> column is in your results (<a href="http://docs.cartodb.com/tips-and-tricks/geospatial-analysis/#about-thegeomwebmercator" target="_blank">CartoDB basic geospatial</a>).
     </p>
   </div>
 </div>
@@ -18,7 +18,18 @@
   <span class="Dialog-resultsBodyIcon NavButton ">2</span>
   <div class="Dialog-resultsBodyTexts">
     <p class="DefaultParagraph DefaultParagraph--tertiary">
-     In order to get the <strong>interactivity layer</strong> in your maps, the column cartodb_id must be in your results.
+     In order to get the <strong>interactivity layer</strong> in your maps, the column <strong>cartodb_id</strong> must be in your results.
+    </p>
+  </div>
+</div>
+<div class="Dialog-body Dialog-resultsBody Dialog-resultsBody--vcenter">
+  <span class="Dialog-resultsBodyIcon NavButton ">?</span>
+  <div class="Dialog-resultsBodyTexts">
+    <p class="DefaultParagraph DefaultParagraph--tertiary">
+      Learn more about using SQL and PostGIS in CartoDB by checking out our
+      <a href="http://academy.cartodb.com/courses/sql-postgis/" target="_blank">SQL and PostGIS</a>
+      course in
+      <a href="http://academy.cartodb.com" target="_blank">Map Academy</a>.
     </p>
   </div>
 </div>
@@ -28,9 +39,9 @@
     <p class="DefaultParagraph DefaultParagraph--tertiary">
       Do you need further information about PostgreSQL and PostGIS?
       Check out the official docs, visit
-      <a href="http://www.postgresql.org/docs/9.2/static/reference.html" target="_blank">PostgreSQL docs</a>
+      <a href="http://www.postgresql.org/docs/9.3/static/reference.html" target="_blank">PostgreSQL docs</a>
       and
-      <a href="http://postgis.net/docs/manual-2.0/reference.html" target="_blank">PostGIS docs</a>.
+      <a href="http://postgis.net/docs/manual-2.2/reference.html" target="_blank">PostGIS docs</a>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
There were some broken links in the following dialog:

<img width="773" alt="screen shot 2016-01-25 at 09 03 34" src="https://cloud.githubusercontent.com/assets/1041056/12552938/8a825a60-c342-11e5-886c-427723ac3758.png">

I fixed those, and am suggesting we link to Map Academy if people need some help learning SQL/PostGIS :) I also linked to the current version of PostGIS and Postgres documentation.