### PR TITLE
Recover options parameter in User#get_connection lost at PR#7042

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -594,7 +594,7 @@ class User < Sequel::Model
 
   def get_connection(options = {}, configuration)
   connection = $pool.fetch(configuration) do
-      db = get_database(_opts = {}, configuration)
+      db = get_database(options, configuration)
       db.extension(:connection_validator)
       db.pool.connection_validation_timeout = configuration.fetch('conn_validator_timeout', -1)
       db


### PR DESCRIPTION
As @javitonino spotted at https://github.com/CartoDB/cartodb/pull/7042/files/4f9200423b2d876a39a80b1c1f41994e27913ef7#r59043297. Thanks mate!

Just to add some background info, [this is the line](https://github.com/CartoDB/cartodb/blob/59d6b44ef23c29dd1ff5251689a738d556f15c14/app/models/user/db_service.rb#L443) in which actually an empty options hash is created to be used at `get_connection`.

cc @rafatower 