### PR TITLE
Add index to eumapi

### DIFF
--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -26,15 +26,25 @@ module Carto
       end
 
       def create
-        account_creator = CartoDB::UserAccountCreator.new(Carto::UserCreation::CREATED_VIA_API).with_organization(@organization)
+        account_creator = CartoDB::UserAccountCreator.new(Carto::UserCreation::CREATED_VIA_API)
+                                                     .with_organization(@organization)
 
         account_creator.with_username(create_params[:username]) if create_params[:username].present?
         account_creator.with_email(create_params[:email]) if create_params[:email].present?
         account_creator.with_password(create_params[:password]) if create_params[:password].present?
         account_creator.with_quota_in_bytes(create_params[:quota_in_bytes]) if create_params[:quota_in_bytes].present?
-        account_creator.with_soft_geocoding_limit(create_params[:soft_geocoding_limit]) if create_params[:soft_geocoding_limit].present?
-        account_creator.with_soft_here_isolines_limit(create_params[:soft_here_isolines_limit]) if create_params[:soft_here_isolines_limit].present?
-        account_creator.with_soft_twitter_datasource_limit(create_params[:soft_twitter_datasource_limit]) if create_params[:soft_twitter_datasource_limit].present?
+
+        if create_params[:soft_geocoding_limit].present?
+          account_creator.with_soft_geocoding_limit(create_params[:soft_geocoding_limit])
+        end
+
+        if create_params[:soft_here_isolines_limit].present?
+          account_creator.with_soft_here_isolines_limit(create_params[:soft_here_isolines_limit])
+        end
+
+        if create_params[:soft_twitter_datasource_limit].present?
+          account_creator.with_soft_twitter_datasource_limit(create_params[:soft_twitter_datasource_limit])
+        end
 
         render_jsonp(account_creator.validation_errors.full_messages, 410) && return unless account_creator.valid?
 

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -7,7 +7,7 @@ module Carto
     class OrganizationUsersController < ::Api::ApplicationController
       include OrganizationUsersHelper
 
-      ssl_required :create, :update, :destroy, :show, :index
+      ssl_required :index, :show, :create, :update, :destroy
 
       before_filter :load_organization
       before_filter :owners_only

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -7,11 +7,19 @@ module Carto
     class OrganizationUsersController < ::Api::ApplicationController
       include OrganizationUsersHelper
 
-      ssl_required :create, :update, :destroy, :show
+      ssl_required :create, :update, :destroy, :show, :index
 
       before_filter :load_organization
       before_filter :owners_only
       before_filter :load_user, only: [:show, :update, :destroy]
+
+      def index
+        presentations = @organization.users.each do |user|
+          Carto::Api::UserPresenter.new(user, current_viewer: current_viewer).to_poro
+        end
+
+        render_jsonp(presentations, 200)
+      end
 
       def show
         render_jsonp(Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer).to_poro, 200)

--- a/app/helpers/organization_users_helper.rb
+++ b/app/helpers/organization_users_helper.rb
@@ -2,14 +2,12 @@
 require_dependency 'carto/uuidhelper'
 
 module OrganizationUsersHelper
+  include Carto::UUIDHelper
+
   def load_organization
     id_or_name = params[:id_or_name]
 
-    @organization = if is_uuid?(id_or_name)
-                      Carto::Organization.where(id: id_or_name).first
-                    else
-                      Carto::Organization.where(name: id_or_name).first
-                    end
+    @organization = ::Organization.where(is_uuid?(id_or_name) ? { id: id_or_name } : { name: id_or_name }).first
 
     unless @organization
       render_jsonp({}, 401) # Not giving clues to guessers via 404

--- a/app/helpers/organization_users_helper.rb
+++ b/app/helpers/organization_users_helper.rb
@@ -1,9 +1,17 @@
 # encoding: UTF-8
+require_dependency 'carto/uuidhelper'
 
 module OrganizationUsersHelper
   def load_organization
