### PR TITLE
[user-mover] fix update_metadata issues w/ orgs

### DIFF
--- a/lib/tasks/user_mover.rake
+++ b/lib/tasks/user_mover.rake
@@ -19,7 +19,7 @@ namespace :cartodb do
       end
       desc 'Export an organization'
       task :export_org, [:organization_name, :path, :job_uuid, :database_only, :metadata_only, :split_user_schemas] => :environment do |_task, args|
-        args.with_defaults(job_uuid: nil, schema_mode: true, database_only: false, metadata_only: false, split_user_schemas: true)
+        args.with_defaults(job_uuid: nil, database_only: false, metadata_only: false)
         job_args = args.to_hash
         if job_args[:database_only] == 'true'
           job_args[:data] = true

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -207,11 +207,11 @@ module CartoDB
         # We first import the owner. If schemas are not split, this will also import the whole org database
         @logger.info("Importing org owner #{@owner_id}..")
         @import_job_admin_instance = ImportJob.new(file: @path + "user_#{@owner_id}.json",
-                      mode: @options[:mode],
-                      host: @target_dbhost,
-                      target_org: @pack_config['organization']['name'],
-                      logger: @logger, data: @options[:data], metadata: @options[:metadata],
-                      update_metadata: @options[:update_metadata])
+                                                   mode: @options[:mode],
+                                                   host: @target_dbhost,
+                                                   target_org: @pack_config['organization']['name'],
+                                                   logger: @logger, data: @options[:data], metadata: @options[:metadata],
+                                                   update_metadata: @options[:update_metadata])
         @import_job_admin_instance.run!
 
         # Fix permissions and metadata settings for owner
@@ -222,11 +222,11 @@ module CartoDB
         @pack_config['users'].reject { |u| u['id'] == @owner_id }.each do |user|
           @logger.info("Importing org user #{user['id']}..")
           i = ImportJob.new(file: @path + "user_#{user['id']}.json",
-                        mode: @options[:mode],
-                        host: @target_dbhost,
-                        target_org: @pack_config['organization']['name'],
-                        logger: @logger, data: @options[:data], metadata: @options[:metadata],
-                        update_metadata: @options[:update_metadata])
+                            mode: @options[:mode],
+                            host: @target_dbhost,
+                            target_org: @pack_config['organization']['name'],
+                            logger: @logger, data: @options[:data], metadata: @options[:metadata],
+                            update_metadata: @options[:update_metadata])
           i.run!
           @import_job_user_instances << i
         end
@@ -553,9 +553,9 @@ module CartoDB
       end
 
       def update_metadata_org_admin(owner_id, target_dbhost)
-          owner_user = ::User.find(id: owner_id)
-          owner_user.database_host = target_dbhost
-          owner_user.db_service.setup_organization_owner
+        owner_user = ::User.find(id: owner_id)
+        owner_user.database_host = target_dbhost
+        owner_user.db_service.setup_organization_owner
       end
 
       def update_metadata_user(target_dbhost)

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -219,13 +219,12 @@ module CartoDB
         # We first import the owner. If schemas are not split, this will also import the whole org database
         @logger.info("Importing org owner #{@owner_id}..")
         @org_owner_import_job = ImportJob.new(file: @path + "user_#{@owner_id}.json",
-                                                   mode: @options[:mode],
-                                                   host: @target_dbhost,
-                                                   target_org: @pack_config['organization']['name'],
-                                                   logger: @logger, data: @options[:data], metadata: @options[:metadata],
-                                                   update_metadata: @options[:update_metadata])
+                                              mode: @options[:mode],
+                                              host: @target_dbhost,
+                                              target_org: @pack_config['organization']['name'],
+                                              logger: @logger, data: @options[:data], metadata: @options[:metadata],
+                                              update_metadata: @options[:update_metadata])
         @org_owner_import_job.run!
-
 
         @pack_config['users'].reject { |u| u['id'] == @owner_id }.each do |user|
           @logger.info("Importing org user #{user['id']}..")
@@ -365,7 +364,7 @@ module CartoDB
         run_command("cat #{@path}#{file} | psql -v ON_ERROR_STOP=1 #{conn_string(@config[:dbuser], @config[:dbhost], @config[:dbport], @config[:dbname])}")
       end
 
