### PR TITLE
Don't persist source nodes

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
@@ -66,6 +66,11 @@ module.exports = cdb.core.Model.extend({
     // Un-flatten the internal attrs to the datastructure that's expected by the API endpoint
     var options = _.omit(this.attributes, OWN_ATTR_NAMES.concat(['cartocss', 'sql']));
 
+    // source node will be re-created for editor when editor is loaded, if it doesn't already exist (through an analysis)
+    if (/[^\d]0$/.test(this.get('source'))) {
+      delete options.source;
+    }
+
     // Map back internal attrs to the expected attrs names by the API endpoint
     var cartocss = this.get('cartocss');
     if (cartocss) {

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -66,6 +66,8 @@ module.exports = Backbone.Collection.extend({
         params: {
           query: o.query
         }
+      }, {
+        merge: true // to add table_name which might not be persisted
       });
     }
 

--- a/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
@@ -43,6 +43,14 @@ describe('data/layer-definition-model', function () {
         }
       });
     });
+
+    it('should not contain source if it is a source node', function () {
+      this.model.set('source', 'a1');
+      expect(this.model.toJSON().options.source).toEqual('a1');
+
+      this.model.set('source', 'a0');
+      expect(this.model.toJSON().options.source).not.toEqual('a0');
+    });
   });
 
   describe('.hasAnalysisNode', function () {


### PR DESCRIPTION
Source nodes are created if needed when the layer definitions models
are instantiated (see layer-definitions-collection), but should not be
persisted unless there is an actual analysis.

This is necessary to avoid cartodb.js throwing exceptions due to
missing analysis nodes of a persisted source id that doesn’t have a
corresponding analysis

@xavijam can you review?
cc @javierarce 