### PR TITLE
6884 viz by name queries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Fixes a memory leak when connecting to user databases
 * Fixed error when accessing an SQL API renamed table through the editor.
 * Ignore non-downloadable GDrive files that made file listing fail (https://github.com/CartoDB/cartodb/pull/6871)
+* Fix slow search of visualizations by name
 
 ## Security fixes
 

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -619,9 +619,13 @@ class Admin::VisualizationsController < Admin::AdminController
   def get_visualization_and_table(table_id, schema, filter)
     user = Carto::User.where(username: schema).first
     # INFO: organization public visualizations
-    user_id = user ? user.id : nil
-
-    visualization = get_priority_visualization(table_id, user_id)
+    if user
+      visualization = get_priority_visualization(table_id, user_id: user.id)
+    else
+      organization = Carto::Organization.where(name: schema).first
+      organization_id = organization.id unless organization.nil?
+      visualization = get_priority_visualization(table_id, organization_id: organization_id)
+    end
 
     return get_visualization_and_table_from_table_id(table_id) if visualization.nil?
     render_pretty_404 if visualization.kind == CartoDB::Visualization::Member::KIND_RASTER

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -491,7 +491,7 @@ class Admin::VisualizationsController < Admin::AdminController
   def resolve_visualization_and_table
     filters = { exclude_raster: true }
     @visualization, @table =
-      get_visualization_and_table(@table_id, @schema || CartoDB.extract_subdomain(request), filters)
+      get_visualization_and_table(@table_id, username_from_schema || CartoDB.extract_subdomain(request), filters)
     if @visualization && @visualization.user
       @more_visualizations = more_visualizations(@visualization.user, @visualization)
     end
@@ -539,6 +539,10 @@ class Admin::VisualizationsController < Admin::AdminController
       end
     end
     url
+  end
+
+  def username_from_schema
+    (@schema && @schema != 'public') ? @schema : nil
   end
 
   def table_and_schema_from_params

--- a/app/controllers/carto/editor/public/embeds_controller.rb
+++ b/app/controllers/carto/editor/public/embeds_controller.rb
@@ -32,7 +32,7 @@ module Carto
         private
 
         def load_visualization
-          @visualization = load_visualization_from_id(params[:visualization_id])
+          @visualization = load_visualization_from_id_or_name(params[:visualization_id])
         end
 
         def ensure_viewable

--- a/app/controllers/carto/editor/visualizations_controller.rb
+++ b/app/controllers/carto/editor/visualizations_controller.rb
@@ -28,7 +28,7 @@ module Carto
       private
 
       def load_visualization
-        @visualization = load_visualization_from_id(params[:id])
+        @visualization = load_visualization_from_id_or_name(params[:id])
       end
 
       def authors_only

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -13,11 +13,11 @@ module VisualizationsControllerHelper
                                     .first
   end
 
-  def load_visualization_from_id_or_name(id)
+  def load_visualization_from_id_or_name(id_or_name)
     user = Carto::User.where(username: CartoDB.extract_subdomain(request)).first
     user_id = user.nil? ? nil : user.id
 
-    visualization = get_priority_visualization(id, user_id: user_id)
+    visualization = get_priority_visualization(id_or_name, user_id: user_id)
 
     render_404 && return if visualization.nil?
 

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -1,9 +1,10 @@
 module VisualizationsControllerHelper
   # Implicit order due to legacy code: 1st return canonical/table/Dataset if present, else derived/visualization/Map
-  def get_priority_visualization(visualization_id, user_id)
+  def get_priority_visualization(visualization_id, user_id: nil, organization_id: nil)
     Carto::VisualizationQueryBuilder.new
                                     .with_id_or_name(visualization_id)
                                     .with_user_id(user_id)
+                                    .with_organization_id(organization_id)
                                     .build
                                     .all
                                     .sort do |vis_a, _vis_b|
@@ -16,7 +17,7 @@ module VisualizationsControllerHelper
     user = Carto::User.where(username: extract_subdomain(request)).first
     user_id = user.nil? ? nil : user.id
 
-    visualization = get_priority_visualization(id, user_id)
+    visualization = get_priority_visualization(id, user_id: user_id)
 
     render_404 && return if visualization.nil?
 

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -14,7 +14,7 @@ module VisualizationsControllerHelper
   end
 
   def load_visualization_from_id_or_name(id)
-    user = Carto::User.where(username: extract_subdomain(request)).first
+    user = Carto::User.where(username: CartoDB.extract_subdomain(request)).first
     user_id = user.nil? ? nil : user.id
 
     visualization = get_priority_visualization(id, user_id: user_id)

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -12,8 +12,9 @@ module VisualizationsControllerHelper
                                     .first
   end
 
-  def load_visualization_from_id(id)
-    user_id = current_user.nil? ? nil : current_user.id
+  def load_visualization_from_id_or_name(id)
+    user = Carto::User.where(username: extract_subdomain(request)).first
+    user_id = user.nil? ? nil : user.id
 
     visualization = get_priority_visualization(id, user_id)
 

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -88,7 +88,6 @@ class Carto::VisualizationQueryBuilder
   end
 
   def with_user_id(user_id)
-    CartoDB.notify_debug("with_user_id with nil user_id", caller: caller.take(25)) unless user_id
     @user_id = user_id
     self
   end
@@ -191,6 +190,10 @@ class Carto::VisualizationQueryBuilder
 
   def build
     query = Carto::Visualization.scoped
+
+    unless @id || @user_id
+      CartoDB.notify_debug("VQB query without viz_id nor user_id", stack: caller.take(25))
+    end
 
     if @id
       query = query.where(id: @id)

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -188,11 +188,16 @@ class Carto::VisualizationQueryBuilder
     self
   end
 
+  def with_organization_id(organization_id)
+    @organization_id = organization_id
+    self
+  end
+
   def build
     query = Carto::Visualization.scoped
 
-    unless @id || @user_id
-      CartoDB.notify_debug("VQB query without viz_id nor user_id", stack: caller.take(25))
+    unless @id || @user_id || @organization_id
+      CartoDB.notify_debug("VQB query without viz_id, user_id nor org_id", stack: caller.take(25))
     end
 
     if @id
@@ -301,6 +306,10 @@ class Carto::VisualizationQueryBuilder
 
     if @only_with_display_name
       query = query.where("display_name is not null")
+    end
+
+    if @organization_id
+      query = query.joins(user: :organization).where(organizations: { id: @organization_id })
     end
 
     @include_associations.each { |association|

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -309,7 +309,7 @@ class Carto::VisualizationQueryBuilder
     end
 
     if @organization_id
-      query = query.joins(user: :organization).where(organizations: { id: @organization_id })
+      query = query.joins(:user).where(users: { organization_id: @organization_id })
     end
 
     @include_associations.each { |association|


### PR DESCRIPTION
This fixes the three detected cases when a global search by visualization name is run:
- Editor-3 public pages (used current_user instead of the user specified in the domain).
- Visualization controller actions with a `public` schema, as `public` was interpreted as a username.
- Visualization controller actions without specifying schema for users belonging to organizations. In this case, a filter by organization is added.

The last change is more involved and separated into its own commit, in case we decide not to merge it yet. The other two changes are relatively harmless: the first only affects the new editor, and the second one only ignores `public` in schemas.

See #6884 