### PR TITLE
Manual addition of visualization_exports FKs #7305

### DIFF
--- a/db/migrate/20160429180000_visualization_exports.rb
+++ b/db/migrate/20160429180000_visualization_exports.rb
@@ -12,6 +12,23 @@ Sequel.migration do
       DateTime :created_at, default: Sequel::CURRENT_TIMESTAMP
       DateTime :updated_at, default: Sequel::CURRENT_TIMESTAMP
     end
+
+    # Note: add "NOT VALID" at the end of each FK if validation takes long.
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE visualization_exports
+        ADD CONSTRAINT visualization_exports_visualization_id_fkey FOREIGN KEY (visualization_id)
+          REFERENCES visualizations (id) ON DELETE CASCADE NOT VALID;
+    })
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE visualization_exports
+        ADD CONSTRAINT visualization_exports_user_id_fkey FOREIGN KEY (user_id)
+          REFERENCES users (id) ON DELETE CASCADE;
+    })
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE visualization_exports
+        ADD CONSTRAINT visualization_exports_log_id_fkey FOREIGN KEY (log_id)
+          REFERENCES logs (id) ON DELETE CASCADE;
+    })
   end
 
   down do


### PR DESCRIPTION
This closes #7305.

This PR addresses the issue of DB locking on FK addition. PostgreSQL 9.3 requires exclusive access lock to the whole table, which enqueues both reads and writes (9.5 won't), and FK creation can take long on big tables (unless `NOT VALID` is used).

@luisbosque I'm adding the FKs to an existing migration so it won't be automatically run for already updated installations. I also use explicit SQL to make the addition of `NOT VALID`, if needed, easier. My current plan is run the FKs manually under monitoring, trying without `NOT VALID` first. What do you think?

cc @gfiorav @javitonino @rafatower 