### PR TITLE
Change debug notice to identify non-downloadable gdrive files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Disable `PROMOTE_TO_MULTI` ogr2ogr option for CSV imports with guessing enabled to avoid MultiPoint imports. (https://github.com/CartoDB/cartodb/pull/6793)
 * Fixes a memory leak when connecting to user databases
 * Fixed error when accessing an SQL API renamed table through the editor.
+* Ignore non-downloadable GDrive files that made file listing fail (https://github.com/CartoDB/cartodb/pull/6871)
 
 ## Security fixes
 

--- a/services/datasources/lib/datasources/url/gdrive.rb
+++ b/services/datasources/lib/datasources/url/gdrive.rb
@@ -338,7 +338,8 @@ module CartoDB
             data[:filename] = item_data.fetch('title')
             data[:size] = item_data.fetch('fileSize').to_i
           else
-            CartoDB.notify_debug('downloadURl key not found @gdrive', item: item_data.inspect, user: @user)
+            # Downloads from files shared by other people can be disabled, ignore them
+            CartoDB.notify_debug('Non downloadable file @gdrive', item: item_data.inspect, user: @user)
             return nil
           end
           data


### PR DESCRIPTION
In previous PRs: https://github.com/CartoDB/cartodb/pull/6855
(Return nil for invalid files + report a debug message when it occurred)

People can share files in GDrive and select in the advanced sharing
options that the users with which these files are shared are not
authorized to download the files. This was causing CartoDB to crash, as
it was expecting a DownloadUrl or an ExportLink, and in this
"non-downloadable" scenario none of the options is available for the
item.

In this case, we just ignore the non-downloadable files and list the
rest of the files. In case we need to debug this in the future, the
non-downloadable debug message can be found at the notifier.

Closes #6854 