### PR TITLE
Migration to add new fields for routing service

### DIFF
--- a/db/migrate/20160212170700_add_routing_quota_and_block_price_fields.rb
+++ b/db/migrate/20160212170700_add_routing_quota_and_block_price_fields.rb
@@ -1,0 +1,19 @@
+Sequel.migration do
+  up do
+    add_column :users, :here_isolines_quota, :integer, null: false, default: 0
+    add_column :users, :here_isolines_block_price, :integer
+    add_column :users, :soft_here_isolines_limit, :boolean
+    add_column :organizations, :here_isolines_quota, :integer, null: false, default: 0
+    add_column :organizations, :here_isolines_block_price, :integer
+    add_column :user_creations, :soft_here_isolines_limit, :boolean
+  end
+
+  down do
+    drop_column :users, :here_isolines_quota
+    drop_column :users, :here_isolines_block_price
+    drop_column :users, :soft_here_isolines_limit
+    drop_column :organizations, :here_isolines_quota
+    drop_column :organizations, :here_isolines_block_price
+    drop_column :user_creations, :soft_here_isolines_limit
+  end
+end


### PR DESCRIPTION
We are adding new fields: quota, block_price and soft_limit for the
here isolines service that are coming. Right now is on dataservices-api
but we need logic here to charge and configure them.