-    @organization = Organization.where(name: params[:name]).first
-    if @organization.nil?
+    id_or_name = params[:id_or_name]
+
+    @organization = if is_uuid?(id_or_name)
+                      Carto::Organization.where(id: id_or_name).first
+                    else
+                      Carto::Organization.where(name: id_or_name).first
+                    end
+
+    unless @organization
       render_jsonp({}, 401) # Not giving clues to guessers via 404
       return false
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -368,11 +368,6 @@ CartoDB::Application.routes.draw do
     # Maps
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/maps/:id'                          => 'maps#show',    as: :api_v1_maps_show
 
-    # Overlays
-    scope '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:visualization_id/', constraints: { visualization_id: /[0-z\-]+/ } do
-      resources :overlays, only: [:index, :show, :create, :update, :destroy], constraints: { id: /[0-z\-]+/ }
-    end
-
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations'                => 'synchronizations#index',     as: :api_v1_synchronizations_index
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/synchronizations/:id'            => 'synchronizations#show',     as: :api_v1_synchronizations_show
     # INFO: sync_now is public API
@@ -400,11 +395,21 @@ CartoDB::Application.routes.draw do
     # Organization (new endpoint that deprecates old, unused one, so v1)
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:id/users' => 'organizations#users', as: :api_v1_organization_users, constraints: { id: /[^\/]+/ }
 
-    # Organization user management
-    post '(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:name/users' => 'organization_users#create', as: :api_v1_organization_users_create
-    get '(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:name/users/:u_username' => 'organization_users#show', as: :api_v1_organization_users_show
-    delete '(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:name/users/:u_username' => 'organization_users#destroy', as: :api_v1_organization_users_delete
-    put '(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:name/users/:u_username' => 'organization_users#update', as: :api_v1_organization_users_update
+    scope '(/user/:user_domain)(/u/:user_domain)/api/v1/' do
+      # Organization user management
+      scope 'organization/:name/' do
+        get    'users',             to: 'organization_users#index',   as: :api_v1_organization_users_index
+        post   'users',             to: 'organization_users#create',  as: :api_v1_organization_users_create
+        get    'users/:u_username', to: 'organization_users#show',    as: :api_v1_organization_users_show
+        delete 'users/:u_username', to: 'organization_users#destroy', as: :api_v1_organization_users_delete
+        put    'users/:u_username', to: 'organization_users#update',  as: :api_v1_organization_users_update
+      end
+
+      # Overlays
+      scope 'viz/:visualization_id/', constraints: { visualization_id: /[0-z\-]+/ } do
+        resources :overlays, only: [:index, :show, :create, :update, :destroy], constraints: { id: /[0-z\-]+/ }
+      end
+    end
 
     # Groups
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:organization_id/groups' => 'groups#index', as: :api_v1_organization_groups, constraints: { organization_id: /[^\/]+/ }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,10 +392,12 @@ CartoDB::Application.routes.draw do
     # User assets
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/users/:user_id/assets' => 'assets#index',   as: :api_v1_users_assets_index
 
+    # Organization (new endpoint that deprecates old, unused one, so v1)
+    get '(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:id/users' => 'organizations#users', as: :api_v1_organization_users, constraints: { id: /[^\/]+/ }
+
     scope '(/user/:user_domain)(/u/:user_domain)/api/v1/' do
       # Organization user management
       scope 'organization/:id_or_name/' do
-        get    'users',             to: 'organization_users#index',   as: :api_v1_organization_users_index
         post   'users',             to: 'organization_users#create',  as: :api_v1_organization_users_create
         get    'users/:u_username', to: 'organization_users#show',    as: :api_v1_organization_users_show
         delete 'users/:u_username', to: 'organization_users#destroy', as: :api_v1_organization_users_delete
@@ -405,6 +407,18 @@ CartoDB::Application.routes.draw do
       # Overlays
       scope 'viz/:visualization_id/', constraints: { visualization_id: /[0-z\-]+/ } do
         resources :overlays, only: [:index, :show, :create, :update, :destroy], constraints: { id: /[0-z\-]+/ }
