### PR TITLE
Layers controller coverage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,7 +113,6 @@ Style/CollectionMethods:
   PreferredMethods:
     collect: map
     collect!: map!
-    find: detect
     find_all: select
     reduce: inject
 Style/CommentAnnotation:
@@ -142,7 +141,7 @@ Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: false
 Style/EmptyLinesAroundBlockBody:
   Description: Keeps track of empty lines around block bodies.
-  Enabled: true
+  Enabled: false
   EnforcedStyle: no_empty_lines
   SupportedStyles:
   - empty_lines

--- a/app/controllers/api/json/layers_controller.rb
+++ b/app/controllers/api/json/layers_controller.rb
@@ -11,7 +11,6 @@ class Api::Json::LayersController < Api::ApplicationController
 
   def create
     @stats_aggregator.timing('layers.create') do
-
       begin
         @layer = ::Layer.new(params.slice(:kind, :options, :infowindow, :tooltip, :order))
         if @parent.is_a?(::Map)
@@ -19,18 +18,19 @@ class Api::Json::LayersController < Api::ApplicationController
             return(render status: 400, text: "Can't add more layers of this type")
           end
           unless @parent.can_add_layer(current_user)
-            return(render_jsonp({:description => 'You cannot add a layer in this visualization'}, 403))
+            return(render_jsonp({ description: 'You cannot add a layer in this visualization' }, 403))
           end
 
           if ::Layer::DATA_LAYER_KINDS.include?(@layer.kind)
             table_visualization = @stats_aggregator.timing('locate') do
-                Helpers::TableLocator.new.get_by_id_or_name(
-                  @layer.options['table_name'],
-                  current_user
-                ).table_visualization
-              end
-            unless table_visualization.has_permission?(current_user, CartoDB::Visualization::Member::PERMISSION_READONLY)
-              return(render_jsonp({:description => 'You do not have permission in the layer you are trying to add'}, 400))
+              Helpers::TableLocator.new.get_by_id_or_name(
+                @layer.options['table_name'],
+                current_user
+              ).table_visualization
+            end
+            unless table_visualization.has_permission?(current_user,
+                                                       CartoDB::Visualization::Member::PERMISSION_READONLY)
+              return render_jsonp({ description: 'You do not have permission in the layer you are trying to add' }, 400)
             end
           end
         end
@@ -60,46 +60,47 @@ class Api::Json::LayersController < Api::ApplicationController
           render_jsonp CartoDB::LayerModule::Presenter.new(@layer, viewer_user: current_user).to_poro
         else
           CartoDB::Logger.info "Error on layers#create", @layer.errors.full_messages
