### PR TITLE
7050 new embed always set vector parameter as true

### DIFF
--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -95,7 +95,7 @@ module Carto
       end
 
       def vizjson3
-        render_vizjson(generate_vizjson3(@visualization, current_viewer, params))
+        render_vizjson(generate_vizjson3(@visualization, params))
       end
 
       def list_watching

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -11,6 +11,8 @@ module Carto
       end
 
       def to_vizjson(https_request: false, vector: false)
+        https_request ||= false
+        vector ||= false
         vizjson = @redis_vizjson_cache.cached(@visualization.id, https_request) do
           calculate_vizjson(https_request: https_request, vector: vector)
         end

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -39,7 +39,7 @@ module Carto
       end
 
       def calculate_vizjson(https_request: false, vector: false)
-        options = default_options.merge(https_request: false, vector: false)
+        options = default_options.merge(https_request: https_request, vector: vector)
 
         user = @visualization.user
         map = @visualization.map

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -35,7 +35,6 @@ module Carto
           https_request: false,
           attributions: @visualization.attributions_from_derived_visualizations,
           user_name: user.username,
-          user_api_key: user.api_key,
           user: user,
           viewer_user: @viewer_user,
           vector: false
@@ -103,7 +102,6 @@ module Carto
         if @visualization.retrieve_named_map?
           presenter_options = {
             user_name: options.fetch(:user_name),
-            api_key: options[:user_api_key],
             https_request: options.fetch(:https_request, false),
             viewer_user: @viewer_user,
             owner: @visualization.user

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -435,7 +435,7 @@ module Carto
           @decoration_data
         )
 
-        {
+        torque = {
           id:         @layer.id,
           type:       'torque',
           order:      @layer.order,
@@ -446,6 +446,18 @@ module Carto
             sql_api_template: ApplicationHelper.sql_api_template(api_templates_type)
           }.merge(layer_options.select { |k| TORQUE_ATTRS.include? k })
         }
+
+        torque[:cartocss] = layer_options[:tile_style]
+
+        torque[:cartocss_version] = @layer.options['style_version'] if @layer
+
+        torque[:sql] = if layer_options[:query].present? || @layer.nil?
+                                layer_options[:query]
+                              else
+                                @layer.options['query']
+                              end
+
+        torque
       end
 
       MUSTACHE_ROOT_PATH = 'lib/assets/javascripts/cartodb3/mustache-templates'.freeze

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -454,10 +454,10 @@ module Carto
         torque[:cartocss_version] = @layer.options['style_version'] if @layer
 
         torque[:sql] = if layer_options[:query].present? || @layer.nil?
-                                layer_options[:query]
-                              else
-                                @layer.options['query']
-                              end
+                         layer_options[:query]
+                       else
+                         @layer.options['query']
+                       end
 
         torque
       end

--- a/app/controllers/carto/editor/public/embeds_controller.rb
+++ b/app/controllers/carto/editor/public/embeds_controller.rb
@@ -17,7 +17,7 @@ module Carto
 
         def show
           @visualization_data = Carto::Api::VisualizationPresenter.new(@visualization, current_viewer, self).to_poro
-          @vizjson = generate_vizjson3(@visualization, current_viewer, params)
+          @vizjson = generate_vizjson3(@visualization, params)
 
           render 'show'
         end

--- a/app/controllers/carto/editor/visualizations_controller.rb
+++ b/app/controllers/carto/editor/visualizations_controller.rb
@@ -21,7 +21,7 @@ module Carto
       def show
         @visualization_data = Carto::Api::VisualizationPresenter.new(@visualization, current_viewer, self).to_poro
         @layers_data = @visualization.layers.map { |l| Carto::Api::LayerPresenter.new(l).to_poro }
-        @vizjson = generate_vizjson3(@visualization, current_viewer, params)
+        @vizjson = generate_vizjson3(@visualization, params)
         @analyses_data = @visualization.analyses.map { |a| Carto::Api::AnalysisPresenter.new(a).to_poro }
       end
 

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -89,8 +89,8 @@ module VisualizationsControllerHelper
     visualization
   end
 
-  def generate_vizjson3(visualization, viewer_user, params)
-    Carto::Api::VizJSON3Presenter.new(visualization, viewer_user)
+  def generate_vizjson3(visualization, params)
+    Carto::Api::VizJSON3Presenter.new(visualization)
                                  .to_vizjson(https_request: is_https?, vector: params[:vector] == 'true')
   end
 end

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -90,7 +90,7 @@ module VisualizationsControllerHelper
   end
 
   def generate_vizjson3(visualization, viewer_user, params)
