### PR TITLE
Run the Rake task only once on migration

### DIFF
--- a/db/migrate/20160329121128_add_permission_id_fk_to_visualization.rb
+++ b/db/migrate/20160329121128_add_permission_id_fk_to_visualization.rb
@@ -1,8 +1,7 @@
 Sequel.migration do
   up do
     Rails::Sequel.connection.transaction do
-      load File.join(Rails.root, 'Rakefile')
-      Rake::Task['cartodb:permissions:fill_missing_permissions'].invoke(true)
+      Rake::Task['cartodb:permissions:fill_missing_permissions'].invoke(true) unless Carto::Visualization.count == 0
       alter_table :visualizations do
         set_column_allow_null :permission_id, false
         add_foreign_key [:permission_id], :permissions, null: false


### PR DESCRIPTION
Loading the Rakefile (already loaded as the migrations run inside a Rake) made the task run twice unnecessarily.

Also added a check so this task is not run on new database creations, as they are empty by default.