### PR TITLE
Correctly check for uniqueness in related_tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@ which should be fixed manually.
 * Update CartoDB PostgreSQL extension to 0.14.3 to support `cartodb_id` text columns in the CartoDBfy process.
   * See instructions to upgrade to the latest extension version [here](https://github.com/CartoDB/cartodb-postgresql#update-cartodb-extension)
 * Fix slow search of visualizations by name
+* Fixed a bug where visualization with two layers using the same dataset could not be deleted
 * Update and improve logging system
 * Fix broken syncs after setting sync options to "Never"
 * Fix broken visualizations due to invalid permissions

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -101,7 +101,8 @@ module CartoDB
 
       def related_tables
         @related_tables ||= layers(:carto_and_torque)
-          .flat_map{|layer| layer.affected_tables.map{|t| t.service}}.uniq
+                            .flat_map { |layer| layer.affected_tables.map(&:service) }
+                            .uniq(&:id)
       end
 
       def related_canonical_visualizations


### PR DESCRIPTION
Fixes #7132 

The `related_tables` check for uniqueness was broken, so if a visualization has two layers to the same UserTable, this returns 2 instead of 1. This breaks checks for visualization dependence, causing #7132.