### PR TITLE
Geocoder improvements

### DIFF
--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -95,7 +95,7 @@ class Geocoding < Sequel::Model
                                                           max_rows: max_geocodable_rows,
                                                           country_column: country_column,
                                                           region_column: region_column,
-                                                          log: self.log)
+                                                          log: log)
       rescue => e
         @table_geocoder = nil
         raise e

--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -171,6 +171,10 @@ class Geocoding < Sequel::Model
     handle_geocoding_success(rows_geocoded_before)
   rescue => e
     handle_geocoding_failure(e, rows_geocoded_before)
+  ensure
+    if table_geocoder && table_geocoder.remote_id
+      self.update remote_id: table_geocoder.remote_id
+    end
   end
 
   def report(error = nil)

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -112,6 +112,11 @@ module CartoDB
       add_to_entries(ENTRY_FORMAT % [ timestamp, content ])
     end
 
+    def append_and_store(content, truncate = true, timestamp = Time.now.utc)
+      append(content, truncate, timestamp)
+      store
+    end
+
     private
 
     def add_to_entries(content)

--- a/services/geocoder/lib/hires_geocoder.rb
+++ b/services/geocoder/lib/hires_geocoder.rb
@@ -53,7 +53,7 @@ module CartoDB
         end
       end
       @status = 'completed'
-      update_stats_log
+      update_log_stats
       @log.append_and_store "Non-batch Here geocoding job finished"
     end
 

--- a/services/geocoder/lib/hires_geocoder.rb
+++ b/services/geocoder/lib/hires_geocoder.rb
@@ -28,29 +28,33 @@ module CartoDB
 
     attr_accessor :input_file
 
-    def initialize(input_csv_file, working_dir)
-      @input_file         = input_csv_file
-      @dir                = working_dir
-
+    def initialize(input_csv_file, working_dir, log)
+      @input_file = input_csv_file
+      @dir = working_dir
+      @log = log
       @non_batch_base_url = config.fetch('non_batch_base_url')
-      @app_id             = config.fetch('app_id')
-      @token              = config.fetch('token')
-      @mailto             = config.fetch('mailto')
+      @app_id = config.fetch('app_id')
+      @token = config.fetch('token')
+      @mailto = config.fetch('mailto')
 
       init_rows_count
     end
 
     def run
       init_rows_count
+      @log.append_and_store "Initialized non batch Here geocoding job"
       @result = File.join(dir, 'generated_csv_out.txt')
       @status = 'running'
       @total_rows = input_rows
+      @log.append_and_store "Total rows to be processed: #{@total_rows}"
       ::CSV.open(@result, "wb") do |output_csv_file|
         ::CSV.foreach(input_file, headers: true) do |input_row|
           process_row(input_row, output_csv_file)
         end
       end
       @status = 'completed'
+      update_stats_log
+      @log.append_and_store "Non-batch Here geocoding job finished"
     end
 
     def used_batch_request?
@@ -104,6 +108,7 @@ module CartoDB
         @empty_processed_rows += 1
       end
     rescue => e
