### PR TITLE
6565 Implement remaining types for add-widgets modal

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option-model.js
@@ -15,11 +15,11 @@ module.exports = cdb.core.Model.extend({
 
     return {
       type: 'category',
-      title: columnName,
       layer_id: item.layerDefinitionModel.id,
       column: columnName,
       aggregation_column: columnName,
-      aggregation: this.get('aggregation')
+      aggregation: this.get('aggregation'),
+      title: this.get('title')
     };
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option-view.js
@@ -3,7 +3,7 @@ var cdb = require('cartodb.js');
 var template = require('./category-option.tpl');
 
 /**
- * View for an individual formula option.
+ * View for an individual category option.
  */
 module.exports = cdb.core.View.extend({
 
@@ -28,7 +28,7 @@ module.exports = cdb.core.View.extend({
 
     return template({
       layerIndex: i,
-      title: tuples[i].columnModel.get('name'),
+      columnName: tuples[i].columnModel.get('name'),
       layerNames: _.map(tuples, function (item) {
         return item.layerDefinitionModel.getName();
       }),

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option-view.js
@@ -1,5 +1,5 @@
-var _ = require('underscore');
 var cdb = require('cartodb.js');
+var LayerSelectorView = require('../layer-selector-view');
 var template = require('./category-option.tpl');
 
 /**
@@ -8,8 +8,7 @@ var template = require('./category-option.tpl');
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-checkbox': '_onSelect',
-    'change .js-layers': '_onLayerIndexChange'
+    'click .js-checkbox': '_onSelect'
   },
 
   initialize: function (opts) {
@@ -18,27 +17,28 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
+    this.clearSubViews();
     this.$el.html(this._html());
+    this._renderLayerSelector();
     return this;
   },
 
   _html: function () {
-    var i = this.model.get('layer_index') || 0;
+    var i = this.model.get('layer_index');
     var tuples = this.model.get('tuples');
 
     return template({
-      layerIndex: i,
       columnName: tuples[i].columnModel.get('name'),
-      layerNames: _.map(tuples, function (item) {
-        return item.layerDefinitionModel.getName();
-      }),
       isSelected: !!this.model.get('selected')
     });
   },
 
-  _onLayerIndexChange: function (ev) {
-    var val = this.$('.js-layers').val();
-    this.model.set('layer_index', parseInt(val, 10));
+  _renderLayerSelector: function () {
+    var view = new LayerSelectorView({
+      model: this.model
+    });
+    this.addView(view);
+    this.$el.append(view.render().el);
   },
 
   _onSelect: function () {

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option.tpl
@@ -1,10 +1,3 @@
 <input type="checkbox" class="js-checkbox" style="-webkit-appearance: checkbox"
   <% if (isSelected) { %>checked="checked"<% } %> />
 <h3 class="DefaultTitle"><%- columnName %></h3>
-<select class="js-layers">
-  <% layerNames.forEach(function (name, i) { %>
-    <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>
-      <%- name %>
-    </option>
-  <% }) %>
-</select>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/category/category-option.tpl
@@ -1,6 +1,6 @@
 <input type="checkbox" class="js-checkbox" style="-webkit-appearance: checkbox"
   <% if (isSelected) { %>checked="checked"<% } %> />
-<h3 class="DefaultTitle"><%- title %></h3>
+<h3 class="DefaultTitle"><%- columnName %></h3>
 <select class="js-layers">
   <% layerNames.forEach(function (name, i) { %>
     <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/create-tuples-items.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/create-tuples-items.js
@@ -1,3 +1,7 @@
+var _ = require('underscore');
+
+var BLACKLISTED_COLUMNS = ['cartodb_id', 'the_geom', 'the_geom_webmercator'];
+
 /**
  * Tmp data structure with column and layer-def models for each unique name+type tuple.
  * Each bucket contains a columnModel and layerDefinitionModel tuple,
@@ -18,16 +22,22 @@ module.exports = function (layerDefinitionsCollection) {
   return layerDefinitionsCollection
     .reduce(function (tuplesItems, layerDefModel) {
       var layerTableModel = layerDefModel.layerTableModel;
+
       if (layerTableModel) {
         layerTableModel.columnsCollection.each(function (m) {
-          var key = m.get('name') + '-' + m.get('type');
-          var tuples = tuplesItems[key] = tuplesItems[key] || [];
-          tuples.push({
-            layerDefinitionModel: layerDefModel,
-            columnModel: m
-          });
+          var columnName = m.get('name');
+
+          if (!_.contains(BLACKLISTED_COLUMNS, columnName)) {
+            var key = columnName + '-' + m.get('type');
+            var tuples = tuplesItems[key] = tuplesItems[key] || [];
+            tuples.push({
+              layerDefinitionModel: layerDefModel,
+              columnModel: m
+            });
+          }
         });
       }
+
       return tuplesItems;
     }, {});
 };

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/create-tuples-items.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/create-tuples-items.js
@@ -2,17 +2,17 @@
  * Tmp data structure with column and layer-def models for each unique name+type tuple.
  * Each bucket contains a columnModel and layerDefinitionModel tuple,
  * since they are unique even if the columns' name+type happen to be the same
- * e.g.
- *   {
- *     foobar-string: [{
- *       columnModel: M({name: 'foobar', type: 'string', …}),
- *       layerDefinitionModel: M({ id: 'abc-123', … })
- *     }]
- *   }
  * From this widget definition options for specific needs
  *
  * @param {Object} layerDefinitionsCollection
- * @return {Object} Where
+ * @return {Object} e.g.
+ *   e.g.
+ *     {
+ *       foobar-string: [{
+ *         columnModel: M({name: 'foobar', type: 'string', …}),
+ *         layerDefinitionModel: M({ id: 'abc-123', … })
+ *       }]
+ *     }
  */
 module.exports = function (layerDefinitionsCollection) {
   return layerDefinitionsCollection

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/create-tuples-items.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/create-tuples-items.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 
-var BLACKLISTED_COLUMNS = ['cartodb_id', 'the_geom', 'the_geom_webmercator'];
+var BLACKLISTED_COLUMNS = ['cartodb_id', 'created_at', 'the_geom', 'the_geom_webmercator', 'updated_at'];
 
 /**
  * Tmp data structure with column and layer-def models for each unique name+type tuple.

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option-model.js
@@ -15,9 +15,9 @@ module.exports = cdb.core.Model.extend({
 
     return {
       type: 'formula',
-      title: columnName,
       layer_id: item.layerDefinitionModel.id,
       column: columnName,
+      title: this.get('title'),
       operation: this.get('operation')
     };
   }

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option-view.js
@@ -28,7 +28,7 @@ module.exports = cdb.core.View.extend({
 
     return template({
       layerIndex: i,
-      title: tuples[i].columnModel.get('name'),
+      columnName: tuples[i].columnModel.get('name'),
       layerNames: _.map(tuples, function (item) {
         return item.layerDefinitionModel.getName();
       }),

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option-view.js
@@ -1,5 +1,5 @@
-var _ = require('underscore');
 var cdb = require('cartodb.js');
+var LayerSelectorView = require('../layer-selector-view');
 var template = require('./formula-option.tpl');
 
 /**
@@ -8,8 +8,7 @@ var template = require('./formula-option.tpl');
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-checkbox': '_onSelect',
-    'change .js-layers': '_onLayerIndexChange'
+    'click .js-checkbox': '_onSelect'
   },
 
   initialize: function (opts) {
@@ -18,27 +17,28 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
+    this.clearSubViews();
     this.$el.html(this._html());
+    this._renderLayerSelector();
     return this;
   },
 
   _html: function () {
-    var i = this.model.get('layer_index') || 0;
+    var i = this.model.get('layer_index');
     var tuples = this.model.get('tuples');
 
     return template({
-      layerIndex: i,
       columnName: tuples[i].columnModel.get('name'),
-      layerNames: _.map(tuples, function (item) {
-        return item.layerDefinitionModel.getName();
-      }),
       isSelected: !!this.model.get('selected')
     });
   },
 
-  _onLayerIndexChange: function (ev) {
-    var val = this.$('.js-layers').val();
-    this.model.set('layer_index', parseInt(val, 10));
+  _renderLayerSelector: function () {
+    var view = new LayerSelectorView({
+      model: this.model
+    });
+    this.addView(view);
+    this.$el.append(view.render().el);
   },
 
   _onSelect: function () {

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option.tpl
@@ -1,10 +1,3 @@
 <input type="checkbox" class="js-checkbox" style="-webkit-appearance: checkbox"
   <% if (isSelected) { %>checked="checked"<% } %> />
 <h3 class="DefaultTitle"><%- columnName %></h3>
-<select class="js-layers">
-  <% layerNames.forEach(function (name, i) { %>
-    <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>
-      <%- name %>
-    </option>
-  <% }) %>
-</select>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/formula/formula-option.tpl
@@ -1,6 +1,6 @@
 <input type="checkbox" class="js-checkbox" style="-webkit-appearance: checkbox"
   <% if (isSelected) { %>checked="checked"<% } %> />
-<h3 class="DefaultTitle"><%- title %></h3>
+<h3 class="DefaultTitle"><%- columnName %></h3>
 <select class="js-layers">
   <% layerNames.forEach(function (name, i) { %>
     <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-model.js
@@ -15,9 +15,9 @@ module.exports = cdb.core.Model.extend({
 
     return {
       type: 'histogram',
-      title: columnName,
       layer_id: item.layerDefinitionModel.id,
       column: columnName,
+      title: this.get('title'),
       bins: this.get('bins')
     };
   }

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-model.js
@@ -1,0 +1,24 @@
+var cdb = require('cartodb.js');
+
+module.exports = cdb.core.Model.extend({
+
+  defaults: {
+    type: 'histogram',
+    layer_index: 0,
+    tuples: []
+  },
+
+  getWidgetDefinitionAttrs: function () {
+    var i = this.get('layer_index');
+    var item = this.get('tuples')[i];
+    var columnName = item.columnModel.get('name');
+
+    return {
+      type: 'histogram',
+      title: columnName,
+      layer_id: item.layerDefinitionModel.id,
+      column: columnName,
+      bins: this.get('bins')
+    };
+  }
+});

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-model.js
@@ -11,12 +11,11 @@ module.exports = cdb.core.Model.extend({
   getWidgetDefinitionAttrs: function () {
     var i = this.get('layer_index');
     var item = this.get('tuples')[i];
-    var columnName = item.columnModel.get('name');
 
     return {
       type: 'histogram',
       layer_id: item.layerDefinitionModel.id,
-      column: columnName,
+      column: item.columnModel.get('name'),
       title: this.get('title'),
       bins: this.get('bins')
     };

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-view.js
@@ -1,5 +1,5 @@
-var _ = require('underscore');
 var cdb = require('cartodb.js');
+var LayerSelectorView = require('../layer-selector-view');
 var template = require('./histogram-option.tpl');
 
 /**
@@ -8,8 +8,7 @@ var template = require('./histogram-option.tpl');
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-checkbox': '_onSelect',
-    'change .js-layers': '_onLayerIndexChange'
+    'click .js-checkbox': '_onSelect'
   },
 
   initialize: function (opts) {
@@ -18,7 +17,9 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
+    this.clearSubViews();
     this.$el.html(this._html());
+    this._renderLayerSelector();
     return this;
   },
 
@@ -27,18 +28,17 @@ module.exports = cdb.core.View.extend({
     var tuples = this.model.get('tuples');
 
     return template({
-      layerIndex: i,
       columnName: tuples[i].columnModel.get('name'),
-      layerNames: _.map(tuples, function (item) {
-        return item.layerDefinitionModel.getName();
-      }),
       isSelected: !!this.model.get('selected')
     });
   },
 
-  _onLayerIndexChange: function (ev) {
-    var val = this.$('.js-layers').val();
-    this.model.set('layer_index', parseInt(val, 10));
+  _renderLayerSelector: function () {
+    var view = new LayerSelectorView({
+      model: this.model
+    });
+    this.addView(view);
+    this.$el.append(view.render().el);
   },
 
   _onSelect: function () {

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-view.js
@@ -1,0 +1,48 @@
+var _ = require('underscore');
+var cdb = require('cartodb.js');
+var template = require('./histogram-option.tpl');
+
+/**
+ * View for an individual formula option.
+ */
+module.exports = cdb.core.View.extend({
+
+  events: {
+    'click .js-checkbox': '_onSelect',
+    'change .js-layers': '_onLayerIndexChange'
+  },
+
+  initialize: function (opts) {
+    this.listenTo(this.model, 'change:layer_index', this.render);
+    this.listenTo(this.model, 'change:selected', this.render);
+  },
+
+  render: function () {
+    this.$el.html(this._html());
+    return this;
+  },
+
+  _html: function () {
+    var i = this.model.get('layer_index') || 0;
+    var tuples = this.model.get('tuples');
+
+    return template({
+      layerIndex: i,
+      title: tuples[i].columnModel.get('name'),
+      layerNames: _.map(tuples, function (item) {
+        return item.layerDefinitionModel.getName();
+      }),
+      isSelected: !!this.model.get('selected')
+    });
+  },
+
+  _onLayerIndexChange: function (ev) {
+    var val = this.$('.js-layers').val();
+    this.model.set('layer_index', parseInt(val, 10));
+  },
+
+  _onSelect: function () {
+    this.model.set('selected', !this.model.get('selected'));
+  }
+
+});

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option-view.js
@@ -3,7 +3,7 @@ var cdb = require('cartodb.js');
 var template = require('./histogram-option.tpl');
 
 /**
- * View for an individual formula option.
+ * View for an individual histogram option.
  */
 module.exports = cdb.core.View.extend({
 
@@ -28,7 +28,7 @@ module.exports = cdb.core.View.extend({
 
     return template({
       layerIndex: i,
-      title: tuples[i].columnModel.get('name'),
+      columnName: tuples[i].columnModel.get('name'),
       layerNames: _.map(tuples, function (item) {
         return item.layerDefinitionModel.getName();
       }),

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option.tpl
@@ -1,10 +1,3 @@
 <input type="checkbox" class="js-checkbox" style="-webkit-appearance: checkbox"
   <% if (isSelected) { %>checked="checked"<% } %> />
 <h3 class="DefaultTitle"><%- columnName %></h3>
-<select class="js-layers">
-  <% layerNames.forEach(function (name, i) { %>
-    <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>
-      <%- name %>
-    </option>
-  <% }) %>
-</select>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option.tpl
@@ -1,0 +1,10 @@
+<input type="checkbox" class="js-checkbox" style="-webkit-appearance: checkbox"
+  <% if (isSelected) { %>checked="checked"<% } %> />
+<h3 class="DefaultTitle"><%- title %></h3>
+<select class="js-layers">
+  <% layerNames.forEach(function (name, i) { %>
+    <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>
+      <%- name %>
+    </option>
+  <% }) %>
+</select>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-option.tpl
@@ -1,6 +1,6 @@
 <input type="checkbox" class="js-checkbox" style="-webkit-appearance: checkbox"
   <% if (isSelected) { %>checked="checked"<% } %> />
-<h3 class="DefaultTitle"><%- title %></h3>
+<h3 class="DefaultTitle"><%- columnName %></h3>
 <select class="js-layers">
   <% layerNames.forEach(function (name, i) { %>
     <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-options-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-options-view.js
@@ -2,7 +2,7 @@ var cdb = require('cartodb.js');
 var HistogramOptionView = require('./histogram-option-view.js');
 
 /**
- * View to select category widget options
+ * View to select histogram widget options
  */
 module.exports = cdb.core.View.extend({
 

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-options-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/histogram/histogram-options-view.js
@@ -1,0 +1,31 @@
+var cdb = require('cartodb.js');
+var HistogramOptionView = require('./histogram-option-view.js');
+
+/**
+ * View to select category widget options
+ */
+module.exports = cdb.core.View.extend({
+
+  render: function () {
+    this.clearSubViews();
+    this.$el.empty();
+    this.collection
+      .chain()
+      .filter(this._isHistogram)
+      .each(this._renderOption, this);
+    return this;
+  },
+
+  _renderOption: function (m) {
+    var view = new HistogramOptionView({
+      model: m
+    });
+    this.addView(view);
+    this.$el.append(view.render().el);
+  },
+
+  _isHistogram: function (m) {
+    return m.get('type') === 'histogram';
+  }
+
+});

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/layer-selector-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/layer-selector-view.js
@@ -1,0 +1,42 @@
+var _ = require('underscore');
+var cdb = require('cartodb.js');
+var template = require('./layer-selector.tpl');
+
+/**
+ * View for selecting the layer through which to load the column data.
+ */
+module.exports = cdb.core.View.extend({
+
+  tagName: 'select',
+
+  events: {
+    'change': '_onChange'
+  },
+
+  initialize: function (opts) {
+    this.listenTo(this.model, 'change:layer_index', this.render);
+  },
+
+  render: function () {
+    this.$el.html(this._html());
+    return this;
+  },
+
+  _html: function () {
+    var i = this.model.get('layer_index');
+    var tuples = this.model.get('tuples');
+
+    return template({
+      layerIndex: i,
+      layerNames: _.map(tuples, function (item) {
+        return item.layerDefinitionModel.getName();
+      })
+    });
+  },
+
+  _onChange: function () {
+    var val = this.$el.val();
+    this.model.set('layer_index', parseInt(val, 10));
+  }
+
+});

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/layer-selector.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/layer-selector.tpl
@@ -1,0 +1,5 @@
+<% layerNames.forEach(function (name, i) { %>
+  <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>
+    <%- name %>
+  </option>
+<% }) %>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-no-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-no-option-view.js
@@ -1,0 +1,61 @@
+var cdb = require('cartodb.js');
+var template = require('./time-series-no-option.tpl');
+
+/**
+ * Represents the (default) no-option view, i.e. since time-series options only can have one selection,
+ * this serves as the "unselect" option.
+ */
+module.exports = cdb.core.View.extend({
+
+  events: {
+    'click .js-radio': '_onSelect',
+    'change .js-layers': '_onLayerIndexChange'
+  },
+
+  initialize: function (opts) {
+    if (!opts.optionsCollection) throw new Error('optionsCollection is required');
+
+    this._optionsCollection = opts.optionsCollection;
+
+    this.listenTo(this._optionsCollection, 'change:selected', this.render);
+    this.add_related_model(this._optionsCollection);
+  },
+
+  render: function () {
+    this.$el.html(this._html());
+    return this;
+  },
+
+  _html: function () {
+    return template({
+      isSelected: !this
+        ._timeSeriesOptionsChain()
+        .any(this._isSelected)
+        .value()
+    });
+  },
+
+  _isSelected: function (m) {
+    return !!m.get('selected');
+  },
+
+  _onSelect: function () {
+    this._timeSeriesOptionsChain().each(this._deselect);
+  },
+
+  _deselect: function (m) {
+    m.set('selected', false);
+  },
+
+  _timeSeriesOptionsChain: function () {
+    return this._optionsCollection
+      .chain()
+      .filter(this._isTimeSeries);
+  },
+
+  _isTimeSeries: function (m) {
+    return m.get('type') === 'time-series';
+  }
+
+
+});

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-no-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-no-option-view.js
@@ -57,5 +57,4 @@ module.exports = cdb.core.View.extend({
     return m.get('type') === 'time-series';
   }
 
-
 });

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-no-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-no-option.tpl
@@ -1,0 +1,3 @@
+<input type="radio" class="js-radio" <% if (isSelected) { %>checked="checked"<% } %> style="-webkit-appearance: radio" />
+<h3 class="DefaultTitle"><%- _t('editor.add-widgets.time-series-no-option-title') %></h3>
+<p class="DefaultDescription"><%- _t('editor.add-widgets.time-series-no-option-desc') %></p>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option-model.js
@@ -1,0 +1,25 @@
+var cdb = require('cartodb.js');
+
+module.exports = cdb.core.Model.extend({
+
+  defaults: {
+    type: 'time-series',
+    layer_index: 0,
+    tuples: []
+  },
+
+  getWidgetDefinitionAttrs: function () {
+    var i = this.get('layer_index');
+    var item = this.get('tuples')[i];
+
+    return {
+      type: 'time-series',
+      layer_id: item.layerDefinitionModel.id,
+      column: item.columnModel.get('name'),
+      title: this.get('title'),
+      bins: this.get('bins'),
+      start: this.get('start'),
+      end: this.get('end')
+    };
+  }
+});

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option-view.js
@@ -1,0 +1,48 @@
+var _ = require('underscore');
+var cdb = require('cartodb.js');
+var template = require('./time-series-option.tpl');
+
+/**
+ * View for an individual time-series option.
+ */
+module.exports = cdb.core.View.extend({
+
+  events: {
+    'click .js-radio': '_onSelect',
+    'change .js-layers': '_onLayerIndexChange'
+  },
+
+  initialize: function (opts) {
+    this.listenTo(this.model, 'change:layer_index', this.render);
+    this.listenTo(this.model, 'change:selected', this.render);
+  },
+
+  render: function () {
+    this.$el.html(this._html());
+    return this;
+  },
+
+  _html: function () {
+    var i = this.model.get('layer_index') || 0;
+    var tuples = this.model.get('tuples');
+
+    return template({
+      layerIndex: i,
+      columnName: tuples[i].columnModel.get('name'),
+      layerNames: _.map(tuples, function (item) {
+        return item.layerDefinitionModel.getName();
+      }),
+      isSelected: !!this.model.get('selected')
+    });
+  },
+
+  _onLayerIndexChange: function (ev) {
+    var val = this.$('.js-layers').val();
+    this.model.set('layer_index', parseInt(val, 10));
+  },
+
+  _onSelect: function () {
+    this.model.set('selected', !this.model.get('selected'));
+  }
+
+});

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option-view.js
@@ -1,5 +1,5 @@
-var _ = require('underscore');
 var cdb = require('cartodb.js');
+var LayerSelectorView = require('../layer-selector-view');
 var template = require('./time-series-option.tpl');
 
 /**
@@ -8,8 +8,7 @@ var template = require('./time-series-option.tpl');
 module.exports = cdb.core.View.extend({
 
   events: {
-    'click .js-radio': '_onSelect',
-    'change .js-layers': '_onLayerIndexChange'
+    'click .js-radio': '_onSelect'
   },
 
   initialize: function (opts) {
@@ -18,7 +17,9 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
+    this.clearSubViews();
     this.$el.html(this._html());
+    this._renderLayerSelector();
     return this;
   },
 
@@ -27,18 +28,17 @@ module.exports = cdb.core.View.extend({
     var tuples = this.model.get('tuples');
 
     return template({
-      layerIndex: i,
       columnName: tuples[i].columnModel.get('name'),
-      layerNames: _.map(tuples, function (item) {
-        return item.layerDefinitionModel.getName();
-      }),
       isSelected: !!this.model.get('selected')
     });
   },
 
-  _onLayerIndexChange: function (ev) {
-    var val = this.$('.js-layers').val();
-    this.model.set('layer_index', parseInt(val, 10));
+  _renderLayerSelector: function () {
+    var view = new LayerSelectorView({
+      model: this.model
+    });
+    this.addView(view);
+    this.$el.append(view.render().el);
   },
 
   _onSelect: function () {

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option.tpl
@@ -1,0 +1,10 @@
+<input type="radio" class="js-radio" style="-webkit-appearance: radio"
+  <% if (isSelected) { %>checked="checked"<% } %> />
+<h3 class="DefaultTitle"><%- columnName %></h3>
+<select class="js-layers">
+  <% layerNames.forEach(function (name, i) { %>
+    <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>
+      <%- name %>
+    </option>
+  <% }) %>
+</select>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-option.tpl
@@ -1,10 +1,3 @@
 <input type="radio" class="js-radio" style="-webkit-appearance: radio"
   <% if (isSelected) { %>checked="checked"<% } %> />
 <h3 class="DefaultTitle"><%- columnName %></h3>
-<select class="js-layers">
-  <% layerNames.forEach(function (name, i) { %>
-    <option value="<%- i %>" <% if (i === layerIndex) { %>selected="selected"<% } %>>
-      <%- name %>
-    </option>
-  <% }) %>
-</select>

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-options-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/time-series/time-series-options-view.js
@@ -1,0 +1,54 @@
+var cdb = require('cartodb.js');
+var TimeSeriesOptionView = require('./time-series-option-view.js');
+var TimeSeriesNoOptionView = require('./time-series-no-option-view.js');
+
+/**
+ * View to select time-series widget options
+ */
+module.exports = cdb.core.View.extend({
+
+  initialize: function () {
+    this.listenTo(this.collection, 'change:selected', this._onSelectedChange);
+  },
+
+  render: function () {
+    this.clearSubViews();
+    this.$el.empty();
+
+    var view = new TimeSeriesNoOptionView({
+      optionsCollection: this.collection
+    });
+    this.addView(view);
+    this.$el.append(view.render().el);
+
+    this.collection
+      .chain()
+      .filter(this._isTimeSeries)
+      .each(this._renderOption, this);
+    return this;
+  },
+
+  _renderOption: function (m) {
+    var view = new TimeSeriesOptionView({
+      model: m
+    });
+    this.addView(view);
+    this.$el.append(view.render().el);
+  },
+
+  _isTimeSeries: function (m) {
+    return m.get('type') === 'time-series';
+  },
+
+  _onSelectedChange: function (selectedModel, isSelected) {
+    // Make sure there can only be one selected time-series widget option
+    if (isSelected) {
+      this.collection.each(function (m) {
+        if (this._isTimeSeries(m) && m !== selectedModel) {
+          m.set('selected', false);
+        }
+      }, this);
+    }
+  }
+
+});

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
@@ -1,7 +1,9 @@
-var FormulaOptionModel = require('./formula/formula-option-model');
-var FormulaOptionsView = require('./formula/formula-options-view');
 var CategoryOptionModel = require('./category/category-option-model');
 var CategoryOptionsView = require('./category/category-options-view');
+var HistogramOptionModel = require('./histogram/histogram-option-model');
+var HistogramOptionsView = require('./histogram/histogram-options-view');
+var FormulaOptionModel = require('./formula/formula-option-model');
+var FormulaOptionsView = require('./formula/formula-options-view');
 
 // Order is the same in how things will be presented in the UI
 module.exports = [
@@ -18,6 +20,28 @@ module.exports = [
         label: _t('editor.add-widgets.tab-pane.category-label'),
         createContentView: function () {
           return new CategoryOptionsView({
+            collection: optionsCollection
+          });
+        }
+      };
+    }
+  },
+  {
+    type: 'histogram',
+    createOptionModels: function (tuples) {
+      var columnModel = tuples[0].columnModel;
+      if (columnModel.get('type') === 'number') {
+        return new HistogramOptionModel({
+          tuples: tuples,
+          bins: 10
+        });
+      }
+    },
+    createTabPaneItem: function (optionsCollection) {
+      return {
+        label: _t('editor.add-widgets.tab-pane.histogram-label'),
+        createContentView: function () {
+          return new HistogramOptionsView({
             collection: optionsCollection
           });
         }

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
@@ -10,8 +10,10 @@ module.exports = [
   {
     type: 'category',
     createOptionModels: function (tuples) {
+      var columnModel = tuples[0].columnModel;
       return new CategoryOptionModel({
         tuples: tuples,
+        title: 'category ' + columnModel.get('name'),
         aggregation: 'sum' // or count
       });
     },
@@ -33,6 +35,7 @@ module.exports = [
       if (columnModel.get('type') === 'number') {
         return new HistogramOptionModel({
           tuples: tuples,
+          title: 'histogram ' + columnModel.get('name'),
           bins: 10
         });
       }
@@ -55,6 +58,7 @@ module.exports = [
       if (columnModel.get('type') === 'number') {
         return new FormulaOptionModel({
           tuples: tuples,
+          title: 'formula ' + columnModel.get('name'),
           operation: 'avg'
         });
       }

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
@@ -15,7 +15,7 @@ module.exports = [
       var columnModel = tuples[0].columnModel;
       return new CategoryOptionModel({
         tuples: tuples,
-        title: 'category ' + columnModel.get('name'),
+        title: 'Category ' + columnModel.get('name'),
         aggregation: 'sum' // or count
       });
     },
@@ -37,7 +37,7 @@ module.exports = [
       if (columnModel.get('type') === 'number') {
         return new HistogramOptionModel({
           tuples: tuples,
-          title: 'histogram ' + columnModel.get('name'),
+          title: 'Histogram ' + columnModel.get('name'),
           bins: 10
         });
       }
@@ -60,7 +60,7 @@ module.exports = [
       if (columnModel.get('type') === 'number') {
         return new FormulaOptionModel({
           tuples: tuples,
-          title: 'formula ' + columnModel.get('name'),
+          title: 'Formula ' + columnModel.get('name'),
           operation: 'avg'
         });
       }

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
@@ -84,9 +84,9 @@ module.exports = [
         return new TimeSeriesOptionModel({
           tuples: tuples,
           title: 'Time-series ' + columnModel.get('name'),
-          bins: 10,
+          bins: 255,
           start: 0,
-          end: 10
+          end: Date.now()
         });
       }
     },

--- a/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/add-widgets/widgets-types.js
@@ -4,6 +4,8 @@ var HistogramOptionModel = require('./histogram/histogram-option-model');
 var HistogramOptionsView = require('./histogram/histogram-options-view');
 var FormulaOptionModel = require('./formula/formula-option-model');
 var FormulaOptionsView = require('./formula/formula-options-view');
+var TimeSeriesOptionModel = require('./time-series/time-series-option-model');
+var TimeSeriesOptionsView = require('./time-series/time-series-options-view');
 
 // Order is the same in how things will be presented in the UI
 module.exports = [
@@ -68,6 +70,31 @@ module.exports = [
         label: _t('editor.add-widgets.tab-pane.formula-label'),
         createContentView: function () {
           return new FormulaOptionsView({
+            collection: optionsCollection
+          });
+        }
+      };
+    }
+  },
+  {
+    type: 'time-series',
+    createOptionModels: function (tuples) {
+      var columnModel = tuples[0].columnModel;
+      if (columnModel.get('type') === 'date') {
+        return new TimeSeriesOptionModel({
+          tuples: tuples,
+          title: 'Time-series ' + columnModel.get('name'),
+          bins: 10,
+          start: 0,
+          end: 10
+        });
+      }
+    },
+    createTabPaneItem: function (optionsCollection) {
+      return {
+        label: _t('editor.add-widgets.tab-pane.time-series-label'),
+        createContentView: function () {
+          return new TimeSeriesOptionsView({
             collection: optionsCollection
           });
         }

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-time-series-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-time-series-data-schema-model.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var cdb = require('cartodb-deep-insights.js');
 
 module.exports = cdb.core.Model.extend({
@@ -6,6 +7,14 @@ module.exports = cdb.core.Model.extend({
     if (!opts.layerTableModel) throw new Error('layerTableModel is required');
 
     this._layerTableModel = opts.layerTableModel;
+  },
+
+  parse: function (r) {
+    // Translate start+end unix timestamps to expected date objects for the form
+    return _.defaults({
+      start: new Date(r.start * 1000),
+      end: new Date(r.end * 1000)
+    }, r);
   },
 
   updateSchema: function () {
@@ -42,6 +51,16 @@ module.exports = cdb.core.Model.extend({
 
   canSave: function () {
     return this.get('column');
+  },
+
+  customUpdateWidgetDefinitionModel: function (widgetDefinitionModel) {
+    var attrs = _.clone(this.attributes);
+
+    // Transform start+end dates back to expected unix timestamps
+    attrs.start = attrs.start.getTime() / 1000;
+    attrs.end = attrs.end.getTime() / 1000;
+
+    widgetDefinitionModel.set(attrs);
   },
 
   _columnsForSelectedLayer: function () {

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data-view.js
@@ -63,7 +63,11 @@ module.exports = cdb.core.View.extend({
 
   _onFormChange: function () {
     if (this._widgetFormModel.canSave()) {
-      this._widgetDefinitionModel.set(this._widgetFormModel.attributes);
+      if (this._widgetFormModel.customUpdateWidgetDefinitionModel) {
+        this._widgetFormModel.customUpdateWidgetDefinitionModel(this._widgetDefinitionModel);
+      } else {
+        this._widgetDefinitionModel.set(this._widgetFormModel.attributes);
+      }
       this._debouncedSave();
     }
   }

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-factory.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-factory.js
@@ -40,6 +40,7 @@ module.exports = {
     var widgetType = widgetDefinitionModel.get('type');
     var Klass = dataMap[widgetType].klass;
     return new Klass(widgetDefinitionModel.attributes, {
+      parse: true, // in case the raw attributes needs to be adapted to the expected form types, e.g. timestamp => Date
       widgetDefinitionModel: widgetDefinitionModel,
       layerTableModel: layerTableModel
     });

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -13,7 +13,9 @@
         "category-label": "Category",
         "formula-label": "Formula",
         "time-series-label": "Time-series"
-      }
+      },
+      "time-series-no-option-title": "None",
+      "time-series-no-option-desc": "This option won't show your time-series widget"
     },
     "layers": {
       "title": "LAYERS"

--- a/lib/assets/test/spec/cartodb3/editor/add-widgets/body-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/add-widgets/body-view.spec.js
@@ -1,0 +1,49 @@
+var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var BodyView = require('../../../../../javascripts/cartodb3/editor/add-widgets/body-view');
+
+describe('editor/add-widgets/body-view', function () {
+  beforeEach(function () {
+    this.optionsCollection = new Backbone.Collection([
+      {
+        type: 'formula'
+      }, {
+        type: 'category'
+      }
+    ]);
+    this.categoryContentView = new cdb.core.View();
+    this.createCategoryContentViewSpy = jasmine.createSpy('category.createTabPaneContentView').and.returnValue(this.categoryContentView);
+    this.createCategoryTabPaneItemSpy = jasmine.createSpy('category.createTabpaneItem').and.returnValue({
+      label: 'category label',
+      createContentView: this.createCategoryContentViewSpy
+    });
+    this.createHistogramTabPaneItemSpy = jasmine.createSpy('histogram.createTabpaneItem');
+    this.widgetsTypes = [
+      {
+        type: 'category',
+        createTabPaneItem: this.createCategoryTabPaneItemSpy
+      }, {
+        type: 'histogram',
+        createTabPaneItem: this.createHistogramTabPaneItemSpy
+      }
+    ];
+    this.view = new BodyView({
+      optionsCollection: this.optionsCollection,
+      widgetsTypes: this.widgetsTypes
+    });
+    this.view = this.view.render();
+  });
+
+  it('should have no leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should render fine', function () {
+    expect(this.view).toBeDefined();
+  });
+
+  it('should create tab pane items when there is at least one option of that type', function () {
+    expect(this.createCategoryTabPaneItemSpy).toHaveBeenCalled();
+    expect(this.createHistogramTabPaneItemSpy).not.toHaveBeenCalled();
+  });
+});

--- a/lib/assets/test/spec/cartodb3/editor/add-widgets/body-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/add-widgets/body-view.spec.js
@@ -1,35 +1,39 @@
 var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var BodyView = require('../../../../../javascripts/cartodb3/editor/add-widgets/body-view');
+var widgetsTypes = require('../../../../../javascripts/cartodb3/editor/add-widgets/widgets-types');
 
 describe('editor/add-widgets/body-view', function () {
   beforeEach(function () {
+    var layerDefinitionModel = new cdb.core.Model();
+    layerDefinitionModel.getName = function () { return 'layer'; };
+    var tuples = [{
+      columnModel: new cdb.core.Model(),
+      layerDefinitionModel: layerDefinitionModel
+    }];
     this.optionsCollection = new Backbone.Collection([
       {
-        type: 'formula'
-      }, {
-        type: 'category'
-      }
-    ]);
-    this.categoryContentView = new cdb.core.View();
-    this.createCategoryContentViewSpy = jasmine.createSpy('category.createTabPaneContentView').and.returnValue(this.categoryContentView);
-    this.createCategoryTabPaneItemSpy = jasmine.createSpy('category.createTabpaneItem').and.returnValue({
-      label: 'category label',
-      createContentView: this.createCategoryContentViewSpy
-    });
-    this.createHistogramTabPaneItemSpy = jasmine.createSpy('histogram.createTabpaneItem');
-    this.widgetsTypes = [
-      {
         type: 'category',
-        createTabPaneItem: this.createCategoryTabPaneItemSpy
+        layer_index: 0,
+        tuples: tuples
       }, {
         type: 'histogram',
-        createTabPaneItem: this.createHistogramTabPaneItemSpy
+        layer_index: 0,
+        tuples: tuples
+      }, {
+        type: 'formula',
+        layer_index: 0,
+        tuples: tuples
+      }, {
+        type: 'time-series',
+        layer_index: 0,
+        tuples: tuples
       }
-    ];
+    ]);
+
     this.view = new BodyView({
       optionsCollection: this.optionsCollection,
-      widgetsTypes: this.widgetsTypes
+      widgetsTypes: widgetsTypes
     });
     this.view = this.view.render();
   });
@@ -43,7 +47,9 @@ describe('editor/add-widgets/body-view', function () {
   });
 
   it('should create tab pane items when there is at least one option of that type', function () {
-    expect(this.createCategoryTabPaneItemSpy).toHaveBeenCalled();
-    expect(this.createHistogramTabPaneItemSpy).not.toHaveBeenCalled();
+    expect(this.view.$el.html()).toContain('formula');
+    expect(this.view.$el.html()).toContain('category');
+    expect(this.view.$el.html()).toContain('histogram');
+    expect(this.view.$el.html()).toContain('time-series');
   });
 });

--- a/lib/assets/test/spec/cartodb3/editor/add-widgets/create-tuples-items.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/add-widgets/create-tuples-items.spec.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Backbone = require('backbone');
 var ConfigModel = require('../../../../../javascripts/cartodb3/data/config-model');
 var LayerDefinitionsCollection = require('../../../../../javascripts/cartodb3/data/layer-definitions-collection');
@@ -38,8 +39,17 @@ describe('editor/add-widgets/create-tuples-items', function () {
     var l1 = this.LayerDefinitionsCollection.get('l1');
     l1.layerTableModel.columnsCollection.reset([
       {
+        name: 'cartodb_id',
+        type: 'number'
+      }, {
         name: 'county_name',
         type: 'string'
+      }, {
+        name: 'the_geom',
+        type: 'geom'
+      }, {
+        name: 'the_geom_webmercator',
+        type: 'geom'
       }, {
         name: 'pop_count',
         type: 'number'
@@ -48,6 +58,9 @@ describe('editor/add-widgets/create-tuples-items', function () {
     var l2 = this.LayerDefinitionsCollection.get('l2');
     l2.layerTableModel.columnsCollection.reset([
       {
+        name: 'cartodb_id',
+        type: 'number'
+      }, {
         name: 'pop_count',
         type: 'number'
       }
@@ -62,6 +75,13 @@ describe('editor/add-widgets/create-tuples-items', function () {
   it('should contain an item for each column name+type match', function () {
     expect(this.tuplesItems['county_name-string'].length).toEqual(1);
     expect(this.tuplesItems['pop_count-number'].length).toEqual(2);
+  });
+
+  it('should not add items for blacklisted columns', function () {
+    var keys = _.keys(this.tuplesItems).toString();
+    expect(keys).not.toContain('cartodb_id');
+    expect(keys).not.toContain('the_geom');
+    expect(keys).not.toContain('the_geom_webmercator');
   });
 
   it('should contain a tuple of column+layer definition in each item', function () {

--- a/lib/assets/test/spec/cartodb3/editor/add-widgets/create-tuples-items.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/add-widgets/create-tuples-items.spec.js
@@ -53,6 +53,12 @@ describe('editor/add-widgets/create-tuples-items', function () {
       }, {
         name: 'pop_count',
         type: 'number'
+      }, {
+        name: 'created_at',
+        type: 'date'
+      }, {
+        name: 'updated_at',
+        type: 'date'
       }
     ]);
     var l2 = this.LayerDefinitionsCollection.get('l2');
@@ -82,6 +88,8 @@ describe('editor/add-widgets/create-tuples-items', function () {
     expect(keys).not.toContain('cartodb_id');
     expect(keys).not.toContain('the_geom');
     expect(keys).not.toContain('the_geom_webmercator');
+    expect(keys).not.toContain('created_at');
+    expect(keys).not.toContain('updated_at');
   });
 
   it('should contain a tuple of column+layer definition in each item', function () {

--- a/lib/assets/test/spec/cartodb3/editor/add-widgets/create-tuples-items.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/add-widgets/create-tuples-items.spec.js
@@ -1,0 +1,75 @@
+var Backbone = require('backbone');
+var ConfigModel = require('../../../../../javascripts/cartodb3/data/config-model');
+var LayerDefinitionsCollection = require('../../../../../javascripts/cartodb3/data/layer-definitions-collection');
+var createTuplesItems = require('../../../../../javascripts/cartodb3/editor/add-widgets/create-tuples-items');
+
+describe('editor/add-widgets/create-tuples-items', function () {
+  beforeEach(function () {
+    var configModel = new ConfigModel({
+      base_url: '/u/pepe'
+    });
+    this.layersCollection = new Backbone.Collection({
+      id: 'l0'
+    }, {
+      id: 'l1'
+    });
+    this.LayerDefinitionsCollection = new LayerDefinitionsCollection([
+      {
+        id: 'l0',
+        type: 'tiled'
+      }, {
+        id: 'l1',
+        type: 'cartodb',
+        options: {
+          table_name: 'foo_table'
+        }
+      }, {
+        id: 'l2',
+        type: 'cartodb',
+        options: {
+          table_name: 'bar_table'
+        }
+      }
+    ], {
+      configModel: configModel,
+      layersCollection: this.layersCollection,
+      mapId: 'm-123'
+    });
+    var l1 = this.LayerDefinitionsCollection.get('l1');
+    l1.layerTableModel.columnsCollection.reset([
+      {
+        name: 'county_name',
+        type: 'string'
+      }, {
+        name: 'pop_count',
+        type: 'number'
+      }
+    ]);
+    var l2 = this.LayerDefinitionsCollection.get('l2');
+    l2.layerTableModel.columnsCollection.reset([
+      {
+        name: 'pop_count',
+        type: 'number'
+      }
+    ]);
+    this.tuplesItems = createTuplesItems(this.LayerDefinitionsCollection);
+  });
+
+  it('should return an object', function () {
+    expect(this.tuplesItems).toEqual(jasmine.any(Object));
+  });
+
+  it('should contain an item for each column name+type match', function () {
+    expect(this.tuplesItems['county_name-string'].length).toEqual(1);
+    expect(this.tuplesItems['pop_count-number'].length).toEqual(2);
+  });
+
+  it('should contain a tuple of column+layer definition in each item', function () {
+    var tuples = this.tuplesItems['pop_count-number'];
+    expect(tuples[0].columnModel).toBeDefined();
+    expect(tuples[0].layerDefinitionModel).toBeDefined();
+
+    expect(tuples[0].columnModel.get('name')).toEqual('pop_count');
+    expect(tuples[0].layerDefinitionModel.id).toEqual('l1');
+  });
+});

--- a/lib/assets/test/spec/cartodb3/editor/add-widgets/layer-selector-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/add-widgets/layer-selector-view.spec.js
@@ -1,0 +1,60 @@
+var cdb = require('cartodb.js');
+var LayerSelectorView = require('../../../../../javascripts/cartodb3/editor/add-widgets/layer-selector-view');
+
+describe('editor/add-widgets/layer-selector-view', function () {
+  beforeEach(function () {
+    this.columnModel1 = new cdb.core.Model({
+      name: 'col',
+      type: 'string'
+    });
+    this.layerDefinitionModel1 = new cdb.core.Model({});
+    this.layerDefinitionModel1.getName = function () { return 'layer1'; };
+    this.columnModel2 = new cdb.core.Model({
+      name: 'col',
+      type: 'string'
+    });
+    this.layerDefinitionModel2 = new cdb.core.Model({});
+    this.layerDefinitionModel2.getName = function () { return 'layer2'; };
+
+    this.model = new cdb.core.Model({
+      layer_index: 0,
+      tuples: [{
+        columnModel: this.columnModel1,
+        layerDefinitionModel: this.layerDefinitionModel1
+      }, {
+        columnModel: this.columnModel2,
+        layerDefinitionModel: this.layerDefinitionModel2
+      }]
+    });
+
+    this.view = new LayerSelectorView({
+      model: this.model
+    });
+    this.view = this.view.render();
+  });
+
+  it('should have no leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should render fine', function () {
+    expect(this.view).toBeDefined();
+    expect(this.view.$el.html()).toContain('layer1');
+    expect(this.view.$el.html()).toContain('layer2');
+  });
+
+  it('should change the selected item', function () {
+    expect(this.model.get('layer_index')).toEqual(0);
+  });
+
+  describe('when a new option is selected', function () {
+    beforeEach(function () {
+      this.view.$el.val(1);
+      this.view.$el.trigger('change');
+    });
+
+    it('should change the selected item', function () {
+      expect(this.model.get('layer_index')).toEqual(1);
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb3/editor/add-widgets/widgets-types.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/add-widgets/widgets-types.spec.js
@@ -1,0 +1,17 @@
+var widgetsTypes = require('../../../../../javascripts/cartodb3/editor/add-widgets/widgets-types');
+
+describe('editor/add-widgets/widgets-types', function () {
+  describe('all items', function () {
+    it('should have a type prop', function () {
+      widgetsTypes.forEach(function (d) {
+        expect(d.type).toMatch(/\w+/);
+      });
+    });
+
+    it('should have a createTabPaneItem method', function () {
+      widgetsTypes.forEach(function (d) {
+        expect(d.createTabPaneItem).toEqual(jasmine.any(Function));
+      });
+    });
+  });
+});

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1447,12 +1447,12 @@
     "cartoassets": {
       "version": "0.1.25",
       "from": "cartodb/CartoAssets#master",
-      "resolved": "git://github.com/cartodb/CartoAssets.git#0c025acd65908e7418108faa3a38914897804ac6"
+      "resolved": "git://github.com/cartodb/CartoAssets.git#008f6aaf8e04fb0aab0ca31c131d83f091374e8a"
     },
     "cartodb-deep-insights.js": {
       "version": "0.0.1",
-      "from": "cartodb/deep-insights.js#855c27b",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#855c27bb48abaeb4a876e5fcdf3d4e1b730f46d9",
+      "from": "cartodb/deep-insights.js#c5da28a",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#c5da28a6dda5242b1a102eb7aa9774936f3bdd2b",
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
@@ -1513,7 +1513,7 @@
             "cartoassets": {
               "version": "0.1.25",
               "from": "cartodb/CartoAssets#master",
-              "resolved": "git://github.com/cartodb/CartoAssets.git#0c025acd65908e7418108faa3a38914897804ac6"
+              "resolved": "git://github.com/cartodb/CartoAssets.git#008f6aaf8e04fb0aab0ca31c131d83f091374e8a"
             }
           }
         },
@@ -2109,7 +2109,7 @@
         "cartoassets": {
           "version": "0.1.25",
           "from": "cartodb/CartoAssets#master",
-          "resolved": "git://github.com/cartodb/CartoAssets.git#0c025acd65908e7418108faa3a38914897804ac6"
+          "resolved": "git://github.com/cartodb/CartoAssets.git#008f6aaf8e04fb0aab0ca31c131d83f091374e8a"
         }
       }
     },
@@ -4010,15 +4010,15 @@
                       "from": "ini@~1.3.0",
                       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                     },
-                    "is-my-json-valid": {
-                      "version": "2.12.3",
-                      "from": "is-my-json-valid@^2.12.3",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
-                    },
                     "is-property": {
                       "version": "1.0.2",
                       "from": "is-property@^1.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.3",
+                      "from": "is-my-json-valid@^2.12.3",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
                     },
                     "is-typedarray": {
                       "version": "1.0.0",
@@ -4145,15 +4145,15 @@
                       "from": "pinkie-promise@^2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
                     },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@~1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                    },
                     "qs": {
                       "version": "5.2.0",
                       "from": "qs@~5.2.0",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@~1.0.6",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "readable-stream": {
                       "version": "2.0.5",
@@ -13202,20 +13202,20 @@
                   "from": "assert-plus@^0.1.5",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
-                "async": {
-                  "version": "1.5.1",
-                  "from": "async@^1.4.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
+                "bl": {
+                  "version": "1.0.0",
+                  "from": "bl@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
                 },
                 "aws-sign2": {
                   "version": "0.6.0",
                   "from": "aws-sign2@~0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
-                "bl": {
-                  "version": "1.0.0",
-                  "from": "bl@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                "async": {
+                  "version": "1.5.1",
+                  "from": "async@^1.4.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
                 },
                 "block-stream": {
                   "version": "0.0.8",
@@ -13226,11 +13226,6 @@
                   "version": "2.10.1",
                   "from": "boom@2.x.x",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@~0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "chalk": {
                   "version": "1.1.1",
@@ -13282,6 +13277,11 @@
                   "from": "delegates@^0.1.0",
                   "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
                 },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                },
                 "escape-string-regexp": {
                   "version": "1.0.4",
                   "from": "escape-string-regexp@^1.0.2",
@@ -13292,20 +13292,15 @@
                   "from": "extend@~3.0.0",
                   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                 },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@~0.6.1",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "extsprintf": {
                   "version": "1.0.2",
                   "from": "extsprintf@1.0.2",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "from": "forever-agent@~0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
                   "version": "1.0.0-rc3",
@@ -13412,11 +13407,6 @@
                   "from": "jodid25519@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
-                "jsbn": {
-                  "version": "0.1.0",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                },
                 "json-schema": {
                   "version": "0.2.2",
                   "from": "json-schema@0.2.2",
@@ -13426,6 +13416,11 @@
                   "version": "5.0.1",
                   "from": "json-stringify-safe@~5.0.1",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "jsbn": {
+                  "version": "0.1.0",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "jsonpointer": {
                   "version": "2.0.0",
@@ -13507,10 +13502,10 @@
                   "from": "once@~1.1.1",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
                 },
-                "pinkie": {
-                  "version": "2.0.1",
-                  "from": "pinkie@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@~0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "pinkie-promise": {
                   "version": "2.0.0",
@@ -13611,6 +13606,11 @@
                   "version": "4.0.1",
                   "from": "xtend@^4.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                },
+                "pinkie": {
+                  "version": "2.0.1",
+                  "from": "pinkie@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                 },
                 "rc": {
                   "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "browserify-resolutions": "1.0.6",
     "browserify-shim": "3.8.10",
     "cartoassets": "CartoDB/CartoAssets#master",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#855c27b",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#c5da28a",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "cartodb/cartodb.js#f09747f",
     "csswring": "^3.0.5",


### PR DESCRIPTION
Final waypoint, resolves #6565 

- Implemented the remaining types, i.e. histogram and time-series.
- Extracted the layer selector logic to a common view
- Adds some basic tests for the WIP stuff that were previously missing
- Don't display some columns that can't be used or are not of interest, e.g. `the_geom`, `the_geoms_webmercator`, `cartodb_id`, `created_at`, `updated_at`
- There are obviously still stuff TBD (and minor bugs) on the modal, ~~I'll create separate issues for those items~~, see https://github.com/CartoDB/cartodb/issues/6635

edit:
Known issues (still being looked into):
- Time-series start/end value should be timestamps; how to get proper values upfront for the option model? Workaround: Set start/end interval of [0, now], can be edited afterwards.
- Torque time-series doesn't work, requires changing/adding missing data for torque layers on vizJSON #6643

@javierarce can you review?
cc @xavijam 