### PR TITLE
Migration to add new fields for routing service

### DIFF
--- a/db/migrate/20160212170700_add_routing_quota_and_block_price_fields.rb
+++ b/db/migrate/20160212170700_add_routing_quota_and_block_price_fields.rb
@@ -1,0 +1,18 @@
+Sequel.migration do
+  up do
+    add_column :users, :routing_quota, :integer, null: false, default: 0
+    add_column :users, :routing_block_price, :integer
+    add_column :users, :soft_routing_limit, :boolean
+    add_column :organizations, :routing_quota, :integer, null: false, default: 0
+    add_column :organizations, :routing_block_price, :integer
+    add_column :user_creations, :soft_routing_limit, :boolean, default: true
+  end
+
+  down do
+    drop_column :users, :routing_quota
+    drop_column :users, :routing_block_price
+    drop_column :users, :soft_routing_limit
+    drop_column :organizations, :routing_quota
+    drop_column :organizations, :routing_block_price
+  end
+end


### PR DESCRIPTION
We are adding new fields: quota, block_price and soft_limit for the
routing services that are coming. Right now is on dataservices-api
but we need logic here to charge and configure them.