### PR TITLE
Remove unnecessary analysis/nodes related view dependencies

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/add-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/add-analysis-view.js
@@ -18,11 +18,10 @@ module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     if (!opts.modalModel) throw new Error('modalModel is required');
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-    if (!opts.analysisDefinitionNodeModel) throw new Error('analysisDefinitionNodeModel is required');
 
     this._modalModel = opts.modalModel;
     this._layerDefinitionModel = opts.layerDefinitionModel;
-    this._analysisDefinitionNodeModel = opts.analysisDefinitionNodeModel;
+    this._analysisDefinitionNodeModel = this._layerDefinitionModel.getAnalysisDefinitionNodeModel();
 
     this._optionsCollection = new AnalysisOptionsCollection();
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/add-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/add-analysis-view.js
@@ -28,9 +28,13 @@ module.exports = cdb.core.View.extend({
     this.listenTo(this._optionsCollection, 'change:selected', this._onSelectedChange);
 
     this._querySchemaModel = this._analysisDefinitionNodeModel.querySchemaModel;
-    this._querySchemaModel.on('change', this._onQuerySchemaChange, this);
+    this._querySchemaModel.on('change', this._resetAnalysisOptions, this);
     this.add_related_model(this._querySchemaModel);
-    this._querySchemaModel.fetch();
+
+    if (!this._isFetching()) {
+      this._resetAnalysisOptions();
+      this._querySchemaModel.fetch();
+    }
   },
 
   render: function () {
@@ -66,7 +70,7 @@ module.exports = cdb.core.View.extend({
     return this.$('.js-body');
   },
 
-  _onQuerySchemaChange: function () {
+  _resetAnalysisOptions: function () {
     if (this._isFetching()) return;
 
     var optionModels = createAnalysisOptionsModels(this._simpleGeometryType(), this._analysisDefinitionNodeModel);

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
@@ -120,11 +120,28 @@ module.exports = cdb.core.Model.extend({
     return cdb.core.Model.prototype.destroy.apply(this, arguments);
   },
 
-  getPrimarySource: function () {
-    return this.collection.get(this.getPrimarySourceId());
+  hasPrimarySource: function () {
+    return !!this.getPrimarySource();
   },
 
-  getPrimarySourceId: function () {
+  hasSecondarySource: function () {
+    return !!this.getSecondarySource();
+  },
+
+  getPrimarySource: function () {
+    return this.collection.get(this._getPrimarySourceId());
+  },
+
+  getSecondarySource: function () {
+    // Assumption: there are only 1-2 sources, so secondary is the one that's not the primary
+    var primarySourceId = this._getPrimarySourceId();
+    var secondarySourceId = _.find(this.sourceIds(), function (sourceId) {
+      return sourceId !== primarySourceId;
+    });
+    return this.collection.get(secondarySourceId);
+  },
+
+  _getPrimarySourceId: function () {
     var primarySourceName = this.get('primary_source_name') || this._sourceNames()[0];
     return this.get(primarySourceName);
   },

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
@@ -120,6 +120,10 @@ module.exports = cdb.core.Model.extend({
     return cdb.core.Model.prototype.destroy.apply(this, arguments);
   },
 
+  getPrimarySource: function () {
+    return this.collection.get(this.getPrimarySourceId());
+  },
+
   getPrimarySourceId: function () {
     var primarySourceName = this.get('primary_source_name') || this._sourceNames()[0];
     return this.get(primarySourceName);

--- a/lib/assets/javascripts/cartodb3/data/analysis-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definitions-collection.js
@@ -12,7 +12,7 @@ module.exports = Backbone.Collection.extend({
     var m = new AnalysisDefinitionModel(d, {
       parse: true,
       collection: self, // used implicitly, for model to use collection.url()
-      analysisDefinitionNodesCollection: self.analysisDefinitionNodesCollection
+      analysisDefinitionNodesCollection: self._analysisDefinitionNodesCollection
     });
 
     return m;
@@ -25,7 +25,7 @@ module.exports = Backbone.Collection.extend({
 
     this._configModel = options.configModel;
     this._vizId = options.vizId;
-    this.analysisDefinitionNodesCollection = options.analysisDefinitionNodesCollection;
+    this._analysisDefinitionNodesCollection = options.analysisDefinitionNodesCollection;
 
     this.on('reset', this._onReset, this);
   },

--- a/lib/assets/javascripts/cartodb3/data/camshaft-reference.js
+++ b/lib/assets/javascripts/cartodb3/data/camshaft-reference.js
@@ -71,26 +71,6 @@ module.exports = {
     ].join('\n');
   },
 
-  getOutputGeometryForType: function (nodeDefinition) {
-    var outputGeometry = '';
-
-    switch (nodeDefinition.type) {
-      case 'buffer':
-        outputGeometry = 'polygon';
-        break;
-      case 'trade-area':
-        outputGeometry = 'polygon';
-        break;
-      case 'point-in-polygon':
-        // TODO but it's still the camshaft reference should yield output geometry based on definition params,
-        //      this param is still missing though so for now always yields point
-        outputGeometry = 'point';
-        break;
-    }
-
-    return outputGeometry;
-  },
-
   getValidInputGeometriesForType: function (type, sourceParamName) {
     var inputGeometries = [];
 

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -97,9 +97,9 @@ module.exports = Backbone.Collection.extend({
 
   createNewAnalysisNode: function (layerDefinitionModel, nodeAttrs) {
     var nodeModel = this._analysisDefinitionNodesCollection.add(nodeAttrs, {parse: false});
-    var sourceNodeId = nodeModel.getPrimarySourceId();
+    var sourceNode = nodeModel.getPrimarySource();
 
-    var analysisDefinitionModel = this._analysisDefinitionsCollection.findByNodeId(sourceNodeId);
+    var analysisDefinitionModel = this._analysisDefinitionsCollection.findByNodeId(sourceNode.id);
     if (analysisDefinitionModel) {
       analysisDefinitionModel.save({node_id: nodeModel.id});
     } else {

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -96,22 +96,22 @@ module.exports = Backbone.Collection.extend({
   },
 
   createNewAnalysisNode: function (layerDefinitionModel, nodeAttrs) {
-    var nodeModel = this._analysisDefinitionNodesCollection.add(nodeAttrs, {parse: false});
-    var sourceNode = nodeModel.getPrimarySource();
+    var nodeDefModel = this._analysisDefinitionNodesCollection.add(nodeAttrs, {parse: false});
+    var sourceNode = nodeDefModel.getPrimarySource();
 
     var analysisDefinitionModel = this._analysisDefinitionsCollection.findByNodeId(sourceNode.id);
     if (analysisDefinitionModel) {
-      analysisDefinitionModel.save({node_id: nodeModel.id});
+      analysisDefinitionModel.save({node_id: nodeDefModel.id});
     } else {
-      this._createAnalysisDefinition(nodeModel);
+      this._createAnalysisDefinition(nodeDefModel);
     }
 
     layerDefinitionModel.save({
-      source: nodeModel.id,
-      cartocss: camshaftReference.getDefaultCartoCSSForType(nodeModel.get('type'))
+      source: nodeDefModel.id,
+      cartocss: camshaftReference.getDefaultCartoCSSForType(nodeDefModel.get('type'))
     });
 
-    return nodeModel;
+    return nodeDefModel;
   },
 
   findAnalysisDefinitionNodeModel: function (id) {
@@ -124,16 +124,15 @@ module.exports = Backbone.Collection.extend({
 
   _onSync: function (m) {
     // Create analysis definition if there is none yet
-    var nodeId = m.get('source');
-    var analysisDefinitionModel = this._analysisDefinitionsCollection.findByNodeId(nodeId);
-    if (nodeId && !analysisDefinitionModel) {
-      var nodeModel = this._analysisDefinitionNodesCollection.get(nodeId);
-      this._createAnalysisDefinition(nodeModel);
+    var nodeDefModel = m.getAnalysisDefinitionNodeModel();
+    var analysisDefinitionModel = this._analysisDefinitionsCollection.findByNodeId(nodeDefModel.id);
+    if (nodeDefModel && !analysisDefinitionModel) {
+      this._createAnalysisDefinition(nodeDefModel);
     }
   },
 
-  _createAnalysisDefinition: function (nodeModel) {
-    this._analysisDefinitionsCollection.create({analysis_definition: nodeModel.toJSON()});
+  _createAnalysisDefinition: function (nodeDefModel) {
+    this._analysisDefinitionsCollection.create({analysis_definition: nodeDefModel.toJSON()});
   },
 
   _letters: function (otherLetters) {

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -181,7 +181,7 @@ deepInsights.createDashboard('#dashboard', vizJSON, {
           modals: modals,
           visDefinitionModel: visDefinitionModel,
           layerDefinitionsCollection: layerDefinitionsCollection,
-          analysisDefinitionsCollection: analysisDefinitionsCollection,
+          analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
           widgetDefinitionsCollection: widgetDefinitionsCollection
         });
       }

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -297,7 +297,7 @@ window.snippets = {
     });
     // destroy all non-source nodes, should not be used anywhere after the layers been update above
     _.clone(window.analysisDefinitionNodesCollection.models).forEach(function (m) {
-      if (m.getPrimarySourceId()) {
+      if (m.hasPrimarySource()) {
         m.destroy();
       }
     });

--- a/lib/assets/javascripts/cartodb3/editor/editor-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/editor-view.js
@@ -16,7 +16,7 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function (opts) {
-    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
+    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
     if (!opts.layerDefinitionsCollection) throw new Error('layerDefinitionsCollection is required');
     if (!opts.widgetDefinitionsCollection) throw new Error('widgetDefinitionsCollection is required');
     if (!opts.visDefinitionModel) throw new Error('visDefinitionModel is required');
@@ -30,7 +30,7 @@ module.exports = cdb.core.View.extend({
     this._modals = opts.modals;
     this._configModel = opts.configModel;
     this._userModel = opts.userModel;
-    this._analysisDefinitionsCollection = opts.analysisDefinitionsCollection;
+    this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
     this._layerDefinitionsCollection = opts.layerDefinitionsCollection;
     this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
     this._visDefinitionModel = opts.visDefinitionModel;
@@ -54,7 +54,7 @@ module.exports = cdb.core.View.extend({
               userModel: self._userModel,
               configModel: self._configModel,
               layerDefinitionsCollection: self._layerDefinitionsCollection,
-              analysisDefinitionsCollection: self._analysisDefinitionsCollection,
+              analysisDefinitionNodesCollection: self._analysisDefinitionNodesCollection,
               analysis: self._analysis,
               modals: self._modals,
               stackLayoutModel: self._mapStackLayoutModel

--- a/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/base-layer-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/base-layer-analysis-view.js
@@ -11,7 +11,7 @@ module.exports = cdb.core.View.extend({
   className: 'js-analysis',
 
   _onClick: function (e) {
-    this.trigger('nodeClicked', this.model.id, this);
+    this.trigger('nodeClicked', this.model, this);
   },
 
   _addDraggableHelper: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/composite-layer-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/composite-layer-analysis-view.js
@@ -69,20 +69,20 @@ module.exports = BaseLayerAnalysisView.extend({
   },
 
   _renderSecondaryNode: function () {
-    var secondarySourceModel = this._getSecondarySource(this.model);
+    var secondarySourceModel = this.model.getSecondarySource();
 
-    var otherLayerDefModel = this._getLayerDefinitionModel(secondarySourceModel);
-    var view = otherLayerDefModel
-      ? this._createRefLayerNodeView(otherLayerDefModel)
+    var layerDefModel = this._findSecondaryLayerDefinitionModel(secondarySourceModel);
+    var view = layerDefModel && layerDefModel !== this._layerDefinitionModel
+      ? this._createRefLayerNodeView(layerDefModel)
       : this._createSourceNodeView(secondarySourceModel);
 
     this.addView(view);
     this.$('.js-secondary-source').append(view.render().el);
   },
 
-  _getLayerDefinitionModel: function (secondarySourceModel) {
+  _findSecondaryLayerDefinitionModel: function (secondarySourceModel) {
     return this._layerDefinitionModel.collection.find(function (m) {
-      return m.get('source') === secondarySourceModel.id;
+      return m.get('letter') === secondarySourceModel.getLetter();
     });
   },
 
@@ -102,15 +102,6 @@ module.exports = BaseLayerAnalysisView.extend({
       layerDefinitionModel: this._layerDefinitionModel,
       isDraggable: false
     });
-  },
-
-  _getSecondarySource: function (parent) {
-    // Assumption: there are only 1-2 sources, so secondary is the one that's not the primary
-    var primarySourceId = parent.getPrimarySourceId();
-    var secondarySourceId = _.find(parent.sourceIds(), function (sourceId) {
-      return sourceId !== primarySourceId;
-    });
-    return this._analysisDefinitionNodesCollection.get(secondarySourceId);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/composite-layer-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/composite-layer-analysis-view.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var template = require('./composite-layer-analysis-view.tpl');
 var DefaultLayerAnalysisView = require('./default-layer-analysis-view');
 var BaseLayerAnalysisView = require('./base-layer-analysis-view');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-analyses-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-analyses-view.js
@@ -9,18 +9,16 @@ module.exports = cdb.core.View.extend({
   tagName: 'ul',
 
   initialize: function (opts) {
-    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
     if (!opts.layerAnalysisViewFactory) throw new Error('layerAnalysisViewFactory is required');
 
-    this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
     this._layerAnalysisViewFactory = opts.layerAnalysisViewFactory;
   },
 
   render: function () {
     this.clearSubViews();
 
-    var sourceModel = this._analysisDefinitionNodesCollection.get(this.model.get('source'));
-    this._renderNode(sourceModel);
+    var nodeDefModel = this.model.getAnalysisDefinitionNodeModel();
+    this._renderNode(nodeDefModel);
 
     return this;
   },
@@ -31,7 +29,7 @@ module.exports = cdb.core.View.extend({
   _renderNode: function (current) {
     this._createNodeView(current);
 
-    var next = this._analysisDefinitionNodesCollection.get(current.getPrimarySourceId());
+    var next = current.getPrimarySource();
     if (next && this.model.hasAnalysisNode(current)) {
       this._renderNode(next);
     }
@@ -44,8 +42,8 @@ module.exports = cdb.core.View.extend({
     this.$el.append(view.render().el);
   },
 
-  _onNodeClicked: function (nodeId) {
-    this.trigger('nodeClicked', nodeId, this);
+  _onNodeClicked: function (selectedNode) {
+    this.trigger('nodeClicked', selectedNode, this);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -13,13 +13,11 @@ module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     if (!opts.layerDefinitionModel) throw new Error('Layer definition is required');
     if (!opts.stackLayoutModel) throw new Error('StackLayoutModel is required');
-    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
     if (!opts.modals) throw new Error('modals is required');
     if (!opts.configModel) throw new Error('configModel is required');
     if (!opts.analysis) throw new Error('analysis is required');
 
     this.layerDefinitionModel = opts.layerDefinitionModel;
-    this.analysisDefinitionsCollection = opts.analysisDefinitionsCollection;
     this.stackLayoutModel = opts.stackLayoutModel;
     this.modals = opts.modals;
     this._configModel = opts.configModel;
@@ -30,20 +28,19 @@ module.exports = cdb.core.View.extend({
     var self = this;
     var tabPaneTabs = [{
       label: _t('editor.layers.menu-tab-pane-labels.data'),
-      selected: !this.options.selectedNodeId,
+      selected: !this.options.selectedNode,
       createContentView: function () {
         return new cdb.core.View();
       }
     }, {
       label: _t('editor.layers.menu-tab-pane-labels.analyses'),
-      selected: this.options.selectedNodeId,
+      selected: !!this.options.selectedNode,
       createContentView: function () {
         return new AnalysesView({
           layerDefinitionModel: self.layerDefinitionModel,
-          analysisDefinitionsCollection: self.analysisDefinitionsCollection,
           modals: self.modals,
           analysis: self.analysis,
-          selectedNodeId: self.options.selectedNodeId
+          selectedNode: self.options.selectedNode
         });
       }
     }, {
@@ -56,7 +53,7 @@ module.exports = cdb.core.View.extend({
       createContentView: function () {
         return new InfowindowView({
           layerDefinitionModel: self.layerDefinitionModel,
-          querySchemaModel: self.analysisDefinitionsCollection.analysisDefinitionNodesCollection.get(self.layerDefinitionModel.get('source')).querySchemaModel,
+          querySchemaModel: self.layerDefinitionModel.getAnalysisDefinitionNodeModel().querySchemaModel,
           configModel: self._configModel
         });
       }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses-form-types/analysis-source-options-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses-form-types/analysis-source-options-model.js
@@ -88,9 +88,8 @@ module.exports = cdb.core.Model.extend({
 
     this._layerDefinitionsCollection
       .each(function (m) {
-        var sourceId = m.get('source');
+        var nodeDefModel = m.getAnalysisDefinitionNodeModel();
         var layerName = m.getName();
-        var nodeDefModel = this._analysisDefinitionNodesCollection.get(sourceId);
 
         if (nodeDefModel) {
           var querySchemaModel = nodeDefModel.querySchemaModel;

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses-view.js
@@ -12,18 +12,15 @@ module.exports = cdb.core.View.extend({
 
   initialize: function (opts) {
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
     if (!opts.modals) throw new Error('modals is required');
     if (!opts.analysis) throw new Error('analysis is required');
 
     this.analysis = opts.analysis;
     this.layerDefinitionModel = opts.layerDefinitionModel;
-    this.analysisDefinitionsCollection = opts.analysisDefinitionsCollection;
-    this.analysisDefinitionNodesCollection = opts.analysisDefinitionsCollection.analysisDefinitionNodesCollection;
     this.modals = opts.modals;
 
     this.viewModel = new cdb.core.Model({
-      selectedNodeId: opts.selectedNodeId || this.layerDefinitionModel.get('source')
+      selectedNode: opts.selectedNode || this.layerDefinitionModel.getAnalysisDefinitionNodeModel()
     });
 
     this._initBinds();
@@ -41,9 +38,15 @@ module.exports = cdb.core.View.extend({
     return this;
   },
 
+  clean: function () {
+    cdb.core.View.prototype.clean.apply(this, arguments);
+    this.viewModel.unset('selectedNode');
+    this.viewModel = null;
+  },
+
   _initBinds: function () {
     this.layerDefinitionModel.bind('change:source', function () {
-      this.viewModel.set('selectedNodeId', this.layerDefinitionModel.get('source'));
+      this.viewModel.set('selectedNode', this.layerDefinitionModel.getAnalysisDefinitionNodeModel());
       this.render();
     }, this);
     this.add_related_model(this.layerDefinitionModel);
@@ -53,7 +56,6 @@ module.exports = cdb.core.View.extend({
     var analysesWorkflow = new AnalysesWorkflowView({
       analysis: this.analysis,
       layerDefinitionModel: this.layerDefinitionModel,
-      analysisDefinitionsCollection: this.analysisDefinitionsCollection,
       openAddAnalysis: this._openAddAnalysis.bind(this),
       viewModel: this.viewModel
     });
@@ -62,7 +64,6 @@ module.exports = cdb.core.View.extend({
 
     var analysisForm = new AnalysisFormView({
       layerDefinitionModel: this.layerDefinitionModel,
-      analysisDefinitionsCollection: this.analysisDefinitionsCollection,
       viewModel: this.viewModel
     });
     this.$el.append(analysisForm.render().el);
@@ -70,20 +71,17 @@ module.exports = cdb.core.View.extend({
   },
 
   _hasAnalyses: function () {
-    var sourceModel = this.analysisDefinitionNodesCollection.get(this.layerDefinitionModel.get('source'));
-    return !sourceModel || sourceModel.get('type') !== 'source';
+    var m = this.layerDefinitionModel.getAnalysisDefinitionNodeModel();
+    return m && m.get('type') !== 'source';
   },
 
   _openAddAnalysis: function () {
     var self = this;
-    var sourceId = this.layerDefinitionModel.get('source');
-    var analysisDefinitionNodeModel = this.analysisDefinitionNodesCollection.get(sourceId);
 
     this.modals.create(function (modalModel) {
       return new AddAnalysisView({
         modalModel: modalModel,
-        layerDefinitionModel: self.layerDefinitionModel,
-        analysisDefinitionNodeModel: analysisDefinitionNodeModel
+        layerDefinitionModel: self.layerDefinitionModel
       });
     });
   }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses-workflow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses-workflow-view.js
@@ -11,14 +11,11 @@ module.exports = cdb.core.View.extend({
 
   initialize: function (opts) {
     if (!opts.layerDefinitionModel) throw new Error('Layer definition is required');
-    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
     if (!opts.viewModel) throw new Error('viewModel is required');
     if (!opts.openAddAnalysis) throw new Error('openAddAnalysis is required');
     if (!opts.analysis) throw new Error('analysis is required');
 
     this.layerDefinitionModel = opts.layerDefinitionModel;
-    this.analysisDefinitionsCollection = opts.analysisDefinitionsCollection;
-    this.analysisDefinitionNodesCollection = opts.analysisDefinitionsCollection.analysisDefinitionNodesCollection;
     this.viewModel = opts.viewModel;
     this.openAddAnalysis = opts.openAddAnalysis;
     this.analysis = opts.analysis;
@@ -31,17 +28,16 @@ module.exports = cdb.core.View.extend({
     this.$el.empty();
     this.$el.append(
       template({
-        selectedNodeId: this.viewModel.get('selectedNodeId')
+        selectedNodeId: this.viewModel.get('selectedNode').id
       })
     );
-    var sourceId = this.layerDefinitionModel.get('source');
-    var sourceModel = this.analysisDefinitionNodesCollection.get(sourceId);
-    this._renderNode(sourceModel);
+    var currentNode = this.layerDefinitionModel.getAnalysisDefinitionNodeModel();
+    this._renderNode(currentNode);
     return this;
   },
 
   _renderNode: function (currentNode) {
-    var next = this.analysisDefinitionNodesCollection.get(currentNode.getPrimarySourceId());
+    var next = currentNode.getPrimarySource();
     if (next) {
       this._createNodeView(currentNode);
 
@@ -54,22 +50,18 @@ module.exports = cdb.core.View.extend({
   _createNodeView: function (nodeModel) {
     var nodeView = new AnalysesWorkflowItemView({
       nodeModel: nodeModel,
-      selected: nodeModel.id === this.viewModel.get('selectedNodeId'),
+      selected: nodeModel === this.viewModel.get('selectedNode'),
       analysisNode: this.analysis.findNodeById(nodeModel.id)
     });
-    nodeView.bind('nodeSelected', function (selectedNode, view) {
-      var currentNodeId = this.viewModel.get('selectedNodeId');
-      var selectedNodeId = selectedNode.get('id');
-      if (currentNodeId !== selectedNodeId) {
-        this.viewModel.set('selectedNodeId', selectedNodeId);
-      }
+    nodeView.bind('nodeSelected', function (selectedNode) {
+      this.viewModel.set('selectedNode', selectedNode);
     }, this);
     this.$('.js-list').append(nodeView.render().el);
     this.addView(nodeView);
   },
 
   _initBinds: function () {
-    this.viewModel.bind('change:selectedNodeId', this.render, this);
+    this.viewModel.bind('change:selectedNode', this.render, this);
     this.add_related_model(this.viewModel);
   },
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analysis-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analysis-form-view.js
@@ -5,12 +5,9 @@ module.exports = cdb.core.View.extend({
 
   initialize: function (opts) {
     if (!opts.layerDefinitionModel) throw new Error('Layer definition is required');
-    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
     if (!opts.viewModel) throw new Error('viewModel is required');
 
     this.layerDefinitionModel = opts.layerDefinitionModel;
-    this.analysisDefinitionsCollection = opts.analysisDefinitionsCollection;
-    this.analysisDefinitionNodesCollection = this.analysisDefinitionsCollection.analysisDefinitionNodesCollection;
     this.viewModel = opts.viewModel;
 
     this._initBinds();
@@ -20,12 +17,10 @@ module.exports = cdb.core.View.extend({
     this.clearSubViews();
     this.$el.empty();
 
-    var currentNodeId = this.viewModel.get('selectedNodeId');
-    var analysisDefinitionNodeModel = this.analysisDefinitionNodesCollection.get(currentNodeId);
-    var type = analysisDefinitionNodeModel.get('type');
-    var FormViewKlass = AnalysisTypeMap.getFormView(type);
+    var m = this.viewModel.get('selectedNode');
+    var FormViewKlass = AnalysisTypeMap.getFormView(m.get('type'));
     var formView = new FormViewKlass({
-      analysisDefinitionNodeModel: analysisDefinitionNodeModel,
+      analysisDefinitionNodeModel: m,
       layerDefinitionModel: this.layerDefinitionModel
     });
 
@@ -36,7 +31,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _initBinds: function () {
-    this.viewModel.bind('change:selectedNodeId', this.render, this);
+    this.viewModel.bind('change:selectedNode', this.render, this);
     this.add_related_model(this.viewModel);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
@@ -119,8 +119,8 @@ module.exports = cdb.core.View.extend({
     this._stackLayoutModel.nextStep(this.model, 'layers');
   },
 
-  _onEditAnalysis: function (nodeId) {
-    this._stackLayoutModel.nextStep(this.model, 'layers', nodeId);
+  _onEditAnalysis: function (selectedNode) {
+    this._stackLayoutModel.nextStep(this.model, 'layers', selectedNode);
   },
 
   _onDestroy: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
@@ -92,14 +92,12 @@ module.exports = cdb.core.View.extend({
     return new LayerAnalysesView({
       el: el,
       model: layerDefinitionModel,
-      analysisDefinitionNodesCollection: this._analysisDefinitionNodesCollection,
       layerAnalysisViewFactory: this._layerAnalysisViewFactory
     });
   },
 
   _openAddAnalysis: function (layerDefinitionModel) {
     var self = this;
-    var sourceId = layerDefinitionModel.get('source');
 
     this._modals.create(function (modalModel) {
       modalModel.once('destroy', function (nodeModel) {
@@ -107,15 +105,14 @@ module.exports = cdb.core.View.extend({
       }, self);
       return new AddAnalysisView({
         modalModel: modalModel,
-        layerDefinitionModel: layerDefinitionModel,
-        analysisDefinitionNodeModel: self._analysisDefinitionNodesCollection.get(sourceId)
+        layerDefinitionModel: layerDefinitionModel
       });
     });
   },
 
   _onNodeCreated: function (layerDefinitionModel, nodeModel) {
     if (nodeModel && !nodeModel.isValid()) {
-      this._stackLayoutModel.nextStep(layerDefinitionModel, 'layers', nodeModel.id);
+      this._stackLayoutModel.nextStep(layerDefinitionModel, 'layers', nodeModel);
     }
   },
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
@@ -20,7 +20,7 @@ module.exports = cdb.core.View.extend({
     if (!opts.stackLayoutModel) throw new Error('stackLayoutModel is required');
     if (!opts.analysis) throw new Error('analysis is required');
     if (!opts.modals) throw new Error('modals is required');
-    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
+    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
     if (!opts.layerDefinitionsCollection) throw new Error('layerDefinitionsCollection is required');
     if (!opts.userModel) throw new Error('userModel is required');
     if (!opts.configModel) throw new Error('configModel is required');
@@ -28,11 +28,10 @@ module.exports = cdb.core.View.extend({
     this._modals = opts.modals;
     this._configModel = opts.configModel;
     this._stackLayoutModel = opts.stackLayoutModel;
-    this._analysisDefinitionNodesCollection = opts.analysisDefinitionsCollection.analysisDefinitionNodesCollection;
     this._layerDefinitionsCollection = opts.layerDefinitionsCollection;
     this._userModel = opts.userModel;
 
-    this._layerAnalysisViewFactory = new LayerAnalysisViewFactory(this._analysisDefinitionNodesCollection, opts.analysis);
+    this._layerAnalysisViewFactory = new LayerAnalysisViewFactory(opts.analysisDefinitionNodesCollection, opts.analysis);
 
     this.listenTo(this._layerDefinitionsCollection, 'add', this.render);
   },

--- a/lib/assets/javascripts/cartodb3/editor/map/map-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/map/map-view.js
@@ -9,7 +9,7 @@ module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     if (!opts.visDefinitionModel) throw new Error('visDefinitionModel is required');
     if (!opts.layerDefinitionsCollection) throw new Error('layerDefinitionsCollection is required');
-    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
+    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
     if (!opts.widgetDefinitionsCollection) throw new Error('widgetDefinitionsCollection is required');
     if (!opts.analysis) throw new Error('analysis is required');
     if (!opts.modals) throw new Error('modals is required');
@@ -23,7 +23,7 @@ module.exports = cdb.core.View.extend({
     this._visDefinitionModel = opts.visDefinitionModel;
     this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
     this._layerDefinitionsCollection = opts.layerDefinitionsCollection;
-    this._analysisDefinitionsCollection = opts.analysisDefinitionsCollection;
+    this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
   },
 
   render: function () {
@@ -39,7 +39,7 @@ module.exports = cdb.core.View.extend({
           configModel: self._configModel,
           visDefinitionModel: self._visDefinitionModel,
           layerDefinitionsCollection: self._layerDefinitionsCollection,
-          analysisDefinitionsCollection: self._analysisDefinitionsCollection,
+          analysisDefinitionNodesCollection: self._analysisDefinitionNodesCollection,
           widgetDefinitionsCollection: self._widgetDefinitionsCollection,
           mapStackLayoutModel: stackLayoutModel,
           selectedTabItem: selectedTabItem
@@ -64,7 +64,7 @@ module.exports = cdb.core.View.extend({
             var widgetDefinitionModel = opts[0];
             return new WidgetsFormContentView({
               widgetDefinitionModel: widgetDefinitionModel,
-              analysisDefinitionNodesCollection: self._analysisDefinitionsCollection.analysisDefinitionNodesCollection,
+              analysisDefinitionNodesCollection: self._analysisDefinitionNodesCollection,
               stackLayoutModel: stackLayoutModel
             });
           case 'elements':

--- a/lib/assets/javascripts/cartodb3/editor/map/map-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/map/map-view.js
@@ -51,15 +51,13 @@ module.exports = cdb.core.View.extend({
         switch (viewType) {
           case 'layers':
             var layerDefinitionModel = opts[0];
-            var selectedNodeId = opts[2];
+            var selectedNode = opts[2];
             return new LayerContentView({
               layerDefinitionModel: layerDefinitionModel,
-              analysisDefinitionsCollection: self._analysisDefinitionsCollection,
-              layerDefinitionsCollection: self._layerDefinitionsCollection,
               analysis: self._analysis,
               modals: self._modals,
               stackLayoutModel: stackLayoutModel,
-              selectedNodeId: selectedNodeId,
+              selectedNode: selectedNode,
               configModel: self._configModel
             });
           case 'widgets':

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -184,7 +184,7 @@
         "modal-desc": "Select the analysis you want to add",
         "loading-title": "Loading options",
         "add-btn": "Add analysis",
-        "disabled-option-desc": "Your layer geometry is %{inputGeometryType} and this analysis needs %{requiredInputGeometries}",
+        "disabled-option-desc": "Your layer geometry is %{simpleGeometryType} and this analysis needs %{requiredInputGeometries}",
         "option-types": {
           "buffer": {
             "title": "Buffer",

--- a/lib/assets/test/spec/cartodb3/components/modals/add-analysis/add-analysis-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-analysis/add-analysis-view.spec.js
@@ -44,11 +44,11 @@ describe('components/modals/add-analysis/add-analysis-view', function () {
 
     this.nodeModel = {};
     spyOn(this.layerDefinitionModel, 'createNewAnalysisNode').and.returnValue(this.nodeModel);
+    spyOn(this.layerDefinitionModel, 'getAnalysisDefinitionNodeModel').and.returnValue(this.analysisDefinitionNodeModel);
 
     this.view = new AddAnalysisView({
       modalModel: this.modalModel,
-      layerDefinitionModel: this.layerDefinitionModel,
-      analysisDefinitionNodeModel: this.analysisDefinitionNodeModel
+      layerDefinitionModel: this.layerDefinitionModel
     });
     this.view.render();
   });

--- a/lib/assets/test/spec/cartodb3/data/analysis-definition-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/analysis-definition-model.spec.js
@@ -8,13 +8,13 @@ describe('data/analysis-definition-model', function () {
       base_url: '/u/pepe'
     });
 
-    var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
+    this.analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
       configModel: {}
     });
 
     this.collection = new AnalysisDefinitionsCollection(null, {
       configModel: configModel,
-      analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
+      analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
       vizId: 'v-123'
     });
 
@@ -36,7 +36,7 @@ describe('data/analysis-definition-model', function () {
   });
 
   it('should have created corresponding source node from analysis definition', function () {
-    expect(this.collection.analysisDefinitionNodesCollection.get('a0')).toBeDefined();
+    expect(this.analysisDefinitionNodesCollection.get('a0')).toBeDefined();
   });
 
   describe('.toJSON', function () {

--- a/lib/assets/test/spec/cartodb3/data/analysis-definition-node-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/analysis-definition-node-model.spec.js
@@ -53,8 +53,11 @@ describe('data/analysis-definition-node-model', function () {
       expect(this.model.getLetter()).toEqual('g');
     });
 
-    it('should not have any primary node', function () {
-      expect(this.model.getPrimarySourceId()).toBeUndefined();
+    it('should not have any sources', function () {
+      expect(this.model.hasPrimarySource()).toBe(false);
+      expect(this.model.hasSecondarySource()).toBe(false);
+      expect(this.model.getPrimarySource()).toBeUndefined();
+      expect(this.model.getSecondarySource()).toBeUndefined();
     });
 
     describe('.destroy', function () {
@@ -138,7 +141,13 @@ describe('data/analysis-definition-node-model', function () {
     });
 
     it('should have a primary source id', function () {
-      expect(this.model.getPrimarySourceId()).toEqual('g0');
+      expect(this.model.hasPrimarySource()).toBe(true);
+      expect(this.model.getPrimarySource().id).toEqual('g0');
+    });
+
+    it('should not have a secondary source', function () {
+      expect(this.model.hasSecondarySource()).toBe(false);
+      expect(this.model.getSecondarySource()).toBeUndefined();
     });
 
     it('should flatten the data for the model', function () {
@@ -226,8 +235,14 @@ describe('data/analysis-definition-node-model', function () {
         expect(this.model.sourceIds()).toEqual(['a0', 'b0']);
       });
 
-      it('should have a primary source id', function () {
-        expect(this.model.getPrimarySourceId()).toEqual('b0');
+      it('should have a primary source', function () {
+        expect(this.model.hasPrimarySource()).toBe(true);
+        expect(this.model.getPrimarySource().id).toEqual('b0');
+      });
+
+      it('should have a secondary source', function () {
+        expect(this.model.hasSecondarySource()).toBe(true);
+        expect(this.model.getSecondarySource().id).toEqual('a0');
       });
 
       it('should flatten the data for the model', function () {
@@ -317,12 +332,18 @@ describe('data/analysis-definition-node-model', function () {
         expect(this.collection.get('b0')).toBeDefined();
       });
 
-      it('should have two sourcei ds', function () {
+      it('should have two source ids', function () {
         expect(this.model.sourceIds()).toEqual(['a0', 'b0']);
       });
 
-      it('should have a primary source id', function () {
-        expect(this.model.getPrimarySourceId()).toEqual('b0');
+      it('should have a primary source', function () {
+        expect(this.model.hasPrimarySource()).toBe(true);
+        expect(this.model.getPrimarySource().id).toEqual('b0');
+      });
+
+      it('should have a secondary source', function () {
+        expect(this.model.hasSecondarySource()).toBe(true);
+        expect(this.model.getSecondarySource().id).toEqual('a0');
       });
 
       it('should unflatten what it can for toJSON', function () {

--- a/lib/assets/test/spec/cartodb3/editor/editor-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/editor-view.spec.js
@@ -16,9 +16,6 @@ describe('editor/editor-view', function () {
       configModel: {}
     });
 
-    var analysisDefinitionsCollection = new Backbone.Collection([]);
-    analysisDefinitionsCollection.analysisDefinitionNodesCollection = {};
-
     this.widgetDefinitionsCollection = new Backbone.Collection();
 
     this.view = new EditorView({
@@ -29,7 +26,7 @@ describe('editor/editor-view', function () {
       analysis: {},
       userModel: {},
       configModel: {},
-      analysisDefinitionsCollection: analysisDefinitionsCollection,
+      analysisDefinitionNodesCollection: {},
       layerDefinitionsCollection: new Backbone.Collection([layerDefinitionModel]),
       widgetDefinitionsCollection: this.widgetDefinitionsCollection,
       mapStackLayoutModel: {},

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var Backbone = require('backbone');
 var LayerDefinitionModel = require('../../../../../javascripts/cartodb3/data/layer-definition-model');
 var LayerContentView = require('../../../../../javascripts/cartodb3/editor/layers/layer-content-view');
 var ConfigModel = require('../../../../../javascripts/cartodb3/data/config-model');
@@ -23,7 +22,6 @@ describe('editor/layers/layer-content-view', function () {
     this.stackLayoutModel = jasmine.createSpyObj('stackLayoutModel', ['prevStep']);
     this.view = new LayerContentView({
       layerDefinitionModel: this.layer,
-      analysisDefinitionsCollection: new Backbone.Collection(),
       modals: {},
       analysis: {},
       stackLayoutModel: this.stackLayoutModel,

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses-view.spec.js
@@ -1,53 +1,38 @@
 var _ = require('underscore');
 var cdb = require('cartodb.js');
-var LayerDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/layer-definitions-collection');
-var AnalysisDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definitions-collection');
-var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
+var AnalysisDefinitionNodeModel = require('../../../../../../javascripts/cartodb3/data/analysis-definition-node-model');
+var LayerDefinitionModel = require('../../../../../../javascripts/cartodb3/data/layer-definition-model');
 var AnalysesView = require('../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses-view');
 var ConfigModel = require('../../../../../../javascripts/cartodb3/data/config-model');
 var ModalsService = require('../../../../../../javascripts/cartodb3/components/modals/modals-service-model');
 
 describe('editor/layers/layer-content-view/analyses-view', function () {
   beforeEach(function () {
-    var configModel = new ConfigModel({
+    this.configModel = new ConfigModel({
       base_url: '/u/pepe'
     });
 
-    var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
-      configModel: configModel
-    });
-    this.analysisDefinitionsCollection = new AnalysisDefinitionsCollection(null, {
-      configModel: configModel,
-      analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
-      vizId: 'v-123'
-    });
-    this.analysisDefinitionsCollection.add({
-      id: 'hello',
-      analysis_definition: {
-        id: 'a0',
-        type: 'source',
-        table_name: 'foo',
-        params: {
-          query: 'SELECT * FROM foo'
-        }
-      }
-    });
-
-    this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
-      configModel: configModel,
-      analysisDefinitionsCollection: {},
-      analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
-      mapId: 'map-123'
-    });
-    this.layerDefinitionModel = this.layerDefinitionsCollection.add({
+    this.layerDefinitionModel = new LayerDefinitionModel({
       id: 'l-1',
       options: {
         type: 'CartoDB',
         table_name: 'foo',
         cartocss: 'asd',
-        source: 'a0'
+        source: 'a1'
       }
+    }, {
+      configModel: this.configModel,
+      collection: new cdb.Backbone.Collection()
     });
+    this.a0 = new AnalysisDefinitionNodeModel({
+      id: 'a0',
+      type: 'source',
+      table_name: 'foo'
+    }, {
+      configModel: this.configModel,
+      collection: new cdb.Backbone.Collection()
+    });
+    spyOn(this.layerDefinitionModel, 'getAnalysisDefinitionNodeModel').and.returnValue(this.a0);
 
     this.modals = new ModalsService();
 
@@ -57,14 +42,13 @@ describe('editor/layers/layer-content-view/analyses-view', function () {
     this.view = new AnalysesView({
       layerDefinitionModel: this.layerDefinitionModel,
       modals: this.modals,
-      analysis: analysis,
-      analysisDefinitionsCollection: this.analysisDefinitionsCollection
+      analysis: analysis
     });
     this.view.render();
   });
 
   describe('render', function () {
-    describe('if there is no analyses', function () {
+    describe('when layer has no analysis', function () {
       it('should render placeholder view', function () {
         expect(this.view.$('.js-new-analysis').length).toBe(1);
       });
@@ -86,30 +70,26 @@ describe('editor/layers/layer-content-view/analyses-view', function () {
         it('should open modal to add analysis', function () {
           expect(this.modals.create).toHaveBeenCalled();
         });
+
+        it('should not have any leaks', function () {
+          expect(this.view).toHaveNoLeaks();
+        });
       });
     });
 
-    describe('if there is any analysis', function () {
+    describe('when an analysis node is added on layer definition', function () {
       beforeEach(function () {
-        this.analysisDefinitionsCollection.add({
-          id: 'xyz123',
-          analysis_definition: {
-            id: 'a1',
-            type: 'trade-area',
-            params: {
-              kind: 'walk',
-              time: '100',
-              source: {
-                id: 'a0',
-                type: 'source',
-                table_name: 'foo',
-                params: {
-                  query: 'SELECT * FROM foo'
-                }
-              }
-            }
-          }
+        this.a1 = new AnalysisDefinitionNodeModel({
+          id: 'a1',
+          type: 'trade-area',
+          kind: 'walk',
+          time: '100'
+        }, {
+          configModel: this.configModel,
+          collection: new cdb.Backbone.Collection()
         });
+        spyOn(this.a1, 'getPrimarySource').and.returnValue(this.a0);
+        this.layerDefinitionModel.getAnalysisDefinitionNodeModel.and.returnValue(this.a1);
         this.layerDefinitionModel.set('source', 'a1');
       });
 
@@ -117,37 +97,14 @@ describe('editor/layers/layer-content-view/analyses-view', function () {
         expect(_.size(this.view._subviews)).toBe(2);
         expect(this.view.$('.js-new-analysis').length).toBe(0);
       });
-    });
-  });
 
-  it('should change selected node when layer definition source changes', function () {
-    spyOn(this.view, 'render');
-    expect(this.view.viewModel.get('selectedNodeId')).toBe('a0');
-    this.analysisDefinitionsCollection.add({
-      id: 'xyz123',
-      analysis_definition: {
-        id: 'a1',
-        type: 'trade-area',
-        params: {
-          kind: 'walk',
-          time: '100',
-          source: {
-            id: 'a0',
-            type: 'source',
-            table_name: 'foo',
-            params: {
-              query: 'SELECT * FROM foo'
-            }
-          }
-        }
-      }
-    });
-    this.layerDefinitionModel.set('source', 'a1');
-    expect(this.view.viewModel.get('selectedNodeId')).toBe('a1');
-    expect(this.view.render).toHaveBeenCalled();
-  });
+      it('should select the new node', function () {
+        expect(this.view.viewModel.get('selectedNode').id).toEqual('a1');
+      });
 
-  it('should not have any leaks', function () {
-    expect(this.view).toHaveNoLeaks();
+      it('should not have any leaks', function () {
+        expect(this.view).toHaveNoLeaks();
+      });
+    });
   });
 });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses-workflow-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses-workflow-view.spec.js
@@ -1,51 +1,17 @@
 var cdb = require('cartodb.js');
 var _ = require('underscore');
 var LayerDefinitionModel = require('../../../../../../javascripts/cartodb3/data/layer-definition-model');
-var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
-var AnalysisDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definitions-collection');
+var AnalysisDefinitionNodeModel = require('../../../../../../javascripts/cartodb3/data/analysis-definition-node-model');
 var AnalysesWorkflowView = require('../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses-workflow-view');
 var ConfigModel = require('../../../../../../javascripts/cartodb3/data/config-model');
 
 describe('editor/layers/layer-content-view/analyses-workflow-view', function () {
-  var analysisDefinitionsCollection;
-  var layer;
-
   beforeEach(function () {
-    var configModel = new ConfigModel({
+    this.configModel = new ConfigModel({
       base_url: '/u/pepe'
     });
 
-    this.analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
-      configModel: configModel
-    });
-
-    analysisDefinitionsCollection = this.analysisDefinitionsCollection = new AnalysisDefinitionsCollection([
-      {
-        id: 'xyz123',
-        analysis_definition: {
-          id: 'a1',
-          type: 'trade-area',
-          params: {
-            kind: 'walk',
-            time: '100',
-            source: {
-              id: 'a0',
-              type: 'source',
-              table_name: 'foo',
-              params: {
-                query: 'SELECT * FROM foo'
-              }
-            }
-          }
-        }
-      }
-    ], {
-      configModel: configModel,
-      analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
-      vizId: 'v-123'
-    });
-
-    layer = this.layer = new LayerDefinitionModel({
+    this.layer = new LayerDefinitionModel({
       id: 'l-1',
       options: {
         type: 'CartoDB',
@@ -55,11 +21,45 @@ describe('editor/layers/layer-content-view/analyses-workflow-view', function () 
       }
     }, {
       parse: true,
-      configModel: configModel
+      collection: new cdb.Backbone.Collection(),
+      configModel: this.configModel
     });
 
+    this.a0 = new AnalysisDefinitionNodeModel({
+      id: 'a0',
+      type: 'source',
+      table_name: 'foo'
+    }, {
+      configModel: this.configModel,
+      collection: new cdb.Backbone.Collection()
+    });
+    this.a1 = new AnalysisDefinitionNodeModel({
+      id: 'a1',
+      type: 'buffer'
+    }, {
+      configModel: this.configModel,
+      collection: new cdb.Backbone.Collection()
+    });
+
+    spyOn(this.a1, 'getPrimarySource').and.returnValue(this.a0);
+    spyOn(this.layer, 'getAnalysisDefinitionNodeModel').and.returnValue(this.a1);
+
+    this._addNewAnalysis = function (newNodeId) {
+      var newNodeDefModel = this[newNodeId] = new AnalysisDefinitionNodeModel({
+        id: newNodeId,
+        type: 'buffer',
+        range: '100'
+      }, {
+        configModel: this.configModel,
+        collection: new cdb.Backbone.Collection()
+      });
+      spyOn(newNodeDefModel, 'getPrimarySource').and.returnValue(this.layer.getAnalysisDefinitionNodeModel());
+      this.layer.getAnalysisDefinitionNodeModel.and.returnValue(newNodeDefModel);
+      this.layer.set('source', newNodeId);
+    };
+
     this.viewModel = new cdb.core.Model({
-      selectedNodeId: 'a1'
+      selectedNode: this.a1
     });
 
     this.openAddAnalysisSpy = jasmine.createSpy('openAddAnalysis');
@@ -73,7 +73,6 @@ describe('editor/layers/layer-content-view/analyses-workflow-view', function () 
     this.view = new AnalysesWorkflowView({
       analysis: analysis,
       layerDefinitionModel: this.layer,
-      analysisDefinitionsCollection: this.analysisDefinitionsCollection,
       openAddAnalysis: this.openAddAnalysisSpy,
       viewModel: this.viewModel
     });
@@ -87,37 +86,41 @@ describe('editor/layers/layer-content-view/analyses-workflow-view', function () 
       expect(this.view.$('.js-delete').length).toBe(1);
     });
 
-    it('should render as many nodes as the layer has, not taking into account the source', function () {
+    it('should render all nodes except for the source', function () {
       expect(_.size(this.view._subviews)).toBe(1);
       expect(this.view.$('.js-list > li').length).toBe(2);
       expect(this.view.$('.js-list li:eq(0) .js-add-analysis').length).toBe(1);
       expect(this.view.$('.js-list li:eq(1)').text()).toContain('a1');
     });
 
-    it('should render when selectedNodeId changes', function () {
-      addNewAnalysis('a3', this.analysisDefinitionNodesCollection.get('a1'));
-      this.viewModel.set('selectedNodeId', 'a3');
+    it('should update when selectedNode changes', function () {
+      this._addNewAnalysis('a3');
+
+      this.viewModel.set('selectedNode', this.a3);
       expect(this.view.$('.js-list > li').length).toBe(3);
       expect(this.view.$('.js-list li:eq(1)').hasClass('is-selected')).toBeTruthy();
       expect(this.view.$('.js-list li:eq(1)').text()).toContain('a3');
-      this.viewModel.set('selectedNodeId', 'a1');
+
+      this.viewModel.set('selectedNode', this.a1);
       expect(this.view.$('.js-list > li').length).toBe(3);
       expect(this.view.$('.js-list li:eq(2)').hasClass('is-selected')).toBeTruthy();
       expect(this.view.$('.js-list li:eq(2)').text()).toContain('a1');
     });
   });
 
-  it('should change selectedNodeId when a different node is clicked', function () {
-    addNewAnalysis('a2', this.analysisDefinitionNodesCollection.get('a1'));
+  it('should change selectedNode when a different node is clicked', function () {
+    this._addNewAnalysis('a2');
     this.view.render();
+
     this.view.$('.js-list li:eq(1)').click();
-    expect(this.viewModel.get('selectedNodeId')).toBe('a2');
+    expect(this.viewModel.get('selectedNode')).toBe(this.a2);
     expect(this.view.$('.js-list li:eq(1)').hasClass('is-selected')).toBeTruthy();
     expect(this.view.$('.js-list li:eq(1)').text()).toContain('a2');
     expect(this.view.$('.js-list li:eq(2)').hasClass('is-selected')).toBeFalsy();
     expect(this.view.$('.js-list li:eq(2)').text()).toContain('a1');
+
     this.view.$('.js-list li:eq(2)').click();
-    expect(this.viewModel.get('selectedNodeId')).toBe('a1');
+    expect(this.viewModel.get('selectedNode')).toBe(this.a1);
     expect(this.view.$('.js-list li:eq(1)').hasClass('is-selected')).toBeFalsy();
     expect(this.view.$('.js-list li:eq(2)').hasClass('is-selected')).toBeTruthy();
   });
@@ -135,19 +138,4 @@ describe('editor/layers/layer-content-view/analyses-workflow-view', function () 
       expect(this.openAddAnalysisSpy).toHaveBeenCalled();
     });
   });
-
-  function addNewAnalysis (newNodeId, source) {
-    analysisDefinitionsCollection.add({
-      id: 'xyz1234',
-      analysis_definition: {
-        id: newNodeId,
-        type: 'buffer',
-        params: {
-          range: '100',
-          source: source.toJSON()
-        }
-      }
-    });
-    layer.set('source', newNodeId);
-  }
 });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analysis-form-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analysis-form-view.spec.js
@@ -1,7 +1,6 @@
 var cdb = require('cartodb.js');
 var LayerDefinitionModel = require('../../../../../../javascripts/cartodb3/data/layer-definition-model');
-var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
-var AnalysisDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definitions-collection');
+var AnalysisDefinitionNodeModel = require('../../../../../../javascripts/cartodb3/data/analysis-definition-node-model');
 var AnalysisFormView = require('../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analysis-form-view');
 var ConfigModel = require('../../../../../../javascripts/cartodb3/data/config-model');
 
@@ -11,33 +10,21 @@ describe('editor/layers/layer-content-view/analyses-form-view', function () {
       base_url: '/u/pepe'
     });
 
-    var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
-      configModel: configModel
-    });
-
-    this.analysisDefinitionsCollection = new AnalysisDefinitionsCollection([
-      {
-        id: 'xyz123',
-        analysis_definition: {
-          id: 'a1',
-          type: 'trade-area',
-          params: {
-            kind: 'walk',
-            time: '100',
-            source: {
-              id: 'a0',
-              type: 'source',
-              params: {
-                query: 'SELECT * FROM foo'
-              }
-            }
-          }
-        }
-      }
-    ], {
+    this.a0 = new AnalysisDefinitionNodeModel({
+      id: 'a0',
+      type: 'source',
+      table_name: 'foo'
+    }, {
       configModel: configModel,
-      analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
-      vizId: 'v-123'
+      collection: new cdb.Backbone.Collection()
+    });
+    this.a1 = new AnalysisDefinitionNodeModel({
+      id: 'a1',
+      type: 'trade-area',
+      source: 'a0'
+    }, {
+      configModel: configModel,
+      collection: new cdb.Backbone.Collection()
     });
 
     this.layer = new LayerDefinitionModel({
@@ -53,20 +40,17 @@ describe('editor/layers/layer-content-view/analyses-form-view', function () {
       configModel: configModel
     });
 
-    this.viewModel = new cdb.core.Model({
-      selectedNodeId: 'a1'
-    });
+    this.viewModel = new cdb.core.Model({selectedNode: this.a1});
     spyOn(AnalysisFormView.prototype, 'render');
     this.view = new AnalysisFormView({
       layerDefinitionModel: this.layer,
-      analysisDefinitionsCollection: this.analysisDefinitionsCollection,
       viewModel: this.viewModel
     });
     this.view.render();
   });
 
-  it('should render when selectedNodeId changes', function () {
-    this.viewModel.set('selectedNodeId', 'a0');
+  it('should render when selectedNode changes', function () {
+    this.viewModel.set('selectedNode', this.a0);
     expect(this.view.render).toHaveBeenCalled();
   });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layers-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layers-view.spec.js
@@ -87,7 +87,7 @@ describe('editor/layers/layers-view', function () {
         expect(this.stackLayoutModel.nextStep).toHaveBeenCalled();
         expect(this.stackLayoutModel.nextStep.calls.argsFor(0)[0]).toBe(this.layerDefinitionsCollection.first());
         expect(this.stackLayoutModel.nextStep.calls.argsFor(0)[1]).toEqual('layers');
-        expect(this.stackLayoutModel.nextStep.calls.argsFor(0)[2]).toEqual('a1');
+        expect(this.stackLayoutModel.nextStep.calls.argsFor(0)[2].id).toEqual('a1');
       });
     });
   });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layers-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layers-view.spec.js
@@ -1,7 +1,6 @@
 var ModalsServiceModel = require('../../../../../javascripts/cartodb3/components/modals/modals-service-model');
 var StackLayoutModel = require('../../../../../javascripts/cartodb3/components/stack-layout/stack-layout-model');
 var AnalysisDefinitionNodesCollection = require('../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
-var AnalysisDefinitionsCollection = require('../../../../../javascripts/cartodb3/data/analysis-definitions-collection');
 var LayerDefinitionsCollection = require('../../../../../javascripts/cartodb3/data/layer-definitions-collection');
 var LayersView = require('../../../../../javascripts/cartodb3/editor/layers/layers-view');
 
@@ -15,11 +14,6 @@ describe('editor/layers/layers-view', function () {
       configModel: {}
     });
 
-    this.analysisDefinitionsCollection = new AnalysisDefinitionsCollection(null, {
-      configModel: {},
-      vizId: 'viz-123',
-      analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection
-    });
     this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
       configModel: {},
       analysisDefinitionsCollection: {},
@@ -43,7 +37,7 @@ describe('editor/layers/layers-view', function () {
       analysis: this.analysis,
       modals: this.modals,
       stackLayoutModel: this.stackLayoutModel,
-      analysisDefinitionsCollection: this.analysisDefinitionsCollection,
+      analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
       layerDefinitionsCollection: this.layerDefinitionsCollection
     });
 

--- a/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
@@ -13,9 +13,6 @@ describe('editor/map/map-view', function () {
       configModel: {}
     });
 
-    var analysisDefinitionsCollection = new Backbone.Collection([]);
-    analysisDefinitionsCollection.analysisDefinitionNodesCollection = {};
-
     this.view = new EditorMapView({
       visDefinitionModel: new cdb.core.Model({
         name: 'My super fun vis'
@@ -24,7 +21,7 @@ describe('editor/map/map-view', function () {
       analysis: {},
       configModel: configModel,
       userModel: new cdb.core.Model({}, { configModel: configModel }),
-      analysisDefinitionsCollection: analysisDefinitionsCollection,
+      analysisDefinitionNodesCollection: {},
       layerDefinitionsCollection: new Backbone.Collection([basemapLayerDefModel]),
       widgetDefinitionsCollection: new Backbone.Collection()
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.83",
+  "version": "3.23.84",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The primary change is removing unnecessary view dependencies and extracting some logic that didn't belong in the views. 

Secondary changes that was enabled by this:
- Removed a lot of unnecessary boilerplate in the test setups. 
- Make the node definitions collection on the analysis definitions collection private, i.e. no more `analysisDefinitionsCollection.analysisDefinitionNodesCollection`…
- Fixed a bug on the composite analysis node view; render a secondary source pointing to the owner-layer even if it isn't the layer's head node

@xavijam can you review, please?
cc @javierarce FYI