### PR TITLE
[cartodb] disable verbose logging on resque script

### DIFF
--- a/script/resque
+++ b/script/resque
@@ -1,2 +1,2 @@
 #!/bin/sh
-VVERBOSE=true QUEUE=imports,users,geocodings,synchronizations,tracker rake environment resque:work
+QUEUE=imports,users,geocodings,synchronizations,tracker rake environment resque:work


### PR DESCRIPTION
This PR disables the verbose logging mode on `script/resque`, it's the script in charge of starting the Resque service in an out of the box CartoDB setup.

Setting `VVERBOSE=true` will log an entry every time a child is spawned, for example:

```bash
  ** [10:48:26 2016-02-10] 4083: Checking imports
  ** [10:48:26 2016-02-10] 4083: Checking users
  ** [10:48:26 2016-02-10] 4083: Checking geocodings
  ** [10:48:26 2016-02-10] 4083: Checking synchronizations
  ** [10:48:26 2016-02-10] 4083: Checking tracker
  ** [10:48:26 2016-02-10] 4083: Sleeping for 5.0 seconds
  ** [10:48:26 2016-02-10] 4083: resque-1.25.2: Waiting for (..)
  ** [10:48:31 2016-02-10] 4083: Checking imports
  ** [10:48:31 2016-02-10] 4083: Checking users
  ** [10:48:31 2016-02-10] 4083: Checking geocodings
  ** [10:48:31 2016-02-10] 4083: Checking synchronizations
  ** [10:48:31 2016-02-10] 4083: Checking tracker
  ** [10:48:31 2016-02-10] 4083: Sleeping for 5.0 seconds
  ** [10:48:31 2016-02-10] 4083: resque-1.25.2: Waiting for (..)
```

That is ~1 KB/minute or ~0.5 GB per year, lets disable this -not required- verbose mode and make more smooth our out of the box setups :)

cc/ @juanignaciosl please review, thanks!