### PR TITLE
Test maps controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,8 +205,6 @@ WORKING_SPECS_9 = \
   spec/requests/superadmin/users_spec.rb \
   spec/requests/superadmin/organizations_spec.rb \
   spec/requests/api/visualizations_spec.rb \
-  spec/requests/api/json/maps_controller_spec.rb \
-  spec/requests/carto/api/maps_controller_spec.rb \
   spec/requests/api/json/overlays_controller_spec.rb \
   spec/requests/carto/api/overlays_controller_spec.rb \
 	spec/models/carto/user_creation_spec.rb \
@@ -228,6 +226,8 @@ WORKING_SPECS_9 = \
 SPEC_HELPER_MIN_SPECS = \
   spec/requests/carto/api/analyses_controller_spec.rb \
 	spec/models/carto/analysis_spec.rb \
+	spec/requests/api/json/maps_controller_spec.rb \
+	spec/requests/carto/api/maps_controller_spec.rb \
 	$(NULL)
 
 # This class must be tested isolated as pollutes namespace

--- a/app/controllers/api/json/maps_controller.rb
+++ b/app/controllers/api/json/maps_controller.rb
@@ -3,7 +3,8 @@
 require_relative '../../../models/visualization/collection'
 
 class Api::Json::MapsController < Api::ApplicationController
-
+  include Carto::UUIDHelper
+  
   ssl_required :update
 
   before_filter :load_map
@@ -42,6 +43,8 @@ class Api::Json::MapsController < Api::ApplicationController
   protected
 
   def load_map
+    raise RecordNotFound unless is_uuid?(params[:id])
+
     # User must be owner or have permissions for the map's visualization
     vis = CartoDB::Visualization::Collection.new.fetch(
         user_id:        current_user.id,

--- a/app/controllers/api/json/maps_controller.rb
+++ b/app/controllers/api/json/maps_controller.rb
@@ -4,7 +4,7 @@ require_relative '../../../models/visualization/collection'
 
 class Api::Json::MapsController < Api::ApplicationController
   include Carto::UUIDHelper
-  
+
   ssl_required :update
 
   before_filter :load_map

--- a/spec/helpers/named_maps_helper.rb
+++ b/spec/helpers/named_maps_helper.rb
@@ -1,0 +1,6 @@
+module NamedMapsHelper
+  def bypass_named_maps
+    CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true, delete: true)
+  end
+end

--- a/spec/requests/api/json/maps_controller_spec.rb
+++ b/spec/requests/api/json/maps_controller_spec.rb
@@ -12,11 +12,6 @@ describe Api::Json::MapsController do
   include Carto::Factories::Visualizations
   include HelperMethods
 
-  def bypass_named_maps
-    CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true, delete: true)
-  end
-
   before(:all) do
     @user = FactoryGirl.create(:carto_user)
     @user2 = FactoryGirl.create(:carto_user)

--- a/spec/requests/api/json/maps_controller_spec.rb
+++ b/spec/requests/api/json/maps_controller_spec.rb
@@ -99,7 +99,7 @@ describe Api::Json::MapsController do
     end
 
     it 'returns 404 for maps not owned by the user' do
-      put_json create_update_map_url(@user2, @map.id), center: [1,1] do |response|
+      put_json create_update_map_url(@user2, @map.id), center: [1, 1] do |response|
         response.status.should eq 404
       end
     end

--- a/spec/requests/api/json/maps_controller_spec.rb
+++ b/spec/requests/api/json/maps_controller_spec.rb
@@ -82,7 +82,6 @@ describe Api::Json::MapsController do
 
     it 'returns 404 for maps not owned by the user' do
       put_json api_v1_maps_update_url(user_domain: @user2.username, api_key: @user2.api_key, id: @map.id), {center: [1,1]} do |response|
-        byebug
         response.status.should eq 404
       end
     end

--- a/spec/requests/api/json/maps_controller_spec.rb
+++ b/spec/requests/api/json/maps_controller_spec.rb
@@ -1,10 +1,96 @@
 # encoding: utf-8
 
-require_relative '../../../spec_helper'
+require_relative '../../../spec_helper_min'
+require 'support/helpers'
 require_relative '../../../../app/controllers/api/json/maps_controller'
 require_relative 'maps_controller_shared_examples'
 
 describe Api::Json::MapsController do
   it_behaves_like 'maps controllers' do