-      def run_file_restore_postgres(file, sections=nil)
+      def run_file_restore_postgres(file, sections = nil)
         command = "pg_restore -e --verbose -j4 --disable-triggers -Fc #{@path}#{file} #{conn_string(
           @config[:dbuser],
           @target_dbhost,
@@ -513,17 +512,15 @@ module CartoDB
       end
 
       def update_database_retries(userid, username, db_host, db_name, retries = 1)
-        begin
-          update_database(userid, username, db_host, db_name)
-        rescue => e
-          @logger.error "Error updating database"
-          if retries > 0
-            @logger.info "Retrying..."
-            update_database_retries(userid, username, db_host, db_name, retries - 1)
-          else
-            @logger.info "No more retries"
-            throw e
-          end
+        update_database(userid, username, db_host, db_name)
+      rescue => e
+        @logger.error "Error updating database"
+        if retries > 0
+          @logger.info "Retrying..."
+          update_database_retries(userid, username, db_host, db_name, retries - 1)
+        else
+          @logger.info "No more retries"
+          throw e
         end
       end
 
@@ -566,7 +563,7 @@ module CartoDB
         user_model = ::User.find(username: @target_username)
         user_model.database_host = target_dbhost
         user_model.database_name = @target_dbname
-        user_model.organization_id = @target_org_id if @target_org_id != nil
+        user_model.organization_id = @target_org_id if !@target_org_id.nil?
 
         user_model.db_service.setup_organization_owner if @target_is_owner
         user_model.db_service.monitor_user_notification # Used to inform the database_server

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -86,9 +86,9 @@ module CartoDB
             @target_dbname = user_database(@target_userid)
             @target_is_owner = true
           else
-            # We find the configuration data for the owner
+            # We fill the missing configuration data for the owner
             organization_owner_data = get_user_info(organization_data['owner_id'])
-            @target_dbhost = organization_owner_data['database_host']
+            @target_dbhost = @options[:host] || organization_owner_data['database_host']
             @target_dbname = organization_owner_data['database_name']
             @target_is_owner = false
           end
@@ -251,7 +251,7 @@ module CartoDB
                         mode: :rollback,
                         host: @target_dbhost,
                         target_org: @pack_config['organization']['name'],
-                        logger: @logger, metadata: true, data: false).run!
+                        logger: @logger, metadata: @options[:metadata], data: false).run!
         end
         rollback_metadata("org_#{@organization_id}_metadata_undo.sql") if @options[:metadata]
         if @options[:data]

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -54,7 +54,7 @@ module CartoDB
       end
 
       def run!
-        if !@pack_config['organization'].nil?
+        if @pack_config['organization']
           process_org
         else
           process_user
@@ -587,7 +587,7 @@ module CartoDB
       end
 
       def update_metadata(target_dbhost)
-        if !@pack_config['organization'].nil?
+        if @pack_config['organization']
           @import_job_admin_instance.update_metadata_org_admin(@owner_id, target_dbhost)
           @import_job_admin_instance.update_metadata_user(target_dbhost)
 

--- a/services/user-mover/spec/user_mover_spec.rb
+++ b/services/user-mover/spec/user_mover_spec.rb
@@ -69,11 +69,9 @@ describe CartoDB::DataMover::ExportJob do
       moved_user
     end
 
-    it_behaves_like 'a migrated user' do
-      before { pending }
-    end
+    it_behaves_like "a migrated user"
 
-    xit "matches old and new user except database_name" do
+    it "matches old and new user except database_name" do
       expect(first_user.as_json.reject { |x| [:updated_at, :database_name, :organization_id, :database_schema].include? x })
         .to eq(subject.as_json.reject { |x| [:updated_at, :database_name, :organization_id, :database_schema].include? x })
       expect(subject.database_name).to eq(@org.owner.database_name)
@@ -81,7 +79,7 @@ describe CartoDB::DataMover::ExportJob do
       expect(subject.organization_id).to eq(@org.id)
     end
 
