### PR TITLE
Check import URLs against a blacklist of IP addresses

### DIFF
--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -177,6 +177,7 @@ defaults: &defaults
       dbname: ''
       user: ''
   importer:
+    blacklisted_ip_addr: []
     content_guessing:        # Depends on geocoding
       enabled:         false # Disabled if false or not present
       threshold:       0.9   # 90% or more matches

--- a/lib/carto/url_validator.rb
+++ b/lib/carto/url_validator.rb
@@ -1,4 +1,6 @@
 require 'uri'
+require 'resolv'
+require 'ipaddr'
 
 module Carto
   module UrlValidator
@@ -18,9 +20,30 @@ module Carto
 
     def valid_url?(str, valid_ports)
       uri = URI.parse(str)
-      return uri.is_a?(URI::HTTP) && valid_ports.include?(uri.port)
+      return uri.is_a?(URI::HTTP) && valid_ports.include?(uri.port) && !blacklisted_ip?(uri)
     rescue URI::InvalidURIError
       return false
+    end
+
+    def blacklisted_ip?(uri)
+      # The uri includes regularly a hostname and is not directly the IP address
+      # so we need to resolve it to compare it with the IP blacklist
+      return false if blacklisted_ip_ranges.empty?
+
+      begin
+        uri_ip = IPAddr.new(Resolv.getaddress(uri.host))
+      rescue Resolv::ResolvError, Resolv::ResolvTimeout
+        return false
+      rescue IPAddr::AddressFamilyError, IPAddr::InvalidAddressError
+        raise InvalidUrlError, str
+      end
+
+      blacklisted_ip_ranges.any? { |ip_range| ip_range.include?(uri_ip) }
+    end
+
+    def blacklisted_ip_ranges
+      @blacklisted_ip_ranges ||= (::Cartodb.get_config(:importer, 'blacklisted_ip_addr') || [])
+        .map { |ip| IPAddr.new(ip) }
     end
   end
 end

--- a/spec/helpers/url_validator_spec.rb
+++ b/spec/helpers/url_validator_spec.rb
@@ -25,7 +25,21 @@ describe 'UUIDHelper' do
       .to raise_error(Carto::UrlValidator::InvalidUrlError)
   end
 
+  it 'raises an error if the IP is blacklisted' do
+    @url_validator.instance_variable_set("@blacklisted_ip_ranges", [IPAddr.new("169.254.169.1")])
+    expect { @url_validator.validate_url!("http://169.254.169.1/blob/blub.csv") }
+      .to raise_error(Carto::UrlValidator::InvalidUrlError)
+  end
+
+  it 'raises an error if the IP belongs to a blacklisted range' do
+    @url_validator.instance_variable_set("@blacklisted_ip_ranges", [IPAddr.new("10.0.0.0/8")])
+    expect { @url_validator.validate_url!("http://10.0.0.92/blob/blub.csv") }
+      .to raise_error(Carto::UrlValidator::InvalidUrlError)
+  end
+
   it 'does nothing if everything is ok' do
+    @url_validator.instance_variable_set("@blacklisted_ip_ranges", [IPAddr.new("169.254.169.1")])
+    @url_validator.validate_url!("http://169.254.169.2/foo.csv")
     @url_validator.validate_url!("http://example.com/foo.csv")
     @url_validator.validate_url!("https://example.com/bar.kml")
     @url_validator.validate_url!("http://example.com/foo.csv:80")


### PR DESCRIPTION
Currently, the importer does not perform any kind of check when a
URL is requested to be imported. In production environments, this
blacklist can be used in order to block imports from specific IPs
to improve security measures.

This commit adds a new entry in the app_config that allows to specify
specific IP addresses or ranges of IP addresses from which
imports will not be allowed.


Notes:

`Resolv` is being used to get the IPs from hostnames given that Typhoeus does not have a resolving function:  https://github.com/typhoeus/typhoeus/issues/482