### PR TITLE
Docs: Remove db:setup from installation process

### DIFF
--- a/doc/manual/source/install.rst
+++ b/doc/manual/source/install.rst
@@ -423,7 +423,6 @@ Editor
   .. code-block:: bash
 
     RAILS_ENV=development bundle exec rake db:migrate
-    RAILS_ENV=development bundle exec rake db:setup
 
 * Create an admin user
 


### PR DESCRIPTION
Not needed and generates errors trying to create the same tables than db:migrate
cc @juanignaciosl 