### PR TITLE
7119 Add exception to report download error after a 200 response

### DIFF
--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -134,6 +134,11 @@ module CartoDB
       what_about: "Provided URL can't be resolved to a known server. Maybe that URL is wrong or behind a private network. Please provide a valid, public URL and try again.",
       source: ERROR_SOURCE_USER
     },
+    1103 => {
+      title: '',
+      what_about: "The resource you are trying to reach is accessible but there was a problem downloading your file. Please, try again.",
+      source: ERROR_SOURCE_USER
+    },
     2001 => {
       title: 'Unable to load data',
       what_about: "We couldn't load data from your file into the database.  Please <a href='mailto:support@cartodb.com?subject=Import load error'>contact us</a> and we will help you to load your data.",

--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -135,8 +135,8 @@ module CartoDB
       source: ERROR_SOURCE_USER
     },
     1103 => {
-      title: '',
-      what_about: "The resource you are trying to reach is accessible but there was a problem downloading your file. Please, try again.",
+      title: 'Interrupted download',
+      what_about: "The resource you are trying to reach is accessible but there was a problem downloading the file. Please, try again.",
       source: ERROR_SOURCE_USER
     },
     2001 => {

--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -135,8 +135,8 @@ module CartoDB
       source: ERROR_SOURCE_USER
     },
     1103 => {
-      title: 'Interrupted download',
-      what_about: "The resource you are trying to reach is accessible but there was a problem downloading the file. Please, try again.",
+      title: 'Partial file error',
+      what_about: "The resource you are trying to reach is accessible but the file transfer was shorter or larger than expected. This happens when the server first reports an expected transfer size, and then delivers data that doesn't match the previously given size. Please, try again.",
       source: ERROR_SOURCE_USER
     },
     2001 => {

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -300,8 +300,12 @@ module CartoDB
           elsif error_response.code == 404
             raise NotFoundDownloadError.new(error_response.body)
           else
-            CartoDB::Logger.debug(message: "Generic download error", response: error_response.inspect)
-            raise DownloadError.new("DOWNLOAD ERROR: Code:#{error_response.code} Body:#{error_response.body}")
+            if error_response.code = 200
+              CartoDB::Logger.debug(message: "Generic download error", response: error_response.inspect)
+              raise IncompleteDownloadError.new("DOWNLOAD ERROR: Server responded with #{error_response.code} code but download failed")
+            else
+              raise DownloadError.new("DOWNLOAD ERROR: Code:#{error_response.code} Body:#{error_response.body}")
+            end
           end
         end
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -299,13 +299,11 @@ module CartoDB
             raise UnauthorizedDownloadError.new(error_response.body)
           elsif error_response.code == 404
             raise NotFoundDownloadError.new(error_response.body)
+          elsif error_response.code == 200
+            CartoDB::Logger.debug(message: "Interrupted download error", response: error_response.inspect)
+            raise InterruptedDownloadError.new("DOWNLOAD ERROR: Server responded with #{error_response.code} code but download failed")
           else
-            if error_response.code = 200
-              CartoDB::Logger.debug(message: "Generic download error", response: error_response.inspect)
-              raise IncompleteDownloadError.new("DOWNLOAD ERROR: Server responded with #{error_response.code} code but download failed")
-            else
-              raise DownloadError.new("DOWNLOAD ERROR: Code:#{error_response.code} Body:#{error_response.body}")
-            end
+            raise DownloadError.new("DOWNLOAD ERROR: Code:#{error_response.code} Body:#{error_response.body}")
           end
         end
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -299,9 +299,8 @@ module CartoDB
             raise UnauthorizedDownloadError.new(error_response.body)
           elsif error_response.code == 404
             raise NotFoundDownloadError.new(error_response.body)
-          elsif error_response.code == 200
-            CartoDB::Logger.debug(message: "Interrupted download error", response: error_response.inspect)
-            raise InterruptedDownloadError.new("DOWNLOAD ERROR: Server responded with #{error_response.code} code but download failed")
+          elsif error_response.return_code == :partial_file
+            raise PartialDownloadError.new("DOWNLOAD ERROR: A file transfer was shorter or larger than expected")
           else
             raise DownloadError.new("DOWNLOAD ERROR: Code:#{error_response.code} Body:#{error_response.body}")
           end

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -90,6 +90,7 @@ module CartoDB
     class NotFoundDownloadError                 < DownloadError; end
     class UnauthorizedDownloadError             < DownloadError; end
     class CouldntResolveDownloadError           < DownloadError; end
+    class IncompleteDownloadError               < DownloadError; end
 
     class TooManyNodesError                     < StandardError; end
     class NotAFileError                         < StandardError; end
@@ -115,6 +116,7 @@ module CartoDB
       NotFoundDownloadError                 => 1100,
       UnauthorizedDownloadError             => 1101,
       CouldntResolveDownloadError           => 1102,
+      IncompleteDownloadError               => 1103,
 
       UnsupportedFormatError                => 1002,
       ExtractionError                       => 1003,

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -90,7 +90,7 @@ module CartoDB
     class NotFoundDownloadError                 < DownloadError; end
     class UnauthorizedDownloadError             < DownloadError; end
     class CouldntResolveDownloadError           < DownloadError; end
-    class InterruptedDownloadError              < DownloadError; end
+    class PartialDownloadError                  < DownloadError; end
 
     class TooManyNodesError                     < StandardError; end
     class NotAFileError                         < StandardError; end
@@ -116,7 +116,7 @@ module CartoDB
       NotFoundDownloadError                 => 1100,
       UnauthorizedDownloadError             => 1101,
       CouldntResolveDownloadError           => 1102,
-      InterruptedDownloadError              => 1103,
+      PartialDownloadError                  => 1103,
 
       UnsupportedFormatError                => 1002,
       ExtractionError                       => 1003,

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -90,7 +90,7 @@ module CartoDB
     class NotFoundDownloadError                 < DownloadError; end
     class UnauthorizedDownloadError             < DownloadError; end
     class CouldntResolveDownloadError           < DownloadError; end
-    class IncompleteDownloadError               < DownloadError; end
+    class InterruptedDownloadError              < DownloadError; end
 
     class TooManyNodesError                     < StandardError; end
     class NotAFileError                         < StandardError; end
@@ -116,7 +116,7 @@ module CartoDB
       NotFoundDownloadError                 => 1100,
       UnauthorizedDownloadError             => 1101,
       CouldntResolveDownloadError           => 1102,
-      IncompleteDownloadError               => 1103,
+      InterruptedDownloadError              => 1103,
 
       UnsupportedFormatError                => 1002,
       ExtractionError                       => 1003,

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -218,7 +218,7 @@ describe Downloader do
       stub_download(
         url:      @file_url,
         filepath: @file_filepath,
-        headers:  { }
+        headers:  {}
       )
 
       Typhoeus::Response.any_instance.stubs(:mock).returns(false)

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -213,6 +213,20 @@ describe Downloader do
       downloader = Downloader.new(@file_url)
       lambda { downloader.run }.should raise_error DownloadError
     end
+
+    it "raises if download fails with partial file error" do
+      stub_download(
+        url:      @file_url,
+        filepath: @file_filepath,
+        headers:  { }
+      )
+
+      Typhoeus::Response.any_instance.stubs(:mock).returns(false)
+      Typhoeus::Response.any_instance.stubs(:return_code).returns(:partial_file)
+
+      downloader = Downloader.new(@file_url)
+      lambda { downloader.run }.should raise_error PartialDownloadError
+    end
   end
 
   describe '#source_file' do
@@ -238,7 +252,7 @@ describe Downloader do
       downloader.run
       downloader.source_file.fullpath.should match /#{@file_url.split('/').last}/
     end
-  end #source_file
+  end
 
   describe '#name_from' do
     it 'gets the file name from the Content-Disposition header if present' do
@@ -293,7 +307,7 @@ describe Downloader do
       downloader = Downloader.new(hard_url)
       downloader.send(:name_from, headers, hard_url).should eq 'my_file.xlsx'
     end
-  end #name_from
+  end
 
   def stub_download(options)
     url       = options.fetch(:url)
@@ -318,19 +332,19 @@ describe Downloader do
         headers:  headers.merge(headers_for(filepath))
      )
      response
-  end #response_for
+  end
 
   def failed_response_for(filepath, headers={})
      Typhoeus::Response.new(code: 404, body: nil, headers: {})
-  end #response_for
+  end
 
   def headers_for(filepath)
     filename = filepath.split('/').last
     { "Content-Disposition" => "attachment; filename=#{filename}" }
-  end #headers_for
+  end
 
   def path_to(filename)
     File.join(File.dirname(__FILE__), '..', 'fixtures', filename)
   end
-end # Downloader
+end
 


### PR DESCRIPTION
We've seen some scenarios in which the HTTP code may be 200 OK but then the download seems to be interrupted (for example caused by a connection issue).

In a previous PR we added a Logger trace in this scenario in order to be able to retrieve more data when this happens, but still it as reported to the user as a Download Error (typically related with 4XX/5XX codes). This new exception takes into account the successful code and returns a "temporal issue, try again" message so that the user can know that the file is available and the URL is okay but there was a problem in the download.

Closes https://github.com/CartoDB/cartodb/issues/7119