### PR TITLE
Use union merge for NEWS.md file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+NEWS.md merge=union


### PR DESCRIPTION
Now that we are updating the `NEWS.md` file more frequently, there are often conflicts when merging PR's due to this file. This conflicts can be easily resolved, as the changes to news are just to add a new line and a correct merge means just adding lines from both branches.

The option `merge=union` does exactly this: automatically add lines from multiple PR when merging, instead of triggering conflicts. This will eliminate merge conflicts in `NEWS.md` when the only changes are adding lines.

Also see https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/

cc @juanignaciosl @xavijam (do we need to ping anyone else?)