### PR TITLE
Fix double render in org signup

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -11,7 +11,7 @@ class SignupController < ApplicationController
 
   skip_before_filter :http_header_authentication, only: [:create_http_authentication]
 
-  before_filter :load_organization, only: [:create_http_authentication]
+  before_filter :check_organization_quotas, only: [:create_http_authentication]
   before_filter :load_mandatory_organization, only: [:signup, :create]
   before_filter :disable_if_ldap_configured
   before_filter :initialize_google_plus_config
@@ -130,8 +130,14 @@ class SignupController < ApplicationController
   end
 
   def load_organization
-    subdomain = CartoDB.subdomain_from_request(request)
-    @organization = ::Organization.where(name: subdomain).first if subdomain
+    unless @organization
+      subdomain = CartoDB.subdomain_from_request(request)
+      @organization = ::Organization.where(name: subdomain).first if subdomain
+    end
+  end
+
+  def check_organization_quotas
+    load_organization
     if @organization
       check_signup_errors = Sequel::Model::Errors.new
       @organization.validate_for_signup(check_signup_errors, ::User.new_with_organization(@organization).quota_in_bytes)
@@ -143,6 +149,7 @@ class SignupController < ApplicationController
   def load_mandatory_organization
     load_organization
     render_404 and return false unless @organization && @organization.signup_page_enabled
+    check_organization_quotas
   end
 
   def disable_if_ldap_configured


### PR DESCRIPTION
Fixes a Double Render that happened when displyaing signup for an organization that had signups disabled and the quota was exceeded. Reorganized the code to check if signup is enabled first.

Closes #6721 
CR @juanignaciosl 