### PR TITLE
Use defaults instead of extend

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
@@ -19,7 +19,7 @@ module.exports = cdb.core.Model.extend({
   parse: function (r, opts) {
     // Flatten the attrs, to avoid having this.get('options').foobar internally
     var attrs = _
-      .extend(
+      .defaults(
         _.pick(r, OWN_ATTR_NAMES),
         _.omit(r.options, ['table_name', 'query'])
       );
@@ -53,7 +53,7 @@ module.exports = cdb.core.Model.extend({
 
   toJSON: function () {
     // Un-flatten the internal attrs to the datastructure that's expected by the API endpoint
-    var options = _.extend(
+    var options = _.defaults(
       {
         table_name: this.layerTableModel.get('table_name'),
         query: this.layerTableModel.get('query')
@@ -61,7 +61,7 @@ module.exports = cdb.core.Model.extend({
       _.omit(this.attributes, OWN_ATTR_NAMES)
     );
 
-    return _.extend(
+    return _.defaults(
       {
         infowindow: this._infowindow,
         tooltip: this._tooltip,

--- a/lib/assets/javascripts/cartodb3/data/table-model.js
+++ b/lib/assets/javascripts/cartodb3/data/table-model.js
@@ -34,7 +34,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   parse: function (r) {
-    var attrs = _.extend({
+    var attrs = _.defaults({
       fetched: true
     }, r);
 

--- a/lib/assets/javascripts/cartodb3/data/widget-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/widget-definition-model.js
@@ -30,7 +30,7 @@ module.exports = cdb.core.Model.extend({
    * @return {Object} attrs to be set on model
    */
   parse: function (r) {
-    return _.extend(
+    return _.defaults(
       _.omit(r, ['options']),
       r.options,
       {
@@ -46,7 +46,7 @@ module.exports = cdb.core.Model.extend({
    * Formats the JSON to match the server-side API
    */
   toJSON: function () {
-    return _.extend(
+    return _.defaults(
       _.pick(this.attributes, ATTRS_AT_TOP_LEVEL),
       {
         options: _.omit(this.attributes, ATTRS_AT_TOP_LEVEL)
@@ -56,7 +56,7 @@ module.exports = cdb.core.Model.extend({
 
   changeType: function (type) {
     var attrsForNewType = _
-      .extend(
+      .defaults(
         { type: type },
         this.collection.attrsForThisType(type, this)
       );

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -43,7 +43,7 @@ var dashboard = cdb.deepInsights.createDashboard('#dashboard', vizJSON, {
 var mapId = visualizationData.map_id;
 var layersCollection = dashboard.vis.map.layers;
 var configModel = new ConfigModel(
-  _.extend(
+  _.defaults(
     {
       base_url: userData.base_url
     },

--- a/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
@@ -53,4 +53,32 @@ describe('data/layer-definition-model', function () {
       expect(m.get('query')).toContain('SELECT');
     });
   });
+
+  describe('for a namedmap layer', function () {
+    beforeEach(function () {
+      this.model = new LayerDefinitionModel({
+        id: 'abc-123',
+        type: 'cartodb',
+        options: {
+          table_name: 'foo_table',
+          query: 'SELECT * FROM pepe.foo_table',
+          id: 'XOXO-999'
+        }
+      }, {
+        parse: true,
+        configModel: this.configModel
+      });
+    });
+
+    it('should maintain its own id', function () {
+      expect(this.model.id).toEqual('abc-123');
+    });
+
+    it('should have a layer table model', function () {
+      var m = this.model.layerTableModel;
+      expect(m).toBeDefined();
+      expect(m.get('table_name')).toContain('foo_table');
+      expect(m.get('query')).toContain('SELECT');
+    });
+  });
 });


### PR DESCRIPTION
To not accidentally overwrite values, e.g. set the id of a namedmap
instead of the keeping the layer id.
cc @xavijam