### PR TITLE
Fixed not rendering org avatar in Firefox in org login page

### DIFF
--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -23,8 +23,21 @@ module LoginHelper
     !organization.nil? ? darken_color(organization.color, 0.7) : "#292E33"
   end
 
-  def show_organization_avatar?
-    @organization && @organization.name != "team" && @organization.avatar_url.present?
+  def render_organization_avatar
+    if @organization && @organization.name != 'team' && @organization.avatar_url.present?
+      avatar_url = @organization.avatar_url.sub(/^https?\:/, '')
+      "<picture class=\"Navbar-brand\">
+        <img src=\"#{avatar_url}\" alt=\"#{@organization.name}\" height=\"48\" />
+      </picture>
+      <sup>
+        <img src=\"#{image_path("layout/sessions/brand.png")}\" alt=\"CartoDB\" height=\"26\" width=\"26\">
+      </sup>".html_safe
+    else
+      "<picture class=\"Navbar-brand\">
+        <source type='image/svg+xml' srcset=\"#{image_path("layout/sessions/brand.png")}\">
+        <img src=\"#{image_path("layout/sessions/brand.png")}\" alt='CartoDB' height=\"48\" width=\"48\" />
+      </picture>".html_safe
+    end
   end
 
   def forget_password_url

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -24,18 +24,20 @@ module LoginHelper
   end
 
   def render_organization_avatar
+    brand_path = image_path("layout/sessions/brand.png")
+
     if @organization && @organization.name != 'team' && @organization.avatar_url.present?
       avatar_url = @organization.avatar_url.sub(/^https?\:/, '')
       "<picture class=\"Navbar-brand\">
         <img src=\"#{avatar_url}\" alt=\"#{@organization.name}\" height=\"48\" />
       </picture>
       <sup>
-        <img src=\"#{image_path("layout/sessions/brand.png")}\" alt=\"CartoDB\" height=\"26\" width=\"26\">
+        <img src=\"#{brand_path}\" alt=\"CartoDB\" height=\"26\" width=\"26\">
       </sup>".html_safe
     else
       "<picture class=\"Navbar-brand\">
-        <source type='image/svg+xml' srcset=\"#{image_path("layout/sessions/brand.png")}\">
-        <img src=\"#{image_path("layout/sessions/brand.png")}\" alt='CartoDB' height=\"48\" width=\"48\" />
+        <source type='image/svg+xml' srcset=\"#{brand_path}\">
+        <img src=\"#{brand_path}\" alt='CartoDB' height=\"48\" width=\"48\" />
       </picture>".html_safe
     end
   end

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -23,13 +23,8 @@ module LoginHelper
     !organization.nil? ? darken_color(organization.color, 0.7) : "#292E33"
   end
 
-  def login_org_avatar
-    if @organization && @organization.name != "team" && !@organization.avatar_url.blank?
-      @organization.avatar_url = @organization.avatar_url.sub(/^https?\:/, '')
-      return true
-    else
-      return false
-    end
+  def present_organization_avatar?
+    @organization.avatar_url.present?
   end
 
   def forget_password_url

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -23,8 +23,8 @@ module LoginHelper
     !organization.nil? ? darken_color(organization.color, 0.7) : "#292E33"
   end
 
-  def present_organization_avatar?
-    @organization.avatar_url.present?
+  def show_organization_avatar?
+    @organization && @organization.name != "team" && @organization.avatar_url.present?
   end
 
   def forget_password_url

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -24,7 +24,12 @@ module LoginHelper
   end
 
   def login_org_avatar
-    @organization && @organization.name != "team" && !@organization.avatar_url.blank?
+    if @organization && @organization.name != "team" && !@organization.avatar_url.blank?
+      @organization.avatar_url = @organization.avatar_url.sub(/^https?\:/, '')
+      return true
+    else
+      return false
+    end
   end
 
   def forget_password_url

--- a/app/views/admin/shared/_sessions_header.html.erb
+++ b/app/views/admin/shared/_sessions_header.html.erb
@@ -5,7 +5,7 @@
         <div class="Navbar-title">
           <picture class="Navbar-brand">
             <% if login_org_avatar %>
-              <img src="<%= @organization.avatar_url.sub(/^https?\:/, '') %>" alt="<%= @organization.name %>" height="48" />
+              <img src="<%= @organization.avatar_url %>" alt="<%= @organization.name %>" height="48" />
             <% else %>
               <source type="image/svg+xml" srcset="<%= image_path "layout/sessions/brand.svg" %>">
               <img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="48" width="48" />