-    xit "has granted the org role" do
+    it "has granted the org role" do
       authed_roles = subject
                       .in_database["select s.rolname from pg_roles r
                         join pg_catalog.pg_auth_members m on r.oid=m.member join pg_catalog.pg_roles
@@ -90,7 +88,7 @@ describe CartoDB::DataMover::ExportJob do
     end
   end
 
-  xit "should move a user from an organization to its own account" do
+  it "should move a user from an organization to its own account" do
     org = create_user_mover_test_organization
     user = create_user(
       quota_in_bytes: 100.megabyte, table_quota: 400, organization: org
@@ -109,7 +107,7 @@ describe CartoDB::DataMover::ExportJob do
     moved_user.organization_id.should eq nil
   end
 
-  xit "should move a whole organization" do
+  it "should move a whole organization" do
     port = find_available_port
     run_test_server(port)
     Cartodb.config[:org_metadata_api]['port'] = port
@@ -154,7 +152,7 @@ describe CartoDB::DataMover::ExportJob do
     @server_thread.terminate
   end
 
-  xit "should move a whole organization without splitting user schemas" do
+  it "should move a whole organization without splitting user schemas" do
 
     org = create_user_mover_test_organization
     user = create_user(

--- a/services/user-mover/spec/user_mover_spec.rb
+++ b/services/user-mover/spec/user_mover_spec.rb
@@ -64,7 +64,9 @@ describe CartoDB::DataMover::ExportJob do
       CartoDB::DataMover::ImportJob.new(
         file: @tmp_path + "user_#{first_user.id}.json", mode: :import, host: '127.0.0.2', target_org: @org.name).run!
 
-      moved_user = ::User.find(username: first_user.username)
+      moved_user = ::User[first_user.id]
+      moved_user.reload # Clean user sequel cache
+
       Carto::GhostTablesManager.new(moved_user.id).link_ghost_tables_synchronously
       moved_user
     end
@@ -102,6 +104,7 @@ describe CartoDB::DataMover::ExportJob do
     CartoDB::DataMover::ImportJob.new(file: @tmp_path + "user_#{user.id}.json", mode: :import).run!
 
     moved_user = ::User.find(username: user.username)
+    moved_user.reload
     Carto::GhostTablesManager.new(moved_user.id).link_ghost_tables_synchronously
     check_tables(moved_user)
     moved_user.organization_id.should eq nil
@@ -143,6 +146,7 @@ describe CartoDB::DataMover::ExportJob do
     CartoDB::DataMover::ImportJob.new(file: @tmp_path + "org_#{org.id}.json", mode: :import, host: '127.0.0.2').run!
 
     moved_user = ::User.find(username: user.username)
+    moved_user.reload
     moved_user.database_host.should eq '127.0.0.2'
     Carto::GhostTablesManager.new(moved_user.id).link_ghost_tables_synchronously
     check_tables(moved_user)
@@ -172,6 +176,7 @@ describe CartoDB::DataMover::ExportJob do
     CartoDB::DataMover::ImportJob.new(file: @tmp_path + "org_#{org.id}.json", mode: :import, host: '127.0.0.2').run!
 
     moved_user = ::User.find(username: user.username)
+    moved_user.reload
     moved_user.database_host.should eq '127.0.0.2'
     Carto::GhostTablesManager.new(moved_user.id).link_ghost_tables_synchronously
     check_tables(moved_user)


### PR DESCRIPTION
This PR makes `ImportJob` class compatible with organization migrations, this feature was broken after adding `update_metadata` method in [PR#7310](https://github.com/CartoDB/cartodb/pull/7310), changes:

- there are 2 new methods in charge of updating specific user or organization metadata
- the generic `update_metadata` method now updates user, organization or both metadata accordingly
- each `ImportJob` instantiation is stored to allow calling `update_metadata` after consistency-checks
- `update_metadata_*` expect a non-referenced `target_dbhost` to support rollback in the future

**IMPORTANT**

-  this PR also enables back again some user-mover tests that were disabled on [PR#7390](https://github.com/CartoDB/cartodb/pull/7390)
- https://github.com/CartoDB/cartodb-platform/pull/1913 must be merged after merging this PR
- make "if not nil" comparison more clear, related: https://github.com/CartoDB/cartodb/pull/7395/commits/1d300e07cc60e55440504b8a054e0d0fb5561e8e

@azamorano @luisbosque please review, thanks!