+      end
+    end
+
+    # Using v2 to add index to EUMAPI since /users is taken in v1
+    scope '(/user/:user_domain)(/u/:user_domain)/api/v2/' do
+      # Organization user management
+      scope 'organization/:id_or_name/' do
+        get    'users',             to: 'organization_users#index',   as: :api_v2_organization_users_index
+        post   'users',             to: 'organization_users#create',  as: :api_v2_organization_users_create
+        get    'users/:u_username', to: 'organization_users#show',    as: :api_v2_organization_users_show
+        delete 'users/:u_username', to: 'organization_users#destroy', as: :api_v2_organization_users_delete
+        put    'users/:u_username', to: 'organization_users#update',  as: :api_v2_organization_users_update
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,12 +392,9 @@ CartoDB::Application.routes.draw do
     # User assets
     get    '(/user/:user_domain)(/u/:user_domain)/api/v1/users/:user_id/assets' => 'assets#index',   as: :api_v1_users_assets_index
 
-    # Organization (new endpoint that deprecates old, unused one, so v1)
-    get '(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:id/users' => 'organizations#users', as: :api_v1_organization_users, constraints: { id: /[^\/]+/ }
-
     scope '(/user/:user_domain)(/u/:user_domain)/api/v1/' do
       # Organization user management
-      scope 'organization/:name/' do
+      scope 'organization/:id_or_name/' do
         get    'users',             to: 'organization_users#index',   as: :api_v1_organization_users_index
         post   'users',             to: 'organization_users#create',  as: :api_v1_organization_users_create
         get    'users/:u_username', to: 'organization_users#show',    as: :api_v1_organization_users_show

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -84,21 +84,21 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user creation' do
     it 'returns 401 for non authorized calls' do
-      post api_v1_organization_users_create_url(name: @organization.name)
+      post api_v1_organization_users_create_url(id_or_name: @organization.name)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      post api_v1_organization_users_create_url(name: @organization.name)
+      post api_v1_organization_users_create_url(id_or_name: @organization.name)
       last_response.status.should == 401
     end
 
     it 'accepts org owners' do
       login(@organization.owner)
 
-      post api_v1_organization_users_create_url(name: @organization.name)
+      post api_v1_organization_users_create_url(id_or_name: @organization.name)
       last_response.status.should == 410
     end
 
@@ -106,7 +106,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       params = { username: unique_name('user'), password: '2{Patrañas}' }
-      post api_v1_organization_users_create_url(name: @organization.name), params
+      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.body.include?('email is not present').should be true
       last_response.status.should == 410
@@ -116,7 +116,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       params = { email: unique_email, password: '2{Patrañas}' }
-      post api_v1_organization_users_create_url(name: @organization.name), params
+      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.body.include?('username is not present').should be true
       last_response.status.should == 410
@@ -127,7 +127,7 @@ describe Carto::Api::OrganizationUsersController do
 
       username = 'manolo'
       params = { username: username, email: "#{username}@cartodb.com" }
-      post api_v1_organization_users_create_url(name: @organization.name), params
+      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 410
       last_response.body.include?('password is not present').should be true
@@ -137,7 +137,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
       username = 'manolo-escobar'
       params = user_params(username)
-      post api_v1_organization_users_create_url(name: @organization.name), params
+      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 200
 
@@ -153,7 +153,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
       username = 'soft-geocoding-limit-false-user'
       params = user_params(username, soft_geocoding_limit: nil)
-      post api_v1_organization_users_create_url(name: @organization.name), params
+      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 200
 
@@ -170,7 +170,7 @@ describe Carto::Api::OrganizationUsersController do
       username = 'soft-limits-true-user'
       params = user_params_soft_limits(username, true)
 
-      post api_v1_organization_users_create_url(name: @organization.name), params
+      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 200
 
@@ -189,7 +189,7 @@ describe Carto::Api::OrganizationUsersController do
       username = 'soft-limits-false-user'
       params = user_params_soft_limits(username, false)
 
-      post api_v1_organization_users_create_url(name: @organization.name), params
+      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 200
 
@@ -207,7 +207,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
       username = 'soft-limits-true-invalid-user'
       params = user_params_soft_limits(username, true)
-      post api_v1_organization_users_create_url(name: @organization.name), params
+      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 410
       errors = JSON.parse(last_response.body)
