### PR TITLE
Fix CI script to run all parallel-disabled tests

### DIFF
--- a/script/ci/generateSpecFull.sh
+++ b/script/ci/generateSpecFull.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Jesus Vazquez
 
+truncate -s 0 *.log
+
 # The following tests are disabled in a parallel environment and are run afterwards, sequentially
 DISABLED_TESTS=(
   'spec/models/asset_spec.rb' # Hangs sometimes when serving files

--- a/script/ci/generateSpecFull.sh
+++ b/script/ci/generateSpecFull.sh
@@ -14,7 +14,7 @@ DISABLED_TEST_REGEX=''
 truncate -s0 specfailed.txt
 for spec in ${DISABLED_TESTS[@]}
 do
-  echo $spec >> specfailed.txt
+  echo $spec >> specfailed.log
   if [[ $first -eq 0 ]]
   then
     DISABLED_TEST_REGEX="$DISABLED_TEST_REGEX\\|$spec"

--- a/script/ci/wrapper.sh
+++ b/script/ci/wrapper.sh
@@ -5,7 +5,6 @@
 rm config/database_*
 rm config/redis_*
 #sudo killall redis-server
-truncate -s 0 *.log
 
 # Start redis servers
 port=6001
@@ -79,4 +78,3 @@ done
 touch specfailed.log
 touch specsuccess.log
 echo "# Wrapper finished"
-


### PR DESCRIPTION
Fixes a silly mistake that was preventing tests disabled in parallel (asset model and user mover) to run since the latest changes to CI.