### PR TITLE
#6465 Do not set resque execution mode for the rest of the tests

### DIFF
--- a/spec/requests/carto/api/imports_controller_spec.rb
+++ b/spec/requests/carto/api/imports_controller_spec.rb
@@ -18,11 +18,8 @@ describe Carto::Api::ImportsController do
 
   after(:all) do
     stub_named_maps_calls
-    Resque.inline = false
     delete_user_data $user_1
   end
-
-  let(:params) { { :api_key => $user_1.api_key } }
 
   let(:params) { { :api_key => $user_1.api_key } }
 
@@ -439,7 +436,5 @@ describe Carto::Api::ImportsController do
 
   end
 
-  #include Rack::Test::Methods
-  #include Warden::Test::Helpers
 end
 


### PR DESCRIPTION
With this change I could execute `make check-4` successfully. Mind that `Resque.inline` is set here: https://github.com/CartoDB/cartodb/blob/e30b6f70d2e5edb45c3abd90b590461d1e3799bd/spec/spec_helper.rb#L45 (which seems to be the "default expected behavior")

@juanignaciosl can you please review?