-          render_jsonp( { :description => @layer.errors.full_messages,
-                          :stack => @layer.errors.full_messages
+          render_jsonp({ description: @layer.errors.full_messages,
+                         stack: @layer.errors.full_messages
                         }, 400)
         end
       end
-
     end
   end
 
   def update
     @stats_aggregator.timing('layers.update') do
-
       begin
         ids = ids_from_url_or_parameters
         layers = []
 
         @stats_aggregator.timing("layers.save-#{layers.count}") do
-          ids.each { |id|
+          ids.each do |id|
             layer = ::Layer[id]
             layer.raise_on_save_failure = true
             # don't allow to override table_name and user_name
             # https://cartodb.atlassian.net/browse/CDB-3350
-            layer_params = ids.length == 1 ? params : params[:layers].select { |p| p['id'] == id }.first
-            layer_params[:options]['table_name'] = layer.options['table_name'] if layer_params.include?(:options) && layer_params[:options].include?('table_name')
-            layer_params[:options]['user_name'] = layer.options['user_name'] if layer_params.include?(:options) && layer_params[:options].include?('user_name')
+            layer_params = ids.length == 1 ? params : params[:layers].find { |p| p['id'] == id }
+            if layer_params.include?(:options) && layer_params[:options].include?('table_name')
+              layer_params[:options]['table_name'] = layer.options['table_name']
+            end
+            if layer_params.include?(:options) && layer_params[:options].include?('user_name')
+              layer_params[:options]['user_name'] = layer.options['user_name']
+            end
             layer.update(layer_params.slice(:options, :kind, :infowindow, :tooltip, :order))
             layers << layer
-          }
+          end
         end
 
         if layers.count > 1
           layers_json = layers.map { |l| CartoDB::LayerModule::Presenter.new(l, viewer_user: current_user).to_poro }
-          render_jsonp({ layers: layers_json })
+          render_jsonp(layers: layers_json)
         else
           render_jsonp CartoDB::LayerModule::Presenter.new(layers[0], viewer_user: current_user).to_poro
         end
       rescue Sequel::ValidationFailed, RuntimeError => e
         render_jsonp({ description: e.message }, 400)
       end
-
     end
   end
 
@@ -119,37 +120,40 @@ class Api::Json::LayersController < Api::ApplicationController
     raise RecordNotFound if @parent.nil?
   end
 
-  def user_from(params={})
+  def user_from(params = {})
     current_user if params[:user_id]
-  end #user_from
+  end
 
-  def map_from(params={})
+  def map_from(params = {})
     return unless params[:map_id]
 
     # User must be owner or have permissions for the map's visualization
     vis_collection = CartoDB::Visualization::Collection.new.fetch(
-        user_id: current_user.id,
-        map_id: params[:map_id]
+      user_id: current_user.id,
+      map_id: params[:map_id]
     )
     raise RecordNotFound if vis_collection.count == 0
 
     ::Map.filter(id: params[:map_id]).first
-  end #map_from
+  end
 
   def ids_from_url_or_parameters
-    params[:id].present? ? [ params[:id] ] : params[:layers].map { |l| l['id'] }
+    params[:id].present? ? [params[:id]] : params[:layers].map { |l| l['id'] }
   end
 
   def validate_read_write_permission
     ids = ids_from_url_or_parameters
-    ids.each { |id|
+    ids.each do |id|
       layer = ::Layer[id]
-      layer.maps.each { |map|
-        map.visualizations.each { |vis|
-          return head(403) unless vis.is_owner?(current_user) || vis.has_permission?(current_user, CartoDB::Visualization::Member::PERMISSION_READWRITE)
-        }
-      }
-    }
+      layer.maps.each do |map|
+        map.visualizations.each do |vis|
+          rw = CartoDB::Visualization::Member::PERMISSION_READWRITE
+          unless vis.is_owner?(current_user) || vis.has_permission?(current_user, rw)
+            return head(403)
+          end
+        end
+      end
+    end
     true
   rescue => e
     render_jsonp({ description: e.message }, 400)

--- a/app/controllers/helpers/table_locator.rb
+++ b/app/controllers/helpers/table_locator.rb
@@ -3,7 +3,7 @@
 module Helpers
   class TableLocator
 
-    UUID_RX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.freeze
+    UUID_RX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
     # Getter by table uuid or table name using canonical visualizations
     # @param id_or_name String If is a name, can become qualified as "schema.tablename"

--- a/app/controllers/helpers/table_locator.rb
+++ b/app/controllers/helpers/table_locator.rb
@@ -3,13 +3,14 @@
 module Helpers
   class TableLocator
 
+    UUID_RX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.freeze
+
     # Getter by table uuid or table name using canonical visualizations
     # @param id_or_name String If is a name, can become qualified as "schema.tablename"
     # @param viewer_user ::User
     def get_by_id_or_name(id_or_name, viewer_user)
       return nil unless viewer_user
 
-      rx = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
       table_name, table_schema = ::Table.table_and_schema(id_or_name)
 
@@ -32,7 +33,7 @@ module Helpers
       }.first
       table = vis.nil? ? nil : vis.table
 
-      if rx.match(id_or_name) && table.nil?
+      if UUID_RX.match(id_or_name) && table.nil?
         table_temp = ::UserTable.where(id: id_or_name).first.try(:service)
         unless table_temp.nil?
           # Make sure we're allowed to see the table
@@ -41,6 +42,7 @@ module Helpers
               map_id: table_temp.map_id,
               type: CartoDB::Visualization::Member::TYPE_CANONICAL
           ).first
+
           table = vis.table unless vis.nil?
         end
       end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,7 +20,7 @@ CartoDB::Application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection    = false
+  config.action_controller.allow_forgery_protection = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
@@ -37,12 +37,12 @@ CartoDB::Application.configure do
   config.active_support.deprecation = :stderr
 
   # Don't fallback to assets pipeline
-  #config.assets.compile = true
+  # config.assets.compile = true
   config.assets.compress = false
   config.assets.digest = false
   config.assets.debug = false
 
-  #config.assets.prefix = 'assets-test'
+  # config.assets.prefix = 'assets-test'
 
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_assets = true

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -13,7 +13,7 @@ module Carto
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)
 
-        map, table, table_visualization, visualization
+        return map, table, table_visualization, visualization
       end
 
     end

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -1,0 +1,21 @@
+module Carto
+  module Factories
+    module Visualizations
+
+      # "Full visualization": with map, table... Metadata only (not actual user table).
+      def create_full_visualization(carto_user, map: FactoryGirl.create(:carto_map, user_id: @user1.id))
+        table = FactoryGirl.create(:carto_user_table, user_id: carto_user.id, map_id: map.id)
+        table_visualization = FactoryGirl.create(
+          :carto_visualization,
+          user: carto_user, type: 'table', name: table.name, map_id: table.map_id)
+        visualization = FactoryGirl.create(:carto_visualization, user_id: carto_user.id, map: map)
+        # Need to mock the nonexistant table because factories use Carto::* models
+        CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
+        CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)
+
+        return map, table, table_visualization, visualization
+      end
+
+    end
+  end
+end

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -13,7 +13,7 @@ module Carto
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)
 
-        return map, table, table_visualization, visualization
+        map, table, table_visualization, visualization
       end
 
     end

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -3,7 +3,7 @@ module Carto
     module Visualizations
 
       # "Full visualization": with map, table... Metadata only (not actual user table).
