### PR TITLE
added target=_blank> to new html links in help dialogs

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/help/carto_css.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/help/carto_css.jst.ejs
@@ -10,7 +10,7 @@
   <span class="Dialog-resultsBodyIcon NavButton">1</span>
   <div class="Dialog-resultsBodyTexts">
     <p class="DefaultParagraph DefaultParagraph--tertiary">
-      If you know how to use CSS to style websites, you already know how to use CartoCSS to style your maps. See  <a href="http://docs.cartodb.com/cartodb-platform/cartocss/">CartoCSS</a> for details.
+      If you know how to use CSS to style websites, you already know how to use CartoCSS to style your maps. See <a href="http://docs.cartodb.com/cartodb-platform/cartocss/" target="_blank">CartoCSS</a> for details.
     </p>
   </div>
 </div>
@@ -18,7 +18,7 @@
   <span class="Dialog-resultsBodyIcon NavButton">?</span>
   <div class="Dialog-resultsBodyTexts">
     <p class="DefaultParagraph DefaultParagraph--tertiary">
-      Visit _The Map Academy_ to view lessons related to CartoCSS,  <a href="http://academy.cartodb.com/courses/design-for-beginners/">Introduction to Map Design</a> and <a href="http://academy.cartodb.com/courses/intermediate-design/">Intermediate Map Design</a>
+      Visit The Map Academy to view lessons related to CartoCSS, <a href="http://academy.cartodb.com/courses/design-for-beginners/" target="_blank">Introduction to Map Design</a> and <a href="http://academy.cartodb.com/courses/intermediate-design/" target="_blank">Intermediate Map Design</a>
     </p>
   </div>
 </div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/help/infowindow_with_images.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/help/infowindow_with_images.jst.ejs
@@ -18,7 +18,7 @@
   <span class="Dialog-resultsBodyIcon NavButton">2</span>
   <div class="Dialog-resultsBodyTexts">
     <p class="DefaultParagraph DefaultParagraph--tertiary">
-      Next, you will need to change the order of the labels by dragging the URL field to the top of the fields list in the <a href="http://docs.cartodb.com/cartodb-editor/maps/#infowindows">infowindow</a> options.
+      Next, you will need to change the order of the labels by dragging the URL field to the top of the fields list in the <a href="http://docs.cartodb.com/cartodb-editor/maps/#infowindows" target="_blank">infowindow</a> options.
     </p>
   </div>
 </div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/help/mustache_templates.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/help/mustache_templates.jst.ejs
@@ -18,7 +18,7 @@
   <span class="Dialog-resultsBodyIcon NavButton ">2</span>
   <div class="Dialog-resultsBodyTexts">
     <p class="DefaultParagraph DefaultParagraph--tertiary">
-      Be sure to have elements with class names of <strong>cartodb-popup</strong> and <strong>close</strong> elements. Reference the <a href="https://github.com/CartoDB/cartodb.js/tree/develop/themes/css/infowindow">CSS Library</a> for the latest infowindow stylesheet code. They are needed for basic interactions.
+      Be sure to have elements with class names of <strong>cartodb-popup</strong> and <strong>close</strong> elements. Reference the <a href="https://github.com/CartoDB/cartodb.js/tree/develop/themes/css/infowindow" target="_blank">CSS Library</a> for the latest infowindow stylesheet code. They are needed for basic interactions.
     </p>
   </div>
 </div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/help/postgres_sql.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/help/postgres_sql.jst.ejs
@@ -37,7 +37,7 @@
   <span class="Dialog-resultsBodyIcon NavButton ">?</span>
   <div class="Dialog-resultsBodyTexts">
     <p class="DefaultParagraph DefaultParagraph--tertiary">
-      Do you need more information? View the FAQ's about  <a href="http://docs.cartodb.com/faqs/postgresql-and-postgis/">PostgreSQL Functions and PostGIS Expressions</a>, or visit the official <a href="http://www.postgresql.org/docs/9.3/static/reference.html" target="_blank">PostgreSQL docs</a> and <a href="http://postgis.net/docs/manual-2.2/reference.html" target="_blank">PostGIS</a> documentation.
+      Do you need more information? View the FAQ's about <a href="http://docs.cartodb.com/faqs/postgresql-and-postgis/" target="_blank">PostgreSQL Functions and PostGIS Expressions</a>, or visit the official <a href="http://www.postgresql.org/docs/9.3/static/reference.html" target="_blank">PostgreSQL docs</a> and <a href="http://postgis.net/docs/manual-2.2/reference.html" target="_blank">PostGIS</a> documentation.
     </p>
   </div>
 </div>


### PR DESCRIPTION
@javierarce , we probably should have added the target="_blank"> to the HTML links so the links open in a separate window. I fixed this. Look good?