### PR TITLE
Let exceptions bubble up to base_job and delete temp stale tables

### DIFF
--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -76,7 +76,7 @@ module CartoDB
         runner.log.append("Table '#{name}' registered")
       rescue => exception
         if exception.message =~ /canceling statement due to statement timeout/i
-          drop("#{ORIGIN_SCHEMA}.#{current_name}")
+          drop("#{ORIGIN_SCHEMA}.#{result.table_name}")
           raise CartoDB::Importer2::StatementTimeoutError.new(
             exception.message,
             CartoDB::Importer2::ERRORS_MAP[CartoDB::Importer2::StatementTimeoutError]

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -117,7 +117,7 @@ module CartoDB
       def drop(table_name)
         database.execute(%Q(DROP TABLE #{table_name}))
       rescue
-        runner.log.append("Couldn't drop table #{table_name}: #{exception}. Backtrace: #{exception.backtrace.to_s}. ")
+        runner.log.append("Couldn't drop table #{table_name}: #{exception}. Backtrace: #{exception.backtrace} ")
         self
       end
 

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -116,7 +116,7 @@ module CartoDB
 
       def drop(table_name)
         database.execute(%Q(DROP TABLE #{table_name}))
-      rescue
+      rescue => exception
         runner.log.append("Couldn't drop table #{table_name}: #{exception}. Backtrace: #{exception.backtrace} ")
         self
       end
@@ -205,8 +205,7 @@ module CartoDB
           RENAME TO "the_geom_#{UUIDTools::UUID.timestamp_create.to_s.gsub('-', '_')}"
         })
       rescue => exception
-        runner.log.append("Silently failed rename_the_geom_index_if_exists from #{current_name} to #{new_name} with exception #{exception}. Backtrace: #{exception.backtrace} ")
-        raise exception
+        runner.log.append("Silently failed rename_the_geom_index_if_exists from #{current_name} to #{new_name} with exception #{exception}. Backtrace: #{exception.backtrace}. ")
       end
 
       def persist_metadata(result, name, data_import_id)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -205,7 +205,7 @@ module CartoDB
           RENAME TO "the_geom_#{UUIDTools::UUID.timestamp_create.to_s.gsub('-', '_')}"
         })
       rescue => exception
-        runner.log.append("Silently failed rename_the_geom_index_if_exists from #{current_name} to #{new_name} with exception #{exception}. Backtrace: #{exception.backtrace.to_s}. ")
+        runner.log.append("Silently failed rename_the_geom_index_if_exists from #{current_name} to #{new_name} with exception #{exception}. Backtrace: #{exception.backtrace} ")
         raise exception
       end
 

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -214,7 +214,6 @@ module CartoDB
         @table = table_registrar.table
         @imported_table_visualization_ids << @table.table_visualization.id
         BoundingBoxHelper.update_visualizations_bbox(table)
-        # clean?
         self
       end
 

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -205,7 +205,7 @@ module CartoDB
           RENAME TO "the_geom_#{UUIDTools::UUID.timestamp_create.to_s.gsub('-', '_')}"
         })
       rescue => exception
-        runner.log.append("Silently failed rename_the_geom_index_if_exists from #{current_name} to #{new_name} with exception #{exception}. Backtrace: #{exception.backtrace}. ")
+        runner.log.append("Silently failed rename_the_geom_index_if_exists from #{current_name} to #{new_name} with exception #{exception}. Backtrace: #{exception.backtrace.to_s}. ")
       end
 
       def persist_metadata(result, name, data_import_id)

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -206,7 +206,7 @@ class DataImport < Sequel::Model
     log.append "Exception: #{exception.to_s}"
     log.append exception.backtrace, truncate = false
     stacktrace = exception.to_s + exception.backtrace.join
-    Rollbar.report_message('Import error', 'error', error_info: stacktrace)
+    CartoDB.notify_exception(exception, 'Import error', { error_info: stacktrace })
     handle_failure(exception)
     raise exception
     self
@@ -879,7 +879,7 @@ class DataImport < Sequel::Model
     rescue => ex
       log.append "Exception: #{ex.message}"
       log.append ex.backtrace, truncate = false
-      Rollbar.report_message('Import error: ', 'error', error_info: ex.message + ex.backtrace.join)
+      CartoDB.notify_exception(ex, 'Import error: ', { error_info: ex.message + ex.backtrace.join })
       raise CartoDB::DataSourceError.new("Datasource #{datasource_name} could not be instantiated")
     end
     if service_item_id.nil?

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -208,6 +208,7 @@ class DataImport < Sequel::Model
     stacktrace = exception.to_s + exception.backtrace.join
     Rollbar.report_message('Import error', 'error', error_info: stacktrace)
     handle_failure(exception)
+    raise exception
     self
   end
 
@@ -378,7 +379,7 @@ class DataImport < Sequel::Model
     new_importer
   rescue => exception
     puts exception.to_s + exception.backtrace.join("\n")
-    raise
+    raise exception
   end
 
   def running_import_ids

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -206,7 +206,7 @@ class DataImport < Sequel::Model
     log.append "Exception: #{exception.to_s}"
     log.append exception.backtrace, truncate = false
     stacktrace = exception.to_s + exception.backtrace.join
-    CartoDB.notify_exception(exception, 'Import error', error_info: stacktrace)
+    CartoDB.report_exception(exception, 'Import error', error_info: stacktrace)
     handle_failure(exception)
     raise exception
     self
