### PR TITLE
Upgrade Rollbar gem to 2.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,8 @@ gem 'redcarpet', '3.3.3'
 gem 'bartt-ssl_requirement',   '~>1.4.0', require: 'ssl_requirement'
 
 # TODO Production gems, put them in :production group
-gem 'rollbar',               '0.12.14'
+gem 'rollbar',               '~> 2.8.0'
+gem 'oj',                    '~> 2.12.14' # Required for Rollbar serialization
 gem 'resque',                '1.25.2'
 gem 'resque-metrics',        '0.1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
     resque-metrics (0.1.1)
       resque (~> 1.19)
     retriable (1.4.1)
-    rollbar (2.8.0)
+    rollbar (2.8.2)
       multi_json
     roo (1.13.2)
       nokogiri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
     oauth (0.4.5)
     oauth-plugin (0.4.0.pre4)
       oauth (>= 0.4.4)
+    oj (2.12.14)
     pg (0.15.0)
     poltergeist (1.0.3)
       capybara (~> 1.1)
@@ -251,8 +252,8 @@ GEM
     resque-metrics (0.1.1)
       resque (~> 1.19)
     retriable (1.4.1)
-    rollbar (0.12.14)
-      multi_json (~> 1.3)
+    rollbar (2.8.0)
+      multi_json
     roo (1.13.2)
       nokogiri
       rubyzip
@@ -387,6 +388,7 @@ DEPENDENCIES
   nokogiri (~> 1.6.6.2)
   oauth (= 0.4.5)
   oauth-plugin (= 0.4.0.pre4)
+  oj (~> 2.12.14)
   pg (= 0.15.0)
   poltergeist (>= 1.0.0)
   rack
@@ -403,7 +405,7 @@ DEPENDENCIES
   resque (= 1.25.2)
   resque-metrics (= 0.1.1)
   retriable (= 1.4.1)
-  rollbar (= 0.12.14)
+  rollbar (~> 2.8.0)
   roo (= 1.13.2)
   rspec-rails (= 2.12.0)
   ruby-prof (= 0.15.1)


### PR DESCRIPTION
Upgrades Rollbar gem to new version. The old reporting functions (`Rollbar-report_exception`) are deprecated but still work.
Closes #6777 

CR @juanignaciosl 