### PR TITLE
Test visualization member using default data repository

### DIFF
--- a/spec/models/synchronization/member_spec.rb
+++ b/spec/models/synchronization/member_spec.rb
@@ -9,10 +9,6 @@ require_relative '../../../app/models/synchronization/member'
 include CartoDB
 
 describe Synchronization::Member do
-  before do
-    Synchronization.repository = DataRepository.new
-  end
-
   describe 'Basic actions' do
     it 'assigns an id by default' do
       member = Synchronization::Member.new


### PR DESCRIPTION
Using an in-memory hash conflicts with other tests (spec/requests/api/json/records_controller_shared_examples.rb:152).
Closes https://github.com/CartoDB/cartodb/issues/6720

CR @juanignaciosl 