### PR TITLE
Stub enable_remote_db_user in user factory

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -60,15 +60,14 @@ FactoryGirl.define do
     quota_in_bytes 5000000
     id { UUIDTools::UUID.timestamp_create.to_s }
 
-    after(:create) do |carto_user|
-      ::User.where(id: carto_user.id).first.after_create
-      CartoDB::UserModule::DBService.any_instance.unstub
-    end
-
     before(:create) do
       CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
     end
 
+    after(:create) do |carto_user|
+      ::User.where(id: carto_user.id).first.after_create
+      CartoDB::UserModule::DBService.any_instance.unstub
+    end
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -62,6 +62,11 @@ FactoryGirl.define do
 
     after(:create) do |carto_user|
       ::User.where(id: carto_user.id).first.after_create
+      CartoDB::UserModule::DBService.any_instance.unstub
+    end
+
+    before(:create) do
+      CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
     end
 
   end


### PR DESCRIPTION
Automatically stubs `enable_remote_db_user` when creating an user with the `carto_user` factory. This eliminates the need to manually do that in each test that uses such factory.

Tests ok in PR and master (fails for different reasons).

CR @juanignaciosl 