@@ -221,21 +221,21 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user update' do
     it 'returns 401 for non authorized calls' do
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: @org_user_1.username)
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: @org_user_1.username)
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'accepts org owners' do
       login(@organization.owner)
 
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: @org_user_1.username)
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 410
     end
 
@@ -243,7 +243,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       user_to_update = @organization.non_owner_users[0]
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username)
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username)
 
       last_response.status.should eq 410
       last_response.body.include?('No update params provided').should be true
@@ -254,7 +254,7 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { password: 'limonero' }
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should == 200
     end
@@ -265,7 +265,7 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.non_owner_users[0]
       new_email = "new-#{user_to_update.email}"
       params = { email: new_email }
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
       last_response.status.should eq 200
 
       user_to_update.reload.email.should == new_email
@@ -276,7 +276,7 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { quota_in_bytes: 2048 }
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should eq 200
 
@@ -290,7 +290,7 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.users[0]
       params = { soft_geocoding_limit: true }
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should eq 410
       user_to_update.reload.soft_geocoding_limit.should be false
@@ -302,13 +302,13 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.users[0]
       params = { soft_geocoding_limit: true }
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should eq 200
       user_to_update.reload.soft_geocoding_limit.should be true
 
       params = { soft_geocoding_limit: false }
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should eq 200
 
@@ -328,7 +328,7 @@ describe Carto::Api::OrganizationUsersController do
                  password: 'pataton',
                  soft_geocoding_limit: true,
                  quota_in_bytes: 2048 }
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should eq 200
 
@@ -346,7 +346,7 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.users[0]
       params = user_params_soft_limits(nil, true)
 
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should eq 200
 
@@ -361,7 +361,7 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.users[0]
       params = user_params_soft_limits(nil, false)
 
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should eq 200
 
@@ -377,7 +377,7 @@ describe Carto::Api::OrganizationUsersController do
       replace_soft_limits(user_to_update, [false, false, false])
       params = user_params_soft_limits(nil, true)
 
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should eq 410
       errors = JSON.parse(last_response.body)
