### PR TITLE
Fix query with id IN (NULL) in visualization search

### DIFF
--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -231,12 +231,12 @@ class Carto::VisualizationQueryBuilder
       # TODO: sql strings are suboptimal and compromise compositability, but
       # I haven't found a better way to do this OR in Rails
       shared_with_viz_ids = ::Carto::VisualizationQueryBuilder.new.with_shared_with_user_id(
-                              @owned_by_or_shared_with_user_id).build.uniq.pluck('visualizations.id')
+        @owned_by_or_shared_with_user_id).build.uniq.pluck('visualizations.id')
       if shared_with_viz_ids.empty?
         query = query.where(' "visualizations"."user_id" = (?)', @owned_by_or_shared_with_user_id)
       else
         query = query.where(' ("visualizations"."user_id" = (?) or "visualizations"."id" in (?))',
-                              @owned_by_or_shared_with_user_id, shared_with_viz_ids)
+                            @owned_by_or_shared_with_user_id, shared_with_viz_ids)
       end
     end
 

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -230,11 +230,14 @@ class Carto::VisualizationQueryBuilder
     if @owned_by_or_shared_with_user_id
       # TODO: sql strings are suboptimal and compromise compositability, but
       # I haven't found a better way to do this OR in Rails
-      query = query.where(' ("visualizations"."user_id" = (?) or "visualizations"."id" in (?))',
-          @owned_by_or_shared_with_user_id,
-          ::Carto::VisualizationQueryBuilder.new.with_shared_with_user_id(@owned_by_or_shared_with_user_id)
-                                            .build.uniq.pluck('visualizations.id')
-        )
+      shared_with_viz_ids = ::Carto::VisualizationQueryBuilder.new.with_shared_with_user_id(
+                              @owned_by_or_shared_with_user_id).build.uniq.pluck('visualizations.id')
+      if (shared_with_viz_ids.empty?)
+        query = query.where(' "visualizations"."user_id" = (?)', @owned_by_or_shared_with_user_id)
+      else
+        query = query.where(' ("visualizations"."user_id" = (?) or "visualizations"."id" in (?))',
+                            @owned_by_or_shared_with_user_id, shared_with_viz_ids)
+      end
     end
 
     if @exclude_synced_external_sources

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -232,11 +232,11 @@ class Carto::VisualizationQueryBuilder
       # I haven't found a better way to do this OR in Rails
       shared_with_viz_ids = ::Carto::VisualizationQueryBuilder.new.with_shared_with_user_id(
                               @owned_by_or_shared_with_user_id).build.uniq.pluck('visualizations.id')
-      if (shared_with_viz_ids.empty?)
+      if shared_with_viz_ids.empty?
         query = query.where(' "visualizations"."user_id" = (?)', @owned_by_or_shared_with_user_id)
       else
         query = query.where(' ("visualizations"."user_id" = (?) or "visualizations"."id" in (?))',
-                            @owned_by_or_shared_with_user_id, shared_with_viz_ids)
+                              @owned_by_or_shared_with_user_id, shared_with_viz_ids)
       end
     end
 


### PR DESCRIPTION
This fixes the case in #6650 when searching for visualization and the user has no access to any shared visualizations.
CR @juanignaciosl 