### PR TITLE
Cc1024 central destroys user even after an error

### DIFF
--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -104,9 +104,9 @@ class Admin::OrganizationUsersController < Admin::AdminController
     redirect_to CartoDB.url(self, 'organization', {}, current_user)
   rescue CartoDB::CentralCommunicationFailure => e
     Rollbar.report_exception(e)
-    if e.user_message =~ /No user found with username/
+    if e.user_message =~ /No organization user found with username/
       @user.destroy
-      flash[:success] = "User was deleted from the organization server. #{e.user_message}"
+      flash[:success] = "#{e.user_message}. User was deleted from the organization server."
       redirect_to CartoDB.url(self, 'organization', {}, current_user)
     else
       set_flash_flags(nil, true)

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -56,7 +56,7 @@ class Superadmin::UsersController < Superadmin::SuperadminController
     respond_with(:superadmin, @user)
   rescue => e
     Rollbar.report_message('Error destroying user', 'error', { error: e.inspect, user: @user.inspect })
-    render json: {"error": "Error destroying user: #{e.message}"}, status: 422
+    render json: { "error": "Error destroying user: #{e.message}" }, status: 422
   end
 
   def dump

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -54,9 +54,6 @@ class Superadmin::UsersController < Superadmin::SuperadminController
   def destroy
     @user.destroy
     respond_with(:superadmin, @user)
-  rescue => e
-    Rollbar.report_message('Error destroying user', 'error', { error: e.inspect, user: @user.inspect })
-    respond_with(:superadmin, @user, status: 500)
   end
 
   def dump

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -54,6 +54,9 @@ class Superadmin::UsersController < Superadmin::SuperadminController
   def destroy
     @user.destroy
     respond_with(:superadmin, @user)
+  rescue => e
+    Rollbar.report_message('Error destroying user', 'error', { error: e.inspect, user: @user.inspect })
+    render json: {"error": "Error destroying user: #{e.message}"}, status: 422
   end
 
   def dump


### PR DESCRIPTION
Error on user destroy should trigger 500. That's handled by `respond_with`, no need to wrap.