### PR TITLE
Use service_item_id or table_name in mail_notifier 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,7 @@ which should be fixed manually.
 * Make `layers.kind` not null. Run `bundle exec rake db:migrate` to update your database.
 * Fix error when deleting organizational users that had created objects via SQL-API
 * Change deprecated PostGIS function `ST_Force_2D` for the new `ST_Force2D`
+* Fix bug in import mail notifier that prevented to obtain the name of tables created by queries or duplications
 
 ## Security fixes
 

--- a/services/importer/lib/importer/mail_notifier.rb
+++ b/services/importer/lib/importer/mail_notifier.rb
@@ -55,7 +55,13 @@ module CartoDB
         else
           # This case happens before process the files when there
           # is no file stats
-          files << File.basename(data_import.service_item_id)
+          if !data_import.service_item_id.blank?
+            # Imports from files, URLs or connectors have a service_item_id
+            files << File.basename(data_import.service_item_id)
+          elsif !data_import.table_name.blank?
+            # Imports from queries or table duplications use table_name
+            files << File.basename(data_import.table_name)
+          end
         end
 
         files


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/6296

The mail notifier was always trying to retrieve `service_item_id` to get the name of the table being imported, but tables created from query or table duplicates do not have this value and the table name is instead being obtained from `table_name`.

