### PR TITLE
1125 error updating user in central

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/requests/api/json/maps_controller_spec.rb \
 	spec/requests/carto/api/analyses_controller_spec.rb \
 	spec/requests/carto/api/maps_controller_spec.rb \
+	spec/requests/admin/users_controller_spec.rb \
 	$(NULL)
 
 # This class must be tested isolated as pollutes namespace

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -66,8 +66,8 @@ class Admin::UsersController < Admin::AdminController
       @user.set_fields(attributes, [:email])
     end
 
-    @user.save(raise_on_failure: true)
     @user.update_in_central
+    @user.save(raise_on_failure: true)
 
     update_session_security_token(@user) if password_change
 

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -47,12 +47,14 @@ module Carto
         # ::User validation requires confirmation
         params_to_update[:password_confirmation] = params_to_update[:password]
 
-        if !(soft_limits_validation(@user, params_to_update) && @user.update_fields(params_to_update, params_to_update.keys))
+        @user.set_fields(params_to_update, params_to_update.keys)
+        if !(soft_limits_validation(@user, params_to_update) && @user.valid?)
           render_jsonp(@user.errors.full_messages, 410)
           return
         end
 
         @user.update_in_central
+        @user.save
 
         render_jsonp Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer).to_poro, 200
       rescue CartoDB::CentralCommunicationFailure => e

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -47,8 +47,10 @@ module Carto
         # ::User validation requires confirmation
         params_to_update[:password_confirmation] = params_to_update[:password]
 
-        @user.set_fields(params_to_update, params_to_update.keys)
-        if !(soft_limits_validation(@user, params_to_update) && @user.valid?)
+        # NOTE: Verify soft limits BEFORE updating the user
+        unless soft_limits_validation(@user, params_to_update) &&
+               @user.set_fields(params_to_update, params_to_update.keys) &&
+               @user.valid?
           render_jsonp(@user.errors.full_messages, 410)
           return
         end

--- a/spec/requests/admin/organization_users_controller_spec.rb
+++ b/spec/requests/admin/organization_users_controller_spec.rb
@@ -92,7 +92,7 @@ describe Admin::OrganizationUsersController do
           last_response.body.should include('There was a problem while updating this user.')
 
           @existing_user.reload
-          @existing_user.quota_in_bytes.should != new_quota
+          @existing_user.quota_in_bytes.should_not eq new_quota
         end
       end
 

--- a/spec/requests/admin/organization_users_controller_spec.rb
+++ b/spec/requests/admin/organization_users_controller_spec.rb
@@ -83,6 +83,17 @@ describe Admin::OrganizationUsersController do
           @existing_user.reload
           @existing_user.quota_in_bytes.should eq new_quota
         end
+
+        it 'does not update users in case of Central failure' do
+          ::User.any_instance.stubs(:update_in_central).raises(CartoDB::CentralCommunicationFailure.new('Failed'))
+          new_quota = @existing_user.quota_in_bytes * 2
+          put update_organization_user_url(user_domain: @org_user_owner.username, id: @existing_user.username),
+              user: { quota_in_bytes: new_quota }
+          last_response.body.should include('There was a problem while updating this user.')
+
+          @existing_user.reload
+          @existing_user.quota_in_bytes.should != new_quota
+        end
       end
 
       describe '#destroy' do

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -52,7 +52,8 @@ describe Admin::OrganizationUsersController do
         @user.email.should end_with('.ok')
       end
 
-      it 'does not update if communication with Central fails' do
+      it 'does not update account if communication with Central fails' do
+        ::User.any_instance.stubs(:update_in_central).raises(CartoDB::CentralCommunicationFailure.new('Failed'))
         params = {
           email: 'fail-' + @user.email
         }
@@ -92,6 +93,7 @@ describe Admin::OrganizationUsersController do
       end
 
       it 'does not update profile if communication with Central fails' do
