### PR TITLE
[wip] Adapt Varnish invalidation keys to multi-database format

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -593,9 +593,9 @@ class Table
 
   def varnish_key
     if owner.db_service.cartodb_extension_version_pre_mu?
-      "(^|;;)#{self.owner.database_name}:((?:(?!;;).)*#{self.name}.*)|(table)$"
+      "(^|;;)#{owner.database_name}:((?:(?!;;).)*#{name}.*)|(table)$"
     else
-      "(^|;;)#{self.owner.database_name}:((?:(?!;;).)*#{owner.database_schema}(\\\\\")?\\.#{self.name}.*)|(table)$"
+      "(^|;;)#{owner.database_name}:((?:(?!;;).)*#{owner.database_schema}(\\\\\")?\\.#{name}.*)|(table)$"
     end
   end
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -593,9 +593,9 @@ class Table
 
   def varnish_key
     if owner.db_service.cartodb_extension_version_pre_mu?
-      "^#{self.owner.database_name}:(.*#{self.name}.*)|(table)$"
+      "(^|;;)#{self.owner.database_name}:((?:(?!;;).)*#{self.name}.*)|(table)$"
     else
-      "^#{self.owner.database_name}:(.*#{owner.database_schema}(\\\\\")?\\.#{self.name}.*)|(table)$"
+      "(^|;;)#{self.owner.database_name}:((?:(?!;;).)#{owner.database_schema}(\\\\\")?\\.#{self.name}.*)|(table)$"
     end
   end
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -595,7 +595,7 @@ class Table
     if owner.db_service.cartodb_extension_version_pre_mu?
       "(^|;;)#{self.owner.database_name}:((?:(?!;;).)*#{self.name}.*)|(table)$"
     else
-      "(^|;;)#{self.owner.database_name}:((?:(?!;;).)#{owner.database_schema}(\\\\\")?\\.#{self.name}.*)|(table)$"
+      "(^|;;)#{self.owner.database_name}:((?:(?!;;).)*#{owner.database_schema}(\\\\\")?\\.#{self.name}.*)|(table)$"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1346,9 +1346,9 @@ class User < Sequel::Model
     end
   end
 
-  # return quoated database_schema when needed
+  # return quoted database_schema only when quotes are needed (i.e: hyphens)
   def sql_safe_database_schema
-    if self.database_schema.include?('-')
+    unless self.database_schema.match ~= /^[a-z_][a-z0-9_$]*$/
       return "\"#{self.database_schema}\""
     end
     self.database_schema

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1348,7 +1348,7 @@ class User < Sequel::Model
 
   # return quoted database_schema only when quotes are needed (i.e: hyphens)
   def sql_safe_database_schema
-    unless self.database_schema.match =~ /^[a-z_][a-z0-9_$]*$/
+    unless self.database_schema =~ /^[a-z_][a-z0-9_$]*$/
       return "\"#{self.database_schema}\""
     end
     self.database_schema

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1348,7 +1348,7 @@ class User < Sequel::Model
 
   # return quoted database_schema only when quotes are needed (i.e: hyphens)
   def sql_safe_database_schema
-    unless self.database_schema.match ~= /^[a-z_][a-z0-9_$]*$/
+    unless self.database_schema.match =~ /^[a-z_][a-z0-9_$]*$/
       return "\"#{self.database_schema}\""
     end
     self.database_schema

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1165,7 +1165,7 @@ module CartoDB
                     #       "not_this_one" when table "this" changes :/
                     #       --strk-20131203;
                     #
-                    client.fetch('#{purge_command} obj.http.X-Cache-Channel ~ "^#{@user.database_name}:(.*%s.*)|(cdb_tablemetadata)|(table)$"' % table_name.replace('"',''))
+                    client.fetch('#{purge_command} obj.http.X-Cache-Channel ~ "(^|;;)#{@user.database_name}:((?:(?!;;).)*%s.*)|(cdb_tablemetadata)|(table)$"' % table_name.replace('"',''))
                     break
                   except Exception as err:
                     if trigger_verbose:
