### PR TITLE
Raise encoding error for filenames with incorrect codepoints

### DIFF
--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -137,7 +137,7 @@ module CartoDB
       end
 
       def filename_valid_encoding?(filename)
-        return filename.force_encoding("UTF-8").valid_encoding?
+        filename.force_encoding("UTF-8").valid_encoding?
       end
 
       def normalize(filename)

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -138,7 +138,7 @@ module CartoDB
       end
 
       def filename_valid_encoding?(filename)
-        return filename.valid_encoding?
+        return filename.force_encoding("UTF-8").valid_encoding?
       end
 
       def normalize(filename)

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -39,7 +39,6 @@ module CartoDB
 
       def run(path)
         return without_unpacking(path) unless compressed?(path)
-        raise EncodingError unless filename_valid_encoding?(path)
         extract(path)
         crawl(temporary_directory).each { |dir_path| process(dir_path) }
         @source_files = split(source_files)
@@ -66,6 +65,7 @@ module CartoDB
 
       def crawl(path, files=[])
         Dir.foreach(path) do |subpath|
+          raise EncodingError unless filename_valid_encoding?(subpath)
           next if hidden?(subpath)
           next if subpath =~ /.*readme.*\.txt/i
           next if subpath =~ /\.version\.txt/i

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -12,7 +12,6 @@ module CartoDB
   module Importer2
     class Unp
       HIDDEN_FILE_REGEX     = /^(\.|\_{2})/
-      UNP_READ_ERROR_REGEX  = /.*Cannot read.*/
       COMPRESSED_EXTENSIONS = %w{ .zip .gz .tgz .tar.gz .bz2 .tar .kmz .rar }
       SUPPORTED_FORMATS     = %w{
         .csv .shp .ods .xls .xlsx .tif .tiff .kml .kmz

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -39,6 +39,7 @@ module CartoDB
 
       def run(path)
         return without_unpacking(path) unless compressed?(path)
+        raise EncodingError unless filename_valid_encoding?(path)
         extract(path)
         crawl(temporary_directory).each { |dir_path| process(dir_path) }
         @source_files = split(source_files)
@@ -132,8 +133,12 @@ module CartoDB
         command
       end
 
-     def supported?(filename)
+      def supported?(filename)
         SUPPORTED_FORMATS.include?(File.extname(filename).downcase)
+      end
+
+      def filename_valid_encoding?(filename)
+        return filename.valid_encoding?
       end
 
       def normalize(filename)
@@ -179,7 +184,7 @@ module CartoDB
       end
 
       def unp_failure?(output, exit_code)
-        !!(output =~ UNP_READ_ERROR_REGEX) || (exit_code != 0)
+        (exit_code != 0)
       end
 
       # Return a new temporary file contained inside a tmp subfolder

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -235,7 +235,7 @@ describe Unp do
 
   describe '#unp_failure?'  do
     it 'returns true if unp cannot read the file' do
-      Unp.new.unp_failure?('Cannot read', 0).should eq true
+      Unp.new.unp_failure?('Cannot read', -1).should eq true
     end
 
     it 'returns true if returned an error exit code' do


### PR DESCRIPTION
Fixes #6276 

In previous attempts of fixing this bug, we tried to normalize and rename the
incorrect user input to build new names that would not raise an exception.
After a discussion time ago, I think it's better to raise an understandable error
that could allow users to fix their files without us having to struggle with it and
manipulate the files.

In this new approach I am adding a new function that checks the validity of the
code points in the filenames that are being crawled after decompression.

This `unp.rb` file is the only place were we are trying to match filenames with 
other strings, such as in:
```ruby
next if hidden?(subpath)
next if subpath =~ /.*readme.*\.txt/i		   next if subpath =~ /.*readme.*\.txt/i
next if subpath =~ /\.version\.txt/i		   next if subpath =~ /\.version\.txt/i
````
where `ArgumentError: invalid byte sequence in UTF-8` is raised if the `subpath` 
string is not valid -- in terms of encoding.

This PR also fixes one of the tests, which was working before only because of the check in `UNP_READ_ERROR_REGEX`, as when an error occurs in `unp` the error_code is `!= 0`.


Now, when a bad filename is detected, we will be raising `EncodingError` (defined 
[here previously](https://github.com/CartoDB/cartodb/blob/09bbff02590d5e0c4eb6c11178cfa59c65428fb1/services/importer/lib/importer/exceptions.rb#L124) -- definition [here](https://github.com/CartoDB/cartodb/blob/2882df5a561aff60bcce3575ef403e9fc8dab12b/lib/cartodb/import_error_codes.rb#L162), which I might probably edit as you might want to open QGIS
instead of your text editor to fix the encoding of your Shapefile).

The result of uploading these files now is:

![image](https://cloud.githubusercontent.com/assets/1730320/13316632/2bf26cec-dbb1-11e5-93c7-09117e5cb3c2.png)

Until now, it was:
![image](https://cloud.githubusercontent.com/assets/1730320/13316634/36cddd68-dbb1-11e5-9c4f-c031d31e2455.png)
