### PR TITLE
Report production errors on the console if Rollbar is disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ which should be fixed manually.
 * Change Varnish table-related invalidations and tagging to use [Surrogate Keys](https://github.com/CartoDB/cartodb/wiki/CartoDB-Surrogate-Keys)
 * Remove Varnish table invalidations from Rails and replaced them with CDB_TableMetadataTouch calls (delegating invalidation responsibility to the database)
 * Adds optional strong passwords for organization signups
+* Improved logging for custom installations where Rollbar is not used
 * Add new function User#direct_db_connection which uses a new direct_port paramerer to be specified in database.yml to connect to the database. Usage instructions:
   * Use `port` in database.yml to specify the port through which the db is accessed for regular queries (such as pgbouncer connections)
   * Use `direct_port` in database.yml to specify the port through which the db can be directly accessed (i.e. the port in which Postgres is running)

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -58,8 +58,7 @@ defaults: &defaults
     primary:          ''
     embeds:           ''
     domain:           ''
-  rollbar:
-    token: ''
+  rollbar_api_key: ''
   tumblr:
     api_key: ''
   trackjs:

--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -2,7 +2,7 @@ require 'rollbar/rails'
 require 'cartodb/logger'
 Rollbar.configure do |config|
   config.access_token = Cartodb.config[:rollbar_api_key]
-  config.enabled = Rails.env.production? || Rails.env.staging?
+  config.enabled = (Rails.env.production? || Rails.env.staging?) && config.access_token.present?
   # Add exception class names to the exception_level_filters hash to
   # change the level that exception is reported at. Note that if an exception
   # has already been reported and logged the level will need to be changed

--- a/lib/cartodb/logger.rb
+++ b/lib/cartodb/logger.rb
@@ -6,7 +6,7 @@ module CartoDB
         additional_data[:stack] = caller
       end
 
-      if Rails.env.development?
+      if !Rollbar.configuration.enabled || Rails.env.development?
         report_error_to_console(level, exception: exception, message: message, user: user, **additional_data)
       end
 
@@ -55,12 +55,14 @@ module CartoDB
       error_msg = "#{level}: #{message}\n"
       unless exception.nil?
         error_msg += exception.inspect + "\n"
-        error_msg += exception.backtrace.inspect + "\n"
+        error_msg += exception.backtrace.join("\n") + "\n"
       end
       unless user.nil?
-        error_msg += user.inspect + "\n"
+        error_msg += "user: #{user}\n"
       end
-      error_msg += additional_data.inspect + "\n"
+      additional_data.each do |k, v|
+        error_msg += "#{k}: #{v}\n"
+      end
 
       ::Logger.new(STDOUT).error(error_msg)
     end


### PR DESCRIPTION
This enables logging errors to the console even in production, if Rollbar is nor configured. Currently, there is no other way than Rollbar to see error logs in production environments, which is a PITA when debugging problems in on-premise installations.

I took the chance to clean up a little the generated console trace so it is easier to read.