-      def create_full_visualization(carto_user, map: FactoryGirl.create(:carto_map, user_id: @user1.id))
+      def create_full_visualization(carto_user, map: FactoryGirl.create(:carto_map, user_id: carto_user.id))
         table = FactoryGirl.create(:carto_user_table, user_id: carto_user.id, map_id: map.id)
         table_visualization = FactoryGirl.create(
           :carto_visualization,

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+
+  factory :carto_permission, class: Carto::Permission do
+    after(:build) do |permission|
+      permission.owner_username = permission.owner.username
+    end
+
+  end
+end

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
 
   factory :carto_permission, class: Carto::Permission do
     after(:build) do |permission|
-      permission.owner_username = permission.owner.username
+      permission.owner_username = permission.owner.username if permission.owner
     end
 
   end

--- a/spec/factories/table_storage.rb
+++ b/spec/factories/table_storage.rb
@@ -4,6 +4,11 @@ FactoryGirl.define do
   end
 
   factory :user_table, class: UserTable do
+    name { String.random(5).downcase }
+  end
+
+  factory :carto_user_table, class: Carto::UserTable do
+    name { String.random(5).downcase }
   end
 
 end

--- a/spec/factories/users_helper.rb
+++ b/spec/factories/users_helper.rb
@@ -9,6 +9,7 @@ shared_context 'users helper' do
 
   before(:all) do
     @user1 = FactoryGirl.create(:valid_user, private_tables_enabled: true)
+    @carto_user1 = Carto::User.find(@user1.id)
     @user2 = FactoryGirl.create(:valid_user, private_tables_enabled: true)
   end
 

--- a/spec/factories/visualizations.rb
+++ b/spec/factories/visualizations.rb
@@ -21,6 +21,14 @@ FactoryGirl.define do
     type 'derived'
     name 'factory visualization'
     privacy 'public'
+
+    after(:create) do |visualization|
+      permission = FactoryGirl.create :carto_permission, entity: visualization, owner: visualization.user, entity_type: 'vis'
+      visualization.permission_id = permission.id
+      visualization.save
+      visualization.reload
+    end
+
   end
 
 end

--- a/spec/factories/visualizations.rb
+++ b/spec/factories/visualizations.rb
@@ -22,6 +22,8 @@ FactoryGirl.define do
     name 'factory visualization'
     privacy 'public'
 
+    association :user, factory: :carto_user
+
     after(:create) do |visualization|
       permission = FactoryGirl.create :carto_permission,
                                       entity: visualization, owner: visualization.user, entity_type: 'vis'

--- a/spec/factories/visualizations.rb
+++ b/spec/factories/visualizations.rb
@@ -23,7 +23,8 @@ FactoryGirl.define do
     privacy 'public'
 
     after(:create) do |visualization|
-      permission = FactoryGirl.create :carto_permission, entity: visualization, owner: visualization.user, entity_type: 'vis'
+      permission = FactoryGirl.create :carto_permission,
+                                      entity: visualization, owner: visualization.user, entity_type: 'vis'
       visualization.permission_id = permission.id
       visualization.save
       visualization.reload

--- a/spec/requests/api/json/layers_controller_spec.rb
+++ b/spec/requests/api/json/layers_controller_spec.rb
@@ -7,8 +7,34 @@ require_relative 'layers_controller_shared_examples'
 describe Api::Json::LayersController do
   it_behaves_like 'layers controllers' do
   end
-  
+
   include Rack::Test::Methods
   include Warden::Test::Helpers
   include CacheHelper
+
+  include_context 'users helper'
+
+  describe '#create' do
+    before(:each) do
+    end
+
+    it 'creates layers' do
+      kind = 'carto'
+      expected_layer_without_id = { options: {}, kind: kind, infowindow: nil, tooltip: nil, order: 1 }
+
+      layer_json = { kind: 'carto', options: {}, order: 1 }
+
+      post_json api_v1_users_layers_create_url(
+        user_domain: @user1.username,
+        user_id: @user1.id,
+        api_key: @user1.api_key), layer_json do |response|
+        response.status.should eq 200
+        layer = response.body
+
+        layer[:id].should_not be_nil
+        layer.delete(:id)
+        layer.should eq expected_layer_without_id
+      end
+    end
+  end
 end

--- a/spec/requests/api/json/layers_controller_spec.rb
+++ b/spec/requests/api/json/layers_controller_spec.rb
@@ -45,7 +45,11 @@ describe Api::Json::LayersController do
     end
 
     def delete_map_layer_url(map_id, layer_id)
-      api_v1_maps_layers_destroy_url(user_domain: @user1.username, map_id: map_id, id: layer_id, api_key: @user1.api_key)
+      api_v1_maps_layers_destroy_url(
+        user_domain: @user1.username,
+        map_id: map_id,
+        id: layer_id,
+        api_key: @user1.api_key)
     end
 
     let(:layer_json) do
@@ -75,7 +79,7 @@ describe Api::Json::LayersController do
         layer_options = layer_response.delete(:options)
         layer_options.should eq ({ "table_name" => @table.name })
 
-        layer_response.should eq (layer_json.except(:options))
+        layer_response.should eq layer_json.except(:options)
 
         @layer = Carto::Layer.find(layer_id)
         @layer.maps.map(&:id).first.should eq @map.id

--- a/spec/requests/api/json/layers_controller_spec.rb
+++ b/spec/requests/api/json/layers_controller_spec.rb
@@ -42,6 +42,10 @@ describe Api::Json::LayersController do
         api_key: @user1.api_key)
     end
 
