### PR TITLE
Upgrade cartodb sql extension to version 0.16.3

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -486,7 +486,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.16.2'
+          cdb_extension_target_version = '0.16.3'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|


### PR DESCRIPTION
The new version fixes a problem creating overviews for organization users with user names that, as schema names, need to be quoted.