### PR TITLE
Fix test ordering by size in psql 9.5

### DIFF
--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -239,7 +239,6 @@ describe Visualization::Collection do
 
       # Latest edited
       vis1.table.add_column!(name: "test_col", type: "text")
-      table = vis1.table
       @user_1.in_database.run("VACUUM #{table1.name}")
       sleep(1) # To avoid same sec storage
       vis1.fetch.store.fetch

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -240,7 +240,6 @@ describe Visualization::Collection do
       # Latest edited
       vis1.table.add_column!(name: "test_col", type: "text")
       table = vis1.table
-      table.insert_row!(test_col: "111")
       @user_1.in_database.run("VACUUM #{table1.name}")
       sleep(1) # To avoid same sec storage
       vis1.fetch.store.fetch


### PR DESCRIPTION
In 9.5, the "order by size" test may fail, as `vis1` and `vis2` have the same size. I think this only happens in 9.5 because some size calculations may have changed (maybe block size). The ordering of `vis1` and `vis2` is arbitrary (by uuid) which fails sometimes.

The problem is probably introduced by #7139 but I have not been able to track exactly how.