### PR TITLE
Removing the key binding properly

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
@@ -13,6 +13,7 @@ module.exports = cdb.core.View.extend({
   tagName: 'div',
 
   initialize: function () {
+    this._onKeyDownBinded = this._onKeyDown.bind(this);
     this._initBinds();
   },
 
@@ -59,20 +60,27 @@ module.exports = cdb.core.View.extend({
   },
 
   _applyArrowBinds: function () {
-    document.addEventListener('keydown', this._onKeyDown.bind(this));
+    document.addEventListener('keydown', this._onKeyDownBinded);
   },
 
   _removeArrowBinds: function () {
-    document.removeEventListener('keydown', this._onKeyDown);
+    document.removeEventListener('keydown', this._onKeyDownBinded);
   },
 
   _onKeyDown: function (e) {
+
+    if (this.model.get('visible') === false) {
+      return;
+    }
+
     var key = e.which;
     var $listItems = this.$('.js-listItem');
     var $highlighted = $listItems.filter('.is-highlighted');
     var $current;
+    var mdl;
+    var itemHeight;
 
-    $listItems.removeClass('is-highlighted');
+    $highlighted.removeClass('is-highlighted');
 
     if (key === ARROW_DOWN_KEY_CODE) {
       if (!$highlighted.length || $highlighted[0] === $listItems.last()[0]) {
@@ -89,7 +97,7 @@ module.exports = cdb.core.View.extend({
     } else if (key === ENTER_KEY_CODE) {
       e.preventDefault();
       if ($highlighted && $highlighted.length) {
-        var mdl = _.first(this.collection.where({ val: $highlighted.data('val') }));
+        mdl = _.first(this.collection.where({ val: $highlighted.data('val') }));
         if (mdl) {
           mdl.set('selected', true);
         }
@@ -99,7 +107,7 @@ module.exports = cdb.core.View.extend({
 
     if ($current) {
       $current.addClass('is-highlighted');
-      var itemHeight = $current.outerHeight();
+      itemHeight = $current.outerHeight();
       this.$('.js-list').scrollTop($current.index() * itemHeight);
     }
   },

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
@@ -67,8 +67,25 @@ module.exports = cdb.core.View.extend({
     document.removeEventListener('keydown', this._onKeyDownBinded);
   },
 
-  _onKeyDown: function (e) {
+  _getSelected: function () {
+    var selectedModel = this.collection.getSelectedItem();
+    var selectedValue;
 
+    if (selectedModel) {
+      selectedValue = selectedModel.getValue();
+      return this.$('[data-val=' + selectedValue + ']');
+    }
+
+    return null;
+  },
+
+  _highlightSelected: function (item) {
+    var itemHeight = item.outerHeight();
+    item.addClass('is-highlighted');
+    this.$('.js-list').scrollTop(item.index() * itemHeight);
+  },
+
+  _onKeyDown: function (e) {
     if (this.model.get('visible') === false) {
       return;
     }
@@ -78,7 +95,6 @@ module.exports = cdb.core.View.extend({
     var $highlighted = $listItems.filter('.is-highlighted');
     var $current;
     var mdl;
-    var itemHeight;
 
     $highlighted.removeClass('is-highlighted');
 
@@ -105,11 +121,7 @@ module.exports = cdb.core.View.extend({
       }
     }
 
-    if ($current) {
-      $current.addClass('is-highlighted');
-      itemHeight = $current.outerHeight();
-      this.$('.js-list').scrollTop($current.index() * itemHeight);
-    }
+    $current && this._highlightSelected($current);
   },
 
   _applyCustomScroll: function () {
@@ -130,6 +142,11 @@ module.exports = cdb.core.View.extend({
     this._removeArrowBinds();
     this._destroyCustomScroll();
     cdb.core.View.prototype.clean.apply(this);
+  },
+
+  highlight: function () {
+    var selected = this._getSelected();
+    selected && this._highlightSelected(selected);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
@@ -90,6 +90,7 @@ module.exports = cdb.core.View.extend({
       itemTemplate: this.options.itemTemplate
     });
     this.$el.append(listView.render().el);
+    listView.highlight();
     this.addView(listView);
   },
 

--- a/lib/assets/test/spec/cartodb3/components/custom-list/custom-list-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/custom-list/custom-list-view.spec.js
@@ -92,6 +92,13 @@ describe('components/custom-list/custom-list-view', function () {
     expect(this.view._destroyCustomScroll).toHaveBeenCalled();
   });
 
+  it('should remove bindings properly', function(){
+    spyOn(this.view, 'render');
+    this.view.clean();
+    dispatchDocumentEvent('keydown', { which: 40 });
+    expect(this.view.render).not.toHaveBeenCalled();
+  });
+
   function dispatchDocumentEvent (type, opts) {
     var e = document.createEvent('HTMLEvents');
     e.initEvent(type, false, true);

--- a/lib/assets/test/spec/cartodb3/components/custom-list/custom-list-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/custom-list/custom-list-view.spec.js
@@ -92,11 +92,18 @@ describe('components/custom-list/custom-list-view', function () {
     expect(this.view._destroyCustomScroll).toHaveBeenCalled();
   });
 
-  it('should remove bindings properly', function(){
+  it('should remove bindings properly', function () {
     spyOn(this.view, 'render');
     this.view.clean();
     dispatchDocumentEvent('keydown', { which: 40 });
     expect(this.view.render).not.toHaveBeenCalled();
+  });
+
+  it('should highlight selected value on show', function () {
+    this.collection.at(2).set({ selected: true });
+    this.view.render();
+    this.view.highlight();
+    expect(this.view.$('li:eq(2)').hasClass('is-highlighted')).toBeTruthy();
   });
 
   function dispatchDocumentEvent (type, opts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.77",
+  "version": "3.23.78",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR implements #7327.

The problem was the way we add the `keydown` handler. We used the `bind` method, that returns a new function. But when we tried to remove the binding, that function didn't exist. The implemented solution set a reference to the binded function, and we use it to add and remove the handler.

Also, in order to avoid unnecessary operations, we only respond to the keyup handler only if the select is open.

