### PR TITLE
Fallbacks for missing vizJSON v3 props for new editor entry

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -19,50 +19,44 @@ var vizJSON = window.vizJSON;
 
 // TODO extract datsource info from an assumed existing layergroup,
 // this should be included in a v3 of vizjSON
-var userName;
-var mapsApiTemplate;
-var statTag;
-_.each(vizJSON.layers, function (layer) {
-  if (layer.type === 'layergroup') {
-    var o = layer.options;
-    userName = o.user_name;
-    mapsApiTemplate = o.maps_api_template;
-    statTag = o.layer_definition.stat_tag;
+if (!vizJSON.datasource) {
+  var userName;
+  var mapsApiTemplate;
+  var statTag;
+  _.each(vizJSON.layers, function (layer) {
+    if (layer.type === 'layergroup') {
+      var o = layer.options;
+      userName = o.user_name;
+      mapsApiTemplate = o.maps_api_template;
+      statTag = o.layer_definition.stat_tag;
+    }
+  });
+
+  if (userName) {
+    vizJSON.datasource = {
+      user_name: userName,
+      maps_api_template: mapsApiTemplate,
+      force_cors: true, // TODO when should this be applied and not?
+      stat_tag: statTag
+    };
+  } else {
+    throw new Error('vizJSON v3 should contain a valid datasource to begin with. for the moment we extract the same info from a layergroup. if you read this the viz did not have any layergroup');
   }
-});
-
-if (userName) {
-  vizJSON.datasource = {
-    type: 'public_map',
-    user_name: userName,
-    maps_api_template: mapsApiTemplate,
-    force_cors: true, // TODO when should this be applied and not?
-    stat_tag: statTag
-  };
-} else {
-  throw new Error('vizJSON v3 should contain a valid datasource to begin with. for the moment we extract the same info from a layergroup. if you read this the viz did not have any layergroup');
 }
-
-var diJSON = {
-  title: '',
-  description: '',
-  user: {
-    fullname: '',
-    avatar_url: ''
-  },
-  updated_at: '2015-10-26T11:50:30+00:00',
-  widgets: [],
-  vizJSON: vizJSON
+vizJSON.user = vizJSON.user || {
+  fullname: '',
+  avatar_url: ''
 };
+vizJSON.widgets = vizJSON.widgets || [];
 
-var visOpts = {
+var dashboard = cdb.deepInsights.createDashboard('#dashboard', vizJSON, {
   no_cdn: false,
   cartodb_logo: false
-};
-cdb.deepInsights.createDashboard('#dashboard', diJSON, visOpts)
-  .vis.done(function (vis, layers) {
-    console.info('vis ready!');
-  })
-  .error(function (err) {
-    console.error(err);
-  });
+});
+
+dashboard.vis.done(function (vis, layers) {
+  console.info('vis ready!');
+})
+.error(function (err) {
+  console.error(err);
+});

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browserify-shim": "3.8.10",
     "cartodb-pecan": "0.2.x",
     "csswring": "^3.0.5",
-    "cartodb-deep-insights.js": "CartoDB/deep-insights.js#f643810",
+    "cartodb-deep-insights.js": "CartoDB/deep-insights.js#1265afb",
     "git-rev": "0.2.1",
     "grunt": "0.4.5",
     "grunt-available-tasks": "0.5.4",


### PR DESCRIPTION
Resolves #6471 by adding fallback values for the new props if they're not present on the vizJSON.
This way we're not blocked by #6472 and can continue with the other stuff.

See https://github.com/CartoDB/deep-insights.js/pull/87/files?w=0 and the examples if you want to more details on what changed "under the hood".

@xavijam review?
FYI @javierarce @javisantana @acanimal 