### PR TITLE
BB - IP Blacklisting - Check final URL after Typhoeus request

### DIFF
--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require_relative '../../lib/importer/downloader'
+require_relative '../../../../lib/carto/url_validator'
 
 include CartoDB::Importer2
 


### PR DESCRIPTION
The original URL validator checks the initial URL that
is provided by the user, but this validation check could
be tricked in case that the checked URL performs a redirect.

Now, the redirect_count is checked after Typhoeus's first
request to know if the URL performs a redirect. In case it does,
the final URL (effective_url) is checked again against the
url_validator.

By checking the redirect_count value we avoid running the
validator in those cases which are already covered by the validation
performed by the import controller.