@@ -1217,7 +1217,7 @@ module CartoDB
                     #       --strk-20131203;
                     #
                     client = httplib.HTTPConnection('#{varnish_host}', #{varnish_port}, False, timeout)
-                    client.request('PURGE', '/batch', '', {"Invalidation-Match": ('^#{@user.database_name}:(.*%s.*)|(cdb_tablemetadata)|(table)$' % table_name.replace('"',''))  })
+                    client.request('PURGE', '/batch', '', {"Invalidation-Match": ('(^|;;)#{@user.database_name}:((?:(?!;;).)*%s.*)|(cdb_tablemetadata)|(table)$' % table_name.replace('"',''))  })
                     response = client.getresponse()
                     assert response.status == 204
                     break

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -433,7 +433,7 @@ module CartoDB
 
       def varnish_key
         sorted_table_names = related_tables.map{ |table|
-          "#{user.database_schema}.#{table.name}"
+          "#{user.sql_safe_database_schema}.#{table.name}"
         }.sort { |i, j|
           i <=> j
         }.join(',')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1027,8 +1027,8 @@ describe User do
     uuid      = UserTable.where(id: table_id).first.table_visualization.id
 
     CartoDB::Varnish.any_instance.expects(:purge)
-      .with("#{doomed_user.database_name}.*")
-      .returns(true)
+                    .with("#{doomed_user.database_name}.*")
+                    .returns(true)
     CartoDB::Varnish.any_instance.expects(:purge)
       .with("(^|;;)#{doomed_user.database_name}:((?:(?!;;).)*public(\\\\\")?\\.clubbing.*)|(table)$")
       .returns(true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# coding: utf-8
 
 require 'ostruct'
 require_relative '../spec_helper'
@@ -1030,7 +1030,7 @@ describe User do
       .with("#{doomed_user.database_name}.*")
       .returns(true)
     CartoDB::Varnish.any_instance.expects(:purge)
-      .with("^#{doomed_user.database_name}:(.*public(\\\\\")?\\.clubbing.*)|(table)$")
+      .with("(^|;;)#{doomed_user.database_name}:((?:(?!;;).)*public(\\\\\")?\\.clubbing.*)|(table)$")
       .returns(true)
     CartoDB::Varnish.any_instance.expects(:purge)
       .with(".*#{uuid}:vizjson")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1026,13 +1026,16 @@ describe User do
     table_id  = data_import.table_id
     uuid      = UserTable.where(id: table_id).first.table_visualization.id
 
-    CartoDB::Varnish.any_instance.expects(:purge)
-                    .with("#{doomed_user.database_name}.*")
-                    .returns(true)
-    CartoDB::Varnish.any_instance.expects(:purge)
+    CartoDB::Varnish
+      .any_instance.expects(:purge)
+      .with("#{doomed_user.database_name}.*")
+      .returns(true)
+    CartoDB::Varnish
+      .any_instance.expects(:purge)
       .with("(^|;;)#{doomed_user.database_name}:((?:(?!;;).)*public(\\\\\")?\\.clubbing.*)|(table)$")
       .returns(true)
-    CartoDB::Varnish.any_instance.expects(:purge)
+    CartoDB::Varnish
+      .any_instance.expects(:purge)
       .with(".*#{uuid}:vizjson")
       .times(2 + 5)
       .returns(true)


### PR DESCRIPTION
With FDWs, tables can come from multiple databases.

This is specified on the X-Cache-Channel by:
`database_name:table1,table2;;other_database_name:table2,table3`

This changes the regex in the invalidation triggers to match this new schema and ensure that tables called the same on different databases don't invalidate each other: 
http://rubular.com/r/TSwsUWnRtL

Also, ensures that X-Cache-Channel keys involving schemas with special characters are fully-qualified (related with https://github.com/CartoDB/cartodb-postgresql/issues/198)

cc @rafatower