### PR TITLE
Change deprecated PostGIS ST_Force_2D function to ST_Force2D

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@ which should be fixed manually.
 * Fix broken visualizations due to invalid permissions
 * Make `layers.kind` not null. Run `bundle exec rake db:migrate` to update your database.
 * Fix error when deleting organizational users that had created objects via SQL-API
+* Change deprecated PostGIS function `ST_Force_2D` for the new `ST_Force2D`
 
 ## Security fixes
 

--- a/services/importer/lib/importer/column.rb
+++ b/services/importer/lib/importer/column.rb
@@ -172,7 +172,7 @@ module CartoDB
           ).execute_update(
               %Q{
                 UPDATE #{qualified_table_name}
-                SET #{column_name} = public.ST_Force_2D(#{column_name})
+                SET #{column_name} = public.ST_Force2D(#{column_name})
               },
               schema, table_name
           )
@@ -241,7 +241,7 @@ module CartoDB
 
       def geometry_type
         sample = db[%Q{
-          SELECT public.GeometryType(ST_Force_2D(#{column_name}))
+          SELECT public.GeometryType(ST_Force2D(#{column_name}))
           AS type
           FROM #{schema}.#{table_name}
           WHERE #{column_name} IS NOT NULL

--- a/services/importer/lib/importer/reprojector.rb
+++ b/services/importer/lib/importer/reprojector.rb
@@ -35,7 +35,7 @@ module CartoDB
       def transform(table_name, origin_column, destination_column)
         db.run(%Q{
           UPDATE #{table_name}
-          SET the_geom = public.ST_Force_2D(
+          SET the_geom = public.ST_Force2D(
             public.ST_Transform(#{origin_column}, #{DEFAULT_SRID})
           ) 
           WHERE #{origin_column} IS NOT NULL


### PR DESCRIPTION
Since PostGIS 2.1 the function `ST_Force_2D` is deprecated so since our PostGIS dependency is now 2.2 for all we have to change it to avoid warnings or future problems