### PR TITLE
Fix missing geocoder api entries in config

### DIFF
--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -172,10 +172,10 @@ defaults: &defaults
       api_key: ''
       table_name: ''
     api:
-      host: ''
-      port: ''
-      dbname: ''
-      user: ''
+      host: 'localhost'
+      port: 12345
+      dbname: 'my_sample_db'
+      user: 'my_sample_user'
   importer:
     content_guessing:        # Depends on geocoding
       enabled:         false # Disabled if false or not present

--- a/config/app_config.yml.testing
+++ b/config/app_config.yml.testing
@@ -109,6 +109,11 @@ defaults: &defaults
       base_url: ''
       api_key: ''
       table_name: ''
+    api:
+      host: 'localhost'
+      port: 12345
+      dbname: 'my_sample_db'
+      user: 'my_sample_user'
   importer:
     s3:
       access_key_id:


### PR DESCRIPTION
@ethervoid please review

This avoids errors such as
```
error: Error installing and configuring geocoder api extension
{:error=>"#<RuntimeError: Geocoder API config incomplete, some fields are missing>", :user=>#<User @values={:email=>"soft-geocoding-limit-false-user@cartodb.com", :crypted_password=>"8cf34ac5b6ae4548aaba06b388d69e69db697595", :salt=>"2809
0225b684d286c446952121d05cbad70fd5e6", :database_name=>"cartodb_test_user_37c02739-7380-49c6-9d94-fc135ecd5c18_db", :username=>"soft-geocoding-limit-false-user", :admin=>nil, :enabled=>true, :invite_token=>"dfb5ae01b4d8e91b6e9984aca22f441
758e154b2", :invite_token_date=>nil, :map_enabled=>true, :quota_in_bytes=>1024, :table_quota=>5, :account_type=>"ORGANIZATION USER", :private_tables_enabled=>true, :period_end_date=>2016-01-26 11:41:51 +0000, :map_view_quota=>10000, :max_
layers=>4, :database_timeout=>300000, :user_timeout=>300000, :upgraded_at=>nil, :map_view_block_price=>nil, :geocoding_quota=>1000, :dashboard_viewed_at=>nil, :sync_tables_enabled=>true, :database_host=>"localhost", :geocoding_block_price
=>1500, :api_key=>"bf0a07b5c860043ca6f55a1b27eba80e478c54f7", :notification=>nil, :organization_id=>"a81c4983-fcba-4023-a7bc-06f46a425a02", :created_at=>2016-01-26 11:46:37 +0000, :updated_at=>2016-01-26 11:46:37 +0000, :disqus_shortname=
>nil, :id=>"eb28bcca-c3df-46ed-a160-e84b580a1764", :twitter_username=>nil, :website=>nil, :description=>nil, :name=>nil, :avatar_url=>nil, :database_schema=>"soft-geocoding-limit-false-user", :soft_geocoding_limit=>false, :auth_token=>nil
, :twitter_datasource_enabled=>nil, :twitter_datasource_block_price=>nil, :twitter_datasource_block_size=>nil, :twitter_datasource_quota=>0, :soft_twitter_datasource_limit=>false, :arcgis_datasource_enabled=>nil, :available_for_hire=>fals
e, :private_maps_enabled=>true, :google_sign_in=>nil, :last_password_change_date=>nil, :max_import_file_size=>157286400, :max_import_table_row_count=>500000, :max_concurrent_import_count=>3, :last_common_data_update_date=>nil, :google_map
s_key=>nil, :google_maps_private_key=>nil, :enable_account_token=>nil, :location=>nil}>}
```

when running tests in CI and local env.