### PR TITLE
Improves localization namespacing

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/editor-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/editor-view.js
@@ -39,7 +39,7 @@ module.exports = cdb.core.View.extend({
     } ]);
 
     var tabPaneTabs = [{
-      label: _t('editor.layers.title'),
+      label: _t('editor.tab-pane.layers.title-label'),
       selected: true,
       createContentView: function () {
         return new LayersView({
@@ -48,12 +48,12 @@ module.exports = cdb.core.View.extend({
         });
       }
     }, {
-      label: _t('editor.elements.title'),
+      label: _t('editor.tab-pane.elements.title-label'),
       createContentView: function () {
         return new cdb.core.View();
       }
     }, {
-      label: _t('editor.widgets.title'),
+      label: _t('editor.tab-pane.widgets.title-label'),
       createContentView: function () {
         return new StackLayoutView({
           collection: stackViewCollection

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model.js
@@ -18,12 +18,12 @@ module.exports = cdb.core.Model.extend({
     this.schema = {
       title: {
         type: 'Text',
-        text: _t('editor.widgets.data.title'),
+        text: _t('editor.widgets.widgets-form.data.title'),
         validators: ['required']
       },
       column: {
         type: 'Select',
-        title: _t('editor.widgets.data.value'),
+        title: _t('editor.widgets.widgets-form.data.value'),
         options: columns,
         editorAttrs: {
           disabled: columns[0].disabled
@@ -31,23 +31,23 @@ module.exports = cdb.core.Model.extend({
       },
       aggregation: {
         type: 'Select',
-        title: _t('editor.widgets.data.aggregation'),
+        title: _t('editor.widgets.widgets-form.data.aggregation'),
         options: ['sum', 'count']
       },
       aggregation_column: {
         type: 'Select',
-        title: _t('editor.widgets.data.aggregation_column'),
+        title: _t('editor.widgets.widgets-form.data.aggregation_column'),
         options: columns,
         editorAttrs: {
           disabled: columns[0].disabled
         }
       },
       suffix: {
-        title: _t('editor.widgets.data.suffix'),
+        title: _t('editor.widgets.widgets-form.data.suffix'),
         type: 'Text'
       },
       prefix: {
-        title: _t('editor.widgets.data.prefix'),
+        title: _t('editor.widgets.widgets-form.data.prefix'),
         type: 'Text'
       }
     };
@@ -74,7 +74,7 @@ module.exports = cdb.core.Model.extend({
         });
     } else {
       return [{
-        label: _t('editor.widgets.data.loading'),
+        label: _t('editor.widgets.widgets-form.data.loading'),
         disabled: true
       }];
     }

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-formula-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-formula-data-schema-model.js
@@ -17,12 +17,12 @@ module.exports = cdb.core.Model.extend({
     this.schema = {
       title: {
         type: 'Text',
-        title: _t('editor.widgets.data.title'),
+        title: _t('editor.widgets.widgets-form.data.title'),
         validators: ['required']
       },
       column: {
         type: 'Select',
-        title: _t('editor.widgets.data.column'),
+        title: _t('editor.widgets.widgets-form.data.column'),
         options: columns,
         editorAttrs: {
           disabled: columns[0].disabled
@@ -30,15 +30,15 @@ module.exports = cdb.core.Model.extend({
       },
       operation: {
         type: 'Select',
-        title: _t('editor.widgets.data.operation'),
+        title: _t('editor.widgets.widgets-form.data.operation'),
         options: ['min', 'max', 'count', 'avg', 'sum']
       },
       suffix: {
-        title: _t('editor.widgets.data.suffix'),
+        title: _t('editor.widgets.widgets-form.data.suffix'),
         type: 'Text'
       },
       prefix: {
-        title: _t('editor.widgets.data.prefix'),
+        title: _t('editor.widgets.widgets-form.data.prefix'),
         type: 'Text'
       }
     };

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-histogram-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-histogram-data-schema-model.js
@@ -13,12 +13,12 @@ module.exports = cdb.core.Model.extend({
 
     this.schema = {
       title: {
-        title: _t('editor.widgets.data.title'),
+        title: _t('editor.widgets.widgets-form.data.title'),
         type: 'Text',
         validators: ['required']
       },
       column: {
-        tile: _t('editor.widgets.data.column'),
+        tile: _t('editor.widgets.widgets-form.data.column'),
         type: 'Select',
         options: columns,
         editorAttrs: {
@@ -26,7 +26,7 @@ module.exports = cdb.core.Model.extend({
         }
       },
       bins: {
-        title: _t('editor.widgets.data.bins'),
+        title: _t('editor.widgets.widgets-form.data.bins'),
         type: 'Number'
       }
     };
@@ -50,7 +50,7 @@ module.exports = cdb.core.Model.extend({
         });
     } else {
       return [{
-        label: _t('editor.widgets.data.loading'),
+        label: _t('editor.widgets.widgets-form.data.loading'),
         disabled: true
       }];
     }

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-time-series-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-time-series-data-schema-model.js
@@ -13,12 +13,12 @@ module.exports = cdb.core.Model.extend({
 
     this.schema = {
       title: {
-        title: _t('editor.widgets.data.title'),
+        title: _t('editor.widgets.widgets-form.data.title'),
         type: 'Text',
         validators: ['required']
       },
       column: {
-        title: _t('editor.widgets.data.column'),
+        title: _t('editor.widgets.widgets-form.data.column'),
         type: 'Select',
         options: columns,
         editorAttrs: {
@@ -26,7 +26,7 @@ module.exports = cdb.core.Model.extend({
         }
       },
       bins: {
-        title: _t('editor.widgets.data.bins'),
+        title: _t('editor.widgets.widgets-form.data.bins'),
         type: 'Number'
       }
     };
@@ -50,7 +50,7 @@ module.exports = cdb.core.Model.extend({
         });
     } else {
       return [{
-        label: _t('editor.widgets.data.loading'),
+        label: _t('editor.widgets.widgets-form.data.loading'),
         disabled: true
       }];
     }

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/style/widgets-form-formula-style-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/style/widgets-form-formula-style-schema-model.js
@@ -6,7 +6,7 @@ module.exports = WidgetsFormStyleSchema.extend({
     WidgetsFormStyleSchema.prototype.initialize.apply(this, arguments);
     this.schema.description = {
       type: 'TextArea',
-      title: _t('editor.widgets.style.description')
+      title: _t('editor.widgets.widgets-form.style.description')
     };
   }
 

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/style/widgets-form-style-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/style/widgets-form-style-schema-model.js
@@ -7,21 +7,21 @@ module.exports = cdb.core.Model.extend({
     var o = [
       {
         val: true,
-        label: _t('editor.widgets.style.yes')
+        label: _t('editor.widgets.widgets-form.style.yes')
       }, {
         val: false,
-        label: _t('editor.widgets.style.no')
+        label: _t('editor.widgets.widgets-form.style.no')
       }
     ];
     this.schema = {
       sync_on_data_change: {
         type: 'Radio',
-        title: _t('editor.widgets.style.sync_on_data_change'),
+        title: _t('editor.widgets.widgets-form.style.sync_on_data_change'),
         options: o
       },
       sync_on_bbox_change: {
         type: 'Radio',
-        title: _t('editor.widgets.style.sync_on_bbox_change'),
+        title: _t('editor.widgets.widgets-form.style.sync_on_bbox_change'),
         options: o
       }
     };

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.js
@@ -36,7 +36,7 @@ module.exports = cdb.core.View.extend({
 
     this.tabPaneItems = [{
       selected: true,
-      label: _t('editor.widgets.widgets-form.data.title'),
+      label: _t('editor.widgets.widgets-form.data.title-label'),
       createContentView: function () {
         var layerId = self._widgetDefinitionModel.get('layer_id');
         var layerDefinitionModel = self._layerDefinitionsCollection.get(layerId);
@@ -48,7 +48,7 @@ module.exports = cdb.core.View.extend({
       }
     }, {
       selected: false,
-      label: _t('editor.widgets.widgets-form.style.title'),
+      label: _t('editor.widgets.widgets-form.style.title-label'),
       createContentView: function () {
         return new WidgetsFormContentStyleView({
           widgetDefinitionModel: self._widgetDefinitionModel

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data-view.js
@@ -27,7 +27,7 @@ module.exports = cdb.core.View.extend({
     this.clearSubViews();
     this.$el.empty();
     this.$el.html(Template({
-      title: _t('editor.widgets.widgets-form.data.title'),
+      title: _t('editor.widgets.widgets-form.data.title-label'),
       description: _t('editor.widgets.widgets-form.data.description')
     }));
     this._initViews();

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-factory.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-factory.js
@@ -2,11 +2,11 @@ var _ = require('underscore');
 
 var dataMap = {
   category: {
-    labelTranslationKey: 'editor.widgets.type.category',
+    labelTranslationKey: 'editor.widgets.widgets-form.type.category',
     Class: require('./data/widgets-form-category-data-schema-model')
   },
   formula: {
-    labelTranslationKey: 'editor.widgets.type.formula',
+    labelTranslationKey: 'editor.widgets.widgets-form.type.formula',
     Class: require('./data/widgets-form-formula-data-schema-model'),
     checkIfValid: function (layerTableModel) {
       return layerTableModel.columnsCollection.any(function (m) {
@@ -15,7 +15,7 @@ var dataMap = {
     }
   },
   histogram: {
-    labelTranslationKey: 'editor.widgets.type.histogram',
+    labelTranslationKey: 'editor.widgets.widgets-form.type.histogram',
     Class: require('./data/widgets-form-histogram-data-schema-model'),
     checkIfValid: function (layerTableModel) {
       return layerTableModel.columnsCollection.any(function (m) {
@@ -24,7 +24,7 @@ var dataMap = {
     }
   },
   'time-series': {
-    labelTranslationKey: 'editor.widgets.type.time_series',
+    labelTranslationKey: 'editor.widgets.widgets-form.type.time_series',
     Class: require('./data/widgets-form-time-series-data-schema-model'),
     checkIfValid: function (layerTableModel) {
       return layerTableModel.columnsCollection.any(function (m) {

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-style-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-style-view.js
@@ -25,7 +25,7 @@ module.exports = cdb.core.View.extend({
     this.clearSubViews();
     this.$el.empty();
     this.$el.html(Template({
-      title: _t('editor.widgets.widgets-form.style.title'),
+      title: _t('editor.widgets.widgets-form.style.title-label'),
       description: _t('editor.widgets.widgets-form.style.description')
     }));
     this._initViews();

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-types.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-types.tpl
@@ -3,7 +3,7 @@
 
   <div class="CDB-HeaderInfo-Inner CDB-Text">
     <div class="CDB-HeaderInfo-Title u-bSpace--m">
-      <h2 class="CDB-Text CDB-HeaderInfo-TitleText CDB-Size-large"><%- _t('editor.widgets.widgets-form.type.title') %></h2>
+      <h2 class="CDB-Text CDB-HeaderInfo-TitleText CDB-Size-large"><%- _t('editor.widgets.widgets-form.type.title-label') %></h2>
     </div>
 
     <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.widgets.widgets-form.type.description') %></p>

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -39,16 +39,33 @@
       },
       "widgets-form": {
         "type": {
-          "title": "Type",
+          "title-label": "Type",
           "description": "Choose the widget type"
         },
         "data": {
-          "title": "Data",
-          "description": "Configure your values"
+          "aggregation": "Aggregation",
+          "aggregation_column": "Aggregation Column",
+          "bins": "Buckets",
+          "column": "Column",
+          "description": "Configure your values",
+          "end": "End",
+          "loading": "loading…",
+          "operation": "Operation",
+          "prefix": "Prefix",
+          "start": "Start",
+          "suffix": "Suffix",
+          "title": "Title",
+          "title-label": "Data",
+          "value": "Value"
         },
         "style": {
-          "title": "Style",
-          "description": "Apply style to your visualization"
+          "title-label": "Style",
+          "description": "Apply style to your visualization",
+          "sync_on_data_change": "Unfiltered",
+          "sync_on_bbox_change": "Dynamic",
+          "description": "Description",
+          "yes": "Yes",
+          "no": "No"
         }
       },
       "edit": "Edit",
@@ -58,27 +75,6 @@
         "histogram": "Histogram",
         "time_series": "Time Series"
       },
-      "data": {
-        "aggregation": "Aggregation",
-        "aggregation_column": "Aggregation Column",
-        "bins": "Buckets",
-        "column": "Column",
-        "end": "End",
-        "loading": "loading…",
-        "operation": "Operation",
-        "prefix": "Prefix",
-        "start": "Start",
-        "suffix": "Suffix",
-        "title": "Title",
-        "value": "Value"
-      },
-      "style": {
-        "sync_on_data_change": "Unfiltered",
-        "sync_on_bbox_change": "Dynamic",
-        "description": "Description",
-        "yes": "Yes",
-        "no": "No"
-      }
     }
   }
 }

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -40,7 +40,11 @@
       "widgets-form": {
         "type": {
           "title-label": "Type",
-          "description": "Choose the widget type"
+          "description": "Choose the widget type",
+          "category": "Category",
+          "formula": "Formula",
+          "histogram": "Histogram",
+          "time_series": "Time Series"
         },
         "data": {
           "aggregation": "Aggregation",
@@ -69,12 +73,6 @@
         }
       },
       "edit": "Edit",
-      "type": {
-        "category": "Category",
-        "formula": "Formula",
-        "histogram": "Histogram",
-        "time_series": "Time Series"
-      },
     }
   }
 }

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -25,15 +25,19 @@
     "map": "map",
     "map_name": "%{name} map",
     "map_pluralize": "%{smart_count} map |||| %{smart_count} maps",
-    "layers": {
-      "title": "Layers",
-      "basemap": "basemap"
-    },
-    "elements": {
-      "title": "Elements"
+    "tab-pane": {
+      "layers": {
+        "title-label": "Layers",
+        "basemap": "basemap"
+      },
+      "elements": {
+        "title-label": "Elements"
+      },
+      "widgets": {
+        "title-label": "Widgets",
+      }
     },
     "widgets": {
-      "title": "Widgets",
       "widgets-view": {
         "add_widget": "Add widget"
       },
@@ -71,8 +75,7 @@
           "yes": "Yes",
           "no": "No"
         }
-      },
-      "edit": "Edit",
+      }
     }
   }
 }

--- a/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
@@ -30,8 +30,8 @@ describe('editor/map/map-view', function () {
 
   it('should render correctly', function () {
     expect(this.view.$el.text()).toContain('My super fun vis');
-    expect(this.view.$el.text()).toContain('editor.tab-pane.layers.title');
-    expect(this.view.$el.text()).toContain('editor.tab-pane.elements.title');
-    expect(this.view.$el.text()).toContain('editor.tab-pane.widgets.title');
+    expect(this.view.$el.text()).toContain('editor.tab-pane.layers.title-label');
+    expect(this.view.$el.text()).toContain('editor.tab-pane.elements.title-label');
+    expect(this.view.$el.text()).toContain('editor.tab-pane.widgets.title-label');
   });
 });

--- a/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
@@ -30,8 +30,8 @@ describe('editor/map/map-view', function () {
 
   it('should render correctly', function () {
     expect(this.view.$el.text()).toContain('My super fun vis');
-    expect(this.view.$el.text()).toContain('editor.layers.title');
-    expect(this.view.$el.text()).toContain('editor.elements.title');
-    expect(this.view.$el.text()).toContain('editor.widgets.title');
+    expect(this.view.$el.text()).toContain('editor.tab-pane.layers.title');
+    expect(this.view.$el.text()).toContain('editor.tab-pane.elements.title');
+    expect(this.view.$el.text()).toContain('editor.tab-pane.widgets.title');
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.45",
+  "version": "3.23.46",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #6831 

This PR improves the namespacing of our localization file. Instead of using a pure semantic structure, we'll now use the path of the elements to define the localization strings too.

As @viddo proposes:
Instead of having 

```json
"editor": {
    "layers": "Layers",
    "elements": "Elements",
    "widgets": "Widgets"
  },
…
```

we'll now have:

```json
"editor": {
  "tab-pane-menu": {
    "layers-label": "Layers",
    "elements-label": "Elements",
    "widgets-label": "Widgets"
  }
…```