### PR TITLE
Use dataset as filename for downloads from organization users

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/export/public_export_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/export/public_export_view.js
@@ -55,6 +55,11 @@ module.exports = ExportView.extend({
     var options = {};
     options.filename = this.model.get('name');
 
+    // Keep dataset part in user.dataset names
+    if (options.filename.contains('.')) {
+      options.filename = options.filename.split('.')[1];
+    }
+    
     if (this.options.user_data) {
       options.api_key = this.options.user_data.api_key;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.32",
+  "version": "3.23.33",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #6409 
We pass "user.dataset" to the SQL-API, and it only uses the name up to the first point. With this patch, we pass "dataset" directly as the filename.

CR @xavijam 