### PR TITLE
Add details to Rollbar exceptions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -365,13 +365,13 @@ class User < Sequel::Model
     external_data_imports = ExternalDataImport.by_user_id(self.id)
     external_data_imports.each { |edi| edi.destroy }
   rescue => e
-    CartoDB.notify_error('Error deleting external data imports at user deletion', { user: self, error: e.inspect })
+    CartoDB.notify_error('Error deleting external data imports at user deletion', user: self, error: e.inspect)
   end
 
   def delete_external_sources
     delete_common_data
   rescue => e
-    CartoDB.notify_error('Error deleting external data imports at user deletion', { user: self, error: e.inspect })
+    CartoDB.notify_error('Error deleting external data imports at user deletion', user: self, error: e.inspect)
   end
 
   def after_destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -246,7 +246,7 @@ class User < Sequel::Model
   def delete_common_data
     CartoDB::Visualization::CommonDataService.new.delete_common_data_for_user(self)
   rescue => e
-    CartoDB.notify_error("Error deleting common data for user", user: inspect, error: e.inspect)
+    CartoDB.notify_error("Error deleting common data for user", user: self, error: e.inspect)
   end
 
   def after_save
@@ -365,13 +365,13 @@ class User < Sequel::Model
     external_data_imports = ExternalDataImport.by_user_id(self.id)
     external_data_imports.each { |edi| edi.destroy }
   rescue => e
-    CartoDB.notify_error('Error deleting external data imports at user deletion', { user: self.inspect, error: e.inspect })
+    CartoDB.notify_error('Error deleting external data imports at user deletion', { user: self, error: e.inspect })
   end
 
   def delete_external_sources
     delete_common_data
   rescue => e
-    CartoDB.notify_error('Error deleting external data imports at user deletion', { user: self.inspect, error: e.inspect })
+    CartoDB.notify_error('Error deleting external data imports at user deletion', { user: self, error: e.inspect })
   end
 
   def after_destroy

--- a/app/services/visualization/common_data_service.rb
+++ b/app/services/visualization/common_data_service.rb
@@ -40,7 +40,7 @@ module CartoDB
         else
           CartoDB.notify_error(
             'cant create common-data url. User doesn\'t exist and base_url is nil',
-            user: common_data_username
+            username: common_data_username
           )
         end
       end

--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -31,7 +31,11 @@ module CartoDB
     if Rails.env.development? || Rails.env.test?
       ::Logger.new(STDOUT).error "error: " + message + "\n" + additional_data.inspect + "\n"
     end
-    Rollbar.report_message(message, 'error', additional_data)
+
+    # Sanity check: Rollbar complains if user is not an object
+    user = additional_data[:user].respond_to?(:id) ? additional_data[:user] : nil
+
+    Rollbar.report_message_with_request(message, 'error', additional_data[:request], user, additional_data)
   end
 
   # Add `:request` and `:user` to additional_data if you want request content


### PR DESCRIPTION
Change the error reporting helpers in order to pass user and request data as Rollbar parameters, so they show up in the error console.
Rollbar complains if a non-object is used as the user, so add a check for that. Reports that do that have been fixed, but just to make sure we do not lose reports.

CR @juanignaciosl 