+      @log.append_and_store "Error processing row with search text #{input_row['searchtext']}: #{e.message}"
       CartoDB.notify_debug("Hires geocoding process row error",
                            error: e.backtrace.join('\n'), 
                            searchtext: input_row["searchtext"],
@@ -152,5 +157,11 @@ module CartoDB
       @empty_processed_rows = 0
     end
 
+    def update_log_stats
+      @log.append_and_store "Geocoding non-batch Here job status update. "\
+        "Status: #{@status} --- Processed rows: #{@processed_rows} "\
+        "--- Success: #{@successful_processed_rows} --- Empty: #{@empty_processed_rows} "\
+        "--- Failed: #{@failed_processed_rows}"
+    end
   end
 end

--- a/services/geocoder/lib/hires_geocoder_factory.rb
+++ b/services/geocoder/lib/hires_geocoder_factory.rb
@@ -10,7 +10,7 @@ module CartoDB
 
     BATCH_FILES_OVER = 1100 # Use Here Batch Geocoder API with tables over x rows
 
-    def self.get(input_csv_file, working_dir)
+    def self.get(input_csv_file, working_dir, log)
       geocoder_class = nil
       if use_batch_process? input_csv_file
         geocoder_class = HiresBatchGeocoder
@@ -18,7 +18,7 @@ module CartoDB
         geocoder_class = HiresGeocoder
       end
 
-      geocoder_class.new(input_csv_file, working_dir)
+      geocoder_class.new(input_csv_file, working_dir, log)
     end
 
 

--- a/services/geocoder/spec/hires_batch_geocoder_spec.rb
+++ b/services/geocoder/spec/hires_batch_geocoder_spec.rb
@@ -15,6 +15,9 @@ describe CartoDB::HiresBatchGeocoder do
   end
 
   before(:each) do
+    @log = mock
+    @log.stubs(:append)
+    @log.stubs(:append_and_store)
     @working_dir = Dir.mktmpdir
     @input_csv_file = path_to '../../table-geocoder/spec/fixtures/nokia_input.csv'
     CartoDB::HiresBatchGeocoder.any_instance.stubs(:config).returns({
@@ -23,7 +26,7 @@ describe CartoDB::HiresBatchGeocoder do
         'token' => '',
         'mailto' => ''
       })
-    @batch_geocoder = CartoDB::HiresBatchGeocoder.new(@input_csv_file, @working_dir)
+    @batch_geocoder = CartoDB::HiresBatchGeocoder.new(@input_csv_file, @working_dir, @log)
   end
 
   after(:each) do

--- a/services/geocoder/spec/hires_geocoder_factory_spec.rb
+++ b/services/geocoder/spec/hires_geocoder_factory_spec.rb
@@ -10,6 +10,12 @@ describe CartoDB::HiresGeocoderFactory do
     CartoDB::GeocoderConfig.instance.set(nil)
   end
 
+  before(:each) do
+    @log = mock
+    @log.stubs(:append)
+    @log.stubs(:append_and_store)
+  end
+
   describe '#get' do
     it 'returns a HiresGeocoder instance if the input file has less than N rows' do
       CartoDB::GeocoderConfig.instance.set({
@@ -23,7 +29,7 @@ describe CartoDB::HiresGeocoderFactory do
       input_rows = CartoDB::HiresGeocoderFactory::BATCH_FILES_OVER - 1
       CartoDB::HiresGeocoderFactory.expects(:input_rows).once.with(dummy_input_file).returns(input_rows)
 
-      CartoDB::HiresGeocoderFactory.get(dummy_input_file, working_dir).class.should == CartoDB::HiresGeocoder
+      CartoDB::HiresGeocoderFactory.get(dummy_input_file, working_dir, @log).class.should == CartoDB::HiresGeocoder
     end
 
     it 'returns a HiresBatchGeocoder instance if the input file is above N rows' do
@@ -38,7 +44,7 @@ describe CartoDB::HiresGeocoderFactory do
       input_rows = CartoDB::HiresGeocoderFactory::BATCH_FILES_OVER + 1
       CartoDB::HiresGeocoderFactory.expects(:input_rows).once.with(dummy_input_file).returns(input_rows)
 
-      CartoDB::HiresGeocoderFactory.get(dummy_input_file, working_dir).class.should == CartoDB::HiresBatchGeocoder
+      CartoDB::HiresGeocoderFactory.get(dummy_input_file, working_dir, @log).class.should == CartoDB::HiresBatchGeocoder
     end
 
     it 'returns a batch geocoder if config has force_batch set to true' do
@@ -53,7 +59,7 @@ describe CartoDB::HiresGeocoderFactory do
       working_dir = '/tmp/any_dir'
       CartoDB::HiresGeocoderFactory.expects(:input_rows).never
 
-      CartoDB::HiresGeocoderFactory.get(dummy_input_file, working_dir).class.should == CartoDB::HiresBatchGeocoder
+      CartoDB::HiresGeocoderFactory.get(dummy_input_file, working_dir, @log).class.should == CartoDB::HiresBatchGeocoder
     end
 
   end

--- a/services/geocoder/spec/hires_geocoder_spec.rb
+++ b/services/geocoder/spec/hires_geocoder_spec.rb
@@ -19,13 +19,16 @@ describe CartoDB::HiresGeocoder do
   before(:each) do
     @working_dir = Dir.mktmpdir
     @input_csv_file = path_to '../../table-geocoder/spec/fixtures/nokia_input.csv'
+    @log = mock
+    @log.stubs(:append)
+    @log.stubs(:append_and_store)
     CartoDB::HiresGeocoder.any_instance.stubs(:config).returns({
         'non_batch_base_url' => 'batch.example.com',
         'app_id' => '',
         'token' => '',
         'mailto' => ''
       })
-    @geocoder = CartoDB::HiresGeocoder.new(@input_csv_file, @working_dir)
+    @geocoder = CartoDB::HiresGeocoder.new(@input_csv_file, @working_dir, @log)
   end
 
   after(:each) do

--- a/services/table-geocoder/lib/geocoder_cache.rb
+++ b/services/table-geocoder/lib/geocoder_cache.rb
@@ -7,6 +7,8 @@ module CartoDB
 
     DEFAULT_BATCH_SIZE = 5000
     DEFAULT_MAX_ROWS   = 1000000
+    HTTP_CONNECT_TIMEOUT = 60
+    HTTP_DEFAULT_TIMEOUT = 600
 
     attr_reader :connection, :working_dir, :table_name, :hits, :misses,
                 :max_rows, :sql_api, :formatter, :cache_results
@@ -134,11 +136,12 @@ module CartoDB
 
     def run_query(query, format = '')
       params = { q: query, api_key: sql_api[:api_key], format: format }
-      http_client = Carto::Http::Client.get('geocoder_cache')
-      response = http_client.post(
-        sql_api[:base_url],
-        body: URI.encode_www_form(params)
-      )
+      http_client = Carto::Http::Client.get('geocoder_cache',
+                                            log_requests: true,
+                                            connecttimeout: HTTP_CONNECT_TIMEOUT,
+                                            timeout: HTTP_DEFAULT_TIMEOUT)
+      response = http_client.post(sql_api[:base_url],
+                                  body: URI.encode_www_form(params))
       response.body
     end
 

--- a/services/table-geocoder/lib/geocoder_cache.rb
+++ b/services/table-geocoder/lib/geocoder_cache.rb
@@ -24,6 +24,7 @@ module CartoDB
       @batch_size = arguments[:batch_size] || DEFAULT_BATCH_SIZE
       @cache_results = File.join(working_dir, "#{temp_table_name}_results.csv")
       @usage_metrics = arguments.fetch(:usage_metrics)
+      @log = arguments.fetch(:log)
       init_rows_count
     end
 

--- a/services/table-geocoder/lib/table_geocoder.rb
+++ b/services/table-geocoder/lib/table_geocoder.rb
@@ -22,6 +22,7 @@ module CartoDB
       @remote_id   = arguments[:remote_id]
       @max_rows    = arguments.fetch(:max_rows)
       @usage_metrics = arguments.fetch(:usage_metrics)
+      @log = arguments.fetch(:log)
       @cache       = CartoDB::GeocoderCache.new(
         connection:  connection,
         formatter:   clean_formatter,
@@ -30,7 +31,8 @@ module CartoDB
         table_name:  table_name,
         qualified_table_name: @qualified_table_name,
         max_rows:    @max_rows,
-        usage_metrics: @usage_metrics
+        usage_metrics: @usage_metrics,
+        log: @log
       )
     end # initialize
 
@@ -43,7 +45,7 @@ module CartoDB
       cache.store unless cache_disabled?
     ensure
       self.remote_id = geocoder.request_id
-      update_metrics()
+      update_metrics
     end
 
     # TODO: make the geocoders update status directly in the model
@@ -87,7 +89,7 @@ module CartoDB
     private
 
     def geocoder
-      @geocoder ||= CartoDB::HiresGeocoderFactory.get(csv_file, working_dir)
+      @geocoder ||= CartoDB::HiresGeocoderFactory.get(csv_file, working_dir, @log)
     end
 
     def cache_disabled?

--- a/services/table-geocoder/lib/table_geocoder.rb
+++ b/services/table-geocoder/lib/table_geocoder.rb
@@ -39,15 +39,11 @@ module CartoDB
       cache.run unless cache_disabled?
       @csv_file = generate_csv()
       geocoder.run
-      self.remote_id = geocoder.request_id
       process_results if geocoder.status == 'completed'
       cache.store unless cache_disabled?
     ensure
-      total_requests = geocoder.successful_processed_rows + geocoder.empty_processed_rows + geocoder.failed_processed_rows
-      @usage_metrics.incr(:geocoder_here, :success_responses, geocoder.successful_processed_rows)
-      @usage_metrics.incr(:geocoder_here, :empty_responses, geocoder.empty_processed_rows)
-      @usage_metrics.incr(:geocoder_here, :failed_responses, geocoder.failed_processed_rows)
-      @usage_metrics.incr(:geocoder_here, :total_requests, total_requests)
+      self.remote_id = geocoder.request_id
+      update_metrics()
     end
 
     # TODO: make the geocoders update status directly in the model
@@ -179,5 +175,13 @@ module CartoDB
       Dir[File.join(working_dir, '*_out.txt')][0]
     end
 
-  end # Geocoder
-end # CartoDB
+    def update_metrics
+      total_requests = geocoder.successful_processed_rows + geocoder.empty_processed_rows + geocoder.failed_processed_rows
+      @usage_metrics.incr(:geocoder_here, :success_responses, geocoder.successful_processed_rows)
+      @usage_metrics.incr(:geocoder_here, :empty_responses, geocoder.empty_processed_rows)
+      @usage_metrics.incr(:geocoder_here, :failed_responses, geocoder.failed_processed_rows)
+      @usage_metrics.incr(:geocoder_here, :total_requests, total_requests)
+    end
+
+  end
+end

--- a/services/table-geocoder/lib/table_geocoder_factory.rb
+++ b/services/table-geocoder/lib/table_geocoder_factory.rb
@@ -53,7 +53,8 @@ module Carto
         geocoder_class = CartoDB::InternalGeocoder::Geocoder
       end
 
-      instance_config.merge!(usage_metrics: get_geocoder_metrics_instance(user))
+      instance_config[:usage_metrics] = get_geocoder_metrics_instance(user)
+      instance_config[:log] = log
 
       log.append "geocoder_class = #{geocoder_class.to_s}"
       instance = geocoder_class.new(instance_config)

--- a/services/table-geocoder/spec/geocoder_cache_spec.rb
+++ b/services/table-geocoder/spec/geocoder_cache_spec.rb
@@ -15,6 +15,9 @@ describe CartoDB::GeocoderCache do
     @pg_options   = conn.pg_options
     @table_name   = "ne_10m_populated_places_simple"
     @usage_metrics_stub = stub
+    @log = mock
+    @log.stubs(:append)
+    @log.stubs(:append_and_store)
 
     # Avoid issues on some machines if postgres system account can't read fixtures subfolder for the COPY
     filename = 'populated_places_short.csv'
@@ -32,7 +35,8 @@ describe CartoDB::GeocoderCache do
       formatter: "concat(name, iso3)",
       connection: @db, sql_api: { table_name: '' },
       qualified_table_name: @table_name,
-      usage_metrics: @usage_metrics_stub
+      usage_metrics: @usage_metrics_stub,
+      log: @log
     } }
 
   describe '#get_cache_results' do

--- a/services/table-geocoder/spec/lib/gme/table_geocoder_spec.rb
+++ b/services/table-geocoder/spec/lib/gme/table_geocoder_spec.rb
@@ -12,13 +12,17 @@ describe Carto::Gme::TableGeocoder do
     connection_stub = mock
     connection_stub.stubs(:run)
     @usage_metrics_stub = stub
+    @log = mock
+    @log.stubs(:append)
+    @log.stubs(:append_and_store)
 
     @mandatory_args = {
       connection: connection_stub,
       original_formatter: '{mock}',
       client_id: 'my_client_id',
       private_key: 'my_private_key',
-      usage_metrics: @usage_metrics_stub
+      usage_metrics: @usage_metrics_stub,
+      log: @log
     }
   end
 
@@ -196,7 +200,8 @@ describe Carto::Gme::TableGeocoder do
         client_id: 'my_client_id',
         private_key: 'my_private_key',
         max_block_size: 4,
-        usage_metrics: @usage_metrics_stub
+        usage_metrics: @usage_metrics_stub,
+        log: @log
       }
 
       @table_geocoder = Carto::Gme::TableGeocoder.new(params)

--- a/spec/factories/log.rb
+++ b/spec/factories/log.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+
+  factory :log, class: CartoDB::Log do
+  end
+
+end


### PR DESCRIPTION
#Closes #6723, #6745 

- [x] Added logger for the hires geocoder in order to have more information while the process is being done. For example have info during the batch geocoding job instead to wait until the job finish to gather all the info
- [x] Add timeouts to the geocoder cache