### PR TITLE
Fix Rollbar report that was too big in sync adapter

### DIFF
--- a/lib/cartodb/logger.rb
+++ b/lib/cartodb/logger.rb
@@ -3,7 +3,7 @@ module CartoDB
     def self.log(level, exception: nil, message: nil, user: nil, **additional_data)
       # Include the call stack if not already present
       if exception.nil? && additional_data[:stack].nil?
-        additional_data[:stack] = caller[0..25]
+        additional_data[:stack] = caller
       end
 
       if Rails.env.development?
@@ -12,7 +12,7 @@ module CartoDB
 
       if rollbar_scope(user).log(level, exception, message, additional_data) == 'error'
         # Error reporting to Rollbar, usually caused by unserializable data in payload
-        Rollbar.log('warning', nil, 'Could not report to Rollbar', stack: caller[0..25])
+        Rollbar.log('warning', nil, 'Could not report to Rollbar', stack: caller)
       end
     rescue
       # Last chance to report error


### PR DESCRIPTION
Fixes a Rollbar report that was too long for Rollbar (> 128kb). We were losing the reports since it was added, see https://github.com/CartoDB/cartodb/pull/6384

CR @gfiorav 