### PR TITLE
Adds trace to make update_cdb_tablemetadata fail safer

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1315,6 +1315,12 @@ class Table
 
   def update_cdb_tablemetadata
     owner.in_database(as: :superuser).run(%{ SELECT CDB_TableMetadataTouch(#{table_id}::oid::regclass) })
+  rescue => exception
+    CartoDB::Logger.error(message: 'update_cdb_tablemetadata failed',
+                          exception: exception,
+                          user: owner,
+                          table_id: @user_table.table_id,
+                          oid: get_table_id)
   end
 
   private

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1319,7 +1319,7 @@ class Table
     CartoDB::Logger.error(message: 'update_cdb_tablemetadata failed',
                           exception: exception,
                           user: owner,
-                          table_id: @user_table.table_id,
+                          table_id: table_id,
                           oid: get_table_id)
   end
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1320,7 +1320,8 @@ class Table
                           exception: exception,
                           user: owner,
                           table_id: table_id,
-                          oid: get_table_id)
+                          oid: get_table_id,
+                          table_name: name)
   end
 
   private


### PR DESCRIPTION
Please CR @javitonino 

This should avoid some ghost tables as well, since this broke `after_destroy` on some tables.

cc/ @juanignaciosl 