### PR TITLE
Fixes tests for FK migration

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -107,21 +107,12 @@ class Organization < Sequel::Model
   # organization destroy
   def destroy_cascade
     destroy_groups
-    destroy_permissions
     destroy_non_owner_users
     if self.owner
       self.owner.destroy
     else
       self.destroy
     end
-  end
-
-  def destroy_permissions
-    self.users.each { |user|
-      CartoDB::Permission.where(owner_id: user.id).each { |permission|
-        permission.destroy
-      }
-    }
   end
 
   def destroy_non_owner_users

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -6,8 +6,13 @@ module Carto
         table = FactoryGirl.create(:carto_user_table, user_id: carto_user.id, map_id: map.id)
         table_visualization = FactoryGirl.create(
           :carto_visualization,
-          user: carto_user, type: 'table', name: table.name, map_id: table.map_id)
-        visualization = FactoryGirl.create(:carto_visualization, user_id: carto_user.id, map: map)
+          user: carto_user, type: 'table', name: table.name, map_id: table.map_id,
+          permission_id: create_permission_for_user(carto_user).id)
+        visualization = FactoryGirl.create(
+          :carto_visualization,
+          user_id: carto_user.id,
+          map: map,
+          permission_id: create_permission_for_user(carto_user).id)
         # Need to mock the nonexistant table because factories use Carto::* models
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)
@@ -17,10 +22,16 @@ module Carto
 
       # Helper method for `create_full_visualization` results cleanup
       def destroy_full_visualization(map, table, table_visualization, visualization)
+        table_visualization.permission.destroy if table_visualization && table_visualization.permission
         table_visualization.destroy if table_visualization
         table.destroy if table
+        visualization.permission.destroy if visualization && visualization.permission
         visualization.destroy if visualization
         map.destroy if map
+      end
+
+      def create_permission_for_user(carto_user)
+        Carto::Permission.create(owner_id: carto_user.id, owner_username: carto_user.username)
       end
     end
   end

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -6,13 +6,8 @@ module Carto
         table = FactoryGirl.create(:carto_user_table, user_id: carto_user.id, map_id: map.id)
         table_visualization = FactoryGirl.create(
           :carto_visualization,
-          user: carto_user, type: 'table', name: table.name, map_id: table.map_id,
-          permission_id: create_permission_for_user(carto_user).id)
-        visualization = FactoryGirl.create(
-          :carto_visualization,
-          user_id: carto_user.id,
-          map: map,
-          permission_id: create_permission_for_user(carto_user).id)
+          user: carto_user, type: 'table', name: table.name, map_id: table.map_id)
+        visualization = FactoryGirl.create(:carto_visualization, user_id: carto_user.id, map: map)
         # Need to mock the nonexistant table because factories use Carto::* models
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)
@@ -22,16 +17,10 @@ module Carto
 
       # Helper method for `create_full_visualization` results cleanup
       def destroy_full_visualization(map, table, table_visualization, visualization)
-        table_visualization.permission.destroy if table_visualization && table_visualization.permission
         table_visualization.destroy if table_visualization
         table.destroy if table
-        visualization.permission.destroy if visualization && visualization.permission
         visualization.destroy if visualization
         map.destroy if map
-      end
-
-      def create_permission_for_user(carto_user)
-        Carto::Permission.create(owner_id: carto_user.id, owner_username: carto_user.username)
       end
     end
   end

--- a/spec/factories/database_configuration_contexts.rb
+++ b/spec/factories/database_configuration_contexts.rb
@@ -1,13 +1,7 @@
 shared_context 'database configuration' do
 
   before(:each) do
-    db_config   = Rails.configuration.database_configuration[Rails.env]
-    @db         = Sequel.postgres(
-                    host:     db_config.fetch('host'),
-                    port:     db_config.fetch('port'),
-                    database: db_config.fetch('database'),
-                    username: db_config.fetch('username')
-                  )
+    @db         = Rails::Sequel.connection
     @repository = DataRepository::Backend::Sequel.new(@db, :visualizations)
     CartoDB::Visualization.repository = @repository
   end

--- a/spec/factories/visualizations.rb
+++ b/spec/factories/visualizations.rb
@@ -24,12 +24,10 @@ FactoryGirl.define do
 
     association :user, factory: :carto_user
 
-    after(:create) do |visualization|
+    before(:create) do |visualization|
       permission = FactoryGirl.create :carto_permission,
                                       entity: visualization, owner: visualization.user, entity_type: 'vis'
       visualization.permission_id = permission.id
-      visualization.save
-      visualization.reload
     end
 
   end

--- a/spec/models/carto/template_spec.rb
+++ b/spec/models/carto/template_spec.rb
@@ -187,6 +187,7 @@ describe Carto::Template do
         })
     template.save.should eq true
 
