### PR TITLE
Update Rollbar to 2.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'redcarpet', '3.3.3'
 gem 'bartt-ssl_requirement',   '~>1.4.0', require: 'ssl_requirement'
 
 # TODO Production gems, put them in :production group
-gem 'rollbar',               '~>2.8.3'
+gem 'rollbar',               '~>2.11.1'
 gem 'resque',                '1.25.2'
 gem 'resque-metrics',        '0.1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
     resque-metrics (0.1.1)
       resque (~> 1.19)
     retriable (1.4.1)
-    rollbar (2.8.3)
+    rollbar (2.11.1)
       multi_json
     roo (1.13.2)
       nokogiri
@@ -401,7 +401,7 @@ DEPENDENCIES
   resque (= 1.25.2)
   resque-metrics (= 0.1.1)
   retriable (= 1.4.1)
-  rollbar (~> 2.8.3)
+  rollbar (~> 2.11.1)
   roo (= 1.13.2)
   rspec-rails (= 2.12.0)
   ruby-prof (= 0.15.1)

--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -3,6 +3,8 @@ require 'cartodb/logger'
 Rollbar.configure do |config|
   config.access_token = Cartodb.config[:rollbar_api_key]
   config.enabled = (Rails.env.production? || Rails.env.staging?) && config.access_token.present?
+  config.net_retries = 1 # This is actually 6 requests (18s), as Rollbar retries two times (failsafes) and CartoDB once
+
   # Add exception class names to the exception_level_filters hash to
   # change the level that exception is reported at. Note that if an exception
   # has already been reported and logged the level will need to be changed


### PR DESCRIPTION
See #7266 

New Rollbar gem has a default timeout of 3s. Each failed request triggers 2 rollbar failsafes and a CartoDB one, totalling at 6 requests. This PR lowers Rollbar retries from 3 to 1 (value before 2.11, as retries were not implemented), so only 6 request are done (instead of 18).

All of this makes Rollbar take 18s to fail which may still be too much (specially for debug messages). Another solution could be running Rollbar in async mode, which creates a thread to do the error reporting while the main program runs.