@@ -393,7 +393,7 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { email: 'fail-' + user_to_update.email }
-      put api_v1_organization_users_update_url(name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
 
       last_response.status.should == 500
       user_to_update.reload
@@ -403,14 +403,14 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user deletion' do
     it 'returns 401 for non authorized calls' do
-      delete api_v1_organization_users_delete_url(name: @organization.name, u_username: @org_user_1.username)
+      delete api_v1_organization_users_delete_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      delete api_v1_organization_users_delete_url(name: @organization.name, u_username: @org_user_1.username)
+      delete api_v1_organization_users_delete_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
@@ -418,7 +418,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       user_to_be_deleted = @organization.non_owner_users[0]
-      delete api_v1_organization_users_delete_url(name: @organization.name, u_username: user_to_be_deleted.username)
+      delete api_v1_organization_users_delete_url(id_or_name: @organization.name, u_username: user_to_be_deleted.username)
 
       last_response.status.should eq 200
 
@@ -429,7 +429,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       user_to_be_deleted = @organization.owner
-      delete api_v1_organization_users_delete_url(name: @organization.name, u_username: user_to_be_deleted.username)
+      delete api_v1_organization_users_delete_url(id_or_name: @organization.name, u_username: user_to_be_deleted.username)
 
       last_response.status.should == 401
     end
@@ -437,21 +437,21 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user show' do
     it 'returns 401 for non authorized calls' do
-      get api_v1_organization_users_show_url(name: @organization.name, u_username: @org_user_1.username)
+      get api_v1_organization_users_show_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      get api_v1_organization_users_show_url(name: @organization.name, u_username: @org_user_1.username)
+      get api_v1_organization_users_show_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'should return 404 for non existing users' do
       login(@organization.owner)
 
-      get api_v1_organization_users_show_url(name: @organization.name, u_username: 'bogus-non-existent-user')
+      get api_v1_organization_users_show_url(id_or_name: @organization.name, u_username: 'bogus-non-existent-user')
 
       last_response.status.should == 404
     end
@@ -461,10 +461,39 @@ describe Carto::Api::OrganizationUsersController do
 
       @organization.reload
       user_to_be_shown = @organization.non_owner_users[0]
-      get api_v1_organization_users_show_url(name: @organization.name, u_username: user_to_be_shown.username)
+      get api_v1_organization_users_show_url(id_or_name: @organization.name, u_username: user_to_be_shown.username)
 
       last_response.status.should eq 200
       last_response.body == Carto::Api::UserPresenter.new(user_to_be_shown, current_viewer: @organization.owner).to_poro
+    end
+  end
+
+  describe 'user list' do
+    it 'returns 401 for non authorized calls' do
+      get api_v1_organization_users_index_url(id_or_name: @organization.name)
+      last_response.status.should == 401
+    end
+
+    it 'returns 401 for non authorized users' do
+      login(@org_user_1)
+
+      get api_v1_organization_users_index_url(id_or_name: @organization.name)
+      last_response.status.should == 401
+    end
+
+    it 'should list users' do
+      login(@organization.owner)
+
+      @organization.reload
+      organization_users_presentations = @organization.users.each do |user|
+        Carto::Api::UserPresenter.new(user, current_viewer: @organization.owner).to_poro
+      end
+
+      get api_v1_organization_users_index_url(id_or_name: @organization.name)
+
+      last_response.status.should eq 200
+
+      last_response.body == organization_users_presentations
     end
   end
 end

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -254,7 +254,8 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { password: 'limonero' }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should == 200
     end
@@ -265,7 +266,8 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.non_owner_users[0]
       new_email = "new-#{user_to_update.email}"
       params = { email: new_email }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
       last_response.status.should eq 200
 
       user_to_update.reload.email.should == new_email
@@ -276,7 +278,8 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { quota_in_bytes: 2048 }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should eq 200
 
@@ -290,7 +293,8 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.users[0]
       params = { soft_geocoding_limit: true }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should eq 410
       user_to_update.reload.soft_geocoding_limit.should be false
@@ -302,13 +306,15 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.users[0]
       params = { soft_geocoding_limit: true }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should eq 200
       user_to_update.reload.soft_geocoding_limit.should be true
 
       params = { soft_geocoding_limit: false }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should eq 200
 
@@ -328,7 +334,8 @@ describe Carto::Api::OrganizationUsersController do
                  password: 'pataton',
                  soft_geocoding_limit: true,
                  quota_in_bytes: 2048 }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should eq 200
 
@@ -346,7 +353,8 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.users[0]
       params = user_params_soft_limits(nil, true)
 
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should eq 200
 
@@ -361,7 +369,8 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.users[0]
       params = user_params_soft_limits(nil, false)
 
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should eq 200
 
@@ -377,7 +386,8 @@ describe Carto::Api::OrganizationUsersController do
       replace_soft_limits(user_to_update, [false, false, false])
       params = user_params_soft_limits(nil, true)
 
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should eq 410
       errors = JSON.parse(last_response.body)
@@ -393,7 +403,8 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { email: 'fail-' + user_to_update.email }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username), params
+      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
 
       last_response.status.should == 500
       user_to_update.reload
@@ -418,7 +429,8 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       user_to_be_deleted = @organization.non_owner_users[0]
-      delete api_v1_organization_users_delete_url(id_or_name: @organization.name, u_username: user_to_be_deleted.username)
+      delete api_v1_organization_users_delete_url(id_or_name: @organization.name,
+                                                  u_username: user_to_be_deleted.username)
 
       last_response.status.should eq 200
 
@@ -429,7 +441,8 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       user_to_be_deleted = @organization.owner
-      delete api_v1_organization_users_delete_url(id_or_name: @organization.name, u_username: user_to_be_deleted.username)
+      delete api_v1_organization_users_delete_url(id_or_name: @organization.name,
+                                                  u_username: user_to_be_deleted.username)
 
       last_response.status.should == 401
     end

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -84,21 +84,21 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user creation' do
     it 'returns 401 for non authorized calls' do
-      post api_v1_organization_users_create_url(id_or_name: @organization.name)
+      post api_v2_organization_users_create_url(id_or_name: @organization.name)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      post api_v1_organization_users_create_url(id_or_name: @organization.name)
+      post api_v2_organization_users_create_url(id_or_name: @organization.name)
       last_response.status.should == 401
     end
 
     it 'accepts org owners' do
       login(@organization.owner)
 
