### PR TITLE
polygon gamma suggestions for simple, choropleth, category, and density default settings

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/carto_wizard_forms.js
@@ -15,7 +15,7 @@ cdb.admin.forms.get = function(what) {
 var polygon_stroke = {
    name: 'Polygon Stroke',
    form: {
-      'line-width': { type: 'width', value: 0.5 },
+      'line-width': { type: 'width', value: 0 },
       'line-color': { type: 'color' , value: '#FFF' },
       'line-opacity': { type: 'opacity', value: 1 }
    }
@@ -43,7 +43,8 @@ var polygon_fill = {
    name: 'Polygon Fill',
    form: {
       'polygon-fill': { type: 'color' , value: '#FF6600', extra: { image_property: 'polygon-pattern-file', image_kind: 'pattern' }},
-      'polygon-opacity': { type: 'opacity_polygon' , value: 0.7 }
+      'polygon-opacity': { type: 'opacity_polygon' , value: 0.7 },
+      'polygon-gamma': { type: 'gamma' , value: 0.2 }
   }
 };
 
@@ -287,7 +288,8 @@ var color_ramp_polygon = {
       'inverted_green', 'inverted_blue', 'spectrum1', 'spectrum2',
       'blue_states', 'purple_states', 'red_states',
       'inverted_blue_states', 'inverted_purple_states', 'inverted_red_states'] },
-    'polygon-opacity': { type: 'opacity', value: 0.8 }
+    'polygon-opacity': { type: 'opacity', value: 0.8 },
+    'polygon-gamma': { type: 'gamma' , value: 0.2 }
   }
 };
 
@@ -422,7 +424,8 @@ cdb.admin.forms.color = {
     {
       name: 'Polygon Fill',
       form: {
-        'polygon-opacity': { type: 'opacity' , value: 0.7 }
+        'polygon-opacity': { type: 'opacity' , value: 0.7 },
+        'polygon-gamma': { type: 'gamma' , value: 0.2 }
       }
     },
     polygon_stroke
@@ -517,7 +520,8 @@ cdb.admin.forms.category = {
     {
       name: 'Polygon Fill',
       form: {
-        'polygon-opacity': { type: 'opacity' , value: 0.7 }
+        'polygon-opacity': { type: 'opacity' , value: 0.7 },
+        'polygon-gamma': { type: 'gamma' , value: 0.2 }
       }
     },
     polygon_stroke
@@ -576,7 +580,8 @@ cdb.admin.forms.density = {
             'inverted_green', 'inverted_blue', 'spectrum1', 'spectrum2', 
             'blue_states', 'purple_states', 'red_states',
             'inverted_blue_states', 'inverted_purple_states', 'inverted_red_states'] },
-         'polygon-opacity': { type: 'opacity', value: 0.8 }
+         'polygon-opacity': { type: 'opacity', value: 0.8 },
+         'polygon-gamma': { type: 'gamma' , value: 0.2 }
        }
     },
 
@@ -584,7 +589,7 @@ cdb.admin.forms.density = {
     {
       name: 'Polygon size',
       form: {
-        'polygon-size': { type: 'number', value: 15, min: 1, max: 100 }
+        'polygon-size': { type: 'number', value: 5, min: 1, max: 100 }
       }
     },
 


### PR DESCRIPTION
@andrewxhill please review

The changes proposed in this pull request are:
- to add `polygon-gamma: 0.2` to simple, choropleth, category, and density polygons
- for each type of polygon map, the `line-width` has been set to `0`
- in addition, I've adjusted the default size of the hexbins from 15 to 5

Explanation and Examples:

By default, `polygon-gamma` (polygon-antialiasing) is set to `1`. If someone is designing a map and removes the outline, there is a noticeable gap in between each polygon. This is especially true with choropleth and category maps that vary in color over a variety of shapes and sizes. Here are two examples of this effect:

<img width="214" alt="screen shot 2016-03-03 at 3 08 57 pm" src="https://cloud.githubusercontent.com/assets/1566273/13507729/f61f069c-e151-11e5-9e56-313f6985ff2b.png">
<img width="213" alt="screen shot 2016-03-03 at 3 09 06 pm" src="https://cloud.githubusercontent.com/assets/1566273/13507738/fd4edb40-e151-11e5-87a7-aef2498b34e2.png">

One solution is to modify the `line-color` of each polygon fill to get a smooth appearance but this can be tedious especially when there are a large number of classes/categories.

A default solution is to adjust the `polygon-gamma` setting to `0.2`. In doing so, the antialiasing is minimized and each polygon appears to have an outline that is a shade of its fill color and makes for an overall smoother looking map:
<img width="280" alt="screen shot 2016-03-03 at 3 12 54 pm" src="https://cloud.githubusercontent.com/assets/1566273/13507846/94146dc4-e152-11e5-8ad0-04b4d5ffc0f1.png">
<img width="264" alt="screen shot 2016-03-03 at 3 12 38 pm" src="https://cloud.githubusercontent.com/assets/1566273/13507824/792cb002-e152-11e5-9b69-06120ffa7b98.png">
<img width="220" alt="screen shot 2016-03-03 at 3 14 37 pm" src="https://cloud.githubusercontent.com/assets/1566273/13507887/c9b8c452-e152-11e5-8c46-53e02356609a.png">
<img width="204" alt="screen shot 2016-03-03 at 3 14 48 pm" src="https://cloud.githubusercontent.com/assets/1566273/13507891/ce9cc518-e152-11e5-99a9-591e61534367.png">

Density Now:
<img width="294" alt="screen shot 2016-03-03 at 3 19 48 pm" src="https://cloud.githubusercontent.com/assets/1566273/13508118/a0a65cc2-e153-11e5-94bd-e62b991b7e93.png">

Proposed (with `polygon-gamma` and default size of `5`):
<img width="348" alt="screen shot 2016-03-03 at 3 20 42 pm" src="https://cloud.githubusercontent.com/assets/1566273/13508145/c13aaaba-e153-11e5-831f-5eb6b0896dab.png">


