### PR TITLE
Add methods for enabling and disabling writes on an user database

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -130,6 +130,8 @@ module CartoDB
       end
 
       def disable_writes
+        # NOTE: This will not affect already opened connections. Run `terminate_database_conections` method after this
+        # to ensure no more writes are possible.
         @user.in_database(as: :cluster_admin) do |database|
           database.run(%{
             ALTER DATABASE "#{@user.database_name}"
@@ -139,6 +141,8 @@ module CartoDB
       end
 
       def enable_writes
+        # NOTE: This will not affect already opened connections. Run `terminate_database_conections` method after this
+        # to ensure no more writes are possible.
         @user.in_database(as: :cluster_admin) do |database|
           database.run(%{
             ALTER DATABASE "#{@user.database_name}"

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -129,6 +129,30 @@ module CartoDB
         end
       end
 
+      def disable_writes
+        @user.in_database(as: :cluster_admin) do |database|
+          database.run(%{
+            ALTER DATABASE "#{@user.database_name}"
+              SET default_transaction_read_only = 'on'
+          })
+        end
+      end
+
+      def enable_writes
+        @user.in_database(as: :cluster_admin) do |database|
+          database.run(%{
+            ALTER DATABASE "#{@user.database_name}"
+              SET default_transaction_read_only = default
+          })
+        end
+      end
+
+      def writes_enabled?
+        @user.in_database(as: :superuser) do |database|
+          database.fetch(%{SHOW default_transaction_read_only}).first[:default_transaction_read_only] == 'off'
+        end
+      end
+
       # Cartodb functions
       def load_cartodb_functions(statement_timeout = nil, cdb_extension_target_version = nil)
         add_python
@@ -1084,6 +1108,10 @@ module CartoDB
 
       def public_user_roles
         @user.organization_user? ? [CartoDB::PUBLIC_DB_USER, @user.database_public_username] : [CartoDB::PUBLIC_DB_USER]
+      end
+
+      def terminate_database_connections
+        CartoDB::UserModule::DBService.terminate_database_connections(@user.database_name, @user.database_host)
       end
 
       def self.terminate_database_connections(database_name, database_host)


### PR DESCRIPTION
This adds two methods to db_service to disable and enable _all_ writes on an user database, from anyone.

Existing connections will not be affected, unless you run a `terminate_database_connections` (I've also added a non-static version of that method to make calling it from an user easier).

All write operations I've tested from the database with writes disabled "work" as in: they fail giving out different errors (table editing passes the underlying PG:Error to the front, imports fail) but haven't been able to cause anything that will leave metadata inconsistencies.
This is expected to be used for a short period of time where the user is aware of what is going on (an announcement will appear on the dashboard) so we consider this acceptable.

@juanignaciosl could you take a look? 🙏 