### PR TITLE
Checks for client= in google_maps_key

### DIFF
--- a/lib/tasks/google_services.rake
+++ b/lib/tasks/google_services.rake
@@ -47,8 +47,8 @@ namespace :cartodb do
           ff.destroy unless ff.nil?
         end
 
-        def parse_google_maps_key(key)
-          key.downcase.include?('client=') ? key : "client=#{key}"
+        def prepend_client_equal_if_needed(key)
+          key.downcase.start_with?('client=') ? key : "client=#{key}"
         end
 
         desc 'Enable Google Services for a given user'
@@ -62,7 +62,7 @@ namespace :cartodb do
           add_feature_flag_to_user('google_maps', user)
 
           puts "Enabling google services for user '#{user.username}'..."
-          user.google_maps_key = parse_google_maps_key(args[:google_maps_key])
+          user.google_maps_key = prepend_client_equal_if_needed(args[:google_maps_key])
           user.google_maps_private_key = args[:google_maps_private_key] unless args[:google_maps_private_key].blank?
 
           puts user.errors.full_messages unless user.save
@@ -84,7 +84,7 @@ namespace :cartodb do
           end
 
           puts "Enabling google services for organization '#{organization.name}'..."
-          organization.google_maps_key = parse_google_maps_key(args[:google_maps_key])
+          organization.google_maps_key = prepend_client_equal_if_needed(args[:google_maps_key])
 
           unless args[:google_maps_private_key].blank?
             organization.google_maps_private_key = args[:google_maps_private_key]
@@ -105,7 +105,7 @@ namespace :cartodb do
             end
 
             puts "Enabling google services for organization '#{organization.name}'..."
-            organization.google_maps_key = parse_google_maps_key(args[:google_maps_key])
+            organization.google_maps_key = prepend_client_equal_if_needed(args[:google_maps_key])
 
             unless args[:google_maps_private_key].blank?
               organization.google_maps_private_key = args[:google_maps_private_key]
@@ -120,7 +120,7 @@ namespace :cartodb do
             add_feature_flag_to_user('google_maps', user)
 
             puts "Enabling google services for non-organization user '#{user.username}'..."
-            user.google_maps_key = parse_google_maps_key(args[:google_maps_key])
+            user.google_maps_key = prepend_client_equal_if_needed(args[:google_maps_key])
             user.google_maps_private_key = args[:google_maps_private_key] unless args[:google_maps_private_key].blank?
 
             puts user.errors.full_messages unless user.save

--- a/lib/tasks/google_services.rake
+++ b/lib/tasks/google_services.rake
@@ -47,6 +47,10 @@ namespace :cartodb do
           ff.destroy unless ff.nil?
         end
 
+        def parse_google_maps_key(key)
+          key.downcase.include?('client=') ? key : "client=#{key}"
+        end
+
         desc 'Enable Google Services for a given user'
         task :enable_for_user, [:google_maps_key, :google_maps_private_key, :username] => [:environment] do |task, args|
           add_feature_flag_if_not_exists('google_maps')
@@ -58,7 +62,7 @@ namespace :cartodb do
           add_feature_flag_to_user('google_maps', user)
 
           puts "Enabling google services for user '#{user.username}'..."
-          user.google_maps_key = "client=#{args[:google_maps_key]}"
+          user.google_maps_key = parse_google_maps_key(args[:google_maps_key])
           user.google_maps_private_key = args[:google_maps_private_key] unless args[:google_maps_private_key].blank?
 
           puts user.errors.full_messages unless user.save
@@ -80,7 +84,7 @@ namespace :cartodb do
           end
 
           puts "Enabling google services for organization '#{organization.name}'..."
-          organization.google_maps_key = "client=#{args[:google_maps_key]}"
+          organization.google_maps_key = parse_google_maps_key(args[:google_maps_key])
 
           unless args[:google_maps_private_key].blank?
             organization.google_maps_private_key = args[:google_maps_private_key]
@@ -101,7 +105,7 @@ namespace :cartodb do
             end
 
             puts "Enabling google services for organization '#{organization.name}'..."
-            organization.google_maps_key = "client=#{args[:google_maps_key]}"
+            organization.google_maps_key = parse_google_maps_key(args[:google_maps_key])
 
             unless args[:google_maps_private_key].blank?
               organization.google_maps_private_key = args[:google_maps_private_key]
@@ -116,7 +120,7 @@ namespace :cartodb do
             add_feature_flag_to_user('google_maps', user)
 
             puts "Enabling google services for non-organization user '#{user.username}'..."
-            user.google_maps_key = "client=#{args[:google_maps_key]}"
+            user.google_maps_key = parse_google_maps_key(args[:google_maps_key])
             user.google_maps_private_key = args[:google_maps_private_key] unless args[:google_maps_private_key].blank?
 
             puts user.errors.full_messages unless user.save


### PR DESCRIPTION
Fixes [#513](https://github.com/CartoDB/cartodb-onpremise/issues/513)

Now this rake task won't prefix `client=` to `google_maps_key` if it's already supplied.

Please CR @juanignaciosl 

cc/ @javisantana @danicarrion 