### PR TITLE
Disable geocoder api notifications for oss users

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -415,7 +415,14 @@ module CartoDB
               SET search_path TO #{build_search_path}") if @user.organization_user?
           return true
         rescue => e
-          CartoDB.notify_error('Error installing and configuring geocoder api extension', error: e.inspect, user: @user)
+          # For now CartoDB.com is the only host with Geocoder API installed
+          # so we want to avoid noise to OSS users
+          if Cartodb.config[:cartodb_com_hosted] == false
+            CartoDB.notify_error(
+              'Error installing and configuring geocoder api extension',
+              error: e.inspect, user: @user
+            )
+          end
           return false
       end
 

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -171,11 +171,6 @@ defaults: &defaults
       base_url: ''
       api_key: ''
       table_name: ''
-    api:
-      host: ''
-      port: ''
-      dbname: ''
-      user: ''
   importer:
     content_guessing:        # Depends on geocoding
       enabled:         false # Disabled if false or not present


### PR DESCRIPTION
We want to disable and remove noise for the OSS users of CartoDB that don't have, by now, a complete instance of Geocoder API