### PR TITLE
Rescue InvalidInputDataError and assign error_code 1012

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -589,6 +589,12 @@ class DataImport < Sequel::Model
         error_code: 1013,
         log_info: ex.to_s
       }
+    rescue InvalidInputDataError => ex
+      had_errors = true
+      manual_fields = {
+        error_code: 1012,
+        log_info: ex.to_s
+      }
     rescue CartoDB::Importer2::FileTooBigError => ex
       had_errors = true
       manual_fields = {

--- a/services/datasources/spec/unit/arcgis_spec.rb
+++ b/services/datasources/spec/unit/arcgis_spec.rb
@@ -150,7 +150,6 @@ describe Url::ArcGIS do
       expect {
         arcgis.send(:get_resource_metadata, @invalid_url)
       }.to raise_error InvalidInputDataError
-
     end
 
     it 'tests metadata retrieval' do

--- a/services/datasources/spec/unit/arcgis_spec.rb
+++ b/services/datasources/spec/unit/arcgis_spec.rb
@@ -9,6 +9,7 @@ describe Url::ArcGIS do
 
   before(:all) do
     @url = 'http://myserver/arcgis/rest/services/MyFakeService/featurename'
+    @invalid_url = 'http://myserver/mysite/rest/myfakefolder/MyFakeService/featurename'
     @user = CartoDB::Datasources::Doubles::User.new
   end
 
@@ -144,6 +145,11 @@ describe Url::ArcGIS do
       expect {
         arcgis.send(:get_subresource_metadata, @url, sub_id)
       }.to raise_error InvalidServiceError
+
+      # Invalid ArcGIS URL
+      expect {
+        arcgis.send(:get_resource_metadata, @invalid_url)
+      }.to raise_error InvalidInputDataError
 
     end
 


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/6707

The exception `InvalidInputDataError` was previously defined in the platform but it was not being rescued when raised from the ArcGIS Server URL connector.

This code rescues the specific exception so that the user receives a proper error code and message, instead of an Unknown 99999 code.

While working in this issue, I noticed that there's a rescue in [this piece of code which is hiding exceptions](https://github.com/CartoDB/cartodb/blob/ce8834ffac1d738aad08d1b12710d7eb3da9694b/app/models/data_import.rb#L598), as we found out at https://github.com/CartoDB/cartodb/pull/6639