### PR TITLE
7094 carto api vis controller spec performance

### DIFF
--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -305,18 +305,15 @@ describe Carto::Api::VisualizationsController do
 
     before(:all) do
       CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
-    end
 
-    before(:each) do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true)
-
-      CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true)
 
       @user_1 = FactoryGirl.create(:valid_user)
       @user_2 = FactoryGirl.create(:valid_user, private_maps_enabled: true)
-
       @api_key = @user_1.api_key
+    end
 
+    before(:each) do
       begin
         delete_user_data @user_1
       rescue => exception
@@ -325,18 +322,18 @@ describe Carto::Api::VisualizationsController do
       end
 
       @headers = {
-        'CONTENT_TYPE'  => 'application/json',
+        'CONTENT_TYPE' => 'application/json'
       }
       host! "#{@user_1.username}.localhost.lan"
     end
 
-    after(:each) do
+    after(:all) do
       @user_1.destroy
       @user_2.destroy
     end
 
     it 'tests exclude_shared and only_shared filters' do
-      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(:get => nil, :create => true, :update => true, :delete => true)
+      CartoDB::NamedMapsWrapper::NamedMaps.any_instance.stubs(get: nil, create: true, update: true)
 
       user_1 = create_user(
         username: unique_name('user'),
@@ -554,7 +551,6 @@ describe Carto::Api::VisualizationsController do
     end
 
     describe 'tests visualization likes endpoints' do
-      include_context 'users helper'
       # TODO: currently new endpoint doesn't match this endpoint
 
       it 'tests like endpoints' do

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1597,14 +1597,13 @@ describe Carto::Api::VisualizationsController do
 
   describe 'visualization url generation' do
     include_context 'visualization creation helpers'
-    include_context 'users helper'
     include_context 'organization with users helper'
 
-    before(:each) do
+    before(:all) do
       @user = FactoryGirl.create(:valid_user)
     end
 
-    after(:each) do
+    after(:all) do
       @user.destroy
     end
 
@@ -1652,14 +1651,15 @@ describe Carto::Api::VisualizationsController do
   describe 'filter canonical viz by bounding box' do
     include_context 'visualization creation helpers'
 
-    before(:each) do
+    before(:all) do
+      bypass_named_maps
       @user = FactoryGirl.create(:valid_user)
 
       @table_inside_bbox = create_geometry_table(@user, BBOX_GEOM)
       @table_outside_bbox = create_geometry_table(@user, OUTSIDE_BBOX_GEOM)
     end
 
-    after(:each) do
+    after(:all) do
       @user.destroy
     end
 


### PR DESCRIPTION
Closes #7094 

This removes a lot of user and tables generation from the Carto::Api::VisualizationsController tests, speeding up the tests. There is lots to do here, as this is a massive spec, but this addresses the low-hanging fruit.

After these changes, it still is the last test to finish by a minute, but it stills offers a noticeable improvement:
Sequential: 8m -> 3m
Parallel: 21m -> 15m (for whole suite), Total build ~55 -> ~45m.