### PR TITLE
fixes avatar urls, now they can point to an absolute url or a local url.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -612,7 +612,7 @@ class User < Sequel::Model
       # If the user doesn't have gravatar try to get a cartodb avatar
       if self.avatar_url.nil? || self.avatar_url == "//#{default_avatar}"
         # Only update the avatar if the user avatar is nil or the default image
-        self.avatar_url = "//#{cartodb_avatar}"
+        self.avatar_url = "#{cartodb_avatar}"
         self.this.update avatar_url: self.avatar_url
       end
     end
@@ -638,7 +638,7 @@ class User < Sequel::Model
   end
 
   def default_avatar
-    return "cartodb.s3.amazonaws.com/static/public_dashboard_default_avatar.png"
+    "/assets/unversioned/images/avatars/public_dashboard_default_avatar.png"
   end
 
   def gravatar(protocol = "http://", size = 128, default_image = default_avatar)

--- a/app/views/admin/shared/_dashboard_header.erb
+++ b/app/views/admin/shared/_dashboard_header.erb
@@ -39,7 +39,7 @@
 
         <li class="Header-settingsItem Header-settingsItem--avatar">
           <button class="UserAvatar js-settings-dropdown">
-            <%= image_tag current_user.avatar, :class => 'UserAvatar-img UserAvatar-img--medium' %>
+              <img src="<%= current_user.avatar %>" class='UserAvatar-img UserAvatar-img--medium' />
           </button>
         </li>
       </ul>

--- a/app/views/admin/shared/_private_header.erb
+++ b/app/views/admin/shared/_private_header.erb
@@ -43,7 +43,7 @@
         <% end %>
         <li class="Header-settingsItem Header-settingsItem--avatar">
           <button class="UserAvatar js-settings-dropdown">
-            <%= image_tag current_user.avatar, :class => 'UserAvatar-img UserAvatar-img--medium' %>
+            <img src="<%= current_user.avatar %>" class='UserAvatar-img UserAvatar-img--medium' />
           </button>
         </li>
       </ul>

--- a/lib/build/tasks/copy.js
+++ b/lib/build/tasks/copy.js
@@ -115,6 +115,14 @@
             dest: '<%= assets_dir %>/images/'
           },
 
+          // avatars should be placed in a unversioned folder
+          {
+            expand: true,
+            cwd: "app/assets/images/avatars/",
+            src: ['**/*'],
+            dest: '<%= root_assets_dir %>/unversioned/images/avatars/'
+          },
+
             // CartoDB.js images
 
           {


### PR DESCRIPTION
- this change requires to modify product chef script so base_url contains a "//" at the begging, rails no longer gets the url as a absolute one cc @santisaez @azamorano 
- requires changes in onpremise configuration, in app_config, avatars section should be like
```
 avatars:
    base_url: '/assets/unversioned/images/avatars'
    kinds: ['star', 'mountain', 'heart', 'ghost', 'planet']
    colors: ['green', 'yellow', 'red', 'orange']

```

- I removed image_tag because was doing magic (prepending assets path when the image is not absolute)

cc @xavijam 
