### PR TITLE
Switch vacuum full by vacuum analyze from table.optimize

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -466,7 +466,7 @@ class Table
   end
 
   def optimize
-    owner.in_database({as: :superuser, statement_timeout: 3600000}).run("VACUUM ANALYZE #{qualified_table_name}")
+    owner.db_service.in_database_direct_connection({statement_timeout: STATEMENT_TIMEOUT}).run("VACUUM ANALYZE #{qualified_table_name}")
   rescue => e
     CartoDB::notify_exception(e, { user: owner })
     false

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -466,7 +466,7 @@ class Table
   end
 
   def optimize
-    owner.in_database({as: :superuser, statement_timeout: 3600000}).run("VACUUM FULL #{qualified_table_name}")
+    owner.in_database({as: :superuser, statement_timeout: 3600000}).run("VACUUM ANALYZE #{qualified_table_name}")
   rescue => e
     CartoDB::notify_exception(e, { user: owner })
     false


### PR DESCRIPTION
Closes #7239

In the past, the import process was highly manipulating the target tables: creating, renaming and dropping columns (for example, in the QueryBatcher). In that scenario, having a vacuum full running for each import might make sense to clean the table.

This `table.optimize` function is called from `app/models/data_import.rb` in `migrate_existing` and `app/models/table_registrar.rb` in `register`. 

Performing a vacuum full on a table which has been newly created and has not suffered those manipulations has a cost in the import time, so we are substituting it by a simpler "VACUUM ANALYZE" which will update the stats (might be important for calculating bounds when the geometries have changed, e.g. in geo-guessing).