### PR TITLE
data-library: fix viewed_user check

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -671,7 +671,7 @@ class Admin::VisualizationsController < Admin::AdminController
   end
 
   def data_library_user?
-    @viewed_user && Cartodb.get_config(:data_library, 'username') && (@viewed_user.username == Cartodb.config[:data_library]['username'])
+    @viewed_user && Cartodb.get_config(:data_library, 'username') == @viewed_user.username
   end
 
 end

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -671,7 +671,7 @@ class Admin::VisualizationsController < Admin::AdminController
   end
 
   def data_library_user?
-    Cartodb.get_config(:data_library, 'username') && (Cartodb.config[:data_library]['username'] == @viewed_user.username)
+    @viewed_user && Cartodb.get_config(:data_library, 'username') && (@viewed_user.username == Cartodb.config[:data_library]['username'])
   end
 
 end


### PR DESCRIPTION
close #6469

finally I could take a look at this, it a weird case because at the moment of the compare, I'm checking the username in the config (if it exists) against @viewed_user, which occurs in the `get_viewed_user` before_filter.

Also, if that helps for debugging, the request is done by googlebot crawler

In any case, I added `@viewed_user &&` check

CR @juanignaciosl 