### PR TITLE
Use column name as values for select list

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model.js
@@ -68,7 +68,7 @@ module.exports = cdb.core.Model.extend({
         .map(function (m) {
           var columnName = m.get('name');
           return {
-            val: m.id,
+            val: columnName,
             label: columnName
           };
         });

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-formula-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-formula-data-schema-model.js
@@ -56,7 +56,7 @@ module.exports = cdb.core.Model.extend({
       .map(function (m) {
         var columnName = m.get('name');
         return {
-          val: m.id,
+          val: columnName,
           label: columnName
         };
       });

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-histogram-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-histogram-data-schema-model.js
@@ -44,7 +44,7 @@ module.exports = cdb.core.Model.extend({
         .map(function (m) {
           var columnName = m.get('name');
           return {
-            val: m.id,
+            val: columnName,
             label: columnName
           };
         });

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-time-series-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-time-series-data-schema-model.js
@@ -44,7 +44,7 @@ module.exports = cdb.core.Model.extend({
         .map(function (m) {
           var columnName = m.get('name');
           return {
-            val: m.id,
+            val: columnName,
             label: columnName
           };
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.39",
+  "version": "3.23.40",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #6738

When using a query result the columns don’t have ids, which caused the form to set the form model with an empty column (thus don’t trigger changes afterwards).

cc @xavijam 