+    def delete_map_layer_url(map_id, layer_id)
+      api_v1_maps_layers_destroy_url(user_domain: @user1.username, map_id: map_id, id: layer_id, api_key: @user1.api_key)
+    end
+
     def create_full_visualization(map: FactoryGirl.create(:carto_map, user_id: @user1.id))
       @map = map
       @table = FactoryGirl.create(:carto_user_table, user_id: @user1.id, map_id: @map.id)
@@ -137,7 +141,6 @@ describe Api::Json::LayersController do
       end
     end
 
-
     it 'does not update table_name or users_name options' do
       map = FactoryGirl.create(:carto_map_with_layers, user_id: @user1.id)
       create_full_visualization(map: map)
@@ -151,6 +154,17 @@ describe Api::Json::LayersController do
         layer_response = response.body
 
         layer_response.delete(:options).should eq layer_json[:options]
+      end
+    end
+
+    it 'destroys layers' do
+      map = FactoryGirl.create(:carto_map_with_layers, user_id: @user1.id)
+      create_full_visualization(map: map)
+      @layer = map.layers.first
+
+      delete_json delete_map_layer_url(map.id, @layer.id), {} do |response|
+        response.status.should eq 204
+        Carto::Layer.exists?(@layer.id).should be_false
       end
     end
   end

--- a/spec/requests/api/json/layers_controller_spec.rb
+++ b/spec/requests/api/json/layers_controller_spec.rb
@@ -15,25 +15,61 @@ describe Api::Json::LayersController do
   include_context 'users helper'
 
   describe '#create' do
-    before(:each) do
+    after(:each) do
+      @table_visualization.destroy if @table_visualization
+      @table.destroy if @table
+      @layer.destroy if @layer
+      @visualization.destroy if @visualization
+      @map.destroy if @map
     end
 
+    let(:kind) { 'carto' }
+
+    let(:create_layer_url) do
+      api_v1_users_layers_create_url(user_domain: @user1.username, user_id: @user1.id, api_key: @user1.api_key)
+    end
+
+    def create_map_layer_url(map_id)
+      api_v1_maps_layers_create_url(user_domain: @user1.username, map_id: map_id, api_key: @user1.api_key)
+    end
+
+    let(:layer_json) { { kind: 'carto', options: {}, order: 1 } }
+
     it 'creates layers' do
-      kind = 'carto'
-      expected_layer_without_id = { options: {}, kind: kind, infowindow: nil, tooltip: nil, order: 1 }
-
-      layer_json = { kind: 'carto', options: {}, order: 1 }
-
-      post_json api_v1_users_layers_create_url(
-        user_domain: @user1.username,
-        user_id: @user1.id,
-        api_key: @user1.api_key), layer_json do |response|
+      post_json create_layer_url, layer_json do |response|
         response.status.should eq 200
-        layer = response.body
+        layer_response = response.body
 
-        layer[:id].should_not be_nil
-        layer.delete(:id)
-        layer.should eq expected_layer_without_id
+        layer_response.delete(:id).should_not be_nil
+        layer_response.should eq ({ options: {}, kind: kind, infowindow: nil, tooltip: nil, order: 1 })
+      end
+    end
+
+    it 'creates layers on maps' do
+      @map = FactoryGirl.create(:carto_map, user_id: @user1.id)
+      @table = FactoryGirl.create(:carto_user_table, user_id: @user1.id, map_id: @map.id)
+      @table_visualization = FactoryGirl.create(
+        :carto_visualization,
+        user: @carto_user1, type: 'table', name: @table.name, map_id: @table.map_id)
+      @visualization = FactoryGirl.create(:carto_visualization, user_id: @user1.id, map: @map)
+      # Need to mock the nonexistant table
+      CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
+      CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)
+
+      post_json create_map_layer_url(@map.id), layer_json.merge(options: { table_name: @table.name }) do |response|
+        response.status.should eq 200
+        layer_response = response.body
+
+        layer_id = layer_response.delete(:id)
+        layer_id.should_not be_nil
+
+        layer_options = layer_response.delete(:options)
+        layer_options.should eq ({ "table_name" => @table.name })
+
+        layer_response.should eq ({ kind: kind, infowindow: nil, tooltip: nil, order: 1 })
+
+        @layer = Carto::Layer.find(layer_id)
+        @layer.maps.map(&:id).first.should eq @map.id
       end
     end
   end

--- a/spec/requests/api/json/layers_controller_spec.rb
+++ b/spec/requests/api/json/layers_controller_spec.rb
@@ -76,8 +76,7 @@ describe Api::Json::LayersController do
         layer_id = layer_response.delete(:id)
         layer_id.should_not be_nil
 
