### PR TITLE
Delete CASCADE on user dbs/schemas

### DIFF
--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -140,9 +140,14 @@ class Admin::OrganizationUsersController < Admin::AdminController
   rescue CartoDB::CentralCommunicationFailure => e
     CartoDB.report_exception(e)
     if e.user_message =~ /No organization user found with username/
-      @user.destroy
-      flash[:success] = "#{e.user_message}. User was deleted from the organization server."
-      redirect_to CartoDB.url(self, 'organization', {}, current_user)
+      begin
+        @user.destroy
+        flash[:success] = "#{e.user_message}. User was deleted from the organization server."
+        redirect_to CartoDB.url(self, 'organization', {}, current_user)
+      rescue => e
+        flash[:error] = "User was not deleted. #{e.message}"
+        redirect_to organization_path(user_domain: params[:user_domain])
+      end
     else
       set_flash_flags(nil, true)
       flash[:error] = "User was not deleted. #{e.user_message}"

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -145,6 +145,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
         flash[:success] = "#{e.user_message}. User was deleted from the organization server."
         redirect_to CartoDB.url(self, 'organization', {}, current_user)
       rescue => e
+        CartoDB::Logger.warning(exception: e, message: 'Error deleting organizational user', target_user: @user.username)
         flash[:error] = "User was not deleted. #{e.message}"
         redirect_to organization_path(user_domain: params[:user_domain])
       end
@@ -154,6 +155,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
       redirect_to CartoDB.url(self, 'organization', {}, current_user)
     end
   rescue => e
+    CartoDB::Logger.warning(exception: e, message: 'Error deleting organizational user', target_user: @user.username)
     flash[:error] = "User was not deleted. #{e.message}"
     redirect_to organization_path(user_domain: params[:user_domain])
   end

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -142,12 +142,12 @@ class Admin::OrganizationUsersController < Admin::AdminController
       flash[:success] = "User was successfully deleted."
       redirect_to CartoDB.url(self, 'organization', {}, current_user)
     else
-      CartoDB::Logger.warning(exception: e, message: 'Error deleting organizational user from central', target_user: @user.username)
+      CartoDB::Logger.error(exception: e, message: 'Error deleting organizational user from central', target_user: @user.username)
       flash[:success] = "#{e.user_message}. User was deleted from the organization server."
       redirect_to organization_path(user_domain: params[:user_domain])
     end
   rescue => e
-    CartoDB::Logger.warning(exception: e, message: 'Error deleting organizational user', target_user: @user.username)
+    CartoDB::Logger.error(exception: e, message: 'Error deleting organizational user', target_user: @user.username)
     flash[:error] = "User was not deleted. #{e.message}"
     redirect_to organization_path(user_domain: params[:user_domain])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -334,31 +334,29 @@ class User < Sequel::Model
       CartoDB::StdoutLogger.info "Error destroying user #{username}. #{exception.message}\n#{exception.backtrace}"
     end
 
-    # Remove metadata from redis
-    $users_metadata.DEL(self.key) unless error_happened
-
     # Invalidate user cache
     invalidate_varnish_cache
 
     # Delete the DB or the schema
     if has_organization
-      db_service.drop_organization_user(org_id, is_owner = !@org_id_for_org_wipe.nil?) unless error_happened
+      db_service.drop_organization_user(org_id, !@org_id_for_org_wipe.nil?) unless error_happened
     else
-      if ::User.where(:database_name => self.database_name).count > 1
+      if ::User.where(database_name: database_name).count > 1
         raise CartoDB::BaseCartoDBError.new('The user is not supposed to be in a organization but another user has the same database_name. Not dropping it')
-      else
-        if !error_happened
-          Thread.new do
-            conn = self.in_database(as: :cluster_admin)
-            db_service.drop_database_and_user(conn)
-            db_service.drop_user(conn)
-          end.join
-          db_service.monitor_user_notification
-        end
+      elsif !error_happened
+        Thread.new {
+          conn = in_database(as: :cluster_admin)
+          db_service.drop_database_and_user(conn)
+          db_service.drop_user(conn)
+        }.join
+        db_service.monitor_user_notification
       end
     end
 
