### PR TITLE
Exclude grunt-timer from load-grunt-tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,7 +72,9 @@
     grunt.loadNpmTasks('grunt-available-tasks');
 
     // Load Grunt tasks
-    require('load-grunt-tasks')(grunt);
+    require('load-grunt-tasks')(grunt, {
+      pattern: ['grunt-*', '@*/grunt-*', '!grunt-timer']
+    });
 
     require('./lib/build/tasks/manifest').register(grunt, ASSETS_DIR);
 


### PR DESCRIPTION
Stop receiving '>> Local Npm module "grunt-timer" not found. Is it installed?'

See https://github.com/leecrossley/grunt-timer/issues/2