### PR TITLE
Avoid table names prefixed by an underscore and reserve public

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1195,9 +1195,8 @@ class Table
       unless register_table_only
         begin
           #  Underscore prefixes have a special meaning in PostgreSQL, hence the ugly hack
-          #  see http://stackoverflow.com/questions/26631976/how-to-rename-a-postgresql-table-by-prefixing-an-underscore
           if name.start_with?('_')
-            temp_name = "#{10.times.map { rand(9) }.join}_" + name
+            temp_name = "t" + "#{9.times.map { rand(9) }.join}" + name
             owner.in_database.rename_table(@name_changed_from, temp_name)
             owner.in_database.rename_table(temp_name, name)
           else
@@ -1379,8 +1378,11 @@ class Table
     name = name.to_s.squish #.downcase
     name = 'untitled_table' if name.blank?
 
-    # Valid names start with a letter or an underscore
-    name = "table_#{name}" unless name[/^[a-z_]{1}/]
+    # Valid names start with a letter. Table names which start
+    # with an underscore are unsupported
+    # see http://stackoverflow.com/questions/26631976/how-to-rename-a-postgresql-table-by-prefixing-an-underscore
+
+    name = "table_#{name}" unless name[/^[a-z]{1}/]
 
     # Subsequent characters can be letters, underscores or digits
     name = name.gsub(/[^a-z0-9]/,'_').gsub(/_{2,}/, '_')

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -48,7 +48,7 @@ class UserTable < Sequel::Model
     values
   }
 
-  RESERVED_TABLE_NAMES = %W{ layergroup all }
+  RESERVED_TABLE_NAMES = %W{ layergroup all public }
 
   PRIVACY_PRIVATE = 0
   PRIVACY_PUBLIC = 1

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -48,7 +48,7 @@ class UserTable < Sequel::Model
     values
   }
 
-  RESERVED_TABLE_NAMES = %W{ layergroup all public }
+  RESERVED_TABLE_NAMES = %w{ layergroup all public }.freeze
 
   PRIVACY_PRIVATE = 0
   PRIVACY_PUBLIC = 1

--- a/services/user-mover/spec/user_mover_spec.rb
+++ b/services/user-mover/spec/user_mover_spec.rb
@@ -164,9 +164,9 @@ module Helpers
   end
 
   def create_tables(user)
-    create_table(user_id: user.id, name: "with_link", privacy: UserTable::PRIVACY_LINK)
-    create_table(user_id: user.id, name: "public",    privacy: UserTable::PRIVACY_PUBLIC)
-    create_table(user_id: user.id, name: "private",   privacy: UserTable::PRIVACY_PRIVATE)
+    create_table(user_id: user.id, name: "with_link_table", privacy: UserTable::PRIVACY_LINK)
+    create_table(user_id: user.id, name: "public_table",    privacy: UserTable::PRIVACY_PUBLIC)
+    create_table(user_id: user.id, name: "private_table",   privacy: UserTable::PRIVACY_PRIVATE)
   end
 
   def share_tables(user1, user2)
@@ -186,9 +186,9 @@ module Helpers
   end
 
   def check_tables(moved_user)
-    Table.new(user_table: moved_user.tables.where(name: "private").first).privacy.should eq UserTable::PRIVACY_PRIVATE
-    Table.new(user_table: moved_user.tables.where(name: "public").first).privacy.should eq UserTable::PRIVACY_PUBLIC
-    Table.new(user_table: moved_user.tables.where(name: "with_link").first).privacy.should eq UserTable::PRIVACY_LINK
+    Table.new(user_table: moved_user.tables.where(name: "private_table").first).privacy.should eq UserTable::PRIVACY_PRIVATE
+    Table.new(user_table: moved_user.tables.where(name: "public_table").first).privacy.should eq UserTable::PRIVACY_PUBLIC
+    Table.new(user_table: moved_user.tables.where(name: "with_link_table").first).privacy.should eq UserTable::PRIVACY_LINK
   end
 
   def create_user_mover_test_organization

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -81,13 +81,21 @@ describe Table do
       table.valid?.should == true
     end
 
-    it 'can use underscore prefixed names for tables' do
+    it 'renames "public" to "public_t"' do
+      table         = Table.new
+      table.user_id = @user.id
+      table.name    = 'public'
+      table.name.should eq 'public_t'
+      table.valid?.should == true
+    end
+
+    it 'renames table when its name is prefixed by an underscore' do
       table = Table.new
       table.user_id = @user.id
-      table.name = '_name'
+      table.name = '_coffee'
       table.save
 
-      table.name.should eq '_name'
+      table.name.should eq 'table_coffee'
       table.valid?.should == true
     end
 


### PR DESCRIPTION
Fixes #6622 
Fixes #6609 

Through the different pieces of the platform, underscored table names
have been causing issues. (i.e. sequel is crashing when georeferencing a
table whose name starts by an underscore). Although Postgres supports
these names, for each table it creates an internal type preceded by an
underscore. Therefore, there are collisions between underscored names
and already existent types.

This commit will rename any table whose name starts by an underscore.
Besides we have added the word "public" to the array of reserved words,
because it is not officially a reserved word in postgres but it can
cause issues and it is a reserved word in other standards.