### PR TITLE
Cast to touch based on actual table name in cdb_tablemetadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Updating CartoDB.js submodule with last changes sanitizing attribution.
 * Fixes a problem with select2 arrow icon.
 * Disable `PROMOTE_TO_MULTI` ogr2ogr option for CSV imports with guessing enabled to avoid MultiPoint imports. (https://github.com/CartoDB/cartodb/pull/6793)
+* Fixed error when accessing an SQL API renamed table through the editor.
 
 ## Security fixes
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -653,7 +653,6 @@ class Table
   end
 
   def name=(value)
-    byebug
     value = value.downcase if value
     return if value == @user_table[:name] || value.blank?
     new_name = get_valid_name(value, current_name: self.name)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -653,6 +653,7 @@ class Table
   end
 
   def name=(value)
+    byebug
     value = value.downcase if value
     return if value == @user_table[:name] || value.blank?
     new_name = get_valid_name(value, current_name: self.name)
@@ -1307,9 +1308,7 @@ class Table
   end
 
   def update_cdb_tablemetadata
-    owner.in_database(as: :superuser).run(%{
-      SELECT CDB_TableMetadataTouch('#{qualified_table_name}')
-      })
+    owner.in_database(as: :superuser).run(%{ SELECT CDB_TableMetadataTouch(#{table_id}::oid::regclass) })
   end
 
   private


### PR DESCRIPTION
This trick allows to touch based on the current `tabname` instead of the `qualified_table_name` in the model. Fixes errors on renaming. 

We're pretty sure it's safe, testing in staging.

Please CR @juanignaciosl 

cc/ @zenitraM 