+  end
+
+  include Carto::Factories::Visualizations
+  include HelperMethods
+
+  def bypass_named_maps
+    CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
+    CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true, delete: true)
+  end
+
+  before(:all) do
+    @user = FactoryGirl.create(:carto_user)
+    @user2 = FactoryGirl.create(:carto_user)
+    @map, @table, @table_visualization, @visualization = create_full_visualization(@user)
+  end
+
+  before(:each) do
+    bypass_named_maps
+  end
+
+  after(:all) do
+    destroy_full_visualization(@map, @table, @table_visualization, @visualization)
+    # This avoids connection leaking.
+    ::User[@user.id].destroy
+    ::User[@user2.id].destroy
+    bypass_named_maps
+  end
+
+  describe '#update' do
+    it 'returns existing map by id' do
+      payload = {
+        provider: 'not_leaflet',
+        bounding_box_sw: [5.123456789, 5.123456789],
+        bounding_box_ne: [10.123456789, 20.123456789],
+        center: [7.123456789, 7.123456789],
+        zoom: 42,
+        view_bounds_sw: [-15.123456789, -15.123456789],
+        view_bounds_ne: [-35.123456789, -55.123456789],
+        legends: false,
+        scrollwheel: true
+      }
+
+      put_json api_v1_maps_update_url(user_domain: @user.username, api_key: @user.api_key, id: @map.id), payload do |response|
+        response.status.should be_success
+        response.body[:provider].should eq payload[:provider]
+        JSON.parse(response.body[:bounding_box_sw]).should eq payload[:bounding_box_sw]
+        JSON.parse(response.body[:bounding_box_ne]).should eq payload[:bounding_box_ne]
+        JSON.parse(response.body[:center]).should eq payload[:center]
+        response.body[:zoom].should eq payload[:zoom]
+        JSON.parse(response.body[:view_bounds_sw]).should eq payload[:view_bounds_sw]
+        JSON.parse(response.body[:view_bounds_ne]).should eq payload[:view_bounds_ne]
+        response.body[:legends].should eq payload[:legends]
+        response.body[:scrollwheel].should eq payload[:scrollwheel]
+      end
+
+      @map.reload
+      @map.provider.should eq payload[:provider]
+      JSON.parse(@map.bounding_box_sw).should eq payload[:bounding_box_sw]
+      JSON.parse(@map.bounding_box_ne).should eq payload[:bounding_box_ne]
+      JSON.parse(@map.center).should eq payload[:center]
+      @map.zoom.should eq payload[:zoom]
+      JSON.parse(@map.view_bounds_sw).should eq payload[:view_bounds_sw]
+      JSON.parse(@map.view_bounds_ne).should eq payload[:view_bounds_ne]
+      @map.legends.should eq payload[:legends]
+      @map.scrollwheel.should eq payload[:scrollwheel]
+    end
+
+    it 'returns 401 for unathorized user' do
+      put_json api_v1_maps_update_url(user_domain: @user2.username, api_key: 'wadus', id: @map.id), {} do |response|
+        response.status.should eq 401
+      end
+    end
+
+    it 'returns 404 for maps not owned by the user' do
+      put_json api_v1_maps_update_url(user_domain: @user2.username, api_key: @user2.api_key, id: @map.id), {center: [1,1]} do |response|
+        byebug
+        response.status.should eq 404
+      end
+    end
+
+    it 'returns 404 for unexisting map' do
+      put_json api_v1_maps_update_url(user_domain: @user.username, api_key: @user.api_key, id: 'wadus'), {} do |response|
+        response.status.should eq 404
+      end
+    end
   end
 end

--- a/spec/requests/api/json/maps_controller_spec.rb
+++ b/spec/requests/api/json/maps_controller_spec.rb
@@ -93,19 +93,19 @@ describe Api::Json::MapsController do
     end
 
     it 'returns 401 for unathorized user' do
-      put_json api_v1_maps_update_url(user_domain: @user2.username, api_key: 'wadus', id: @map.id), {} do |response|
+      put_json api_v1_maps_update_url(user_domain: @user2.username, api_key: 'wadus', id: @map.id) do |response|
         response.status.should eq 401
       end
     end
 
     it 'returns 404 for maps not owned by the user' do
-      put_json create_update_map_url(@user2, @map.id), {center: [1,1]} do |response|
+      put_json create_update_map_url(@user2, @map.id), center: [1,1] do |response|
         response.status.should eq 404
       end
     end
 
     it 'returns 404 for unexisting map' do
-      put_json create_update_map_url(@user, 'wadus'), {} do |response|
+      put_json create_update_map_url(@user, 'wadus') do |response|
         response.status.should eq 404
       end
     end

--- a/spec/requests/api/json/maps_controller_spec.rb
+++ b/spec/requests/api/json/maps_controller_spec.rb
@@ -30,6 +30,10 @@ describe Api::Json::MapsController do
     bypass_named_maps
   end
 
+  def create_update_map_url(user, map_id)
+    api_v1_maps_update_url(user_domain: user.username, api_key: user.api_key, id: map_id)
+  end
+
   describe '#update' do
     it 'updates existing map by id' do
       # Intentionally uses long decimal numbers to test against JSON serialization problems
@@ -45,7 +49,7 @@ describe Api::Json::MapsController do
         scrollwheel: true
       }
 
