### PR TITLE
Adds options format validation for widgets and tests for it

### DIFF
--- a/app/models/carto/widget.rb
+++ b/app/models/carto/widget.rb
@@ -5,7 +5,7 @@ class Carto::Widget < ActiveRecord::Base
 
   validates :layer, :order, :type, :options, presence: true
 
-  validate :options_format
+  validate :options_must_be_json
 
   def self.from_visualization_id(visualization_id)
     Carto::Visualization.find(visualization_id).layers.map(&:widgets).flatten
@@ -31,7 +31,7 @@ class Carto::Widget < ActiveRecord::Base
 
   private
 
-  def options_format
+  def options_must_be_json
     options_json
   rescue JSON::ParserError
     errors.add(:options, 'is wrongly formatted (invalid JSON)')

--- a/app/models/carto/widget.rb
+++ b/app/models/carto/widget.rb
@@ -5,6 +5,8 @@ class Carto::Widget < ActiveRecord::Base
 
   validates :layer, :order, :type, :options, presence: true
 
+  validate :options_format
+
   def self.from_visualization_id(visualization_id)
     Carto::Visualization.find(visualization_id).layers.map(&:widgets).flatten
   end
@@ -27,4 +29,11 @@ class Carto::Widget < ActiveRecord::Base
     layer.maps { |l| l.writable_by_user?(user) }.select { |writable| !writable }.empty?
   end
 
+  private
+
+  def options_format
+    options_json
+  rescue JSON::ParserError
+    errors.add(:options, 'is wrongly formatted (invalid JSON)')
+  end
 end

--- a/spec/models/carto/widget_spec.rb
+++ b/spec/models/carto/widget_spec.rb
@@ -24,7 +24,7 @@ describe Carto::Widget do
 
   describe 'Format and validation' do
     before(:all) do
-      @widget = FactoryGirl.create(:widget_with_layer, options: {valid: 'format'}.to_json)
+      @widget = FactoryGirl.create(:widget_with_layer, options: { valid: 'format' }.to_json)
     end
 
     it 'validates correct options format' do
@@ -38,7 +38,7 @@ describe Carto::Widget do
       @widget.valid?.should be_false
       @widget.errors[:options].empty?.should be_false
 
-      @widget.options = {valid: 'format'}.to_json
+      @widget.options = { valid: 'format' }.to_json
     end
   end
 

--- a/spec/models/carto/widget_spec.rb
+++ b/spec/models/carto/widget_spec.rb
@@ -22,6 +22,20 @@ describe Carto::Widget do
     end
   end
 
+  describe 'Format and validation' do
+    it 'checks options format is correct' do
+      widget = FactoryGirl.create(:widget_with_layer)
+      widget.save
+
+      widget.errors[:options].empty?.should be_true
+
+      widget.options = 'badformat'
+      widget.save
+
+      widget.errors[:options].empty?.should be_false
+    end
+  end
+
   describe '#from_visualization_id' do
     before(:each) do
       @map = FactoryGirl.create(:carto_map_with_layers)

--- a/spec/models/carto/widget_spec.rb
+++ b/spec/models/carto/widget_spec.rb
@@ -23,16 +23,22 @@ describe Carto::Widget do
   end
 
   describe 'Format and validation' do
-    it 'checks options format is correct' do
-      widget = FactoryGirl.create(:widget_with_layer)
-      widget.save
+    before(:all) do
+      @widget = FactoryGirl.create(:widget_with_layer, options: {valid: 'format'}.to_json)
+    end
 
-      widget.errors[:options].empty?.should be_true
+    it 'validates correct options format' do
+      @widget.valid?.should be_true
+      @widget.errors[:options].empty?.should be_true
+    end
 
-      widget.options = 'badformat'
-      widget.save
+    it 'validates incorrect options format' do
+      @widget.options = 'badformat'
 
-      widget.errors[:options].empty?.should be_false
+      @widget.valid?.should be_false
+      @widget.errors[:options].empty?.should be_false
+
+      @widget.options = {valid: 'format'}.to_json
     end
   end
 

--- a/spec/models/carto/widget_spec.rb
+++ b/spec/models/carto/widget_spec.rb
@@ -23,8 +23,8 @@ describe Carto::Widget do
   end
 
   describe 'Format and validation' do
-    before(:all) do
-      @widget = FactoryGirl.create(:widget_with_layer, options: { valid: 'format' }.to_json)
+    before(:each) do
+      @widget = FactoryGirl.build(:widget_with_layer, options: { valid: 'format' }.to_json)
     end
 
     it 'validates correct options format' do
@@ -37,8 +37,6 @@ describe Carto::Widget do
 
       @widget.valid?.should be_false
       @widget.errors[:options].empty?.should be_false
-
-      @widget.options = { valid: 'format' }.to_json
     end
   end
 


### PR DESCRIPTION
Fixes #6506 

Adds a options' format validation to prove it's a valid JSON. The validation consists in trying to load the JSON into a hash and capturing `JSON::ParserError` exceptions that might occur, adding the appropriate validation error message.

Please, CR @juanignaciosl 