### PR TITLE
Drop usage of permission fields entity_*

### DIFF
--- a/app/models/carto/permission.rb
+++ b/app/models/carto/permission.rb
@@ -15,11 +15,7 @@ class Carto::Permission < ActiveRecord::Base
   ENTITY_TYPE_VISUALIZATION = 'vis'
 
   belongs_to :owner, class_name: Carto::User, select: Carto::User::SELECT_WITH_DATABASE
-  belongs_to :entity, class_name: Carto::Visualization
-  # AR polymorphism does not allow for custom type mappings,
-  # and it seems the only implemented type is 'viz' which translates to Visualization.
-  # TODO: Add a migration to translate the type values to fully-qualified class types
-  # so we can use AR polymorphism (once we intend to use entities of different types)
+  has_one :entity, inverse_of: :permission, class_name: Carto::Visualization, foreign_key: :permission_id
 
   def acl
     @acl ||= self.access_control_list.nil? ? DEFAULT_ACL_VALUE : JSON.parse(self.access_control_list, symbolize_names: true)
@@ -42,6 +38,14 @@ class Carto::Permission < ActiveRecord::Base
 
   def is_owner_user?(user)
     self.owner_id == user.id
+  end
+
+  def entity_type
+    ENTITY_TYPE_VISUALIZATION
+  end
+
+  def entity_id
+    entity.id
   end
 
   private

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -27,7 +27,7 @@ class Carto::Visualization < ActiveRecord::Base
 
   belongs_to :user_table, class_name: Carto::UserTable, primary_key: :map_id, foreign_key: :map_id, inverse_of: :visualization
 
-  has_one :permission, inverse_of: :entity, conditions: { entity_type: 'vis' }, foreign_key: :entity_id
+  belongs_to :permission
 
   has_many :likes, foreign_key: :subject
   has_many :shared_entities, foreign_key: :entity_id, inverse_of: :visualization

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -45,11 +45,7 @@ module CartoDB
     end
 
     def real_entity_type
-      if entity.type == CartoDB::Visualization::Member::TYPE_CANONICAL
-        CartoDB::Visualization::Member::TYPE_CANONICAL
-      else
-        CartoDB::Visualization::Member::TYPE_DERIVED
-      end
+      entity.type
     end
 
     def notify_permissions_change(permissions_changes)

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -299,12 +299,15 @@ module CartoDB
 
     def validate
       super
-      errors.add(:owner_id, 'cannot be nil') if (self.owner_id.nil? || self.owner_id.empty?)
-      errors.add(:owner_username, 'cannot be nil') if (self.owner_username.nil? || self.owner_username.empty?)
-      unless new?
+      errors.add(:owner_id, 'cannot be nil') if owner_id.nil? || owner_id.empty?
+      errors.add(:owner_username, 'cannot be nil') if owner_username.nil? || owner_username.empty?
+
+      if new?
+        errors.add(:acl, 'must be empty on initial creation') if acl.present?
+      else
         validates_presence [:id]
       end
-    end #validate
+    end
 
     def before_save
       super

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -293,8 +293,8 @@ module CartoDB
 
     # @return Mixed|nil
     def entity
-      viz_id = Carto::Visualization.where(permission_id: id).first.id
-      @visualization ||= CartoDB::Visualization::Member.new(id: viz_id).fetch unless viz_id.nil?
+      viz = Carto::Visualization.where(permission_id: id).first
+      @visualization ||= CartoDB::Visualization::Member.new(id: viz.id).fetch unless viz.nil?
     end
 
     def validate
@@ -315,10 +315,7 @@ module CartoDB
       if !@old_acl.nil?
         self.notify_permissions_change(CartoDB::Permission.compare_new_acl(@old_acl, self.acl))
       end
-    end
-
-    def after_save
-      update_shared_entities unless new?
+      update_shared_entities
     end
 
     def after_destroy

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -293,8 +293,7 @@ module CartoDB
 
     # @return Mixed|nil
     def entity
