### PR TITLE
Do not recreate viz table in collection_spec

### DIFF
--- a/app/models/visualization/migrator.rb
+++ b/app/models/visualization/migrator.rb
@@ -10,7 +10,7 @@ module CartoDB
         @db = db
       end
 
-      def migrate(relation=:visualizations)
+      def migrate(relation = :visualizations)
         @db.create_table(relation.to_sym) do
           UUID      :id, primary_key: true
           String    :name
@@ -27,30 +27,29 @@ module CartoDB
           String    :url_options
           UUID      :user_id
           UUID      :permission_id
-          Boolean   :locked
+          Boolean   :locked, null: false, default: false
           String    :license
           String    :source
           String    :attributions
           String    :title
           String    :parent_id
-          String    :kind
+          String    :kind, null: false, default: 'geom'
           String    :prev_id
           String    :next_id
-          String    :slide_transition_options
+          String    :slide_transition_options, null: false, default: '{}'
           String    :active_child
         end
 
-        @db.run(%Q{
+        @db.run(%{
           ALTER TABLE "#{relation}"
           ADD COLUMN tags text[],
           ADD COLUMN bbox geometry
         })
       end
 
-      def drop(relation=:visualizations)
-        @db.drop_table(relation.to_sym, :cascade=>true)
+      def drop(relation = :visualizations)
+        @db.drop_table(relation.to_sym, cascade: true)
       end
     end
   end
 end
-

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -10,15 +10,7 @@ include CartoDB
 
 describe Visualization::Collection do
   before(:each) do
-    db_config   = Rails.configuration.database_configuration[Rails.env]
-    # Why not passing db_config directly to Sequel.postgres here ?
-    # See https://github.com/CartoDB/cartodb/issues/421
-    @db         = Sequel.postgres(
-                    host:     db_config.fetch('host'),
-                    port:     db_config.fetch('port'),
-                    database: db_config.fetch('database'),
-                    username: db_config.fetch('username')
-                  )
+    @db = Rail::Sequel::connection
     # Careful, uses another DB table (and deletes it at after:(each) )
     @relation   = "visualizations_#{Time.now.to_i}".to_sym
     @repository = DataRepository::Backend::Sequel.new(@db, @relation)

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -10,7 +10,7 @@ include CartoDB
 
 describe Visualization::Collection do
   before(:each) do
-    @db = Rail::Sequel::connection
+    @db = Rails::Sequel::connection
     # Careful, uses another DB table (and deletes it at after:(each) )
     @relation   = "visualizations_#{Time.now.to_i}".to_sym
     @repository = DataRepository::Backend::Sequel.new(@db, @relation)

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -32,7 +32,7 @@ describe Visualization::Collection do
 
   after(:each) do
     Visualization::Migrator.new(@db).drop(@relation)
-    restore_vis_backend_to_normal_table_so_relator_works
+    restore_backend_to_normal_table
   end
 
   after(:all) do
@@ -40,7 +40,7 @@ describe Visualization::Collection do
     @user_2.destroy
   end
 
-  def restore_vis_backend_to_normal_table_so_relator_works
+  def restore_backend_to_normal_table
     Visualization.repository = DataRepository::Backend::Sequel.new(@db, :visualizations)
   end
 
@@ -251,7 +251,7 @@ describe Visualization::Collection do
       # TODO: Add mapviews test. As it uses redis requires more work
 
       # Restore Vis backend to normal table so Relator works
-      restore_vis_backend_to_normal_table_so_relator_works
+      restore_backend_to_normal_table
 
       CartoDB::Visualization::Relator.any_instance.stubs(:user).returns(@user_1)
 
@@ -375,7 +375,7 @@ describe Visualization::Collection do
     end
 
     it 'counts total liked' do
-      restore_vis_backend_to_normal_table_so_relator_works
+      restore_backend_to_normal_table
 
       @user_1.stubs(:organization).returns(nil)
       @user_2.stubs(:organization).returns(nil)
@@ -480,7 +480,7 @@ describe Visualization::Collection do
     end
 
     it "checks filtering by 'liked' " do
-      restore_vis_backend_to_normal_table_so_relator_works
+      restore_backend_to_normal_table
 
       user3 = create_user(:quota_in_bytes => 524288000, :table_quota => 500, :private_tables_enabled => true)
       CartoDB::Visualization::Relator.any_instance.stubs(:user).returns(@user_1)


### PR DESCRIPTION
`collection_spec` creates copies of the visualization tables to perform its tests. However, some tests (namely, testing the visualizations locator) use the main table, but still recreate it every time.

This PR avoids this situation by never recreating the main table and ensuring that the visualization repository is left pointing to the main table (instead of one of the temp tables). This fixes Maps API controller tests in master CI.

It also updates the Migrator schema to the current schema so tests are run against the real table.

See #6848 