### PR TITLE
Generate correct links to maps related to datasets in public view

### DIFF
--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -225,7 +225,7 @@
         <% @total_visualizations.last(3).each do |vis| %>
           <li class="MapsList-item">
             <div class="MapCard" data-vis-id="<%= vis.id %>" data-vis-owner-name="<%= vis.user[:username] %>">
-              <a href="<%= CartoDB.url(self, 'public_visualizations_public_map', {id: vis.id}, user) %>" class="MapCard-header js-header">
+              <a href="<%= CartoDB.url(self, 'public_visualizations_public_map', {id: vis.id}, vis.user) %>" class="MapCard-header js-header">
                 <div class="MapCard-loader"></div>
               </a>
               <div class="MapCard-content MapCard-content--compact">


### PR DESCRIPTION
Fixes #7351 

The problem started when restricting queries to the visualizations table by name, without user/org filter, but the link has always been generated incorrectly. This fixes the link generation. This seems like a type, as this only affects the link by clicking the map icon, but the link in the map name works fine.

I also tried to modify the controller to make the old incorrect URL's work, but ran into the usual problems when loading visualizations by id/name, etc.