@@ -879,7 +879,7 @@ class DataImport < Sequel::Model
     rescue => ex
       log.append "Exception: #{ex.message}"
       log.append ex.backtrace, truncate = false
-      CartoDB.notify_exception(ex, 'Import error: ', error_info: ex.message + ex.backtrace.join)
+      CartoDB.report_exception(ex, 'Import error: ', error_info: ex.message + ex.backtrace.join)
       raise CartoDB::DataSourceError.new("Datasource #{datasource_name} could not be instantiated")
     end
     if service_item_id.nil?

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -206,7 +206,7 @@ class DataImport < Sequel::Model
     log.append "Exception: #{exception.to_s}"
     log.append exception.backtrace, truncate = false
     stacktrace = exception.to_s + exception.backtrace.join
-    CartoDB.notify_exception(exception, 'Import error', { error_info: stacktrace })
+    CartoDB.notify_exception(exception, 'Import error', error_info: stacktrace)
     handle_failure(exception)
     raise exception
     self
@@ -879,7 +879,7 @@ class DataImport < Sequel::Model
     rescue => ex
       log.append "Exception: #{ex.message}"
       log.append ex.backtrace, truncate = false
-      CartoDB.notify_exception(ex, 'Import error: ', { error_info: ex.message + ex.backtrace.join })
+      CartoDB.notify_exception(ex, 'Import error: ', error_info: ex.message + ex.backtrace.join)
       raise CartoDB::DataSourceError.new("Datasource #{datasource_name} could not be instantiated")
     end
     if service_item_id.nil?

--- a/app/models/table_registrar.rb
+++ b/app/models/table_registrar.rb
@@ -51,7 +51,7 @@ module CartoDB
         end
       end
     rescue => e
-      Rollbar.report_exception(e)
+      CartoDB.notify_exception(e)
       raise e
     end
   end # TableRegistrar

--- a/app/models/table_registrar.rb
+++ b/app/models/table_registrar.rb
@@ -52,6 +52,7 @@ module CartoDB
       end
     rescue => e
       Rollbar.report_exception(e)
+      raise e
     end
   end # TableRegistrar
 end # CartoDB

--- a/lib/resque/base_job.rb
+++ b/lib/resque/base_job.rb
@@ -32,10 +32,12 @@ module Resque
             retry
           else
             raise e
-          end  
+          end
         else
           raise e
         end
+      rescue => e
+        CartoDB.notify_error("Job error", error: e.inspect, error_info: stacktrace)
       end
     end #self.perform
 

--- a/lib/resque/base_job.rb
+++ b/lib/resque/base_job.rb
@@ -38,6 +38,7 @@ module Resque
         end
       rescue => e
         CartoDB.notify_exception(e)
+        raise e
       end
     end #self.perform
 

--- a/lib/resque/base_job.rb
+++ b/lib/resque/base_job.rb
@@ -37,7 +37,7 @@ module Resque
           raise e
         end
       rescue => e
-        CartoDB.notify_error("Job error", error: e.inspect, error_info: stacktrace)
+        CartoDB.notify_exception(e)
       end
     end #self.perform
 

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -97,6 +97,9 @@ module CartoDB
         @downloader.multi_resource_import_supported? ? multi_resource_import : single_resource_import
         self
       rescue => exception
+        # Delete job temporary table from cdb_importer schema
+        delete_job_table
+
         log.append "Errored importing data:"
         log.append "#{exception.class.to_s}: #{exception.to_s}", truncate=false
         log.append '----------------------------------------------------'
@@ -199,7 +202,7 @@ module CartoDB
         end
 
         # Delete job temporary table from cdb_importer schema
-        @job.delete_job_table
+        delete_job_table
 
         @job.log "Errored importing data from #{source_file.fullpath}:"
         @job.log "#{exception.class.to_s}: #{exception.to_s}", truncate=false
@@ -395,6 +398,10 @@ module CartoDB
 
       def add_warning(warning)
         @warnings.merge!(warning)
+      end
+
+      def delete_job_table
+        @job.delete_job_table
       end
 
       def raise_if_over_storage_quota(source_file)

--- a/spec/connectors/importer_spec.rb
+++ b/spec/connectors/importer_spec.rb
@@ -246,7 +246,8 @@ describe CartoDB::Connector::Importer do
     )
     data_import.values[:data_source] = filepath
 
-    data_import.run_import!
+    # It raises #<RuntimeError: Error: User doesn't have private tables enabled>
+    expect{data_import.run_import!}.to raise_error(RuntimeError)
 
     data_import.success.should_not eq true
   end

--- a/spec/connectors/importer_spec.rb
+++ b/spec/connectors/importer_spec.rb
@@ -247,7 +247,7 @@ describe CartoDB::Connector::Importer do
     data_import.values[:data_source] = filepath
 
     # It raises #<RuntimeError: Error: User doesn't have private tables enabled>
-    expect{data_import.run_import!}.to raise_error(RuntimeError)
+    expect { data_import.run_import! }.to raise_error(RuntimeError)
 
     data_import.success.should_not eq true
   end


### PR DESCRIPTION
Fixes #6628 
Fixes https://github.com/CartoDB/cartodb/issues/2917

While checking the importer flow, I've seen that there are multiple exceptions which get rescued and never get notified.

This PR adds several `raise` for those exceptions that were getting hidden and notifies them with our error notifier.

When those exceptions happened, we weren't cleaning the stale tables in the `cdb_importer` schema, which was also treated at #2917, so this new iteration tries to get rid of the tables that get stuck when an exception occurs. 