-        layer_options = layer_response.delete(:options)
-        layer_options.should eq ({ "table_name" => @table.name })
+        layer_response.delete(:options).should eq ({ "table_name" => @table.name })
 
         layer_response.should eq layer_json.except(:options)
 
@@ -100,9 +99,9 @@ describe Api::Json::LayersController do
         response.status.should eq 200
         layer_response = response.body
 
-        layer_response.delete(:id).should eq @layer.id
-        layer_response.delete(:options).should eq new_layer_json[:options]
-        layer_response.delete(:order).should eq new_order
+        layer_response[:id].should eq @layer.id
+        layer_response[:options].should eq new_layer_json[:options]
+        layer_response[:order].should eq new_order
       end
     end
 
@@ -129,8 +128,8 @@ describe Api::Json::LayersController do
 
         layer_response[:layers].map { |l| l['id'] }.should eq [@layer.id, @layer2.id]
         layer_response[:layers].each do |layer|
-          layer.delete('options').should eq new_layer_json[:options]
-          layer.delete('order').should eq new_order
+          layer['options'].should eq new_layer_json[:options]
+          layer['order'].should eq new_order
         end
       end
     end
@@ -147,7 +146,7 @@ describe Api::Json::LayersController do
         response.status.should eq 200
         layer_response = response.body
 
-        layer_response.delete(:options).should eq layer_json[:options]
+        layer_response[:options].should eq layer_json[:options]
       end
     end
 

--- a/spec/requests/api/json/layers_controller_spec.rb
+++ b/spec/requests/api/json/layers_controller_spec.rb
@@ -33,7 +33,29 @@ describe Api::Json::LayersController do
       api_v1_maps_layers_create_url(user_domain: @user1.username, map_id: map_id, api_key: @user1.api_key)
     end
 
-    let(:layer_json) { { kind: 'carto', options: {}, order: 1 } }
+    def update_map_layer_url(map_id, layer_id)
+      api_v1_maps_layers_update_url(
+        user_domain: @user1.username,
+        map_id: map_id,
+        id: layer_id,
+        api_key: @user1.api_key)
+    end
+
+    def create_full_visualization(map: FactoryGirl.create(:carto_map, user_id: @user1.id))
+      @map = map
+      @table = FactoryGirl.create(:carto_user_table, user_id: @user1.id, map_id: @map.id)
+      @table_visualization = FactoryGirl.create(
+        :carto_visualization,
+        user: @carto_user1, type: 'table', name: @table.name, map_id: @table.map_id)
+      @visualization = FactoryGirl.create(:carto_visualization, user_id: @user1.id, map: @map)
+      # Need to mock the nonexistant table because factories use Carto::* models
+      CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
+      CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)
+    end
+
+    let(:layer_json) do
+      { kind: kind, options: { 'table_name' => nil, 'user_name' => nil }, order: 1, infowindow: {}, tooltip: {} }
+    end
 
     it 'creates layers' do
       post_json create_layer_url, layer_json do |response|
@@ -41,20 +63,12 @@ describe Api::Json::LayersController do
         layer_response = response.body
 
         layer_response.delete(:id).should_not be_nil
-        layer_response.should eq ({ options: {}, kind: kind, infowindow: nil, tooltip: nil, order: 1 })
+        layer_response.should eq layer_json
       end
     end
 
     it 'creates layers on maps' do
-      @map = FactoryGirl.create(:carto_map, user_id: @user1.id)
-      @table = FactoryGirl.create(:carto_user_table, user_id: @user1.id, map_id: @map.id)
-      @table_visualization = FactoryGirl.create(
-        :carto_visualization,
-        user: @carto_user1, type: 'table', name: @table.name, map_id: @table.map_id)
-      @visualization = FactoryGirl.create(:carto_visualization, user_id: @user1.id, map: @map)
-      # Need to mock the nonexistant table
-      CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
-      CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)
+      create_full_visualization
 
       post_json create_map_layer_url(@map.id), layer_json.merge(options: { table_name: @table.name }) do |response|
         response.status.should eq 200
@@ -66,10 +80,46 @@ describe Api::Json::LayersController do
         layer_options = layer_response.delete(:options)
         layer_options.should eq ({ "table_name" => @table.name })
 
-        layer_response.should eq ({ kind: kind, infowindow: nil, tooltip: nil, order: 1 })
+        layer_response.should eq (layer_json.except(:options))
 
         @layer = Carto::Layer.find(layer_id)
         @layer.maps.map(&:id).first.should eq @map.id
