### PR TITLE
Fix layers' letter representations

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
 var LayerDefinitionModel = require('./layer-definition-model');
-var LayerLetters = require('./layer-letters');
+var layerLetters = require('./layer-letters');
 var nodeIds = require('./analysis-definition-node-ids.js');
 
 /**
@@ -20,9 +20,9 @@ module.exports = Backbone.Collection.extend({
     var o = _.clone(d.options || {});
     var attrs = _.defaults({ options: o }, _.omit(d, ['options']));
 
-    // E.g. basemap should not have a letter representation
-    if (o.type !== 'Tiled') {
-      o.letter = o.letter || self._letters.next();
+    if (attrs.order !== 0) {
+      // Only for non-basemap layers
+      o.letter = o.letter || layerLetters.next(self._letters());
     }
 
     if (o.table_name) {
@@ -59,13 +59,7 @@ module.exports = Backbone.Collection.extend({
     this._layersCollection = options.layersCollection;
     this._analysisDefinitionNodesCollection = options.analysisDefinitionNodesCollection;
 
-    // A collection may be reset at any time (actually used silently when collection is created),
-    // to be able to know what letter representation should be generated in nextLetter we store them in this internal
-    // data structure.
-    this._letters = new LayerLetters();
-
     this.mapId = options.mapId;
-    this.on('remove', this._onRemove, this);
   },
 
   url: function () {
@@ -77,8 +71,17 @@ module.exports = Backbone.Collection.extend({
     return r.layers;
   },
 
-  _onRemove: function (m) {
-    this._letters.remove(m.get('letter'));
+  _letters: function () {
+    var modelsLetters = _.compact(this.pluck('letter'));
+
+    // When adding multiple items the models created so far are stored in the internal object this._byId,
+    // need to make sure to take them into account when returning already taken letters.
+    return _
+        .chain(this._byId)
+        .values()
+        .invoke('get', 'letter')
+        .union(modelsLetters)
+        .value();
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/layer-letters.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-letters.js
@@ -1,41 +1,23 @@
 var _ = require('underscore');
 
-var LayerLetters = function () {
-  this.letters = [];
-};
+module.exports = {
 
-/**
- * Generate a new letter and returns it
- * @return {String} e.g. 'c'
- */
-LayerLetters.prototype.next = function () {
-  // TODO bug in Backbone; this.chain().pluck('letter') returns [undefined, undefined, ...]
-  var letter = _.chain(this.letters)
-    .sort()
-    .reduce(this.getNextAvailable, 'a')
-    .value();
-
-  this.letters.push(letter);
-
-  return letter;
-};
-
-/**
- * @private
- */
-LayerLetters.prototype.getNextAvailable = function (memo, letter) {
-  if (letter === memo) {
-    return String.fromCharCode(letter.charCodeAt() + 1);
-  } else {
-    return memo;
+  /**
+   * Get the next available letter.
+   * @param {Array} letters e.g. ['a', 'b', 'd']
+   * @return {String} e.g. 'c'
+   */
+  next: function (letters) {
+    return _.chain(letters)
+      .sort()
+      .reduce(function (memo, letter) {
+        if (letter === memo) {
+          return String.fromCharCode(letter.charCodeAt() + 1);
+        } else {
+          return memo;
+        }
+      }, 'a')
+      .value();
   }
-};
 
-/**
- * @param {String} letter
- */
-LayerLetters.prototype.remove = function (letter) {
-  this.letters = _.without(this.letters, letter);
 };
-
-module.exports = LayerLetters;

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -21,38 +21,44 @@ describe('data/layer-definitions-collection', function () {
   it('should create the layer with the next letter representation available', function () {
     // Adds A-D, like if the collection was creatd from scratch
     this.collection.reset([{}, {}, {}, {}], { silent: true });
-    expect(this.collection.first().get('letter')).toEqual('a');
-    expect(this.collection.at(2).get('letter')).toEqual('c');
-    expect(this.collection.last().get('letter')).toEqual('d');
+    expect(this.collection.pluck('letter')).toEqual(['a', 'b', 'c', 'd']);
 
     // Remove C
     this.collection.remove(this.collection.at(2));
+    expect(this.collection.pluck('letter')).toEqual(['a', 'b', 'd']);
 
     // Add new as C
     this.collection.add({});
-    expect(this.collection.last().get('letter')).toEqual('c');
+    expect(this.collection.pluck('letter')).toEqual(['a', 'b', 'd', 'c']);
 
-    // Add new as E
-    this.collection.add({});
-    expect(this.collection.last().get('letter')).toEqual('e');
+    // Add new as E, F, G
+    this.collection.add([{}, {}, {}]);
+    expect(this.collection.pluck('letter')).toEqual(['a', 'b', 'd', 'c', 'e', 'f', 'g']);
+
+    // Remove all existing and add a new
+    this.collection.reset([{}, {}]);
+    expect(this.collection.pluck('letter')).toEqual(['a', 'b']);
   });
 
   describe('when there are some layers', function () {
     beforeEach(function () {
       this.collection.reset([{
         id: 'l-0',
+        order: 0,
         options: {
           type: 'Tiled',
           name: 'Basemap'
         }
       }, {
         id: 'l-1',
+        order: 1,
         options: {
           type: 'CartoDB',
           table_name: 'foobar'
         }
       }, {
         id: 'l-2',
+        order: 2,
         options: {
           type: 'CartoDB',
           table_name: 'foobar',


### PR DESCRIPTION
Especially on reset/adding multiple layers, to yield correct letters.

Removed the need to track letters separately, derive from collections layers at the time it's needed instead.

Also fix bug with basemap being a non-tiled layer (e.g. background/plain one)

@javierarce please review