-      post api_v1_organization_users_create_url(id_or_name: @organization.name)
+      post api_v2_organization_users_create_url(id_or_name: @organization.name)
       last_response.status.should == 410
     end
 
@@ -106,7 +106,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       params = { username: unique_name('user'), password: '2{Patrañas}' }
-      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
+      post api_v2_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.body.include?('email is not present').should be true
       last_response.status.should == 410
@@ -116,7 +116,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       params = { email: unique_email, password: '2{Patrañas}' }
-      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
+      post api_v2_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.body.include?('username is not present').should be true
       last_response.status.should == 410
@@ -127,7 +127,7 @@ describe Carto::Api::OrganizationUsersController do
 
       username = 'manolo'
       params = { username: username, email: "#{username}@cartodb.com" }
-      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
+      post api_v2_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 410
       last_response.body.include?('password is not present').should be true
@@ -137,7 +137,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
       username = 'manolo-escobar'
       params = user_params(username)
-      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
+      post api_v2_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 200
 
@@ -153,7 +153,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
       username = 'soft-geocoding-limit-false-user'
       params = user_params(username, soft_geocoding_limit: nil)
-      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
+      post api_v2_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 200
 
@@ -170,7 +170,7 @@ describe Carto::Api::OrganizationUsersController do
       username = 'soft-limits-true-user'
       params = user_params_soft_limits(username, true)
 
-      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
+      post api_v2_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 200
 
@@ -189,7 +189,7 @@ describe Carto::Api::OrganizationUsersController do
       username = 'soft-limits-false-user'
       params = user_params_soft_limits(username, false)
 
-      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
+      post api_v2_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 200
 
@@ -207,7 +207,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
       username = 'soft-limits-true-invalid-user'
       params = user_params_soft_limits(username, true)
-      post api_v1_organization_users_create_url(id_or_name: @organization.name), params
+      post api_v2_organization_users_create_url(id_or_name: @organization.name), params
 
       last_response.status.should eq 410
       errors = JSON.parse(last_response.body)
@@ -221,21 +221,21 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user update' do
     it 'returns 401 for non authorized calls' do
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'accepts org owners' do
       login(@organization.owner)
 
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 410
     end
 
@@ -243,7 +243,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       user_to_update = @organization.non_owner_users[0]
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username)
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username)
 
       last_response.status.should eq 410
       last_response.body.include?('No update params provided').should be true
@@ -254,7 +254,7 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { password: 'limonero' }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should == 200
@@ -266,7 +266,7 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.non_owner_users[0]
       new_email = "new-#{user_to_update.email}"
       params = { email: new_email }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
       last_response.status.should eq 200
 
@@ -278,7 +278,7 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { quota_in_bytes: 2048 }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should eq 200
@@ -293,7 +293,7 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.users[0]
       params = { soft_geocoding_limit: true }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should eq 410
@@ -306,14 +306,14 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.users[0]
       params = { soft_geocoding_limit: true }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should eq 200
       user_to_update.reload.soft_geocoding_limit.should be true
 
       params = { soft_geocoding_limit: false }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should eq 200
@@ -334,7 +334,7 @@ describe Carto::Api::OrganizationUsersController do
                  password: 'pataton',
                  soft_geocoding_limit: true,
                  quota_in_bytes: 2048 }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should eq 200
@@ -353,7 +353,7 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.users[0]
       params = user_params_soft_limits(nil, true)
 
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should eq 200
@@ -369,7 +369,7 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update = @organization.users[0]
       params = user_params_soft_limits(nil, false)
 
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should eq 200
@@ -386,7 +386,7 @@ describe Carto::Api::OrganizationUsersController do
       replace_soft_limits(user_to_update, [false, false, false])
       params = user_params_soft_limits(nil, true)
 
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should eq 410
@@ -403,7 +403,7 @@ describe Carto::Api::OrganizationUsersController do
 
       user_to_update = @organization.non_owner_users[0]
       params = { email: 'fail-' + user_to_update.email }
