### PR TITLE
Revamp parallel testing scripts

### DIFF
--- a/script/ci/executor.sh
+++ b/script/ci/executor.sh
@@ -27,18 +27,13 @@ main() {
     redis_file
     # Lock the redis file
     lock $redisfile;
-    
-    # Choose redis-server port 
+
+    # Choose redis-server port
     port=$(cat config/$redisfile)
 
     # Run the rspec
-    # Some dirty logic here
-    if [[ $1 == *"services/importer"* ]] || [[ $1 == *"services/platform-limits/spec/unit/"* ]] || [[ $1 == *"services/wms/spec/unit/wms_spec.rb"* ]] || [[ $1 == *"services/datasources"* ]] || [[ $1 == *"spec/models/overlay/collection_spec.rb"* ]]; then
-      RAILS_ENV=test PARALLEL=true RAILS_DATABASE_FILE=database_${2}.yml REDIS_PORT=$port bundle exec rspec $1 >> $port.log 2>&1;
-    else
-      RAILS_ENV=test PARALLEL=true RAILS_DATABASE_FILE=database_${2}.yml REDIS_PORT=$port bundle exec rspec --require ./spec/rspec_configuration.rb $1 >> $port.log 2>&1;
-    fi
-    
+    RAILS_ENV=test PARALLEL=true RAILS_DATABASE_FILE=database_${2}.yml REDIS_PORT=$port bundle exec rspec --require ./spec/rspec_configuration.rb $1 >> $port.log 2>&1;
+
     # Give some feedback
     if [ $? -eq 0 ]; then
       echo "Finished: $1 Port: $port";

--- a/script/ci/generateSpecFull.sh
+++ b/script/ci/generateSpecFull.sh
@@ -27,6 +27,13 @@ done
 cat Makefile | \
 grep -v $DISABLED_TEST_REGEX | \
 grep -v 'require ./spec/rspec_configuration.rb'| \
-grep 'rb'| sed -e 's/^\s*//' -e '/^$/d' | sed '/^#/ d' | sed 's/\\//' | sed 's/\s.*$//' > specfull.txt
+grep 'rb'| sed -e 's/^\s*//' -e '/^$/d' | sed '/^#/ d' | sed 's/\\//' | sed 's/\s.*$//' > temp.txt
+
+i=6001;
+while read -r line
+do
+  echo "$line $i" >> specfull.txt;
+  i=$((i+1))
+done < temp.txt
 
 echo "# Speclist has been created"

--- a/script/ci/generateSpecFull.sh
+++ b/script/ci/generateSpecFull.sh
@@ -1,17 +1,32 @@
 #!/bin/bash
 # Jesus Vazquez
-truncate -s 0 specfull.txt
-cat Makefile | grep -v 'spec/lib/varnish_spec.rb'| \
-grep -v 'spec/models/asset_spec.rb'| \
-grep -v 'services/user-mover/spec/user_mover_spec.rb'| \
-grep -v 'require ./spec/rspec_configuration.rb'| \
-grep 'rb'| sed -e 's/^\s*//' -e '/^$/d' | sed '/^#/ d' | sed 's/\\//' | sed 's/\s.*$//' > temp.txt
 
-i=6001;
-while read -r line
+# The following tests are disabled in a parallel environment and are run afterwards, sequentially
+DISABLED_TESTS=(
+  'spec/models/asset_spec.rb' # Hangs sometimes when serving files
+  'services/user-mover/spec/user_mover_spec.rb' # Database recreation fails in parallel
+)
+
+# Disabled tests get put into specfailed.txt for later execution and are omitted from
+# specfull.txt by builiding and OR regex (spec\|spec\|spec)
+first=1
+DISABLED_TEST_REGEX=''
+truncate -s0 specfailed.txt
+for spec in ${DISABLED_TESTS[@]}
 do
-  echo "$line $i" >> specfull.txt;
-  i=$((i+1))
-done < temp.txt
+  echo $spec >> specfailed.txt
+  if [[ $first -eq 0 ]]
+  then
+    DISABLED_TEST_REGEX="$DISABLED_TEST_REGEX\\|$spec"
+  else
+    DISABLED_TEST_REGEX="$DISABLED_TEST_REGEX$spec"
+  fi
+  first=0
+done
+
+cat Makefile | \
+grep -v $DISABLED_TEST_REGEX | \
+grep -v 'require ./spec/rspec_configuration.rb'| \
+grep 'rb'| sed -e 's/^\s*//' -e '/^$/d' | sed '/^#/ d' | sed 's/\\//' | sed 's/\s.*$//' > specfull.txt
 
 echo "# Speclist has been created"

--- a/script/ci/generateSpecFull.sh
+++ b/script/ci/generateSpecFull.sh
@@ -24,7 +24,7 @@ do
   first=0
 done
 
-cat Makefile | \
+cat Makefile | grep -v 'spec/lib/varnish_spec.rb' | \
 grep -v $DISABLED_TEST_REGEX | \
 grep -v 'require ./spec/rspec_configuration.rb'| \
 grep 'rb'| sed -e 's/^\s*//' -e '/^$/d' | sed '/^#/ d' | sed 's/\\//' | sed 's/\s.*$//' > temp.txt


### PR DESCRIPTION
A little cleanup of the CI scripts and a better way to disable problematic specs from parallel execution directly from the scripts.