-    Carto::Api::VizJSON3Presenter.new(visualization, viewer_user).to_vizjson(https_request: is_https?,
-                                                                                  vector: params[:vector] == 'true')
+    Carto::Api::VizJSON3Presenter.new(visualization, viewer_user)
+                                 .to_vizjson(https_request: is_https?, vector: params[:vector] == 'true')
   end
 end

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -62,6 +62,14 @@ describe Carto::Api::VizJSON3Presenter do
       v2_vizjson[:version].should eq '0.1.0'
       v3_vizjson[:version].should eq '3.0.0'
     end
+
+    it 'does not cache vector' do
+      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user)
+      vizjson_a = v3_presenter.to_vizjson(vector: true)
+      vizjson_b = v3_presenter.to_vizjson(vector: false)
+      vizjson_a[:vector].should eq true
+      vizjson_b[:vector].should eq false
+    end
   end
 
 end

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -26,14 +26,12 @@ describe Carto::Api::VizJSON3Presenter do
       destroy_full_visualization(@map, @table, @table_visualization, @visualization)
     end
 
-    let(:viewer_user) { @visualization.user }
-
     it 'uses the redis vizjson cache' do
       fake_vizjson = { fake: 'sure!', layers: [] }
 
       cache_mock = mock
       cache_mock.stubs(:cached).with(@visualization.id, false).returns(fake_vizjson).twice
-      presenter = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user, cache_mock)
+      presenter = Carto::Api::VizJSON3Presenter.new(@visualization, cache_mock)
       v1 = presenter.to_vizjson
       v2 = presenter.to_vizjson
       v1.should eq v2
@@ -41,7 +39,7 @@ describe Carto::Api::VizJSON3Presenter do
 
     it 'is not overriden by v2 caching' do
       v2_presenter = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata)
-      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user)
+      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization)
 
       v2_vizjson = v2_presenter.to_vizjson
       v3_vizjson = v3_presenter.to_vizjson
@@ -53,7 +51,7 @@ describe Carto::Api::VizJSON3Presenter do
 
     it 'does not override v2 caching' do
       v2_presenter = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata)
-      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user)
+      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization)
 
       v3_vizjson = v3_presenter.to_vizjson
       v2_vizjson = v2_presenter.to_vizjson
@@ -64,7 +62,7 @@ describe Carto::Api::VizJSON3Presenter do
     end
 
     it 'does not cache vector' do
-      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user)
+      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization)
       vizjson_a = v3_presenter.to_vizjson(vector: true)
       vizjson_b = v3_presenter.to_vizjson(vector: false)
       vizjson_a[:vector].should eq true

--- a/spec/requests/carto/api/widgets_controller_spec.rb
+++ b/spec/requests/carto/api/widgets_controller_spec.rb
@@ -253,7 +253,7 @@ describe Carto::Api::WidgetsController do
       end
 
       it 'contains widget data' do
-        vizjson3 = get_vizjson3(Carto::Visualization.find(@visualization.id), @visualization.user)
+        vizjson3 = get_vizjson3(Carto::Visualization.find(@visualization.id))
         layer = vizjson3[:layers][0][:options][:layer_definition][:layers][0]
         options = CartoDB::NamedMapsWrapper::NamedMap.options_for_layer(layer, 1, { placeholders: {} })
         widget_options = options[:layer_options][:widgets]
@@ -272,8 +272,8 @@ describe Carto::Api::WidgetsController do
       end
     end
 
-    def get_vizjson3(carto_visualization, viewer_user)
-      Carto::Api::VizJSON3Presenter.new(carto_visualization, viewer_user).to_vizjson
+    def get_vizjson3(carto_visualization)
+      Carto::Api::VizJSON3Presenter.new(carto_visualization).to_vizjson
     end
   end
 end


### PR DESCRIPTION
This fixes #7050 and also improves the v3 generation design to avoid further errors:
- Removes `options` hash for generation, limiting the options to `vector` and `https_request`. This is key for safe caching and easy maintenance.
- Removes `viewer_user` from options, since vizjson output can't depend on current viewer.
- Removes some unused parameters.

Some of the previous changed had been inherited from old code and not cleaned. Previous vizjson generation was also used at some other parts (backup, private editor) which is no longer needed.