### PR TITLE
Set maxredirs Typhoeus value

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -25,6 +25,7 @@ module CartoDB
       # in seconds
       HTTP_CONNECT_TIMEOUT = 60
       DEFAULT_HTTP_REQUEST_TIMEOUT = 600
+      MAX_REDIRECTS = 5
       URL_ESCAPED_CHARACTERS = 'áéíóúÁÉÍÓÚñÑçÇàèìòùÀÈÌÒÙ'
 
       DEFAULT_FILENAME        = 'importer'
@@ -230,7 +231,8 @@ module CartoDB
           ssl_verifyhost:   (verify_ssl ? 2 : 0),
           forbid_reuse:     true,
           connecttimeout:   HTTP_CONNECT_TIMEOUT,
-          timeout:          http_options.fetch(:http_timeout, DEFAULT_HTTP_REQUEST_TIMEOUT)
+          timeout:          http_options.fetch(:http_timeout, DEFAULT_HTTP_REQUEST_TIMEOUT),
+          maxredirs:        MAX_REDIRECTS
         }
       end
 


### PR DESCRIPTION
This change add a new option for Typhoeus in the importer downloader
that could avoid infinite loops on it. The MAX_REDIRECT constant has
been set to 5.

Closes https://github.com/CartoDB/cartodb/issues/6550

When tested at development and exceeded the maximum, the following
import error is being reported:

![image](https://cloud.githubusercontent.com/assets/1730320/13051579/343bdbae-d3fa-11e5-8e4a-40ec2bf55917.png)

Find Typhoeus options [here](http://www.rubydoc.info/gems/typhoeus/0.4.2/Typhoeus/Curl).