### PR TITLE
Rebuild the geocoder api for the user when change to be an organization

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -68,6 +68,9 @@ module CartoDB
         if @user.organization_owner?
           setup_organization_owner
         end
+
+        # Rebuild the geocoder api user config to reflect that is an organization user
+        install_and_configure_geocoder_api_extension
       end
 
       # INFO: main setup for non-org users


### PR DESCRIPTION
When an user is promoted to be organization user/owner, the geocoder api config is not changed to be an organization config.