### PR TITLE
6865 reported slow queries

### DIFF
--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -88,6 +88,7 @@ class Carto::VisualizationQueryBuilder
   end
 
   def with_user_id(user_id)
+    CartoDB.notify_debug("with_user_id with nil user_id", caller: caller.take(25)) unless user_id
     @user_id = user_id
     self
   end

--- a/lib/cartodb/stats/platform.rb
+++ b/lib/cartodb/stats/platform.rb
@@ -55,7 +55,7 @@ module CartoDB
 
       # Total active users
       def active_users
-        active_users = "SELECT COUNT(DISTINCT(user_id)) FROM visualizations WHERE type != 'remote'"
+        active_users = "select count(distinct(user_id)) from visualizations where type in ('derived', 'table', 'slide')"
         db = ::Rails::Sequel.configuration.environment_for(Rails.env)
         conn = Sequel.connect(db)
         au_count = conn.fetch(active_users).first[:count]

--- a/lib/cartodb/stats/platform.rb
+++ b/lib/cartodb/stats/platform.rb
@@ -50,7 +50,7 @@ module CartoDB
 
       # Total maps
       def maps
-        Carto::Visualization.where("type != 'remote'").count
+        Carto::Visualization.where("type in ('derived', 'table', 'slide')").count
       end
 
       # Total active users


### PR DESCRIPTION
@javitonino CR this, please. 
- 1st: I haven't been able to find it. I've added debug log at `VisualizationQueryBuilder` to check my only current hypothesis: `with_user_id` being called with `nil`.
- 2nd: I didn't find it either. Nevertheless it's not a big problem, it's a ~2s query (other 2 are > 70s).
- 3rd (platform.rb one) time improved by ~ x29 (see 414ad1d for details).