+        ::User.any_instance.stubs(:update_in_central).raises(CartoDB::CentralCommunicationFailure.new('Failed'))
         params = {
           name: 'fail-' + @user.name
         }

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -1,0 +1,108 @@
+# encoding: utf-8
+
+require_relative '../../spec_helper_min'
+require_relative '../../support/factories/users'
+
+describe Admin::OrganizationUsersController do
+  include Rack::Test::Methods
+  include Warden::Test::Helpers
+  include CartoDB::Factories
+
+  before(:all) do
+    @user = create_user(password: 'abcdefgh')
+  end
+
+  after(:all) do
+    @user.destroy
+  end
+
+  before(:each) do
+    host! "#{@user.username}.localhost.lan"
+    login_as(@user, scope: @user.username)
+  end
+
+  describe '#update' do
+    describe '#account' do
+      it 'updates password' do
+        params = {
+          old_password:     'abcdefgh',
+          new_password:     'zyxwvuts',
+          confirm_password: 'zyxwvuts'
+        }
+
+        ::User.any_instance.stubs(:update_in_central).returns(true)
+        put account_update_user_url, user: params
+
+        last_response.status.should eq 302
+        @user.reload
+        @user.validate_old_password('abcdefgh').should be_false
+        @user.validate_old_password('zyxwvuts').should be_true
+      end
+
+      it 'updates email' do
+        params = {
+          email: @user.email + '.ok'
+        }
+
+        ::User.any_instance.stubs(:update_in_central).returns(true)
+        put account_update_user_url, user: params
+
+        last_response.status.should eq 302
+        @user.reload
+        @user.email.should end_with('.ok')
+      end
+
+      it 'does not update if communication with Central fails' do
+        params = {
+          email: 'fail-' + @user.email
+        }
+
+        put account_update_user_url, user: params
+
+        last_response.status.should eq 200
+        last_response.body.should   include('There was a problem while updating your data')
+        @user.reload
+        @user.email.should_not start_with('fail-')
+      end
+    end
+
+    describe '#profile' do
+      it 'updates profile' do
+        params = {
+          name:               'Mengano',
+          website:            'http://somesite.com',
+          description:        'I describe myself',
+          location:           'Nowhere',
+          twitter_username:   'asd',
+          disqus_shortname:   'qwe',
+          available_for_hire: true
+        }
+        ::User.any_instance.stubs(:update_in_central).returns(true)
+        put profile_update_user_url, user: params
+
+        last_response.status.should eq 302
+        @user.reload
+        @user.name.should               eq params[:name]
+        @user.website.should            eq params[:website]
+        @user.description.should        eq params[:description]
+        @user.location.should           eq params[:location]
+        @user.twitter_username.should   eq params[:twitter_username]
+        @user.disqus_shortname.should   eq params[:disqus_shortname]
+        @user.available_for_hire.should eq params[:available_for_hire]
+      end
+
+      it 'does not update profile if communication with Central fails' do
+        params = {
+          name: 'fail-' + @user.name
+        }
+
+        put profile_update_user_url, user: params
+
+        last_response.status.should eq 200
+        last_response.body.should   include('There was a problem while updating your data')
+        @user.reload
+        @user.name.should_not start_with('fail-')
+      end
+    end
+  end
+end

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -385,6 +385,18 @@ describe Carto::Api::OrganizationUsersController do
       verify_soft_limits(user_to_update, false)
     end
 
+    it 'should not update if it cannot update in central' do
+      ::User.any_instance.stubs(:update_in_central).raises(CartoDB::CentralCommunicationFailure.new('Failed'))
+      login(@organization.owner)
+
+      user_to_update = @organization.non_owner_users[0]
+      params = { email: 'fail-' + user_to_update.email }
+      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+
+      last_response.status.should == 500
+      user_to_update.reload
+      user_to_update.email.should_not start_with('fail-')
+    end
   end
 
   describe 'user deletion' do


### PR DESCRIPTION
This ensures that no local changes are made before they can be saved at Central, so the state is kept in sync. Adds tests to check this behaviour (by stubbing `update_in_central` to fail).

Closes cartodb/cartodb-central#1125

CR @gfiorav 