### PR TITLE
Clean final breaklines from SQL geocoder output

### DIFF
--- a/services/table-geocoder/lib/internal_geocoder.rb
+++ b/services/table-geocoder/lib/internal_geocoder.rb
@@ -81,7 +81,7 @@ module CartoDB
             # Count empty and successfully geocoded responses
             empty_responses = 0
             success_responses = 0
-            CSV.parse(response) do |row|
+            CSV.parse(response.chomp) do |row|
               empty_responses += 1 if row[4] == "false"
               success_responses += 1 if row[4] == "true"
             end
@@ -89,7 +89,7 @@ module CartoDB
             @usage_metrics.incr(:geocoder_internal, :empty_responses, empty_responses)
 
             log.append "Saving results to #{geocoding_results}"
-            File.open(geocoding_results, 'a') { |f| f.write(response.force_encoding("UTF-8")) } unless response == "\n"
+            File.open(geocoding_results, 'a') { |f| f.write(response.force_encoding("UTF-8")) } unless response.blank?
           end
         end while search_terms.size >= @batch_size
         @processed_rows = `wc -l '#{geocoding_results}' 2>&1`.to_i


### PR DESCRIPTION
Fixes #6532. For single-line CSVs, the parser does not handle correctly
the final \r\n that the SQL API returns. This code chomps the response
so that it can get rid of this \r\n.

This also includes a minor improvement, checking `response.blank?`
instead of `response = '\n'` to check if it's empty or not.