### PR TITLE
Infowindow help dialog fixed

### DIFF
--- a/lib/assets/javascripts/cartodb/table/infowindow.js
+++ b/lib/assets/javascripts/cartodb/table/infowindow.js
@@ -61,7 +61,7 @@
     },
 
     _createHelpDialog: function() {
-      this.helpDialog = cdb.editor.ViewFactory.createDialogByTemplate('common/dialogs/help/infowindow_with_images');
+      this.helpDialog = cdb.editor.ViewFactory.createDialogByTemplate('common/dialogs/help/infowindow_with_images', {}, { clean_on_hide: false });
       this.addView(this.helpDialog);
     },
 


### PR DESCRIPTION
Fixes #6700 

The issue reported was that the infowindow help dialog was not able to close after opening it the first time. The problem was that after closing the dialog the first time, the events related to it were unbinded, among the rest of internals of the dialog, due to a parameter called `clean_on_hide` set to true. So the next time the dialog was shown, the dialog view had no events listening.

The solution was set the parameter `clean_on_hide` to false to avoid the cleaning of the dialog.

![untitled](https://cloud.githubusercontent.com/assets/2141690/13393160/e8ddaeb2-dedf-11e5-9863-0fcbb2715ff1.gif)

CR @xavijam cc @javierarce 
