### PR TITLE
Op555 invalid home url generation

### DIFF
--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -163,20 +163,25 @@ module CartoDB
     base_url
   end
 
-  def self.domainless_base_url(subdomain, protocol_override=nil)
+  def self.domainless_base_url(subdomain, protocol_override = nil)
+    base_domain = domainless_base_domain(protocol_override)
+    if !subdomain.nil? && !subdomain.empty?
+      "#{base_domain}/user/#{subdomain}"
+    else
+      base_domain
+    end
+  end
+
+  def self.domainless_base_domain(protocol_override = nil)
     protocol = self.protocol(protocol_override)
-    port = protocol == 'http' ? self.http_port : self.https_port
+    port = protocol == 'http' ? http_port : https_port
     if ip?(request_host)
-      "#{protocol}://#{request_host}#{port}/user/#{subdomain}"
+      "#{protocol}://#{request_host}#{port}"
     else
       request_subdomain = request_host.sub(session_domain, '')
-      request_subdomain += '.' if request_subdomain.length > 0 && !request_subdomain.end_with?('.')
+      request_subdomain += '.' if !request_subdomain.empty? && !request_subdomain.end_with?('.')
 
-      if !subdomain.nil? && subdomain != ''
-        "#{protocol}://#{request_subdomain}#{session_domain}#{port}/user/#{subdomain}"
-      else
-        "#{protocol}://#{request_subdomain}#{session_domain}#{port}"
-      end
+      "#{protocol}://#{request_subdomain}#{session_domain}#{port}"
     end
   end
 
@@ -238,4 +243,3 @@ module CartoDB
   end
 
 end
-

--- a/spec/lib/initializers/carto_db_spec.rb
+++ b/spec/lib/initializers/carto_db_spec.rb
@@ -169,6 +169,23 @@ describe CartoDB do
         .should eq "#{protocol_override_http}://#{expected_session_domain}#{expected_http_port}/user/#{username}"
     end
 
+    it 'tests base_url() without logged user' do
+      expected_session_domain = 'cartodb.com'
+      expected_ip = '127.0.0.1'
+      expected_https_port = ':67890'
+
+      CartoDB.clear_internal_cache
+      CartoDB.stubs(:use_https?).returns(true)
+      CartoDB.stubs(:get_https_port).returns(expected_https_port)
+
+      CartoDB.stubs(:get_subdomainless_urls).returns(true)
+      CartoDB.stubs(:get_session_domain).returns(expected_session_domain)
+      CartoDB.base_url(nil, nil, nil).should eq "https://#{expected_session_domain}#{expected_https_port}"
+
+      CartoDB.stubs(:request_host).returns(expected_ip)
+      CartoDB.base_url(nil, nil, nil).should eq "https://#{expected_ip}#{expected_https_port}"
+    end
+
   end
 
 end


### PR DESCRIPTION
Fixes wrong redirection when:
- Using domainless urls
- Accessing by IP address
- Not logged in

In these circumstances, a URL of the form `http://cartodb.lan/user//login` was generated, with a blank username in the URL, which gives a 404 (no user found). This was fixed for domains in #6715 but not for the IP route.