### PR TITLE
Regex change /^http:/ to 'https:' in user avatar url

### DIFF
--- a/app/views/admin/visualizations/embed_map.html.erb
+++ b/app/views/admin/visualizations/embed_map.html.erb
@@ -32,7 +32,7 @@
       <% username = @visualization.user.name.blank? ? @visualization.user.username : @visualization.user.name %>
       <a class="user" href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>?utm_source=Footer_Link&utm_medium=referral&utm_campaign=Embed_v1&utm_content=<%= @visualization.user.username %>" target="_blank">
         <% if !@visualization.user.avatar_url.blank? %>
-          <img src="<%= @visualization.user.avatar_url %>" width="16" height="16" alt="<%= username %>" title="<%= username %>" />
+          <img src="<%= @visualization.user.avatar_url.sub!(/^http:/,'https:') %>" width="16" height="16" alt="<%= username %>" title="<%= username %>" />
         <% end %>
         <span class="username"><%= username %></span>
       </a>

--- a/app/views/admin/visualizations/embed_map.html.erb
+++ b/app/views/admin/visualizations/embed_map.html.erb
@@ -32,7 +32,7 @@
       <% username = @visualization.user.name.blank? ? @visualization.user.username : @visualization.user.name %>
       <a class="user" href="<%= CartoDB.url(self, 'public_user_feed_home', {}, @visualization.user) %>?utm_source=Footer_Link&utm_medium=referral&utm_campaign=Embed_v1&utm_content=<%= @visualization.user.username %>" target="_blank">
         <% if !@visualization.user.avatar_url.blank? %>
-          <img src="<%= @visualization.user.avatar_url.sub!(/^http:/,'https:') %>" width="16" height="16" alt="<%= username %>" title="<%= username %>" />
+          <img src="<%= @visualization.user.avatar_url.sub(/^http:/,'https:') %>" width="16" height="16" alt="<%= username %>" title="<%= username %>" />
         <% end %>
         <span class="username"><%= username %></span>
       </a>


### PR DESCRIPTION
- User avatars are being served over HTTP even if the map embed is HTTPS, causing mixed content warnings on sites with SSL (#6904)
- Assets on S3 should always have a HTTPS equivalent, so this should not break anything