+      end
+    end
+
+    it 'updates layers' do
+      map = FactoryGirl.create(:carto_map_with_layers, user_id: @user1.id)
+      create_full_visualization(map: map)
+      @layer = map.layers.first
+
+      new_order = 2
+      new_layer_json = layer_json.merge(
+        options: { 'random' => '1' },
+        order: new_order
+      )
+      put_json update_map_layer_url(map.id, @layer.id), new_layer_json do |response|
+        response.status.should eq 200
+        layer_response = response.body
+
+        layer_response.delete(:id).should eq @layer.id
+        layer_response.delete(:options).should eq new_layer_json[:options]
+        layer_response.delete(:order).should eq new_order
+      end
+    end
+
+    it 'does not update table_name or users_name options' do
+      map = FactoryGirl.create(:carto_map_with_layers, user_id: @user1.id)
+      create_full_visualization(map: map)
+      @layer = map.layers.first
+
+      new_layer_json = layer_json.merge(
+        options: { 'table_name' => 'other_table_name', 'user_name' => 'other_username' }
+      )
+      put_json update_map_layer_url(map.id, @layer.id), new_layer_json do |response|
+        response.status.should eq 200
+        layer_response = response.body
+
+        layer_response.delete(:options).should eq layer_json[:options]
       end
     end
   end

--- a/spec/requests/carto/api/layers_controller_spec.rb
+++ b/spec/requests/carto/api/layers_controller_spec.rb
@@ -265,7 +265,7 @@ describe Carto::Api::LayersController do
         response_body['total_entries'].should eq 2 + existing_layers_count
         body['layers'].count { |l| l['kind'] != 'tiled' }.should eq 2 + existing_layers_count
         new_layers_ids = response_body['layers'].map { |l| l['id'] }
-        (new_layers_ids - existing_layers_ids - expected_layers_ids).should == []
+        (new_layers_ids - existing_layers_ids).should == expected_layers_ids
       end
 
       get api_v1_maps_layers_show_url(

--- a/spec/requests/carto/api/layers_controller_spec.rb
+++ b/spec/requests/carto/api/layers_controller_spec.rb
@@ -159,7 +159,6 @@ describe Carto::Api::LayersController do
       default_url_options[:host] = "#{user_2.subdomain}.localhost.lan"
 
       table = create_table(privacy: UserTable::PRIVACY_PRIVATE, name: "table#{rand(9999)}_1", user_id: user_1.id)
-      table.table_visualization.id
       u1_t_1_perm_id = table.table_visualization.permission.id
 
       put api_v1_permissions_update_url(user_domain: user_1.username, api_key: user_1.api_key, id: u1_t_1_perm_id),

--- a/spec/requests/carto/api/layers_controller_spec.rb
+++ b/spec/requests/carto/api/layers_controller_spec.rb
@@ -4,9 +4,7 @@ require_relative '../../../spec_helper'
 require_relative '../../../../app/controllers/carto/api/layers_controller'
 require_relative '../../../../spec/requests/api/json/layers_controller_shared_examples'
 
-
 describe Carto::Api::LayersController do
-
   it_behaves_like 'layers controllers' do
   end
 
@@ -18,7 +16,7 @@ describe Carto::Api::LayersController do
       CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true, delete: true)
       CartoDB::Visualization::Member.any_instance.stubs(:invalidate_cache).returns(nil)
 
-      @headers = {'CONTENT_TYPE'  => 'application/json'}
+      @headers = { 'CONTENT_TYPE' => 'application/json' }
 
       @user = FactoryGirl.create(:valid_user)
     end
@@ -27,67 +25,65 @@ describe Carto::Api::LayersController do
       @user.destroy
     end
 
-    it 'attribution chanes in a visualization propagate to associated layers' do
-        table_1_attribution = 'attribution 1'
-        table_2_attribution = 'attribution 2'
-        modified_table_2_attribution = 'modified attribution 2'
+    it 'attribution changes in a visualization propagate to associated layers' do
+      table_1_attribution = 'attribution 1'
+      table_2_attribution = 'attribution 2'
+      modified_table_2_attribution = 'modified attribution 2'
 
-        table1 = create_table(privacy: UserTable::PRIVACY_PUBLIC, name: "table#{rand(9999)}_1", user_id: @user.id)
-        table2 = create_table(privacy: UserTable::PRIVACY_PUBLIC, name: "table#{rand(9999)}_2", user_id: @user.id)
+      table1 = create_table(privacy: UserTable::PRIVACY_PUBLIC, name: "table#{rand(9999)}_1", user_id: @user.id)
+      table2 = create_table(privacy: UserTable::PRIVACY_PUBLIC, name: "table#{rand(9999)}_2", user_id: @user.id)
 
-        payload = {
-          name: 'new visualization',
-          tables: [
-            table1.name,
-            table2.name
-          ],
-          privacy: 'public'
-        }
+      payload = {
+        name: 'new visualization',
+        tables: [
+          table1.name,
+          table2.name
+        ],
+        privacy: 'public'
+      }
 
-        login_as(@user, scope: @user.username)
-        host! "#{@user.username}.localhost.lan"
-        post api_v1_visualizations_create_url(api_key: @api_key), payload.to_json, @headers do |response|
-          response.status.should == 200
-          @visualization_data = JSON.parse(response.body)
-        end
+      login_as(@user, scope: @user.username)
+      host! "#{@user.username}.localhost.lan"
+      post api_v1_visualizations_create_url(api_key: @api_key), payload.to_json, @headers do |response|
+        response.status.should eq 200
+        @visualization_data = JSON.parse(response.body)
+      end
 