-      viz = Carto::Visualization.where(permission_id: id).first
-      @visualization ||= CartoDB::Visualization::Member.new(id: viz.id).fetch unless viz.nil?
+      @visualization ||= CartoDB::Visualization::Collection.new.fetch(permission_id: id).first
     end
 
     def validate

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1571,10 +1571,10 @@ class User < Sequel::Model
 
   def destroy_shared_with
     CartoDB::SharedEntity.where(recipient_id: id).each do |se|
-      CartoDB::Permission.where(entity_id: se.entity_id).each do |p|
-        p.remove_user_permission(self)
-        p.save
-      end
+      viz = CartoDB::Visualization::Member.new(id: se.entity_id).fetch
+      permission = viz.permission
+      permission.remove_user_permission(self)
+      permission.save
     end
   end
 

--- a/app/models/visualization/collection.rb
+++ b/app/models/visualization/collection.rb
@@ -370,6 +370,7 @@ module CartoDB
         dataset = filter_by_min_date('updated_at', dataset, filters.delete(:min_updated_at)) if filters.has_key?(:min_updated_at)
         dataset = filter_by_min_date('created_at', dataset, filters.delete(:min_created_at)) if filters.has_key?(:min_created_at)
         dataset = filter_by_ids(dataset, filters.delete(:ids))
+        dataset = filter_by_permission_id(dataset, filters.delete(:permission_id))
         order_desc = filters.delete(:order_asc_desc)
         order(dataset, filters.delete(:order), order_desc.nil? || order_desc == :desc)
       end
@@ -483,6 +484,11 @@ module CartoDB
         dataset.where(:id => ids)
       end
 
+      def filter_by_permission_id(dataset, permission_id)
+        return dataset if permission_id.nil?
+        dataset.where(permission_id: permission_id)
+      end
+
       def filter_by_only_shared(dataset, filters)
         return dataset \
           unless (filters[:user_id].present? && filters[:only_shared].present? && filters[:only_shared].to_s == 'true')
@@ -534,4 +540,3 @@ module CartoDB
     end
   end
 end
-

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -753,7 +753,6 @@ module CartoDB
         if permission.nil?
           perm = CartoDB::Permission.new
           perm.owner = user
-          perm.entity = self
           perm.save
           @permission_id = perm.id
           # Need to save again

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -500,9 +500,9 @@ describe CartoDB::Permission do
           owner_username: @user.username,
           entity_id:      entity_id,
           entity_type:    Permission::ENTITY_TYPE_VISUALIZATION
-      )
+      ).save
 
-      # Before saving, create old entries
+      # Create old entries
       CartoDB::SharedEntity.new(
           recipient_id:   @user.id,
           recipient_type: CartoDB::SharedEntity::RECIPIENT_TYPE_USER,

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -46,7 +46,7 @@ describe CartoDB::Permission do
       vis_entity_mock.stubs(:privacy=)
       vis_entity_mock.stubs(:store)
       vis_entity_mock.stubs(:type).returns(CartoDB::Visualization::Member::TYPE_DERIVED)
-      vis_entity_mock.stubs(:id).returns(UUIDTools::UUID.timestamp_create.to_s)
+      vis_entity_mock.stubs(:id).returns(entity_id)
       vis_entity_mock.stubs(:name).returns("foobar_visualization")
       Permission.any_instance.stubs(:entity).returns(vis_entity_mock)
 
@@ -105,26 +105,6 @@ describe CartoDB::Permission do
         permission2.save
       }.to raise_exception
 
-      # Missing entity_type
-      permission2 = Permission.new(
-          owner_id:       @user.id,
-          owner_username: @user.username,
-          entity_id:      entity_id,
-      )
-      expect {
-        permission2.save
-      }.to raise_exception
-
-      # Missing entity_id
-      permission2 = Permission.new(
-          owner_id:       @user.id,
-          owner_username: @user.username,
-          entity_type:      entity_type,
-      )
-      expect {
-        permission2.save
-      }.to raise_exception
-
       # Owner helper methods
       permission2 = Permission.new
       permission2.owner = @user
@@ -145,7 +125,6 @@ describe CartoDB::Permission do
       Visualization::Member.any_instance.stubs(:new).returns vis_mock
       permission2 = Permission.new
       permission2.owner = @user
-      permission2.entity = vis_mock
       permission2.save
 
       # invalid ACL formats
