### PR TITLE
Op557 option for disabling gravatar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@ which should be fixed manually.
   * This change is backwards compatible and will fallback to `port` whenever `direct_port` is not specified in the database configuration file.
 * Update ogr2ogr version to 2.1, configurable in `app_config.yml`. To install it in the system, run:
   * `sudo apt-get install gdal2.1-static-bin`
+* Added config option `avatars.gravatar_enabled` to disabled gravatar loading (i.e: in offline installations)
 * Ghost table linking is now concurrent per user (avoids race conditions)
 * Experimental support for [visualization metadata export](https://github.com/CartoDB/cartodb/pull/7114).
 * Update CartoDB PostgreSQL extension to 0.15.1 to support overviews.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -714,10 +714,8 @@ class User < Sequel::Model
 
   def gravatar_enabled?
     # Enabled by default, only disabled if specified in the config
-    gravatar_disabled = !Cartodb.config[:avatars].nil? &&
-                        !Cartodb.config[:avatars]['gravatar_enabled'].nil? &&
-                        !Cartodb.config[:avatars]['gravatar_enabled']
-    !gravatar_disabled
+    value = Cartodb.get_config(:avatars, 'gravatar_enabled')
+    value.nil? || value
   end
 
   def gravatar(protocol = "http://", size = 128, default_image = default_avatar)

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -244,6 +244,7 @@ defaults: &defaults
   app_assets:
     asset_host: "//cartodb-libs.global.ssl.fastly.net/cartodbui"
   avatars:
+    gravatar_enabled: true
     base_url: 'example.com/avatars'
     kinds: ['stars', 'mountains']
     colors: ['red', 'blue']

--- a/config/app_config.yml.testing
+++ b/config/app_config.yml.testing
@@ -119,8 +119,8 @@ defaults: &defaults
   error_track:
     url: 'https://viz2.cartodb.com/api/v1/sql'
     percent_users: 10
-  mailer: 
-    from: 'cartodb.com <support@cartodb.com>' 
+  mailer:
+    from: 'cartodb.com <support@cartodb.com>'
     address: ''
     port: ''
     user_name: ''
@@ -131,7 +131,7 @@ defaults: &defaults
   # graphite endpoint used to post frontend stats
   #graphite_public:
     #host: ""
-    #port: 
+    #port:
 
   basemaps:
     GMaps:
@@ -223,6 +223,7 @@ defaults: &defaults
     s3_bucket_name: "tests"
     max_file_size: 5242880 # 5.megabytes
   avatars:
+    gravatar_enabled: false
     base_url: 'example.com/avatars'
     kinds: ['stars', 'mountains']
     colors: ['red', 'blue']


### PR DESCRIPTION
Adds an option to disable Gravatar, specially useful for offline installations (as the timeout if unable to connect to gravatar is 5 minutes).

It is disabled by default on tests (the relevant tests, stub this to the correct value for testing). This (+ #7246) fixes offline tests.

From CartoDB/cartodb-onpremise#557