### PR TITLE
Move node destroy method to correct model

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
@@ -29,10 +29,6 @@ module.exports = cdb.core.Model.extend({
       id: this.id,
       analysis_definition: this._analysisDefinitionNodesCollection.get(this.get('node_id')).toJSON()
     };
-  },
-
-  destroy: function () {
-    this.collection.remove(this);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
@@ -68,6 +68,10 @@ module.exports = cdb.core.Model.extend({
     };
   },
 
+  destroy: function () {
+    this.collection.remove(this);
+  },
+
   /**
    * @return {Array} e.g. ['c3', 'b2']
    */

--- a/lib/assets/test/spec/cartodb3/data/analysis-definition-node-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/analysis-definition-node-model.spec.js
@@ -4,24 +4,43 @@ var AnalysisDefinitionNodeModel = require('../../../../javascripts/cartodb3/data
 describe('data/analysis-definition-node-model', function () {
   beforeEach(function () {
     this.collection = new AnalysisDefinitionNodesCollection(null);
+    this.model = new AnalysisDefinitionNodeModel({
+      id: 'g0',
+      type: 'source',
+      params: {
+        query: 'SELECT * FROM bar'
+      }
+    }, {
+      parse: true,
+      collection: this.collection
+    });
+    this.collection.add(this.model);
   });
 
-  describe('when a source analysis is created', function () {
+  it('should have no source ids', function () {
+    expect(this.model.sourceIds()).toEqual([]);
+  });
+
+  describe('.destroy', function () {
     beforeEach(function () {
-      this.model = new AnalysisDefinitionNodeModel({
+      expect(this.collection.pluck('id')).toEqual(['g0']);
+      this.model.destroy();
+    });
+
+    it('should remove the node from the collection', function () {
+      expect(this.collection.pluck('id')).toEqual([]);
+    });
+  });
+
+  describe('.toJSON', function () {
+    it('should serialize the model', function () {
+      expect(this.model.toJSON()).toEqual({
         id: 'g0',
         type: 'source',
         params: {
           query: 'SELECT * FROM bar'
         }
-      }, {
-        parse: true,
-        collection: this.collection
       });
-    });
-
-    it('should have no source ids', function () {
-      expect(this.model.sourceIds()).toEqual([]);
     });
   });
 


### PR DESCRIPTION
Nodes don’t have API endpoint, so the custom destroy (i.e. remove from
collection) should be on the node, not on the analysis definition.

@javierarce 