### PR TITLE
Memory profiling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,8 +99,9 @@ group :test do
   gem 'mock_redis'
 end
 
+# Profiling
+gem 'rbtrace',                 '0.4.8'
 group :test, :development do
-  gem 'rbtrace',               '0.4.8'
   gem 'gc_tracer',             '1.5.1'
   gem 'memory_profiler'
 end

--- a/config/initializers/memory_profiling.rb
+++ b/config/initializers/memory_profiling.rb
@@ -24,7 +24,7 @@ end
 module CartoDB
   def self.memory_dump(filename)
     # Dump classes (id -> name)
-    cls = ObjectSpace.each_object.inject(Hash.new 0) { |h, o| h[o.class.object_id] = o.class.name; h }
+    cls = ObjectSpace.each_object.inject(Hash.new(0)) { |h, o| h[o.class.object_id] = o.class.name; h }
     File.open(filename + '.classes', 'w') do |f|
       JSON.dump(cls, f)
     end

--- a/config/initializers/memory_profiling.rb
+++ b/config/initializers/memory_profiling.rb
@@ -20,3 +20,20 @@ if ENV['MEMORY_REPORTING']
   require 'rbtrace'
   require 'memory_profiler'
 end
+
+module CartoDB
+  def self.memory_dump(filename)
+    # Dump classes (id -> name)
+    cls = ObjectSpace.each_object.inject(Hash.new 0) { |h, o| h[o.class.object_id] = o.class.name; h }
+    File.open(filename + '.classes', 'w') do |f|
+      JSON.dump(cls, f)
+    end
+
+    GC.start
+
+    # Dump objects
+    File.open(filename + '.dump', 'w') do |f|
+      ObjectSpace.dump_all(output: f)
+    end
+  end
+end

--- a/config/initializers/memory_profiling.rb
+++ b/config/initializers/memory_profiling.rb
@@ -1,6 +1,5 @@
 # See http://www.be9.io/2015/09/21/memory-leak/
 # This enables memory logging in order to check memory consumption (reproducing memory leaks)
-require 'objspace'
 if ENV['MEMORY_REPORTING']
   Thread.new do
     while true
@@ -15,6 +14,7 @@ if ENV['MEMORY_REPORTING']
   require 'rack/gc_tracer'
   Rails.configuration.middleware.use Rack::GCTracerMiddleware, view_page_path: '/gc_tracer', filename: 'log/gc.log'
 
+  require 'objspace'
   ObjectSpace.trace_object_allocations_start
 
   require 'rbtrace'
@@ -23,6 +23,7 @@ end
 
 module CartoDB
   def self.memory_dump(filename)
+    require 'objspace'
     # Dump classes (id -> name)
     cls = ObjectSpace.each_object.inject(Hash.new(0)) { |h, o| h[o.class.object_id] = o.class.name; h }
     File.open(filename + '.classes', 'w') do |f|

--- a/config/initializers/memory_profiling.rb
+++ b/config/initializers/memory_profiling.rb
@@ -1,5 +1,6 @@
 # See http://www.be9.io/2015/09/21/memory-leak/
 # This enables memory logging in order to check memory consumption (reproducing memory leaks)
+require 'objspace'
 if ENV['MEMORY_REPORTING']
   Thread.new do
     while true
@@ -14,7 +15,6 @@ if ENV['MEMORY_REPORTING']
   require 'rack/gc_tracer'
   Rails.configuration.middleware.use Rack::GCTracerMiddleware, view_page_path: '/gc_tracer', filename: 'log/gc.log'
 
-  require 'objspace'
   ObjectSpace.trace_object_allocations_start
 
   require 'rbtrace'

--- a/lib/cartodb/analyzer.rb
+++ b/lib/cartodb/analyzer.rb
@@ -67,25 +67,27 @@ end
 
 class AnalyzerClasses
   def initialize(filename)
