### PR TITLE
7120 keep raster base table

### DIFF
--- a/services/importer/lib/importer/raster2pgsql.rb
+++ b/services/importer/lib/importer/raster2pgsql.rb
@@ -13,6 +13,7 @@ module CartoDB
       SQL_FILENAME                  = '%s%s.sql'
       OVERLAY_TABLENAME             = 'o_%s_%s'
       RASTER_COLUMN_NAME            = 'the_raster_webmercator'
+      GDALWARP_COMMON_OPTIONS       = '-co "COMPRESS=LZW" -co "BIGTIFF=IF_SAFER"'
 
       def initialize(table_name, filepath, pg_options, db)
         self.filepath             = filepath
@@ -62,7 +63,7 @@ module CartoDB
                     :basepath, :additional_tables, :db, :base_table_fqtn
 
       def align_raster(scale)
-        gdalwarp_command = %Q(#{gdalwarp_path} -co "COMPRESS=LZW" -tr #{scale} -#{scale} #{webmercator_filepath} #{aligned_filepath} )
+        gdalwarp_command = %Q(#{gdalwarp_path} #{GDALWARP_COMMON_OPTIONS} -tr #{scale} -#{scale} #{webmercator_filepath} #{aligned_filepath} )
 
         stdout, stderr, status  = Open3.capture3(gdalwarp_command)
         output_message = "(#{status}) |#{stdout + stderr}| Command: #{gdalwarp_command}"
@@ -72,7 +73,7 @@ module CartoDB
       end
 
       def reproject_raster
-        gdalwarp_command = %Q(#{gdalwarp_path} -ot Byte -co "COMPRESS=LZW" -t_srs EPSG:#{PROJECTION} #{filepath} #{webmercator_filepath})
+        gdalwarp_command = %Q(#{gdalwarp_path} -ot Byte #{GDALWARP_COMMON_OPTIONS} -t_srs EPSG:#{PROJECTION} #{filepath} #{webmercator_filepath})
 
         stdout, stderr, status  = Open3.capture3(gdalwarp_command)
         output_message = "(#{status}) |#{stdout + stderr}| Command: #{gdalwarp_command}"

--- a/services/importer/lib/importer/raster2pgsql.rb
+++ b/services/importer/lib/importer/raster2pgsql.rb
@@ -183,7 +183,7 @@ module CartoDB
         overview_fqtn = SCHEMA + '.' + overview_name
         db.run %{CREATE TABLE #{overview_fqtn} AS SELECT * FROM #{base_table_fqtn}}
         db.run %{CREATE INDEX ON "#{SCHEMA}"."#{overview_name}" USING gist (st_convexhull("#{RASTER_COLUMN_NAME}"))}
-        db.run %{SELECT AddRasterConstraints(#{SCHEMA}, #{overview_name},'#{RASTER_COLUMN_NAME}',TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE)}
+        db.run %{SELECT AddRasterConstraints('#{SCHEMA}', '#{overview_name}','#{RASTER_COLUMN_NAME}',TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE)}
         db.run %{SELECT AddOverviewConstraints('#{SCHEMA}', '#{overview_name}'::name, '#{RASTER_COLUMN_NAME}'::name, '#{SCHEMA}', '#{table_name}'::name, '#{RASTER_COLUMN_NAME}'::name, 1)}
         additional_tables = [1] + additional_tables
       end

--- a/services/importer/lib/importer/raster2pgsql.rb
+++ b/services/importer/lib/importer/raster2pgsql.rb
@@ -182,7 +182,7 @@ module CartoDB
         overview_name = OVERLAY_TABLENAME % [1, table_name]
         overview_fqtn = SCHEMA + '.' + overview_name
         db.run %{CREATE TABLE #{overview_fqtn} AS SELECT * FROM #{base_table_fqtn}}
-        db.run %{CREATE INDEX ON "#{SCHEMA}"."#{overview_fqtn}" USING gist (st_convexhull("#{RASTER_COLUMN_NAME}"))}
+        db.run %{CREATE INDEX ON "#{SCHEMA}"."#{overview_name}" USING gist (st_convexhull("#{RASTER_COLUMN_NAME}"))}
         db.run %{SELECT AddRasterConstraints(#{SCHEMA}, #{overview_name},'#{RASTER_COLUMN_NAME}',TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE)}
         db.run %{SELECT AddOverviewConstraints('#{SCHEMA}', '#{overview_name}'::name, '#{RASTER_COLUMN_NAME}'::name, '#{SCHEMA}', '#{table_name}'::name, '#{RASTER_COLUMN_NAME}'::name, 1)}
         additional_tables = [1] + additional_tables

--- a/services/importer/lib/importer/raster2pgsql.rb
+++ b/services/importer/lib/importer/raster2pgsql.rb
@@ -67,7 +67,7 @@ module CartoDB
       end
 
       def reproject_raster
-        gdalwarp_command = %Q(#{gdalwarp_path} -co "COMPRESS=LZW" -t_srs EPSG:#{PROJECTION} #{filepath} #{webmercator_filepath})
+        gdalwarp_command = %Q(#{gdalwarp_path} -ot Int16 -co "COMPRESS=LZW" -t_srs EPSG:#{PROJECTION} #{filepath} #{webmercator_filepath})
 
         stdout, stderr, status  = Open3.capture3(gdalwarp_command)
         output_message = "(#{status}) |#{stdout + stderr}| Command: #{gdalwarp_command}"

--- a/services/importer/lib/importer/raster2pgsql.rb
+++ b/services/importer/lib/importer/raster2pgsql.rb
@@ -185,7 +185,7 @@ module CartoDB
         db.run %{CREATE INDEX ON "#{SCHEMA}"."#{overview_name}" USING gist (st_convexhull("#{RASTER_COLUMN_NAME}"))}
         db.run %{SELECT AddRasterConstraints('#{SCHEMA}', '#{overview_name}','#{RASTER_COLUMN_NAME}',TRUE,TRUE,TRUE,TRUE,TRUE,TRUE,FALSE,TRUE,TRUE,TRUE,TRUE,FALSE)}
         db.run %{SELECT AddOverviewConstraints('#{SCHEMA}', '#{overview_name}'::name, '#{RASTER_COLUMN_NAME}'::name, '#{SCHEMA}', '#{table_name}'::name, '#{RASTER_COLUMN_NAME}'::name, 1)}
-        additional_tables = [1] + additional_tables
+        @additional_tables = [1] + @additional_tables
       end
 
       # Import the original raster file without reprojections, adjusting or scales.

--- a/services/importer/lib/importer/raster2pgsql.rb
+++ b/services/importer/lib/importer/raster2pgsql.rb
@@ -72,7 +72,7 @@ module CartoDB
       end
 
       def reproject_raster
-        gdalwarp_command = %Q(#{gdalwarp_path} -ot Int16 -co "COMPRESS=LZW" -t_srs EPSG:#{PROJECTION} #{filepath} #{webmercator_filepath})
+        gdalwarp_command = %Q(#{gdalwarp_path} -ot Byte -co "COMPRESS=LZW" -t_srs EPSG:#{PROJECTION} #{filepath} #{webmercator_filepath})
 
         stdout, stderr, status  = Open3.capture3(gdalwarp_command)
         output_message = "(#{status}) |#{stdout + stderr}| Command: #{gdalwarp_command}"

--- a/services/importer/lib/importer/tiff_loader.rb
+++ b/services/importer/lib/importer/tiff_loader.rb
@@ -58,7 +58,7 @@ module CartoDB
       end
 
       def raster2pgsql
-        @raster2pgsql ||= Raster2Pgsql.new(job.table_name, source_file.fullpath, job.pg_options)
+        @raster2pgsql ||= Raster2Pgsql.new(job.table_name, source_file.fullpath, job.pg_options, job.db)
       end
 
       def valid_table_names

--- a/services/importer/spec/acceptance/raster2pgsql_spec.rb
+++ b/services/importer/spec/acceptance/raster2pgsql_spec.rb
@@ -9,6 +9,7 @@ require_relative '../doubles/log'
 require_relative 'cdb_importer_context'
 require_relative 'acceptance_helpers'
 require_relative 'no_stats_context'
+require 'active_support'
 
 include CartoDB::Importer2
 
@@ -109,5 +110,41 @@ describe 'raster2pgsql acceptance tests' do
       raster_tables.should be 0
   end
 
-end
+  it 'keeps the original table unaltered regardless of overviews' do
+    TOLERANCE = 1e-6
 
+    filepath    = path_to('raster_simple.tif')
+    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    log         = CartoDB::Importer2::Doubles::Log.new(@user)
+    job         = Job.new({ logger: log, pg_options: @user.db_service.db_configuration_for.with_indifferent_access })
+    runner      = CartoDB::Importer2::Runner.new({
+        pg: @user.db_service.db_configuration_for,
+        downloader: downloader,
+        log: CartoDB::Importer2::Doubles::Log.new(@user),
+        user: @user,
+        job: job
+      })
+
+    runner.run
+
+    # Values taken from `gdalinfo -stats services/importer/spec/fixtures/raster_simple.tif`
+    metadata = @user.in_database.fetch(%{
+        SELECT * FROM raster_columns
+        WHERE r_table_schema = '#{job.schema}' AND r_table_name = '#{job.table_name}'
+      }).first
+    metadata[:srid].should eq 4326
+    metadata[:scale_x].should be_within(TOLERANCE).of +0.148148148148133
+    metadata[:scale_y].should be_within(TOLERANCE).of -0.148148148148133
+
+    stats = @user.in_database.fetch(%{
+        WITH foo AS (
+          SELECT the_raster_webmercator rast FROM #{job.schema}.#{job.table_name}
+        ) SELECT (stats).* FROM (SELECT ST_summarystatsagg(rast, TRUE, 1) stats FROM foo) bar;
+      }).first
+    stats[:count].should eq 2430 * 1215
+    stats[:mean].should be_within(TOLERANCE).of 204.51453640197
+    stats[:stddev].should be_within(TOLERANCE).of 11.11767348697
+    stats[:min].should be_within(TOLERANCE).of 58
+    stats[:max].should be_within(TOLERANCE).of 253
+  end
+end

--- a/services/importer/spec/acceptance/raster2pgsql_spec.rb
+++ b/services/importer/spec/acceptance/raster2pgsql_spec.rb
@@ -34,7 +34,7 @@ describe 'raster2pgsql acceptance tests' do
   it 'tests extracting size from a tif' do
     expected_size = [2052, 1780]
 
-    rasterizer = Raster2Pgsql.new(@table_name, @filepath, {})
+    rasterizer = Raster2Pgsql.new(@table_name, @filepath, {}, @user.db)
 
     size = rasterizer.send(:extract_raster_size)
     size.should eq expected_size
@@ -54,7 +54,7 @@ describe 'raster2pgsql acceptance tests' do
                                      "o_32_raster_test", "o_64_raster_test", "o_128_raster_test", \
                                      "o_256_raster_test", "o_512_raster_test" ]
 
-    rasterizer = Raster2Pgsql.new(@table_name, @filepath, {})
+    rasterizer = Raster2Pgsql.new(@table_name, @filepath, {}, @user.db)
 
     overviews = rasterizer.send(:calculate_raster_overviews, raster_1_size)
     overviews.should eq expected_overviews_1
@@ -72,7 +72,7 @@ describe 'raster2pgsql acceptance tests' do
   it 'tests calculating raster scale' do
     pixel_size = 3667.822831377844
 
-    rasterizer = Raster2Pgsql.new(@table_name, @filepath, {})
+    rasterizer = Raster2Pgsql.new(@table_name, @filepath, {}, @user.db)
 
     scale = rasterizer.send(:calculate_raster_scale, pixel_size)
     expected_scale = 2445.7403258239747


### PR DESCRIPTION
What this changeset does:
- Force output band of raster overviews to be Int16, as Float32 is not supported for rendering
- Create an additional overview table with factor = 1 called `o_1_original_table_name` from the reprojected and adjusted base table
- Import "as-is" the original raster file and keep it as the base table

It is only partially compatible with current tiler/mapnik without needing the changes in pgraster plugin: https://github.com/CartoDB/mapnik/pull/14 meaning that new imports won't be rendered when the factor/scale is <= 2 (high zoom levels relative to raster scale/resolution).

It works as intended with the mapnik changes.

there's some things remaining:
- a small refactor
- some more smoke testing in staging (with the pgraster plugin change)
- some "unit test"

for the test I was thinking of using something in the lines of:
```
WITH foo AS (
    SELECT the_raster_webmercator rast FROM test_borneo
) SELECT (stats).* FROM (SELECT ST_summarystatsagg(rast, FALSE, 1) stats FROM foo) bar;
```
and comparing with gdalinfo output on the original raster. I already did that manually and don't expect surprises. A bit more elaborated:

```
SELECT (pvc).value, SUM((pvc).count) as count
FROM (SELECT st_valuecount(the_raster_webmercator) AS pvc FROM test_borneo) AS foo
GROUP BY (pvc).value ORDER BY count DESC;
```

@javisantana can you please review? if it is really urgent I guess somebody from dataservices can take over these changes and deploy them.