### PR TITLE
Use branch heads for internal deps

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18,13 +18,13 @@
           "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
         },
         "caniuse-db": {
-          "version": "1.0.30000430",
+          "version": "1.0.30000431",
           "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000430.tgz"
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000431.tgz"
         },
         "postcss": {
           "version": "4.1.16",
-          "from": "postcss@>=4.1.12 <4.2.0",
+          "from": "postcss@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
           "dependencies": {
             "es6-promise": {
@@ -104,7 +104,7 @@
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
+              "from": "through@>=2.2.7 <3.0.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
@@ -162,7 +162,7 @@
         },
         "browser-resolve": {
           "version": "1.11.1",
-          "from": "browser-resolve@>=1.11.0 <2.0.0",
+          "from": "browser-resolve@>=1.7.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
         },
         "browserify-zlib": {
@@ -540,7 +540,7 @@
         },
         "deps-sort": {
           "version": "1.3.9",
-          "from": "deps-sort@>=1.3.5 <2.0.0",
+          "from": "deps-sort@>=1.3.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz"
         },
         "domain-browser": {
@@ -615,7 +615,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
@@ -683,7 +683,7 @@
         },
         "insert-module-globals": {
           "version": "6.6.3",
-          "from": "insert-module-globals@>=6.4.1 <7.0.0",
+          "from": "insert-module-globals@>=6.2.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
           "dependencies": {
             "combine-source-map": {
@@ -763,7 +763,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13 <2.0.0",
+                  "from": "readable-stream@>=1.1.13-1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -789,7 +789,7 @@
         },
         "module-deps": {
           "version": "3.9.1",
-          "from": "module-deps@>=3.7.0 <4.0.0",
+          "from": "module-deps@>=3.7.11 <4.0.0",
           "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
           "dependencies": {
             "detective": {
@@ -893,7 +893,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "from": "readable-stream@>=1.0.31 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -1172,7 +1172,7 @@
             },
             "map-obj": {
               "version": "1.0.1",
-              "from": "map-obj@>=1.0.1 <1.1.0",
+              "from": "map-obj@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
             },
             "replace-requires": {
@@ -1207,12 +1207,12 @@
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.0 <3.0.0",
+                          "from": "esutils@>=2.0.2 <3.0.0",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "esprima": {
                           "version": "2.7.2",
-                          "from": "esprima@>=2.1.0 <3.0.0",
+                          "from": "esprima@>=2.7.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                         },
                         "optionator": {
@@ -1275,7 +1275,7 @@
                   "dependencies": {
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "escape-string-regexp@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     }
                   }
@@ -1287,7 +1287,7 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -1345,7 +1345,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@>=1.1.13 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -1463,13 +1463,13 @@
     },
     "cartodb-deep-insights.js": {
       "version": "0.0.1",
-      "from": "cartodb/deep-insights.js#5a8d314",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#5a8d3146e151dfc86f0989a063c24c4de7663943",
+      "from": "cartodb/deep-insights.js#master",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#83392c76dbec85b46cdaa8abbac05dd1eed6de11",
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
-          "from": "cartodb/cartodb.js#3079e6d",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#3079e6d60eb8aa177af33980cc419cb0fe2730cb",
+          "from": "cartodb/cartodb.js#v4",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#11437811119b7f06c73ecf4a7f7e21cc3ab5cf9c",
           "dependencies": {
             "leaflet": {
               "version": "0.7.3",
@@ -1528,9 +1528,9 @@
               "resolved": "git://github.com/cartodb/CartoAssets.git#fd009fd68b0ac811ef7220e95c1ff4c708fefc41"
             },
             "d3.cartodb": {
-              "version": "1.0.1",
-              "from": "cartodb/d3.cartodb#7816870",
-              "resolved": "git://github.com/cartodb/d3.cartodb.git#78168701bfa09bb240ab686313ff887c978107f9",
+              "version": "1.0.2",
+              "from": "cartodb/d3.cartodb#gh-pages",
+              "resolved": "git://github.com/cartodb/d3.cartodb.git#8e4f70947e74ca77634a806b1c3415b8c4504c16",
               "dependencies": {
                 "carto": {
                   "version": "0.15.1-cdb1",
@@ -2130,7 +2130,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
@@ -2176,7 +2176,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -2203,7 +2203,7 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -2231,8 +2231,8 @@
     },
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
-      "from": "cartodb/cartodb.js#3079e6d",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#3079e6d60eb8aa177af33980cc419cb0fe2730cb",
+      "from": "cartodb/cartodb.js#v4",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#11437811119b7f06c73ecf4a7f7e21cc3ab5cf9c",
       "dependencies": {
         "jstify": {
           "version": "0.12.0",
@@ -2403,7 +2403,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
@@ -2449,7 +2449,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.26 <1.1.0",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -2476,7 +2476,7 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -2557,9 +2557,9 @@
           "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.8.tgz"
         },
         "d3.cartodb": {
-          "version": "1.0.1",
-          "from": "cartodb/d3.cartodb#7816870",
-          "resolved": "git://github.com/cartodb/d3.cartodb.git#78168701bfa09bb240ab686313ff887c978107f9",
+          "version": "1.0.2",
+          "from": "cartodb/d3.cartodb#gh-pages",
+          "resolved": "git://github.com/cartodb/d3.cartodb.git#8e4f70947e74ca77634a806b1c3415b8c4504c16",
           "dependencies": {
             "carto": {
               "version": "0.15.1-cdb1",
@@ -3029,7 +3029,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -3091,7 +3091,7 @@
         },
         "postcss": {
           "version": "4.1.16",
-          "from": "postcss@>=4.1.12 <4.2.0",
+          "from": "postcss@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
           "dependencies": {
             "es6-promise": {
@@ -3357,7 +3357,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -3367,7 +3367,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -3379,7 +3379,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -3415,7 +3415,7 @@
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.10 <0.3.0",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "lodash": {
@@ -3757,7 +3757,7 @@
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.6 <3.0.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
@@ -3815,7 +3815,7 @@
                 },
                 "browser-resolve": {
                   "version": "1.11.1",
-                  "from": "browser-resolve@>=1.11.0 <2.0.0",
+                  "from": "browser-resolve@>=1.7.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
                 },
                 "browserify-zlib": {
@@ -4428,9 +4428,9 @@
                   }
                 },
                 "shell-quote": {
-                  "version": "1.4.3",
+                  "version": "1.5.0",
                   "from": "shell-quote@>=1.4.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.5.0.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
@@ -4680,11 +4680,6 @@
                         }
                       }
                     },
-                    "ansi-styles": {
-                      "version": "2.1.0",
-                      "from": "ansi-styles@^2.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                    },
                     "ansi": {
                       "version": "0.3.1",
                       "from": "ansi@~0.3.1",
@@ -4695,20 +4690,25 @@
                       "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     },
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "from": "assert-plus@^0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "ansi-styles@^2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.6",
+                      "from": "are-we-there-yet@~1.0.6",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz"
                     },
                     "asn1": {
                       "version": "0.2.3",
                       "from": "asn1@>=0.2.3 <0.3.0",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
-                    "are-we-there-yet": {
-                      "version": "1.0.6",
-                      "from": "are-we-there-yet@~1.0.6",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz"
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "from": "assert-plus@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                     },
                     "async": {
                       "version": "1.5.2",
@@ -4760,6 +4760,11 @@
                       "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
                     "dashdash": {
                       "version": "1.12.2",
                       "from": "dashdash@>=1.10.1 <2.0.0",
@@ -4769,11 +4774,6 @@
                       "version": "2.2.0",
                       "from": "debug@~2.2.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                     },
                     "deep-extend": {
                       "version": "0.4.1",
@@ -4785,6 +4785,11 @@
                       "from": "delayed-stream@~1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     },
+                    "delegates": {
+                      "version": "1.0.0",
+                      "from": "delegates@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                    },
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "from": "ecc-jsbn@>=0.0.1 <1.0.0",
@@ -4794,11 +4799,6 @@
                       "version": "1.0.4",
                       "from": "escape-string-regexp@^1.0.2",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                    },
-                    "delegates": {
-                      "version": "1.0.0",
-                      "from": "delegates@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                     },
                     "extend": {
                       "version": "3.0.0",
@@ -4825,25 +4825,20 @@
                       "from": "fstream@^1.0.2",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                     },
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
                     "gauge": {
                       "version": "1.2.5",
                       "from": "gauge@~1.2.5",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz"
                     },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
                     "generate-object-property": {
                       "version": "1.2.0",
                       "from": "generate-object-property@^1.1.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-                    },
-                    "har-validator": {
-                      "version": "2.0.6",
-                      "from": "har-validator@~2.0.6",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                     },
                     "graceful-fs": {
                       "version": "4.1.3",
@@ -4855,15 +4850,20 @@
                       "from": "graceful-readlink@>= 1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     },
-                    "has-unicode": {
-                      "version": "2.0.0",
-                      "from": "has-unicode@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                    "har-validator": {
+                      "version": "2.0.6",
+                      "from": "har-validator@~2.0.6",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
                       "from": "has-ansi@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    },
+                    "has-unicode": {
+                      "version": "2.0.0",
+                      "from": "has-unicode@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                     },
                     "hawk": {
                       "version": "3.1.3",
@@ -4885,11 +4885,6 @@
                       "from": "inherits@*",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
-                    "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    },
                     "ini": {
                       "version": "1.3.4",
                       "from": "ini@~1.3.0",
@@ -4899,6 +4894,11 @@
                       "version": "2.12.4",
                       "from": "is-my-json-valid@^2.12.4",
                       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz"
+                    },
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     },
                     "is-typedarray": {
                       "version": "1.0.0",
@@ -4925,11 +4925,6 @@
                       "from": "jsbn@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
-                    "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                    },
                     "json-schema": {
                       "version": "0.2.2",
                       "from": "json-schema@0.2.2",
@@ -4939,6 +4934,11 @@
                       "version": "5.0.1",
                       "from": "json-stringify-safe@~5.0.1",
                       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "jsprim": {
                       "version": "1.2.2",
@@ -4950,15 +4950,15 @@
                       "from": "lodash._basetostring@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                     },
-                    "lodash._root": {
-                      "version": "3.0.0",
-                      "from": "lodash._root@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.0.tgz"
-                    },
                     "lodash._createpadding": {
                       "version": "3.6.1",
                       "from": "lodash._createpadding@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                    },
+                    "lodash._root": {
+                      "version": "3.0.0",
+                      "from": "lodash._root@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.0.tgz"
                     },
                     "lodash.pad": {
                       "version": "3.3.0",
@@ -4985,15 +4985,15 @@
                       "from": "mime-db@~1.21.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                     },
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    },
                     "mime-types": {
                       "version": "2.1.9",
                       "from": "mime-types@~2.1.7",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
@@ -5020,15 +5020,15 @@
                       "from": "oauth-sign@~0.8.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                     },
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "from": "pinkie@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    },
                     "once": {
                       "version": "1.3.3",
                       "from": "once@~1.3.3",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                    },
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "from": "pinkie@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.0",
@@ -5065,6 +5065,11 @@
                       "from": "sntp@1.x.x",
                       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                     },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
                     "sshpk": {
                       "version": "1.7.3",
                       "from": "sshpk@^1.7.0",
@@ -5084,11 +5089,6 @@
                       "version": "1.0.4",
                       "from": "strip-json-comments@~1.0.4",
                       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "supports-color": {
                       "version": "2.0.0",
@@ -5130,15 +5130,15 @@
                       "from": "util-deprecate@~1.0.1",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     },
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    },
                     "verror": {
                       "version": "1.3.6",
                       "from": "verror@1.3.6",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
@@ -5287,9 +5287,9 @@
               "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
               "dependencies": {
                 "shell-quote": {
-                  "version": "1.4.3",
+                  "version": "1.5.0",
                   "from": "shell-quote@>=1.4.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.5.0.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
@@ -5499,7 +5499,7 @@
                         },
                         "decamelize": {
                           "version": "1.2.0",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
+                          "from": "decamelize@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "loud-rejection": {
@@ -5558,7 +5558,7 @@
                                   "dependencies": {
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                     }
                                   }
@@ -5575,7 +5575,7 @@
                                     },
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                     }
                                   }
@@ -6007,7 +6007,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -6017,7 +6017,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -6029,7 +6029,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -6065,7 +6065,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -6075,7 +6075,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -6087,7 +6087,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -6443,7 +6443,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -6491,7 +6491,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -6635,7 +6635,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "ini": {
@@ -6669,7 +6669,7 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -6691,7 +6691,7 @@
                         },
                         "os-tmpdir": {
                           "version": "1.0.1",
-                          "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                          "from": "os-tmpdir@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                         }
                       }
@@ -6720,7 +6720,7 @@
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.26 <1.1.0",
+                          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
@@ -6903,7 +6903,7 @@
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.0 <5.0.0",
+              "from": "semver@>=4.0.3 <5.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "temporary": {
@@ -7050,7 +7050,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -7060,7 +7060,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -7072,7 +7072,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -7158,7 +7158,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -7229,7 +7229,7 @@
                     },
                     "readable-stream": {
                       "version": "2.0.6",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "from": "readable-stream@>=2.0.2 <3.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
@@ -7263,7 +7263,7 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
+                  "from": "browserify-zlib@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
@@ -7304,7 +7304,7 @@
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "decamelize@>=1.1.2 <2.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "loud-rejection": {
@@ -7331,7 +7331,7 @@
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@>=1.1.3 <2.0.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "normalize-package-data": {
@@ -7373,7 +7373,7 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                 }
                               }
@@ -7390,7 +7390,7 @@
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                 }
                               }
@@ -7564,7 +7564,7 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "strip-indent@>=1.0.0 <2.0.0",
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                         }
                       }
@@ -7836,7 +7836,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -7951,9 +7951,9 @@
       "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.13.0.tgz",
       "dependencies": {
         "html-minifier": {
-          "version": "1.2.0",
+          "version": "1.3.0",
           "from": "html-minifier@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.3.0.tgz",
           "dependencies": {
             "change-case": {
               "version": "2.3.1",
@@ -8097,7 +8097,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -8126,7 +8126,7 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -8167,7 +8167,7 @@
                 },
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -8196,6 +8196,18 @@
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
+                }
+              }
+            },
+            "ncname": {
+              "version": "1.0.0",
+              "from": "ncname@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+              "dependencies": {
+                "xml-char-classes": {
+                  "version": "1.0.0",
+                  "from": "xml-char-classes@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
                 }
               }
             },
@@ -8325,7 +8337,7 @@
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "decamelize@>=1.1.2 <2.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
@@ -8626,7 +8638,7 @@
             },
             "doctrine": {
               "version": "0.7.2",
-              "from": "doctrine@>=0.7.1 <0.8.0",
+              "from": "doctrine@>=0.7.0 <0.8.0",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
               "dependencies": {
                 "esutils": {
@@ -8648,7 +8660,7 @@
             },
             "escope": {
               "version": "3.6.0",
-              "from": "escope@>=3.3.0 <4.0.0",
+              "from": "escope@>=3.2.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
               "dependencies": {
                 "es6-map": {
@@ -8678,7 +8690,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     },
                     "event-emitter": {
@@ -8710,7 +8722,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     }
                   }
@@ -8731,7 +8743,7 @@
             },
             "espree": {
               "version": "2.2.5",
-              "from": "espree@>=2.0.3 <3.0.0",
+              "from": "espree@>=2.2.4 <3.0.0",
               "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
             },
             "estraverse": {
@@ -8924,7 +8936,7 @@
             },
             "glob": {
               "version": "5.0.15",
-              "from": "glob@>=5.0.14 <6.0.0",
+              "from": "glob@>=5.0.10 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
@@ -8946,7 +8958,7 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
@@ -9188,7 +9200,7 @@
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "lodash@>=3.3.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "readline2": {
@@ -9289,7 +9301,7 @@
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.6 <3.0.0",
+                  "from": "through@>=2.2.7 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
@@ -9641,7 +9653,7 @@
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
@@ -9951,7 +9963,7 @@
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.14 <6.0.0",
+                  "from": "glob@>=5.0.10 <6.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
@@ -10098,7 +10110,7 @@
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "debug@>=2.1.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
@@ -10122,7 +10134,7 @@
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "debug@>=2.1.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
@@ -10156,7 +10168,7 @@
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "debug@>=2.1.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
@@ -10471,7 +10483,7 @@
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.0 <4.0.0",
+                      "from": "lodash@>=3.3.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "minimatch": {
@@ -10715,7 +10727,7 @@
                                       "dependencies": {
                                         "align-text": {
                                           "version": "0.1.4",
-                                          "from": "align-text@>=0.1.1 <0.2.0",
+                                          "from": "align-text@>=0.1.3 <0.2.0",
                                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                           "dependencies": {
                                             "kind-of": {
@@ -10822,9 +10834,9 @@
                                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                                 },
                                 "y18n": {
-                                  "version": "3.2.0",
+                                  "version": "3.2.1",
                                   "from": "y18n@>=3.2.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
                                 }
                               }
                             }
@@ -10849,7 +10861,7 @@
                         },
                         "through": {
                           "version": "2.3.8",
-                          "from": "through@>=2.3.8 <2.4.0",
+                          "from": "through@>=2.2.7 <3.0.0",
                           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                         }
                       }
@@ -10861,7 +10873,7 @@
                       "dependencies": {
                         "esprima": {
                           "version": "2.7.2",
-                          "from": "esprima@>=2.6.0 <3.0.0",
+                          "from": "esprima@>=2.7.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                         },
                         "recast": {
@@ -11012,7 +11024,7 @@
                     },
                     "object-keys": {
                       "version": "1.0.9",
-                      "from": "object-keys@>=1.0.6 <2.0.0",
+                      "from": "object-keys@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
                     }
                   }
@@ -11108,7 +11120,7 @@
               "dependencies": {
                 "espree": {
                   "version": "2.2.5",
-                  "from": "espree@>=2.0.3 <3.0.0",
+                  "from": "espree@>=2.2.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
                 },
                 "rocambole": {
@@ -11171,7 +11183,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -11200,7 +11212,7 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -11311,7 +11323,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
@@ -11367,7 +11379,7 @@
                 },
                 "doctrine": {
                   "version": "0.7.2",
-                  "from": "doctrine@>=0.7.1 <0.8.0",
+                  "from": "doctrine@>=0.7.0 <0.8.0",
                   "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
                   "dependencies": {
                     "esutils": {
@@ -11389,7 +11401,7 @@
                 },
                 "escope": {
                   "version": "3.6.0",
-                  "from": "escope@>=3.3.0 <4.0.0",
+                  "from": "escope@>=3.2.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
                   "dependencies": {
                     "es6-map": {
@@ -11419,7 +11431,7 @@
                         },
                         "es6-symbol": {
                           "version": "3.0.2",
-                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "from": "es6-symbol@>=3.0.1 <3.1.0",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                         },
                         "event-emitter": {
@@ -11451,7 +11463,7 @@
                         },
                         "es6-symbol": {
                           "version": "3.0.2",
-                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "from": "es6-symbol@>=3.0.1 <3.1.0",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                         }
                       }
@@ -11472,7 +11484,7 @@
                 },
                 "espree": {
                   "version": "2.2.5",
-                  "from": "espree@>=2.0.3 <3.0.0",
+                  "from": "espree@>=2.2.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
                 },
                 "estraverse": {
@@ -11665,7 +11677,7 @@
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.14 <6.0.0",
+                  "from": "glob@>=5.0.10 <6.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
@@ -11687,7 +11699,7 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -11929,7 +11941,7 @@
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.0 <4.0.0",
+                      "from": "lodash@>=3.3.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "readline2": {
@@ -12030,7 +12042,7 @@
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.6 <3.0.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
@@ -12377,7 +12389,7 @@
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "from": "minimatch@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
@@ -12538,7 +12550,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -12603,7 +12615,7 @@
             },
             "decamelize": {
               "version": "1.2.0",
-              "from": "decamelize@>=1.1.2 <2.0.0",
+              "from": "decamelize@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
             },
             "window-size": {
@@ -12647,7 +12659,7 @@
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.6 <3.0.0",
+                  "from": "through@>=2.2.7 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
@@ -12755,7 +12767,7 @@
             },
             "browser-resolve": {
               "version": "1.11.1",
-              "from": "browser-resolve@>=1.11.0 <2.0.0",
+              "from": "browser-resolve@>=1.7.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
             },
             "browserify-zlib": {
@@ -13121,7 +13133,7 @@
             },
             "deps-sort": {
               "version": "1.3.9",
-              "from": "deps-sort@>=1.3.5 <2.0.0",
+              "from": "deps-sort@>=1.3.7 <2.0.0",
               "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
               "dependencies": {
                 "JSONStream": {
@@ -13136,7 +13148,7 @@
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.6 <3.0.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
@@ -13201,7 +13213,7 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
@@ -13249,7 +13261,7 @@
             },
             "insert-module-globals": {
               "version": "6.6.3",
-              "from": "insert-module-globals@>=6.4.1 <7.0.0",
+              "from": "insert-module-globals@>=6.2.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
               "dependencies": {
                 "JSONStream": {
@@ -13370,7 +13382,7 @@
             },
             "module-deps": {
               "version": "3.9.1",
-              "from": "module-deps@>=3.7.0 <4.0.0",
+              "from": "module-deps@>=3.7.11 <4.0.0",
               "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
               "dependencies": {
                 "JSONStream": {
@@ -13994,15 +14006,15 @@
                   "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 },
-                "are-we-there-yet": {
-                  "version": "1.0.6",
-                  "from": "are-we-there-yet@~1.0.6",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz"
-                },
                 "ansi-styles": {
                   "version": "2.1.0",
                   "from": "ansi-styles@^2.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                },
+                "are-we-there-yet": {
+                  "version": "1.0.6",
+                  "from": "are-we-there-yet@~1.0.6",
+                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz"
                 },
                 "asn1": {
                   "version": "0.2.3",
@@ -14024,15 +14036,15 @@
                   "from": "aws-sign2@~0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
-                "block-stream": {
-                  "version": "0.0.8",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                },
                 "bl": {
                   "version": "1.0.2",
                   "from": "bl@~1.0.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz"
+                },
+                "block-stream": {
+                  "version": "0.0.8",
+                  "from": "block-stream@*",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
@@ -14084,15 +14096,15 @@
                   "from": "deep-extend@~0.4.0",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
-                "delegates": {
-                  "version": "1.0.0",
-                  "from": "delegates@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-                },
                 "delayed-stream": {
                   "version": "1.0.0",
                   "from": "delayed-stream@~1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "from": "delegates@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
@@ -14139,11 +14151,6 @@
                   "from": "generate-function@^2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>= 1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                },
                 "generate-object-property": {
                   "version": "1.2.0",
                   "from": "generate-object-property@^1.1.0",
@@ -14153,6 +14160,11 @@
                   "version": "4.1.3",
                   "from": "graceful-fs@^4.1.2",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                },
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>= 1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 },
                 "har-validator": {
                   "version": "2.0.6",
@@ -14164,15 +14176,15 @@
                   "from": "has-ansi@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                 },
-                "has-unicode": {
-                  "version": "2.0.0",
-                  "from": "has-unicode@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
-                },
                 "hawk": {
                   "version": "3.1.3",
                   "from": "hawk@~3.1.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                },
+                "has-unicode": {
+                  "version": "2.0.0",
+                  "from": "has-unicode@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                 },
                 "hoek": {
                   "version": "2.16.3",
@@ -14189,11 +14201,6 @@
                   "from": "inherits@*",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
-                "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                },
                 "is-my-json-valid": {
                   "version": "2.12.4",
                   "from": "is-my-json-valid@^2.12.4",
@@ -14209,25 +14216,30 @@
                   "from": "is-typedarray@~1.0.0",
                   "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                 },
-                "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@~0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
-                "jsbn": {
-                  "version": "0.1.0",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@~1.3.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@~0.1.2",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
                   "from": "jodid25519@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "jsbn": {
+                  "version": "0.1.0",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.2",
@@ -14249,15 +14261,15 @@
                   "from": "jsprim@^1.2.2",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                 },
-                "lodash._createpadding": {
-                  "version": "3.6.1",
-                  "from": "lodash._createpadding@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-                },
                 "lodash._basetostring": {
                   "version": "3.0.1",
                   "from": "lodash._basetostring@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                },
+                "lodash._createpadding": {
+                  "version": "3.6.1",
+                  "from": "lodash._createpadding@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
                 },
                 "lodash._root": {
                   "version": "3.0.0",
@@ -14269,15 +14281,15 @@
                   "from": "lodash.pad@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.3.0.tgz"
                 },
-                "lodash.padright": {
-                  "version": "3.1.1",
-                  "from": "lodash.padright@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-                },
                 "lodash.padleft": {
                   "version": "3.1.1",
                   "from": "lodash.padleft@^3.0.0",
                   "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                },
+                "lodash.padright": {
+                  "version": "3.1.1",
+                  "from": "lodash.padright@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
                 },
                 "lodash.repeat": {
                   "version": "3.2.0",
@@ -14289,25 +14301,20 @@
                   "from": "mime-db@~1.21.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                 },
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                },
                 "mime-types": {
                   "version": "2.1.9",
                   "from": "mime-types@~2.1.7",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
                 },
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                },
                 "mkdirp": {
                   "version": "0.5.1",
                   "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                },
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "node-uuid": {
                   "version": "1.4.7",
@@ -14319,30 +14326,30 @@
                   "from": "npmlog@~2.0.0",
                   "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.2.tgz"
                 },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@~1.3.3",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-                },
                 "oauth-sign": {
                   "version": "0.8.1",
                   "from": "oauth-sign@~0.8.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@~1.3.3",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
                 },
                 "pinkie": {
                   "version": "2.0.4",
                   "from": "pinkie@^2.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "process-nextick-args@~1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
                 "pinkie-promise": {
                   "version": "2.0.0",
                   "from": "pinkie-promise@^2.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@~1.0.6",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "qs": {
                   "version": "6.0.2",
@@ -14359,20 +14366,25 @@
                   "from": "request@2.x",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
                 },
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                },
                 "semver": {
                   "version": "5.1.0",
                   "from": "semver@~5.1.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                 },
-                "sshpk": {
-                  "version": "1.7.3",
-                  "from": "sshpk@^1.7.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
-                },
                 "sntp": {
                   "version": "1.0.9",
                   "from": "sntp@1.x.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                },
+                "sshpk": {
+                  "version": "1.7.3",
+                  "from": "sshpk@^1.7.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -14399,15 +14411,15 @@
                   "from": "supports-color@^2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 },
-                "tar-pack": {
-                  "version": "3.1.3",
-                  "from": "tar-pack@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
-                },
                 "tar": {
                   "version": "2.2.1",
                   "from": "tar@~2.2.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                },
+                "tar-pack": {
+                  "version": "3.1.3",
+                  "from": "tar-pack@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
                 },
                 "tough-cookie": {
                   "version": "2.2.1",
@@ -14423,11 +14435,6 @@
                   "version": "0.13.3",
                   "from": "tweetnacl@>=0.13.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "from": "uid-number@~0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
@@ -14448,6 +14455,11 @@
                   "version": "4.0.1",
                   "from": "xtend@^4.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "from": "uid-number@~0.0.6",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                 },
                 "aws4": {
                   "version": "1.2.1",
@@ -14591,9 +14603,9 @@
           "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
           "dependencies": {
             "shell-quote": {
-              "version": "1.4.3",
+              "version": "1.5.0",
               "from": "shell-quote@>=1.4.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.5.0.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,6 @@
     ]
   },
   "scripts": {
-    "update-internal-deps": "npm update cartodb.js cartodb-deep-insights.js && npm shrinkwrap --dev"
+    "update-internal-deps": "npm update camshaft-reference cartoassets cartodb-deep-insights.js cartodb.js && npm shrinkwrap --dev"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "browserify-shim": "3.8.10",
     "camshaft-reference": "^0.1.0",
     "cartoassets": "cartodb/CartoAssets#master",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#5a8d314",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "cartodb/cartodb.js#3079e6d",
+    "cartodb.js": "cartodb/cartodb.js#v4",
     "csswring": "^3.0.5",
     "git-rev": "0.2.1",
     "grunt": "0.4.5",
@@ -130,5 +130,8 @@
       "/tmp",
       "/vendor"
     ]
+  },
+  "scripts": {
+    "update-internal-deps": "npm update cartodb.js cartodb-deep-insights.js && npm shrinkwrap --dev"
   }
 }


### PR DESCRIPTION
Ditto https://github.com/CartoDB/cartodb.js/pull/1199

A plain `npm install` will install dependencies defined in the shrinkwrap file, regardless of what's stated in package.json. To update an arbitrary dependency you would need to modify the `package.json`, and then do a `npm update name-of-pkg && npm shrinkwrap --dev`.

To ease development for ourselves, I've added a npm script that basically does the above for our own owned libs:

```bash
$ npm run update-internal-deps
> npm update camshaft-reference cartoassets cartodb-deep-insights.js cartodb.js && npm shrinkwrap --dev
…
```

Running the command above will change `npm-shrinkwrap.json`, review it before the commit/PR, so the changes you want are included in there.

cc @javisantana @fdansv @alonsogarciapablo @xavijam @javierarce  @rochoa (did I miss someone? feel free to mention them)
