### PR TITLE
6895 integrate layers api

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
@@ -22,7 +22,7 @@ module.exports = cdb.core.Model.extend({
         _.omit(r.options, ['table_name', 'query'])
     );
 
-    // Only use one type internally, is mapped back to kind when serialized (see .toJSON)
+    // Only use type on the frontend, it will be mapped back when the model is serialized (see .toJSON)
     attrs.type = attrs.type || layerTypesAndKinds.getType(attrs.kind);
 
     var tableName = r.options.table_name;

--- a/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
@@ -3,7 +3,7 @@ var _ = require('underscore');
 var LayerTableModel = require('./layer-table-model');
 var nodeIds = require('./analysis-definition-node-ids.js');
 
-var OWN_ATTR_NAMES = ['id', 'kind', 'order', 'table_name_alias'];
+var OWN_ATTR_NAMES = ['id', 'infowindow', 'kind', 'order', 'table_name_alias', 'tooltip'];
 
 /**
  * Model to edit a layer definition.

--- a/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
@@ -2,14 +2,16 @@ var cdb = require('cartodb-deep-insights.js');
 var _ = require('underscore');
 var LayerTableModel = require('./layer-table-model');
 var nodeIds = require('./analysis-definition-node-ids.js');
+var layerTypesAndKinds = require('./layer-types-and-kinds');
 
-var OWN_ATTR_NAMES = ['id', 'infowindow', 'kind', 'order', 'table_name_alias', 'tooltip'];
+var OWN_ATTR_NAMES = ['id', 'infowindow', 'order', 'table_name_alias', 'tooltip'];
 
 /**
  * Model to edit a layer definition.
  * Should always exist as part of a LayerDefinitionsCollection, so its URL is given from there.
  */
 module.exports = cdb.core.Model.extend({
+
   parse: function (r, opts) {
     r.options = r.options || {};
 
@@ -19,6 +21,9 @@ module.exports = cdb.core.Model.extend({
         _.pick(r, OWN_ATTR_NAMES),
         _.omit(r.options, ['table_name', 'query'])
     );
+
+    // Only use one type internally, is mapped back to kind when serialized (see .toJSON)
+    attrs.type = attrs.type || layerTypesAndKinds.getType(attrs.kind);
 
     var tableName = r.options.table_name;
     if (tableName) {
@@ -62,8 +67,11 @@ module.exports = cdb.core.Model.extend({
     _.defaults(options, _.omit(this.attributes, OWN_ATTR_NAMES));
 
     var json = _.defaults(
-      _.pick(this.attributes, OWN_ATTR_NAMES),
-      { options: options }
+      {
+        kind: layerTypesAndKinds.getKind(this.get('type')),
+        options: options
+      },
+      _.pick(this.attributes, OWN_ATTR_NAMES)
     );
 
     return json;

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -49,7 +49,7 @@ module.exports = Backbone.Collection.extend({
     var self = opts.collection;
 
     // Add data required for new editor if not set (e.g. a vis created on old editor doesn't contain letter and source)
-    var o = _.clone(d.options || {});
+    var o = _.clone(d.options) || {};
     var attrs = _.defaults({ options: o }, _.omit(d, ['options']));
 
     if (!attrs.kind) {
@@ -67,8 +67,8 @@ module.exports = Backbone.Collection.extend({
       o.source = o.source || sourceId;
 
       // TODO new props for cartodb.js v4; how should these really be set?
-      o.sql = o.query || 'SELECT * FROM ' + o.table_name;
-      o.cartocss = o.tile_style;
+      o.sql = o.sql || o.query || 'SELECT * FROM ' + o.table_name;
+      o.cartocss = o.cartocss || o.tile_style;
 
       // Add analysis definition unless already existing
       self._analysisDefinitionNodesCollection.add({

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -15,9 +15,8 @@ var LAYER_TYPE_TO_LAYER_CREATE_METHOD = {
 };
 
 var TYPE_TO_KIND_MAP = {
-  'Background': 'background',
   'CartoDB': 'carto',
-  'Plain': 'plain',
+  'Plain': 'background',
   'Tiled': 'tiled',
   'Torque': 'torque',
   'Wms': 'wms'

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -14,14 +14,6 @@ var LAYER_TYPE_TO_LAYER_CREATE_METHOD = {
   'wms': 'createWMSLayer'
 };
 
-var TYPE_TO_KIND_MAP = {
-  'CartoDB': 'carto',
-  'Plain': 'background',
-  'Tiled': 'tiled',
-  'Torque': 'torque',
-  'Wms': 'wms'
-};
-
 /**
  * Collection of layer definitions
  */
@@ -50,11 +42,10 @@ module.exports = Backbone.Collection.extend({
 
     // Add data required for new editor if not set (e.g. a vis created on old editor doesn't contain letter and source)
     var o = _.clone(d.options) || {};
-    var attrs = _.defaults({ options: o }, _.omit(d, ['options']));
-
-    if (!attrs.kind) {
-      attrs.kind = TYPE_TO_KIND_MAP[o.type];
-    }
+    var attrs = _.defaults(
+      { options: o },
+      _.omit(d, ['options']
+    ));
 
     if (attrs.order !== 0) {
       // Only for non-basemap layers
@@ -135,8 +126,6 @@ module.exports = Backbone.Collection.extend({
 
     if (!m.isNew()) {
       if (attrs.type) {
-        // Should be ok to set silently, since we should no longer use kind in the rest of the editor code
-        m.set('kind', TYPE_TO_KIND_MAP[attrs.type], {silent: true});
         layer.remove();
         this._createLayer(m);
       } else {

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -14,6 +14,15 @@ var LAYER_TYPE_TO_LAYER_CREATE_METHOD = {
   'wms': 'createWMSLayer'
 };
 
+var TYPE_TO_KIND_MAP = {
+  'Background': 'background',
+  'CartoDB': 'carto',
+  'Plain': 'plain',
+  'Tiled': 'tiled',
+  'Torque': 'torque',
+  'Wms': 'wms'
+};
+
 /**
  * Collection of layer definitions
  */
@@ -29,6 +38,10 @@ module.exports = Backbone.Collection.extend({
     // Add data required for new editor if not set (e.g. a vis created on old editor doesn't contain letter and source)
     var o = _.clone(d.options || {});
     var attrs = _.defaults({ options: o }, _.omit(d, ['options']));
+
+    if (!attrs.kind) {
+      attrs.kind = TYPE_TO_KIND_MAP[o.type];
+    }
 
     // E.g. basemap should not have a letter representation
     if (o.type !== 'Tiled') {
@@ -93,7 +106,7 @@ module.exports = Backbone.Collection.extend({
 
   _onAdd: function (m) {
     // If added but not yet saved, postpone the creation until persisted (see sync listener)
-    if (m.id) {
+    if (!m.isNew()) {
       this._createLayer(m);
     }
   },
@@ -108,8 +121,10 @@ module.exports = Backbone.Collection.extend({
     var attrs = m.changedAttributes();
     var layer = this._getLayer(m);
 
-    if (m.id) {
+    if (!m.isNew()) {
       if (attrs.type) {
+        // Should be ok to set silently, since we should no longer use kind in the rest of the editor code
+        m.set('kind', TYPE_TO_KIND_MAP[attrs.type], {silent: true});
         layer.remove();
         this._createLayer(m);
       } else {
@@ -121,14 +136,13 @@ module.exports = Backbone.Collection.extend({
   _onRemove: function (m) {
     this._letters.remove(m.get('letter'));
 
-    if (m.id) {
+    if (!m.isNew()) {
       this._getLayer(m).remove();
     }
   },
 
-  _getLayer: function () {
-    var id = arguments[0].id || arguments[0];
-    return this._vis.map.layers.get(id);
+  _getLayer: function (m) {
+    return this._vis.map.layers.get(m.id);
   },
 
   _createLayer: function (m) {

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -66,12 +66,16 @@ module.exports = Backbone.Collection.extend({
       var sourceId = nodeIds.next(o.letter);
       o.source = o.source || sourceId;
 
+      // TODO new props for cartodb.js v4; how should these really be set?
+      o.sql = o.query || 'SELECT * FROM ' + o.table_name;
+      o.cartocss = o.tile_style;
+
       // Add analysis definition unless already existing
       self._analysisDefinitionNodesCollection.add({
         id: sourceId,
         type: 'source',
         params: {
-          query: o.query || 'SELECT * FROM ' + o.table_name
+          query: o.sql
         }
       });
     }
@@ -152,7 +156,7 @@ module.exports = Backbone.Collection.extend({
   },
 
   _createLayer: function (m) {
-    var attrs = _.clone(m.attributes);
+    var attrs = this._deepClone(m.attributes);
 
     var createMethodName = LAYER_TYPE_TO_LAYER_CREATE_METHOD[attrs.type.toLowerCase()];
     if (!createMethodName) throw new Error('no create method name found for type ' + attrs.type);
@@ -171,6 +175,10 @@ module.exports = Backbone.Collection.extend({
     var lettersFromModelsNotYetAdded = _.chain(this._byId).values().invoke('get', 'letter').value();
 
     return _.union(lettersFromAddedModels, lettersFromModelsNotYetAdded, otherLetters);
+  },
+
+  _deepClone: function (obj) {
+    return JSON.parse(JSON.stringify(obj)); // deep clone;
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -81,12 +81,12 @@ module.exports = Backbone.Collection.extend({
 
   initialize: function (models, options) {
     if (!options.configModel) throw new Error('configModel is required');
-    if (!options.vis) throw new Error('vis is required');
+    if (!options.visMap) throw new Error('visMap (vis.map) is required');
     if (!options.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
     if (!options.mapId) throw new Error('mapId is required');
 
     this._configModel = options.configModel;
-    this._vis = options.vis;
+    this._visMap = options.visMap;
     this._analysisDefinitionNodesCollection = options.analysisDefinitionNodesCollection;
 
     this.mapId = options.mapId;
@@ -140,7 +140,7 @@ module.exports = Backbone.Collection.extend({
   },
 
   _getLayer: function (m) {
-    return this._vis.map.layers.get(m.id);
+    return this._visMap.getLayerById(m.id);
   },
 
   _createLayer: function (m) {
@@ -149,10 +149,10 @@ module.exports = Backbone.Collection.extend({
     var createMethodName = LAYER_TYPE_TO_LAYER_CREATE_METHOD[attrs.type.toLowerCase()];
     if (!createMethodName) throw new Error('no create method name found for type ' + attrs.type);
 
-    var createMethod = this._vis.map[createMethodName];
+    var createMethod = this._visMap[createMethodName];
     if (!_.isFunction(createMethod)) throw new Error(createMethodName + ' is not a function');
 
-    createMethod.call(this._vis.map, attrs);
+    createMethod.call(this._visMap, attrs);
   },
 
   _letters: function (otherLetters) {

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -4,6 +4,16 @@ var LayerDefinitionModel = require('./layer-definition-model');
 var LayerLetters = require('./layer-letters');
 var nodeIds = require('./analysis-definition-node-ids.js');
 
+var LAYER_TYPE_TO_LAYER_CREATE_METHOD = {
+  'background': 'createBackgroundLayer',
+  'cartodb': 'createCartoDBLayer',
+  'gmaps': 'createGMapsBaseLayer',
+  'plain': 'createPlainLayer',
+  'tiled': 'createTileLayer',
+  'torque': 'createTorqueLayer',
+  'wms': 'createWMSLayer'
+};
+
 /**
  * Collection of layer definitions
  */
@@ -51,12 +61,12 @@ module.exports = Backbone.Collection.extend({
 
   initialize: function (models, options) {
     if (!options.configModel) throw new Error('configModel is required');
-    if (!options.layersCollection) throw new Error('layersCollection is required');
+    if (!options.vis) throw new Error('vis is required');
     if (!options.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
     if (!options.mapId) throw new Error('mapId is required');
 
     this._configModel = options.configModel;
-    this._layersCollection = options.layersCollection;
+    this._vis = options.vis;
     this._analysisDefinitionNodesCollection = options.analysisDefinitionNodesCollection;
 
     // A collection may be reset at any time (actually used silently when collection is created),
@@ -65,6 +75,10 @@ module.exports = Backbone.Collection.extend({
     this._letters = new LayerLetters();
 
     this.mapId = options.mapId;
+
+    this.on('add', this._onAdd, this);
+    this.on('sync', this._onSync, this);
+    this.on('change', this._onChange, this);
     this.on('remove', this._onRemove, this);
   },
 
@@ -77,8 +91,56 @@ module.exports = Backbone.Collection.extend({
     return r.layers;
   },
 
+  _onAdd: function (m) {
+    // If added but not yet saved, postpone the creation until persisted (see sync listener)
+    if (m.id) {
+      this._createLayer(m);
+    }
+  },
+
+  _onSync: function (m) {
+    if (!this._getLayer(m)) {
+      this._createLayer(m);
+    }
+  },
+
+  _onChange: function (m) {
+    var attrs = m.changedAttributes();
+    var layer = this._getLayer(m);
+
+    if (m.id) {
+      if (attrs.type) {
+        layer.remove();
+        this._createLayer(m);
+      } else {
+        layer.update(attrs);
+      }
+    }
+  },
+
   _onRemove: function (m) {
     this._letters.remove(m.get('letter'));
+
+    if (m.id) {
+      this._getLayer(m).remove();
+    }
+  },
+
+  _getLayer: function () {
+    var id = arguments[0].id || arguments[0];
+    return this._vis.map.layers.get(id);
+  },
+
+  _createLayer: function (m) {
+    var attrs = _.clone(m.attributes);
+
+    var createMethodName = LAYER_TYPE_TO_LAYER_CREATE_METHOD[attrs.type.toLowerCase()];
+    if (!createMethodName) throw new Error('no create method name found for type ' + attrs.type);
+
+    var createMethod = this._vis.map[createMethodName];
+    if (!_.isFunction(createMethod)) throw new Error(createMethodName + ' is not a function');
+
+    createMethod.call(this._vis.map, attrs);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -5,7 +5,6 @@ var layerLetters = require('./layer-letters');
 var nodeIds = require('./analysis-definition-node-ids.js');
 
 var LAYER_TYPE_TO_LAYER_CREATE_METHOD = {
-  'background': 'createBackgroundLayer',
   'cartodb': 'createCartoDBLayer',
   'gmapsbase': 'createGMapsBaseLayer',
   'plain': 'createPlainLayer',

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -7,7 +7,7 @@ var nodeIds = require('./analysis-definition-node-ids.js');
 var LAYER_TYPE_TO_LAYER_CREATE_METHOD = {
   'background': 'createBackgroundLayer',
   'cartodb': 'createCartoDBLayer',
-  'gmaps': 'createGMapsBaseLayer',
+  'gmapsbase': 'createGMapsBaseLayer',
   'plain': 'createPlainLayer',
   'tiled': 'createTileLayer',
   'torque': 'createTorqueLayer',

--- a/lib/assets/javascripts/cartodb3/data/layer-types-and-kinds.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-types-and-kinds.js
@@ -1,0 +1,42 @@
+// Migrated from old models (models/map.js, cdb.admin.Layers)
+var KIND_TO_TYPE_MAP = {
+  'background': 'Plain',
+  'carto': 'CartoDB',
+  'gmapsbase': 'GMapsBase',
+  'tiled': 'Tiled',
+  'torque': 'torque',
+  'wms': 'WMS',
+  'Layer::Tiled': 'Tiled',
+  'Layer::Carto': 'CartoDB',
+  'Layer::Background': 'Plain'
+};
+
+module.exports = {
+
+  getType: function (kind) {
+    var type = KIND_TO_TYPE_MAP[kind];
+
+    if (!type) {
+      throw new Error('no type found for given kind ' + kind);
+    }
+
+    return type;
+  },
+
+  getKind: function (type) {
+    var kind;
+
+    for (kind in KIND_TO_TYPE_MAP) {
+      if (KIND_TO_TYPE_MAP[kind] === type) {
+        break;
+      }
+    }
+
+    if (!kind) {
+      throw new Error('no kind found for given type ' + type);
+    }
+
+    return kind;
+  }
+
+};

--- a/lib/assets/javascripts/cartodb3/data/widget-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/widget-definitions-collection.js
@@ -23,12 +23,12 @@ module.exports = Backbone.Collection.extend({
 
   initialize: function (models, options) {
     if (!options.configModel) throw new Error('configModel is required');
-    if (!options.layersCollection) throw new Error('layersCollection is required');
+    if (!options.visMap) throw new Error('visMap is required');
     if (!options.dashboardWidgets) throw new Error('dashboardWidgets is required');
     if (!options.mapId) throw new Error('mapId is required');
 
     this._configModel = options.configModel;
-    this._layersCollection = options.layersCollection;
+    this._visMap = options.visMap;
     this._dashboardWidgets = options.dashboardWidgets;
     this._mapId = options.mapId;
 
@@ -113,7 +113,7 @@ module.exports = Backbone.Collection.extend({
 
   _createWidgetModel: function (m) {
     var layerId = m.get('layer_id');
-    var layerModel = this._layersCollection.get(layerId);
+    var layerModel = this._visMap.getLayerById(layerId);
     var methodName = this._typesMap[m.get('type')].widgetModelCreateMethod;
 
     var widgetModel = this._dashboardWidgets[methodName](m.attributes, layerModel);

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -62,7 +62,7 @@ var analysisDefinitionsCollection = new AnalysisDefinitionsCollection(analysesDa
 });
 var layerDefinitionsCollection = new LayerDefinitionsCollection(layersData, {
   configModel: configModel,
-  layersCollection: layersCollection,
+  vis: dashboard.vis,
   analysisDefinitionNodesCollection: analysisDefinitionsCollection.analysisDefinitionNodesCollection,
   mapId: mapId
 });

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -41,7 +41,7 @@ var dashboard = cdb.deepInsights.createDashboard('#dashboard', vizJSON, {
 });
 
 var mapId = visualizationData.map_id;
-var layersCollection = dashboard.vis.map.layers;
+var visMap = dashboard.vis.map;
 var configModel = new ConfigModel(
   _.defaults(
     {
@@ -62,14 +62,14 @@ var analysisDefinitionsCollection = new AnalysisDefinitionsCollection(analysesDa
 });
 var layerDefinitionsCollection = new LayerDefinitionsCollection([], {
   configModel: configModel,
-  vis: dashboard.vis,
+  visMap: visMap,
   analysisDefinitionNodesCollection: analysisDefinitionsCollection.analysisDefinitionNodesCollection,
   mapId: mapId
 });
 layerDefinitionsCollection.resetByLayersData(layersData);
 var widgetDefinitionsCollection = new WidgetDefinitionsCollection([], {
   configModel: configModel,
-  layersCollection: layersCollection,
+  visMap: visMap,
   dashboardWidgets: dashboard.widgets,
   mapId: mapId
 });

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -152,3 +152,27 @@ window.visDefinitionModel = visDefinitionModel;
 window.widgetDefinitionsCollection = widgetDefinitionsCollection;
 window.analysisDefinitionsCollection = analysisDefinitionsCollection;
 window.analysisDefinitionNodesCollection = analysisDefinitionsCollection.analysisDefinitionNodesCollection;
+
+// WIP, these shortcut snippets can be used to modify the state of the vis being edited
+window.snippets = {
+
+  createTableLayer: function (tableName) {
+    if (!tableName) throw new Error('a table name must be provied (make sure it exists!)');
+
+    // based on https://github.com/CartoDB/cartodb/blob/132d4589c19cfa47826e20f617a74074b364b049/lib/assets/javascripts/cartodb/models/cartodb_layer.js#L214-L219
+    var m = layerDefinitionsCollection.first();
+    var attrs = JSON.parse(JSON.stringify(m.toJSON())); // deep clone
+    delete attrs.id;
+    delete attrs.options.source;
+    delete attrs.options.letter;
+    attrs.order = _.max(layerDefinitionsCollection.pluck('order')) + 1;
+
+    layerDefinitionsCollection.create(attrs, {
+      wait: true,
+      success: function () {
+        console.info('layer created, access it through layerDefinitionsCollection.first()');
+      }
+    });
+    layerDefinitionsCollection.sort();
+  }
+};

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-layer-view.js
@@ -15,9 +15,14 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
+    var desc = _t('editor.tab-pane.layers.basemap');
+    var title = this.model.getName() || desc;
+
     this.$el.html(template({
-      title: this.model.getName()
+      title: title,
+      desc: title === desc ? '' : desc
     }));
+
     return this;
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-layer.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-layer.tpl
@@ -3,5 +3,5 @@
   <div class="BlockList-Title u-bSpace">
     <h2 class="BlockList-TitleText CDB-Text CDB-Size-large u-ellipsis"><%- title %></h2>
   </div>
-  <p class="CDB-Text CDB-Size-medium u-secondaryTextColor"><%- _t('editor.layers.basemap') %></p>
+  <p class="CDB-Text CDB-Size-medium u-secondaryTextColor"><%- desc %></p>
 </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
@@ -1,34 +1,16 @@
-var _ = require('underscore');
 var cdb = require('cartodb-deep-insights.js');
-var DefaultLayerView = require('./layer-view');
-var BasemapLayerView = require('./basemap-layer-view');
 var LayerAnalysisViewFactory = require('./layer-analysis-view-factory');
 var LayerAnalysisViews = require('./layer-analysis-views');
-
-var DEFAULT_VIEW_TYPE = {
-  createView: function (opts) {
-    return new DefaultLayerView(opts);
-  }
-};
-
-var LAYER_VIEW_TYPES = [
-  {
-    match: function (m) {
-      return m.get('type') === 'Tiled' && m.get('order') === 0;
-    },
-    createView: function (opts) {
-      return new BasemapLayerView(opts);
-    }
-  }
-];
+var DefaultLayerView = require('./layer-view');
+var BasemapLayerView = require('./basemap-layer-view');
 
 /**
  * View to render layer definitions list
  */
 module.exports = cdb.core.View.extend({
-  className: 'BlockList',
 
   tagName: 'ul',
+  className: 'BlockList',
 
   initialize: function (opts) {
     if (!opts.stackLayoutModel) throw new Error('stackLayoutModel is required');
@@ -54,13 +36,11 @@ module.exports = cdb.core.View.extend({
   },
 
   _addLayerView: function (m) {
-    var item = _.find(LAYER_VIEW_TYPES, function (item) {
-      return item.match(m);
-    });
+    var LayerView = m.get('order') === 0
+      ? BasemapLayerView
+      : DefaultLayerView;
 
-    item = item || DEFAULT_VIEW_TYPE;
-
-    var view = item.createView({
+    var view = new LayerView({
       model: m,
       newAnalysisViews: this._newAnalysisViews.bind(this),
       stackLayoutModel: this._stackLayoutModel

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -28,13 +28,13 @@
     "tab-pane": {
       "layers": {
         "title-label": "Layers",
-        "basemap": "basemap"
+        "basemap": "Basemap"
       },
       "elements": {
         "title-label": "Elements"
       },
       "widgets": {
-        "title-label": "Widgets",
+        "title-label": "Widgets"
       }
     },
     "layers": {

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/add-widgets-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/add-widgets-view.spec.js
@@ -4,6 +4,7 @@ var ConfigModel = require('../../../../../../javascripts/cartodb3/data/config-mo
 var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var LayerDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/layer-definitions-collection');
 var AddWidgetsView = require('../../../../../../javascripts/cartodb3/components/modals/add-widgets/add-widgets-view');
+var createDefaultVis = require('../../../create-default-vis');
 
 describe('components/modals/add-widgets/add-widgets-view', function () {
   var FETCHING_TITLE = 'fetching-';
@@ -12,11 +13,10 @@ describe('components/modals/add-widgets/add-widgets-view', function () {
     var configModel = new ConfigModel({
       base_url: '/u/pepe'
     });
-    var layersCollection = new Backbone.Collection();
     var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection();
     this.layerDefinitionsCollection = new LayerDefinitionsCollection([], {
       configModel: configModel,
-      layersCollection: layersCollection,
+      vis: createDefaultVis(),
       analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
       mapId: 'map-123'
     });
@@ -24,21 +24,26 @@ describe('components/modals/add-widgets/add-widgets-view', function () {
     this.layerDefinitionsCollection.add({
       id: 'l0',
       options: {
-        type: 'Tiled'
+        type: 'Tiled',
+        urlTemplate: ''
       }
     });
     this.layerDefinitionsCollection.add({
       id: 'l1',
       options: {
         type: 'CartoDB',
-        table_name: 'foobar'
+        table_name: 'foobar',
+        sql: '',
+        cartocss: ''
       }
     });
     this.layerDefinitionsCollection.add({
       id: 'l2',
       options: {
         type: 'CartoDB',
-        table_name: 'foobar'
+        table_name: 'foobar',
+        sql: '',
+        cartocss: ''
       }
     });
     this.lt1 = this.layerDefinitionsCollection.at(1).layerTableModel;

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/add-widgets-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/add-widgets-view.spec.js
@@ -14,9 +14,10 @@ describe('components/modals/add-widgets/add-widgets-view', function () {
       base_url: '/u/pepe'
     });
     var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection();
+    var vis = createDefaultVis();
     this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
       configModel: configModel,
-      vis: createDefaultVis(),
+      visMap: vis.map,
       analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
       mapId: 'map-123'
     });

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/add-widgets-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/add-widgets-view.spec.js
@@ -14,7 +14,7 @@ describe('components/modals/add-widgets/add-widgets-view', function () {
       base_url: '/u/pepe'
     });
     var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection();
-    this.layerDefinitionsCollection = new LayerDefinitionsCollection([], {
+    this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
       configModel: configModel,
       vis: createDefaultVis(),
       analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
@@ -33,8 +33,7 @@ describe('components/modals/add-widgets/add-widgets-view', function () {
       options: {
         type: 'CartoDB',
         table_name: 'foobar',
-        sql: '',
-        cartocss: ''
+        cartocss: 'asd'
       }
     });
     this.layerDefinitionsCollection.add({
@@ -42,8 +41,7 @@ describe('components/modals/add-widgets/add-widgets-view', function () {
       options: {
         type: 'CartoDB',
         table_name: 'foobar',
-        sql: '',
-        cartocss: ''
+        cartocss: 'asd'
       }
     });
     this.lt1 = this.layerDefinitionsCollection.at(1).layerTableModel;

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/create-tuples-items.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/create-tuples-items.spec.js
@@ -17,6 +17,7 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
       id: 'l1'
     });
     var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection();
+    var vis = createDefaultVis();
     this.LayerDefinitionsCollection = new LayerDefinitionsCollection([
       {
         id: 'l0',
@@ -38,7 +39,7 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
       }
     ], {
       configModel: configModel,
-      vis: createDefaultVis(),
+      visMap: vis.map,
       analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
       mapId: 'm-123'
     });

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/create-tuples-items.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/create-tuples-items.spec.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var Backbone = require('backbone');
 var ConfigModel = require('../../../../../../javascripts/cartodb3/data/config-model');
 var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var LayerDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/layer-definitions-collection');
@@ -10,11 +9,6 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
   beforeEach(function () {
     var configModel = new ConfigModel({
       base_url: '/u/pepe'
-    });
-    this.layersCollection = new Backbone.Collection({
-      id: 'l0'
-    }, {
-      id: 'l1'
     });
     var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection();
     var vis = createDefaultVis();

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/create-tuples-items.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/create-tuples-items.spec.js
@@ -4,6 +4,7 @@ var ConfigModel = require('../../../../../../javascripts/cartodb3/data/config-mo
 var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var LayerDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/layer-definitions-collection');
 var createTuplesItems = require('../../../../../../javascripts/cartodb3/components/modals/add-widgets/create-tuples-items');
+var createDefaultVis = require('../../../create-default-vis');
 
 describe('components/modals/add-widgets/create-tuples-items', function () {
   beforeEach(function () {
@@ -37,7 +38,7 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
       }
     ], {
       configModel: configModel,
-      layersCollection: this.layersCollection,
+      vis: createDefaultVis(),
       analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
       mapId: 'm-123'
     });

--- a/lib/assets/test/spec/cartodb3/create-default-vis.js
+++ b/lib/assets/test/spec/cartodb3/create-default-vis.js
@@ -1,0 +1,16 @@
+var cdb = require('cartodb.js');
+
+/**
+ * Spec helper, to create a default vis object.
+ * @return {Object} returns a vis instance
+ */
+module.exports = function () {
+  return cdb.createVis(document.createElement('div'), {
+    bounds: [[24.206889622398023, -84.0234375], [76.9206135182968, 169.1015625]],
+    datasource: {
+      maps_api_template: 'asd',
+      user_name: 'pepe'
+    },
+    layers: [{type: 'torque'}]
+  });
+};

--- a/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
@@ -24,6 +24,7 @@ describe('data/layer-definition-model', function () {
     it('should return the original data', function () {
       expect(this.model.toJSON()).toEqual({
         id: 'abc-123',
+        kind: 'carto',
         options: {
           type: 'CartoDB',
           table_name: 'foo',
@@ -120,6 +121,7 @@ describe('data/layer-definition-model', function () {
     beforeEach(function () {
       this.model = new LayerDefinitionModel({
         id: 'abc-123',
+        kind: 'carto',
         options: {
           type: 'CartoDB',
           table_name: 'foo_table',
@@ -139,6 +141,7 @@ describe('data/layer-definition-model', function () {
       it('should return the original data', function () {
         expect(this.model.toJSON()).toEqual({
           id: 'abc-123',
+          kind: 'carto',
           options: {
             type: 'CartoDB',
             table_name: 'foo_table',

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -92,17 +92,22 @@ describe('data/layer-definitions-collection', function () {
       this.collection.add({
         id: 'integration-test',
         options: {
-          type: 'plain',
+          type: 'Plain',
           color: 'blue'
         }
       });
       this.layerDefinitionModel = this.collection.get('integration-test');
     });
 
+    it('should have created new definition with a kind derived from type', function () {
+      expect(this.layerDefinitionModel.get('kind')).toEqual('plain');
+    });
+
     it('should have created the layer', function () {
       var l = this.vis.map.layers.get(this.layerDefinitionModel.id);
       expect(l).toBeDefined();
       expect(l.get('color')).toEqual('blue');
+      expect(l.get('type')).toEqual('Plain');
     });
 
     describe('when update some layer attrs', function () {
@@ -131,9 +136,14 @@ describe('data/layer-definitions-collection', function () {
         this.layerAfter = this.vis.map.layers.get(this.layerDefinitionModel.id);
       });
 
+      it('should have changed kind', function () {
+        expect(this.layerDefinitionModel.get('kind')).toEqual('carto');
+      });
+
       it('should have re-created layer', function () {
-        expect(this.layerAfter.get('sql')).toEqual('SELECT * FROM my_table');
         expect(this.layerAfter).not.toBe(this.layerBefore);
+        expect(this.layerAfter.get('sql')).toEqual('SELECT * FROM my_table');
+        expect(this.layerAfter.get('kind')).toEqual('carto');
       });
     });
 

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -24,11 +24,10 @@ describe('data/layer-definitions-collection', function () {
   it('should create the layer with the next letter representation available', function () {
     // layer example data
     var d = function (customOpts) {
+      var opts = customOpts || {};
+      opts.type = opts || 'CartoDB';
       return {
-        options: _.defaults({}, customOpts, {
-          type: 'Plain',
-          color: 'black'
-        })
+        options: opts
       };
     };
 
@@ -112,10 +111,6 @@ describe('data/layer-definitions-collection', function () {
       this.layerDefinitionModel = this.collection.get('integration-test');
     });
 
-    it('should have created new definition with a kind derived from type', function () {
-      expect(this.layerDefinitionModel.get('kind')).toEqual('background');
-    });
-
     it('should have created the layer', function () {
       var l = this.vis.map.layers.get(this.layerDefinitionModel.id);
       expect(l).toBeDefined();
@@ -149,14 +144,10 @@ describe('data/layer-definitions-collection', function () {
         this.layerAfter = this.vis.map.layers.get(this.layerDefinitionModel.id);
       });
 
-      it('should have changed kind', function () {
-        expect(this.layerDefinitionModel.get('kind')).toEqual('carto');
-      });
-
       it('should have re-created layer', function () {
         expect(this.layerAfter).not.toBe(this.layerBefore);
         expect(this.layerAfter.get('sql')).toEqual('SELECT * FROM my_table');
-        expect(this.layerAfter.get('kind')).toEqual('carto');
+        expect(this.layerAfter.get('type')).toEqual('CartoDB');
       });
     });
 

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var ConfigModel = require('../../../../javascripts/cartodb3/data/config-model');
 var AnalysisDefinitionNodesCollection = require('../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var LayerDefinitionsCollection = require('../../../../javascripts/cartodb3/data/layer-definitions-collection');

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -143,7 +143,7 @@ describe('data/layer-definitions-collection', function () {
         this.layerDefinitionModel.set({
           type: 'CartoDB',
           table_name: 'my_table',
-          cartocss: '',
+          cartocss: 'asd',
           sql: 'SELECT * FROM my_table'
         });
         this.layerAfter = this.vis.map.layers.get(this.layerDefinitionModel.id);

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -14,7 +14,7 @@ describe('data/layer-definitions-collection', function () {
 
     this.collection = new LayerDefinitionsCollection(null, {
       configModel: configModel,
-      vis: this.vis,
+      visMap: this.vis.map,
       analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
       mapId: 'm-123'
     });

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -105,7 +105,7 @@ describe('data/layer-definitions-collection', function () {
     });
 
     it('should have created new definition with a kind derived from type', function () {
-      expect(this.layerDefinitionModel.get('kind')).toEqual('plain');
+      expect(this.layerDefinitionModel.get('kind')).toEqual('background');
     });
 
     it('should have created the layer', function () {

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -1,7 +1,7 @@
-var Backbone = require('backbone');
 var ConfigModel = require('../../../../javascripts/cartodb3/data/config-model');
 var AnalysisDefinitionNodesCollection = require('../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var LayerDefinitionsCollection = require('../../../../javascripts/cartodb3/data/layer-definitions-collection');
+var createDefaultVis = require('../create-default-vis');
 
 describe('data/layer-definitions-collection', function () {
   beforeEach(function () {
@@ -10,9 +10,11 @@ describe('data/layer-definitions-collection', function () {
     });
     this.analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection();
 
+    this.vis = createDefaultVis();
+
     this.collection = new LayerDefinitionsCollection(null, {
       configModel: configModel,
-      layersCollection: new Backbone.Collection(),
+      vis: this.vis,
       analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
       mapId: 'm-123'
     });
@@ -29,11 +31,21 @@ describe('data/layer-definitions-collection', function () {
     this.collection.remove(this.collection.at(2));
 
     // Add new as C
-    this.collection.add({});
+    this.collection.add({
+      options: {
+        type: 'Plain',
+        color: 'black'
+      }
+    });
     expect(this.collection.last().get('letter')).toEqual('c');
 
     // Add new as E
-    this.collection.add({});
+    this.collection.add({
+      options: {
+        type: 'Plain',
+        color: 'black'
+      }
+    });
     expect(this.collection.last().get('letter')).toEqual('e');
   });
 
@@ -72,6 +84,67 @@ describe('data/layer-definitions-collection', function () {
 
       expect(this.l2.get('source')).toEqual('b0');
       expect(this.analysisDefinitionNodesCollection.get('b0')).toBeDefined();
+    });
+  });
+
+  describe('when a layer is created', function () {
+    beforeEach(function () {
+      this.collection.add({
+        id: 'integration-test',
+        options: {
+          type: 'plain',
+          color: 'blue'
+        }
+      });
+      this.layerDefinitionModel = this.collection.get('integration-test');
+    });
+
+    it('should have created the layer', function () {
+      var l = this.vis.map.layers.get(this.layerDefinitionModel.id);
+      expect(l).toBeDefined();
+      expect(l.get('color')).toEqual('blue');
+    });
+
+    describe('when update some layer attrs', function () {
+      beforeEach(function () {
+        this.layerDefinitionModel.set({
+          color: 'pink',
+          letter: 'c'
+        });
+      });
+
+      it('should update the equivalent layer', function () {
+        var l = this.vis.map.layers.get(this.layerDefinitionModel.id);
+        expect(l.get('color')).toEqual('pink');
+      });
+    });
+
+    describe('when update layer includes change of type', function () {
+      beforeEach(function () {
+        this.layerBefore = this.vis.map.layers.get(this.layerDefinitionModel.id);
+        this.layerDefinitionModel.set({
+          type: 'CartoDB',
+          table_name: 'my_table',
+          cartocss: '',
+          sql: 'SELECT * FROM my_table'
+        });
+        this.layerAfter = this.vis.map.layers.get(this.layerDefinitionModel.id);
+      });
+
+      it('should have re-created layer', function () {
+        expect(this.layerAfter.get('sql')).toEqual('SELECT * FROM my_table');
+        expect(this.layerAfter).not.toBe(this.layerBefore);
+      });
+    });
+
+    describe('when removing layer', function () {
+      beforeEach(function () {
+        this.layerDefinitionModel.destroy();
+      });
+
+      it('should no longer be accessible', function () {
+        expect(this.vis.map.layers.get(this.layerDefinitionModel.id)).toBeUndefined();
+      });
     });
   });
 });

--- a/lib/assets/test/spec/cartodb3/data/layer-types-and-kinds.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-types-and-kinds.spec.js
@@ -1,0 +1,29 @@
+var layerTypesAndKinds = require('../../../../javascripts/cartodb3/data/layer-types-and-kinds');
+
+describe('data/layer-types-and-kinds', function () {
+  describe('.getKind', function () {
+    it('should return the kind for a given type', function () {
+      expect(layerTypesAndKinds.getKind('Tiled')).toEqual('tiled');
+      expect(layerTypesAndKinds.getKind('CartoDB')).toEqual('carto');
+      expect(layerTypesAndKinds.getKind('WMS')).toEqual('wms');
+      expect(layerTypesAndKinds.getKind('Plain')).toEqual('background');
+      expect(layerTypesAndKinds.getKind('GMapsBase')).toEqual('gmapsbase');
+      expect(layerTypesAndKinds.getKind('torque')).toEqual('torque');
+    });
+  });
+
+  describe('.getType', function () {
+    it('should return the type for a given kind', function () {
+      expect(layerTypesAndKinds.getType('tiled')).toEqual('Tiled');
+      expect(layerTypesAndKinds.getType('carto')).toEqual('CartoDB');
+      expect(layerTypesAndKinds.getType('wms')).toEqual('WMS');
+      expect(layerTypesAndKinds.getType('background')).toEqual('Plain');
+      expect(layerTypesAndKinds.getType('gmapsbase')).toEqual('GMapsBase');
+      expect(layerTypesAndKinds.getType('torque')).toEqual('torque');
+
+      expect(layerTypesAndKinds.getType('Layer::Tiled')).toEqual('Tiled');
+      expect(layerTypesAndKinds.getType('Layer::Carto')).toEqual('CartoDB');
+      expect(layerTypesAndKinds.getType('Layer::Background')).toEqual('Plain');
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb3/data/widget-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/widget-definitions-collection.spec.js
@@ -28,7 +28,7 @@ describe('data/widget-definitions-collection', function () {
     this.dashboardWidgets = this.dashboard.widgets;
     this.collection = new WidgetDefinitionsCollection([], {
       configModel: configModel,
-      layersCollection: this.dashboard.vis.map.layers,
+      visMap: this.dashboard.vis.map,
       dashboardWidgets: this.dashboardWidgets,
       mapId: 'm-123'
     });

--- a/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/composite-layers-analysis-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/composite-layers-analysis-view.spec.js
@@ -41,7 +41,10 @@ describe('editor/layers/analysis-views/composite-layer-analysis-view', function 
     });
 
     this.layerDefinitionModel = new LayerDefinitionModel({
-      table_name: 'districts'
+      options: {
+        type: 'CartoDB',
+        table_name: 'districts'
+      }
     }, {
       configModel: {},
       parse: true

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-views.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-views.spec.js
@@ -23,8 +23,7 @@ describe('editor/layers/layer-analysis-views', function () {
         options: {
           type: 'CartoDB',
           table_name: 'own_source',
-          sql: '',
-          cartocss: ''
+          cartocss: 'asd'
         }
       });
       this.view = new LayerAnalysisViews({
@@ -68,8 +67,7 @@ describe('editor/layers/layer-analysis-views', function () {
         options: {
           type: 'CartoDB',
           table_name: 'foo',
-          sql: '',
-          cartocss: '',
+          cartocss: 'asd',
           letter: 'b',
           source: 'b1',
           name: 'layerB'
@@ -111,8 +109,7 @@ describe('editor/layers/layer-analysis-views', function () {
           options: {
             type: 'CartoDB',
             table_name: 'foo',
-            sql: '',
-            cartocss: '',
+            cartocss: 'asd',
             letter: 'c',
             source: 'c1',
             name: 'layerC'

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-views.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-views.spec.js
@@ -7,9 +7,10 @@ var createDefaultVis = require('../../create-default-vis');
 describe('editor/layers/layer-analysis-views', function () {
   beforeEach(function () {
     this.analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection();
+    var vis = createDefaultVis();
     this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
       configModel: {},
-      vis: createDefaultVis(),
+      visMap: vis.map,
       analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
       mapId: 'm-123'
     });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-views.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-views.spec.js
@@ -2,13 +2,14 @@ var AnalysisDefinitionNodesCollection = require('../../../../../javascripts/cart
 var LayerDefinitionsCollection = require('../../../../../javascripts/cartodb3/data/layer-definitions-collection');
 var LayerAnalysisViews = require('../../../../../javascripts/cartodb3/editor/layers/layer-analysis-views');
 var LayerAnalysisViewFactory = require('../../../../../javascripts/cartodb3/editor/layers/layer-analysis-view-factory');
+var createDefaultVis = require('../../create-default-vis');
 
 describe('editor/layers/layer-analysis-views', function () {
   beforeEach(function () {
     this.analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection();
     this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
       configModel: {},
-      layersCollection: {},
+      vis: createDefaultVis(),
       analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
       mapId: 'm-123'
     });
@@ -21,7 +22,9 @@ describe('editor/layers/layer-analysis-views', function () {
         id: 'l1',
         options: {
           type: 'CartoDB',
-          table_name: 'own_source'
+          table_name: 'own_source',
+          sql: '',
+          cartocss: ''
         }
       });
       this.view = new LayerAnalysisViews({
@@ -65,6 +68,8 @@ describe('editor/layers/layer-analysis-views', function () {
         options: {
           type: 'CartoDB',
           table_name: 'foo',
+          sql: '',
+          cartocss: '',
           letter: 'b',
           source: 'b1',
           name: 'layerB'
@@ -106,6 +111,8 @@ describe('editor/layers/layer-analysis-views', function () {
           options: {
             type: 'CartoDB',
             table_name: 'foo',
+            sql: '',
+            cartocss: '',
             letter: 'c',
             source: 'c1',
             name: 'layerC'

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
@@ -11,7 +11,10 @@ describe('editor/layers/layer-content-view', function () {
     });
     this.layer = new LayerDefinitionModel({
       id: 'l-1',
-      type: 'tile'
+      options: {
+        type: 'CartoDB',
+        table_name: 'foo'
+      }
     }, {
       parse: true,
       configModel: configModel

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widget-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widget-view.spec.js
@@ -21,7 +21,9 @@ describe('editor/widgets/widget-view', function () {
 
     this.layer = new LayerDefinitionModel({
       id: 'l-1',
-      type: 'tile'
+      options: {
+        type: 'CartoDB'
+      }
     }, {
       parse: true,
       configModel: configModel

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.spec.js
@@ -13,6 +13,7 @@ describe('editor/widgets/widgets-form/widgets-form-content-view', function () {
     this.layerDefinitionModel = new LayerDefinitionModel({
       id: 'l1',
       options: {
+        type: 'CartoDB',
         table_name: 'foobar'
       }
     }, {

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
@@ -11,7 +11,9 @@ describe('editor/widgets/widgets-view', function () {
     });
     this.model = new LayerDefinitionModel({
       id: 'l-100',
-      type: 'tile'
+      options: {
+        type: 'CartoDB'
+      }
     }, {
       parse: true,
       configModel: this.configModel

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -18,13 +18,13 @@
           "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
         },
         "caniuse-db": {
-          "version": "1.0.30000430",
+          "version": "1.0.30000431",
           "from": "caniuse-db@>=1.0.30000214 <2.0.0",
-          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000430.tgz"
+          "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000431.tgz"
         },
         "postcss": {
           "version": "4.1.16",
-          "from": "postcss@>=4.1.12 <4.2.0",
+          "from": "postcss@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
           "dependencies": {
             "es6-promise": {
@@ -104,7 +104,7 @@
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
+              "from": "through@>=2.2.7 <3.0.0",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
@@ -162,7 +162,7 @@
         },
         "browser-resolve": {
           "version": "1.11.1",
-          "from": "browser-resolve@>=1.11.0 <2.0.0",
+          "from": "browser-resolve@>=1.7.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
         },
         "browserify-zlib": {
@@ -540,7 +540,7 @@
         },
         "deps-sort": {
           "version": "1.3.9",
-          "from": "deps-sort@>=1.3.5 <2.0.0",
+          "from": "deps-sort@>=1.3.7 <2.0.0",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz"
         },
         "domain-browser": {
@@ -615,7 +615,7 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "once@>=1.3.0 <1.4.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
@@ -683,7 +683,7 @@
         },
         "insert-module-globals": {
           "version": "6.6.3",
-          "from": "insert-module-globals@>=6.4.1 <7.0.0",
+          "from": "insert-module-globals@>=6.2.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
           "dependencies": {
             "combine-source-map": {
@@ -763,7 +763,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13 <2.0.0",
+                  "from": "readable-stream@>=1.1.13-1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -789,7 +789,7 @@
         },
         "module-deps": {
           "version": "3.9.1",
-          "from": "module-deps@>=3.7.0 <4.0.0",
+          "from": "module-deps@>=3.7.11 <4.0.0",
           "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
           "dependencies": {
             "detective": {
@@ -893,7 +893,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.9 <1.2.0",
+              "from": "readable-stream@>=1.0.31 <2.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -1172,7 +1172,7 @@
             },
             "map-obj": {
               "version": "1.0.1",
-              "from": "map-obj@>=1.0.1 <1.1.0",
+              "from": "map-obj@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
             },
             "replace-requires": {
@@ -1207,12 +1207,12 @@
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.0 <3.0.0",
+                          "from": "esutils@>=2.0.2 <3.0.0",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "esprima": {
                           "version": "2.7.2",
-                          "from": "esprima@>=2.1.0 <3.0.0",
+                          "from": "esprima@>=2.7.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                         },
                         "optionator": {
@@ -1275,7 +1275,7 @@
                   "dependencies": {
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "escape-string-regexp@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     }
                   }
@@ -1287,7 +1287,7 @@
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -1345,7 +1345,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "readable-stream@>=1.1.13 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -1464,12 +1464,12 @@
     "cartodb-deep-insights.js": {
       "version": "0.0.1",
       "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#bcbf7c26617c24efc98cbd0c86803468a55f070b",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#d82a1c4382ac5a038a480145e8cbb30a7723332b",
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#11437811119b7f06c73ecf4a7f7e21cc3ab5cf9c",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#71f069ca3afe328d25c0080cc4c8112142f159bd",
           "dependencies": {
             "leaflet": {
               "version": "0.7.3",
@@ -2232,7 +2232,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#11437811119b7f06c73ecf4a7f7e21cc3ab5cf9c",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#71f069ca3afe328d25c0080cc4c8112142f159bd",
       "dependencies": {
         "jstify": {
           "version": "0.12.0",
@@ -3029,7 +3029,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -3091,7 +3091,7 @@
         },
         "postcss": {
           "version": "4.1.16",
-          "from": "postcss@>=4.1.12 <4.2.0",
+          "from": "postcss@>=4.1.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
           "dependencies": {
             "es6-promise": {
@@ -3357,7 +3357,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -3367,7 +3367,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -3379,7 +3379,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -3415,7 +3415,7 @@
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.10 <0.3.0",
+          "from": "async@>=0.2.9 <0.3.0",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "lodash": {
@@ -3757,7 +3757,7 @@
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.6 <3.0.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
@@ -3815,7 +3815,7 @@
                 },
                 "browser-resolve": {
                   "version": "1.11.1",
-                  "from": "browser-resolve@>=1.11.0 <2.0.0",
+                  "from": "browser-resolve@>=1.7.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
                 },
                 "browserify-zlib": {
@@ -4428,9 +4428,9 @@
                   }
                 },
                 "shell-quote": {
-                  "version": "1.4.3",
+                  "version": "1.5.0",
                   "from": "shell-quote@>=1.4.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.5.0.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
@@ -4690,6 +4690,11 @@
                       "from": "ansi-regex@^2.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     },
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "ansi-styles@^2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
                     "asn1": {
                       "version": "0.2.3",
                       "from": "asn1@>=0.2.3 <0.3.0",
@@ -4700,20 +4705,15 @@
                       "from": "are-we-there-yet@~1.0.6",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz"
                     },
-                    "ansi-styles": {
-                      "version": "2.1.0",
-                      "from": "ansi-styles@^2.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    "async": {
+                      "version": "1.5.2",
+                      "from": "async@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     },
                     "assert-plus": {
                       "version": "0.2.0",
                       "from": "assert-plus@^0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                    },
-                    "async": {
-                      "version": "1.5.2",
-                      "from": "async@^1.4.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     },
                     "aws-sign2": {
                       "version": "0.6.0",
@@ -4735,50 +4735,50 @@
                       "from": "chalk@^1.1.1",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
                     },
-                    "caseless": {
-                      "version": "0.11.0",
-                      "from": "caseless@~0.11.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                    },
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@2.x.x",
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@~0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                     },
                     "combined-stream": {
                       "version": "1.0.5",
                       "from": "combined-stream@~1.0.5",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                     },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
                     "commander": {
                       "version": "2.9.0",
                       "from": "commander@^2.9.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.12.2",
+                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "deep-extend": {
-                      "version": "0.4.1",
-                      "from": "deep-extend@~0.4.0",
-                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
-                    },
                     "debug": {
                       "version": "2.2.0",
                       "from": "debug@~2.2.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                     },
-                    "dashdash": {
-                      "version": "1.12.2",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
+                    "deep-extend": {
+                      "version": "0.4.1",
+                      "from": "deep-extend@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                     },
                     "delayed-stream": {
                       "version": "1.0.0",
@@ -4805,50 +4805,50 @@
                       "from": "extend@~3.0.0",
                       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                     },
-                    "form-data": {
-                      "version": "1.0.0-rc3",
-                      "from": "form-data@~1.0.0-rc3",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "forever-agent": {
                       "version": "0.6.1",
                       "from": "forever-agent@~0.6.1",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
                     "fstream": {
                       "version": "1.0.8",
                       "from": "fstream@^1.0.2",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                     },
-                    "gauge": {
-                      "version": "1.2.5",
-                      "from": "gauge@~1.2.5",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz"
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@~1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
                     },
                     "generate-function": {
                       "version": "2.0.0",
                       "from": "generate-function@^2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
+                    "gauge": {
+                      "version": "1.2.5",
+                      "from": "gauge@~1.2.5",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz"
+                    },
                     "generate-object-property": {
                       "version": "1.2.0",
                       "from": "generate-object-property@^1.1.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
                     },
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>= 1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    },
                     "graceful-fs": {
                       "version": "4.1.3",
                       "from": "graceful-fs@^4.1.2",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                    },
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     },
                     "har-validator": {
                       "version": "2.0.6",
@@ -4860,30 +4860,30 @@
                       "from": "has-ansi@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                     },
-                    "has-unicode": {
-                      "version": "2.0.0",
-                      "from": "has-unicode@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
-                    },
                     "hawk": {
                       "version": "3.1.3",
                       "from": "hawk@~3.1.0",
                       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                     },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@*",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "has-unicode": {
+                      "version": "2.0.0",
+                      "from": "has-unicode@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "http-signature": {
                       "version": "1.1.1",
                       "from": "http-signature@~1.1.0",
                       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
                     },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@2.x.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@*",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "ini": {
                       "version": "1.3.4",
@@ -4905,20 +4905,20 @@
                       "from": "is-typedarray@~1.0.0",
                       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                     },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "isstream": {
                       "version": "0.1.2",
                       "from": "isstream@~0.1.2",
                       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                     },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.0",
@@ -4940,55 +4940,50 @@
                       "from": "jsonpointer@2.0.0",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
-                    "lodash._basetostring": {
-                      "version": "3.0.1",
-                      "from": "lodash._basetostring@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                    },
                     "jsprim": {
                       "version": "1.2.2",
                       "from": "jsprim@^1.2.2",
                       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
-                    },
-                    "lodash._root": {
-                      "version": "3.0.0",
-                      "from": "lodash._root@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.0.tgz"
                     },
                     "lodash._createpadding": {
                       "version": "3.6.1",
                       "from": "lodash._createpadding@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
                     },
-                    "lodash.pad": {
-                      "version": "3.3.0",
-                      "from": "lodash.pad@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.3.0.tgz"
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "from": "lodash._basetostring@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                    },
+                    "lodash._root": {
+                      "version": "3.0.0",
+                      "from": "lodash._root@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.0.tgz"
                     },
                     "lodash.padleft": {
                       "version": "3.1.1",
                       "from": "lodash.padleft@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
                     },
+                    "lodash.pad": {
+                      "version": "3.3.0",
+                      "from": "lodash.pad@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.3.0.tgz"
+                    },
                     "lodash.padright": {
                       "version": "3.1.1",
                       "from": "lodash.padright@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-                    },
-                    "lodash.repeat": {
-                      "version": "3.2.0",
-                      "from": "lodash.repeat@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz"
                     },
                     "mime-db": {
                       "version": "1.21.0",
                       "from": "mime-db@~1.21.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
                     },
-                    "mime-types": {
-                      "version": "2.1.9",
-                      "from": "mime-types@~2.1.7",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                    "lodash.repeat": {
+                      "version": "3.2.0",
+                      "from": "lodash.repeat@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz"
                     },
                     "minimist": {
                       "version": "0.0.8",
@@ -5000,6 +4995,11 @@
                       "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                     },
+                    "mime-types": {
+                      "version": "2.1.9",
+                      "from": "mime-types@~2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                    },
                     "ms": {
                       "version": "0.7.1",
                       "from": "ms@0.7.1",
@@ -5009,11 +5009,6 @@
                       "version": "1.4.7",
                       "from": "node-uuid@~1.4.7",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.1",
-                      "from": "oauth-sign@~0.8.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                     },
                     "once": {
                       "version": "1.3.3",
@@ -5030,15 +5025,20 @@
                       "from": "pinkie@^2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
-                      "from": "pinkie-promise@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                    "oauth-sign": {
+                      "version": "0.8.1",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
                       "from": "process-nextick-args@~1.0.6",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "from": "pinkie-promise@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
                     },
                     "qs": {
                       "version": "6.0.2",
@@ -5130,32 +5130,20 @@
                       "from": "util-deprecate@~1.0.1",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    },
                     "wrappy": {
                       "version": "1.0.1",
                       "from": "wrappy@1",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
                     "xtend": {
                       "version": "4.0.1",
                       "from": "xtend@^4.0.0",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "from": "rc@~1.1.0",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@^1.2.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
                     },
                     "aws4": {
                       "version": "1.2.1",
@@ -5166,6 +5154,18 @@
                           "version": "2.7.3",
                           "from": "lru-cache@^2.6.5",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.1.6",
+                      "from": "rc@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@^1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         }
                       }
                     },
@@ -5287,9 +5287,9 @@
               "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
               "dependencies": {
                 "shell-quote": {
-                  "version": "1.4.3",
+                  "version": "1.5.0",
                   "from": "shell-quote@>=1.4.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.5.0.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
@@ -5499,7 +5499,7 @@
                         },
                         "decamelize": {
                           "version": "1.2.0",
-                          "from": "decamelize@>=1.1.2 <2.0.0",
+                          "from": "decamelize@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "loud-rejection": {
@@ -5558,7 +5558,7 @@
                                   "dependencies": {
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                     }
                                   }
@@ -5575,7 +5575,7 @@
                                     },
                                     "spdx-license-ids": {
                                       "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                     }
                                   }
@@ -6007,7 +6007,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -6017,7 +6017,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -6029,7 +6029,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -6065,7 +6065,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -6075,7 +6075,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -6087,7 +6087,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -6443,7 +6443,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -6491,7 +6491,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "chalk@>=1.1.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
@@ -6635,7 +6635,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "ini": {
@@ -6669,7 +6669,7 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -6691,7 +6691,7 @@
                         },
                         "os-tmpdir": {
                           "version": "1.0.1",
-                          "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                          "from": "os-tmpdir@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
                         }
                       }
@@ -6720,7 +6720,7 @@
                       "dependencies": {
                         "readable-stream": {
                           "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.26 <1.1.0",
+                          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
@@ -6903,7 +6903,7 @@
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.0 <5.0.0",
+              "from": "semver@>=4.0.3 <5.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "temporary": {
@@ -7050,7 +7050,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -7060,7 +7060,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -7072,7 +7072,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -7158,7 +7158,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -7229,7 +7229,7 @@
                     },
                     "readable-stream": {
                       "version": "2.0.6",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "from": "readable-stream@>=2.0.2 <3.0.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
@@ -7263,7 +7263,7 @@
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
-                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
+                  "from": "browserify-zlib@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
@@ -7304,7 +7304,7 @@
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "decamelize@>=1.1.2 <2.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "loud-rejection": {
@@ -7331,7 +7331,7 @@
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@>=1.1.3 <2.0.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "normalize-package-data": {
@@ -7373,7 +7373,7 @@
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                 }
                               }
@@ -7390,7 +7390,7 @@
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.2.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                                 }
                               }
@@ -7564,7 +7564,7 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "strip-indent@>=1.0.0 <2.0.0",
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                         }
                       }
@@ -7836,7 +7836,7 @@
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
@@ -7951,9 +7951,9 @@
       "resolved": "https://registry.npmjs.org/jstify/-/jstify-0.13.0.tgz",
       "dependencies": {
         "html-minifier": {
-          "version": "1.2.0",
+          "version": "1.3.0",
           "from": "html-minifier@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.3.0.tgz",
           "dependencies": {
             "change-case": {
               "version": "2.3.1",
@@ -8097,7 +8097,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -8126,7 +8126,7 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -8167,7 +8167,7 @@
                 },
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -8196,6 +8196,18 @@
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
+                }
+              }
+            },
+            "ncname": {
+              "version": "1.0.0",
+              "from": "ncname@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+              "dependencies": {
+                "xml-char-classes": {
+                  "version": "1.0.0",
+                  "from": "xml-char-classes@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
                 }
               }
             },
@@ -8325,7 +8337,7 @@
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "decamelize@>=1.1.2 <2.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
@@ -8626,7 +8638,7 @@
             },
             "doctrine": {
               "version": "0.7.2",
-              "from": "doctrine@>=0.7.1 <0.8.0",
+              "from": "doctrine@>=0.7.0 <0.8.0",
               "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
               "dependencies": {
                 "esutils": {
@@ -8648,7 +8660,7 @@
             },
             "escope": {
               "version": "3.6.0",
-              "from": "escope@>=3.3.0 <4.0.0",
+              "from": "escope@>=3.2.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
               "dependencies": {
                 "es6-map": {
@@ -8678,7 +8690,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     },
                     "event-emitter": {
@@ -8710,7 +8722,7 @@
                     },
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
+                      "from": "es6-symbol@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                     }
                   }
@@ -8731,7 +8743,7 @@
             },
             "espree": {
               "version": "2.2.5",
-              "from": "espree@>=2.0.3 <3.0.0",
+              "from": "espree@>=2.2.4 <3.0.0",
               "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
             },
             "estraverse": {
@@ -8924,7 +8936,7 @@
             },
             "glob": {
               "version": "5.0.15",
-              "from": "glob@>=5.0.14 <6.0.0",
+              "from": "glob@>=5.0.10 <6.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "dependencies": {
                 "inflight": {
@@ -8946,7 +8958,7 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
@@ -9188,7 +9200,7 @@
                 },
                 "lodash": {
                   "version": "3.10.1",
-                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "from": "lodash@>=3.3.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                 },
                 "readline2": {
@@ -9289,7 +9301,7 @@
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.6 <3.0.0",
+                  "from": "through@>=2.2.7 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
@@ -9641,7 +9653,7 @@
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "from": "minimatch@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
@@ -9951,7 +9963,7 @@
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.14 <6.0.0",
+                  "from": "glob@>=5.0.10 <6.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
@@ -10098,7 +10110,7 @@
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "debug@>=2.1.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
@@ -10122,7 +10134,7 @@
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "debug@>=2.1.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
@@ -10156,7 +10168,7 @@
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "debug@>=2.1.1 <3.0.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
@@ -10471,7 +10483,7 @@
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.0 <4.0.0",
+                      "from": "lodash@>=3.3.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "minimatch": {
@@ -10715,7 +10727,7 @@
                                       "dependencies": {
                                         "align-text": {
                                           "version": "0.1.4",
-                                          "from": "align-text@>=0.1.1 <0.2.0",
+                                          "from": "align-text@>=0.1.3 <0.2.0",
                                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                           "dependencies": {
                                             "kind-of": {
@@ -10822,9 +10834,9 @@
                                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                                 },
                                 "y18n": {
-                                  "version": "3.2.0",
+                                  "version": "3.2.1",
                                   "from": "y18n@>=3.2.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
                                 }
                               }
                             }
@@ -10849,7 +10861,7 @@
                         },
                         "through": {
                           "version": "2.3.8",
-                          "from": "through@>=2.3.8 <2.4.0",
+                          "from": "through@>=2.2.7 <3.0.0",
                           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                         }
                       }
@@ -10861,7 +10873,7 @@
                       "dependencies": {
                         "esprima": {
                           "version": "2.7.2",
-                          "from": "esprima@>=2.6.0 <3.0.0",
+                          "from": "esprima@>=2.7.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                         },
                         "recast": {
@@ -11012,7 +11024,7 @@
                     },
                     "object-keys": {
                       "version": "1.0.9",
-                      "from": "object-keys@>=1.0.6 <2.0.0",
+                      "from": "object-keys@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
                     }
                   }
@@ -11108,7 +11120,7 @@
               "dependencies": {
                 "espree": {
                   "version": "2.2.5",
-                  "from": "espree@>=2.0.3 <3.0.0",
+                  "from": "espree@>=2.2.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
                 },
                 "rocambole": {
@@ -11171,7 +11183,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -11200,7 +11212,7 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -11311,7 +11323,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
@@ -11367,7 +11379,7 @@
                 },
                 "doctrine": {
                   "version": "0.7.2",
-                  "from": "doctrine@>=0.7.1 <0.8.0",
+                  "from": "doctrine@>=0.7.0 <0.8.0",
                   "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
                   "dependencies": {
                     "esutils": {
@@ -11389,7 +11401,7 @@
                 },
                 "escope": {
                   "version": "3.6.0",
-                  "from": "escope@>=3.3.0 <4.0.0",
+                  "from": "escope@>=3.2.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
                   "dependencies": {
                     "es6-map": {
@@ -11419,7 +11431,7 @@
                         },
                         "es6-symbol": {
                           "version": "3.0.2",
-                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "from": "es6-symbol@>=3.0.1 <3.1.0",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                         },
                         "event-emitter": {
@@ -11451,7 +11463,7 @@
                         },
                         "es6-symbol": {
                           "version": "3.0.2",
-                          "from": "es6-symbol@>=3.0.0 <4.0.0",
+                          "from": "es6-symbol@>=3.0.1 <3.1.0",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
                         }
                       }
@@ -11472,7 +11484,7 @@
                 },
                 "espree": {
                   "version": "2.2.5",
-                  "from": "espree@>=2.0.3 <3.0.0",
+                  "from": "espree@>=2.2.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
                 },
                 "estraverse": {
@@ -11665,7 +11677,7 @@
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.14 <6.0.0",
+                  "from": "glob@>=5.0.10 <6.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
@@ -11687,7 +11699,7 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -11929,7 +11941,7 @@
                     },
                     "lodash": {
                       "version": "3.10.1",
-                      "from": "lodash@>=3.10.0 <4.0.0",
+                      "from": "lodash@>=3.3.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                     },
                     "readline2": {
@@ -12030,7 +12042,7 @@
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.6 <3.0.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
@@ -12377,7 +12389,7 @@
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "from": "minimatch@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
@@ -12538,7 +12550,7 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -12603,7 +12615,7 @@
             },
             "decamelize": {
               "version": "1.2.0",
-              "from": "decamelize@>=1.1.2 <2.0.0",
+              "from": "decamelize@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
             },
             "window-size": {
@@ -12647,7 +12659,7 @@
                 },
                 "through": {
                   "version": "2.3.8",
-                  "from": "through@>=2.3.6 <3.0.0",
+                  "from": "through@>=2.2.7 <3.0.0",
                   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                 }
               }
@@ -12755,7 +12767,7 @@
             },
             "browser-resolve": {
               "version": "1.11.1",
-              "from": "browser-resolve@>=1.11.0 <2.0.0",
+              "from": "browser-resolve@>=1.7.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz"
             },
             "browserify-zlib": {
@@ -13121,7 +13133,7 @@
             },
             "deps-sort": {
               "version": "1.3.9",
-              "from": "deps-sort@>=1.3.5 <2.0.0",
+              "from": "deps-sort@>=1.3.7 <2.0.0",
               "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
               "dependencies": {
                 "JSONStream": {
@@ -13136,7 +13148,7 @@
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.6 <3.0.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
@@ -13201,7 +13213,7 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "once@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
@@ -13249,7 +13261,7 @@
             },
             "insert-module-globals": {
               "version": "6.6.3",
-              "from": "insert-module-globals@>=6.4.1 <7.0.0",
+              "from": "insert-module-globals@>=6.2.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
               "dependencies": {
                 "JSONStream": {
@@ -13370,7 +13382,7 @@
             },
             "module-deps": {
               "version": "3.9.1",
-              "from": "module-deps@>=3.7.0 <4.0.0",
+              "from": "module-deps@>=3.7.11 <4.0.0",
               "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
               "dependencies": {
                 "JSONStream": {
@@ -14014,35 +14026,35 @@
                   "from": "assert-plus@^0.2.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
-                "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "aws-sign2@~0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                },
                 "async": {
                   "version": "1.5.2",
                   "from": "async@^1.4.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 },
-                "bl": {
-                  "version": "1.0.2",
-                  "from": "bl@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz"
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@~0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
                 "block-stream": {
                   "version": "0.0.8",
                   "from": "block-stream@*",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
-                "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@~0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                "bl": {
+                  "version": "1.0.2",
+                  "from": "bl@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
                   "from": "boom@2.x.x",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@~0.11.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                 },
                 "chalk": {
                   "version": "1.1.1",
@@ -14069,11 +14081,6 @@
                   "from": "cryptiles@2.x.x",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
-                "dashdash": {
-                  "version": "1.12.2",
-                  "from": "dashdash@>=1.10.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
-                },
                 "debug": {
                   "version": "2.2.0",
                   "from": "debug@~2.2.0",
@@ -14084,15 +14091,20 @@
                   "from": "deep-extend@~0.4.0",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                "dashdash": {
+                  "version": "1.12.2",
+                  "from": "dashdash@>=1.10.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                 },
                 "delegates": {
                   "version": "1.0.0",
                   "from": "delegates@^1.0.0",
                   "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
@@ -14134,25 +14146,20 @@
                   "from": "gauge@~1.2.5",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz"
                 },
-                "generate-function": {
-                  "version": "2.0.0",
-                  "from": "generate-function@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                },
                 "generate-object-property": {
                   "version": "1.2.0",
                   "from": "generate-object-property@^1.1.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
                 },
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
                 "graceful-fs": {
                   "version": "4.1.3",
                   "from": "graceful-fs@^4.1.2",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "from": "har-validator@~2.0.6",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                 },
                 "graceful-readlink": {
                   "version": "1.0.1",
@@ -14163,6 +14170,11 @@
                   "version": "2.0.0",
                   "from": "has-ansi@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "from": "har-validator@~2.0.6",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                 },
                 "hawk": {
                   "version": "3.1.3",
@@ -14234,6 +14246,11 @@
                   "from": "json-schema@0.2.2",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                 },
+                "jsprim": {
+                  "version": "1.2.2",
+                  "from": "jsprim@^1.2.2",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                },
                 "json-stringify-safe": {
                   "version": "5.0.1",
                   "from": "json-stringify-safe@~5.0.1",
@@ -14243,11 +14260,6 @@
                   "version": "2.0.0",
                   "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "from": "jsprim@^1.2.2",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                 },
                 "lodash._basetostring": {
                   "version": "3.0.1",
@@ -14294,15 +14306,15 @@
                   "from": "mime-types@~2.1.7",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
                 },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                },
                 "minimist": {
                   "version": "0.0.8",
                   "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
@@ -14359,11 +14371,6 @@
                   "from": "request@2.x",
                   "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
                 },
-                "semver": {
-                  "version": "5.1.0",
-                  "from": "semver@~5.1.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
-                },
                 "sntp": {
                   "version": "1.0.9",
                   "from": "sntp@1.x.x",
@@ -14374,20 +14381,25 @@
                   "from": "sshpk@^1.7.0",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
                 },
+                "semver": {
+                  "version": "5.1.0",
+                  "from": "semver@~5.1.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@~0.10.x",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-                },
                 "stringstream": {
                   "version": "0.0.5",
                   "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
                 },
                 "strip-json-comments": {
                   "version": "1.0.4",
@@ -14398,6 +14410,11 @@
                   "version": "2.0.0",
                   "from": "supports-color@^2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.2.1",
+                  "from": "tough-cookie@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
                 },
                 "tar": {
                   "version": "2.2.1",
@@ -14414,16 +14431,6 @@
                   "from": "tunnel-agent@~0.4.1",
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                 },
-                "tough-cookie": {
-                  "version": "2.2.1",
-                  "from": "tough-cookie@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-                },
-                "uid-number": {
-                  "version": "0.0.6",
-                  "from": "uid-number@~0.0.6",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                },
                 "tweetnacl": {
                   "version": "0.13.3",
                   "from": "tweetnacl@>=0.13.0 <1.0.0",
@@ -14433,6 +14440,11 @@
                   "version": "1.0.2",
                   "from": "util-deprecate@~1.0.1",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "from": "uid-number@~0.0.6",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
@@ -14591,9 +14603,9 @@
           "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
           "dependencies": {
             "shell-quote": {
-              "version": "1.4.3",
+              "version": "1.5.0",
               "from": "shell-quote@>=1.4.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.5.0.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1469,7 +1469,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#71f069ca3afe328d25c0080cc4c8112142f159bd",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#3a4dd78fdf95c06dae5f6a31544817395cf9838d",
           "dependencies": {
             "leaflet": {
               "version": "0.7.3",
@@ -2232,7 +2232,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#71f069ca3afe328d25c0080cc4c8112142f159bd",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#3a4dd78fdf95c06dae5f6a31544817395cf9838d",
       "dependencies": {
         "jstify": {
           "version": "0.12.0",
@@ -4695,25 +4695,25 @@
                       "from": "ansi-styles@^2.1.0",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                     },
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
                     "are-we-there-yet": {
                       "version": "1.0.6",
                       "from": "are-we-there-yet@~1.0.6",
                       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz"
                     },
-                    "async": {
-                      "version": "1.5.2",
-                      "from": "async@^1.4.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
                       "version": "0.2.0",
                       "from": "assert-plus@^0.2.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    },
+                    "async": {
+                      "version": "1.5.2",
+                      "from": "async@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                     },
                     "aws-sign2": {
                       "version": "0.6.0",
@@ -4730,11 +4730,6 @@
                       "from": "block-stream@*",
                       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                     },
-                    "chalk": {
-                      "version": "1.1.1",
-                      "from": "chalk@^1.1.1",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-                    },
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@2.x.x",
@@ -4750,25 +4745,30 @@
                       "from": "combined-stream@~1.0.5",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                     },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@^1.1.1",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
                     },
                     "commander": {
                       "version": "2.9.0",
                       "from": "commander@^2.9.0",
                       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
                     },
-                    "dashdash": {
-                      "version": "1.12.2",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
-                    },
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.12.2",
+                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                     },
                     "debug": {
                       "version": "2.2.0",
@@ -4780,15 +4780,15 @@
                       "from": "deep-extend@~0.4.0",
                       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                     },
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    },
                     "delegates": {
                       "version": "1.0.0",
                       "from": "delegates@^1.0.0",
                       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                    },
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
@@ -4815,25 +4815,25 @@
                       "from": "forever-agent@~0.6.1",
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
-                    "fstream": {
-                      "version": "1.0.8",
-                      "from": "fstream@^1.0.2",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-                    },
                     "form-data": {
                       "version": "1.0.0-rc3",
                       "from": "form-data@~1.0.0-rc3",
                       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
                     },
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    "fstream": {
+                      "version": "1.0.8",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
                     },
                     "gauge": {
                       "version": "1.2.5",
                       "from": "gauge@~1.2.5",
                       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
@@ -4845,11 +4845,6 @@
                       "from": "graceful-fs@^4.1.2",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                     },
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>= 1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    },
                     "har-validator": {
                       "version": "2.0.6",
                       "from": "har-validator@~2.0.6",
@@ -4860,15 +4855,20 @@
                       "from": "has-ansi@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                     },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "from": "hawk@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     },
                     "has-unicode": {
                       "version": "2.0.0",
                       "from": "has-unicode@^2.0.0",
                       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "3.1.3",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                     },
                     "hoek": {
                       "version": "2.16.3",
@@ -4945,25 +4945,20 @@
                       "from": "jsprim@^1.2.2",
                       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                     },
-                    "lodash._createpadding": {
-                      "version": "3.6.1",
-                      "from": "lodash._createpadding@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-                    },
                     "lodash._basetostring": {
                       "version": "3.0.1",
                       "from": "lodash._basetostring@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
                     },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "from": "lodash._createpadding@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                    },
                     "lodash._root": {
                       "version": "3.0.0",
                       "from": "lodash._root@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.0.tgz"
-                    },
-                    "lodash.padleft": {
-                      "version": "3.1.1",
-                      "from": "lodash.padleft@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
                     },
                     "lodash.pad": {
                       "version": "3.3.0",
@@ -4975,30 +4970,35 @@
                       "from": "lodash.padright@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
                     },
-                    "mime-db": {
-                      "version": "1.21.0",
-                      "from": "mime-db@~1.21.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                    "lodash.padleft": {
+                      "version": "3.1.1",
+                      "from": "lodash.padleft@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
                     },
                     "lodash.repeat": {
                       "version": "3.2.0",
                       "from": "lodash.repeat@^3.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz"
                     },
+                    "mime-db": {
+                      "version": "1.21.0",
+                      "from": "mime-db@~1.21.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                    },
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                    },
                     "mime-types": {
                       "version": "2.1.9",
                       "from": "mime-types@~2.1.7",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
@@ -5010,30 +5010,25 @@
                       "from": "node-uuid@~1.4.7",
                       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                     },
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@~1.3.3",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                    "oauth-sign": {
+                      "version": "0.8.1",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                     },
                     "npmlog": {
                       "version": "2.0.2",
                       "from": "npmlog@~2.0.0",
                       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.2.tgz"
                     },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@~1.3.3",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
+                    },
                     "pinkie": {
                       "version": "2.0.4",
                       "from": "pinkie@^2.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.1",
-                      "from": "oauth-sign@~0.8.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@~1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.0",
@@ -5045,15 +5040,20 @@
                       "from": "qs@~6.0.2",
                       "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
                     },
-                    "readable-stream": {
-                      "version": "2.0.5",
-                      "from": "readable-stream@^2.0.0 || ^1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                    "process-nextick-args": {
+                      "version": "1.0.6",
+                      "from": "process-nextick-args@~1.0.6",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "request": {
                       "version": "2.69.0",
                       "from": "request@2.x",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@^2.0.0 || ^1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
                     },
                     "semver": {
                       "version": "5.1.0",
@@ -5100,25 +5100,25 @@
                       "from": "tar@~2.2.0",
                       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                     },
-                    "tar-pack": {
-                      "version": "3.1.3",
-                      "from": "tar-pack@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
-                    },
                     "tough-cookie": {
                       "version": "2.2.1",
                       "from": "tough-cookie@~2.2.0",
                       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
                     },
-                    "tunnel-agent": {
-                      "version": "0.4.2",
-                      "from": "tunnel-agent@~0.4.1",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                    "tar-pack": {
+                      "version": "3.1.3",
+                      "from": "tar-pack@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
                       "from": "tweetnacl@>=0.13.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2",
+                      "from": "tunnel-agent@~0.4.1",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                     },
                     "uid-number": {
                       "version": "0.0.6",
@@ -5130,15 +5130,15 @@
                       "from": "util-deprecate@~1.0.1",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     },
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    },
                     "verror": {
                       "version": "1.3.6",
                       "from": "verror@1.3.6",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
@@ -13996,15 +13996,15 @@
                     }
                   }
                 },
-                "ansi": {
-                  "version": "0.3.1",
-                  "from": "ansi@~0.3.1",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
-                },
                 "ansi-regex": {
                   "version": "2.0.0",
                   "from": "ansi-regex@^2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                },
+                "ansi": {
+                  "version": "0.3.1",
+                  "from": "ansi@~0.3.1",
+                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
                 },
                 "ansi-styles": {
                   "version": "2.1.0",
@@ -14036,15 +14036,15 @@
                   "from": "aws-sign2@~0.6.0",
                   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                 },
-                "block-stream": {
-                  "version": "0.0.8",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-                },
                 "bl": {
                   "version": "1.0.2",
                   "from": "bl@~1.0.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.2.tgz"
+                },
+                "block-stream": {
+                  "version": "0.0.8",
+                  "from": "block-stream@*",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
@@ -14066,15 +14066,15 @@
                   "from": "combined-stream@~1.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
                 },
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "commander@^2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-                },
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@~1.0.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "from": "commander@^2.9.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
@@ -14086,25 +14086,25 @@
                   "from": "debug@~2.2.0",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
                 },
-                "deep-extend": {
-                  "version": "0.4.1",
-                  "from": "deep-extend@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
-                },
                 "dashdash": {
                   "version": "1.12.2",
                   "from": "dashdash@>=1.10.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                 },
-                "delegates": {
-                  "version": "1.0.0",
-                  "from": "delegates@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                "deep-extend": {
+                  "version": "0.4.1",
+                  "from": "deep-extend@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
                 "delayed-stream": {
                   "version": "1.0.0",
                   "from": "delayed-stream@~1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "from": "delegates@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
@@ -14146,20 +14146,25 @@
                   "from": "gauge@~1.2.5",
                   "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz"
                 },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "from": "generate-object-property@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-                },
                 "generate-function": {
                   "version": "2.0.0",
                   "from": "generate-function@^2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "generate-object-property@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                },
                 "graceful-fs": {
                   "version": "4.1.3",
                   "from": "graceful-fs@^4.1.2",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "from": "har-validator@~2.0.6",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
                 },
                 "graceful-readlink": {
                   "version": "1.0.1",
@@ -14171,16 +14176,6 @@
                   "from": "has-ansi@^2.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                 },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "from": "har-validator@~2.0.6",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "from": "hawk@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-                },
                 "has-unicode": {
                   "version": "2.0.0",
                   "from": "has-unicode@^2.0.0",
@@ -14190,6 +14185,11 @@
                   "version": "2.16.3",
                   "from": "hoek@2.x.x",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "from": "hawk@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
                 },
                 "http-signature": {
                   "version": "1.1.1",
@@ -14206,15 +14206,15 @@
                   "from": "ini@~1.3.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
-                "is-my-json-valid": {
-                  "version": "2.12.4",
-                  "from": "is-my-json-valid@^2.12.4",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz"
-                },
                 "is-property": {
                   "version": "1.0.2",
                   "from": "is-property@^1.0.0",
                   "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                },
+                "is-my-json-valid": {
+                  "version": "2.12.4",
+                  "from": "is-my-json-valid@^2.12.4",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz"
                 },
                 "is-typedarray": {
                   "version": "1.0.0",
@@ -14231,11 +14231,6 @@
                   "from": "isstream@~0.1.2",
                   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                 },
-                "jodid25519": {
-                  "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                },
                 "jsbn": {
                   "version": "0.1.0",
                   "from": "jsbn@>=0.1.0 <0.2.0",
@@ -14246,10 +14241,10 @@
                   "from": "json-schema@0.2.2",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                 },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "from": "jsprim@^1.2.2",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
@@ -14260,6 +14255,11 @@
                   "version": "2.0.0",
                   "from": "jsonpointer@2.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.2.2",
+                  "from": "jsprim@^1.2.2",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
                 },
                 "lodash._basetostring": {
                   "version": "3.0.1",
@@ -14326,15 +14326,15 @@
                   "from": "node-uuid@~1.4.7",
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
-                "npmlog": {
-                  "version": "2.0.2",
-                  "from": "npmlog@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.2.tgz"
-                },
                 "oauth-sign": {
                   "version": "0.8.1",
                   "from": "oauth-sign@~0.8.0",
                   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+                },
+                "npmlog": {
+                  "version": "2.0.2",
+                  "from": "npmlog@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.2.tgz"
                 },
                 "once": {
                   "version": "1.3.3",
@@ -14351,15 +14351,15 @@
                   "from": "pinkie-promise@^2.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
                 },
-                "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "process-nextick-args@~1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                },
                 "qs": {
                   "version": "6.0.2",
                   "from": "qs@~6.0.2",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@~1.0.6",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "readable-stream": {
                   "version": "2.0.5",
@@ -14376,15 +14376,15 @@
                   "from": "sntp@1.x.x",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 },
-                "sshpk": {
-                  "version": "1.7.3",
-                  "from": "sshpk@^1.7.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
-                },
                 "semver": {
                   "version": "5.1.0",
                   "from": "semver@~5.1.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                },
+                "sshpk": {
+                  "version": "1.7.3",
+                  "from": "sshpk@^1.7.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -14406,45 +14406,45 @@
                   "from": "strip-json-comments@~1.0.4",
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 },
+                "tar-pack": {
+                  "version": "3.1.3",
+                  "from": "tar-pack@~3.1.0",
+                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
+                },
                 "supports-color": {
                   "version": "2.0.0",
                   "from": "supports-color@^2.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.2.1",
-                  "from": "tough-cookie@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
                 },
                 "tar": {
                   "version": "2.2.1",
                   "from": "tar@~2.2.0",
                   "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
                 },
-                "tar-pack": {
-                  "version": "3.1.3",
-                  "from": "tar-pack@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.3.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2",
-                  "from": "tunnel-agent@~0.4.1",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                "tough-cookie": {
+                  "version": "2.2.1",
+                  "from": "tough-cookie@~2.2.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.13.3",
                   "from": "tweetnacl@>=0.13.0 <1.0.0",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                 },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                },
                 "uid-number": {
                   "version": "0.0.6",
                   "from": "uid-number@~0.0.6",
                   "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2",
+                  "from": "tunnel-agent@~0.4.1",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@~1.0.1",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",


### PR DESCRIPTION
Resolves #6895

Replicated how new layers are created in the current editor, i.e. cloning an existing layer and remove/change values as necessary to avoid inconsistent layers.

Sorting of layers needs to be done later, that's out of scope for this issue, for now you can go to some tab view and return to layers to see them sorted.

I added a `snippets` object to the entry point, where we can add temporary code while WIP, and keep'em up-to-date as we change things, instead of each one of us stashing their own snippets.

```js
snippets.createTableLayer('trazado_metro')
// wait for layer to be created
l = layerDefinitionsCollection.first()
// try changing some props
l.set({
  name: 'my layer',
  visible: false
})
```

@xavijam @javierarce can you both review? I think the layers part is quite important to get right.

cc @alonsogarciapablo @juanignaciosl 