-    @filename = filename
+    load(filename)
+  end
+
+  def load(filename)
+    @classes = {}
+    File.open(filename + '.classes') do |f|
+      @classes = JSON.load(f)
+    end
+
+    @data = []
+    File.open(filename + '.dump') do |f|
+      f.each_line do |line|
+        @data << JSON.parse(line)
+      end
+    end
   end
 
   def analyze
-    classes = {}
-    File.open(@filename + '.classes') do |f|
-      classes = JSON.load(f)
-    end
-
-    data = []
-    File.open(@filename + '.dump') do |f|
-      f.each_line do |line|
-        data << JSON.parse(line)
-      end
-    end
-
-    data.group_by { |row| "#{row['type']}:#{row['class']}" }.each do |k, v|
+    @data.group_by { |row| "#{row['type']}:#{row['class']}" }.each do |_, v|
       memsize = v.inject(0) { |s, x| s + x['memsize'].to_i }
-      class_name = v[0]['class'].nil? ? '' : classes[(v[0]['class'].hex / 2).to_s]
+      class_name = v[0]['class'].nil? ? '' : @classes[(v[0]['class'].hex / 2).to_s]
       puts "#{v[0]['type']},#{v[0]['class']},#{class_name},#{v.count},#{memsize}"
     end
   end

--- a/lib/cartodb/analyzer.rb
+++ b/lib/cartodb/analyzer.rb
@@ -8,12 +8,13 @@ require 'json'
 #     Edit `config/initializers/carto_db.rb` making `use_https?` return `false`.
 # 1.- Start server in production mode enabling memory profiling:
 #       `MEMORY_REPORTING=true RAILS_ENV=production bundle exec rails s -p 3000`
+#     DO NOT run with MEMORY_REPORTING=true in production environments
 # 2.- Use the features that you want to profile as much as possible.
 # 3.- Memory dump. Find server PID and request the dump:
 #       `ps xah | grep ruby`, for example
-#       `bundle exec rbtrace -p <PID> -e 'Thread.new{GC.start;require "objspace";io=File.open("/tmp/ruby-heap.dump", "w"); ObjectSpace.dump_all(output: io); io.close}'`
+#       `bundle exec rbtrace -p <PID> -e 'Thread.new{CartoDB::memory_dump("/tmp/dump")}'`
 # 4.- Run the Analyzer to get some insights about objects:
-#       `ruby lib/cartodb/analyzer.rb /tmp/ruby-heap.dump > /tmp/ruby-heap.dump.analysis`
+#       `ruby lib/cartodb/analyzer.rb /tmp/dump > /tmp/dump.analysis.csv`
 
 require 'json'
 class Analyzer
@@ -64,4 +65,30 @@ class Analyzer2
   end
 end
 
-Analyzer2.new(ARGV[0]).analyze
+class AnalyzerClasses
+  def initialize(filename)
+    @filename = filename
+  end
+
+  def analyze
+    classes = {}
+    File.open(@filename + '.classes') do |f|
+      classes = JSON.load(f)
+    end
+
+    data = []
+    File.open(@filename + '.dump') do |f|
+      f.each_line do |line|
+        data << JSON.parse(line)
+      end
+    end
+
+    data.group_by { |row| "#{row['type']}:#{row['class']}" }.each do |k, v|
+      memsize = v.inject(0) { |s, x| s + x['memsize'].to_i }
+      class_name = v[0]['class'].nil? ? '' : classes[(v[0]['class'].hex / 2).to_s]
+      puts "#{v[0]['type']},#{v[0]['class']},#{class_name},#{v.count},#{memsize}"
+    end
+  end
+end
+
+AnalyzerClasses.new(ARGV[0]).analyze


### PR DESCRIPTION
Add some infrastructure to enable profiling:
- Moves the rbtrace gem to all environments
- Adds a memory_dump function that dumps object information as well as class names (map object_id->class_name), in order to be able to extract class names from the object dump
- An analyzer that parses the two generated files and generates a csv file of memory usage per class

CR @juanignaciosl 