-        visualization = Carto::Visualization.find(@visualization_data.fetch('id'))
-        table1_visualization = CartoDB::Visualization::Member.new(id: table1.table_visualization.id).fetch
-        table1_visualization.attributions = table_1_attribution
-        table1_visualization.store
-        table2_visualization = CartoDB::Visualization::Member.new(id: table2.table_visualization.id).fetch
-        table2_visualization.attributions = table_2_attribution
-        table2_visualization.store
+      visualization = Carto::Visualization.find(@visualization_data.fetch('id'))
+      table1_visualization = CartoDB::Visualization::Member.new(id: table1.table_visualization.id).fetch
+      table1_visualization.attributions = table_1_attribution
+      table1_visualization.store
+      table2_visualization = CartoDB::Visualization::Member.new(id: table2.table_visualization.id).fetch
+      table2_visualization.attributions = table_2_attribution
+      table2_visualization.store
 
-        get api_v1_maps_layers_index_url(map_id: visualization.map.id, api_key: @api_key) do |response|
-          response.status.should be_success
-          @layers_data = JSON.parse(response.body)
-        end
-        # Done this way to preserve the order
-        data_layers = @layers_data['layers']
-        data_layers.delete_if { |layer| layer['kind'] != 'carto' }
-        data_layers.count.should eq 2
+      get api_v1_maps_layers_index_url(map_id: visualization.map.id, api_key: @api_key) do |response|
+        response.status.should be_success
+        @layers_data = JSON.parse(response.body)
+      end
+      # Done this way to preserve the order
+      data_layers = @layers_data['layers']
+      data_layers.delete_if { |layer| layer['kind'] != 'carto' }
+      data_layers.count.should eq 2
 
-        # Rembember, layers by default added at top
-        data_layers[0]['options']['attribution'].should eq table_2_attribution
-        data_layers[1]['options']['attribution'].should eq table_1_attribution
+      # Rembember, layers by default added at top
+      data_layers[0]['options']['attribution'].should eq table_2_attribution
+      data_layers[1]['options']['attribution'].should eq table_1_attribution
 
+      table2_visualization.attributions = modified_table_2_attribution
+      table2_visualization.store
 
-        table2_visualization.attributions = modified_table_2_attribution
-        table2_visualization.store
+      get api_v1_maps_layers_index_url(map_id: visualization.map.id, api_key: @api_key) do |response|
+        response.status.should be_success
+        @layers_data = JSON.parse(response.body)
+      end
+      data_layers = @layers_data['layers'].select { |layer| layer['kind'] == 'carto' }
+      data_layers.count.should eq 2
 
-        get api_v1_maps_layers_index_url(map_id: visualization.map.id, api_key: @api_key) do |response|
-          response.status.should be_success
-          @layers_data = JSON.parse(response.body)
-        end
-        data_layers = @layers_data['layers'].select { |layer| layer['kind'] == 'carto' }
-        data_layers.count.should eq 2
-
-        # Rembember, layers by default added at top
-        data_layers[0]['options']['attribution'].should eq modified_table_2_attribution
-        data_layers[1]['options']['attribution'].should eq table_1_attribution
+      # Rembember, layers by default added at top
+      data_layers[0]['options']['attribution'].should eq modified_table_2_attribution
+      data_layers[1]['options']['attribution'].should eq table_1_attribution
     end
-
   end
 
   describe 'index' do
@@ -99,11 +95,11 @@ describe Carto::Api::LayersController do
 
     it 'fetches layers from shared visualizations' do
       # TODO: refactor this with helpers (pending to merge)
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true, delete: true)
       CartoDB::Visualization::Member.any_instance.stubs(:invalidate_cache).returns(nil)
-      @headers = {'CONTENT_TYPE'  => 'application/json'}
+      @headers = { 'CONTENT_TYPE' => 'application/json' }
 
