### PR TITLE
Add tab pane and numbered header styles

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-factory.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-factory.js
@@ -18,6 +18,8 @@ module.exports = {
    * }
    */
   createWithTextLabels: function (paneItems, options) {
+    var tabPaneItemLabelOptions = options && options.tabPaneItemLabelOptions;
+
     var items = _.map(paneItems, function (paneItem) {
       _.each(['label', 'createContentView'], function (check) {
         if (!paneItem[check]) {
@@ -29,7 +31,7 @@ module.exports = {
         selected: paneItem.selected,
         label: paneItem.label,
         createButtonView: function () {
-          return new LabelView({ model: this });
+          return new LabelView(_.extend({ model: this }, tabPaneItemLabelOptions));
         },
         createContentView: function () {
           return paneItem.createContentView && paneItem.createContentView() || new cdb.core.View();
@@ -39,7 +41,9 @@ module.exports = {
 
     var collection = new TabPaneCollection(items);
 
-    return new TabPaneView(_.extend({}, options, {
+    var tabPaneOptions = options && options.tabPaneOptions;
+
+    return new TabPaneView(_.extend({}, tabPaneOptions, {
       collection: collection
     }));
   },
@@ -73,7 +77,9 @@ module.exports = {
 
     var collection = new TabPaneCollection(items);
 
-    return new TabPaneView(_.extend({}, options, {
+    var tabPaneOptions = options && options.tabPaneOptions;
+
+    return new TabPaneView(_.extend({}, tabPaneOptions, {
       collection: collection
     }));
   }

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-factory.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-factory.js
@@ -56,6 +56,8 @@ module.exports = {
    * }
    */
   createWithIcons: function (paneItems, options) {
+    var tabPaneItemIconOptions = options && options.tabPaneItemIconOptions;
+
     var items = _.map(paneItems, function (paneItem) {
       _.each(['icon', 'createContentView'], function (check) {
         if (!paneItem[check]) {
@@ -67,7 +69,7 @@ module.exports = {
         selected: paneItem.selected,
         icon: paneItem.icon,
         createButtonView: function () {
-          return new IconView({ model: this });
+          return new IconView(_.extend({ model: this }, tabPaneItemIconOptions));
         },
         createContentView: function () {
           return paneItem.createContentView && paneItem.createContentView() || new cdb.core.View();

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-item-view.js
@@ -23,6 +23,7 @@ module.exports = cdb.core.View.extend({
     var view = this.model.get('createButtonView').call(this.model);
     this.addView(view);
     this.$el.append(view.render().$el);
+    this.$el.toggleClass('is-selected', !!this.model.get('selected'));
 
     return this;
   },

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-label-view.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-label-view.js
@@ -14,7 +14,7 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
-    this.$el.append(this.model.get('label'));
+    this.$el.html(this.model.get('label'));
     return this;
   }
 });

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-view.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-view.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var cdb = require('cartodb-deep-insights.js');
 var TabPaneItem = require('./tab-pane-item-view.js');
 var Template = require('./tab-pane.tpl');
@@ -14,6 +15,7 @@ module.exports = cdb.core.View.extend({
       throw new Error('A TabPaneCollection should be provided');
     }
 
+    this._tabPaneItemOptions = this.options.tabPaneItemOptions;
     this.template = this.options.template || Template;
 
     this.collection.bind('change:selected', this._renderSelected, this);
@@ -51,7 +53,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderTabPaneItemView: function (model) {
-    var tabPaneItemView = new TabPaneItem({ model: model });
+    var tabPaneItemView = new TabPaneItem(_.extend({ model: model }, this._tabPaneItemOptions));
     this.addView(tabPaneItemView);
     this.$('.js-menu').append(tabPaneItemView.render().$el);
   },

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -118,8 +118,10 @@ var editorTabPaneView = TabPaneViewFactory.createWithIcons([
       });
     }
   }], {
-    className: 'Editor-wrapper',
-    template: EditorPaneTemplate
+    tabPaneOptions: {
+      className: 'Editor-wrapper',
+      template: EditorPaneTemplate
+    }
   });
 
 $('.js-editor').prepend(editorTabPaneView.render().$el);

--- a/lib/assets/javascripts/cartodb3/editor/map/map-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/map/map-view.js
@@ -45,18 +45,18 @@ module.exports = cdb.core.View.extend({
     }]);
 
     var mapTabPaneView = TabPaneViewFactory.createWithTextLabels([{
-      label: 'LAYERS',
+      label: _t('editor.layers.title'),
       selected: true,
       createContentView: function () {
         return new cdb.core.View();
       }
     }, {
-      label: 'ELEMENTS',
+      label: _t('editor.elements.title'),
       createContentView: function () {
         return new cdb.core.View();
       }
     }, {
-      label: 'WIDGETS',
+      label: _t('editor.widgets.title'),
       createContentView: function () {
         return new StackLayoutView({
           collection: stackViewCollection

--- a/lib/assets/javascripts/cartodb3/editor/map/map-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/map/map-view.js
@@ -4,6 +4,7 @@ var EditorWidgetsView = require('../widgets/widgets-view');
 var TabPaneViewFactory = require('../../components/tab-pane/tab-pane-factory');
 var StackLayoutView = require('../../components/stack-layout/stack-layout-view');
 var WidgetsFormContentView = require('../widgets/widgets-form/widgets-form-content-view');
+var TabPaneTemplate = require('./tab-pane-template.tpl');
 
 module.exports = cdb.core.View.extend({
   initialize: function (opts) {
@@ -38,24 +39,38 @@ module.exports = cdb.core.View.extend({
     }]);
 
     var mapTabPaneView = TabPaneViewFactory.createWithTextLabels([{
-      label: 'layers',
+      label: 'LAYERS',
       selected: true,
       createContentView: function () {
         return new cdb.core.View();
       }
     }, {
-      label: 'elements',
+      label: 'ELEMENTS',
       createContentView: function () {
         return new cdb.core.View();
       }
     }, {
-      label: 'widgets',
+      label: 'WIDGETS',
       createContentView: function () {
         return new StackLayoutView({
           collection: stackViewCollection
         });
       }
-    }]);
+    }], {
+      tabPaneOptions: {
+        tagName: 'nav',
+        className: 'CDB-NavMenu',
+        template: TabPaneTemplate,
+        tabPaneItemOptions: {
+          tagName: 'li',
+          className: 'CDB-NavMenu-Item'
+        }
+      },
+      tabPaneItemLabelOptions: {
+        tagName: 'button',
+        className: 'CDB-NavMenu-Link'
+      }
+    });
 
     this.$el.append(mapTabPaneView.render().$el);
     return this;

--- a/lib/assets/javascripts/cartodb3/editor/map/tab-pane-template.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/map/tab-pane-template.tpl
@@ -1,0 +1,4 @@
+<nav class="CDB-NavMenu">
+  <ul class="CDB-NavMenu-Inner CDB-Text is-semibold CDB-Size-medium js-menu"></ul>
+  <div class="js-content"></div>
+</nav>

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-data-view.js
@@ -26,7 +26,12 @@ module.exports = cdb.core.View.extend({
     // TODO: carousel -> Form Widget Type
     var types = WidgetFormFactory.getDataTypes(this._tableModel);
 
-    var $typeSelect = $(typesTemplate({ types: types }));
+    var $typeSelect = $(typesTemplate({
+      types: types,
+      title: _t('editor.widgets.widgets-form.type.title'),
+      description: _t('editor.widgets.widgets-form.type.description')
+    }));
+
     $typeSelect.change(function (newType) {
       self._widgetDefinitionModel.changeType(this.value);
     });

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.js
@@ -3,6 +3,7 @@ var $ = require('jquery');
 var WidgetsFormContentDataView = require('./widgets-form-content-data-view');
 var WidgetsFormContentStyleView = require('./widgets-form-content-style-view');
 var TabPaneViewFactory = require('../../../components/tab-pane/tab-pane-factory');
+var TabPaneTemplate = require('../../map/tab-pane-template.tpl');
 
 /**
  * View to render all necessary for the widget form
@@ -45,7 +46,7 @@ module.exports = cdb.core.View.extend({
 
     this.tabPaneItems = [{
       selected: true,
-      label: _t('editor.widgets.widgets-form.data'),
+      label: _t('editor.widgets.widgets-form.data.title'),
       createContentView: function () {
         return new WidgetsFormContentDataView({
           widgetDefinitionModel: self._widgetDefinitionModel,
@@ -54,7 +55,7 @@ module.exports = cdb.core.View.extend({
       }
     }, {
       selected: false,
-      label: _t('editor.widgets.widgets-form.style'),
+      label: _t('editor.widgets.widgets-form.style.title'),
       createContentView: function () {
         return new WidgetsFormContentStyleView({
           widgetDefinitionModel: self._widgetDefinitionModel
@@ -62,7 +63,23 @@ module.exports = cdb.core.View.extend({
       }
     }];
 
-    this.tabPaneView = TabPaneViewFactory.createWithTextLabels(this.tabPaneItems);
+    var options = {
+      tabPaneOptions: {
+        tagName: 'nav',
+        className: 'CDB-NavMenu',
+        template: TabPaneTemplate,
+        tabPaneItemOptions: {
+          tagName: 'li',
+          className: 'CDB-NavMenu-Item'
+        }
+      },
+      tabPaneItemLabelOptions: {
+        tagName: 'button',
+        className: 'CDB-NavMenu-Link'
+      }
+    };
+
+    this.tabPaneView = TabPaneViewFactory.createWithTextLabels(this.tabPaneItems, options);
     this.$el.append(this.tabPaneView.render().$el);
   },
 

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data-view.js
@@ -2,6 +2,7 @@ var cdb = require('cartodb.js');
 var $ = require('jquery');
 var WidgetFormFactory = require('./widgets-form-factory');
 var Backbone = require('backbone');
+var Template = require('./widgets-form-data.tpl');
 require('backbone-forms');
 Backbone.$ = $;
 
@@ -22,15 +23,31 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
-    if (this._widgetFormView) this._widgetFormView.remove();
+    this.clearSubViews();
+    this.$el.empty();
+    this.$el.html(Template({
+      title: _t('editor.widgets.widgets-form.data.title'),
+      description: _t('editor.widgets.widgets-form.data.description')
+    }));
+    this._initViews();
+    return this;
+  },
+
+  _initViews: function () {
+    if (this._widgetFormView) {
+      this._widgetFormView.remove();
+    }
+
     this._widgetFormView = new Backbone.Form({
       model: this._widgetFormModel
     });
+
     this._widgetFormView.bind('change', function () {
       var errors = this.commit();
       console.log('errors', errors);
     });
-    this.$el.html(this._widgetFormView.render().$el);
+
+    this.$('.js-content').html(this._widgetFormView.render().$el);
 
     return this;
   },

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data.tpl
@@ -1,17 +1,13 @@
 <div class="CDB-HeaderInfo">
-  <div class="CDB-HeaderNumeration CDB-Text is-semibold u-rSpace--m">1</div>
+  <div class="CDB-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
 
   <div class="CDB-HeaderInfo-Inner CDB-Text">
     <div class="CDB-HeaderInfo-Title u-bSpace--m">
       <h2 class="CDB-Text CDB-HeaderInfo-TitleText CDB-Size-large"><%- title %></h2>
     </div>
-
     <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- description %></p>
 
-    <select>
-      <% _.each(types, function(type) { %>
-      <option value="<%- type.value %>"><%- type.label %></option>
-      <% }); %>
-    </select>
+    <div class="js-content"></div>
+
   </div>
 </div>

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-style-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-style-view.js
@@ -2,11 +2,12 @@ var cdb = require('cartodb.js');
 var $ = require('jquery');
 var WidgetFormFactory = require('./widgets-form-factory');
 var Backbone = require('backbone');
+var Template = require('./widgets-form-style.tpl');
 require('backbone-forms');
 Backbone.$ = $;
 
 /**
- * View to render widgets form
+ * View of form to edit a widget definition's style
  */
 module.exports = cdb.core.View.extend({
 
@@ -23,6 +24,10 @@ module.exports = cdb.core.View.extend({
   render: function () {
     this.clearSubViews();
     this.$el.empty();
+    this.$el.html(Template({
+      title: _t('editor.widgets.widgets-form.style.title'),
+      description: _t('editor.widgets.widgets-form.style.description')
+    }));
     this._initViews();
     return this;
   },
@@ -35,11 +40,13 @@ module.exports = cdb.core.View.extend({
     this._widgetFormView = new Backbone.Form({
       model: this._widgetFormModel
     });
+
     this._widgetFormView.bind('change', function () {
       var errors = this.commit();
       console.log('errors', errors);
     });
-    this.$el.append(this._widgetFormView.render().$el);
+
+    this.$('.js-content').html(this._widgetFormView.render().$el);
   },
 
   clean: function () {

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-style.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-style.tpl
@@ -5,13 +5,9 @@
     <div class="CDB-HeaderInfo-Title u-bSpace--m">
       <h2 class="CDB-Text CDB-HeaderInfo-TitleText CDB-Size-large"><%- title %></h2>
     </div>
-
     <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- description %></p>
 
-    <select>
-      <% _.each(types, function(type) { %>
-      <option value="<%- type.value %>"><%- type.label %></option>
-      <% }); %>
-    </select>
+    <div class="js-content"></div>
+
   </div>
 </div>

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -9,7 +9,14 @@
       "continue-btn": "Continue",
       "fetching-tables-title": "Loading tables"
     },
+    "layers": {
+      "title": "LAYERS",
+    },
+    "elements": {
+      "title": "ELEMENTS",
+    },
     "widgets": {
+      "title": "WIDGETS",
       "widgets-form": {
         "type": {
           "title": "Type",

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -5,8 +5,18 @@
     "map_pluralize": "%{smart_count} map |||| %{smart_count} maps",
     "widgets": {
       "widgets-form": {
-        "data": "Data",
-        "style": "Style"
+        "type": {
+          "title": "Type",
+          "description": "Choose the widget type"
+        },
+        "data": {
+          "title": "Data",
+          "description": "Configure your values"
+        },
+        "style": {
+          "title": "Style",
+          "description": "Apply style to your visualization"
+        },
       },
       "edit": "Edit",
       "type": {

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-factory.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-factory.spec.js
@@ -7,18 +7,18 @@ describe('components/tab-pane-factory', function () {
   describe('with text labels', function () {
     beforeEach(function () {
       this.items = [{
-          selected: false,
-          label: 'label one',
-          createContentView: function () {
-            return new cdb.core.View();
-          }
-        }, {
-          selected: false,
-          label: 'label two',
-          createContentView: function () {
-            return new cdb.core.View();
-          }
-        }];
+        selected: false,
+        label: 'label one',
+        createContentView: function () {
+          return new cdb.core.View();
+        }
+      }, {
+        selected: false,
+        label: 'label two',
+        createContentView: function () {
+          return new cdb.core.View();
+        }
+      }];
     });
 
     it('should create view', function () {
@@ -117,14 +117,24 @@ describe('components/tab-pane-factory', function () {
       expect(function () { TabPaneViewFactory.createWithIcons(items); }).toThrow(new Error('createContentView should be provided'));
     });
 
-    it('should allow to set the className', function () {
+    it('should allow to set custom options for the pane and its items', function () {
       var view = TabPaneViewFactory.createWithIcons(this.items, {
         tabPaneOptions: {
-          className: 'MyCoolIconTabPane'
+          className: 'MyCoolIconTabPane',
+          tabPaneItemOptions: {
+            tagName: 'li',
+            className: 'CDB-NavMenu-Item'
+          }
+        },
+        tabPaneItemIconOptions: {
+          tagName: 'button',
+          className: 'CDB-NavMenu-Link'
         }
       });
       view.render();
       expect(view.$el.hasClass('MyCoolIconTabPane')).toBeTruthy();
+      expect(view.$el.find('li.CDB-NavMenu-Item').length).toBe(2);
+      expect(view.$el.find('button.CDB-NavMenu-Link').length).toBe(2);
     });
   });
 });

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-factory.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-factory.spec.js
@@ -53,7 +53,9 @@ describe('components/tab-pane-factory', function () {
 
     it('should allow to set the className', function () {
       var view = TabPaneViewFactory.createWithTextLabels(this.items, {
-        className: 'MyCoolLabelTabPane'
+        tabPaneOptions: {
+          className: 'MyCoolLabelTabPane'
+        }
       });
       view.render();
       expect(view.$el.hasClass('MyCoolLabelTabPane')).toBeTruthy();
@@ -109,7 +111,9 @@ describe('components/tab-pane-factory', function () {
 
     it('should allow to set the className', function () {
       var view = TabPaneViewFactory.createWithIcons(this.items, {
-        className: 'MyCoolIconTabPane'
+        tabPaneOptions: {
+          className: 'MyCoolIconTabPane'
+        }
       });
       view.render();
       expect(view.$el.hasClass('MyCoolIconTabPane')).toBeTruthy();

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-factory.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-factory.spec.js
@@ -6,8 +6,7 @@ var cdb = require('cartodb-deep-insights.js');
 describe('components/tab-pane-factory', function () {
   describe('with text labels', function () {
     beforeEach(function () {
-      this.items = [
-        {
+      this.items = [{
           selected: false,
           label: 'label one',
           createContentView: function () {
@@ -19,8 +18,7 @@ describe('components/tab-pane-factory', function () {
           createContentView: function () {
             return new cdb.core.View();
           }
-        }
-      ];
+        }];
     });
 
     it('should create view', function () {
@@ -51,14 +49,24 @@ describe('components/tab-pane-factory', function () {
       expect(function () { TabPaneViewFactory.createWithTextLabels(items); }).toThrow(new Error('createContentView should be provided'));
     });
 
-    it('should allow to set the className', function () {
+    it('should allow to set custom options for the pane and its items', function () {
       var view = TabPaneViewFactory.createWithTextLabels(this.items, {
         tabPaneOptions: {
-          className: 'MyCoolLabelTabPane'
+          className: 'MyCoolLabelTabPane',
+          tabPaneItemOptions: {
+            tagName: 'li',
+            className: 'CDB-NavMenu-Item'
+          }
+        },
+        tabPaneItemLabelOptions: {
+          tagName: 'button',
+          className: 'CDB-NavMenu-Link'
         }
       });
       view.render();
       expect(view.$el.hasClass('MyCoolLabelTabPane')).toBeTruthy();
+      expect(view.$el.find('li.CDB-NavMenu-Item').length).toBe(2);
+      expect(view.$el.find('button.CDB-NavMenu-Link').length).toBe(2);
     });
   });
 

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-item-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-item-view.spec.js
@@ -22,6 +22,20 @@ describe('components/tab-pane-item-view', function () {
   it('should select the view', function () {
     this.view.$el.click();
     expect(this.view.model.get('selected')).toBeTruthy();
+    expect(this.view.$el.hasClass('is-selected')).toBeTruthy();
+  });
+
+  it('should add the selected class on the start', function () {
+    var view = new TabPaneItemView({
+      model: new cdb.core.Model({
+        selected: true,
+        createButtonView: function () {
+          return new cdb.core.View();
+        }
+      })
+    }).render();
+
+    expect(view.$el.hasClass('is-selected')).toBeTruthy();
   });
 
   afterEach(function () {

--- a/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
@@ -19,8 +19,8 @@ describe('editor/map/map-view', function () {
   });
 
   it('should render correctly', function () {
-    expect(this.view.$el.text()).toContain('LAYERS');
-    expect(this.view.$el.text()).toContain('ELEMENTS');
-    expect(this.view.$el.text()).toContain('WIDGETS');
+    expect(this.view.$el.text()).toContain('editor.layers.title');
+    expect(this.view.$el.text()).toContain('editor.elements.title');
+    expect(this.view.$el.text()).toContain('editor.widgets.title');
   });
 });

--- a/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
@@ -16,8 +16,8 @@ describe('editor/map/map-view', function () {
   });
 
   it('should render correctly', function () {
-    expect(this.view.$el.text()).toContain('layers');
-    expect(this.view.$el.text()).toContain('elements');
-    expect(this.view.$el.text()).toContain('widgets');
+    expect(this.view.$el.text()).toContain('LAYERS');
+    expect(this.view.$el.text()).toContain('ELEMENTS');
+    expect(this.view.$el.text()).toContain('WIDGETS');
   });
 });

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.spec.js
@@ -40,7 +40,7 @@ describe('editor/widgets/widgets-form/widgets-form-content-view', function () {
   });
 
   it('should generate the right tabs', function () {
-    expect(this.widgetsFormContentView.$el.text()).toContain('editor.widgets.widgets-form.data');
-    expect(this.widgetsFormContentView.$el.text()).toContain('editor.widgets.widgets-form.style');
+    expect(this.widgetsFormContentView.$el.text()).toContain('editor.widgets.widgets-form.data.title');
+    expect(this.widgetsFormContentView.$el.text()).toContain('editor.widgets.widgets-form.style.title');
   });
 });


### PR DESCRIPTION
![tabpane](https://cloud.githubusercontent.com/assets/4933/13105786/2ffc6556-d565-11e5-890f-22a8858a44df.gif)

In order to style the different elements of the tab pane, the factories have been modified to allow the use custom options:

```      
var view = TabPaneViewFactory.createWithTextLabels(this.items, {
  tabPaneOptions: {
    className: 'MyCoolLabelTabPane',
    tabPaneItemOptions: {
      tagName: 'li',
      className: 'CDB-NavMenu-Item'
    }
  },
  tabPaneItemLabelOptions: {
    tagName: 'button',
    className: 'CDB-NavMenu-Link'
  }
});
```
Closes #6604 