### PR TITLE
Fix for undefined method `*' for nil:NilClass

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+3.12.3 (2016-03-01)
+-------------------
+* Fixes in HTTP Header authentication.
+* Fixes in avatar urls
+* Fixes in organization sigup
+* Fixes in high resolution geocoder when using google provider
+
 3.12.2 (2016-05-15)
 -------------------
 * Support for HTTP Header authentication.

--- a/app/models/geocoding.rb
+++ b/app/models/geocoding.rb
@@ -189,7 +189,7 @@ class Geocoding < Sequel::Model
   end # self.processable_rows
 
   def calculate_used_credits
-    return 0 unless kind == 'high-resolution'
+    return 0 unless kind == 'high-resolution' && geocoder_type == 'heremaps'
     total_rows       = processed_rows.to_i + cache_hits.to_i
     geocoding_quota  = user.organization.present? ? user.organization.geocoding_quota.to_i : user.geocoding_quota
     used_geocoding_calls = user.organization_user? ? user.organization.get_geocoding_calls : user.get_geocoding_calls

--- a/spec/models/geocoding_spec.rb
+++ b/spec/models/geocoding_spec.rb
@@ -276,13 +276,13 @@ describe Geocoding do
     end
 
     it 'returns the used credits when the user is over geocoding quota' do
-      geocoding = FactoryGirl.create(:geocoding, user: @user, processed_rows: 0, cache_hits: 100, kind: 'high-resolution', formatter: 'foo')
+      geocoding = FactoryGirl.create(:geocoding, user: @user, processed_rows: 0, cache_hits: 100, kind: 'high-resolution', geocoder_type: 'heremaps', formatter: 'foo')
       # 100 total (user has 200) => 0 used credits
       geocoding.calculate_used_credits.should eq 0
-      geocoding = FactoryGirl.create(:geocoding, user: @user, processed_rows: 0, cache_hits: 150, kind: 'high-resolution', formatter: 'foo')
+      geocoding = FactoryGirl.create(:geocoding, user: @user, processed_rows: 0, cache_hits: 150, kind: 'high-resolution', geocoder_type: 'heremaps', formatter: 'foo')
       # 250 total => 50 used credits
       geocoding.calculate_used_credits.should eq 50
-      geocoding = FactoryGirl.create(:geocoding, user: @user, processed_rows: 100, cache_hits: 0, kind: 'high-resolution', formatter: 'foo')
+      geocoding = FactoryGirl.create(:geocoding, user: @user, processed_rows: 100, cache_hits: 0, kind: 'high-resolution', geocoder_type: 'heremaps', formatter: 'foo')
       # 350 total => 100 used credits
       geocoding.calculate_used_credits.should eq 100
     end


### PR DESCRIPTION
exception when using google geocoder.

Conflicts:
	NEWS.md

**Note**: cherry-picked from 3.12.X branch