### PR TITLE
Cache overquota users and do it in background

### DIFF
--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -18,7 +18,8 @@ class Superadmin::UsersController < Superadmin::SuperadminController
 
   def index
     if params[:overquota].present?
-      @users =  ::User.overquota(0.20)
+      users = ::User.get_stored_overquota_users(Date.today)
+      respond_with(:superadmin, users)
     elsif params[:db_size_in_bytes_change].present?
       # This use case is specific: we only return cached db_size_in_bytes, which is
       # much faster and doesn't add load to the database.
@@ -27,9 +28,9 @@ class Superadmin::UsersController < Superadmin::SuperadminController
         { 'username' => username, 'db_size_in_bytes' => db_size_in_bytes }
       end) and return
     else
-      @users = ::User.all
+      users = ::User.all
+      respond_with(:superadmin, users.map(&:data))
     end
-    respond_with(:superadmin, @users.map { |user| user.data })
   end
 
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -447,7 +447,8 @@ class User < Sequel::Model
   #        example: 0.20 will get all users at 80% of their map view limit
   #
   def self.overquota(delta = 0)
-    ::User.where(enabled: true).all.reject{ |u| u.organization_id.present? }.select do |u|
+    users_overquota = []
+    ::User.where(enabled: true, organization_id: nil).each do |u|
         limit = u.geocoding_quota.to_i - (u.geocoding_quota.to_i * delta)
         over_geocodings = u.get_geocoding_calls > limit
 
@@ -457,7 +458,37 @@ class User < Sequel::Model
         limit = u.here_isolines_quota.to_i - (u.here_isolines_quota.to_i * delta)
         over_here_isolines = u.get_here_isolines_calls > limit
 
-        over_geocodings || over_twitter_imports || over_here_isolines
+        if over_geocodings || over_twitter_imports || over_here_isolines
+          users_overquota.push(u)
+        end
+    end
+    users_overquota
+  end
+
+  def self.store_overquota_users(delta, date)
+    overquota_users = overquota(delta)
+    today = date.strftime('%Y%m%d')
+    key = "overquota:users:#{today}"
+    overquota_users.each do |user|
+      $users_metadata.hmset key, user.id, user.data.to_json
+    end
+    # Expire the cache after two months. Enough time to review data if needed
+    $users_metadata.expire key, 2.months
+  end
+
+  def self.get_stored_overquota_users(date)
+    formated_date = date.strftime('%Y%m%d')
+    key = "overquota:users:#{formated_date}"
+    if $users_metadata.exists key
+      users = []
+      users_json = $users_metadata.hgetall key
+      users_json.each do |_k, v|
+        users.push(JSON.parse(v))
+      end
+      users
+    else
+      CartoDB::Logger.warning(message: "There is no overquota cached users for date #{formated_date}")
+      []
     end
   end
 

--- a/lib/resque/user_jobs.rb
+++ b/lib/resque/user_jobs.rb
@@ -76,7 +76,6 @@ module Resque
 
     end
 
-
     module CommonData
       module LoadCommonData
         @queue = :users
@@ -87,7 +86,6 @@ module Resque
       end
 
     end
-
 
     module Mail
 

--- a/lib/tasks/user_overquota.rake
+++ b/lib/tasks/user_overquota.rake
@@ -1,0 +1,12 @@
+namespace :cartodb do
+  namespace :user_overquota do
+      desc 'Calculate and store the daily users with overquota greater than some delta'
+      task :calculate, [:delta] => :environment do |_task, args|
+        args.with_defaults(delta: 0.20)
+        delta = args[:delta].to_f
+        puts 'Executing overquota calculation'
+        ::User.store_overquota_users(delta, Date.today)
+        puts "Ended getting the overquota users for delta #{delta}"
+      end
+    end
+end

--- a/spec/requests/superadmin/users_spec.rb
+++ b/spec/requests/superadmin/users_spec.rb
@@ -374,6 +374,7 @@ feature "Superadmin's users API" do
 
     it "gets overquota users" do
       ::User.stubs(:overquota).returns [@user]
+      ::User.stubs(:get_stored_overquota_users).returns [@user.data]
       get_json superadmin_users_path, { overquota: true }, superadmin_headers do |response|
         response.status.should == 200
         response.body[0]["username"].should == @user.username


### PR DESCRIPTION
The ::User.overquota method is a heavy proccess due to the need
of iterate all the users checking if he/she is near of his/her quota.
Right now we are doing it without Resque, we are moving it to a Resque
process.

Also other processes use this method but most of the only need it daily
so we have created a new method to cache it daily in order to be able
to execute it one time by, for example, a rake task