### PR TITLE
Make overquota tests only use internal users

### DIFF
--- a/spec/lib/carto/users_metadata_redis_cache_spec.rb
+++ b/spec/lib/carto/users_metadata_redis_cache_spec.rb
@@ -38,8 +38,8 @@ describe Carto::UserDbSizeCache do
       umrc.update_if_old(updatable_user_mock)
 
       db_size_in_bytes_change_users = umrc.db_size_in_bytes_change_users
-      db_size_in_bytes_change_users.keys.should == [updatable_user_mock.username]
-      db_size_in_bytes_change_users.values.should == [updatable_user_mock.db_size_in_bytes]
+      db_size_in_bytes_change_users.keys.include?(updatable_user_mock.username).should be_true
+      db_size_in_bytes_change_users[updatable_user_mock.username].should == updatable_user_mock.db_size_in_bytes
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -559,15 +559,20 @@ describe User do
   end
 
   describe '#overquota' do
+    # Filter overquota users to only those created by this spec
+    def overquota(delta = 0)
+      ::User.overquota(delta).select { |u| [@user, @user2].include?(u) }
+    end
+
     it "should return users near their geocoding quota" do
       ::User.any_instance.stubs(:get_api_calls).returns([0])
       ::User.any_instance.stubs(:map_view_quota).returns(120)
       ::User.any_instance.stubs(:get_geocoding_calls).returns(81)
       ::User.any_instance.stubs(:geocoding_quota).returns(100)
-      ::User.overquota.should be_empty
-      ::User.overquota(0.20).map(&:id).should include(@user.id)
-      ::User.overquota(0.20).size.should == ::User.reject{|u| u.organization_id.present? }.count
-      ::User.overquota(0.10).should be_empty
+      overquota.should be_empty
+      overquota(0.20).map(&:id).should include(@user.id)
+      overquota(0.20).size.should == 2
+      overquota(0.10).should be_empty
     end
 
     it "should return users near their here isolines quota" do
@@ -577,10 +582,10 @@ describe User do
       ::User.any_instance.stubs(:geocoding_quota).returns(100)
       ::User.any_instance.stubs(:get_here_isolines_calls).returns(81)
       ::User.any_instance.stubs(:here_isolines_quota).returns(100)
-      ::User.overquota.should be_empty
-      ::User.overquota(0.20).map(&:id).should include(@user.id)
-      ::User.overquota(0.20).size.should == ::User.reject{|u| u.organization_id.present? }.count
-      ::User.overquota(0.10).should be_empty
+      overquota.should be_empty
+      overquota(0.20).map(&:id).should include(@user.id)
+      overquota(0.20).size.should == 2
+      overquota(0.10).should be_empty
     end
 
     it "should return users near their twitter quota" do
@@ -590,16 +595,16 @@ describe User do
       ::User.any_instance.stubs(:geocoding_quota).returns(100)
       ::User.any_instance.stubs(:get_twitter_imports_count).returns(81)
       ::User.any_instance.stubs(:twitter_datasource_quota).returns(100)
-      ::User.overquota.should be_empty
-      ::User.overquota(0.20).map(&:id).should include(@user.id)
-      ::User.overquota(0.20).size.should == ::User.reject{|u| u.organization_id.present? }.count
-      ::User.overquota(0.10).should be_empty
+      overquota.should be_empty
+      overquota(0.20).map(&:id).should include(@user.id)
+      overquota(0.20).size.should == 2
+      overquota(0.10).should be_empty
     end
 
     it "should not return organization users" do
       ::User.any_instance.stubs(:organization_id).returns("organization-id")
       ::User.any_instance.stubs(:organization).returns(Organization.new)
-      ::User.overquota.should be_empty
+      overquota.should be_empty
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -561,7 +561,7 @@ describe User do
   describe '#overquota' do
     # Filter overquota users to only those created by this spec
     def overquota(delta = 0)
-      ::User.overquota(delta).select { |u| [@user, @user2].include?(u) }
+      ::User.overquota(delta).select { |u| [@user.id, @user2.id].include?(u.id) }
     end
 
     it "should return users near their geocoding quota" do

--- a/spec/requests/api/json/columns_controller_shared_examples.rb
+++ b/spec/requests/api/json/columns_controller_shared_examples.rb
@@ -11,7 +11,7 @@ shared_examples_for "columns controllers" do
     before(:each) do
       stub_named_maps_calls
       delete_user_data @user
-      @table = create_table :user_id => @user.id
+      @table = create_table user_id: @user.id
     end
 
     after(:all) do
@@ -21,12 +21,11 @@ shared_examples_for "columns controllers" do
 
     let(:params) { { api_key: @user.api_key, table_id: @table.name, user_domain: @user.username } }
 
-
     it "gets the columns from a table" do
       get_json api_v1_tables_columns_index_url(params) do |response|
         response.status.should be_success
         # Filter out timestamp columns for compatibility as they won't be added in new cartodbfy
-        (response.body - default_schema - [["created_at", "date"],["updated_at", "date"]]).should be_empty
+        (response.body - default_schema - [["created_at", "date"], ["updated_at", "date"]]).should be_empty
       end
     end
 
@@ -93,9 +92,9 @@ shared_examples_for "columns controllers" do
 
     it "Drop a column" do
       delete_user_data @user
-      @table = create_table :user_id => @user.id
+      @table = create_table user_id: @user.id
 
