### PR TITLE
Use cartodb_id as FID in ogr2ogr and handle exceptions

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -212,6 +212,12 @@ class DataImport < Sequel::Model
     CartoDB::notify_warning_exception(invalid_cartodb_id_exception)
     handle_failure(invalid_cartodb_id_exception)
     self
+  rescue CartoDB::Importer2::CartoDBfyInvalidID => invalid_cartodb_id_exception
+    invalid_cartodb_id_exception = CartoDB::Importer2::CartoDBfyInvalidID.new
+    log.append "Exception: #{invalid_cartodb_id_exception}"
+    CartoDB::notify_warning_exception(invalid_cartodb_id_exception)
+    handle_failure(invalid_cartodb_id_exception)
+    self
   rescue => exception
     log.append "Exception: #{exception.to_s}"
     log.append exception.backtrace, truncate = false

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -213,7 +213,6 @@ class DataImport < Sequel::Model
     handle_failure(invalid_cartodb_id_exception)
     self
   rescue CartoDB::Importer2::CartoDBfyInvalidID => invalid_cartodb_id_exception
-    invalid_cartodb_id_exception = CartoDB::Importer2::CartoDBfyInvalidID.new
     log.append "Exception: #{invalid_cartodb_id_exception}"
     CartoDB::notify_warning_exception(invalid_cartodb_id_exception)
     handle_failure(invalid_cartodb_id_exception)

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -137,6 +137,8 @@ module CartoDB
       RowsEncodingColumnError               => 2007,
       MalformedXLSException                 => 2008,
       KmlWithoutStyleIdError                => 2009,
+      CartoDBfyError                        => 2010,
+      CartoDBfyInvalidID                    => 2011,
       InvalidGeoJSONError                   => 3007,
       UnknownSridError                      => 3008,
       ShpNormalizationError                 => 3009,

--- a/services/importer/lib/importer/loader.rb
+++ b/services/importer/lib/importer/loader.rb
@@ -317,6 +317,14 @@ module CartoDB
           raise KmlWithoutStyleIdError.new(job.logger)
         end
 
+        if ogr2ogr.duplicated_cartodb_id?
+          raise CartoDB::Importer2::CartoDBfyInvalidID.new(job.logger)
+        end
+
+        if ogr2ogr.invalid_cartodb_id?
+          raise CartoDB::Importer2::CartoDBfyInvalidID.new(job.logger)
+        end
+
         # Could be OOM, could be wrong input
         if ogr2ogr.segfault_error?
           raise LoadError.new(job.logger)

--- a/services/importer/lib/importer/loader.rb
+++ b/services/importer/lib/importer/loader.rb
@@ -318,11 +318,11 @@ module CartoDB
         end
 
         if ogr2ogr.duplicated_cartodb_id?
-          raise CartoDB::Importer2::CartoDBfyInvalidID.new(job.logger)
+          raise CartoDB::Importer2::CartoDBfyInvalidID.new
         end
 
         if ogr2ogr.invalid_cartodb_id?
-          raise CartoDB::Importer2::CartoDBfyInvalidID.new(job.logger)
+          raise CartoDB::Importer2::CartoDBfyInvalidID.new
         end
 
         # Could be OOM, could be wrong input

--- a/services/importer/lib/importer/ogr2ogr.rb
+++ b/services/importer/lib/importer/ogr2ogr.rb
@@ -83,6 +83,14 @@ module CartoDB
         command_output =~ /has no equivalent in encoding/i || command_output =~ /invalid byte sequence for encoding/i
       end
 
+      def duplicated_cartodb_id?
+        command_output =~ /Key \(cartodb_id\)=\(.*\) already exists/i
+      end
+
+      def invalid_cartodb_id?
+        command_output =~ /Wrong field type for cartodb_id/i
+      end
+
       def invalid_dates?
         command_output =~ /date\/time field value out of range/i
       end
@@ -202,7 +210,7 @@ module CartoDB
 
       def layer_creation_options
         # Dimension option, precision option
-        "-lco DIM=2 -lco PRECISION=NO"
+        "-lco DIM=2 -lco PRECISION=NO -lco FID='cartodb_id'"
       end
 
       def projection_option


### PR DESCRIPTION
ogr2ogr2 uses by default a primary key called `ogc_fid` (integer, non-null, with a sequence as default value). This is exactly what we do with `cartodb_id`, which we are later generating/converting/checking in the cartodbfication.

By using `cartodb_id` as the name of the ogr2ogr primary key we directly obtain the column. Also, it recognizes `cartodb_id` columns from the imported file, and has exactly the same constraints we have on it: it detects null, repeated and non integer values. In case the `cartodb_id` is incorrect, the import process would fail straight away instead of going through the whole process and failing when CartoDBfying, as it does now.