### PR TITLE
Fix: incorrect delete overviews method

### DIFF
--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -127,7 +127,7 @@ module CartoDB
       end
 
       def drop(table_name)
-        Carto::OverviewsService.new(database).drop_overviews table_name
+        Carto::OverviewsService.new(database).delete_overviews table_name
         database.execute(%(DROP TABLE #{table_name}))
       rescue => exception
         runner.log.append("Couldn't drop table #{table_name}: #{exception}. Backtrace: #{exception.backtrace} ")


### PR DESCRIPTION
This problem would leave temporary import tables when imports fail