-      delete_json api_v1_tables_columns_destroy_url(params.merge({id: "name"})) do |response|
+      delete_json api_v1_tables_columns_destroy_url(params.merge(id: "name")) do |response|
         response.status.should eql(204)
       end
     end

--- a/spec/requests/api/json/columns_controller_shared_examples.rb
+++ b/spec/requests/api/json/columns_controller_shared_examples.rb
@@ -5,8 +5,7 @@ shared_examples_for "columns controllers" do
   describe '#show legacy tests' do
 
     before(:all) do
-      @user = create_user(:username => 'test', :email => "client@example.com", :password => "clientex")
-      host! 'test.localhost.lan'
+      @user = FactoryGirl.create(:valid_user)
     end
 
     before(:each) do
@@ -20,10 +19,10 @@ shared_examples_for "columns controllers" do
       @user.destroy
     end
 
-    let(:params) { { :api_key => @user.api_key, table_id: @table.name } }
+    let(:params) { { api_key: @user.api_key, table_id: @table.name, user_domain: @user.username } }
 
 
-    it "gets the columns from a table" do    
+    it "gets the columns from a table" do
       get_json api_v1_tables_columns_index_url(params) do |response|
         response.status.should be_success
         # Filter out timestamp columns for compatibility as they won't be added in new cartodbfy
@@ -94,8 +93,8 @@ shared_examples_for "columns controllers" do
 
     it "Drop a column" do
       delete_user_data @user
-      @table = create_table :user_id => @user.id    
-      
+      @table = create_table :user_id => @user.id
+
       delete_json api_v1_tables_columns_destroy_url(params.merge({id: "name"})) do |response|
         response.status.should eql(204)
       end

--- a/spec/requests/api/json/records_controller_shared_examples.rb
+++ b/spec/requests/api/json/records_controller_shared_examples.rb
@@ -5,14 +5,7 @@ shared_examples_for "records controllers" do
   describe '#show legacy tests' do
 
     before(:all) do
-      @user = create_user(
-        username: 'test',
-        email:    'client@example.com',
-        password: 'clientex'
-      )
-      @api_key = @user.api_key
-
-      host! 'test.localhost.lan'
+      @user = FactoryGirl.create(:valid_user)
     end
 
     before(:each) do
@@ -27,7 +20,7 @@ shared_examples_for "records controllers" do
     end
 
 
-    let(:params) { { :api_key => @user.api_key, table_id: @table.name } }
+    let(:params) { { api_key: @user.api_key, table_id: @table.name, user_domain: @user.username } }
 
 
     it "Insert a new row and get the record" do
@@ -163,18 +156,18 @@ shared_examples_for "records controllers" do
       # this test uses its own table
       custom_params = params.merge({table_id: table_name})
 
-      payload = { 
-        name: 'Fernando Blat', 
-        age: '29' 
+      payload = {
+        name: 'Fernando Blat',
+        age: '29'
       }
 
       post_json api_v1_tables_records_create_url(custom_params.merge(payload)) do |response|
         response.status.should be_success
       end
 
-      payload = { 
-        name: 'Beatriz', 
-        age: 30.2 
+      payload = {
+        name: 'Beatriz',
+        age: 30.2
       }
 
       row_id = post_json api_v1_tables_records_create_url(custom_params.merge(payload)) do |response|
@@ -209,11 +202,11 @@ shared_examples_for "records controllers" do
       end
     end
 
-    it "Update a row including the_geom field" do    
+    it "Update a row including the_geom field" do
       lat = Float.random_latitude
       lon = Float.random_longitude
       pk = nil
-      
+
 
       payload = {
         name:         "Fernando Blat",

--- a/spec/requests/superadmin/users_spec.rb
+++ b/spec/requests/superadmin/users_spec.rb
@@ -31,6 +31,7 @@ feature "Superadmin's users API" do
     @user_atts.delete(:salt)
     @user_atts.merge!(password: "this_is_a_password")
 
+    CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
     post_json superadmin_users_path, { user: @user_atts }, superadmin_headers do |response|
       response.status.should == 201
       response.body[:email].should == @user_atts[:email]
@@ -48,6 +49,7 @@ feature "Superadmin's users API" do
   end
 
   scenario "user create with crypted_password and salt success" do
+    CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
     post_json superadmin_users_path, { user: @user_atts }, superadmin_headers do |response|
       response.status.should == 201
       response.body[:email].should == @user_atts[:email]
@@ -70,6 +72,8 @@ feature "Superadmin's users API" do
     @user_atts[:map_view_quota] = 80
     t = Time.now
     @user_atts[:upgraded_at] = t
+
+    CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
     post_json superadmin_users_path, { user: @user_atts }, superadmin_headers do |response|
       response.status.should == 201
       response.body[:quota_in_bytes].should == 104857600
@@ -103,6 +107,7 @@ feature "Superadmin's users API" do
     @user_atts[:here_isolines_block_price] = 5
     @user_atts[:notification] = 'Test'
 
+    CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
     post_json superadmin_users_path, { user: @user_atts }, superadmin_headers do |response|
       response.status.should == 201
       response.body[:quota_in_bytes].should == 2000


### PR DESCRIPTION
This fixes some tests that used to fail when run in parallel, mainly because they made wrong assumptions about the state of the whole database, or inadvertently reused resources between tests.

This avoids doing a second run for any tests, and reduces CI times to ~35 minutes.