### PR TITLE
Apply shrinkwrap to lock down package to latest versions

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,13906 @@
+{
+  "name": "cartodb-ui",
+  "version": "3.23.32",
+  "dependencies": {
+    "autoprefixer-core": {
+      "version": "5.2.1",
+      "from": "autoprefixer-core@5.2.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
+      "dependencies": {
+        "browserslist": {
+          "version": "0.4.0",
+          "from": "browserslist@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz"
+        },
+        "num2fraction": {
+          "version": "1.2.2",
+          "from": "num2fraction@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+        },
+        "caniuse-db": {
+          "version": "1.0.30000409",
+          "from": "caniuse-db@>=1.0.30000214 <2.0.0",
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000409.tgz"
+        },
+        "postcss": {
+          "version": "4.1.16",
+          "from": "postcss@>=4.1.8 <5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+          "dependencies": {
+            "es6-promise": {
+              "version": "2.3.0",
+              "from": "es6-promise@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.8 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "aws-sdk": {
+      "version": "2.0.0-rc11",
+      "from": "aws-sdk@2.0.0-rc11",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.0.0-rc11.tgz",
+      "dependencies": {
+        "xml2js": {
+          "version": "0.2.4",
+          "from": "xml2js@0.2.4",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.4.tgz",
+          "dependencies": {
+            "sax": {
+              "version": "1.1.5",
+              "from": "sax@>=0.4.2",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
+            }
+          }
+        },
+        "xmlbuilder": {
+          "version": "0.4.2",
+          "from": "xmlbuilder@0.4.2",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+        }
+      }
+    },
+    "backbone": {
+      "version": "1.2.3",
+      "from": "backbone@1.2.3",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.3.tgz"
+    },
+    "backbone-forms": {
+      "version": "0.14.0",
+      "from": "backbone-forms@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/backbone-forms/-/backbone-forms-0.14.0.tgz"
+    },
+    "browserify": {
+      "version": "11.0.1",
+      "from": "browserify@11.0.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-11.0.1.tgz",
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.0.7",
+          "from": "JSONStream@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.2.0",
+              "from": "jsonparse@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "through@>=2.2.7 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "assert": {
+          "version": "1.3.0",
+          "from": "assert@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+        },
+        "browser-pack": {
+          "version": "5.0.1",
+          "from": "browser-pack@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
+          "dependencies": {
+            "combine-source-map": {
+              "version": "0.6.1",
+              "from": "combine-source-map@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+              "dependencies": {
+                "convert-source-map": {
+                  "version": "1.1.3",
+                  "from": "convert-source-map@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                },
+                "inline-source-map": {
+                  "version": "0.5.0",
+                  "from": "inline-source-map@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                },
+                "lodash.memoize": {
+                  "version": "3.0.4",
+                  "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "source-map@>=0.4.2 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "umd": {
+              "version": "3.0.1",
+              "from": "umd@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
+            }
+          }
+        },
+        "browser-resolve": {
+          "version": "1.11.1",
+          "from": "browser-resolve@>=1.7.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "from": "browserify-zlib@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "dependencies": {
+            "pako": {
+              "version": "0.2.8",
+              "from": "pako@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+            }
+          }
+        },
+        "buffer": {
+          "version": "3.6.0",
+          "from": "buffer@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "dependencies": {
+            "base64-js": {
+              "version": "0.0.8",
+              "from": "base64-js@0.0.8",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+            },
+            "ieee754": {
+              "version": "1.1.6",
+              "from": "ieee754@>=1.1.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            }
+          }
+        },
+        "builtins": {
+          "version": "0.0.7",
+          "from": "builtins@>=0.0.3 <0.1.0",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+        },
+        "commondir": {
+          "version": "0.0.1",
+          "from": "commondir@0.0.1",
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+        },
+        "concat-stream": {
+          "version": "1.4.10",
+          "from": "concat-stream@>=1.4.1 <1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "dependencies": {
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "from": "constants-browserify@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+        },
+        "crypto-browserify": {
+          "version": "3.11.0",
+          "from": "crypto-browserify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+          "dependencies": {
+            "browserify-cipher": {
+              "version": "1.0.0",
+              "from": "browserify-cipher@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+              "dependencies": {
+                "browserify-aes": {
+                  "version": "1.0.6",
+                  "from": "browserify-aes@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                  "dependencies": {
+                    "buffer-xor": {
+                      "version": "1.0.3",
+                      "from": "buffer-xor@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                    },
+                    "cipher-base": {
+                      "version": "1.0.2",
+                      "from": "cipher-base@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                    }
+                  }
+                },
+                "browserify-des": {
+                  "version": "1.0.0",
+                  "from": "browserify-des@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+                  "dependencies": {
+                    "cipher-base": {
+                      "version": "1.0.2",
+                      "from": "cipher-base@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                    },
+                    "des.js": {
+                      "version": "1.0.0",
+                      "from": "des.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "evp_bytestokey": {
+                  "version": "1.0.0",
+                  "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                }
+              }
+            },
+            "browserify-sign": {
+              "version": "4.0.0",
+              "from": "browserify-sign@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.10.3",
+                  "from": "bn.js@>=4.1.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                },
+                "browserify-rsa": {
+                  "version": "4.0.0",
+                  "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+                },
+                "elliptic": {
+                  "version": "6.2.3",
+                  "from": "elliptic@>=6.0.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    },
+                    "hash.js": {
+                      "version": "1.0.3",
+                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "parse-asn1": {
+                  "version": "5.0.0",
+                  "from": "parse-asn1@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+                  "dependencies": {
+                    "asn1.js": {
+                      "version": "4.5.0",
+                      "from": "asn1.js@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "browserify-aes": {
+                      "version": "1.0.6",
+                      "from": "browserify-aes@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                      "dependencies": {
+                        "buffer-xor": {
+                          "version": "1.0.3",
+                          "from": "buffer-xor@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                        },
+                        "cipher-base": {
+                          "version": "1.0.2",
+                          "from": "cipher-base@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "evp_bytestokey": {
+                      "version": "1.0.0",
+                      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "create-ecdh": {
+              "version": "4.0.0",
+              "from": "create-ecdh@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.10.3",
+                  "from": "bn.js@>=4.1.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                },
+                "elliptic": {
+                  "version": "6.2.3",
+                  "from": "elliptic@>=6.0.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    },
+                    "hash.js": {
+                      "version": "1.0.3",
+                      "from": "hash.js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "create-hash": {
+              "version": "1.1.2",
+              "from": "create-hash@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+              "dependencies": {
+                "cipher-base": {
+                  "version": "1.0.2",
+                  "from": "cipher-base@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                },
+                "ripemd160": {
+                  "version": "1.0.1",
+                  "from": "ripemd160@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+                },
+                "sha.js": {
+                  "version": "2.4.4",
+                  "from": "sha.js@>=2.3.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+                }
+              }
+            },
+            "create-hmac": {
+              "version": "1.1.4",
+              "from": "create-hmac@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+            },
+            "diffie-hellman": {
+              "version": "5.0.2",
+              "from": "diffie-hellman@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.10.3",
+                  "from": "bn.js@>=4.1.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                },
+                "miller-rabin": {
+                  "version": "4.0.0",
+                  "from": "miller-rabin@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "pbkdf2": {
+              "version": "3.0.4",
+              "from": "pbkdf2@>=3.0.3 <4.0.0",
+              "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
+            },
+            "public-encrypt": {
+              "version": "4.0.0",
+              "from": "public-encrypt@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "4.10.3",
+                  "from": "bn.js@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                },
+                "browserify-rsa": {
+                  "version": "4.0.0",
+                  "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+                },
+                "parse-asn1": {
+                  "version": "5.0.0",
+                  "from": "parse-asn1@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+                  "dependencies": {
+                    "asn1.js": {
+                      "version": "4.5.0",
+                      "from": "asn1.js@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "browserify-aes": {
+                      "version": "1.0.6",
+                      "from": "browserify-aes@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                      "dependencies": {
+                        "buffer-xor": {
+                          "version": "1.0.3",
+                          "from": "buffer-xor@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                        },
+                        "cipher-base": {
+                          "version": "1.0.2",
+                          "from": "cipher-base@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "evp_bytestokey": {
+                      "version": "1.0.0",
+                      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "randombytes": {
+              "version": "2.0.2",
+              "from": "randombytes@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.2.tgz"
+            }
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "from": "defined@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+        },
+        "deps-sort": {
+          "version": "1.3.9",
+          "from": "deps-sort@>=1.3.7 <2.0.0",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz"
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "from": "domain-browser@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "from": "duplexer2@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "events": {
+          "version": "1.0.2",
+          "from": "events@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.0.5 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "has": {
+          "version": "1.0.1",
+          "from": "has@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+          "dependencies": {
+            "function-bind": {
+              "version": "1.1.0",
+              "from": "function-bind@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            }
+          }
+        },
+        "htmlescape": {
+          "version": "1.1.0",
+          "from": "htmlescape@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.0.tgz"
+        },
+        "stream-http": {
+          "version": "1.7.1",
+          "from": "stream-http@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-1.7.1.tgz",
+          "dependencies": {
+            "builtin-status-codes": {
+              "version": "1.0.0",
+              "from": "builtin-status-codes@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-1.0.0.tgz"
+            },
+            "foreach": {
+              "version": "2.0.5",
+              "from": "foreach@>=2.0.5 <3.0.0",
+              "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+            },
+            "indexof": {
+              "version": "0.0.1",
+              "from": "indexof@0.0.1",
+              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+            },
+            "object-keys": {
+              "version": "1.0.9",
+              "from": "object-keys@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+            }
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.1",
+          "from": "https-browserify@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "insert-module-globals": {
+          "version": "6.6.3",
+          "from": "insert-module-globals@>=6.4.1 <7.0.0",
+          "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+          "dependencies": {
+            "combine-source-map": {
+              "version": "0.6.1",
+              "from": "combine-source-map@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+              "dependencies": {
+                "convert-source-map": {
+                  "version": "1.1.3",
+                  "from": "convert-source-map@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                },
+                "inline-source-map": {
+                  "version": "0.5.0",
+                  "from": "inline-source-map@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                },
+                "lodash.memoize": {
+                  "version": "3.0.4",
+                  "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "source-map@>=0.4.2 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "is-buffer": {
+              "version": "1.1.2",
+              "from": "is-buffer@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+            },
+            "lexical-scope": {
+              "version": "1.2.0",
+              "from": "lexical-scope@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+              "dependencies": {
+                "astw": {
+                  "version": "2.0.0",
+                  "from": "astw@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "1.2.2",
+                      "from": "acorn@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "labeled-stream-splicer": {
+          "version": "1.0.2",
+          "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+          "dependencies": {
+            "stream-splicer": {
+              "version": "1.3.2",
+              "from": "stream-splicer@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.13-1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    }
+                  }
+                },
+                "readable-wrap": {
+                  "version": "1.0.0",
+                  "from": "readable-wrap@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+                },
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "module-deps": {
+          "version": "3.9.1",
+          "from": "module-deps@>=3.7.11 <4.0.0",
+          "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+          "dependencies": {
+            "detective": {
+              "version": "4.3.1",
+              "from": "detective@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "1.2.2",
+                  "from": "acorn@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                }
+              }
+            },
+            "stream-combiner2": {
+              "version": "1.0.2",
+              "from": "stream-combiner2@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "dependencies": {
+                "through2": {
+                  "version": "0.5.1",
+                  "from": "through2@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "from": "xtend@>=3.0.0 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "from": "os-browserify@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+        },
+        "parents": {
+          "version": "1.0.1",
+          "from": "parents@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+          "dependencies": {
+            "path-platform": {
+              "version": "0.11.15",
+              "from": "path-platform@>=0.11.15 <0.12.0",
+              "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+            }
+          }
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "from": "path-browserify@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+        },
+        "process": {
+          "version": "0.11.2",
+          "from": "process@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+        },
+        "punycode": {
+          "version": "1.4.0",
+          "from": "punycode@>=1.3.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+        },
+        "read-only-stream": {
+          "version": "1.1.1",
+          "from": "read-only-stream@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                }
+              }
+            },
+            "readable-wrap": {
+              "version": "1.0.0",
+              "from": "readable-wrap@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.0.5",
+          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.6",
+              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "from": "resolve@>=1.1.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+        },
+        "shasum": {
+          "version": "1.0.2",
+          "from": "shasum@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+          "dependencies": {
+            "json-stable-stringify": {
+              "version": "0.0.1",
+              "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            },
+            "sha.js": {
+              "version": "2.4.4",
+              "from": "sha.js@>=2.4.4 <2.5.0",
+              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+            }
+          }
+        },
+        "shell-quote": {
+          "version": "0.0.1",
+          "from": "shell-quote@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "from": "stream-browserify@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "subarg": {
+          "version": "1.0.0",
+          "from": "subarg@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            }
+          }
+        },
+        "syntax-error": {
+          "version": "1.1.5",
+          "from": "syntax-error@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.5.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "2.7.0",
+              "from": "acorn@>=2.7.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "from": "tty-browserify@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+        },
+        "url": {
+          "version": "0.10.3",
+          "from": "url@>=0.10.1 <0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            },
+            "querystring": {
+              "version": "0.2.0",
+              "from": "querystring@0.2.0",
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "util@>=0.10.1 <0.11.0",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "from": "vm-browserify@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "dependencies": {
+            "indexof": {
+              "version": "0.0.1",
+              "from": "indexof@0.0.1",
+              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+            }
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "xtend@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        }
+      }
+    },
+    "browserify-resolutions": {
+      "version": "1.0.6",
+      "from": "browserify-resolutions@1.0.6",
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.5 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.26 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "browserify-shim": {
+      "version": "3.8.10",
+      "from": "browserify-shim@3.8.10",
+      "dependencies": {
+        "exposify": {
+          "version": "0.4.3",
+          "from": "exposify@>=0.4.3 <0.5.0",
+          "resolved": "https://registry.npmjs.org/exposify/-/exposify-0.4.3.tgz",
+          "dependencies": {
+            "globo": {
+              "version": "1.0.2",
+              "from": "globo@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/globo/-/globo-1.0.2.tgz",
+              "dependencies": {
+                "accessory": {
+                  "version": "1.0.1",
+                  "from": "accessory@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/accessory/-/accessory-1.0.1.tgz",
+                  "dependencies": {
+                    "dot-parts": {
+                      "version": "1.0.1",
+                      "from": "dot-parts@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/dot-parts/-/dot-parts-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-defined": {
+                  "version": "1.0.0",
+                  "from": "is-defined@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/is-defined/-/is-defined-1.0.0.tgz"
+                },
+                "ternary": {
+                  "version": "1.0.0",
+                  "from": "ternary@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/ternary/-/ternary-1.0.0.tgz"
+                }
+              }
+            },
+            "has-require": {
+              "version": "1.1.0",
+              "from": "has-require@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/has-require/-/has-require-1.1.0.tgz"
+            },
+            "map-obj": {
+              "version": "1.0.1",
+              "from": "map-obj@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+            },
+            "replace-requires": {
+              "version": "1.0.3",
+              "from": "replace-requires@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/replace-requires/-/replace-requires-1.0.3.tgz",
+              "dependencies": {
+                "detective": {
+                  "version": "4.1.1",
+                  "from": "detective@>=4.1.0 <4.2.0",
+                  "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "1.2.2",
+                      "from": "acorn@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                    },
+                    "defined": {
+                      "version": "1.0.0",
+                      "from": "defined@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                    },
+                    "escodegen": {
+                      "version": "1.8.0",
+                      "from": "escodegen@>=1.4.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
+                      "dependencies": {
+                        "estraverse": {
+                          "version": "1.9.3",
+                          "from": "estraverse@>=1.9.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "esprima": {
+                          "version": "2.7.2",
+                          "from": "esprima@>=2.7.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                        },
+                        "optionator": {
+                          "version": "0.8.1",
+                          "from": "optionator@>=0.8.1 <0.9.0",
+                          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
+                          "dependencies": {
+                            "prelude-ls": {
+                              "version": "1.1.2",
+                              "from": "prelude-ls@>=1.1.2 <1.2.0",
+                              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                            },
+                            "deep-is": {
+                              "version": "0.1.3",
+                              "from": "deep-is@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                            },
+                            "wordwrap": {
+                              "version": "1.0.0",
+                              "from": "wordwrap@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                            },
+                            "type-check": {
+                              "version": "0.3.2",
+                              "from": "type-check@>=0.3.2 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                            },
+                            "levn": {
+                              "version": "0.3.0",
+                              "from": "levn@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+                            },
+                            "fast-levenshtein": {
+                              "version": "1.1.3",
+                              "from": "fast-levenshtein@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
+                            }
+                          }
+                        },
+                        "source-map": {
+                          "version": "0.2.0",
+                          "from": "source-map@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "has-require": {
+                  "version": "1.2.2",
+                  "from": "has-require@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/has-require/-/has-require-1.2.2.tgz",
+                  "dependencies": {
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    }
+                  }
+                },
+                "patch-text": {
+                  "version": "1.0.2",
+                  "from": "patch-text@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/patch-text/-/patch-text-1.0.2.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <4.1.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.4.2",
+              "from": "through2@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "from": "xtend@>=2.1.1 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "from": "object-keys@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "transformify": {
+              "version": "0.1.2",
+              "from": "transformify@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/transformify/-/transformify-0.1.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "mothership": {
+          "version": "0.2.0",
+          "from": "mothership@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/mothership/-/mothership-0.2.0.tgz",
+          "dependencies": {
+            "find-parent-dir": {
+              "version": "0.3.0",
+              "from": "find-parent-dir@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz"
+            }
+          }
+        },
+        "rename-function-calls": {
+          "version": "0.1.1",
+          "from": "rename-function-calls@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/rename-function-calls/-/rename-function-calls-0.1.1.tgz",
+          "dependencies": {
+            "detective": {
+              "version": "3.1.0",
+              "from": "detective@>=3.1.0 <3.2.0",
+              "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
+              "dependencies": {
+                "escodegen": {
+                  "version": "1.1.0",
+                  "from": "escodegen@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.4 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    },
+                    "estraverse": {
+                      "version": "1.5.1",
+                      "from": "estraverse@>=1.5.0 <1.6.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                    },
+                    "esutils": {
+                      "version": "1.0.0",
+                      "from": "esutils@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.30 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "esprima-fb": {
+                  "version": "3001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                }
+              }
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.6.3",
+          "from": "resolve@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz"
+        },
+        "through": {
+          "version": "2.3.8",
+          "from": "through@>=2.3.4 <2.4.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        }
+      }
+    },
+    "cartoassets": {
+      "version": "0.1.25",
+      "from": "cartodb/CartoAssets#master",
+      "resolved": "git://github.com/cartodb/CartoAssets.git#1d207bdf5ccb5082716cf01e55b7fc1341638038"
+    },
+    "cartodb-deep-insights.js": {
+      "version": "0.0.1",
+      "from": "cartodb/deep-insights.js#179783e",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#179783ef33e2889eb6021c25c442e8cec3e42736",
+      "dependencies": {
+        "cartodb.js": {
+          "version": "4.0.0-alpha.1",
+          "from": "cartodb/cartodb.js#94bb6f3",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#94bb6f37f3b1a948bda3d59d12d60b94cbe0125d",
+          "dependencies": {
+            "leaflet": {
+              "version": "0.7.3",
+              "from": "leaflet@0.7.3",
+              "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
+            },
+            "mustache": {
+              "version": "1.1.0",
+              "from": "mustache@1.1.0",
+              "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
+            },
+            "torque.js": {
+              "version": "2.15.0",
+              "from": "torque.js@2.15.0",
+              "resolved": "https://registry.npmjs.org/torque.js/-/torque.js-2.15.0.tgz",
+              "dependencies": {
+                "carto": {
+                  "version": "0.15.1-cdb1",
+                  "from": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+                  "resolved": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+                  "dependencies": {
+                    "underscore": {
+                      "version": "1.6.0",
+                      "from": "underscore@>=1.6.0 <1.7.0",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                    },
+                    "mapnik-reference": {
+                      "version": "6.0.5",
+                      "from": "mapnik-reference@>=6.0.2 <6.1.0",
+                      "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
+                    },
+                    "optimist": {
+                      "version": "0.6.1",
+                      "from": "optimist@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                        },
+                        "minimist": {
+                          "version": "0.0.10",
+                          "from": "minimist@>=0.0.1 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "cartoassets": {
+              "version": "0.1.25",
+              "from": "cartodb/CartoAssets#master",
+              "resolved": "git://github.com/cartodb/CartoAssets.git#1d207bdf5ccb5082716cf01e55b7fc1341638038"
+            }
+          }
+        },
+        "d3": {
+          "version": "3.5.8",
+          "from": "d3@3.5.8",
+          "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.8.tgz"
+        },
+        "jstify": {
+          "version": "0.12.0",
+          "from": "jstify@0.12.0",
+          "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.12.0.tgz",
+          "dependencies": {
+            "html-minifier": {
+              "version": "0.7.2",
+              "from": "html-minifier@>=0.7.2 <0.8.0",
+              "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.2.tgz",
+              "dependencies": {
+                "change-case": {
+                  "version": "2.3.1",
+                  "from": "change-case@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+                  "dependencies": {
+                    "camel-case": {
+                      "version": "1.2.2",
+                      "from": "camel-case@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
+                    },
+                    "constant-case": {
+                      "version": "1.1.2",
+                      "from": "constant-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+                    },
+                    "dot-case": {
+                      "version": "1.1.2",
+                      "from": "dot-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
+                    },
+                    "is-lower-case": {
+                      "version": "1.1.3",
+                      "from": "is-lower-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+                    },
+                    "is-upper-case": {
+                      "version": "1.1.2",
+                      "from": "is-upper-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+                    },
+                    "lower-case": {
+                      "version": "1.1.3",
+                      "from": "lower-case@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
+                    },
+                    "lower-case-first": {
+                      "version": "1.0.2",
+                      "from": "lower-case-first@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
+                    },
+                    "param-case": {
+                      "version": "1.1.2",
+                      "from": "param-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
+                    },
+                    "pascal-case": {
+                      "version": "1.1.2",
+                      "from": "pascal-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
+                    },
+                    "path-case": {
+                      "version": "1.1.2",
+                      "from": "path-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
+                    },
+                    "sentence-case": {
+                      "version": "1.1.3",
+                      "from": "sentence-case@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
+                    },
+                    "snake-case": {
+                      "version": "1.1.2",
+                      "from": "snake-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
+                    },
+                    "swap-case": {
+                      "version": "1.1.2",
+                      "from": "swap-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+                    },
+                    "title-case": {
+                      "version": "1.1.2",
+                      "from": "title-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
+                    },
+                    "upper-case": {
+                      "version": "1.1.3",
+                      "from": "upper-case@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+                    },
+                    "upper-case-first": {
+                      "version": "1.1.2",
+                      "from": "upper-case-first@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+                    }
+                  }
+                },
+                "clean-css": {
+                  "version": "3.1.9",
+                  "from": "clean-css@>=3.1.0 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.1.9.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.6.0",
+                      "from": "commander@>=2.6.0 <2.7.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.43 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "cli": {
+                  "version": "0.6.6",
+                  "from": "cli@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "from": "glob@>=3.2.1 <3.3.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "exit": {
+                      "version": "0.1.2",
+                      "from": "exit@0.1.2",
+                      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                    }
+                  }
+                },
+                "concat-stream": {
+                  "version": "1.4.10",
+                  "from": "concat-stream@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "relateurl": {
+                  "version": "0.2.6",
+                  "from": "relateurl@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.3 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "lodash.escape": {
+              "version": "3.0.0",
+              "from": "lodash.escape@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cartodb-pecan": {
+      "version": "0.2.0",
+      "from": "cartodb-pecan@>=0.2.0 <0.3.0"
+    },
+    "cartodb.js": {
+      "version": "4.0.0-alpha.1",
+      "from": "cartodb/cartodb.js#94bb6f3",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#94bb6f37f3b1a948bda3d59d12d60b94cbe0125d",
+      "dependencies": {
+        "jstify": {
+          "version": "0.12.0",
+          "from": "jstify@0.12.0",
+          "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.12.0.tgz",
+          "dependencies": {
+            "html-minifier": {
+              "version": "0.7.2",
+              "from": "html-minifier@>=0.7.2 <0.8.0",
+              "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-0.7.2.tgz",
+              "dependencies": {
+                "change-case": {
+                  "version": "2.3.1",
+                  "from": "change-case@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+                  "dependencies": {
+                    "camel-case": {
+                      "version": "1.2.2",
+                      "from": "camel-case@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
+                    },
+                    "constant-case": {
+                      "version": "1.1.2",
+                      "from": "constant-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+                    },
+                    "dot-case": {
+                      "version": "1.1.2",
+                      "from": "dot-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
+                    },
+                    "is-lower-case": {
+                      "version": "1.1.3",
+                      "from": "is-lower-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+                    },
+                    "is-upper-case": {
+                      "version": "1.1.2",
+                      "from": "is-upper-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+                    },
+                    "lower-case": {
+                      "version": "1.1.3",
+                      "from": "lower-case@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
+                    },
+                    "lower-case-first": {
+                      "version": "1.0.2",
+                      "from": "lower-case-first@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
+                    },
+                    "param-case": {
+                      "version": "1.1.2",
+                      "from": "param-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
+                    },
+                    "pascal-case": {
+                      "version": "1.1.2",
+                      "from": "pascal-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
+                    },
+                    "path-case": {
+                      "version": "1.1.2",
+                      "from": "path-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
+                    },
+                    "sentence-case": {
+                      "version": "1.1.3",
+                      "from": "sentence-case@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
+                    },
+                    "snake-case": {
+                      "version": "1.1.2",
+                      "from": "snake-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
+                    },
+                    "swap-case": {
+                      "version": "1.1.2",
+                      "from": "swap-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+                    },
+                    "title-case": {
+                      "version": "1.1.2",
+                      "from": "title-case@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
+                    },
+                    "upper-case": {
+                      "version": "1.1.3",
+                      "from": "upper-case@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+                    },
+                    "upper-case-first": {
+                      "version": "1.1.2",
+                      "from": "upper-case-first@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+                    }
+                  }
+                },
+                "clean-css": {
+                  "version": "3.1.9",
+                  "from": "clean-css@>=3.1.0 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.1.9.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.6.0",
+                      "from": "commander@>=2.6.0 <2.7.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.43 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "cli": {
+                  "version": "0.6.6",
+                  "from": "cli@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.2.11",
+                      "from": "glob@>=3.2.1 <3.3.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.3.0",
+                          "from": "minimatch@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.7.3",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "exit": {
+                      "version": "0.1.2",
+                      "from": "exit@0.1.2",
+                      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                    }
+                  }
+                },
+                "concat-stream": {
+                  "version": "1.4.10",
+                  "from": "concat-stream@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "relateurl": {
+                  "version": "0.2.6",
+                  "from": "relateurl@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.3 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "lodash.escape": {
+              "version": "3.0.0",
+              "from": "lodash.escape@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "leaflet": {
+          "version": "0.7.3",
+          "from": "leaflet@0.7.3",
+          "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
+        },
+        "mustache": {
+          "version": "1.1.0",
+          "from": "mustache@1.1.0",
+          "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
+        },
+        "torque.js": {
+          "version": "2.15.0",
+          "from": "torque.js@2.15.0",
+          "resolved": "https://registry.npmjs.org/torque.js/-/torque.js-2.15.0.tgz",
+          "dependencies": {
+            "carto": {
+              "version": "0.15.1-cdb1",
+              "from": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+              "resolved": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@>=1.6.0 <1.7.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                },
+                "mapnik-reference": {
+                  "version": "6.0.5",
+                  "from": "mapnik-reference@>=6.0.2 <6.1.0",
+                  "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cartoassets": {
+          "version": "0.1.25",
+          "from": "cartodb/CartoAssets#master",
+          "resolved": "git://github.com/cartodb/CartoAssets.git#1d207bdf5ccb5082716cf01e55b7fc1341638038"
+        }
+      }
+    },
+    "csswring": {
+      "version": "3.0.7",
+      "from": "csswring@>=3.0.5 <4.0.0",
+      "resolved": "https://registry.npmjs.org/csswring/-/csswring-3.0.7.tgz",
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.18.4",
+          "from": "fs-extra@>=0.18.0 <0.19.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.4.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.8",
+              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+            },
+            "jsonfile": {
+              "version": "2.2.3",
+              "from": "jsonfile@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+            },
+            "rimraf": {
+              "version": "2.5.2",
+              "from": "rimraf@>=2.2.8 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "7.0.0",
+                  "from": "glob@>=7.0.0 <8.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "onecolor": {
+          "version": "2.5.0",
+          "from": "onecolor@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.5.0.tgz"
+        },
+        "postcss": {
+          "version": "4.1.16",
+          "from": "postcss@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+          "dependencies": {
+            "es6-promise": {
+              "version": "2.3.0",
+              "from": "es6-promise@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.8 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "git-rev": {
+      "version": "0.2.1",
+      "from": "git-rev@0.2.1",
+      "resolved": "https://registry.npmjs.org/git-rev/-/git-rev-0.2.1.tgz"
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "from": "grunt@0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "from": "async@>=0.1.22 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "coffee-script@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "dateformat@1.0.2-1.2.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "from": "eventemitter2@>=0.4.13 <0.5.0",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@>=3.1.21 <3.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "inherits": {
+              "version": "1.0.2",
+              "from": "inherits@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "iconv-lite@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.12 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "lodash@>=0.9.2 <0.10.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "underscore.string@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "argparse@>=0.1.11 <0.2.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "underscore.string@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "getobject@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "from": "grunt-legacy-util@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.3",
+          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+          "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-available-tasks": {
+      "version": "0.5.4",
+      "from": "grunt-available-tasks@0.5.4",
+      "dependencies": {
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "underscore.string": {
+          "version": "2.4.0",
+          "from": "underscore.string@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+        }
+      }
+    },
+    "grunt-aws": {
+      "version": "0.3.0",
+      "from": "grunt-aws@0.3.0",
+      "dependencies": {
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@>=1.2.11 <1.3.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "lodash": {
+          "version": "1.3.1",
+          "from": "lodash@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz"
+        },
+        "aws-sdk": {
+          "version": "1.12.0",
+          "from": "aws-sdk@>=1.12.0 <1.13.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-1.12.0.tgz",
+          "dependencies": {
+            "xml2js": {
+              "version": "0.2.4",
+              "from": "xml2js@0.2.4",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.4.tgz",
+              "dependencies": {
+                "sax": {
+                  "version": "1.1.5",
+                  "from": "sax@>=0.4.2",
+                  "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz"
+                }
+              }
+            },
+            "xmlbuilder": {
+              "version": "0.4.2",
+              "from": "xmlbuilder@0.4.2",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-browserify": {
+      "version": "4.0.0",
+      "from": "grunt-browserify@4.0.0",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.5 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "from": "resolve@>=1.1.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+        },
+        "watchify": {
+          "version": "3.7.0",
+          "from": "watchify@>=3.3.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.7.0.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.0",
+              "from": "anymatch@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "dependencies": {
+                "arrify": {
+                  "version": "1.0.1",
+                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                },
+                "micromatch": {
+                  "version": "2.3.7",
+                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "from": "arr-diff@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1",
+                          "from": "arr-flatten@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1",
+                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                    },
+                    "braces": {
+                      "version": "1.8.3",
+                      "from": "braces@>=1.8.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.1",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0",
+                                  "from": "is-number@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                },
+                                "isobject": {
+                                  "version": "2.0.0",
+                                  "from": "isobject@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "randomatic": {
+                                  "version": "1.1.5",
+                                  "from": "randomatic@>=1.1.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.4",
+                      "from": "expand-brackets@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                    },
+                    "extglob": {
+                      "version": "0.3.2",
+                      "from": "extglob@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    },
+                    "is-glob": {
+                      "version": "2.0.1",
+                      "from": "is-glob@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+                    },
+                    "kind-of": {
+                      "version": "3.0.2",
+                      "from": "kind-of@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.2",
+                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.0.1",
+                      "from": "normalize-path@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                    },
+                    "object.omit": {
+                      "version": "2.0.0",
+                      "from": "object.omit@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.3",
+                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1",
+                          "from": "is-extendable@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "from": "parse-glob@>=3.0.4 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0",
+                          "from": "glob-base@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                          "dependencies": {
+                            "glob-parent": {
+                              "version": "2.0.0",
+                              "from": "glob-parent@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.2",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.2",
+                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "browserify": {
+              "version": "13.0.0",
+              "from": "browserify@>=13.0.0 <14.0.0",
+              "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.0.0.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "1.0.7",
+                  "from": "JSONStream@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "1.2.0",
+                      "from": "jsonparse@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.2.7 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "assert": {
+                  "version": "1.3.0",
+                  "from": "assert@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+                },
+                "browser-pack": {
+                  "version": "6.0.1",
+                  "from": "browser-pack@>=6.0.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.1.tgz",
+                  "dependencies": {
+                    "combine-source-map": {
+                      "version": "0.7.1",
+                      "from": "combine-source-map@>=0.7.1 <0.8.0",
+                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.1.tgz",
+                      "dependencies": {
+                        "convert-source-map": {
+                          "version": "1.1.3",
+                          "from": "convert-source-map@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                        },
+                        "inline-source-map": {
+                          "version": "0.6.1",
+                          "from": "inline-source-map@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.1.tgz"
+                        },
+                        "lodash.memoize": {
+                          "version": "3.0.4",
+                          "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.4.2",
+                          "from": "source-map@0.4.2",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "umd": {
+                      "version": "3.0.1",
+                      "from": "umd@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
+                    }
+                  }
+                },
+                "browser-resolve": {
+                  "version": "1.11.1",
+                  "from": "browser-resolve@>=1.11.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
+                },
+                "browserify-zlib": {
+                  "version": "0.1.4",
+                  "from": "browserify-zlib@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "dependencies": {
+                    "pako": {
+                      "version": "0.2.8",
+                      "from": "pako@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+                    }
+                  }
+                },
+                "buffer": {
+                  "version": "4.5.0",
+                  "from": "buffer@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.5.0.tgz",
+                  "dependencies": {
+                    "base64-js": {
+                      "version": "1.0.4",
+                      "from": "base64-js@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.4.tgz"
+                    },
+                    "ieee754": {
+                      "version": "1.1.6",
+                      "from": "ieee754@>=1.1.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    }
+                  }
+                },
+                "concat-stream": {
+                  "version": "1.5.1",
+                  "from": "concat-stream@>=1.5.1 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                  "dependencies": {
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    }
+                  }
+                },
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "from": "console-browserify@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "from": "date-now@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                    }
+                  }
+                },
+                "constants-browserify": {
+                  "version": "1.0.0",
+                  "from": "constants-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
+                },
+                "crypto-browserify": {
+                  "version": "3.11.0",
+                  "from": "crypto-browserify@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+                  "dependencies": {
+                    "browserify-cipher": {
+                      "version": "1.0.0",
+                      "from": "browserify-cipher@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+                      "dependencies": {
+                        "browserify-aes": {
+                          "version": "1.0.6",
+                          "from": "browserify-aes@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                          "dependencies": {
+                            "buffer-xor": {
+                              "version": "1.0.3",
+                              "from": "buffer-xor@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                            },
+                            "cipher-base": {
+                              "version": "1.0.2",
+                              "from": "cipher-base@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "browserify-des": {
+                          "version": "1.0.0",
+                          "from": "browserify-des@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+                          "dependencies": {
+                            "cipher-base": {
+                              "version": "1.0.2",
+                              "from": "cipher-base@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                            },
+                            "des.js": {
+                              "version": "1.0.0",
+                              "from": "des.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "evp_bytestokey": {
+                          "version": "1.0.0",
+                          "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "browserify-sign": {
+                      "version": "4.0.0",
+                      "from": "browserify-sign@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "4.10.3",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                        },
+                        "browserify-rsa": {
+                          "version": "4.0.0",
+                          "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+                        },
+                        "elliptic": {
+                          "version": "6.2.3",
+                          "from": "elliptic@>=6.0.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.0.5",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                            },
+                            "hash.js": {
+                              "version": "1.0.3",
+                              "from": "hash.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "parse-asn1": {
+                          "version": "5.0.0",
+                          "from": "parse-asn1@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+                          "dependencies": {
+                            "asn1.js": {
+                              "version": "4.5.0",
+                              "from": "asn1.js@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "browserify-aes": {
+                              "version": "1.0.6",
+                              "from": "browserify-aes@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                              "dependencies": {
+                                "buffer-xor": {
+                                  "version": "1.0.3",
+                                  "from": "buffer-xor@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                                },
+                                "cipher-base": {
+                                  "version": "1.0.2",
+                                  "from": "cipher-base@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "evp_bytestokey": {
+                              "version": "1.0.0",
+                              "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "create-ecdh": {
+                      "version": "4.0.0",
+                      "from": "create-ecdh@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "4.10.3",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                        },
+                        "elliptic": {
+                          "version": "6.2.3",
+                          "from": "elliptic@>=6.0.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.0.5",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                            },
+                            "hash.js": {
+                              "version": "1.0.3",
+                              "from": "hash.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "create-hash": {
+                      "version": "1.1.2",
+                      "from": "create-hash@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+                      "dependencies": {
+                        "cipher-base": {
+                          "version": "1.0.2",
+                          "from": "cipher-base@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                        },
+                        "ripemd160": {
+                          "version": "1.0.1",
+                          "from": "ripemd160@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+                        },
+                        "sha.js": {
+                          "version": "2.4.4",
+                          "from": "sha.js@>=2.3.6 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+                        }
+                      }
+                    },
+                    "create-hmac": {
+                      "version": "1.1.4",
+                      "from": "create-hmac@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+                    },
+                    "diffie-hellman": {
+                      "version": "5.0.2",
+                      "from": "diffie-hellman@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "4.10.3",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                        },
+                        "miller-rabin": {
+                          "version": "4.0.0",
+                          "from": "miller-rabin@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+                          "dependencies": {
+                            "brorand": {
+                              "version": "1.0.5",
+                              "from": "brorand@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pbkdf2": {
+                      "version": "3.0.4",
+                      "from": "pbkdf2@>=3.0.3 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
+                    },
+                    "public-encrypt": {
+                      "version": "4.0.0",
+                      "from": "public-encrypt@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+                      "dependencies": {
+                        "bn.js": {
+                          "version": "4.10.3",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                        },
+                        "browserify-rsa": {
+                          "version": "4.0.0",
+                          "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+                        },
+                        "parse-asn1": {
+                          "version": "5.0.0",
+                          "from": "parse-asn1@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+                          "dependencies": {
+                            "asn1.js": {
+                              "version": "4.5.0",
+                              "from": "asn1.js@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "browserify-aes": {
+                              "version": "1.0.6",
+                              "from": "browserify-aes@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                              "dependencies": {
+                                "buffer-xor": {
+                                  "version": "1.0.3",
+                                  "from": "buffer-xor@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                                },
+                                "cipher-base": {
+                                  "version": "1.0.2",
+                                  "from": "cipher-base@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "evp_bytestokey": {
+                              "version": "1.0.0",
+                              "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "randombytes": {
+                      "version": "2.0.2",
+                      "from": "randombytes@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.2.tgz"
+                    }
+                  }
+                },
+                "deps-sort": {
+                  "version": "2.0.0",
+                  "from": "deps-sort@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz"
+                },
+                "domain-browser": {
+                  "version": "1.1.7",
+                  "from": "domain-browser@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+                },
+                "duplexer2": {
+                  "version": "0.1.4",
+                  "from": "duplexer2@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
+                },
+                "events": {
+                  "version": "1.1.0",
+                  "from": "events@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+                },
+                "has": {
+                  "version": "1.0.1",
+                  "from": "has@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+                  "dependencies": {
+                    "function-bind": {
+                      "version": "1.1.0",
+                      "from": "function-bind@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+                    }
+                  }
+                },
+                "htmlescape": {
+                  "version": "1.1.0",
+                  "from": "htmlescape@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.0.tgz"
+                },
+                "stream-http": {
+                  "version": "2.1.1",
+                  "from": "stream-http@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.1.1.tgz",
+                  "dependencies": {
+                    "builtin-status-codes": {
+                      "version": "2.0.0",
+                      "from": "builtin-status-codes@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
+                    },
+                    "to-arraybuffer": {
+                      "version": "1.0.1",
+                      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+                    }
+                  }
+                },
+                "https-browserify": {
+                  "version": "0.0.1",
+                  "from": "https-browserify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "insert-module-globals": {
+                  "version": "7.0.1",
+                  "from": "insert-module-globals@>=7.0.0 <8.0.0",
+                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+                  "dependencies": {
+                    "combine-source-map": {
+                      "version": "0.7.1",
+                      "from": "combine-source-map@>=0.7.1 <0.8.0",
+                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.1.tgz",
+                      "dependencies": {
+                        "convert-source-map": {
+                          "version": "1.1.3",
+                          "from": "convert-source-map@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                        },
+                        "inline-source-map": {
+                          "version": "0.6.1",
+                          "from": "inline-source-map@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.1.tgz"
+                        },
+                        "lodash.memoize": {
+                          "version": "3.0.4",
+                          "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.4.2",
+                          "from": "source-map@0.4.2",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-buffer": {
+                      "version": "1.1.2",
+                      "from": "is-buffer@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                    },
+                    "lexical-scope": {
+                      "version": "1.2.0",
+                      "from": "lexical-scope@>=1.2.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+                      "dependencies": {
+                        "astw": {
+                          "version": "2.0.0",
+                          "from": "astw@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "from": "acorn@>=1.0.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "labeled-stream-splicer": {
+                  "version": "2.0.0",
+                  "from": "labeled-stream-splicer@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+                  "dependencies": {
+                    "stream-splicer": {
+                      "version": "2.0.0",
+                      "from": "stream-splicer@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz"
+                    }
+                  }
+                },
+                "module-deps": {
+                  "version": "4.0.5",
+                  "from": "module-deps@>=4.0.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.0.5.tgz",
+                  "dependencies": {
+                    "detective": {
+                      "version": "4.3.1",
+                      "from": "detective@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                      "dependencies": {
+                        "acorn": {
+                          "version": "1.2.2",
+                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                        }
+                      }
+                    },
+                    "stream-combiner2": {
+                      "version": "1.1.1",
+                      "from": "stream-combiner2@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
+                    }
+                  }
+                },
+                "os-browserify": {
+                  "version": "0.1.2",
+                  "from": "os-browserify@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+                },
+                "parents": {
+                  "version": "1.0.1",
+                  "from": "parents@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+                  "dependencies": {
+                    "path-platform": {
+                      "version": "0.11.15",
+                      "from": "path-platform@>=0.11.15 <0.12.0",
+                      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+                    }
+                  }
+                },
+                "path-browserify": {
+                  "version": "0.0.0",
+                  "from": "path-browserify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+                },
+                "process": {
+                  "version": "0.11.2",
+                  "from": "process@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+                },
+                "punycode": {
+                  "version": "1.4.0",
+                  "from": "punycode@>=1.3.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+                },
+                "querystring-es3": {
+                  "version": "0.2.1",
+                  "from": "querystring-es3@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+                },
+                "read-only-stream": {
+                  "version": "2.0.0",
+                  "from": "read-only-stream@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                },
+                "shasum": {
+                  "version": "1.0.2",
+                  "from": "shasum@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+                  "dependencies": {
+                    "json-stable-stringify": {
+                      "version": "0.0.1",
+                      "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                      "dependencies": {
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "from": "jsonify@>=0.0.0 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                        }
+                      }
+                    },
+                    "sha.js": {
+                      "version": "2.4.4",
+                      "from": "sha.js@>=2.4.4 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+                    }
+                  }
+                },
+                "shell-quote": {
+                  "version": "1.4.3",
+                  "from": "shell-quote@>=1.4.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+                  "dependencies": {
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "from": "jsonify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    },
+                    "array-filter": {
+                      "version": "0.0.1",
+                      "from": "array-filter@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+                    },
+                    "array-reduce": {
+                      "version": "0.0.0",
+                      "from": "array-reduce@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                    },
+                    "array-map": {
+                      "version": "0.0.0",
+                      "from": "array-map@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+                    }
+                  }
+                },
+                "stream-browserify": {
+                  "version": "2.0.1",
+                  "from": "stream-browserify@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "subarg": {
+                  "version": "1.0.0",
+                  "from": "subarg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "syntax-error": {
+                  "version": "1.1.5",
+                  "from": "syntax-error@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.5.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "2.7.0",
+                      "from": "acorn@>=2.7.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+                    }
+                  }
+                },
+                "timers-browserify": {
+                  "version": "1.4.2",
+                  "from": "timers-browserify@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+                },
+                "tty-browserify": {
+                  "version": "0.0.0",
+                  "from": "tty-browserify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+                },
+                "url": {
+                  "version": "0.11.0",
+                  "from": "url@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@1.3.2",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                    },
+                    "querystring": {
+                      "version": "0.2.0",
+                      "from": "querystring@0.2.0",
+                      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                    }
+                  }
+                },
+                "util": {
+                  "version": "0.10.3",
+                  "from": "util@>=0.10.1 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+                },
+                "vm-browserify": {
+                  "version": "0.0.4",
+                  "from": "vm-browserify@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+                  "dependencies": {
+                    "indexof": {
+                      "version": "0.0.1",
+                      "from": "indexof@0.0.1",
+                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "chokidar": {
+              "version": "1.4.2",
+              "from": "chokidar@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
+              "dependencies": {
+                "async-each": {
+                  "version": "0.1.6",
+                  "from": "async-each@>=0.1.6 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "is-binary-path": {
+                  "version": "1.0.1",
+                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.4.0",
+                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "readdirp": {
+                  "version": "2.0.0",
+                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.3",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.10 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "fsevents": {
+                  "version": "1.0.7",
+                  "from": "fsevents@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.2.0",
+                      "from": "nan@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.19",
+                      "from": "node-pre-gyp@>=0.6.17 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.19.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.6",
+                          "from": "nopt@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.7",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    },
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "ansi-styles@^2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.5",
+                      "from": "are-we-there-yet@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "async": {
+                      "version": "1.5.1",
+                      "from": "async@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
+                    },
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "from": "aws-sign2@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "bl": {
+                      "version": "1.0.0",
+                      "from": "bl@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                    },
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@2.x.x",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@~0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@^1.1.1",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@~1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@^2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.11.0",
+                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.4.0",
+                      "from": "deep-extend@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                    },
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    },
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "delegates@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.4",
+                      "from": "escape-string-regexp@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@~3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@~1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.8",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "gauge@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@^4.1.2",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    },
+                    "har-validator": {
+                      "version": "2.0.3",
+                      "from": "har-validator@~2.0.2",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    },
+                    "has-unicode": {
+                      "version": "1.0.1",
+                      "from": "has-unicode@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                    },
+                    "hawk": {
+                      "version": "3.1.2",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@*",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "http-signature": {
+                      "version": "1.1.0",
+                      "from": "http-signature@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.3",
+                      "from": "is-my-json-valid@^2.12.3",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                    },
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@~0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "from": "json-schema@0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "from": "jsprim@^1.2.2",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "from": "lodash._basetostring@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "from": "lodash._createpadding@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                    },
+                    "lodash.padleft": {
+                      "version": "3.1.1",
+                      "from": "lodash.padleft@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                    },
+                    "lodash.pad": {
+                      "version": "3.1.1",
+                      "from": "lodash.pad@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                    },
+                    "lodash.padright": {
+                      "version": "3.1.1",
+                      "from": "lodash.padright@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                    },
+                    "lodash.repeat": {
+                      "version": "3.0.1",
+                      "from": "lodash.repeat@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                    },
+                    "mime-db": {
+                      "version": "1.21.0",
+                      "from": "mime-db@~1.21.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.9",
+                      "from": "mime-types@~2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@~1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "npmlog": {
+                      "version": "2.0.0",
+                      "from": "npmlog@~2.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "once": {
+                      "version": "1.1.1",
+                      "from": "once@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                    },
+                    "pinkie": {
+                      "version": "2.0.1",
+                      "from": "pinkie@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "from": "pinkie-promise@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@~1.0.6",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.0",
+                      "from": "qs@~5.2.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@^2.0.0 || ^1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                    },
+                    "request": {
+                      "version": "2.67.0",
+                      "from": "request@2.x",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                    },
+                    "semver": {
+                      "version": "5.1.0",
+                      "from": "semver@~5.1.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "from": "strip-ansi@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "1.0.4",
+                      "from": "strip-json-comments@~1.0.4",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "from": "tough-cookie@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2",
+                      "from": "tunnel-agent@~0.4.1",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.2",
+                      "from": "tweetnacl@>=0.13.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                    },
+                    "uid-number": {
+                      "version": "0.0.3",
+                      "from": "uid-number@0.0.3",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@~1.0.1",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@^4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "rc": {
+                      "version": "1.1.6",
+                      "from": "rc@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@^1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.2",
+                      "from": "sshpk@^1.7.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.2.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "from": "assert-plus@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.3",
+                      "from": "fstream-ignore@~1.0.3",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "minimatch@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.2",
+                              "from": "brace-expansion@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "balanced-match@^0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.0",
+                      "from": "rimraf@~2.5.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "6.0.3",
+                          "from": "glob@^6.0.1",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@^1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "minimatch@2 || 3",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.2",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "balanced-match@^0.3.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@^1.3.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "3.1.2",
+                      "from": "tar-pack@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.2.tgz",
+                      "dependencies": {
+                        "rimraf": {
+                          "version": "2.4.5",
+                          "from": "rimraf@~2.4.4",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "6.0.3",
+                              "from": "glob@^6.0.1",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@^1.0.4",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@1",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "minimatch": {
+                                  "version": "3.0.0",
+                                  "from": "minimatch@2 || 3",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.2",
+                                      "from": "brace-expansion@^1.0.0",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "0.3.0",
+                                          "from": "balanced-match@^0.3.0",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "concat-map@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "from": "once@^1.3.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@1",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "path-is-absolute": {
+                                  "version": "1.0.0",
+                                  "from": "path-is-absolute@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "defined": {
+              "version": "1.0.0",
+              "from": "defined@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
+            "outpipe": {
+              "version": "1.1.1",
+              "from": "outpipe@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+              "dependencies": {
+                "shell-quote": {
+                  "version": "1.4.3",
+                  "from": "shell-quote@>=1.4.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+                  "dependencies": {
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "from": "jsonify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    },
+                    "array-filter": {
+                      "version": "0.0.1",
+                      "from": "array-filter@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+                    },
+                    "array-reduce": {
+                      "version": "0.0.0",
+                      "from": "array-reduce@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                    },
+                    "array-map": {
+                      "version": "0.0.0",
+                      "from": "array-map@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.1",
+              "from": "through2@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-cli": {
+      "version": "0.1.13",
+      "from": "grunt-cli@>=0.1.13 <0.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@>=1.0.10 <1.1.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.9 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.3.1",
+          "from": "resolve@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
+        }
+      }
+    },
+    "grunt-contrib-clean": {
+      "version": "0.6.0",
+      "from": "grunt-contrib-clean@0.6.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.1 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        }
+      }
+    },
+    "grunt-contrib-compass": {
+      "version": "1.0.4",
+      "from": "grunt-contrib-compass@1.0.4",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compass/-/grunt-contrib-compass-1.0.4.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "bin-version-check": {
+          "version": "2.1.0",
+          "from": "bin-version-check@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+          "dependencies": {
+            "bin-version": {
+              "version": "1.0.4",
+              "from": "bin-version@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+              "dependencies": {
+                "find-versions": {
+                  "version": "1.2.1",
+                  "from": "find-versions@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.2",
+                      "from": "array-uniq@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "meow": {
+                      "version": "3.7.0",
+                      "from": "meow@>=3.5.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "2.0.0",
+                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "2.1.0",
+                              "from": "camelcase@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                            }
+                          }
+                        },
+                        "decamelize": {
+                          "version": "1.1.2",
+                          "from": "decamelize@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                          "dependencies": {
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            }
+                          }
+                        },
+                        "loud-rejection": {
+                          "version": "1.3.0",
+                          "from": "loud-rejection@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
+                          "dependencies": {
+                            "array-find-index": {
+                              "version": "1.0.1",
+                              "from": "array-find-index@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                            },
+                            "signal-exit": {
+                              "version": "2.1.2",
+                              "from": "signal-exit@>=2.1.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                            }
+                          }
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        },
+                        "normalize-package-data": {
+                          "version": "2.3.5",
+                          "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.1.4",
+                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.1",
+                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                                }
+                              }
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.2.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-exceptions": {
+                                      "version": "1.0.4",
+                                      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                    },
+                                    "spdx-license-ids": {
+                                      "version": "1.2.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "object-assign": {
+                          "version": "4.0.1",
+                          "from": "object-assign@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                        },
+                        "read-pkg-up": {
+                          "version": "1.0.1",
+                          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                          "dependencies": {
+                            "find-up": {
+                              "version": "1.1.0",
+                              "from": "find-up@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                              "dependencies": {
+                                "path-exists": {
+                                  "version": "2.1.0",
+                                  "from": "path-exists@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "read-pkg": {
+                              "version": "1.1.0",
+                              "from": "read-pkg@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                              "dependencies": {
+                                "load-json-file": {
+                                  "version": "1.1.0",
+                                  "from": "load-json-file@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.3",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                                    },
+                                    "parse-json": {
+                                      "version": "2.2.0",
+                                      "from": "parse-json@>=2.2.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                      "dependencies": {
+                                        "error-ex": {
+                                          "version": "1.3.0",
+                                          "from": "error-ex@>=1.2.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                          "dependencies": {
+                                            "is-arrayish": {
+                                              "version": "0.2.1",
+                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "pify": {
+                                      "version": "2.3.0",
+                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.4",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                        }
+                                      }
+                                    },
+                                    "strip-bom": {
+                                      "version": "2.0.0",
+                                      "from": "strip-bom@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                      "dependencies": {
+                                        "is-utf8": {
+                                          "version": "0.2.1",
+                                          "from": "is-utf8@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "path-type": {
+                                  "version": "1.1.0",
+                                  "from": "path-type@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.3",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                                    },
+                                    "pify": {
+                                      "version": "2.3.0",
+                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.4",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "redent": {
+                          "version": "1.0.0",
+                          "from": "redent@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                          "dependencies": {
+                            "indent-string": {
+                              "version": "2.1.0",
+                              "from": "indent-string@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "dependencies": {
+                                "repeating": {
+                                  "version": "2.0.0",
+                                  "from": "repeating@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "strip-indent": {
+                              "version": "1.0.1",
+                              "from": "strip-indent@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "trim-newlines": {
+                          "version": "1.0.0",
+                          "from": "trim-newlines@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "semver-regex": {
+                      "version": "1.0.0",
+                      "from": "semver-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "semver": {
+              "version": "4.3.6",
+              "from": "semver@>=4.0.3 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            },
+            "semver-truncate": {
+              "version": "1.1.0",
+              "from": "semver-truncate@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.0.tgz",
+              "dependencies": {
+                "semver": {
+                  "version": "5.1.0",
+                  "from": "semver@>=5.0.3 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "dargs": {
+          "version": "2.1.0",
+          "from": "dargs@>=2.0.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-2.1.0.tgz"
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "from": "onetime@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+        },
+        "tmp": {
+          "version": "0.0.24",
+          "from": "tmp@0.0.24",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
+        }
+      }
+    },
+    "grunt-contrib-compress": {
+      "version": "0.13.0",
+      "from": "grunt-contrib-compress@0.13.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-0.13.0.tgz",
+      "dependencies": {
+        "archiver": {
+          "version": "0.13.1",
+          "from": "archiver@>=0.13.0 <0.14.0",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.13.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "buffer-crc32": {
+              "version": "0.2.5",
+              "from": "buffer-crc32@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
+            },
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@>=4.3.0 <4.4.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lazystream": {
+              "version": "0.1.0",
+              "from": "lazystream@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.26 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "1.1.5",
+              "from": "tar-stream@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.5",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "zip-stream": {
+              "version": "0.5.2",
+              "from": "zip-stream@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
+              "dependencies": {
+                "compress-commons": {
+                  "version": "0.2.9",
+                  "from": "compress-commons@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
+                  "dependencies": {
+                    "crc32-stream": {
+                      "version": "0.3.4",
+                      "from": "crc32-stream@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz"
+                    },
+                    "node-int64": {
+                      "version": "0.3.3",
+                      "from": "node-int64@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.2.0",
+                  "from": "lodash@>=3.2.0 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "prettysize": {
+          "version": "0.0.3",
+          "from": "prettysize@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-0.0.3.tgz"
+        }
+      }
+    },
+    "grunt-contrib-concat": {
+      "version": "0.5.1",
+      "from": "grunt-contrib-concat@0.5.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.5.1.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.3.0",
+          "from": "source-map@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-connect": {
+      "version": "0.11.2",
+      "from": "grunt-contrib-connect@0.11.2",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-0.11.2.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "connect": {
+          "version": "3.4.1",
+          "from": "connect@>=3.4.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-3.4.1.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.4.1",
+              "from": "finalhandler@0.4.1",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.3",
+                  "from": "escape-html@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                    }
+                  }
+                },
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "parseurl@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            }
+          }
+        },
+        "connect-livereload": {
+          "version": "0.5.4",
+          "from": "connect-livereload@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz"
+        },
+        "morgan": {
+          "version": "1.7.0",
+          "from": "morgan@>=1.6.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz",
+          "dependencies": {
+            "basic-auth": {
+              "version": "1.0.3",
+              "from": "basic-auth@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "1.1.0",
+              "from": "depd@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+            },
+            "on-finished": {
+              "version": "2.3.0",
+              "from": "on-finished@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.1",
+                  "from": "ee-first@1.1.1",
+                  "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.1",
+              "from": "on-headers@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+            }
+          }
+        },
+        "opn": {
+          "version": "1.0.2",
+          "from": "opn@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+        },
+        "portscanner": {
+          "version": "1.0.0",
+          "from": "portscanner@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.15",
+              "from": "async@0.1.15",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
+            }
+          }
+        },
+        "serve-index": {
+          "version": "1.7.3",
+          "from": "serve-index@>=1.7.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.2.13",
+              "from": "accepts@>=1.2.13 <1.3.0",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+              "dependencies": {
+                "negotiator": {
+                  "version": "0.5.3",
+                  "from": "negotiator@0.5.3",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+                }
+              }
+            },
+            "batch": {
+              "version": "0.5.3",
+              "from": "batch@0.5.3",
+              "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "from": "escape-html@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "from": "http-errors@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                }
+              }
+            },
+            "mime-types": {
+              "version": "2.1.10",
+              "from": "mime-types@>=2.1.9 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0",
+                  "from": "mime-db@>=1.22.0 <1.23.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "parseurl@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.10.2",
+          "from": "serve-static@>=1.10.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
+          "dependencies": {
+            "escape-html": {
+              "version": "1.0.3",
+              "from": "escape-html@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "parseurl@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            },
+            "send": {
+              "version": "0.13.1",
+              "from": "send@0.13.1",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+                },
+                "depd": {
+                  "version": "1.1.0",
+                  "from": "depd@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                },
+                "destroy": {
+                  "version": "1.0.4",
+                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                },
+                "etag": {
+                  "version": "1.7.0",
+                  "from": "etag@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+                },
+                "fresh": {
+                  "version": "0.3.0",
+                  "from": "fresh@0.3.0",
+                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+                },
+                "http-errors": {
+                  "version": "1.3.1",
+                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                    }
+                  }
+                },
+                "range-parser": {
+                  "version": "1.0.3",
+                  "from": "range-parser@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-copy": {
+      "version": "0.8.1",
+      "from": "grunt-contrib-copy@0.8.1",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0",
+                  "from": "color-convert@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "file-sync-cmp": {
+          "version": "0.1.1",
+          "from": "file-sync-cmp@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
+        }
+      }
+    },
+    "grunt-contrib-jasmine": {
+      "version": "0.9.1",
+      "from": "grunt-contrib-jasmine@0.9.1",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0",
+                  "from": "color-convert@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "es5-shim": {
+          "version": "4.5.4",
+          "from": "es5-shim@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.4.tgz"
+        },
+        "grunt-lib-phantomjs": {
+          "version": "0.7.1",
+          "from": "grunt-lib-phantomjs@>=0.7.1 <0.8.0",
+          "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.7.1.tgz",
+          "dependencies": {
+            "eventemitter2": {
+              "version": "0.4.14",
+              "from": "eventemitter2@>=0.4.9 <0.5.0",
+              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+            },
+            "phantomjs": {
+              "version": "1.9.19",
+              "from": "phantomjs@>=1.9.15 <2.0.0",
+              "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.19.tgz",
+              "dependencies": {
+                "adm-zip": {
+                  "version": "0.4.4",
+                  "from": "adm-zip@0.4.4",
+                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                },
+                "fs-extra": {
+                  "version": "0.23.1",
+                  "from": "fs-extra@>=0.23.1 <0.24.0",
+                  "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.3",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                    },
+                    "jsonfile": {
+                      "version": "2.2.3",
+                      "from": "jsonfile@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "kew": {
+                  "version": "0.4.0",
+                  "from": "kew@0.4.0",
+                  "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
+                },
+                "md5": {
+                  "version": "2.0.0",
+                  "from": "md5@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/md5/-/md5-2.0.0.tgz",
+                  "dependencies": {
+                    "charenc": {
+                      "version": "0.0.1",
+                      "from": "charenc@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.1.tgz"
+                    },
+                    "crypt": {
+                      "version": "0.0.1",
+                      "from": "crypt@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.1.tgz"
+                    },
+                    "is-buffer": {
+                      "version": "1.0.2",
+                      "from": "is-buffer@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.0.2.tgz"
+                    }
+                  }
+                },
+                "npmconf": {
+                  "version": "2.1.1",
+                  "from": "npmconf@2.1.1",
+                  "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+                  "dependencies": {
+                    "config-chain": {
+                      "version": "1.1.10",
+                      "from": "config-chain@>=1.1.8 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
+                      "dependencies": {
+                        "proto-list": {
+                          "version": "1.2.4",
+                          "from": "proto-list@>=1.2.1 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@>=1.2.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "nopt": {
+                      "version": "3.0.6",
+                      "from": "nopt@>=3.0.1 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.7",
+                          "from": "abbrev@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "osenv": {
+                      "version": "0.1.3",
+                      "from": "osenv@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                      "dependencies": {
+                        "os-homedir": {
+                          "version": "1.0.1",
+                          "from": "os-homedir@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                        },
+                        "os-tmpdir": {
+                          "version": "1.0.1",
+                          "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "uid-number": {
+                      "version": "0.0.5",
+                      "from": "uid-number@0.0.5",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                    }
+                  }
+                },
+                "progress": {
+                  "version": "1.1.8",
+                  "from": "progress@1.1.8",
+                  "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+                },
+                "request": {
+                  "version": "2.42.0",
+                  "from": "request@2.42.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.5",
+                      "from": "bl@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.26 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.6.0",
+                      "from": "caseless@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "qs": {
+                      "version": "1.2.2",
+                      "from": "qs@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "from": "mime-types@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2",
+                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "from": "form-data@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.7",
+                          "from": "combined-stream@>=0.0.4 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        },
+                        "mime": {
+                          "version": "1.2.11",
+                          "from": "mime@>=1.2.11 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                        },
+                        "async": {
+                          "version": "0.9.2",
+                          "from": "async@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.10.1",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "from": "ctype@0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.4.0",
+                      "from": "oauth-sign@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "from": "hawk@1.1.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@>=0.4.0 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "request-progress": {
+                  "version": "0.3.1",
+                  "from": "request-progress@0.3.1",
+                  "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+                  "dependencies": {
+                    "throttleit": {
+                      "version": "0.0.2",
+                      "from": "throttleit@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.0.9",
+                  "from": "which@>=1.0.5 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.6",
+              "from": "semver@>=4.0.3 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+            },
+            "temporary": {
+              "version": "0.0.8",
+              "from": "temporary@>=0.0.8 <0.0.9",
+              "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
+              "dependencies": {
+                "package": {
+                  "version": "1.0.1",
+                  "from": "package@>=1.0.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "jasmine-core": {
+          "version": "2.4.1",
+          "from": "jasmine-core@>=2.0.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.4.1.tgz"
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "rimraf": {
+          "version": "2.5.2",
+          "from": "rimraf@>=2.1.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "7.0.0",
+              "from": "glob@>=7.0.0 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-jst": {
+      "version": "0.5.1",
+      "from": "git://github.com/javisantana/grunt-contrib-jst.git#master",
+      "resolved": "git://github.com/javisantana/grunt-contrib-jst.git#7a1bf369cee738ab73cf619d518324b2afae045c",
+      "dependencies": {
+        "lodash": {
+          "version": "1.0.2",
+          "from": "lodash@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+        },
+        "grunt-lib-contrib": {
+          "version": "0.5.3",
+          "from": "grunt-lib-contrib@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.5.3.tgz",
+          "dependencies": {
+            "zlib-browserify": {
+              "version": "0.0.1",
+              "from": "zlib-browserify@0.0.1",
+              "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-sass": {
+      "version": "0.9.2",
+      "from": "grunt-contrib-sass@0.9.2",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "0.2.9",
+          "from": "cross-spawn@>=0.2.3 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "from": "lru-cache@>=2.5.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+            }
+          }
+        },
+        "dargs": {
+          "version": "4.1.0",
+          "from": "dargs@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+          "dependencies": {
+            "number-is-nan": {
+              "version": "1.0.0",
+              "from": "number-is-nan@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+            }
+          }
+        },
+        "which": {
+          "version": "1.2.4",
+          "from": "which@>=1.0.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+          "dependencies": {
+            "is-absolute": {
+              "version": "0.1.7",
+              "from": "is-absolute@>=0.1.7 <0.2.0",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "dependencies": {
+                "is-relative": {
+                  "version": "0.1.3",
+                  "from": "is-relative@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                }
+              }
+            },
+            "isexe": {
+              "version": "1.1.2",
+              "from": "isexe@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-uglify": {
+      "version": "0.9.2",
+      "from": "grunt-contrib-uglify@>=0.9.0 <0.10.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.9.2.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0",
+                  "from": "color-convert@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "maxmin": {
+          "version": "1.1.0",
+          "from": "maxmin@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-1.1.0.tgz",
+          "dependencies": {
+            "figures": {
+              "version": "1.4.0",
+              "from": "figures@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+            },
+            "gzip-size": {
+              "version": "1.0.0",
+              "from": "gzip-size@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.5.1",
+                  "from": "concat-stream@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "browserify-zlib": {
+                  "version": "0.1.4",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "dependencies": {
+                    "pako": {
+                      "version": "0.2.8",
+                      "from": "pako@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "pretty-bytes": {
+              "version": "1.0.4",
+              "from": "pretty-bytes@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.7.0",
+                  "from": "meow@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "2.0.0",
+                      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "2.1.0",
+                          "from": "camelcase@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.2",
+                      "from": "decamelize@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                      "dependencies": {
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        }
+                      }
+                    },
+                    "loud-rejection": {
+                      "version": "1.3.0",
+                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
+                      "dependencies": {
+                        "array-find-index": {
+                          "version": "1.0.1",
+                          "from": "array-find-index@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                        },
+                        "signal-exit": {
+                          "version": "2.1.2",
+                          "from": "signal-exit@>=2.1.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                        }
+                      }
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.4",
+                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.1.0",
+                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.2.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.2",
+                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "1.0.4",
+                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                },
+                                "spdx-license-ids": {
+                                  "version": "1.2.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.0.1",
+                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "dependencies": {
+                        "find-up": {
+                          "version": "1.1.0",
+                          "from": "find-up@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                          "dependencies": {
+                            "path-exists": {
+                              "version": "2.1.0",
+                              "from": "path-exists@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.0",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "1.1.0",
+                          "from": "read-pkg@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "1.1.0",
+                              "from": "load-json-file@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.3",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                                },
+                                "parse-json": {
+                                  "version": "2.2.0",
+                                  "from": "parse-json@>=2.2.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.3.0",
+                                      "from": "error-ex@>=1.2.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-bom": {
+                                  "version": "2.0.0",
+                                  "from": "strip-bom@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "dependencies": {
+                                    "is-utf8": {
+                                      "version": "0.2.1",
+                                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "1.1.0",
+                              "from": "path-type@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.3",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.4",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "1.0.0",
+                      "from": "redent@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "2.1.0",
+                          "from": "indent-string@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                          "dependencies": {
+                            "repeating": {
+                              "version": "2.0.0",
+                              "from": "repeating@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-indent": {
+                          "version": "1.0.1",
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "1.0.0",
+                      "from": "trim-newlines@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "uri-path": {
+          "version": "0.0.2",
+          "from": "uri-path@0.0.2",
+          "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-0.0.2.tgz"
+        }
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "0.6.1",
+      "from": "grunt-contrib-watch@0.6.1",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "dependencies": {
+        "gaze": {
+          "version": "0.5.2",
+          "from": "gaze@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+          "dependencies": {
+            "globule": {
+              "version": "0.1.0",
+              "from": "globule@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "1.0.2",
+                  "from": "lodash@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                },
+                "glob": {
+                  "version": "3.1.21",
+                  "from": "glob@>=3.1.21 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                    },
+                    "inherits": {
+                      "version": "1.0.2",
+                      "from": "inherits@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@>=0.2.11 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tiny-lr-fork": {
+          "version": "0.0.5",
+          "from": "tiny-lr-fork@0.0.5",
+          "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@>=0.5.2 <0.6.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            },
+            "faye-websocket": {
+              "version": "0.4.4",
+              "from": "faye-websocket@>=0.4.3 <0.5.0",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+            },
+            "noptify": {
+              "version": "0.0.3",
+              "from": "noptify@>=0.0.3 <0.1.0",
+              "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "2.0.0",
+                  "from": "nopt@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@>=0.7.0 <0.8.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        }
+      }
+    },
+    "grunt-exorcise": {
+      "version": "2.1.0",
+      "from": "grunt-exorcise@2.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-exorcise/-/grunt-exorcise-2.1.0.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "resumer": {
+          "version": "0.0.0",
+          "from": "resumer@0.0.0",
+          "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.8",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.4.10",
+          "from": "concat-stream@>=1.4.1 <1.5.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                }
+              }
+            }
+          }
+        },
+        "exorcist": {
+          "version": "0.4.0",
+          "from": "exorcist@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/exorcist/-/exorcist-0.4.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.5",
+              "from": "minimist@0.0.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz"
+            },
+            "mold-source-map": {
+              "version": "0.4.0",
+              "from": "mold-source-map@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/mold-source-map/-/mold-source-map-0.4.0.tgz",
+              "dependencies": {
+                "convert-source-map": {
+                  "version": "1.1.3",
+                  "from": "convert-source-map@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                },
+                "through": {
+                  "version": "2.2.7",
+                  "from": "through@>=2.2.7 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
+                }
+              }
+            },
+            "nave": {
+              "version": "0.5.3",
+              "from": "nave@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/nave/-/nave-0.5.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-mustache": {
+      "version": "0.1.7",
+      "from": "grunt-mustache@0.1.7",
+      "resolved": "https://registry.npmjs.org/grunt-mustache/-/grunt-mustache-0.1.7.tgz",
+      "dependencies": {
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        }
+      }
+    },
+    "grunt-postcss": {
+      "version": "0.5.5",
+      "from": "grunt-postcss@0.5.5",
+      "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.5.5.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.10.2",
+          "from": "bluebird@>=2.9.33 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+        },
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0",
+                  "from": "color-convert@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "from": "diff@>=1.3.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+        },
+        "postcss": {
+          "version": "4.1.16",
+          "from": "postcss@>=4.1.8 <5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
+          "dependencies": {
+            "es6-promise": {
+              "version": "2.3.0",
+              "from": "es6-promise@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.8 <2.2.0",
+              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "grunt-timer": {
+      "version": "0.3.3",
+      "from": "grunt-timer@0.3.3",
+      "dependencies": {
+        "duration": {
+          "version": "0.1.4",
+          "from": "duration@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/duration/-/duration-0.1.4.tgz",
+          "dependencies": {
+            "es5-ext": {
+              "version": "0.9.2",
+              "from": "es5-ext@>=0.9.1 <0.10.0",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz"
+            }
+          }
+        },
+        "bash-color": {
+          "version": "0.0.3",
+          "from": "bash-color@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.3.tgz"
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+        }
+      }
+    },
+    "jquery": {
+      "version": "2.1.4",
+      "from": "jquery@2.1.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
+    },
+    "jstify": {
+      "version": "0.13.0",
+      "from": "jstify@0.13.0",
+      "dependencies": {
+        "html-minifier": {
+          "version": "1.2.0",
+          "from": "html-minifier@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.2.0.tgz",
+          "dependencies": {
+            "change-case": {
+              "version": "2.3.1",
+              "from": "change-case@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+              "dependencies": {
+                "camel-case": {
+                  "version": "1.2.2",
+                  "from": "camel-case@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
+                },
+                "constant-case": {
+                  "version": "1.1.2",
+                  "from": "constant-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+                },
+                "dot-case": {
+                  "version": "1.1.2",
+                  "from": "dot-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
+                },
+                "is-lower-case": {
+                  "version": "1.1.3",
+                  "from": "is-lower-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+                },
+                "is-upper-case": {
+                  "version": "1.1.2",
+                  "from": "is-upper-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+                },
+                "lower-case": {
+                  "version": "1.1.3",
+                  "from": "lower-case@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
+                },
+                "lower-case-first": {
+                  "version": "1.0.2",
+                  "from": "lower-case-first@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
+                },
+                "param-case": {
+                  "version": "1.1.2",
+                  "from": "param-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
+                },
+                "pascal-case": {
+                  "version": "1.1.2",
+                  "from": "pascal-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
+                },
+                "path-case": {
+                  "version": "1.1.2",
+                  "from": "path-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
+                },
+                "sentence-case": {
+                  "version": "1.1.3",
+                  "from": "sentence-case@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
+                },
+                "snake-case": {
+                  "version": "1.1.2",
+                  "from": "snake-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
+                },
+                "swap-case": {
+                  "version": "1.1.2",
+                  "from": "swap-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+                },
+                "title-case": {
+                  "version": "1.1.2",
+                  "from": "title-case@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
+                },
+                "upper-case": {
+                  "version": "1.1.3",
+                  "from": "upper-case@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+                },
+                "upper-case-first": {
+                  "version": "1.1.2",
+                  "from": "upper-case-first@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+                }
+              }
+            },
+            "clean-css": {
+              "version": "3.4.9",
+              "from": "clean-css@>=3.4.0 <3.5.0",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.8.1",
+                  "from": "commander@>=2.8.0 <2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "source-map@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "cli": {
+              "version": "0.11.1",
+              "from": "cli@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.11.1.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "glob@>=5.0.10 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "exit": {
+                  "version": "0.1.2",
+                  "from": "exit@0.1.2",
+                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                }
+              }
+            },
+            "concat-stream": {
+              "version": "1.5.1",
+              "from": "concat-stream@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "relateurl": {
+              "version": "0.2.6",
+              "from": "relateurl@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
+            },
+            "uglify-js": {
+              "version": "2.6.1",
+              "from": "uglify-js@>=2.6.0 <2.7.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.5.3",
+                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.2",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.2",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.3",
+                              "from": "lazy-cache@>=1.0.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.2",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.2",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.2",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                      "dependencies": {
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        }
+                      }
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "load-grunt-tasks": {
+      "version": "3.2.0",
+      "from": "load-grunt-tasks@3.2.0",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@>=4.3.0 <4.4.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "from": "multimatch@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "from": "arrify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "moment": {
+      "version": "2.10.6",
+      "from": "moment@2.10.6",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+    },
+    "node-polyglot": {
+      "version": "1.0.0",
+      "from": "node-polyglot@1.0.0"
+    },
+    "open": {
+      "version": "0.0.5",
+      "from": "open@0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
+    },
+    "perfect-scrollbar": {
+      "version": "0.6.7",
+      "from": "perfect-scrollbar@0.6.7"
+    },
+    "queue-async": {
+      "version": "1.2.1",
+      "from": "queue-async@>=1.0.7 <2.0.0"
+    },
+    "semistandard": {
+      "version": "7.0.4",
+      "from": "semistandard@7.0.4",
+      "dependencies": {
+        "defaults": {
+          "version": "1.0.3",
+          "from": "defaults@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "from": "clone@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+            }
+          }
+        },
+        "eslint": {
+          "version": "1.10.3",
+          "from": "eslint@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "1.0.0",
+                      "from": "color-convert@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                    }
+                  }
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "concat-stream": {
+              "version": "1.5.1",
+              "from": "concat-stream@>=1.4.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "doctrine": {
+              "version": "0.7.2",
+              "from": "doctrine@>=0.7.1 <0.8.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.1.6",
+                  "from": "esutils@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "escope": {
+              "version": "3.4.0",
+              "from": "escope@>=3.3.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/escope/-/escope-3.4.0.tgz",
+              "dependencies": {
+                "es6-map": {
+                  "version": "0.1.3",
+                  "from": "es6-map@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.11",
+                      "from": "es5-ext@>=0.10.8 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                    },
+                    "es6-iterator": {
+                      "version": "2.0.0",
+                      "from": "es6-iterator@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                    },
+                    "es6-set": {
+                      "version": "0.1.4",
+                      "from": "es6-set@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "3.0.2",
+                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                    },
+                    "event-emitter": {
+                      "version": "0.3.4",
+                      "from": "event-emitter@>=0.3.4 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+                    }
+                  }
+                },
+                "es6-weak-map": {
+                  "version": "2.0.1",
+                  "from": "es6-weak-map@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+                  "dependencies": {
+                    "d": {
+                      "version": "0.1.1",
+                      "from": "d@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                    },
+                    "es5-ext": {
+                      "version": "0.10.11",
+                      "from": "es5-ext@>=0.10.8 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                    },
+                    "es6-iterator": {
+                      "version": "2.0.0",
+                      "from": "es6-iterator@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "3.0.2",
+                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                    }
+                  }
+                },
+                "esrecurse": {
+                  "version": "3.1.1",
+                  "from": "esrecurse@>=3.1.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "3.1.0",
+                      "from": "estraverse@>=3.1.0 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "espree": {
+              "version": "2.2.5",
+              "from": "espree@>=2.2.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+            },
+            "estraverse": {
+              "version": "4.1.1",
+              "from": "estraverse@>=4.1.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+            },
+            "estraverse-fb": {
+              "version": "1.3.1",
+              "from": "estraverse-fb@>=1.3.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "file-entry-cache": {
+              "version": "1.2.4",
+              "from": "file-entry-cache@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+              "dependencies": {
+                "flat-cache": {
+                  "version": "1.0.10",
+                  "from": "flat-cache@>=1.0.9 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
+                  "dependencies": {
+                    "del": {
+                      "version": "2.2.0",
+                      "from": "del@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
+                      "dependencies": {
+                        "globby": {
+                          "version": "4.0.0",
+                          "from": "globby@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
+                          "dependencies": {
+                            "array-union": {
+                              "version": "1.0.1",
+                              "from": "array-union@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                              "dependencies": {
+                                "array-uniq": {
+                                  "version": "1.0.2",
+                                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "arrify": {
+                              "version": "1.0.1",
+                              "from": "arrify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                            },
+                            "glob": {
+                              "version": "6.0.4",
+                              "from": "glob@>=6.0.1 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-path-cwd": {
+                          "version": "1.0.0",
+                          "from": "is-path-cwd@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                        },
+                        "is-path-in-cwd": {
+                          "version": "1.0.0",
+                          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                          "dependencies": {
+                            "is-path-inside": {
+                              "version": "1.0.0",
+                              "from": "is-path-inside@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "from": "pify@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.0",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.5.2",
+                          "from": "rimraf@>=2.2.8 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                          "dependencies": {
+                            "glob": {
+                              "version": "7.0.0",
+                              "from": "glob@>=7.0.0 <8.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.3",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                    },
+                    "read-json-sync": {
+                      "version": "1.1.1",
+                      "from": "read-json-sync@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
+                    },
+                    "write": {
+                      "version": "0.2.1",
+                      "from": "write@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@>=5.0.14 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "globals": {
+              "version": "8.18.0",
+              "from": "globals@>=8.11.0 <9.0.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+            },
+            "handlebars": {
+              "version": "4.0.5",
+              "from": "handlebars@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "from": "async@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.1",
+                  "from": "optimist@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "source-map@>=0.4.4 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.6.1",
+                  "from": "uglify-js@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.5.3",
+                      "from": "source-map@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                    },
+                    "yargs": {
+                      "version": "3.10.0",
+                      "from": "yargs@>=3.10.0 <3.11.0",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "camelcase@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "cliui": {
+                          "version": "2.1.0",
+                          "from": "cliui@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                          "dependencies": {
+                            "center-align": {
+                              "version": "0.1.3",
+                              "from": "center-align@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.4",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.0.2",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.2",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                },
+                                "lazy-cache": {
+                                  "version": "1.0.3",
+                                  "from": "lazy-cache@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                }
+                              }
+                            },
+                            "right-align": {
+                              "version": "0.1.3",
+                              "from": "right-align@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.4",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.0.2",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.2",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@0.0.2",
+                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                            }
+                          }
+                        },
+                        "decamelize": {
+                          "version": "1.1.2",
+                          "from": "decamelize@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
+                        },
+                        "window-size": {
+                          "version": "0.1.0",
+                          "from": "window-size@0.1.0",
+                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "inquirer": {
+              "version": "0.11.4",
+              "from": "inquirer@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+              "dependencies": {
+                "ansi-escapes": {
+                  "version": "1.1.1",
+                  "from": "ansi-escapes@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.1.tgz"
+                },
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
+                "cli-cursor": {
+                  "version": "1.0.2",
+                  "from": "cli-cursor@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                  "dependencies": {
+                    "restore-cursor": {
+                      "version": "1.0.1",
+                      "from": "restore-cursor@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                      "dependencies": {
+                        "exit-hook": {
+                          "version": "1.1.1",
+                          "from": "exit-hook@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+                        },
+                        "onetime": {
+                          "version": "1.1.0",
+                          "from": "onetime@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "cli-width": {
+                  "version": "1.1.1",
+                  "from": "cli-width@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
+                },
+                "figures": {
+                  "version": "1.4.0",
+                  "from": "figures@>=1.3.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.3.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "readline2": {
+                  "version": "1.0.1",
+                  "from": "readline2@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.0.0",
+                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "mute-stream": {
+                      "version": "0.0.5",
+                      "from": "mute-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "run-async": {
+                  "version": "0.1.0",
+                  "from": "run-async@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rx-lite": {
+                  "version": "3.1.2",
+                  "from": "rx-lite@>=3.1.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+                },
+                "string-width": {
+                  "version": "1.0.1",
+                  "from": "string-width@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.0.0",
+                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.3.6 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.13.0",
+              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.0.tgz",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "2.0.0",
+                  "from": "jsonpointer@2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "is-resolvable": {
+              "version": "1.0.0",
+              "from": "is-resolvable@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+              "dependencies": {
+                "tryit": {
+                  "version": "1.0.2",
+                  "from": "tryit@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.4.5",
+              "from": "js-yaml@3.4.5",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.5.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.6",
+                  "from": "argparse@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.7.2",
+                  "from": "esprima@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                }
+              }
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            },
+            "lodash.clonedeep": {
+              "version": "3.0.2",
+              "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+              "dependencies": {
+                "lodash._baseclone": {
+                  "version": "3.3.0",
+                  "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+                  "dependencies": {
+                    "lodash._arraycopy": {
+                      "version": "3.0.0",
+                      "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                    },
+                    "lodash._arrayeach": {
+                      "version": "3.0.0",
+                      "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                    },
+                    "lodash._baseassign": {
+                      "version": "3.2.0",
+                      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._basefor": {
+                      "version": "3.0.3",
+                      "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        },
+                        "lodash.isarguments": {
+                          "version": "3.0.7",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                }
+              }
+            },
+            "lodash.merge": {
+              "version": "3.3.2",
+              "from": "lodash.merge@>=3.3.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.9",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                    }
+                  }
+                },
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.7",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                },
+                "lodash.isplainobject": {
+                  "version": "3.2.0",
+                  "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basefor": {
+                      "version": "3.0.3",
+                      "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                    }
+                  }
+                },
+                "lodash.istypedarray": {
+                  "version": "3.0.5",
+                  "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+                },
+                "lodash.toplainobject": {
+                  "version": "3.0.0",
+                  "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.omit": {
+              "version": "3.1.0",
+              "from": "lodash.omit@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+              "dependencies": {
+                "lodash._arraymap": {
+                  "version": "3.0.0",
+                  "from": "lodash._arraymap@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
+                },
+                "lodash._basedifference": {
+                  "version": "3.0.3",
+                  "from": "lodash._basedifference@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+                  "dependencies": {
+                    "lodash._baseindexof": {
+                      "version": "3.1.0",
+                      "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+                    },
+                    "lodash._cacheindexof": {
+                      "version": "3.0.2",
+                      "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+                    },
+                    "lodash._createcache": {
+                      "version": "3.1.2",
+                      "from": "lodash._createcache@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                      "dependencies": {
+                        "lodash._getnative": {
+                          "version": "3.9.1",
+                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._baseflatten": {
+                  "version": "3.1.4",
+                  "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.7",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                },
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                },
+                "lodash._pickbyarray": {
+                  "version": "3.0.2",
+                  "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+                },
+                "lodash._pickbycallback": {
+                  "version": "3.0.0",
+                  "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+                  "dependencies": {
+                    "lodash._basefor": {
+                      "version": "3.0.3",
+                      "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                    }
+                  }
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.7",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.0.1",
+              "from": "object-assign@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+            },
+            "optionator": {
+              "version": "0.6.0",
+              "from": "optionator@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "prelude-ls@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "deep-is@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.2",
+                  "from": "type-check@>=0.3.1 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "levn@>=0.2.5 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.7",
+                  "from": "fast-levenshtein@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "path-is-inside": {
+              "version": "1.0.1",
+              "from": "path-is-inside@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+            },
+            "shelljs": {
+              "version": "0.5.3",
+              "from": "shelljs@>=0.5.3 <0.6.0",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.4",
+              "from": "strip-json-comments@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            },
+            "user-home": {
+              "version": "2.0.0",
+              "from": "user-home@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.1",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                }
+              }
+            },
+            "xml-escape": {
+              "version": "1.0.0",
+              "from": "xml-escape@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+            }
+          }
+        },
+        "eslint-config-semistandard": {
+          "version": "5.0.0",
+          "from": "eslint-config-semistandard@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-semistandard/-/eslint-config-semistandard-5.0.0.tgz"
+        },
+        "eslint-config-standard": {
+          "version": "4.4.0",
+          "from": "eslint-config-standard@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-4.4.0.tgz"
+        },
+        "eslint-config-standard-react": {
+          "version": "1.2.1",
+          "from": "eslint-config-standard-react@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-standard-react/-/eslint-config-standard-react-1.2.1.tgz"
+        },
+        "eslint-plugin-react": {
+          "version": "3.16.1",
+          "from": "eslint-plugin-react@>=3.9.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.16.1.tgz"
+        },
+        "eslint-plugin-standard": {
+          "version": "1.3.2",
+          "from": "eslint-plugin-standard@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-1.3.2.tgz"
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
+        "semistandard-format": {
+          "version": "1.6.7",
+          "from": "semistandard-format@>=1.3.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/semistandard-format/-/semistandard-format-1.6.7.tgz",
+          "dependencies": {
+            "deglob": {
+              "version": "1.1.0",
+              "from": "deglob@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.1.0.tgz",
+              "dependencies": {
+                "find-root": {
+                  "version": "0.1.2",
+                  "from": "find-root@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz"
+                },
+                "glob": {
+                  "version": "6.0.4",
+                  "from": "glob@>=6.0.4 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "ignore": {
+                  "version": "2.2.19",
+                  "from": "ignore@>=2.2.15 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ignore/-/ignore-2.2.19.tgz"
+                },
+                "pkg-config": {
+                  "version": "1.1.0",
+                  "from": "pkg-config@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.0.tgz",
+                  "dependencies": {
+                    "debug-log": {
+                      "version": "1.0.0",
+                      "from": "debug-log@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.0.tgz"
+                    }
+                  }
+                },
+                "run-parallel": {
+                  "version": "1.1.4",
+                  "from": "run-parallel@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.4.tgz"
+                },
+                "uniq": {
+                  "version": "1.0.1",
+                  "from": "uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "esformatter": {
+              "version": "0.7.3",
+              "from": "esformatter@>=0.7.3 <0.8.0",
+              "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.7.3.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@>=0.7.4 <0.8.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "disparity": {
+                  "version": "2.0.0",
+                  "from": "disparity@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.0",
+                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.0.0",
+                          "from": "color-convert@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "diff": {
+                      "version": "1.4.0",
+                      "from": "diff@>=1.3.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+                    }
+                  }
+                },
+                "espree": {
+                  "version": "1.12.3",
+                  "from": "espree@>=1.12.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/espree/-/espree-1.12.3.tgz"
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "glob@>=5.0.3 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "mout": {
+                  "version": "0.11.1",
+                  "from": "mout@>=0.9.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz"
+                },
+                "npm-run": {
+                  "version": "1.1.1",
+                  "from": "npm-run@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-1.1.1.tgz",
+                  "dependencies": {
+                    "npm-path": {
+                      "version": "1.1.0",
+                      "from": "npm-path@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz",
+                      "dependencies": {
+                        "which": {
+                          "version": "1.2.4",
+                          "from": "which@>=1.2.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+                          "dependencies": {
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "is-absolute@>=0.1.7 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "is-relative@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "isexe": {
+                              "version": "1.1.2",
+                              "from": "isexe@>=1.1.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "serializerr": {
+                      "version": "1.0.2",
+                      "from": "serializerr@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.2.tgz",
+                      "dependencies": {
+                        "protochain": {
+                          "version": "1.0.3",
+                          "from": "protochain@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "sync-exec": {
+                      "version": "0.5.0",
+                      "from": "sync-exec@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.5.0.tgz"
+                    }
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.7",
+                  "from": "resolve@>=1.1.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+                },
+                "rocambole": {
+                  "version": "0.7.0",
+                  "from": "rocambole@>=0.6.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.7.2",
+                      "from": "esprima@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                    }
+                  }
+                },
+                "rocambole-indent": {
+                  "version": "2.0.4",
+                  "from": "rocambole-indent@>=2.0.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.1.3 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rocambole-linebreak": {
+                  "version": "1.0.1",
+                  "from": "rocambole-linebreak@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.1.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.1.3 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "4.3.6",
+                      "from": "semver@>=4.3.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                    }
+                  }
+                },
+                "rocambole-node": {
+                  "version": "1.0.0",
+                  "from": "rocambole-node@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-node/-/rocambole-node-1.0.0.tgz"
+                },
+                "rocambole-token": {
+                  "version": "1.2.1",
+                  "from": "rocambole-token@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
+                },
+                "rocambole-whitespace": {
+                  "version": "1.0.0",
+                  "from": "rocambole-whitespace@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.1.3 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "repeat-string": {
+                      "version": "1.5.2",
+                      "from": "repeat-string@>=1.5.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "2.2.1",
+                  "from": "semver@>=2.2.1 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "0.1.3",
+                  "from": "strip-json-comments@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                },
+                "supports-color": {
+                  "version": "1.3.1",
+                  "from": "supports-color@>=1.3.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                },
+                "user-home": {
+                  "version": "2.0.0",
+                  "from": "user-home@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "esformatter-eol-last": {
+              "version": "1.0.0",
+              "from": "esformatter-eol-last@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esformatter-eol-last/-/esformatter-eol-last-1.0.0.tgz",
+              "dependencies": {
+                "string.prototype.endswith": {
+                  "version": "0.2.0",
+                  "from": "string.prototype.endswith@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz"
+                }
+              }
+            },
+            "esformatter-jsx": {
+              "version": "2.3.11",
+              "from": "esformatter-jsx@>=2.0.11 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esformatter-jsx/-/esformatter-jsx-2.3.11.tgz",
+              "dependencies": {
+                "babel-core": {
+                  "version": "5.8.35",
+                  "from": "babel-core@>=5.8.34 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.35.tgz",
+                  "dependencies": {
+                    "babel-plugin-constant-folding": {
+                      "version": "1.0.1",
+                      "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                    },
+                    "babel-plugin-dead-code-elimination": {
+                      "version": "1.0.2",
+                      "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                    },
+                    "babel-plugin-eval": {
+                      "version": "1.0.1",
+                      "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                    },
+                    "babel-plugin-inline-environment-variables": {
+                      "version": "1.0.1",
+                      "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                    },
+                    "babel-plugin-jscript": {
+                      "version": "1.0.4",
+                      "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                    },
+                    "babel-plugin-member-expression-literals": {
+                      "version": "1.0.1",
+                      "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                    },
+                    "babel-plugin-property-literals": {
+                      "version": "1.0.1",
+                      "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                    },
+                    "babel-plugin-proto-to-assign": {
+                      "version": "1.0.4",
+                      "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                    },
+                    "babel-plugin-react-constant-elements": {
+                      "version": "1.0.3",
+                      "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                    },
+                    "babel-plugin-react-display-name": {
+                      "version": "1.0.3",
+                      "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                    },
+                    "babel-plugin-remove-console": {
+                      "version": "1.0.1",
+                      "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                    },
+                    "babel-plugin-remove-debugger": {
+                      "version": "1.0.1",
+                      "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                    },
+                    "babel-plugin-runtime": {
+                      "version": "1.0.7",
+                      "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                    },
+                    "babel-plugin-undeclared-variables-check": {
+                      "version": "1.0.2",
+                      "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                      "dependencies": {
+                        "leven": {
+                          "version": "1.0.2",
+                          "from": "leven@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-plugin-undefined-to-void": {
+                      "version": "1.1.6",
+                      "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                    },
+                    "babylon": {
+                      "version": "5.8.35",
+                      "from": "babylon@>=5.8.35 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.35.tgz"
+                    },
+                    "bluebird": {
+                      "version": "2.10.2",
+                      "from": "bluebird@>=2.9.33 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.0",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                          "dependencies": {
+                            "color-convert": {
+                              "version": "1.0.0",
+                              "from": "color-convert@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "convert-source-map": {
+                      "version": "1.1.3",
+                      "from": "convert-source-map@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                    },
+                    "core-js": {
+                      "version": "1.2.6",
+                      "from": "core-js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.1.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "detect-indent": {
+                      "version": "3.0.1",
+                      "from": "detect-indent@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz"
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "fs-readdir-recursive": {
+                      "version": "0.1.2",
+                      "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                    },
+                    "globals": {
+                      "version": "6.4.1",
+                      "from": "globals@>=6.4.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                    },
+                    "home-or-tmp": {
+                      "version": "1.0.0",
+                      "from": "home-or-tmp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                      "dependencies": {
+                        "os-tmpdir": {
+                          "version": "1.0.1",
+                          "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                        },
+                        "user-home": {
+                          "version": "1.1.1",
+                          "from": "user-home@>=1.1.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "is-integer": {
+                      "version": "1.0.6",
+                      "from": "is-integer@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "js-tokens": {
+                      "version": "1.0.1",
+                      "from": "js-tokens@1.0.1",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                    },
+                    "json5": {
+                      "version": "0.4.0",
+                      "from": "json5@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                    },
+                    "line-numbers": {
+                      "version": "0.2.0",
+                      "from": "line-numbers@0.2.0",
+                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                      "dependencies": {
+                        "left-pad": {
+                          "version": "0.0.3",
+                          "from": "left-pad@0.0.3",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.3 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "output-file-sync": {
+                      "version": "1.1.1",
+                      "from": "output-file-sync@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+                      "dependencies": {
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "mkdirp@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-exists": {
+                      "version": "1.0.0",
+                      "from": "path-exists@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    },
+                    "private": {
+                      "version": "0.1.6",
+                      "from": "private@>=0.1.6 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                    },
+                    "regenerator": {
+                      "version": "0.8.40",
+                      "from": "regenerator@0.8.40",
+                      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                      "dependencies": {
+                        "commoner": {
+                          "version": "0.10.4",
+                          "from": "commoner@>=0.10.3 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                          "dependencies": {
+                            "commander": {
+                              "version": "2.9.0",
+                              "from": "commander@>=2.5.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                              "dependencies": {
+                                "graceful-readlink": {
+                                  "version": "1.0.1",
+                                  "from": "graceful-readlink@>=1.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "detective": {
+                              "version": "4.3.1",
+                              "from": "detective@>=4.3.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                              "dependencies": {
+                                "acorn": {
+                                  "version": "1.2.2",
+                                  "from": "acorn@>=1.0.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                                },
+                                "defined": {
+                                  "version": "1.0.0",
+                                  "from": "defined@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "glob": {
+                              "version": "5.0.15",
+                              "from": "glob@>=5.0.15 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.4",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "4.1.3",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                            },
+                            "iconv-lite": {
+                              "version": "0.4.13",
+                              "from": "iconv-lite@>=0.4.5 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                            },
+                            "mkdirp": {
+                              "version": "0.5.1",
+                              "from": "mkdirp@>=0.5.0 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                              "dependencies": {
+                                "minimist": {
+                                  "version": "0.0.8",
+                                  "from": "minimist@0.0.8",
+                                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                }
+                              }
+                            },
+                            "q": {
+                              "version": "1.4.1",
+                              "from": "q@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                            }
+                          }
+                        },
+                        "defs": {
+                          "version": "1.1.1",
+                          "from": "defs@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                          "dependencies": {
+                            "alter": {
+                              "version": "0.2.0",
+                              "from": "alter@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+                              "dependencies": {
+                                "stable": {
+                                  "version": "0.1.5",
+                                  "from": "stable@>=0.1.3 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                                }
+                              }
+                            },
+                            "ast-traverse": {
+                              "version": "0.1.1",
+                              "from": "ast-traverse@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                            },
+                            "breakable": {
+                              "version": "1.0.0",
+                              "from": "breakable@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                            },
+                            "simple-fmt": {
+                              "version": "0.1.0",
+                              "from": "simple-fmt@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                            },
+                            "simple-is": {
+                              "version": "0.2.0",
+                              "from": "simple-is@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                            },
+                            "stringmap": {
+                              "version": "0.2.2",
+                              "from": "stringmap@>=0.2.2 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                            },
+                            "stringset": {
+                              "version": "0.2.1",
+                              "from": "stringset@>=0.2.1 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                            },
+                            "tryor": {
+                              "version": "0.1.2",
+                              "from": "tryor@>=0.1.2 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                            },
+                            "yargs": {
+                              "version": "3.27.0",
+                              "from": "yargs@>=3.27.0 <3.28.0",
+                              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                              "dependencies": {
+                                "camelcase": {
+                                  "version": "1.2.1",
+                                  "from": "camelcase@>=1.2.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                                },
+                                "cliui": {
+                                  "version": "2.1.0",
+                                  "from": "cliui@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                                  "dependencies": {
+                                    "center-align": {
+                                      "version": "0.1.3",
+                                      "from": "center-align@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                      "dependencies": {
+                                        "align-text": {
+                                          "version": "0.1.4",
+                                          "from": "align-text@>=0.1.3 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.0.2",
+                                              "from": "kind-of@>=3.0.2 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.2",
+                                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                                }
+                                              }
+                                            },
+                                            "longest": {
+                                              "version": "1.0.1",
+                                              "from": "longest@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                            },
+                                            "repeat-string": {
+                                              "version": "1.5.2",
+                                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "lazy-cache": {
+                                          "version": "1.0.3",
+                                          "from": "lazy-cache@>=1.0.3 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                        }
+                                      }
+                                    },
+                                    "right-align": {
+                                      "version": "0.1.3",
+                                      "from": "right-align@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                      "dependencies": {
+                                        "align-text": {
+                                          "version": "0.1.4",
+                                          "from": "align-text@>=0.1.1 <0.2.0",
+                                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.0.2",
+                                              "from": "kind-of@>=3.0.2 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.2",
+                                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                                }
+                                              }
+                                            },
+                                            "longest": {
+                                              "version": "1.0.1",
+                                              "from": "longest@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                            },
+                                            "repeat-string": {
+                                              "version": "1.5.2",
+                                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "wordwrap": {
+                                      "version": "0.0.2",
+                                      "from": "wordwrap@0.0.2",
+                                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "decamelize": {
+                                  "version": "1.1.2",
+                                  "from": "decamelize@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.5",
+                                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                    }
+                                  }
+                                },
+                                "os-locale": {
+                                  "version": "1.4.0",
+                                  "from": "os-locale@>=1.4.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                                  "dependencies": {
+                                    "lcid": {
+                                      "version": "1.0.0",
+                                      "from": "lcid@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                      "dependencies": {
+                                        "invert-kv": {
+                                          "version": "1.0.0",
+                                          "from": "invert-kv@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "window-size": {
+                                  "version": "0.1.4",
+                                  "from": "window-size@>=0.1.2 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                                },
+                                "y18n": {
+                                  "version": "3.2.0",
+                                  "from": "y18n@>=3.2.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "recast": {
+                          "version": "0.10.33",
+                          "from": "recast@0.10.33",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.8.12",
+                              "from": "ast-types@0.8.12",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                            }
+                          }
+                        },
+                        "through": {
+                          "version": "2.3.8",
+                          "from": "through@>=2.3.8 <2.4.0",
+                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                        }
+                      }
+                    },
+                    "regexpu": {
+                      "version": "1.3.0",
+                      "from": "regexpu@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                      "dependencies": {
+                        "esprima": {
+                          "version": "2.7.2",
+                          "from": "esprima@>=2.6.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                        },
+                        "recast": {
+                          "version": "0.10.43",
+                          "from": "recast@>=0.10.10 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                          "dependencies": {
+                            "esprima-fb": {
+                              "version": "15001.1001.0-dev-harmony-fb",
+                              "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                            },
+                            "ast-types": {
+                              "version": "0.8.15",
+                              "from": "ast-types@0.8.15",
+                              "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+                            }
+                          }
+                        },
+                        "regenerate": {
+                          "version": "1.2.1",
+                          "from": "regenerate@>=1.2.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                        },
+                        "regjsgen": {
+                          "version": "0.2.0",
+                          "from": "regjsgen@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                        },
+                        "regjsparser": {
+                          "version": "0.1.5",
+                          "from": "regjsparser@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                          "dependencies": {
+                            "jsesc": {
+                              "version": "0.5.0",
+                              "from": "jsesc@>=0.5.0 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "resolve": {
+                      "version": "1.1.7",
+                      "from": "resolve@>=1.1.6 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+                    },
+                    "shebang-regex": {
+                      "version": "1.0.0",
+                      "from": "shebang-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                    },
+                    "slash": {
+                      "version": "1.0.0",
+                      "from": "slash@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.5.3",
+                      "from": "source-map@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                    },
+                    "source-map-support": {
+                      "version": "0.2.10",
+                      "from": "source-map-support@>=0.2.10 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.1.32",
+                          "from": "source-map@0.1.32",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "from": "to-fast-properties@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    },
+                    "trim-right": {
+                      "version": "1.0.1",
+                      "from": "trim-right@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                    },
+                    "try-resolve": {
+                      "version": "1.0.1",
+                      "from": "try-resolve@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                    }
+                  }
+                },
+                "esformatter-ignore": {
+                  "version": "0.1.3",
+                  "from": "esformatter-ignore@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/esformatter-ignore/-/esformatter-ignore-0.1.3.tgz"
+                },
+                "extend": {
+                  "version": "2.0.1",
+                  "from": "extend@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+                },
+                "fresh-falafel": {
+                  "version": "1.2.0",
+                  "from": "fresh-falafel@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fresh-falafel/-/fresh-falafel-1.2.0.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "1.2.2",
+                      "from": "acorn@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                    },
+                    "foreach": {
+                      "version": "2.0.5",
+                      "from": "foreach@>=2.0.5 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "object-keys": {
+                      "version": "1.0.9",
+                      "from": "object-keys@>=1.0.6 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+                    }
+                  }
+                },
+                "js-beautify": {
+                  "version": "1.6.2",
+                  "from": "js-beautify@>=1.5.10 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.2.tgz",
+                  "dependencies": {
+                    "config-chain": {
+                      "version": "1.1.10",
+                      "from": "config-chain@>=1.1.5 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
+                      "dependencies": {
+                        "proto-list": {
+                          "version": "1.2.4",
+                          "from": "proto-list@>=1.2.1 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                        },
+                        "ini": {
+                          "version": "1.3.4",
+                          "from": "ini@>=1.3.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "nopt": {
+                      "version": "3.0.6",
+                      "from": "nopt@>=3.0.1 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.7",
+                          "from": "abbrev@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "esformatter-literal-notation": {
+              "version": "1.0.1",
+              "from": "esformatter-literal-notation@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esformatter-literal-notation/-/esformatter-literal-notation-1.0.1.tgz",
+              "dependencies": {
+                "rocambole": {
+                  "version": "0.3.6",
+                  "from": "rocambole@>=0.3.6 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.3.6.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                    }
+                  }
+                },
+                "rocambole-token": {
+                  "version": "1.2.1",
+                  "from": "rocambole-token@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
+                }
+              }
+            },
+            "esformatter-quotes": {
+              "version": "1.0.3",
+              "from": "esformatter-quotes@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esformatter-quotes/-/esformatter-quotes-1.0.3.tgz"
+            },
+            "esformatter-semicolons": {
+              "version": "1.1.2",
+              "from": "esformatter-semicolons@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esformatter-semicolons/-/esformatter-semicolons-1.1.2.tgz"
+            },
+            "esformatter-semicolon-first": {
+              "version": "1.1.0",
+              "from": "esformatter-semicolon-first@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esformatter-semicolon-first/-/esformatter-semicolon-first-1.1.0.tgz",
+              "dependencies": {
+                "espree": {
+                  "version": "2.2.5",
+                  "from": "espree@>=2.0.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+                },
+                "rocambole": {
+                  "version": "0.7.0",
+                  "from": "rocambole@>=0.6.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.7.2",
+                      "from": "esprima@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                    }
+                  }
+                },
+                "rocambole-token": {
+                  "version": "1.2.1",
+                  "from": "rocambole-token@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz"
+                }
+              }
+            },
+            "esformatter-spaced-lined-comment": {
+              "version": "2.0.1",
+              "from": "esformatter-spaced-lined-comment@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esformatter-spaced-lined-comment/-/esformatter-spaced-lined-comment-2.0.1.tgz"
+            },
+            "stdin": {
+              "version": "0.0.1",
+              "from": "stdin@0.0.1",
+              "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz"
+            }
+          }
+        },
+        "standard-engine": {
+          "version": "2.2.5",
+          "from": "standard-engine@>=2.0.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-2.2.5.tgz",
+          "dependencies": {
+            "deglob": {
+              "version": "1.1.0",
+              "from": "deglob@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/deglob/-/deglob-1.1.0.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "6.0.4",
+                  "from": "glob@>=6.0.4 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "ignore": {
+                  "version": "2.2.19",
+                  "from": "ignore@>=2.2.15 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ignore/-/ignore-2.2.19.tgz"
+                },
+                "run-parallel": {
+                  "version": "1.1.4",
+                  "from": "run-parallel@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.4.tgz"
+                },
+                "uniq": {
+                  "version": "1.0.1",
+                  "from": "uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                }
+              }
+            },
+            "dezalgo": {
+              "version": "1.0.3",
+              "from": "dezalgo@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.3",
+                  "from": "asap@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                },
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "eslint": {
+              "version": "1.9.0",
+              "from": "eslint@1.9.0",
+              "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.9.0.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.1",
+                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.0",
+                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.0.0",
+                          "from": "color-convert@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "concat-stream": {
+                  "version": "1.5.1",
+                  "from": "concat-stream@>=1.4.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.1.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "doctrine": {
+                  "version": "0.7.2",
+                  "from": "doctrine@>=0.7.0 <0.8.0",
+                  "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "1.1.6",
+                      "from": "esutils@>=1.1.6 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "escope": {
+                  "version": "3.4.0",
+                  "from": "escope@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/escope/-/escope-3.4.0.tgz",
+                  "dependencies": {
+                    "es6-map": {
+                      "version": "0.1.3",
+                      "from": "es6-map@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "from": "d@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.11",
+                          "from": "es5-ext@>=0.10.8 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                        },
+                        "es6-iterator": {
+                          "version": "2.0.0",
+                          "from": "es6-iterator@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                        },
+                        "es6-set": {
+                          "version": "0.1.4",
+                          "from": "es6-set@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "3.0.2",
+                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                        },
+                        "event-emitter": {
+                          "version": "0.3.4",
+                          "from": "event-emitter@>=0.3.4 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+                        }
+                      }
+                    },
+                    "es6-weak-map": {
+                      "version": "2.0.1",
+                      "from": "es6-weak-map@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "from": "d@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.11",
+                          "from": "es5-ext@>=0.10.8 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                        },
+                        "es6-iterator": {
+                          "version": "2.0.0",
+                          "from": "es6-iterator@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "3.0.2",
+                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "esrecurse": {
+                      "version": "3.1.1",
+                      "from": "esrecurse@>=3.1.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+                      "dependencies": {
+                        "estraverse": {
+                          "version": "3.1.0",
+                          "from": "estraverse@>=3.1.0 <3.2.0",
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "espree": {
+                  "version": "2.2.5",
+                  "from": "espree@>=2.2.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+                },
+                "estraverse": {
+                  "version": "4.1.1",
+                  "from": "estraverse@>=4.1.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+                },
+                "estraverse-fb": {
+                  "version": "1.3.1",
+                  "from": "estraverse-fb@>=1.3.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "file-entry-cache": {
+                  "version": "1.2.4",
+                  "from": "file-entry-cache@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+                  "dependencies": {
+                    "flat-cache": {
+                      "version": "1.0.10",
+                      "from": "flat-cache@>=1.0.9 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
+                      "dependencies": {
+                        "del": {
+                          "version": "2.2.0",
+                          "from": "del@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
+                          "dependencies": {
+                            "globby": {
+                              "version": "4.0.0",
+                              "from": "globby@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
+                              "dependencies": {
+                                "array-union": {
+                                  "version": "1.0.1",
+                                  "from": "array-union@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                                  "dependencies": {
+                                    "array-uniq": {
+                                      "version": "1.0.2",
+                                      "from": "array-uniq@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "arrify": {
+                                  "version": "1.0.1",
+                                  "from": "arrify@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                                },
+                                "glob": {
+                                  "version": "6.0.4",
+                                  "from": "glob@>=6.0.1 <7.0.0",
+                                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                                  "dependencies": {
+                                    "inflight": {
+                                      "version": "1.0.4",
+                                      "from": "inflight@>=1.0.4 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1",
+                                          "from": "wrappy@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "once": {
+                                      "version": "1.3.3",
+                                      "from": "once@>=1.3.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1",
+                                          "from": "wrappy@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "is-path-cwd": {
+                              "version": "1.0.0",
+                              "from": "is-path-cwd@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                            },
+                            "is-path-in-cwd": {
+                              "version": "1.0.0",
+                              "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                              "dependencies": {
+                                "is-path-inside": {
+                                  "version": "1.0.0",
+                                  "from": "is-path-inside@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.0",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            },
+                            "rimraf": {
+                              "version": "2.5.2",
+                              "from": "rimraf@>=2.2.8 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
+                              "dependencies": {
+                                "glob": {
+                                  "version": "7.0.0",
+                                  "from": "glob@>=7.0.0 <8.0.0",
+                                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+                                  "dependencies": {
+                                    "inflight": {
+                                      "version": "1.0.4",
+                                      "from": "inflight@>=1.0.4 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1",
+                                          "from": "wrappy@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    },
+                                    "once": {
+                                      "version": "1.3.3",
+                                      "from": "once@>=1.3.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1",
+                                          "from": "wrappy@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.3",
+                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                        },
+                        "read-json-sync": {
+                          "version": "1.1.1",
+                          "from": "read-json-sync@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
+                        },
+                        "write": {
+                          "version": "0.2.1",
+                          "from": "write@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "glob@>=5.0.14 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "8.18.0",
+                  "from": "globals@>=8.11.0 <9.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+                },
+                "handlebars": {
+                  "version": "4.0.5",
+                  "from": "handlebars@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.2",
+                      "from": "async@>=1.4.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                    },
+                    "optimist": {
+                      "version": "0.6.1",
+                      "from": "optimist@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                        },
+                        "minimist": {
+                          "version": "0.0.10",
+                          "from": "minimist@>=0.0.1 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.4.4",
+                      "from": "source-map@>=0.4.4 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "uglify-js": {
+                      "version": "2.6.1",
+                      "from": "uglify-js@>=2.6.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.2.10",
+                          "from": "async@>=0.2.6 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                        },
+                        "source-map": {
+                          "version": "0.5.3",
+                          "from": "source-map@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                        },
+                        "uglify-to-browserify": {
+                          "version": "1.0.2",
+                          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                        },
+                        "yargs": {
+                          "version": "3.10.0",
+                          "from": "yargs@>=3.10.0 <3.11.0",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "camelcase@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "cliui": {
+                              "version": "2.1.0",
+                              "from": "cliui@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.3",
+                                  "from": "center-align@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.2",
+                                          "from": "kind-of@>=3.0.2 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.2",
+                                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "longest@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.2",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "1.0.3",
+                                      "from": "lazy-cache@>=1.0.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "from": "right-align@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.4",
+                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "3.0.2",
+                                          "from": "kind-of@>=3.0.2 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.2",
+                                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "longest@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.2",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "from": "wordwrap@0.0.2",
+                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.1.2",
+                              "from": "decamelize@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz"
+                            },
+                            "window-size": {
+                              "version": "0.1.0",
+                              "from": "window-size@0.1.0",
+                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "inquirer": {
+                  "version": "0.11.4",
+                  "from": "inquirer@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
+                  "dependencies": {
+                    "ansi-escapes": {
+                      "version": "1.1.1",
+                      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.1.tgz"
+                    },
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    },
+                    "cli-cursor": {
+                      "version": "1.0.2",
+                      "from": "cli-cursor@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                      "dependencies": {
+                        "restore-cursor": {
+                          "version": "1.0.1",
+                          "from": "restore-cursor@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                          "dependencies": {
+                            "exit-hook": {
+                              "version": "1.1.1",
+                              "from": "exit-hook@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+                            },
+                            "onetime": {
+                              "version": "1.1.0",
+                              "from": "onetime@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "cli-width": {
+                      "version": "1.1.1",
+                      "from": "cli-width@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
+                    },
+                    "figures": {
+                      "version": "1.4.0",
+                      "from": "figures@>=1.3.5 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.3.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "readline2": {
+                      "version": "1.0.1",
+                      "from": "readline2@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.0",
+                          "from": "code-point-at@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "mute-stream": {
+                          "version": "0.0.5",
+                          "from": "mute-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "run-async": {
+                      "version": "0.1.0",
+                      "from": "run-async@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rx-lite": {
+                      "version": "3.1.2",
+                      "from": "rx-lite@>=3.1.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+                    },
+                    "string-width": {
+                      "version": "1.0.1",
+                      "from": "string-width@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.0",
+                          "from": "code-point-at@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.3.6 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.0",
+                  "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.0.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    }
+                  }
+                },
+                "is-resolvable": {
+                  "version": "1.0.0",
+                  "from": "is-resolvable@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+                  "dependencies": {
+                    "tryit": {
+                      "version": "1.0.2",
+                      "from": "tryit@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
+                    }
+                  }
+                },
+                "js-yaml": {
+                  "version": "3.5.3",
+                  "from": "js-yaml@>=3.2.5 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.6",
+                      "from": "argparse@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.6.tgz",
+                      "dependencies": {
+                        "sprintf-js": {
+                          "version": "1.0.3",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "2.7.2",
+                      "from": "esprima@>=2.6.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                    }
+                  }
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                  "dependencies": {
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "from": "jsonify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.clonedeep": {
+                  "version": "3.0.2",
+                  "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+                  "dependencies": {
+                    "lodash._baseclone": {
+                      "version": "3.3.0",
+                      "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+                      "dependencies": {
+                        "lodash._arraycopy": {
+                          "version": "3.0.0",
+                          "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                        },
+                        "lodash._arrayeach": {
+                          "version": "3.0.0",
+                          "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                        },
+                        "lodash._baseassign": {
+                          "version": "3.2.0",
+                          "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                          "dependencies": {
+                            "lodash._basecopy": {
+                              "version": "3.0.1",
+                              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._basefor": {
+                          "version": "3.0.3",
+                          "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        },
+                        "lodash.keys": {
+                          "version": "3.1.2",
+                          "from": "lodash.keys@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                          "dependencies": {
+                            "lodash._getnative": {
+                              "version": "3.9.1",
+                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                            },
+                            "lodash.isarguments": {
+                              "version": "3.0.7",
+                              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash.merge": {
+                  "version": "3.3.2",
+                  "from": "lodash.merge@>=3.3.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+                  "dependencies": {
+                    "lodash._arraycopy": {
+                      "version": "3.0.0",
+                      "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                    },
+                    "lodash._arrayeach": {
+                      "version": "3.0.0",
+                      "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                    },
+                    "lodash._createassigner": {
+                      "version": "3.1.1",
+                      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                      "dependencies": {
+                        "lodash._bindcallback": {
+                          "version": "3.0.1",
+                          "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.9",
+                          "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.1",
+                          "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.7",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    },
+                    "lodash.isplainobject": {
+                      "version": "3.2.0",
+                      "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+                      "dependencies": {
+                        "lodash._basefor": {
+                          "version": "3.0.3",
+                          "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                        }
+                      }
+                    },
+                    "lodash.istypedarray": {
+                      "version": "3.0.5",
+                      "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.5.tgz"
+                    },
+                    "lodash.keys": {
+                      "version": "3.1.2",
+                      "from": "lodash.keys@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                    },
+                    "lodash.keysin": {
+                      "version": "3.0.8",
+                      "from": "lodash.keysin@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+                    },
+                    "lodash.toplainobject": {
+                      "version": "3.0.0",
+                      "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.omit": {
+                  "version": "3.1.0",
+                  "from": "lodash.omit@>=3.1.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+                  "dependencies": {
+                    "lodash._arraymap": {
+                      "version": "3.0.0",
+                      "from": "lodash._arraymap@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
+                    },
+                    "lodash._basedifference": {
+                      "version": "3.0.3",
+                      "from": "lodash._basedifference@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+                      "dependencies": {
+                        "lodash._baseindexof": {
+                          "version": "3.1.0",
+                          "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+                        },
+                        "lodash._cacheindexof": {
+                          "version": "3.0.2",
+                          "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+                        },
+                        "lodash._createcache": {
+                          "version": "3.1.2",
+                          "from": "lodash._createcache@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                          "dependencies": {
+                            "lodash._getnative": {
+                              "version": "3.9.1",
+                              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._baseflatten": {
+                      "version": "3.1.4",
+                      "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+                      "dependencies": {
+                        "lodash.isarguments": {
+                          "version": "3.0.7",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    },
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._pickbyarray": {
+                      "version": "3.0.2",
+                      "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+                    },
+                    "lodash._pickbycallback": {
+                      "version": "3.0.0",
+                      "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+                      "dependencies": {
+                        "lodash._basefor": {
+                          "version": "3.0.3",
+                          "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                        }
+                      }
+                    },
+                    "lodash.keysin": {
+                      "version": "3.0.8",
+                      "from": "lodash.keysin@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                      "dependencies": {
+                        "lodash.isarguments": {
+                          "version": "3.0.7",
+                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                        },
+                        "lodash.isarray": {
+                          "version": "3.0.4",
+                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                        }
+                      }
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "from": "minimatch@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "4.0.1",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                },
+                "optionator": {
+                  "version": "0.6.0",
+                  "from": "optionator@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
+                  "dependencies": {
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "from": "deep-is@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.2",
+                      "from": "type-check@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "from": "levn@>=0.2.5 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.7",
+                      "from": "fast-levenshtein@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "path-is-inside": {
+                  "version": "1.0.1",
+                  "from": "path-is-inside@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+                },
+                "shelljs": {
+                  "version": "0.5.3",
+                  "from": "shelljs@>=0.5.3 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "from": "strip-json-comments@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                },
+                "text-table": {
+                  "version": "0.2.0",
+                  "from": "text-table@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+                },
+                "to-double-quotes": {
+                  "version": "2.0.0",
+                  "from": "to-double-quotes@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz"
+                },
+                "to-single-quotes": {
+                  "version": "2.0.0",
+                  "from": "to-single-quotes@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.0.tgz"
+                },
+                "user-home": {
+                  "version": "2.0.0",
+                  "from": "user-home@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.1",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                    }
+                  }
+                },
+                "xml-escape": {
+                  "version": "1.0.0",
+                  "from": "xml-escape@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+                }
+              }
+            },
+            "find-root": {
+              "version": "0.1.2",
+              "from": "find-root@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/find-root/-/find-root-0.1.2.tgz"
+            },
+            "multiline": {
+              "version": "1.0.2",
+              "from": "multiline@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/multiline/-/multiline-1.0.2.tgz",
+              "dependencies": {
+                "strip-indent": {
+                  "version": "1.0.1",
+                  "from": "strip-indent@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                }
+              }
+            },
+            "pkg-config": {
+              "version": "1.1.0",
+              "from": "pkg-config@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.0.tgz",
+              "dependencies": {
+                "debug-log": {
+                  "version": "1.0.0",
+                  "from": "debug-log@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.0.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "source-map-support": {
+      "version": "0.3.2",
+      "from": "source-map-support@0.3.2",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "uglify-js": {
+      "version": "2.4.24",
+      "from": "uglify-js@>=2.4.0 <2.5.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "source-map": {
+          "version": "0.1.34",
+          "from": "source-map@0.1.34",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+        },
+        "yargs": {
+          "version": "3.5.4",
+          "from": "yargs@>=3.5.4 <3.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+          "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "from": "camelcase@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+            },
+            "decamelize": {
+              "version": "1.1.2",
+              "from": "decamelize@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                }
+              }
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "from": "window-size@0.1.0",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "from": "underscore@1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+    },
+    "watchify": {
+      "version": "3.1.1",
+      "from": "watchify@3.1.1",
+      "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.1.1.tgz",
+      "dependencies": {
+        "browserify": {
+          "version": "9.0.8",
+          "from": "browserify@>=9.0.2 <10.0.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-9.0.8.tgz",
+          "dependencies": {
+            "JSONStream": {
+              "version": "0.10.0",
+              "from": "JSONStream@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.2.7 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                }
+              }
+            },
+            "assert": {
+              "version": "1.3.0",
+              "from": "assert@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+            },
+            "browser-pack": {
+              "version": "4.0.4",
+              "from": "browser-pack@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-4.0.4.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "1.0.7",
+                  "from": "JSONStream@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "1.2.0",
+                      "from": "jsonparse@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.2.7 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "combine-source-map": {
+                  "version": "0.3.0",
+                  "from": "combine-source-map@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "dependencies": {
+                    "inline-source-map": {
+                      "version": "0.3.1",
+                      "from": "inline-source-map@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.3.0",
+                          "from": "source-map@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "convert-source-map": {
+                      "version": "0.3.5",
+                      "from": "convert-source-map@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.31 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "defined": {
+                  "version": "1.0.0",
+                  "from": "defined@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                },
+                "through2": {
+                  "version": "0.5.1",
+                  "from": "through2@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.17 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "umd": {
+                  "version": "3.0.1",
+                  "from": "umd@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
+                }
+              }
+            },
+            "browser-resolve": {
+              "version": "1.11.1",
+              "from": "browser-resolve@>=1.7.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "from": "browserify-zlib@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.8",
+                  "from": "pako@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+                }
+              }
+            },
+            "buffer": {
+              "version": "3.6.0",
+              "from": "buffer@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+              "dependencies": {
+                "base64-js": {
+                  "version": "0.0.8",
+                  "from": "base64-js@0.0.8",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+                },
+                "ieee754": {
+                  "version": "1.1.6",
+                  "from": "ieee754@>=1.1.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                }
+              }
+            },
+            "builtins": {
+              "version": "0.0.7",
+              "from": "builtins@>=0.0.3 <0.1.0",
+              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+            },
+            "commondir": {
+              "version": "0.0.1",
+              "from": "commondir@0.0.1",
+              "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+            },
+            "concat-stream": {
+              "version": "1.4.10",
+              "from": "concat-stream@>=1.4.1 <1.5.0",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "0.0.1",
+              "from": "constants-browserify@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+            },
+            "crypto-browserify": {
+              "version": "3.11.0",
+              "from": "crypto-browserify@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+              "dependencies": {
+                "browserify-cipher": {
+                  "version": "1.0.0",
+                  "from": "browserify-cipher@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+                  "dependencies": {
+                    "browserify-aes": {
+                      "version": "1.0.6",
+                      "from": "browserify-aes@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                      "dependencies": {
+                        "buffer-xor": {
+                          "version": "1.0.3",
+                          "from": "buffer-xor@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                        },
+                        "cipher-base": {
+                          "version": "1.0.2",
+                          "from": "cipher-base@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "browserify-des": {
+                      "version": "1.0.0",
+                      "from": "browserify-des@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+                      "dependencies": {
+                        "cipher-base": {
+                          "version": "1.0.2",
+                          "from": "cipher-base@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                        },
+                        "des.js": {
+                          "version": "1.0.0",
+                          "from": "des.js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                          "dependencies": {
+                            "minimalistic-assert": {
+                              "version": "1.0.0",
+                              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "evp_bytestokey": {
+                      "version": "1.0.0",
+                      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                    }
+                  }
+                },
+                "browserify-sign": {
+                  "version": "4.0.0",
+                  "from": "browserify-sign@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "4.10.3",
+                      "from": "bn.js@>=4.1.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                    },
+                    "browserify-rsa": {
+                      "version": "4.0.0",
+                      "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+                    },
+                    "elliptic": {
+                      "version": "6.2.3",
+                      "from": "elliptic@>=6.0.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                      "dependencies": {
+                        "brorand": {
+                          "version": "1.0.5",
+                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                        },
+                        "hash.js": {
+                          "version": "1.0.3",
+                          "from": "hash.js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "parse-asn1": {
+                      "version": "5.0.0",
+                      "from": "parse-asn1@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+                      "dependencies": {
+                        "asn1.js": {
+                          "version": "4.5.0",
+                          "from": "asn1.js@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz",
+                          "dependencies": {
+                            "minimalistic-assert": {
+                              "version": "1.0.0",
+                              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "browserify-aes": {
+                          "version": "1.0.6",
+                          "from": "browserify-aes@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                          "dependencies": {
+                            "buffer-xor": {
+                              "version": "1.0.3",
+                              "from": "buffer-xor@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                            },
+                            "cipher-base": {
+                              "version": "1.0.2",
+                              "from": "cipher-base@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "evp_bytestokey": {
+                          "version": "1.0.0",
+                          "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "create-ecdh": {
+                  "version": "4.0.0",
+                  "from": "create-ecdh@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "4.10.3",
+                      "from": "bn.js@>=4.1.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                    },
+                    "elliptic": {
+                      "version": "6.2.3",
+                      "from": "elliptic@>=6.0.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                      "dependencies": {
+                        "brorand": {
+                          "version": "1.0.5",
+                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                        },
+                        "hash.js": {
+                          "version": "1.0.3",
+                          "from": "hash.js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "create-hash": {
+                  "version": "1.1.2",
+                  "from": "create-hash@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+                  "dependencies": {
+                    "cipher-base": {
+                      "version": "1.0.2",
+                      "from": "cipher-base@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                    },
+                    "ripemd160": {
+                      "version": "1.0.1",
+                      "from": "ripemd160@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+                    },
+                    "sha.js": {
+                      "version": "2.4.4",
+                      "from": "sha.js@>=2.3.6 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+                    }
+                  }
+                },
+                "create-hmac": {
+                  "version": "1.1.4",
+                  "from": "create-hmac@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+                },
+                "diffie-hellman": {
+                  "version": "5.0.2",
+                  "from": "diffie-hellman@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "4.10.3",
+                      "from": "bn.js@>=4.1.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                    },
+                    "miller-rabin": {
+                      "version": "4.0.0",
+                      "from": "miller-rabin@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+                      "dependencies": {
+                        "brorand": {
+                          "version": "1.0.5",
+                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "pbkdf2": {
+                  "version": "3.0.4",
+                  "from": "pbkdf2@>=3.0.3 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
+                },
+                "public-encrypt": {
+                  "version": "4.0.0",
+                  "from": "public-encrypt@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+                  "dependencies": {
+                    "bn.js": {
+                      "version": "4.10.3",
+                      "from": "bn.js@>=4.1.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+                    },
+                    "browserify-rsa": {
+                      "version": "4.0.0",
+                      "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+                    },
+                    "parse-asn1": {
+                      "version": "5.0.0",
+                      "from": "parse-asn1@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
+                      "dependencies": {
+                        "asn1.js": {
+                          "version": "4.5.0",
+                          "from": "asn1.js@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz",
+                          "dependencies": {
+                            "minimalistic-assert": {
+                              "version": "1.0.0",
+                              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "browserify-aes": {
+                          "version": "1.0.6",
+                          "from": "browserify-aes@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+                          "dependencies": {
+                            "buffer-xor": {
+                              "version": "1.0.3",
+                              "from": "buffer-xor@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                            },
+                            "cipher-base": {
+                              "version": "1.0.2",
+                              "from": "cipher-base@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "evp_bytestokey": {
+                          "version": "1.0.0",
+                          "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "randombytes": {
+                  "version": "2.0.2",
+                  "from": "randombytes@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.2.tgz"
+                }
+              }
+            },
+            "deep-equal": {
+              "version": "1.0.1",
+              "from": "deep-equal@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+            },
+            "deps-sort": {
+              "version": "1.3.9",
+              "from": "deps-sort@>=1.3.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "1.0.7",
+                  "from": "JSONStream@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "1.2.0",
+                      "from": "jsonparse@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.2.7 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.7",
+              "from": "domain-browser@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+            },
+            "duplexer2": {
+              "version": "0.0.2",
+              "from": "duplexer2@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+            },
+            "events": {
+              "version": "1.0.2",
+              "from": "events@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+            },
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.0.5 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "has": {
+              "version": "1.0.1",
+              "from": "has@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+              "dependencies": {
+                "function-bind": {
+                  "version": "1.1.0",
+                  "from": "function-bind@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+                }
+              }
+            },
+            "http-browserify": {
+              "version": "1.7.0",
+              "from": "http-browserify@>=1.4.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+              "dependencies": {
+                "Base64": {
+                  "version": "0.2.1",
+                  "from": "Base64@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                }
+              }
+            },
+            "https-browserify": {
+              "version": "0.0.1",
+              "from": "https-browserify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "insert-module-globals": {
+              "version": "6.6.3",
+              "from": "insert-module-globals@>=6.2.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "1.0.7",
+                  "from": "JSONStream@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "1.2.0",
+                      "from": "jsonparse@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.2.7 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "combine-source-map": {
+                  "version": "0.6.1",
+                  "from": "combine-source-map@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+                  "dependencies": {
+                    "convert-source-map": {
+                      "version": "1.1.3",
+                      "from": "convert-source-map@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                    },
+                    "inline-source-map": {
+                      "version": "0.5.0",
+                      "from": "inline-source-map@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                    },
+                    "lodash.memoize": {
+                      "version": "3.0.4",
+                      "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.4.4",
+                      "from": "source-map@>=0.4.2 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-buffer": {
+                  "version": "1.1.2",
+                  "from": "is-buffer@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                },
+                "lexical-scope": {
+                  "version": "1.2.0",
+                  "from": "lexical-scope@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+                  "dependencies": {
+                    "astw": {
+                      "version": "2.0.0",
+                      "from": "astw@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
+                      "dependencies": {
+                        "acorn": {
+                          "version": "1.2.2",
+                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "process": {
+                  "version": "0.11.2",
+                  "from": "process@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "labeled-stream-splicer": {
+              "version": "1.0.2",
+              "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+              "dependencies": {
+                "stream-splicer": {
+                  "version": "1.3.2",
+                  "from": "stream-splicer@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+                  "dependencies": {
+                    "readable-wrap": {
+                      "version": "1.0.0",
+                      "from": "readable-wrap@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+                    },
+                    "indexof": {
+                      "version": "0.0.1",
+                      "from": "indexof@0.0.1",
+                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "module-deps": {
+              "version": "3.9.1",
+              "from": "module-deps@>=3.7.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "1.0.7",
+                  "from": "JSONStream@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "1.2.0",
+                      "from": "jsonparse@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.2.7 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "defined": {
+                  "version": "1.0.0",
+                  "from": "defined@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                },
+                "detective": {
+                  "version": "4.3.1",
+                  "from": "detective@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                  "dependencies": {
+                    "acorn": {
+                      "version": "1.2.2",
+                      "from": "acorn@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                    }
+                  }
+                },
+                "stream-combiner2": {
+                  "version": "1.0.2",
+                  "from": "stream-combiner2@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+                  "dependencies": {
+                    "through2": {
+                      "version": "0.5.1",
+                      "from": "through2@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.17 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "3.0.0",
+                          "from": "xtend@>=3.0.0 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "os-browserify": {
+              "version": "0.1.2",
+              "from": "os-browserify@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+            },
+            "parents": {
+              "version": "1.0.1",
+              "from": "parents@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+              "dependencies": {
+                "path-platform": {
+                  "version": "0.11.15",
+                  "from": "path-platform@>=0.11.15 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
+                }
+              }
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "from": "path-browserify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "process": {
+              "version": "0.10.1",
+              "from": "process@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
+            },
+            "punycode": {
+              "version": "1.2.4",
+              "from": "punycode@>=1.2.3 <1.3.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+            },
+            "querystring-es3": {
+              "version": "0.2.1",
+              "from": "querystring-es3@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+            },
+            "read-only-stream": {
+              "version": "1.1.1",
+              "from": "read-only-stream@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-1.1.1.tgz",
+              "dependencies": {
+                "readable-wrap": {
+                  "version": "1.0.0",
+                  "from": "readable-wrap@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                }
+              }
+            },
+            "resolve": {
+              "version": "1.1.7",
+              "from": "resolve@>=1.1.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+            },
+            "shallow-copy": {
+              "version": "0.0.1",
+              "from": "shallow-copy@0.0.1",
+              "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+            },
+            "shasum": {
+              "version": "1.0.2",
+              "from": "shasum@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+              "dependencies": {
+                "json-stable-stringify": {
+                  "version": "0.0.1",
+                  "from": "json-stable-stringify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+                  "dependencies": {
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "from": "jsonify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    }
+                  }
+                },
+                "sha.js": {
+                  "version": "2.4.4",
+                  "from": "sha.js@>=2.4.4 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+                }
+              }
+            },
+            "shell-quote": {
+              "version": "0.0.1",
+              "from": "shell-quote@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+            },
+            "stream-browserify": {
+              "version": "1.0.0",
+              "from": "stream-browserify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "subarg": {
+              "version": "1.0.0",
+              "from": "subarg@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                }
+              }
+            },
+            "syntax-error": {
+              "version": "1.1.5",
+              "from": "syntax-error@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.5.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "2.7.0",
+                  "from": "acorn@>=2.7.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "1.1.1",
+              "from": "through2@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "timers-browserify": {
+              "version": "1.4.2",
+              "from": "timers-browserify@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+              "dependencies": {
+                "process": {
+                  "version": "0.11.2",
+                  "from": "process@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+                }
+              }
+            },
+            "tty-browserify": {
+              "version": "0.0.0",
+              "from": "tty-browserify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+            },
+            "url": {
+              "version": "0.10.3",
+              "from": "url@>=0.10.1 <0.11.0",
+              "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@1.3.2",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                },
+                "querystring": {
+                  "version": "0.2.0",
+                  "from": "querystring@0.2.0",
+                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "from": "util@>=0.10.1 <0.11.0",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+            },
+            "vm-browserify": {
+              "version": "0.0.4",
+              "from": "vm-browserify@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+            }
+          }
+        },
+        "chokidar": {
+          "version": "1.4.2",
+          "from": "chokidar@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.0",
+              "from": "anymatch@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "dependencies": {
+                "arrify": {
+                  "version": "1.0.1",
+                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                },
+                "micromatch": {
+                  "version": "2.3.7",
+                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "from": "arr-diff@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1",
+                          "from": "arr-flatten@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1",
+                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                    },
+                    "braces": {
+                      "version": "1.8.3",
+                      "from": "braces@>=1.8.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.1",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0",
+                                  "from": "is-number@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                },
+                                "isobject": {
+                                  "version": "2.0.0",
+                                  "from": "isobject@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "randomatic": {
+                                  "version": "1.1.5",
+                                  "from": "randomatic@>=1.1.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.4",
+                      "from": "expand-brackets@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                    },
+                    "extglob": {
+                      "version": "0.3.2",
+                      "from": "extglob@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    },
+                    "kind-of": {
+                      "version": "3.0.2",
+                      "from": "kind-of@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.2",
+                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.0.1",
+                      "from": "normalize-path@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                    },
+                    "object.omit": {
+                      "version": "2.0.0",
+                      "from": "object.omit@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.3",
+                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1",
+                          "from": "is-extendable@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "from": "parse-glob@>=3.0.4 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0",
+                          "from": "glob-base@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.2",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.2",
+                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "from": "glob-parent@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "is-binary-path": {
+              "version": "1.0.1",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.4.0",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "from": "is-glob@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "readdirp": {
+              "version": "2.0.0",
+              "from": "readdirp@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.3",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.10 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fsevents": {
+              "version": "1.0.7",
+              "from": "fsevents@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "2.2.0",
+                  "from": "nan@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.19",
+                  "from": "node-pre-gyp@>=0.6.17 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.19.tgz",
+                  "dependencies": {
+                    "nopt": {
+                      "version": "3.0.6",
+                      "from": "nopt@~3.0.1",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.7",
+                          "from": "abbrev@1",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ansi": {
+                  "version": "0.3.0",
+                  "from": "ansi@~0.3.0",
+                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                },
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@^2.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                },
+                "are-we-there-yet": {
+                  "version": "1.0.5",
+                  "from": "are-we-there-yet@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.2.3",
+                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@^0.1.5",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "async": {
+                  "version": "1.5.1",
+                  "from": "async@^1.4.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
+                },
+                "bl": {
+                  "version": "1.0.0",
+                  "from": "bl@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                },
+                "block-stream": {
+                  "version": "0.0.8",
+                  "from": "block-stream@*",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@2.x.x",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@~0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@~0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                },
+                "chalk": {
+                  "version": "1.1.1",
+                  "from": "chalk@^1.1.1",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@~1.0.5",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "from": "commander@^2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@2.x.x",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "dashdash": {
+                  "version": "1.11.0",
+                  "from": "dashdash@>=1.10.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
+                },
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@~0.7.2",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                },
+                "deep-extend": {
+                  "version": "0.4.0",
+                  "from": "deep-extend@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                },
+                "delegates": {
+                  "version": "0.1.0",
+                  "from": "delegates@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                },
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@~3.0.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@~0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "from": "form-data@~1.0.0-rc3",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                },
+                "fstream": {
+                  "version": "1.0.8",
+                  "from": "fstream@^1.0.2",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                },
+                "gauge": {
+                  "version": "1.2.2",
+                  "from": "gauge@~1.2.0",
+                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+                },
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "generate-object-property@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                },
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "from": "graceful-fs@^4.1.2",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                },
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>= 1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                },
+                "har-validator": {
+                  "version": "2.0.3",
+                  "from": "har-validator@~2.0.2",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+                },
+                "has-unicode": {
+                  "version": "1.0.1",
+                  "from": "has-unicode@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.2",
+                  "from": "hawk@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@2.x.x",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "http-signature": {
+                  "version": "1.1.0",
+                  "from": "http-signature@~1.1.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@*",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "is-typedarray@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                },
+                "is-my-json-valid": {
+                  "version": "2.12.3",
+                  "from": "is-my-json-valid@^2.12.3",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                },
+                "is-property": {
+                  "version": "1.0.2",
+                  "from": "is-property@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@~0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "jsbn": {
+                  "version": "0.1.0",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@~5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "json-schema": {
+                  "version": "0.2.2",
+                  "from": "json-schema@0.2.2",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                },
+                "jsonpointer": {
+                  "version": "2.0.0",
+                  "from": "jsonpointer@2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.2.2",
+                  "from": "jsprim@^1.2.2",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                },
+                "lodash._createpadding": {
+                  "version": "3.6.1",
+                  "from": "lodash._createpadding@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                },
+                "lodash.pad": {
+                  "version": "3.1.1",
+                  "from": "lodash.pad@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                },
+                "lodash.padleft": {
+                  "version": "3.1.1",
+                  "from": "lodash.padleft@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                },
+                "lodash.padright": {
+                  "version": "3.1.1",
+                  "from": "lodash.padright@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                },
+                "lodash.repeat": {
+                  "version": "3.0.1",
+                  "from": "lodash.repeat@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.9",
+                  "from": "mime-types@~2.1.7",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                },
+                "mime-db": {
+                  "version": "1.21.0",
+                  "from": "mime-db@~1.21.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "from": "node-uuid@~1.4.7",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "oauth-sign@~0.8.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                },
+                "npmlog": {
+                  "version": "2.0.0",
+                  "from": "npmlog@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                },
+                "once": {
+                  "version": "1.1.1",
+                  "from": "once@~1.1.1",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                },
+                "pinkie": {
+                  "version": "2.0.1",
+                  "from": "pinkie@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                },
+                "pinkie-promise": {
+                  "version": "2.0.0",
+                  "from": "pinkie-promise@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@~1.0.6",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "from": "qs@~5.2.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                },
+                "request": {
+                  "version": "2.67.0",
+                  "from": "request@2.x",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "from": "readable-stream@^2.0.0 || ^1.1.13",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@1.x.x",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "stringstream@~0.0.4",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "semver": {
+                  "version": "5.1.0",
+                  "from": "semver@~5.1.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "from": "tar@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "from": "strip-json-comments@~1.0.4",
+                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2",
+                  "from": "tunnel-agent@~0.4.1",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.2.1",
+                  "from": "tough-cookie@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                },
+                "tweetnacl": {
+                  "version": "0.13.2",
+                  "from": "tweetnacl@>=0.13.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "from": "verror@1.3.6",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.3",
+                  "from": "uid-number@0.0.3",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@~1.0.1",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@^4.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                },
+                "rc": {
+                  "version": "1.1.6",
+                  "from": "rc@~1.1.0",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@^1.2.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.7.2",
+                  "from": "sshpk@^1.7.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.2.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "from": "assert-plus@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    }
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.3",
+                  "from": "fstream-ignore@~1.0.3",
+                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "from": "minimatch@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.2",
+                          "from": "brace-expansion@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@^0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.5.0",
+                  "from": "rimraf@~2.5.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "6.0.3",
+                      "from": "glob@^6.0.1",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@^1.0.4",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@1",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "minimatch@2 || 3",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.2",
+                              "from": "brace-expansion@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "balanced-match@^0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@^1.3.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@1",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "path-is-absolute@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "tar-pack": {
+                  "version": "3.1.2",
+                  "from": "tar-pack@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.2.tgz",
+                  "dependencies": {
+                    "rimraf": {
+                      "version": "2.4.5",
+                      "from": "rimraf@~2.4.4",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "6.0.3",
+                          "from": "glob@^6.0.1",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@^1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "minimatch@2 || 3",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.2",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "balanced-match@^0.3.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@^1.3.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "defined": {
+          "version": "0.0.0",
+          "from": "defined@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+        },
+        "outpipe": {
+          "version": "1.1.1",
+          "from": "outpipe@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+          "dependencies": {
+            "shell-quote": {
+              "version": "1.4.3",
+              "from": "shell-quote@>=1.4.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                },
+                "array-filter": {
+                  "version": "0.0.1",
+                  "from": "array-filter@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+                },
+                "array-reduce": {
+                  "version": "0.0.0",
+                  "from": "array-reduce@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                },
+                "array-map": {
+                  "version": "0.0.0",
+                  "from": "array-map@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.5 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.26 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "from": "xtend@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Except for es5-shim where I set v4.5.4 instead of latest v4.5.5 which caused some tests to break. Need further investigation to why that is. This dependency is through `grunt-contrib-jasmine`, so only affects the test run.

cc @xavijam