-      put_json api_v1_maps_update_url(user_domain: @user.username, api_key: @user.api_key, id: @map.id), payload do |response|
+      put_json create_update_map_url(@user, @map.id), payload do |response|
         response.status.should be_success
         response.body[:provider].should eq payload[:provider]
         JSON.parse(response.body[:bounding_box_sw]).should eq payload[:bounding_box_sw]
@@ -76,7 +80,7 @@ describe Api::Json::MapsController do
         user_id: 'wadus'
       }
 
-      put_json api_v1_maps_update_url(user_domain: @user.username, api_key: @user.api_key, id: @map.id), payload do |response|
+      put_json create_update_map_url(@user, @map.id), payload do |response|
         response.status.should be_success
         response.body[:id].should eq @map.id
         response.body[:user_id].should eq @user.id
@@ -95,13 +99,13 @@ describe Api::Json::MapsController do
     end
 
     it 'returns 404 for maps not owned by the user' do
-      put_json api_v1_maps_update_url(user_domain: @user2.username, api_key: @user2.api_key, id: @map.id), {center: [1,1]} do |response|
+      put_json create_update_map_url(@user2, @map.id), {center: [1,1]} do |response|
         response.status.should eq 404
       end
     end
 
     it 'returns 404 for unexisting map' do
-      put_json api_v1_maps_update_url(user_domain: @user.username, api_key: @user.api_key, id: 'wadus'), {} do |response|
+      put_json create_update_map_url(@user, 'wadus'), {} do |response|
         response.status.should eq 404
       end
     end

--- a/spec/requests/carto/api/maps_controller_spec.rb
+++ b/spec/requests/carto/api/maps_controller_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require_relative '../../../spec_helper_min'
+require 'support/helpers'
 require_relative '../../../../app/controllers/carto/api/maps_controller'
 require_relative '../../../../spec/requests/api/json/maps_controller_shared_examples'
 

--- a/spec/requests/carto/api/maps_controller_spec.rb
+++ b/spec/requests/carto/api/maps_controller_spec.rb
@@ -27,9 +27,13 @@ describe Carto::Api::MapsController do
     ::User[@user2.id].destroy
   end
 
+  def create_show_map_url(user, map_id)
+    api_v1_maps_show_url(user_domain: user.username, api_key: user.api_key, id: map_id)
+  end
+
   describe '#show' do
     it 'returns existing map by id' do
-      get_json api_v1_maps_show_url(user_domain: @user.username, api_key: @user.api_key, id: @map.id) do |response|
+      get_json create_show_map_url(@user, @map.id) do |response|
         response.status.should be_success
         response.body[:id].should eq @map.id
         response.body[:user_id].should eq @map.user_id
@@ -52,13 +56,13 @@ describe Carto::Api::MapsController do
     end
 
     it 'returns 404 for maps not owned by the user' do
-      get_json api_v1_maps_show_url(user_domain: @user2.username, api_key: @user2.api_key, id: @map.id) do |response|
+      get_json create_show_map_url(@user2, @map.id) do |response|
         response.status.should eq 404
       end
     end
 
     it 'returns 404 for unexisting map' do
-      get_json api_v1_maps_show_url(user_domain: @user.username, api_key: @user.api_key, id: 'wadus') do |response|
+      get_json create_show_map_url(@user, 'wadus') do |response|
         response.status.should eq 404
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require_relative './simplecov_helper'
 require 'uuidtools'
 require_relative './rspec_configuration'
 require 'helpers/spec_helper_helpers'
+require 'helpers/named_maps_helper'
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
@@ -21,11 +22,6 @@ def random_uuid
   UUIDTools::UUID.timestamp_create.to_s
 end
 
-def bypass_named_maps
-  CartoDB::Visualization::Member.any_instance.stubs(:has_named_map?).returns(false)
-  CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true, delete: true)
-end
-
 # Inline Resque for queue handling
 Resque.inline = true
 
@@ -33,6 +29,7 @@ RSpec.configure do |config|
   config.include SpecHelperHelpers
   config.include CartoDB::Factories
   config.include HelperMethods
+  config.include NamedMapsHelper
 
   unless ENV['PARALLEL']
     config.before(:suite) do

--- a/spec/spec_helper_min.rb
+++ b/spec/spec_helper_min.rb
@@ -4,6 +4,7 @@ require 'simplecov_helper'
 require 'rspec_configuration'
 require 'helpers/spec_helper_helpers'
 require 'support/redis'
+require 'helpers/named_maps_helper'
 
 ENV['RAILS_ENV'] ||= 'test'
 # INFO: this is the only slow step of the test boot process
@@ -14,6 +15,7 @@ Resque.inline = true
 
 RSpec.configure do |config|
   config.include SpecHelperHelpers
+  config.include NamedMapsHelper
 
   unless ENV['PARALLEL']
     config.before(:suite) do


### PR DESCRIPTION
Closes #6808 

This adds tests to both maps API endpoints, moving the existing tests to use the new spec_helper_min. A couple of bugs where discovered by this and are fixed in the same PR.

CR @gfiorav @juanignaciosl 