### PR TITLE
Require rspec_configuration as in executor, avoids mocha errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,17 +275,17 @@ endif
 
 # TODO: Ongoing removal of groups, that's the reason of holes in numbering
 check-1:
-	CHECK_SPEC=1 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_1)
+	CHECK_SPEC=1 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_1)
 check-2:
-	CHECK_SPEC=2 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_2)
+	CHECK_SPEC=2 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_2)
 check-4:
-	CHECK_SPEC=4 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_4)
+	CHECK_SPEC=4 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_4)
 check-5:
-	CHECK_SPEC=5 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_5)
+	CHECK_SPEC=5 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_5)
 check-7:
-	CHECK_SPEC=7 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_7)
+	CHECK_SPEC=7 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_7)
 check-9:
-	CHECK_SPEC=9 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_9)
+	CHECK_SPEC=9 RAILS_ENV=test bundle exec rspec --require ./spec/rspec_configuration.rb $(WORKING_SPECS_9)
 check-spec-helper-min:
 	CHECK_SPEC=50 RAILS_ENV=test bundle exec rspec $(SPEC_HELPER_MIN_SPECS)
 check-carto-db-class:

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,6 @@ WORKING_SPECS_9 = \
 	spec/lib/initializers/carto_db_spec.rb \
 	spec/requests/carto/api/oembed_controller_spec.rb \
 	spec/models/asset_spec.rb \
-	spec/models/log_spec.rb \
 	spec/models/access_token_spec.rb \
 	spec/requests/api/permissions_controller_spec.rb \
 	spec/models/shared_entity_spec.rb \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ WORKING_SPECS_INTEGRATIONS = \
 	$(NULL)
 
 WORKING_SPECS_1 = \
-	spec/rspec_configuration.rb \
 	spec/models/table_spec.rb \
 	spec/models/table_privacy_manager_spec.rb \
 	spec/models/table/relator_spec.rb \
@@ -138,7 +137,6 @@ WORKING_SPECS_2 = \
 	$(NULL)
 
 WORKING_SPECS_4 = \
-	spec/rspec_configuration.rb \
 	services/wms/spec/unit/wms_spec.rb \
 	services/sql-api/spec/sql_api_spec.rb \
 	spec/requests/admin/visualizations_spec.rb \
@@ -161,7 +159,6 @@ WORKING_SPECS_4 = \
 	$(NULL)
 
 WORKING_SPECS_5 = \
-	spec/rspec_configuration.rb \
 	spec/requests/api/assets_spec.rb \
 	spec/requests/carto/api/assets_controller_spec.rb \
 	spec/requests/api/user_layers_spec.rb \
@@ -192,13 +189,11 @@ WORKING_SPECS_5 = \
 
 # TODO: This block also breaks if run alongside other specs, needs checking why
 WORKING_SPECS_7 = \
-	spec/rspec_configuration.rb \
 	spec/requests/api/json/geocodings_controller_spec.rb \
 	spec/requests/carto/api/geocodings_controller_spec.rb \
 	$(NULL)
 
 WORKING_SPECS_9 = \
-	spec/rspec_configuration.rb \
 	services/twitter-search/spec/unit/json_to_csv_converter_spec.rb \
 	services/twitter-search/spec/unit/search_api_spec.rb \
 	services/datasources/spec/acceptance/datasources_factory_spec.rb \
@@ -222,7 +217,6 @@ WORKING_SPECS_9 = \
 	spec/models/asset_spec.rb \
 	spec/models/log_spec.rb \
 	spec/models/access_token_spec.rb \
-	spec/rspec_configuration.rb \
 	spec/requests/api/permissions_controller_spec.rb \
 	spec/models/shared_entity_spec.rb \
 	spec/requests/signup_controller_spec.rb \
@@ -282,17 +276,17 @@ endif
 
 # TODO: Ongoing removal of groups, that's the reason of holes in numbering
 check-1:
-	CHECK_SPEC=1 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_1)
+	CHECK_SPEC=1 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_1)
 check-2:
-	CHECK_SPEC=2 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_2)
+	CHECK_SPEC=2 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_2)
 check-4:
-	CHECK_SPEC=4 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_4)
+	CHECK_SPEC=4 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_4)
 check-5:
-	CHECK_SPEC=5 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_5)
+	CHECK_SPEC=5 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_5)
 check-7:
-	CHECK_SPEC=7 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_7)
+	CHECK_SPEC=7 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_7)
 check-9:
-	CHECK_SPEC=9 RAILS_ENV=test bundle exec rspec $(WORKING_SPECS_9)
+	CHECK_SPEC=9 RAILS_ENV=test bundle exec rspec --require spec/rspec_configuration.rb $(WORKING_SPECS_9)
 check-spec-helper-min:
 	CHECK_SPEC=50 RAILS_ENV=test bundle exec rspec $(SPEC_HELPER_MIN_SPECS)
 check-carto-db-class:

--- a/script/ci/generateSpecFull.sh
+++ b/script/ci/generateSpecFull.sh
@@ -4,7 +4,7 @@ truncate -s 0 specfull.txt
 cat Makefile | grep -v 'spec/lib/varnish_spec.rb'| \
 grep -v 'spec/models/asset_spec.rb'| \
 grep -v 'services/user-mover/spec/user_mover_spec.rb'| \
-grep -v 'require spec/rspec_configuration.rb'| \
+grep -v 'require ./spec/rspec_configuration.rb'| \
 grep 'rb'| sed -e 's/^\s*//' -e '/^$/d' | sed '/^#/ d' | sed 's/\\//' | sed 's/\s.*$//' > temp.txt
 
 i=6001;

--- a/script/ci/generateSpecFull.sh
+++ b/script/ci/generateSpecFull.sh
@@ -4,6 +4,7 @@ truncate -s 0 specfull.txt
 cat Makefile | grep -v 'spec/lib/varnish_spec.rb'| \
 grep -v 'spec/models/asset_spec.rb'| \
 grep -v 'services/user-mover/spec/user_mover_spec.rb'| \
+grep -v 'require spec/rspec_configuration.rb'| \
 grep 'rb'| sed -e 's/^\s*//' -e '/^$/d' | sed '/^#/ d' | sed 's/\\//' | sed 's/\s.*$//' > temp.txt
 
 i=6001;

--- a/spec/lib/initializers/carto_db_spec.rb
+++ b/spec/lib/initializers/carto_db_spec.rb
@@ -29,6 +29,7 @@ describe CartoDB do
       username = 'test'
       expected_session_domain = '.cartodb.com'
 
+      CartoDB.clear_internal_cache
       CartoDB.expects(:get_session_domain).returns(expected_session_domain)
 
       request = Doubles::Request.new({


### PR DESCRIPTION
This fixes tests in master. Basically, this is the same problem that #dataservices had some weeks ago when adding tests, but this time is happening in master CI instead of PR.

Basically, just passing `rspec_configuration` with the require flag to rspec does the right thing (loads this as the first file). Before, it was added as a normal test and was loaded in alphabetical order, which failed for some test groups when adding new tests. This should be safer when adding new tests.

Also disables `log_spec` because it fails sometimes as some of the assertions are based on timestamps, which is not such a good idea.

Tests passing for PR and master testing, hopefully this stabilizes the situation for now.