### PR TITLE
Use a hash to store watcher information

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ which should be fixed manually.
 * Fixes a problem with select2 arrow icon.
 * Disable `PROMOTE_TO_MULTI` ogr2ogr option for CSV imports with guessing enabled to avoid MultiPoint imports. (https://github.com/CartoDB/cartodb/pull/6793)
 * Source and attributions copied to visualizations when you import a dataset from the Data Library (https://github.com/CartoDB/cartodb/issues/5970).
+* Improved performance of the check for multiple users editing the same visualization
 * Fixes a memory leak when connecting to user databases
 * Fixed error when accessing an SQL API renamed table through the editor.
 * Refactored and fixed error handling for visualization overlays.

--- a/app/models/visualization/watcher.rb
+++ b/app/models/visualization/watcher.rb
@@ -7,7 +7,7 @@ module CartoDB
     class Watcher
 
       # watcher:_orgid_:_vis_id_:_user_id_
-      KEY_FORMAT = "watcher:%s:%s:%s"
+      KEY_FORMAT = "watcher:%s".freeze
 
       # @params user ::User
       # @params visualization CartoDB::Visualization::Member
@@ -19,35 +19,33 @@ module CartoDB
 
         default_ttl = Cartodb.config[:watcher].present? ? Cartodb.config[:watcher].try("fetch", 'ttl', 60) : 60
         @notification_ttl = notification_ttl.nil? ? default_ttl : notification_ttl
-      end #initialize
+      end
 
       # Notifies that is editing the visualization
       # NOTE: Expiration is handled internally by redis
       def notify
-        key = KEY_FORMAT % [@user.organization.id, @visualization.id, @user.username]
+        key = KEY_FORMAT % @visualization.id
         $tables_metadata.multi do
-          $tables_metadata.set(key, @user.username)
+          $tables_metadata.hset(key, @user.username, current_timestamp + @notification_ttl)
           $tables_metadata.expire(key, @notification_ttl)
         end
       end
 
       # Returns a list of usernames currently editing the visualization
       def list
-        key = KEY_FORMAT % [@user.organization.id, @visualization.id, '*']
-        keys = $tables_metadata.keys(key)
-        if keys.empty?
-          []
-        else
-          # Cannot use MGET directly
-          $tables_metadata.multi {
-            keys.each { |k| $tables_metadata.get(k) }
-          }.flatten.compact
-        end
+        key = KEY_FORMAT % @visualization.id
+        users_expiry = $tables_metadata.hgetall(key)
+        now = current_timestamp
+        users_expiry.select { |_, expiry| expiry.to_i > now }.keys
       end
 
+      private
+
+      def current_timestamp
+        Time.now.getutc.to_i
+      end
     end
 
     class WatcherError < BaseCartoDBError; end
-
   end
 end


### PR DESCRIPTION
The old method used a list of keys and searched it in O(N) time, degrading Redis performance. This uses a single hash per visualization and handles user expiry within Rails.

The hash is identified by the visualization uuid (organization was unneeded) and stores pairs of the form "user -> expiry_timestamp".
- Notifying is then inserting into the hash with the username and the current time + TTL
- Checking the list of users is just retrieving the hash and filtering expired elements.

Redis-wise, this should be much better as they are direct accesses by key. This requires the Rails servers to have syncronized time (which is the case). I could change the code to get the time from Redis, but that seems unnecessary.

CR @ethervoid @juanignaciosl 

Closes #7008 