-      def factory(user, attributes={})
+      def factory(user, attributes = {})
         {
           name:                     attributes.fetch(:name, "visualization #{rand(9999)}"),
           tags:                     attributes.fetch(:tags, ['foo', 'bar']),
@@ -163,24 +159,24 @@ describe Carto::Api::LayersController do
       default_url_options[:host] = "#{user_2.subdomain}.localhost.lan"
 
       table = create_table(privacy: UserTable::PRIVACY_PRIVATE, name: "table#{rand(9999)}_1", user_id: user_1.id)
-      u1_t_1_id = table.table_visualization.id
+      table.table_visualization.id
       u1_t_1_perm_id = table.table_visualization.permission.id
 
-      put api_v1_permissions_update_url(user_domain:user_1.username, api_key: user_1.api_key, id: u1_t_1_perm_id),
-          {acl: [{
+      put api_v1_permissions_update_url(user_domain: user_1.username, api_key: user_1.api_key, id: u1_t_1_perm_id),
+          { acl: [{
             type: CartoDB::Permission::TYPE_USER,
             entity: {
-              id:   user_2.id,
+              id:   user_2.id
             },
             access: CartoDB::Permission::ACCESS_READONLY
-          }]}.to_json, @headers
+          }] }.to_json, @headers
 
-      layer = Layer.create({
-          kind: 'carto',
-          tooltip: {},
-          options: {},
-          infowindow: {}
-        })
+      layer = Layer.create(
+        kind: 'carto',
+        tooltip: {},
+        options: {},
+        infowindow: {}
+      )
 
       table.map.add_layer layer
 
@@ -197,13 +193,10 @@ describe Carto::Api::LayersController do
       get api_v1_maps_layers_index_url(user_domain: user_3.username, map_id: table.map.id) do |response|
         response.status.should == 404
       end
-
     end
-
   end
 
   describe '#show legacy tests' do
-
     before(:all) do
       @user = create_user(
         username: 'test',
@@ -217,7 +210,7 @@ describe Carto::Api::LayersController do
     before(:each) do
       stub_named_maps_calls
       delete_user_data @user
-      @table = create_table :user_id => @user.id
+      @table = create_table user_id: @user.id
     end
 
     after(:all) do
@@ -225,8 +218,7 @@ describe Carto::Api::LayersController do
       @user.destroy
     end
 
-
-    let(:params) { { :api_key => @user.api_key } }
+    let(:params) { { api_key: @user.api_key } }
 
     it "Get all user layers" do
       layer = Layer.create kind: 'carto'
@@ -235,7 +227,7 @@ describe Carto::Api::LayersController do
       @user.add_layer layer2
 
       default_url_options[:host] = "#{@user.subdomain}.localhost.lan"
-      get api_v1_users_layers_index_url(params.merge(user_id: @user.id)) do |response|
+      get api_v1_users_layers_index_url(params.merge(user_id: @user.id)) do |_|
         last_response.status.should be_success
         response_body = JSON.parse(last_response.body)
         response_body['total_entries'].should   eq 2
@@ -246,51 +238,47 @@ describe Carto::Api::LayersController do
     end
 
     it "Gets layers by map id" do
-      layer = Layer.create({
-          kind: 'carto',
-          tooltip: {},
-          options: {},
-          infowindow: {}
-        })
-      layer2 = Layer.create({
-          kind: 'tiled',
-          tooltip: {},
-          options: {},
-          infowindow: {}
-        })
+      layer = Layer.create(
+        kind: 'carto',
+        tooltip: {},
+        options: {},
+        infowindow: {}
+      )
+      layer2 = Layer.create(
+        kind: 'tiled',
+        tooltip: {},
+        options: {},
+        infowindow: {}
+      )
 
       expected_layers_ids = [layer.id, layer2.id]
 
-      existing_layers_ids = @table.map.layers.collect(&:id)
+      existing_layers_ids = @table.map.layers.map(&:id)
       existing_layers_count = @table.map.layers.count
 
       @table.map.add_layer layer
       @table.map.add_layer layer2
 
       default_url_options[:host] = "#{@user.subdomain}.localhost.lan"
-      get api_v1_maps_layers_index_url(params.merge(map_id: @table.map.id)) do |response|
+      get api_v1_maps_layers_index_url(params.merge(map_id: @table.map.id)) do |_|
         last_response.status.should be_success
         response_body = JSON.parse(last_response.body)
-        response_body['total_entries'].should == 2 + existing_layers_count
-        body['layers'].count { |l| l['kind'] != 'tiled' }.should == 2 + existing_layers_count
-        new_layers_ids = response_body['layers'].collect { |layer| layer['id'] }
+        response_body['total_entries'].should eq 2 + existing_layers_count
+        body['layers'].count { |l| l['kind'] != 'tiled' }.should eq 2 + existing_layers_count
+        new_layers_ids = response_body['layers'].map { |l| l['id'] }
         (new_layers_ids - existing_layers_ids - expected_layers_ids).should == []
       end
 
-      get api_v1_maps_layers_show_url(params.merge({
-            map_id: @table.map.id,
-            id: layer.id
-          })) do |response|
+      get api_v1_maps_layers_show_url(
+        params.merge(
+          map_id: @table.map.id,
+          id: layer.id
+        )) do |_|
         last_response.status.should be_success
         response_body = JSON.parse(last_response.body)
-        response_body['id'].should == layer.id
-        response_body['kind'].should == layer.kind
+        response_body['id'].should eq layer.id
+        response_body['kind'].should eq layer.kind
       end
-
-
     end
-
   end
-
-
 end


### PR DESCRIPTION
This closes #6759, although it's focused on improving testing.

@gfiorav , @javitonino CR and comment this, please. Highlights:
- Shift towards the use of `Carto::*` models for factories. That's not something I'd do in production code, which should still instantiate "old" models for old classes, but being able to use FactoryGirl eases testing.
- Creation and explicit including of helper modules: (`Carto::Factories::Visualizations`). Explicit includes make easier to find which methods are being called and avoids namespace cluttering.
- `create_full_visualization`. Although I'm not a big fan of this kind of factory methods with parameters I think it's useful now and can be improved in the future.