### PR TITLE
Update version of cartodb-postgresql to 0.14.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * Fixes a memory leak when connecting to user databases
 * Fixed error when accessing an SQL API renamed table through the editor.
 * Ignore non-downloadable GDrive files that made file listing fail (https://github.com/CartoDB/cartodb/pull/6871)
+* Update CartoDB PostgreSQL extension to 0.14.3 to support `cartodb_id` text columns in the CartoDBfy process.
+  * See instructions to upgrade to the latest extension version [here](https://github.com/CartoDB/cartodb-postgresql#update-cartodb-extension)
 
 ## Security fixes
 

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -437,7 +437,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.14.1'
+          cdb_extension_target_version = '0.14.3'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -6,6 +6,7 @@
 # 1235 # Table merging two+ tables should import and then export file SHP1.zip
 # 1256 # Table merging two+ tables should import and then export file SHP1.zip as kml
 # 1275 # Table merging two+ tables should import and then export file SHP1.zip as sql
+
 require_relative '../spec_helper'
 
 def check_schema(table, expected_schema, options={})

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -6,7 +6,6 @@
 # 1235 # Table merging two+ tables should import and then export file SHP1.zip
 # 1256 # Table merging two+ tables should import and then export file SHP1.zip as kml
 # 1275 # Table merging two+ tables should import and then export file SHP1.zip as sql
-
 require_relative '../spec_helper'
 
 def check_schema(table, expected_schema, options={})
@@ -1453,26 +1452,29 @@ describe Table do
       cartodb_id_schema[:allow_null].should == false
     end
 
-    it "should add a 'cartodb_id_' column when importing a file with invalid data on the cartodb_id column" do
-      data_import = DataImport.create( :user_id       => @user.id,
-                                       :data_source   =>  '/../db/fake_data/duplicated_cartodb_id.zip')
+    # Legacy test commented: Invalid data on cartodb_id will provoke an import failure and this behavior
+    # is tested in the data_import specs.
+    #
+    # it "should add a 'cartodb_id_' column when importing a file with invalid data on the cartodb_id column" do
+    #   data_import = DataImport.create( :user_id       => @user.id,
+    #                                    :data_source   =>  '/../db/fake_data/duplicated_cartodb_id.zip')
 
-      data_import.run_import!
-      table = Table.new(user_table: UserTable[data_import.table_id])
-      table.should_not be_nil, "Import failure: #{data_import.log}"
+    #   data_import.run_import!
+    #   table = Table.new(user_table: UserTable[data_import.table_id])
+    #   table.should_not be_nil, "Import failure: #{data_import.log}"
 
-      table_schema = @user.in_database.schema(table.name)
+    #   table_schema = @user.in_database.schema(table.name)
 
-      cartodb_id_schema = table_schema.detect {|s| s[0].to_s == 'cartodb_id'}
-      cartodb_id_schema.should be_present
-      cartodb_id_schema = cartodb_id_schema[1]
-      cartodb_id_schema[:db_type].should == 'bigint'
-      cartodb_id_schema[:default].should == "nextval('#{table.name}_cartodb_id_seq'::regclass)"
-      cartodb_id_schema[:primary_key].should == true
-      cartodb_id_schema[:allow_null].should == false
-      invalid_cartodb_id_schema = table_schema.detect {|s| s[0].to_s == 'cartodb_id_0'}
-      invalid_cartodb_id_schema.should be_present
-    end
+    #   cartodb_id_schema = table_schema.detect {|s| s[0].to_s == 'cartodb_id'}
+    #   cartodb_id_schema.should be_present
+    #   cartodb_id_schema = cartodb_id_schema[1]
+    #   cartodb_id_schema[:db_type].should == 'bigint'
+    #   cartodb_id_schema[:default].should == "nextval('#{table.name}_cartodb_id_seq'::regclass)"
+    #   cartodb_id_schema[:primary_key].should == true
+    #   cartodb_id_schema[:allow_null].should == false
+    #   invalid_cartodb_id_schema = table_schema.detect {|s| s[0].to_s == 'cartodb_id_0'}
+    #   invalid_cartodb_id_schema.should be_present
+    # end
 
     it "should return geometry types when guessing is enabled" do
       data_import = DataImport.create( :user_id       => @user.id,


### PR DESCRIPTION
Includes a commit of `table_spec.rb` in which a test has been commented as it represented legacy behavior -- I'm not deleting it directly in order to keep track of information that might be interesting in the future for further changes on the extension. This test is no longer needed because incorrect data in the `cartodb_id` column will not generate a new invalid column, but it will suppose an error in the import process.