+    template.destroy
     delete_user_data org2_user_owner
     org2.destroy_cascade
   end

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -85,15 +85,7 @@ describe Visualization::Member do
 
       Permission.any_instance.stubs(:update_shared_entities).returns(nil)
 
-      db_config   = Rails.configuration.database_configuration[Rails.env]
-      # Why not passing db_config directly to Sequel.postgres here ?
-      # See https://github.com/CartoDB/cartodb/issues/421
-      db          = Sequel.postgres(
-                      host:     db_config.fetch('host'),
-                      port:     db_config.fetch('port'),
-                      database: db_config.fetch('database'),
-                      username: db_config.fetch('username')
-                    )
+      db = Rails::Sequel.connection
       relation    = "visualizations_#{relation_id}".to_sym
       repository  = DataRepository::Backend::Sequel.new(db, relation)
       Visualization::Migrator.new(db).migrate(relation)

--- a/spec/models/visualization/name_checker_spec.rb
+++ b/spec/models/visualization/name_checker_spec.rb
@@ -15,6 +15,9 @@ describe Visualization::NameChecker do
     @db = Rails::Sequel.connection
     Visualization.repository = DataRepository::Backend::Sequel.new(@db, :visualizations)
 
+    # Dummy permission
+    @permission = CartoDB::Permission.new(owner_id: 'b21ff32c-45c2-4300-a49b-786d35524d52', owner_username: 'user').save
+
     @user = OpenStruct.new(
       id:   'b21ff32c-45c2-4300-a49b-786d35524d52',
       maps: [OpenStruct.new(id: 'c21ff32c-45c2-4300-a49b-786d35524d52'),
@@ -22,33 +25,36 @@ describe Visualization::NameChecker do
     )
 
     @db[:visualizations].insert(
-      id:         'd21ff32c-45c2-4300-a49b-786d35524d52',
-      name:       'Visualization 1',
-      privacy:    'public',
-      created_at: Time.now,
-      updated_at: Time.now,
-      map_id:     'c21ff32c-45c2-4300-a49b-786d35524d52',
-      user_id:    'b21ff32c-45c2-4300-a49b-786d35524d52'
+      id:            'd21ff32c-45c2-4300-a49b-786d35524d52',
+      name:          'Visualization 1',
+      privacy:       'public',
+      created_at:    Time.now,
+      updated_at:    Time.now,
+      map_id:        'c21ff32c-45c2-4300-a49b-786d35524d52',
+      user_id:       'b21ff32c-45c2-4300-a49b-786d35524d52',
+      permission_id: @permission.id
     )
 
     @db[:visualizations].insert(
-      id:         'd21ff32c-45c2-4300-a49b-786d35524d57',
-      name:       'Visualization 2',
-      privacy:    'public',
-      created_at: Time.now,
-      updated_at: Time.now,
-      map_id:     'c21ff32c-45c2-4300-a49b-786d35524d57',
-      user_id:    'b21ff32c-45c2-4300-a49b-786d35524d52'
+      id:            'd21ff32c-45c2-4300-a49b-786d35524d57',
+      name:          'Visualization 2',
+      privacy:       'public',
+      created_at:    Time.now,
+      updated_at:    Time.now,
+      map_id:        'c21ff32c-45c2-4300-a49b-786d35524d57',
+      user_id:       'b21ff32c-45c2-4300-a49b-786d35524d52',
+      permission_id: @permission.id
     )
 
     @db[:visualizations].insert(
-      id:         'd21ff32c-45c2-4300-a49b-786d35524d59',
-      name:       'Visualization 4',
-      privacy:    'public',
-      created_at: Time.now,
-      updated_at: Time.now,
-      map_id:     'c21ff32c-45c2-4300-a49b-786d35524d57',
-      user_id:    'b21ff32c-45c2-4300-a49b-786d35524d46'
+      id:            'd21ff32c-45c2-4300-a49b-786d35524d59',
+      name:          'Visualization 4',
+      privacy:       'public',
+      created_at:    Time.now,
+      updated_at:    Time.now,
+      map_id:        'c21ff32c-45c2-4300-a49b-786d35524d57',
+      user_id:       'b21ff32c-45c2-4300-a49b-786d35524d46',
+      permission_id: @permission.id
     )
 
     @db[:shared_entities].insert(
@@ -60,6 +66,7 @@ describe Visualization::NameChecker do
   end
 
   after :all do
+    @permission.destroy
     @user.destroy
   end
 

--- a/spec/models/visualization/organization_visualization_spec.rb
+++ b/spec/models/visualization/organization_visualization_spec.rb
@@ -8,15 +8,7 @@ include CartoDB
 
 describe Visualization::Member do
   before do
-    db_config   = Rails.configuration.database_configuration[Rails.env]
-    # Why not passing db_config directly to Sequel.postgres here ?
-    # See https://github.com/CartoDB/cartodb/issues/421
-    db = Sequel.postgres(
-        host:     db_config.fetch('host'),
-        port:     db_config.fetch('port'),
-        database: db_config.fetch('database'),
-        username: db_config.fetch('username')
-    )
+    db = Rails::Sequel.connection
     Visualization.repository  = DataRepository::Backend::Sequel.new(db, :visualizations)
 
     CartoDB::UserModule::DBService.any_instance.stubs(:move_to_own_schema).returns(nil)

--- a/spec/requests/admin/visualizations_spec.rb
+++ b/spec/requests/admin/visualizations_spec.rb
@@ -25,11 +25,6 @@ describe Admin::VisualizationsController do
     @api_key = @user.api_key
     @user.stubs(:should_load_common_data?).returns(false)
 
-    @db = Rails::Sequel.connection
-    Sequel.extension(:pagination)
-
-    CartoDB::Visualization.repository  = DataRepository::Backend::Sequel.new(@db, :visualizations)
-
     @headers = {
       'CONTENT_TYPE'  => 'application/json',
     }
@@ -341,17 +336,6 @@ describe Admin::VisualizationsController do
 
   describe 'org user visualization redirection' do
     it 'if A shares a (shared) vis link to B with A username, performs a redirect to B username' do
-      db_config   = Rails.configuration.database_configuration[Rails.env]
-      # Why not passing db_config directly to Sequel.postgres here ?
-      # See https://github.com/CartoDB/cartodb/issues/421
-      db = Sequel.postgres(
-          host:     db_config.fetch('host'),
-          port:     db_config.fetch('port'),
-          database: db_config.fetch('database'),
-          username: db_config.fetch('username')
-      )
-      CartoDB::Visualization.repository  = DataRepository::Backend::Sequel.new(db, :visualizations)
-
       CartoDB::UserModule::DBService.any_instance.stubs(:move_to_own_schema).returns(nil)
       CartoDB::TablePrivacyManager.any_instance.stubs(
           :set_from_table_privacy => nil,
@@ -449,17 +433,6 @@ describe Admin::VisualizationsController do
 
     # @see https://github.com/CartoDB/cartodb/issues/6081
     it 'If logged user navigates to legacy url from org user without org name, gets redirected properly' do
-      db_config   = Rails.configuration.database_configuration[Rails.env]
-      # Why not passing db_config directly to Sequel.postgres here ?
-      # See https://github.com/CartoDB/cartodb/issues/421
-      db = Sequel.postgres(
-        host:     db_config.fetch('host'),
-        port:     db_config.fetch('port'),
-        database: db_config.fetch('database'),
-        username: db_config.fetch('username')
-      )
-      CartoDB::Visualization.repository = DataRepository::Backend::Sequel.new(db, :visualizations)
-
       CartoDB::UserModule::DBService.any_instance.stubs(:move_to_own_schema).returns(nil)
       CartoDB::TablePrivacyManager.any_instance.stubs(
         set_from_table_privacy: nil,

--- a/spec/requests/api/visualizations_spec.rb
+++ b/spec/requests/api/visualizations_spec.rb
@@ -36,10 +36,6 @@ describe Api::Json::VisualizationsController do
   before(:each) do
     CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
     stub_named_maps_calls
-    @db = Rails::Sequel.connection
-    Sequel.extension(:pagination)
-
-    CartoDB::Visualization.repository = DataRepository::Backend::Sequel.new(@db, :visualizations)
 
     begin
       delete_user_data @user
@@ -639,7 +635,7 @@ describe Api::Json::VisualizationsController do
 
   def table_factory(options={})
     privacy = options.fetch(:privacy, 1)
-    
+
     name    = unique_name('table')
     payload = {
       name:         name,

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -328,10 +328,6 @@ describe Carto::Api::VisualizationsController do
       CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
 
       CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
-      @db = Rails::Sequel.connection
-      Sequel.extension(:pagination)
-
-      CartoDB::Visualization.repository = DataRepository::Backend::Sequel.new(@db, :visualizations)
 
       @user_1 = FactoryGirl.create(:valid_user)
       @user_2 = FactoryGirl.create(:valid_user, private_maps_enabled: true)


### PR DESCRIPTION
Part of #7013 

Tests were failing with the migration. The main problem was the modification of the Visualizations repository in some tests, creating a new connection to the database instead of using Rails' one. The problem with that and the FK was that inserting the permission and the visualization was being done in different transactions/connections, and so, the permission was not seen by the visualization transaction.

I also removed the permission destruction from organization deletion, as they will be deleted when destroying the visualizations of the users. Destroying the permissions before the visualizations causes and integrity failure.

There are some more minor changes for specific tests.

Tests pass:
- [With migration](https://ci.cartodb.net/job/CartoDB-PR-testing/1315/)
- [Without migration](https://ci.cartodb.net/job/CartoDB-PR-testing/1329/)