-    self.feature_flags_user.each { |ffu| ffu.delete }
+    # Remove metadata from redis last (to avoid cutting off access to SQL API if db deletion fails)
+    $users_metadata.DEL(key) unless error_happened
+
+    feature_flags_user.each(&:delete)
   end
 
   def delete_external_data_imports

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -359,9 +359,8 @@ module CartoDB
             conn.run("DROP DATABASE \"#{@user.database_name}\"")
           end
           drop_user(conn)
+          CartoDB::UserModule::DBService.terminate_database_connections(@user.database_name, @user.database_host)
         end.join
-
-        CartoDB::UserModule::DBService.terminate_database_connections(@user.database_name, @user.database_host)
 
         monitor_user_notification
       end

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -965,6 +965,7 @@ module CartoDB
         conn ||= @user.in_database(as: :cluster_admin)
 
         if !@user.database_name.nil? && !@user.database_name.empty?
+          @user.in_database(as: :superuser).run("DROP SCHEMA \"#{@user.database_schema}\" CASCADE")
           conn.run("UPDATE pg_database SET datallowconn = 'false' WHERE datname = '#{@user.database_name}'")
           CartoDB::UserModule::DBService.terminate_database_connections(@user.database_name, @user.database_host)
           conn.run("DROP DATABASE \"#{@user.database_name}\"")

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -347,7 +347,7 @@ module CartoDB
                 [@user.database_username, @user.database_public_username, CartoDB::PUBLIC_DB_USER])
               database.run(%{ DROP FUNCTION IF EXISTS "#{@user.database_schema}"._CDB_UserQuotaInBytes()})
               drop_all_functions_from_schema(@user.database_schema)
-              database.run(%{ DROP SCHEMA IF EXISTS "#{@user.database_schema}" })
+              database.run(%{ DROP SCHEMA IF EXISTS "#{@user.database_schema}" CASCADE })
             end
           end
 

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -349,6 +349,7 @@ module CartoDB
           end
 
           conn = @user.in_database(as: :cluster_admin)
+          CartoDB::UserModule::DBService.terminate_database_connections(@user.database_name, @user.database_host)
 
           # If user is in an organization should never have public schema, but to be safe (& tests which stub stuff)
           unless @user.database_schema == SCHEMA_PUBLIC
@@ -359,7 +360,6 @@ module CartoDB
             conn.run("DROP DATABASE \"#{@user.database_name}\"")
           end
           drop_user(conn)
-          CartoDB::UserModule::DBService.terminate_database_connections(@user.database_name, @user.database_host)
         end.join
 
         monitor_user_notification

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -342,12 +342,9 @@ module CartoDB
 
             # If user is in an organization should never have public schema, but to be safe (& tests which stub stuff)
             unless @user.database_schema == SCHEMA_PUBLIC
-              drop_users_privileges_in_schema(
-                @user.database_schema,
-                [@user.database_username, @user.database_public_username, CartoDB::PUBLIC_DB_USER])
               database.run(%{ DROP FUNCTION IF EXISTS "#{@user.database_schema}"._CDB_UserQuotaInBytes()})
               drop_all_functions_from_schema(@user.database_schema)
-              database.run(%{ DROP SCHEMA IF EXISTS "#{@user.database_schema}" CASCADE })
+              database.run(%{ DROP SCHEMA IF EXISTS "#{@user.database_schema}" })
             end
           end
 

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -349,7 +349,6 @@ module CartoDB
           end
 
           conn = @user.in_database(as: :cluster_admin)
-          CartoDB::UserModule::DBService.terminate_database_connections(@user.database_name, @user.database_host)
 
           # If user is in an organization should never have public schema, but to be safe (& tests which stub stuff)
           unless @user.database_schema == SCHEMA_PUBLIC
@@ -361,6 +360,8 @@ module CartoDB
           end
           drop_user(conn)
         end.join
+
+        CartoDB::UserModule::DBService.terminate_database_connections(@user.database_name, @user.database_host)
 
         monitor_user_notification
       end


### PR DESCRIPTION
Fixes #6995 

This deletes cascade user databases (single users) or schemas (organization users) when deleting the user. This way, objects created by the user via SQL-API are deleted. Otherwise, the deletion fails, leaking db's for single users, and preventing user deletion for org users.

CR @juanignaciosl @zenitraM @luisbosque 