### PR TITLE
Rollbar failsafe

### DIFF
--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -63,7 +63,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
     @user.organization.notify_if_seat_limit_reached
     redirect_to CartoDB.url(self, 'organization', {}, current_user), flash: { success: "New user created successfully" }
   rescue Carto::UnprocesableEntityError => e
-    CartoDB.report_exception(e, "Validation error", request: request, user: current_user)
+    CartoDB::Logger.error(exception: e, message: "Validation error")
     set_flash_flags
     flash.now[:error] = e.user_message
     render 'new', status: 422
@@ -118,7 +118,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
 
     redirect_to CartoDB.url(self, 'edit_organization_user', { id: @user.username }, current_user), flash: { success: "Your changes have been saved correctly." }
   rescue Carto::UnprocesableEntityError => e
-    CartoDB.report_exception(e, "Validation error", request: request, user: current_user)
+    CartoDB::Logger.error(exception: e, message: "Validation error")
     set_flash_flags
     flash.now[:error] = e.user_message
     render 'edit', status: 422

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -64,7 +64,7 @@ module Carto
       rescue CartoDB::BoundingBoxError => e
         render_jsonp({ error: e.message }, 400)
       rescue => e
-        CartoDB.notify_exception(e, request: request, user: current_user)
+        CartoDB::Logger.error(exception: e)
         render_jsonp({ error: e.message }, 500)
       end
 

--- a/app/controllers/carto/api/widgets_controller.rb
+++ b/app/controllers/carto/api/widgets_controller.rb
@@ -26,7 +26,7 @@ module Carto
         widget.save!
         render_jsonp(WidgetPresenter.new(widget).to_poro, 201)
       rescue => e
-        CartoDB.report_exception(e, "Error creating widget", { widget: (widget ? widget : 'not created'), request: request, user: current_user })
+        CartoDB::Logger.error(exception: e, message: "Error creating widget", widget: (widget ? widget : 'not created'))
         render json: { errors: e.message }, status: 500
       end
 
@@ -37,7 +37,7 @@ module Carto
 
         render_jsonp(WidgetPresenter.new(@widget).to_poro)
       rescue => e
-        CartoDB.report_exception(e, "Error updating widget", { widget: @widget, request: request, user: current_user })
+        CartoDB::Logger.error(exception: e, message: "Error updating widget", widget: @widget)
         render json: { errors: e.message }, status: 500
       end
 
@@ -45,7 +45,7 @@ module Carto
         @widget.destroy
         render_jsonp(WidgetPresenter.new(@widget).to_poro)
       rescue => e
-        CartoDB.report_exception(e, "Error destroying widget", { widget: @widget, request: request, user: current_user })
+        CartoDB::Logger.error(exception: e, message: "Error destroying widget", widget: @widget)
         render json: { errors: e.message }, status: 500
       end
 

--- a/app/controllers/carto/controller_helper.rb
+++ b/app/controllers/carto/controller_helper.rb
@@ -58,7 +58,7 @@ module Carto
     end
 
     def rescue_from_standard_error(error)
-      CartoDB.report_exception(error, "Error", request: request, user: current_user)
+      CartoDB::Logger.error(exception: error)
       message = error.message
       respond_to do |format|
         format.html { render text: message, status: 500 }

--- a/lib/cartodb/logger.rb
+++ b/lib/cartodb/logger.rb
@@ -3,7 +3,7 @@ module CartoDB
     def self.log(level, exception: nil, message: nil, user: nil, **additional_data)
       # Include the call stack if not already present
       if exception.nil? && additional_data[:stack].nil?
-        additional_data[:stack] = caller
+        additional_data[:stack] = caller[0..25]
       end
 
       if Rails.env.development?
@@ -12,7 +12,7 @@ module CartoDB
 
       if rollbar_scope(user).log(level, exception, message, additional_data) == 'error'
         # Error reporting to Rollbar, usually caused by unserializable data in payload
-        Rollbar.log('warning', nil, 'Could not report to Rollbar', stack: caller)
+        Rollbar.log('warning', nil, 'Could not report to Rollbar', stack: caller[0..25])
       end
     rescue
       # Last chance to report error


### PR DESCRIPTION
Fixes some failures on Rollbar reporting that fail due to including too much information (>128kb) or I/O objects (including the request object) in the additional data.

Fixes part of #6999 

CR @gfiorav 