### PR TITLE
Getting tipsy element size with getBoundingClientRect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.65",
+  "version": "3.23.66",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/vendor/assets/javascripts/jquery.tipsy.js
+++ b/vendor/assets/javascripts/jquery.tipsy.js
@@ -45,8 +45,8 @@
 
             //  Fixed by Arce
             var pos = $.extend({}, this.$element.offset(), {
-              width: this.$element[0].offsetWidth,
-              height: this.$element[0].offsetHeight
+              width: this.$element[0].getBoundingClientRect().width,
+              height: this.$element[0].getBoundingClientRect().height
             });
 
             var actualWidth = $tip[0].offsetWidth,


### PR DESCRIPTION
There is a problem right now with the map views tooltip, and it is due to the calculation of the size of the element. We use within tipsy:

https://github.com/CartoDB/cartodb/blob/master/vendor/assets/javascripts/jquery.tipsy.js#L48

But for any reason, over svg elements, that function doesn't work properly (it returns 0 for width and height). Using `getboundingClientRect` fixes the bug.

Tested in several browsers (firefox, safari, chrome) and in several places.

#### Before:

<img width="651" alt="screen shot 2016-04-27 at 10 30 59" src="https://cloud.githubusercontent.com/assets/132146/14846326/87d945a2-0c63-11e6-8df9-0f05f81acca8.png">

#### After:

<img width="237" alt="screen shot 2016-04-27 at 10 28 23" src="https://cloud.githubusercontent.com/assets/132146/14846331/8cd3af48-0c63-11e6-89cc-2ca8a783b37a.png">
<img width="342" alt="screen shot 2016-04-27 at 10 28 01" src="https://cloud.githubusercontent.com/assets/132146/14846333/8eb17c14-0c63-11e6-9147-5fae8f63e45d.png">
<img width="456" alt="screen shot 2016-04-27 at 10 27 50" src="https://cloud.githubusercontent.com/assets/132146/14846336/91ae7b60-0c63-11e6-8018-445f49fbedd8.png">


CR: @javierarce 
cc @saleiva 
Fixes #7256.