### PR TITLE
Ensure correct ordering on Viz/permission creation/deletion

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -324,10 +324,6 @@ module CartoDB
       self.notify_permissions_change(CartoDB::Permission.compare_new_acl(self.acl, []))
     end
 
-    def before_destroy
-      destroy_shared_entities
-    end
-
     # @param subject ::User
     # @return String Permission::ACCESS_xxx
     def permission_for_user(subject)

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -294,10 +294,10 @@ module CartoDB
                                           }
         }
 
+        safe_sequel_delete { permission.destroy_shared_entities } if permission
         safe_sequel_delete { repository.delete(id) }
-        safe_sequel_delete { CartoDB::SharedEntity.where(entity_id: id).delete }
         safe_sequel_delete { permission.destroy } if permission
-        self.attributes.keys.each { |key| self.send("#{key}=", nil) }
+        attributes.keys.each { |key| send("#{key}=", nil) }
 
         self
       end

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -293,8 +293,8 @@ module CartoDB
                                             child.fetch.delete
                                           }
         }
-        safe_sequel_delete { permission.destroy } if permission
         safe_sequel_delete { repository.delete(id) }
+        safe_sequel_delete { permission.destroy }
         self.attributes.keys.each { |key| self.send("#{key}=", nil) }
 
         self
@@ -747,9 +747,7 @@ module CartoDB
 
         set_timestamps
 
-        repository.store(id, attributes.to_hash)
-
-        # Careful to not call Permission.save until after persisted the vis
+        # Ensure a permission is set before saving the visualization
         if permission.nil?
           perm = CartoDB::Permission.new
           perm.owner = user
@@ -759,6 +757,7 @@ module CartoDB
           # Need to save again
           repository.store(id, attributes.to_hash)
         end
+        repository.store(id, attributes.to_hash)
 
         begin
           save_named_map

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -755,8 +755,6 @@ module CartoDB
           perm.owner = user
           perm.save
           @permission_id = perm.id
-          # Need to save again
-          repository.store(id, attributes.to_hash)
         end
         repository.store(id, attributes.to_hash)
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -293,7 +293,9 @@ module CartoDB
                                             child.fetch.delete
                                           }
         }
+
         safe_sequel_delete { repository.delete(id) }
+        safe_sequel_delete { CartoDB::SharedEntity.where(entity_id: id).delete }
         safe_sequel_delete { permission.destroy }
         self.attributes.keys.each { |key| self.send("#{key}=", nil) }
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -296,7 +296,7 @@ module CartoDB
 
         safe_sequel_delete { repository.delete(id) }
         safe_sequel_delete { CartoDB::SharedEntity.where(entity_id: id).delete }
-        safe_sequel_delete { permission.destroy }
+        safe_sequel_delete { permission.destroy } if permission
         self.attributes.keys.each { |key| self.send("#{key}=", nil) }
 
         self


### PR DESCRIPTION
Part of #7013

This is a simple change before adding the FK (`viz.permission_id`). This ensure that permission is created before the visualization, and gets deleted after the visualization to keep with the order of the FK.

Before, it was just the reverse, as the permission required an `entity_id` to be specified (not anymore).