### PR TITLE
Fixes the URL generation for the geocoding & import models

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/background-importer/background-importer-geocodings-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/background-importer-geocodings-collection.js
@@ -25,7 +25,8 @@ module.exports = Backbone.Collection.extend({
 
   url: function (method) {
     var version = this._configModel.urlVersion('geocoding');
-    return '/api/' + version + '/geocodings';
+    var baseUrl = this._configModel.get('base_url');
+    return baseUrl + '/api/' + version + '/geocodings/';
   },
 
   parse: function (r) {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/background-importer-geocodings-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/background-importer-geocodings-collection.js
@@ -26,7 +26,7 @@ module.exports = Backbone.Collection.extend({
   url: function (method) {
     var version = this._configModel.urlVersion('geocoding');
     var baseUrl = this._configModel.get('base_url');
-    return baseUrl + '/api/' + version + '/geocodings/';
+    return baseUrl + '/api/' + version + '/geocodings';
   },
 
   parse: function (r) {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/background-importer-imports-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/background-importer-imports-collection.js
@@ -16,7 +16,8 @@ module.exports = Backbone.Collection.extend({
 
   url: function (method) {
     var version = this._configModel.urlVersion('import');
-    return '/api/' + version + '/imports';
+    var baseUrl = this._configModel.get('base_url');
+    return baseUrl + '/api/' + version + '/imports/';
   },
 
   initialize: function (models, opts) {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/background-importer-imports-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/background-importer-imports-collection.js
@@ -17,7 +17,7 @@ module.exports = Backbone.Collection.extend({
   url: function (method) {
     var version = this._configModel.urlVersion('import');
     var baseUrl = this._configModel.get('base_url');
-    return baseUrl + '/api/' + version + '/imports/';
+    return baseUrl + '/api/' + version + '/imports';
   },
 
   initialize: function (models, opts) {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/geocoding-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/geocoding-model.js
@@ -33,15 +33,11 @@ module.exports = cdb.core.Model.extend({
     }
   },
 
-  url: function (method) {
+  urlRoot: function () {
     var version = this._configModel.urlVersion('geocoding');
     var baseUrl = this._configModel.get('base_url');
-    var geocodingsPath = '/api/' + version + '/geocodings';
 
-    if (this.isNew()) {
-      return baseUrl + geocodingsPath;
-    }
-    return baseUrl + geocodingsPath + '/' + this.id;
+    return baseUrl + '/api/' + version + '/geocodings';
   },
 
   setUrlRoot: function (urlRoot) {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/geocoding-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/geocoding-model.js
@@ -35,13 +35,13 @@ module.exports = cdb.core.Model.extend({
 
   url: function (method) {
     var version = this._configModel.urlVersion('geocoding');
-
-    var base = '/api/' + version + '/geocodings/';
+    var baseUrl = this._configModel.get('base_url');
+    var geocodingsPath = '/api/' + version + '/geocodings/';
 
     if (this.isNew()) {
-      return base;
+      return baseUrl + geocodingsPath;
     }
-    return base + this.id;
+    return baseUrl + geocodingsPath + this.id;
   },
 
   setUrlRoot: function (urlRoot) {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/geocoding-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/geocoding-model.js
@@ -36,12 +36,12 @@ module.exports = cdb.core.Model.extend({
   url: function (method) {
     var version = this._configModel.urlVersion('geocoding');
     var baseUrl = this._configModel.get('base_url');
-    var geocodingsPath = '/api/' + version + '/geocodings/';
+    var geocodingsPath = '/api/' + version + '/geocodings';
 
     if (this.isNew()) {
       return baseUrl + geocodingsPath;
     }
-    return baseUrl + geocodingsPath + this.id;
+    return baseUrl + geocodingsPath + '/' + this.id;
   },
 
   setUrlRoot: function (urlRoot) {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/import-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/import-model.js
@@ -25,12 +25,12 @@ module.exports = cdb.core.Model.extend({
     var version = this._configModel.urlVersion('import');
     var baseUrl = this._configModel.get('base_url');
 
-    var importsPath = '/api/' + version + '/imports/';
+    var importsPath = '/api/' + version + '/imports';
 
     if (this.isNew()) {
       return baseUrl + importsPath;
     }
-    return baseUrl + importsPath + this.id;
+    return baseUrl + importsPath + '/' + this.id;
   },
 
   _initBinds: function () {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/import-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/import-model.js
@@ -23,12 +23,14 @@ module.exports = cdb.core.Model.extend({
 
   url: function (method) {
     var version = this._configModel.urlVersion('import');
-    var base = '/api/' + version + '/imports';
+    var baseUrl = this._configModel.get('base_url');
+
+    var importsPath = '/api/' + version + '/imports/';
 
     if (this.isNew()) {
-      return base;
+      return baseUrl + importsPath;
     }
-    return base + '/' + this.id;
+    return baseUrl + importsPath + this.id;
   },
 
   _initBinds: function () {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/import-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/import-model.js
@@ -21,16 +21,11 @@ module.exports = cdb.core.Model.extend({
     this.poller = new ImportModelPoller(this);
   },
 
-  url: function (method) {
+  urlRoot: function () {
     var version = this._configModel.urlVersion('import');
     var baseUrl = this._configModel.get('base_url');
 
-    var importsPath = '/api/' + version + '/imports';
-
-    if (this.isNew()) {
-      return baseUrl + importsPath;
-    }
-    return baseUrl + importsPath + '/' + this.id;
+    return baseUrl + '/api/' + version + '/imports';
   },
 
   _initBinds: function () {

--- a/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-collection.spec.js
@@ -52,6 +52,10 @@ describe('common/background-polling/geocodings-collection', function () {
     });
   });
 
+  it('should generate the right URL', function () {
+    expect(this.collection.url()).toBe('/u/pepe/api/v1/geocodings/');
+  });
+
   describe('polling', function () {
     it('should start polling the geocoding model because visualization is defined and layer added to it', function () {
       this.collection.vis = this.vis;

--- a/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-collection.spec.js
@@ -53,7 +53,7 @@ describe('common/background-polling/geocodings-collection', function () {
   });
 
   it('should generate the right URL', function () {
-    expect(this.collection.url()).toBe('/u/pepe/api/v1/geocodings/');
+    expect(this.collection.url()).toBe('/u/pepe/api/v1/geocodings');
   });
 
   describe('polling', function () {

--- a/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-model.spec.js
@@ -15,6 +15,10 @@ describe('common/background-polling/geocoding-model', function () {
     spyOn(this.model, 'bind').and.callThrough();
   });
 
+  it('should generate the right URL', function () {
+    expect(this.model.url()).toBe('/u/pepe/api/v1/geocodings/');
+  });
+
   it('should not start polling when option is not enabled', function () {
     spyOn(this.model, 'fetch');
     this.model.options.startPollingAutomatically = false;

--- a/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-model.spec.js
@@ -16,7 +16,7 @@ describe('common/background-polling/geocoding-model', function () {
   });
 
   it('should generate the right URL', function () {
-    expect(this.model.url()).toBe('/u/pepe/api/v1/geocodings/');
+    expect(this.model.url()).toBe('/u/pepe/api/v1/geocodings');
   });
 
   it('should not start polling when option is not enabled', function () {

--- a/lib/assets/test/spec/cartodb3/data/background-importer/import-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/import-model.spec.js
@@ -13,7 +13,7 @@ describe('common/background-polling/import-model', function () {
   });
 
   it('should generate the right URL', function () {
-    expect(this.model.url()).toBe('/u/pepe/api/v1/imports/');
+    expect(this.model.url()).toBe('/u/pepe/api/v1/imports');
   });
 
   it('should have several change binds', function () {

--- a/lib/assets/test/spec/cartodb3/data/background-importer/import-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/import-model.spec.js
@@ -1,0 +1,64 @@
+var ConfigModel = require('../../../../../javascripts/cartodb3/data/config-model');
+var ImportModel = require('../../../../../javascripts/cartodb3/data/background-importer/import-model.js');
+
+describe('common/background-polling/import-model', function () {
+  beforeEach(function () {
+    this.configModel = new ConfigModel({
+      base_url: '/u/pepe'
+    });
+    this.model = new ImportModel(null, {
+      configModel: this.configModel
+    });
+    spyOn(this.model, 'bind').and.callThrough();
+  });
+
+  it('should generate the right URL', function () {
+    expect(this.model.url()).toBe('/u/pepe/api/v1/imports/');
+  });
+
+  it('should have several change binds', function () {
+    this.model._initBinds();
+    var args_0 = this.model.bind.calls.argsFor(0);
+    expect(args_0[0]).toEqual('change:item_queue_id');
+  });
+
+  it('should create a sync import when interval is greater than 0', function () {
+    spyOn(this.model, '_createSyncImport');
+    spyOn(this.model, '_createRegularImport');
+    this.model.createImport({ interval: 10 });
+    expect(this.model._createSyncImport).toHaveBeenCalled();
+    expect(this.model._createRegularImport).not.toHaveBeenCalled();
+  });
+
+  it('should create a sync import when there\'s no interval', function () {
+    spyOn(this.model, '_createSyncImport');
+    spyOn(this.model, '_createRegularImport');
+    this.model.createImport({ interval: null });
+    expect(this.model._createSyncImport).toHaveBeenCalled();
+    expect(this.model._createRegularImport).not.toHaveBeenCalled();
+  });
+
+  it('should create a regular import when interval is 0', function () {
+    spyOn(this.model, '_createSyncImport');
+    spyOn(this.model, '_createRegularImport');
+    this.model.createImport({ interval: 0 });
+    expect(this.model._createRegularImport).toHaveBeenCalled();
+    expect(this.model._createSyncImport).not.toHaveBeenCalled();
+  });
+
+  it('should stop polling when import post fails', function () {
+    this.model.sync = function (type, mdl, opts) {
+      opts.error();
+    };
+    spyOn(this.model, 'pollCheck');
+    this.model.createImport({ interval: 0 });
+    expect(this.model.get('state')).toBe('failure');
+    expect(this.model.pollCheck).not.toHaveBeenCalled();
+  });
+
+  it('should start polling when item_queue_id is set', function () {
+    spyOn(this.model, 'pollCheck');
+    this.model.set('item_queue_id', 'vamos-neno');
+    expect(this.model.pollCheck).toHaveBeenCalled();
+  });
+});

--- a/lib/assets/test/spec/cartodb3/data/background-importer/imports-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/imports-collection.spec.js
@@ -23,6 +23,10 @@ describe('common/background-polling/imports-collection', function () {
     });
   });
 
+  it('should generate the right URL', function () {
+    expect(this.collection.url()).toBe('/u/pepe/api/v1/imports/');
+  });
+
   describe('.failedItems', function () {
     it('should return the failed items', function () {
       expect(this.collection.failedItems()).toEqual([]);

--- a/lib/assets/test/spec/cartodb3/data/background-importer/imports-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/imports-collection.spec.js
@@ -24,7 +24,7 @@ describe('common/background-polling/imports-collection', function () {
   });
 
   it('should generate the right URL', function () {
-    expect(this.collection.url()).toBe('/u/pepe/api/v1/imports/');
+    expect(this.collection.url()).toBe('/u/pepe/api/v1/imports');
   });
 
   describe('.failedItems', function () {

--- a/lib/assets/test/spec/cartodb3/data/background-importer/imports-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/imports-model.spec.js
@@ -1,5 +1,4 @@
 var ImportsModel = require('../../../../../javascripts/cartodb3/data/background-importer/imports-model.js');
-var ImportModel = require('../../../../../javascripts/cartodb3/data/background-importer/import-model.js');
 var UploadModel = require('../../../../../javascripts/cartodb3/data/upload-model.js');
 var UserModel = require('../../../../../javascripts/cartodb3/data/user-model');
 var ConfigModel = require('../../../../../javascripts/cartodb3/data/config-model');
@@ -251,61 +250,6 @@ describe('common/background-polling/imports-model', function () {
       it('should omit the create_vis value since set in constructor', function () {
         expect(this._uploadModel.set.calls.argsFor(0)[0]).not.toEqual(jasmine.objectContaining({ create_vis: true }));
       });
-    });
-  });
-
-  describe('import model', function () {
-    beforeEach(function () {
-      this.importModel = new ImportModel({}, {
-        configModel: this.configModel
-      });
-      spyOn(this.importModel, 'bind').and.callThrough();
-    });
-
-    it('should have several change binds', function () {
-      this.importModel._initBinds();
-      var args_0 = this.importModel.bind.calls.argsFor(0);
-      expect(args_0[0]).toEqual('change:item_queue_id');
-    });
-
-    it('should create a sync import when interval is greater than 0', function () {
-      spyOn(this.importModel, '_createSyncImport');
-      spyOn(this.importModel, '_createRegularImport');
-      this.importModel.createImport({ interval: 10 });
-      expect(this.importModel._createSyncImport).toHaveBeenCalled();
-      expect(this.importModel._createRegularImport).not.toHaveBeenCalled();
-    });
-
-    it('should create a sync import when there\'s no interval', function () {
-      spyOn(this.importModel, '_createSyncImport');
-      spyOn(this.importModel, '_createRegularImport');
-      this.importModel.createImport({ interval: null });
-      expect(this.importModel._createSyncImport).toHaveBeenCalled();
-      expect(this.importModel._createRegularImport).not.toHaveBeenCalled();
-    });
-
-    it('should create a regular import when interval is 0', function () {
-      spyOn(this.importModel, '_createSyncImport');
-      spyOn(this.importModel, '_createRegularImport');
-      this.importModel.createImport({ interval: 0 });
-      expect(this.importModel._createRegularImport).toHaveBeenCalled();
-      expect(this.importModel._createSyncImport).not.toHaveBeenCalled();
-    });
-
-    it('should stop polling when import post fails', function () {
-      this.importModel.sync = function (type, mdl, opts) {
-        opts.error();
-      };
-      spyOn(this.importModel, 'pollCheck');
-      this.importModel.createImport({ interval: 0 });
-      expect(this.importModel.get('state')).toBe('failure');
-      expect(this.importModel.pollCheck).not.toHaveBeenCalled();
-    });
-
-    it('should start polling when item_queue_id is set', function () {
-      spyOn(this.importModel, 'pollCheck');
-      this.importModel.set('item_queue_id', 'vamos-neno');
-      expect(this.importModel.pollCheck).toHaveBeenCalled();
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.67",
+  "version": "3.23.68",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The URLs used to check the status of the imports and geocodings weren't adding the `baseURL` component in the path, and therefore failing in some cases.