### PR TITLE
Avoid ArcGIS URLs limitation in ArcGIS webserver name

### DIFF
--- a/services/datasources/lib/datasources/url/arcgis.rb
+++ b/services/datasources/lib/datasources/url/arcgis.rb
@@ -14,9 +14,7 @@ module CartoDB
         # Required for all datasources
         DATASOURCE_NAME = 'arcgis'
 
-        VALID_ARCGIS_WEBSERVERS = %w{ arcgis gis arcgiswebadaptor arcgis_web_adaptor }
-
-        ARCGIS_API_LIKE_URL_RE = /\/(#{VALID_ARCGIS_WEBSERVERS.join('|')})\/rest/i
+        ARCGIS_API_LIKE_URL_RE = /\/rest\/services/i
 
         METADATA_URL     = '%s?f=json'
         FEATURE_IDS_URL  = '%s/query?where=1%%3D1&returnIdsOnly=true&f=json'


### PR DESCRIPTION
Fixes #2300

The ArcGIS Server endpoint URLs can look like `http://<host>/<site>/rest/services/<folder>/<serviceName>/<serviceType>/` so this commit is removing the `<site>` limitation that was being imposed with the `VALID_ARCGIS_WEBSERVERS` constant and looks for `/rest/services` in the URLs instead. This opens the possibility of ArcGIS server imports to all those services where the "site" name is not the common or default ones (arcgis, arcgis_web_adaptor...).

Official ArcGIS Server information about the URL schema can be found [here](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Getting_started/02r3000000sq000000/).

Related: https://github.com/CartoDB/cartodb/issues/6704