--- a/app/views/admin/shared/_sessions_header.html.erb
+++ b/app/views/admin/shared/_sessions_header.html.erb
@@ -4,15 +4,19 @@
       <div class="Navbar-header">
         <div class="Navbar-title">
           <picture class="Navbar-brand">
-            <% if login_org_avatar %>
-              <img src="<%= @organization.avatar_url %>" alt="<%= @organization.name %>" height="48" />
+            <% if @organization && @organization.name != "team" %>
+              <% if present_organization_avatar? %>
+                <img src="<%= @organization.avatar_url.sub(/^https?\:/, '') %>" alt="<%= @organization.name %>" height="48" />
+              <% end %>
             <% else %>
               <source type="image/svg+xml" srcset="<%= image_path "layout/sessions/brand.svg" %>">
               <img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="48" width="48" />
             <% end %>
           </picture>
-          <% if login_org_avatar %>
-            <sup><img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="26" width="26"></sup>
+          <% if @organization && @organization.name != "team" %>
+            <% if present_organization_avatar? %>
+              <sup><img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="26" width="26"></sup>
+            <% end %>
           <% end %>
         </div>
         <% if !Cartodb.config[:cartodb_com_hosted].present? && @organization.present? %>

--- a/app/views/admin/shared/_sessions_header.html.erb
+++ b/app/views/admin/shared/_sessions_header.html.erb
@@ -5,7 +5,7 @@
         <div class="Navbar-title">
           <picture class="Navbar-brand">
             <% if login_org_avatar %>
-              <img src="<%= @organization.avatar_url %>" alt="<%= @organization.name %>" height="48" />
+              <img src="<%= @organization.avatar_url.sub(/^https?\:/, '') %>" alt="<%= @organization.name %>" height="48" />
             <% else %>
               <source type="image/svg+xml" srcset="<%= image_path "layout/sessions/brand.svg" %>">
               <img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="48" width="48" />

--- a/app/views/admin/shared/_sessions_header.html.erb
+++ b/app/views/admin/shared/_sessions_header.html.erb
@@ -3,17 +3,7 @@
     <nav class="Navbar <%= align %>">
       <div class="Navbar-header">
         <div class="Navbar-title">
-          <picture class="Navbar-brand">
-            <% if show_organization_avatar? %>
-              <img src="<%= @organization.avatar_url.sub(/^https?\:/, '') %>" alt="<%= @organization.name %>" height="48" />
-            <% else %>
-              <source type="image/svg+xml" srcset="<%= image_path "layout/sessions/brand.svg" %>">
-              <img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="48" width="48" />
-            <% end %>
-          </picture>
-          <% if show_organization_avatar? %>
-            <sup><img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="26" width="26"></sup>
-          <% end %>
+          <%= render_organization_avatar %>
         </div>
         <% if !Cartodb.config[:cartodb_com_hosted].present? && @organization.present? %>
           <div class="Navbar-text">Not part of <%= @organization.name %>? Go to <a class="Navbar-textLink" href="http://cartodb.com">cartodb.com</a></div>

--- a/app/views/admin/shared/_sessions_header.html.erb
+++ b/app/views/admin/shared/_sessions_header.html.erb
@@ -4,19 +4,15 @@
       <div class="Navbar-header">
         <div class="Navbar-title">
           <picture class="Navbar-brand">
-            <% if @organization && @organization.name != "team" %>
-              <% if present_organization_avatar? %>
-                <img src="<%= @organization.avatar_url.sub(/^https?\:/, '') %>" alt="<%= @organization.name %>" height="48" />
-              <% end %>
+            <% if show_organization_avatar? %>
+              <img src="<%= @organization.avatar_url.sub(/^https?\:/, '') %>" alt="<%= @organization.name %>" height="48" />
             <% else %>
               <source type="image/svg+xml" srcset="<%= image_path "layout/sessions/brand.svg" %>">
               <img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="48" width="48" />
             <% end %>
           </picture>
-          <% if @organization && @organization.name != "team" %>
-            <% if present_organization_avatar? %>
-              <sup><img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="26" width="26"></sup>
-            <% end %>
+          <% if show_organization_avatar? %>
+            <sup><img src="<%= image_path "layout/sessions/brand.png" %>" alt="CartoDB" height="26" width="26"></sup>
           <% end %>
         </div>
         <% if !Cartodb.config[:cartodb_com_hosted].present? && @organization.present? %>


### PR DESCRIPTION
Avatar source was not rendered because the url was set with `http` protocol when the content is located in a `https` page. More info [here](https://developer.mozilla.org/en-US/docs/Security/Mixed_content).

The solution was remove the protocol from the url (i.e. `//s3.whatever.com/logo.svg`).

CR @xavijam cc @juanignaciosl 