### PR TITLE
Shared datasets in org group count text fix

### DIFF
--- a/lib/assets/javascripts/cartodb/organization/groups_admin/group_view.js
+++ b/lib/assets/javascripts/cartodb/organization/groups_admin/group_view.js
@@ -24,7 +24,7 @@ module.exports = cdb.core.View.extend({
       this.getTemplate('organization/groups_admin/group')({
         displayName: this.model.get('display_name'),
         sharedMapsCount: pluralizeStr('1 shared map', sharedMapsCount + ' shared maps', sharedMapsCount),
-        sharedDatasetsCount: pluralizeStr('1 shared map', sharedDatasetsCount + ' shared datasets', sharedDatasetsCount),
+        sharedDatasetsCount: pluralizeStr('1 shared dataset', sharedDatasetsCount + ' shared datasets', sharedDatasetsCount),
         url: this.options.url,
         previewUsers: this.model.users.toArray().slice(0, this._PREVIEW_COUNT),
         usersCount: Math.max(this.model.users.length - this._PREVIEW_COUNT, 0)


### PR DESCRIPTION
Fixes #6150 

Now it shows "1 shared **dataset**" instead of "1 shared map".

![screen shot 2016-04-18 at 14 58 58](https://cloud.githubusercontent.com/assets/2141690/14604884/1ef9139e-0576-11e6-97e1-238355365509.png)

CR @xavijam