### PR TITLE
Match overview tables privacy to that of the base table

### DIFF
--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -83,7 +83,7 @@ module CartoDB
       self.privacy = ::UserTable::PRIVACY_PUBLIC
       set_database_permissions(grant_query)
       overviews_service = Carto::OverviewsService.new(owner.in_database)
-      overviews_service.overview_tables(table.name).each do |overview_table|
+      overviews_service.overview_tables(fully_qualified_table_name(table.name)).each do |overview_table|
         set_database_permissions(grant_query(overview_table))
       end
       self
@@ -93,7 +93,7 @@ module CartoDB
       self.privacy = ::UserTable::PRIVACY_PRIVATE
       set_database_permissions(revoke_query)
       overviews_service = Carto::OverviewsService.new(owner.in_database)
-      overviews_service.overview_tables(table.name).each do |overview_table|
+      overviews_service.overview_tables(fully_qualified_table_name(table.name)).each do |overview_table|
         set_database_permissions(revoke_query(overview_table))
       end
       self
@@ -103,7 +103,7 @@ module CartoDB
       self.privacy = ::UserTable::PRIVACY_LINK
       set_database_permissions(grant_query)
       overviews_service = Carto::OverviewsService.new(owner.in_database)
-      overviews_service.overview_tables(table.name).each do |overview_table|
+      overviews_service.overview_tables(fully_qualified_table_name(table.name)).each do |overview_table|
         set_database_permissions(grant_query(overview_table))
       end
       self
@@ -120,7 +120,7 @@ module CartoDB
     def revoke_query(table_name = nil)
       table_name ||= table.name
       %{
-        REVOKE SELECT ON "#{owner.database_schema}"."#{table_name}"
+        REVOKE SELECT ON #{fully_qualified_table_name(table_name)}
         FROM #{CartoDB::PUBLIC_DB_USER}
       }
     end
@@ -128,7 +128,7 @@ module CartoDB
     def grant_query(table_name = nil)
       table_name ||= table.name
       %{
-        GRANT SELECT ON "#{owner.database_schema}"."#{table_name}"
+        GRANT SELECT ON #{fully_qualified_table_name(table_name)}
         TO #{CartoDB::PUBLIC_DB_USER};
       }
     end
@@ -166,6 +166,10 @@ module CartoDB
     def notify_privacy_affected_entities(metadata_table)
       propagate_to(metadata_table.affected_visualizations, true)
       update_cdb_tablemetadata
+    end
+
+    def fully_qualified_table_name(table_name)
+      %{"#{owner.database_schema}"."#{table_name}"}
     end
   end
 end

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -117,8 +117,7 @@ module CartoDB
       owner.in_database(as: :superuser).run(query)
     end
 
-    def revoke_query(table_name = nil)
-      table_name ||= table.name
+    def revoke_query(table_name = @table.name)
       %{
         REVOKE SELECT ON #{fully_qualified_table_name(table_name)}
         FROM #{CartoDB::PUBLIC_DB_USER}

--- a/app/services/carto/overviews_service.rb
+++ b/app/services/carto/overviews_service.rb
@@ -31,8 +31,6 @@ module Carto
       raise unless e.to_s.match /relation .+ does not exist/
     end
 
-    private
-
     def overview_tables(table_name)
       overviews_data = @database.fetch(%{SELECT * FROM cartodb.CDB_Overviews('#{table_name}'::REGCLASS)})
       if overviews_data

--- a/spec/connectors/importer_overviews_spec.rb
+++ b/spec/connectors/importer_overviews_spec.rb
@@ -267,7 +267,7 @@ describe CartoDB::Importer2::Overviews do
       has_overviews?(user, table.name).should eq true
       ov_tables = overview_tables(user, table.name)
       # Check overviews are private
-      ov_tables.any? { |ov_table| public_table?(user, ov_table) }.should eq false
+      ov_tables.none? { |ov_table| public_table?(user, ov_table) }.should eq true
 
       set_table_privacy table, public_privacy
       # Check overviews are public
@@ -275,7 +275,7 @@ describe CartoDB::Importer2::Overviews do
 
       set_table_privacy table, private_privacy
       # Check overviews are private
-      ov_tables.any? { |ov_table| public_table?(user, ov_table) }.should eq false
+      ov_tables.none? { |ov_table| public_table?(user, ov_table) }.should eq true
 
       set_table_privacy table, link_privacy
       # Check overviews are public

--- a/spec/connectors/importer_overviews_spec.rb
+++ b/spec/connectors/importer_overviews_spec.rb
@@ -58,19 +58,13 @@ describe CartoDB::Importer2::Overviews do
     end
   end
 
-  def table_privileges(user, table)
-    privileges = user.in_database do |db|
+  def public_table?(user, table)
+    has_privilege = user.in_database do |db|
       db.fetch %{
-        SELECT relacl
-        FROM pg_class
-        WHERE oid = '#{table}'::regclass;
+        SELECT has_table_privilege('publicuser', '#{table}'::regclass, 'SELECT');
       }
     end
-    privileges.map(:relacl).first
-  end
-
-  def public_table?(user, table)
-    !!(table_privileges(user, table) =~ /publicuser/)
+    has_privilege.first[:has_table_privilege]
   end
 
   def set_table_privacy(table, privacy)

--- a/spec/connectors/importer_overviews_spec.rb
+++ b/spec/connectors/importer_overviews_spec.rb
@@ -273,19 +273,19 @@ describe CartoDB::Importer2::Overviews do
       has_overviews?(user, table.name).should eq true
       ov_tables = overview_tables(user, table.name)
       # Check overviews are private
-      ov_tables.any?{ |ov_table| public_table?(user, ov_table) }.should eq false
+      ov_tables.any? { |ov_table| public_table?(user, ov_table) }.should eq false
 
       set_table_privacy table, public_privacy
       # Check overviews are public
-      ov_tables.all?{ |ov_table| public_table?(user, ov_table) }.should eq true
+      ov_tables.all? { |ov_table| public_table?(user, ov_table) }.should eq true
 
       set_table_privacy table, private_privacy
       # Check overviews are private
-      ov_tables.any?{ |ov_table| public_table?(user, ov_table) }.should eq false
+      ov_tables.any? { |ov_table| public_table?(user, ov_table) }.should eq false
 
       set_table_privacy table, link_privacy
       # Check overviews are public
-      ov_tables.all?{ |ov_table| public_table?(user, ov_table) }.should eq true
+      ov_tables.all? { |ov_table| public_table?(user, ov_table) }.should eq true
     end
   end
 


### PR DESCRIPTION
Fixes #6955
Change the overview tables permissions when the base table
privacy changes.