-      put api_v1_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 
       last_response.status.should == 500
@@ -414,14 +414,14 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user deletion' do
     it 'returns 401 for non authorized calls' do
-      delete api_v1_organization_users_delete_url(id_or_name: @organization.name, u_username: @org_user_1.username)
+      delete api_v2_organization_users_delete_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      delete api_v1_organization_users_delete_url(id_or_name: @organization.name, u_username: @org_user_1.username)
+      delete api_v2_organization_users_delete_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
@@ -429,7 +429,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       user_to_be_deleted = @organization.non_owner_users[0]
-      delete api_v1_organization_users_delete_url(id_or_name: @organization.name,
+      delete api_v2_organization_users_delete_url(id_or_name: @organization.name,
                                                   u_username: user_to_be_deleted.username)
 
       last_response.status.should eq 200
@@ -441,7 +441,7 @@ describe Carto::Api::OrganizationUsersController do
       login(@organization.owner)
 
       user_to_be_deleted = @organization.owner
-      delete api_v1_organization_users_delete_url(id_or_name: @organization.name,
+      delete api_v2_organization_users_delete_url(id_or_name: @organization.name,
                                                   u_username: user_to_be_deleted.username)
 
       last_response.status.should == 401
@@ -450,21 +450,21 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user show' do
     it 'returns 401 for non authorized calls' do
-      get api_v1_organization_users_show_url(id_or_name: @organization.name, u_username: @org_user_1.username)
+      get api_v2_organization_users_show_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      get api_v1_organization_users_show_url(id_or_name: @organization.name, u_username: @org_user_1.username)
+      get api_v2_organization_users_show_url(id_or_name: @organization.name, u_username: @org_user_1.username)
       last_response.status.should == 401
     end
 
     it 'should return 404 for non existing users' do
       login(@organization.owner)
 
-      get api_v1_organization_users_show_url(id_or_name: @organization.name, u_username: 'bogus-non-existent-user')
+      get api_v2_organization_users_show_url(id_or_name: @organization.name, u_username: 'bogus-non-existent-user')
 
       last_response.status.should == 404
     end
@@ -474,7 +474,7 @@ describe Carto::Api::OrganizationUsersController do
 
       @organization.reload
       user_to_be_shown = @organization.non_owner_users[0]
-      get api_v1_organization_users_show_url(id_or_name: @organization.name, u_username: user_to_be_shown.username)
+      get api_v2_organization_users_show_url(id_or_name: @organization.name, u_username: user_to_be_shown.username)
 
       last_response.status.should eq 200
       last_response.body == Carto::Api::UserPresenter.new(user_to_be_shown, current_viewer: @organization.owner).to_poro
@@ -483,14 +483,14 @@ describe Carto::Api::OrganizationUsersController do
 
   describe 'user list' do
     it 'returns 401 for non authorized calls' do
-      get api_v1_organization_users_index_url(id_or_name: @organization.name)
+      get api_v2_organization_users_index_url(id_or_name: @organization.name)
       last_response.status.should == 401
     end
 
     it 'returns 401 for non authorized users' do
       login(@org_user_1)
 
-      get api_v1_organization_users_index_url(id_or_name: @organization.name)
+      get api_v2_organization_users_index_url(id_or_name: @organization.name)
       last_response.status.should == 401
     end
 
@@ -502,7 +502,7 @@ describe Carto::Api::OrganizationUsersController do
         Carto::Api::UserPresenter.new(user, current_viewer: @organization.owner).to_poro
       end
 
-      get api_v1_organization_users_index_url(id_or_name: @organization.name)
+      get api_v2_organization_users_index_url(id_or_name: @organization.name)
 
       last_response.status.should eq 200
 


### PR DESCRIPTION
Fixes #7148 

I had to use v2, since there is already a `'(/user/:user_domain)(/u/:user_domain)/api/v1/organization/:id/users'`

that conflicts with RESTfull list. I couldn't refactor that one since it accepts a complex paged query.

All other routes are updated and backwards compatible with v1, so shouldn't be a major drama.

Please review, @juanignaciosl .