### PR TITLE
Fix connection pool tests and drop global users from spec_helper

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -47,6 +47,9 @@ FactoryGirl.define do
       crypted_password 'kkkkkkkkk'
     end
 
+    before(:create) do
+      CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
+    end
   end
 
   factory :carto_user, class: Carto::User do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,30 +45,13 @@ RSpec.configure do |config|
       close_pool_connections
       drop_leaked_test_user_databases
     end
-
-    $user_1 = create_user(quota_in_bytes: 524288000, table_quota: 500, private_tables_enabled: true, name: 'User 1 Full Name')
-    $user_2 = create_user(quota_in_bytes: 524288000, table_quota: 500, private_tables_enabled: true)
   end
 
   config.after(:all) do
     unless ENV['PARALLEL']
-      begin
-        stub_named_maps_calls
-        delete_user_data($user_1)
-        delete_user_data($user_2)
-        $user_1.destroy
-        $user_2.destroy
-      ensure
-        close_pool_connections
-        drop_leaked_test_user_databases
-        delete_database_test_users
-      end
-    else
-      stub_named_maps_calls
-      delete_user_data($user_1)
-      delete_user_data($user_2)
-      $user_1.destroy
-      $user_2.destroy
+      close_pool_connections
+      drop_leaked_test_user_databases
+      delete_database_test_users
     end
   end
 


### PR DESCRIPTION
Fixes the connection pool tests by using its own users. They were broken when tests in make spec 2 started using spec_helper which creates/destroys the global users this test used.

Delete $user_* users as they were not being used and were recreated for each spec using spec_helper. Saves about 20 minutes of testing in master (much less in parallel).