@@ -230,7 +209,7 @@ describe CartoDB::Permission do
       vis_entity_mock.stubs(:privacy=)
       vis_entity_mock.stubs(:store)
       vis_entity_mock.stubs(:type).returns(CartoDB::Visualization::Member::TYPE_DERIVED)
-      vis_entity_mock.stubs(:id).returns(UUIDTools::UUID.timestamp_create.to_s)
+      vis_entity_mock.stubs(:id).returns(entity_id)
       vis_entity_mock.stubs(:name).returns("foobar_visualization")
       Permission.any_instance.stubs(:entity).returns(vis_entity_mock)
 
@@ -514,7 +493,7 @@ describe CartoDB::Permission do
       Permission.any_instance.stubs(:revoke_previous_permissions).returns(nil)
       Permission.any_instance.stubs(:grant_db_permission).returns(nil)
       # No need to check for real DB visualizations
-      prepare_vis_mock_in_permission
+      prepare_vis_mock_in_permission(entity_id)
 
       permission = Permission.new(
           owner_id:       @user.id,
@@ -733,17 +712,16 @@ describe CartoDB::Permission do
 
   end
 
-  def prepare_vis_mock_in_permission
+  def prepare_vis_mock_in_permission(viz_id = UUIDTools::UUID.timestamp_create.to_s)
     vis_entity_mock = mock
     vis_entity_mock.stubs(:table).returns(nil)
     vis_entity_mock.stubs(:related_tables).returns([])
     vis_entity_mock.stubs(:table?).returns(true)
     vis_entity_mock.stubs(:invalidate_cache).returns(nil)
     vis_entity_mock.stubs(:type).returns(CartoDB::Visualization::Member::TYPE_DERIVED)
-    vis_entity_mock.stubs(:id).returns(UUIDTools::UUID.timestamp_create.to_s)
+    vis_entity_mock.stubs(:id).returns(viz_id)
     vis_entity_mock.stubs(:name).returns("foobar_visualization")
     Permission.any_instance.stubs(:entity).returns(vis_entity_mock)
   end
 
 end
-

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -72,9 +72,7 @@ describe CartoDB::Permission do
 
       permission = Permission.new(
         owner_id:       @user.id,
-        owner_username: @user.username,
-        entity_id:      entity_id,
-        entity_type:    entity_type
+        owner_username: @user.username
         #check default acl is correct
       )
       permission.save
@@ -108,8 +106,6 @@ describe CartoDB::Permission do
       # Owner helper methods
       permission2 = Permission.new
       permission2.owner = @user
-      permission2.entity_id = entity_id
-      permission2.entity_type = entity_type
       permission2.save
       permission2.owner.should eq @user
       permission2.owner_id.should eq @user.id
@@ -237,9 +233,7 @@ describe CartoDB::Permission do
 
       permission = Permission.new(
         owner_id:       @user.id,
-        owner_username: @user.username,
-        entity_id:      entity_id,
-        entity_type:    entity_type
+        owner_username: @user.username
         #check default acl is correct
       )
       permission.save
@@ -285,9 +279,7 @@ describe CartoDB::Permission do
 
       permission = Permission.new(
         owner_id:       @user.id,
-        owner_username: @user.username,
-        entity_id: UUIDTools::UUID.timestamp_create.to_s,
-        entity_type: Permission::ENTITY_TYPE_VISUALIZATION
+        owner_username: @user.username
       ).save
       permission.acl = [
         {
@@ -337,9 +329,7 @@ describe CartoDB::Permission do
 
       permission = Permission.new(
         owner_id:       @user.id,
-        owner_username: @user.username,
-        entity_id: UUIDTools::UUID.timestamp_create.to_s,
-        entity_type: Permission::ENTITY_TYPE_VISUALIZATION
+        owner_username: @user.username
       ).save
       permission.acl = [
         {
@@ -388,9 +378,7 @@ describe CartoDB::Permission do
 
       permission = Permission.new(
           owner_id:       @user.id,
-          owner_username: @user.username,
-          entity_id: UUIDTools::UUID.timestamp_create.to_s,
-          entity_type: Permission::ENTITY_TYPE_VISUALIZATION
+          owner_username: @user.username
       ).save
       # User has more access than org
       permission.acl = [
@@ -497,23 +485,21 @@ describe CartoDB::Permission do
 
       permission = Permission.new(
           owner_id:       @user.id,
-          owner_username: @user.username,
-          entity_id:      entity_id,
-          entity_type:    Permission::ENTITY_TYPE_VISUALIZATION
+          owner_username: @user.username
       ).save
 
       # Create old entries
       CartoDB::SharedEntity.new(
-          recipient_id:   @user.id,
-          recipient_type: CartoDB::SharedEntity::RECIPIENT_TYPE_USER,
-          entity_id:      entity_id,
-          entity_type:    CartoDB::SharedEntity::ENTITY_TYPE_VISUALIZATION
+        recipient_id:   @user.id,
+        recipient_type: CartoDB::SharedEntity::RECIPIENT_TYPE_USER,
+        entity_id:      entity_id,
+        entity_type:    CartoDB::SharedEntity::ENTITY_TYPE_VISUALIZATION
       ).save
       CartoDB::SharedEntity.new(
-          recipient_id:   user2_mock.id,
-          recipient_type: CartoDB::SharedEntity::RECIPIENT_TYPE_USER,
-          entity_id:      entity_id,
-          entity_type:    CartoDB::SharedEntity::ENTITY_TYPE_VISUALIZATION
+        recipient_id:   user2_mock.id,
+        recipient_type: CartoDB::SharedEntity::RECIPIENT_TYPE_USER,
+        entity_id:      entity_id,
+        entity_type:    CartoDB::SharedEntity::ENTITY_TYPE_VISUALIZATION
       ).save
 
       CartoDB::SharedEntity.all.count.should eq 2
@@ -602,10 +588,8 @@ describe CartoDB::Permission do
 
       permission = Permission.new(
         owner_id:       @user.id,
-        owner_username: @user.username,
-        entity_type: Permission::ENTITY_TYPE_VISUALIZATION
+        owner_username: @user.username
       )
-      permission.entity_id = permission.entity.id
 
       permission.save
 
@@ -645,10 +629,8 @@ describe CartoDB::Permission do
 
       permission = Permission.new(
         owner_id:       @user.id,
-        owner_username: @user.username,
-        entity_type: Permission::ENTITY_TYPE_VISUALIZATION
+        owner_username: @user.username
       ).save
-      permission.entity_id = permission.entity.id
 
       Resque.stubs(:enqueue).returns(nil)
 

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -288,7 +288,7 @@ describe CartoDB::Permission do
         owner_username: @user.username,
         entity_id: UUIDTools::UUID.timestamp_create.to_s,
         entity_type: Permission::ENTITY_TYPE_VISUALIZATION
-      )
+      ).save
       permission.acl = [
         {
           type: Permission::TYPE_USER,
@@ -340,7 +340,7 @@ describe CartoDB::Permission do
         owner_username: @user.username,
         entity_id: UUIDTools::UUID.timestamp_create.to_s,
         entity_type: Permission::ENTITY_TYPE_VISUALIZATION
-      )
+      ).save
       permission.acl = [
         {
           type: Permission::TYPE_USER,
@@ -391,7 +391,7 @@ describe CartoDB::Permission do
           owner_username: @user.username,
           entity_id: UUIDTools::UUID.timestamp_create.to_s,
           entity_type: Permission::ENTITY_TYPE_VISUALIZATION
-      )
+      ).save
       # User has more access than org
       permission.acl = [
           {
@@ -647,7 +647,7 @@ describe CartoDB::Permission do
         owner_id:       @user.id,
         owner_username: @user.username,
         entity_type: Permission::ENTITY_TYPE_VISUALIZATION
-      )
+      ).save
       permission.entity_id = permission.entity.id
 
       Resque.stubs(:enqueue).returns(nil)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1429,12 +1429,7 @@ describe User do
 
       # Grant permission
       user2_vis  = CartoDB::Visualization::Collection.new.fetch(user_id: @user2.id, name: table3.name).first
-      permission = CartoDB::Permission.new(
-        owner_id:       @user2.id,
-        owner_username: @user2.username,
-        entity_id:      user2_vis.id,
-        entity_type:    CartoDB::Permission::ENTITY_TYPE_VISUALIZATION
-      )
+      permission = user2_vis.permission
       permission.acl = [
         {
           type: CartoDB::Permission::TYPE_USER,

--- a/spec/requests/api/permissions_controller_spec.rb
+++ b/spec/requests/api/permissions_controller_spec.rb
@@ -97,9 +97,7 @@ describe Api::Json::PermissionsController do
 
       permission = CartoDB::Permission.new(
           owner_id: @user.id,
-          owner_username: @user.username,
-          entity_id:      @entity_id,
-          entity_type:    entity_type
+          owner_username: @user.username
       )
       permission.acl = acl_initial
       permission.save
@@ -135,9 +133,7 @@ describe Api::Json::PermissionsController do
     it "makes sure we don't expose unwanted call types" do
       permission = CartoDB::Permission.new(
           owner_id: @user.id,
-          owner_username: @user.username,
-          entity_id:      UUIDTools::UUID.timestamp_create.to_s,
-          entity_type:    Permission::ENTITY_TYPE_VISUALIZATION
+          owner_username: @user.username
       )
       permission.save
 
@@ -205,9 +201,7 @@ describe 'group permission support' do
 
     permission = CartoDB::Permission.new(
         owner_id: @org_user_1.id,
-        owner_username: @org_user_1.username,
-        entity_id:      entity_id,
-        entity_type:    entity_type
+        owner_username: @org_user_1.username
     )
     permission.acl = acl_initial
     permission.save
@@ -240,9 +234,7 @@ describe 'group permission support' do
 
     permission = CartoDB::Permission.new(
         owner_id: @org_user_1.id,
-        owner_username: @org_user_1.username,
-        entity_id:      entity_id,
-        entity_type:    entity_type
+        owner_username: @org_user_1.username
     )
     permission.acl = acl_initial
     permission.save

--- a/spec/requests/api/permissions_controller_spec.rb
+++ b/spec/requests/api/permissions_controller_spec.rb
@@ -40,6 +40,7 @@ describe Api::Json::PermissionsController do
   end
 
   before(:each) do
+    @entity_id = UUIDTools::UUID.timestamp_create.to_s
     stub_named_maps_calls
     delete_user_data @user
     delete_user_data @user2
@@ -53,6 +54,7 @@ describe Api::Json::PermissionsController do
     Permission.any_instance.stubs(:notify_permissions_change).returns(nil)
     vis_entity_mock = mock
     vis_entity_mock.stubs(:table?).returns(false)
+    vis_entity_mock.stubs(:id).returns(@entity_id)
     Permission.any_instance.stubs(:entity).returns(vis_entity_mock)
   end
 
@@ -66,7 +68,6 @@ describe Api::Json::PermissionsController do
   describe 'PUT /api/v1/perm' do
 
     it 'modifies an existing permission' do
-      entity_id = UUIDTools::UUID.timestamp_create.to_s
       entity_type = Permission::ENTITY_TYPE_VISUALIZATION
 
       acl_initial = [ ]
@@ -97,7 +98,7 @@ describe Api::Json::PermissionsController do
       permission = CartoDB::Permission.new(
           owner_id: @user.id,
           owner_username: @user.username,
-          entity_id:      entity_id,
+          entity_id:      @entity_id,
           entity_type:    entity_type
       )
       permission.acl = acl_initial
@@ -113,7 +114,7 @@ describe Api::Json::PermissionsController do
       owner_fragment[:id].should eq permission.owner_id
       owner_fragment[:username].should eq permission.owner_username
       entity_fragment = response.fetch(:entity)
-      entity_fragment[:id].should eq entity_id
+      entity_fragment[:id].should eq @entity_id
       entity_fragment[:type].should eq entity_type
       Time.parse(response.fetch(:created_at)).to_i.should eq permission.created_at.to_i
       Time.parse(response.fetch(:updated_at)).to_i.should_not eq permission.updated_at.to_i
@@ -171,12 +172,14 @@ describe 'group permission support' do
   end
 
   it 'adds group read permission' do
+    entity_id = UUIDTools::UUID.timestamp_create.to_s
+
     vis_entity_mock = mock
     vis_entity_mock.stubs(:table?).returns(false)
+    vis_entity_mock.stubs(:id).returns(entity_id)
     Permission.any_instance.stubs(:entity).returns(vis_entity_mock)
     Permission.any_instance.stubs(:revoke_previous_permissions).returns(nil)
 
-    entity_id = UUIDTools::UUID.timestamp_create.to_s
     entity_type = Permission::ENTITY_TYPE_VISUALIZATION
 
     acl_initial = [ ]
@@ -224,12 +227,13 @@ describe 'group permission support' do
   end
 
   it 'creates a shared entity per shared group' do
+    entity_id = UUIDTools::UUID.timestamp_create.to_s
     vis_entity_mock = mock
     vis_entity_mock.stubs(:table?).returns(false)
+    vis_entity_mock.stubs(:id).returns(entity_id)
     Permission.any_instance.stubs(:entity).returns(vis_entity_mock)
     Permission.any_instance.stubs(:revoke_previous_permissions).returns(nil)
 
-    entity_id = UUIDTools::UUID.timestamp_create.to_s
     entity_type = Permission::ENTITY_TYPE_VISUALIZATION
 
     acl_initial = [ ]
@@ -265,4 +269,3 @@ describe 'group permission support' do
   end
 
 end
-

--- a/spec/requests/carto/api/database_groups_controller_spec.rb
+++ b/spec/requests/carto/api/database_groups_controller_spec.rb
@@ -87,7 +87,7 @@ describe Carto::Api::DatabaseGroupsController do
       put api_v1_databases_group_update_permission_url(database_name: group.database_name, name: group.name, username: @org_user_2.username, table_name: @table_user_2['name']), permission.to_json, org_metadata_api_headers
       response.status.should == 200
 
-      permission = ::Permission.where(entity_id: @table_user_2['table_visualization']['id']).first
+      permission = ::Visualization::Member.new(id: @table_user_2['table_visualization']['id']).fetch.permission
       permission.should_not be_nil
 
       expected_acl = [
@@ -133,7 +133,7 @@ describe Carto::Api::DatabaseGroupsController do
       put api_v1_databases_group_update_permission_url(database_name: group.database_name, name: group.name, username: @org_user_1.username, table_name: @table_user_1['name']), permission.to_json, org_metadata_api_headers
       response.status.should == 200
 
-      permission = ::Permission.where(entity_id: @table_user_1['table_visualization']['id']).first
+      permission = ::Visualization::Member.new(id: @table_user_1['table_visualization']['id']).fetch.permission
       permission.should_not be_nil
 
       expected_acl = [
@@ -162,7 +162,7 @@ describe Carto::Api::DatabaseGroupsController do
 
       delete api_v1_databases_group_destroy_permission_url(database_name: group.database_name, name: group.name, username: @org_user_1.username, table_name: @table_user_1['name']), '', org_metadata_api_headers
       response.status.should == 200
-      permission = ::Permission.where(entity_id: @table_user_1['table_visualization']['id']).first
+      permission = ::Visualization::Member.new(id: @table_user_1['table_visualization']['id']).fetch.permission
       permission.to_poro[:acl].should == expected_acl
 
       # Check it doesn't duplicate


### PR DESCRIPTION
Part of https://github.com/CartoDB/cartodb/issues/7013

This PR removes the use of `entity_id` and `entity_type` fields from the Permissions model. This is to be run after the rake in #7015 but before the migration that actually drops the fields (WIP).

As the Permission model needs the visualization for several operations, the `entity` family of methods have been replaced to search the corresponding Visualization by checking the `permission_id` column of the visualizations table. This field is already indexed, so queries should be fast.

This also introduces a restriction on Permission creation. As permissions will be created before visualizations, the visualization will not exists at creation time. This means that no permissions can be granted at creation time (ACL must be empty), only after the visualization has been created.

There is no place in the code base that does this, all visualizations are created with default permissions, and there isn't an API for permission creation. Some tests did, and have been modified so permissions are created empty and then updated. A validation has been added to check for this, to avoid exceptions when saving.