### PR TITLE
Upgrade Rollbar to 2.8.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'redcarpet', '3.3.3'
 gem 'bartt-ssl_requirement',   '~>1.4.0', require: 'ssl_requirement'
 
 # TODO Production gems, put them in :production group
-gem 'rollbar',               '0.12.14'
+gem 'rollbar',               '~>2.8.3'
 gem 'resque',                '1.25.2'
 gem 'resque-metrics',        '0.1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,8 +251,8 @@ GEM
     resque-metrics (0.1.1)
       resque (~> 1.19)
     retriable (1.4.1)
-    rollbar (0.12.14)
-      multi_json (~> 1.3)
+    rollbar (2.8.3)
+      multi_json
     roo (1.13.2)
       nokogiri
       rubyzip
@@ -403,7 +403,7 @@ DEPENDENCIES
   resque (= 1.25.2)
   resque-metrics (= 0.1.1)
   retriable (= 1.4.1)
-  rollbar (= 0.12.14)
+  rollbar (~> 2.8.3)
   roo (= 1.13.2)
   rspec-rails (= 2.12.0)
   ruby-prof (= 0.15.1)


### PR DESCRIPTION
This upgrades the Rollbar gem to the latest version 2.8.3. This time, it does not adds oj as a JSON parser, so it will use the standard JSON parser (as we don't have anything else installed).

Rollbar has an interesting history with JSON parsers, going from `multi_json` to `Json`, to `multi_json` again, then `oj`, and then a system that tries to use `oj` but falls back on `multi_json` :confused: 

As of 2.8.3 they reversed many of the changes and they now use `multi_json` (same as in 0.12, that we currently run), with the only difference that they will load `oj` if available. As this PR does not include it, JSON parsing behaviour in CartoDB is not affected by this change.

This has been tested with the tests from PR https://github.com/CartoDB/cartodb/pull/6839 and the board is green. Staging tests pending.

CR @juanignaciosl 
Closes #6777 