### PR TITLE
Add geojson to the text/plain headers

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -44,7 +44,7 @@ module CartoDB
       CONTENT_TYPES_MAPPING = [
         {
           content_types: ['text/plain'],
-          extensions: ['txt', 'kml']
+          extensions: ['txt', 'kml', 'geojson']
         },
         {
           content_types: ['text/csv'],

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -125,6 +125,32 @@ describe Downloader do
       downloader.source_file.filename.should eq 'ok_data.csv.gz'
     end
 
+    it 'uses the geojson extension if the header is text/plain' do
+      url_geojson = "http://www.example.com/tm_world_borders_simpl_0_8.geojson"
+      filepath_geojson  = path_to('tm_world_borders_simpl_0_8.geojson')
+      stub_download(
+          url: url_geojson,
+          filepath: filepath_geojson,
+          headers: { 'Content-Type' => 'text/plain' }
+      )
+      downloader = Downloader.new(url_geojson)
+      downloader.run
+      downloader.source_file.filename.should eq 'tm_world_borders_simpl_0_8.geojson'
+    end
+
+    it 'uses the kml extension if the header is text/plain' do
+      url_kml = "http://www.example.com/abandoned.kml"
+      filepath_kml  = path_to('abandoned.kml')
+      stub_download(
+          url: url_kml,
+          filepath: filepath_kml,
+          headers: { 'Content-Type' => 'text/plain' }
+      )
+      downloader = Downloader.new(url_kml)
+      downloader.run
+      downloader.source_file.filename.should eq 'abandoned.kml'
+    end
+
     it 'extracts the source_file name from Content-Disposition header' do
       stub_download(
         url: @fusion_tables_url,


### PR DESCRIPTION
Some urls, for example raw.github.com, return geojson files with the
text/plain header and as we have it, we are going to try to process it
as a .txt file (CSV) and fails.