### PR TITLE
Fix rake task after updating the models

### DIFF
--- a/app/models/carto/permission.rb
+++ b/app/models/carto/permission.rb
@@ -40,12 +40,14 @@ class Carto::Permission < ActiveRecord::Base
     self.owner_id == user.id
   end
 
+  # TODO: Delete entity_* once the fields are dropped
+  # Meanwhile it is needed as a transitional method and are called by AR (as the fields still exists)
   def entity_type
     ENTITY_TYPE_VISUALIZATION
   end
 
   def entity_id
-    entity.id
+    entity.id if entity
   end
 
   private

--- a/lib/tasks/permissions.rake
+++ b/lib/tasks/permissions.rake
@@ -8,7 +8,7 @@ namespace :cartodb do
         # This uses the new models to avoid triggering side-effects
         viz = Carto::Visualization.select('visualizations.*')
                                   .joins('LEFT JOIN permissions ON visualizations.permission_id = permissions.id')
-                                  .where('permissions.id IS NULL OR permissions.entity_id != visualizations.id')
+                                  .where('permissions.id IS NULL OR permissions.entity_id != visualizations.id').all
         puts "*** Updating permissions for #{viz.count} visualization"
         puts "*** Automatically fixing conflicts" if auto_fix
         sleep 5
@@ -21,7 +21,7 @@ namespace :cartodb do
             if perms.empty?
               puts '  - Creating new default permission'
 
-              user_id = v.user_id
+              user_id = v.user_id ? v.user_id : '00000000-0000-0000-0000-000000000000'
               username = v.user ? v.user.username : 'cdb_unknown' # Workaround for invalid users
               perm = Carto::Permission.create(
                 owner_id:       user_id,


### PR DESCRIPTION
Part of #7013 

A few fixes for the Rake task:
- Fix `Carto::Visualization.entity_id` for use in the Rake. This is a quick hack that will be deleted once we drop the `entity_*` fields from the permissions table.
- Load all data in the first query, before it performed a `count` and then an `all`, doubling the work.
- Handle the cases where the `user_id` is null. Previously it only handled the case when the user didn't exist but the uuid was valid.