### PR TITLE
6920 buggy caching between editors and embeds

### DIFF
--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -1,4 +1,5 @@
-require_relative 'vizjson_presenter'
+require_dependency 'carto/api/vizjson_presenter'
+require_dependency 'carto/api/layer_vizjson_adapter'
 
 module Carto
   module Api
@@ -42,12 +43,14 @@ module Carto
         layer_definitions_from_layer_data(layer_data).each do |layer_definition|
           infowindow = layer_definition[:infowindow]
           if infowindow
-            infowindow[:template] = v3_infowindow_template(infowindow[:template_name], infowindow[:template])
+            infowindow_sym = infowindow.deep_symbolize_keys
+            infowindow[:template] = v3_infowindow_template(infowindow_sym[:template_name], infowindow_sym[:template])
           end
 
           tooltip = layer_definition[:tooltip]
           if tooltip
-            tooltip[:template] = v3_tooltip_template(tooltip[:template_name], tooltip[:template])
+            tooltip_sym = tooltip.deep_symbolize_keys
+            tooltip[:template] = v3_tooltip_template(tooltip_sym[:template_name], tooltip_sym[:template])
           end
         end
       end

--- a/app/controllers/carto/api/vizjson_presenter.rb
+++ b/app/controllers/carto/api/vizjson_presenter.rb
@@ -1,6 +1,6 @@
-require_relative '../../../models/visualization/vizjson'
+require_dependency 'visualization/vizjson'
+require_dependency 'carto/api/visualization_vizjson_adapter'
 require_relative '../../../helpers/redis_vizjson_cache'
-require_relative 'visualization_vizjson_adapter'
 
 module Carto
   module Api

--- a/app/controllers/carto/editor/public/embeds_controller.rb
+++ b/app/controllers/carto/editor/public/embeds_controller.rb
@@ -1,4 +1,4 @@
-require 'carto/api/vizjson3_presenter'
+require_dependency 'carto/api/vizjson3_presenter'
 
 module Carto
   module Editor

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -1,3 +1,5 @@
+require_dependency 'carto/api/vizjson3_presenter'
+
 module VisualizationsControllerHelper
   # Implicit order due to legacy code: 1st return canonical/table/Dataset if present, else derived/visualization/Map
   def get_priority_visualization(visualization_id, user_id: nil, organization_id: nil)


### PR DESCRIPTION
This fixes #6920. When vizjson3 becomes created on its own instead of overriding vizjson2 I'll symbolize everything from the very beginning.

@javitonino CR this, please.