### PR TITLE
Add debug information for "key not found: downloadurl" @gdrive

### DIFF
--- a/services/datasources/lib/datasources/url/gdrive.rb
+++ b/services/datasources/lib/datasources/url/gdrive.rb
@@ -182,7 +182,7 @@ module CartoDB
           end
 
           @client.execute(batch_request)
-          all_results
+          all_results.compact
         rescue Google::APIClient::InvalidIDTokenError => ex
           raise TokenExpiredOrInvalidError.new("Invalid token: #{ex.message}", DATASOURCE_NAME)
         rescue Google::APIClient::BatchError, Google::APIClient::TransmissionError, Google::APIClient::ClientError, \
@@ -332,11 +332,14 @@ module CartoDB
             data[:url] = data[:url][0..data[:url].rindex('=')] + 'csv'
             data[:filename] = clean_filename(item_data.fetch('title')) + '.csv'
             data[:size] = NO_CONTENT_SIZE_PROVIDED
-          else
+          elsif item_data.include?('downloadUrl')
             data[:url] = item_data.fetch('downloadUrl')
             # For Drive files, title == filename + extension
             data[:filename] = item_data.fetch('title')
             data[:size] = item_data.fetch('fileSize').to_i
+          else
+            CartoDB.notify_debug('downloadURl key not found @gdrive', item: item_data.to_s, user: @user)
+            return nil
           end
           data
         end

--- a/services/datasources/lib/datasources/url/gdrive.rb
+++ b/services/datasources/lib/datasources/url/gdrive.rb
@@ -338,7 +338,7 @@ module CartoDB
             data[:filename] = item_data.fetch('title')
             data[:size] = item_data.fetch('fileSize').to_i
           else
-            CartoDB.notify_debug('downloadURl key not found @gdrive', item: item_data.to_s, user: @user)
+            CartoDB.notify_debug('downloadURl key not found @gdrive', item: item_data.inspect, user: @user)
             return nil
           end
           data


### PR DESCRIPTION
Related: https://github.com/CartoDB/cartodb/issues/6854

We need some extra debug information for the issue reported in #6854. We know that gdrive file listing is failing because the item that we are parsing does not have a `downloadUrl` neither an `exportLink` (for gdrive files).

We're using a pretty old Ruby library for the Google Drive client which perhaps has something to do with the exception that we were facing, but we would need to know which are the details of the elements that make the list crash.

This PR basically adds a notfiy_debug for "malformed" items and ignores them when listing to workaround the issue.
