### PR TITLE
Allow anonymous visualization exports

### DIFF
--- a/app/controllers/carto/api/visualization_exports_controller.rb
+++ b/app/controllers/carto/api/visualization_exports_controller.rb
@@ -8,8 +8,8 @@ module Carto
 
       ssl_required :create, :show
 
-      skip_before_filter :api_authorization_required
-      before_filter :optional_api_authorization
+      skip_before_filter :api_authorization_required, only: [:create, :show]
+      before_filter :optional_api_authorization, only: [:create, :show]
 
       before_filter :load_visualization, only: :create
       before_filter :load_visualization_export, only: :show

--- a/app/models/carto/visualization_export.rb
+++ b/app/models/carto/visualization_export.rb
@@ -70,7 +70,7 @@ module Carto
     end
 
     def visualization_exportable_by_user?
-      errors.add(:user, 'Must be accessible by the user') unless visualization.is_accesible_by_user?(user)
+      errors.add(:user, 'Must be viewable by the user') unless visualization.is_viewable_by_user?(user)
     end
 
     def user_tables_ids_valid?

--- a/db/migrate/20160516103200_drop_visualization_exports_user_id_null_constraint.rb
+++ b/db/migrate/20160516103200_drop_visualization_exports_user_id_null_constraint.rb
@@ -1,0 +1,13 @@
+Sequel.migration do
+  up do
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE visualization_exports alter column user_id drop not null;
+    })
+  end
+
+  down do
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE visualization_exports alter column user_id set not null;
+    })
+  end
+end

--- a/db/migrate/20160516103200_drop_visualization_exports_user_id_null_constraint.rb
+++ b/db/migrate/20160516103200_drop_visualization_exports_user_id_null_constraint.rb
@@ -6,8 +6,11 @@ Sequel.migration do
   end
 
   down do
-    Rails::Sequel.connection.run(%{
-      ALTER TABLE visualization_exports alter column user_id set not null;
-    })
+    # This is the symmetric action, but it's not safe (there could be null `user_id`s)
+    # and it's not needed for `up` to be safe (`up` code is idempotent).
+    #
+    # Rails::Sequel.connection.run(%{
+    #   ALTER TABLE visualization_exports alter column user_id set not null;
+    # })
   end
 end

--- a/spec/factories/users_helper.rb
+++ b/spec/factories/users_helper.rb
@@ -9,6 +9,7 @@ shared_context 'users helper' do
     @user1 = FactoryGirl.create(:valid_user, private_tables_enabled: true)
     @carto_user1 = Carto::User.find(@user1.id)
     @user2 = FactoryGirl.create(:valid_user, private_tables_enabled: true)
+    @carto_user2 = Carto::User.find(@user2.id)
   end
 
   before(:each) do

--- a/spec/models/carto/visualization_export_spec.rb
+++ b/spec/models/carto/visualization_export_spec.rb
@@ -36,7 +36,7 @@ end
 
 describe Carto::VisualizationExport do
   include Carto::ExporterConfig
-  include_context 'user helper'
+  include_context 'users helper'
   include Carto::Factories::Visualizations
 
   class FakeCartoHttpClientFileToucher
@@ -70,14 +70,14 @@ describe Carto::VisualizationExport do
 
   describe '#export' do
     it 'exports a .carto file including the carto.json and the files' do
-      table1 = FactoryGirl.create(:private_user_table, user: @carto_user)
-      table2 = FactoryGirl.create(:private_user_table, user: @carto_user)
+      table1 = FactoryGirl.create(:private_user_table, user: @carto_user1)
+      table2 = FactoryGirl.create(:private_user_table, user: @carto_user1)
 
       layer1 = FactoryGirl.create(:carto_layer, options: { table_name: table1.name })
       layer2 = FactoryGirl.create(:carto_layer, options: { table_name: table2.name })
 
-      map = FactoryGirl.create(:carto_map, layers: [layer1, layer2], user: @carto_user)
-      map, table, table_visualization, visualization = create_full_visualization(@carto_user,
+      map = FactoryGirl.create(:carto_map, layers: [layer1, layer2], user: @carto_user1)
+      map, table, table_visualization, visualization = create_full_visualization(@carto_user1,
                                                                                  map: map,
                                                                                  table: table1,
                                                                                  data_layer: layer1)
@@ -86,7 +86,7 @@ describe Carto::VisualizationExport do
 
       exported_file = Carto::VisualizationExport.new.export(
         visualization,
-        @carto_user,
+        @carto_user1,
         base_dir: base_dir,
         data_exporter: Carto::DataExporter.new(fake_carto_http_client_toucher))
 
@@ -104,15 +104,13 @@ describe Carto::VisualizationExport do
       destroy_full_visualization(map, table, table_visualization, visualization)
     end
 
-    it 'excludes layers and user_tables with user_tables_ids parameter' do
-      table1 = FactoryGirl.create(:private_user_table, user: @carto_user)
-      table2 = FactoryGirl.create(:private_user_table, user: @carto_user)
+    it 'excludes data not accessible by the user' do
+      table1 = FactoryGirl.create(:private_user_table, user: @carto_user1)
 
       layer1 = FactoryGirl.create(:carto_layer, options: { table_name: table1.name })
-      layer2 = FactoryGirl.create(:carto_layer, options: { table_name: table2.name })
 
-      map = FactoryGirl.create(:carto_map, layers: [layer1, layer2], user: @carto_user)
-      map, table, table_visualization, visualization = create_full_visualization(@carto_user,
+      map = FactoryGirl.create(:carto_map, layers: [layer1], user: @carto_user1)
+      map, table, table_visualization, visualization = create_full_visualization(@carto_user1,
                                                                                  map: map,
                                                                                  table: table1,
                                                                                  data_layer: layer1)
@@ -121,7 +119,40 @@ describe Carto::VisualizationExport do
 
       exported_file = Carto::VisualizationExport.new.export(
         visualization,
-        @carto_user,
+        @carto_user2,
+        base_dir: base_dir,
+        data_exporter: Carto::DataExporter.new(fake_carto_http_client_toucher))
+
+      touched_files = fake_carto_http_client_toucher.touched_files
+      CartoDB::Importer2::Unp.new.open(exported_file) do |files|
+        files.length.should eq 1 # visualization export
+        names = files.map(&:path)
+        names.count { |f| f =~ /\.carto\.json$/ }.should eq 1
+      end
+
+      ([exported_file] + touched_files).map { |f| File.delete(f) if File.exists?(f) }
+
+      destroy_full_visualization(map, table, table_visualization, visualization)
+    end
+
+    it 'excludes layers and user_tables with user_tables_ids parameter' do
+      table1 = FactoryGirl.create(:private_user_table, user: @carto_user1)
+      table2 = FactoryGirl.create(:private_user_table, user: @carto_user1)
+
+      layer1 = FactoryGirl.create(:carto_layer, options: { table_name: table1.name })
+      layer2 = FactoryGirl.create(:carto_layer, options: { table_name: table2.name })
+
+      map = FactoryGirl.create(:carto_map, layers: [layer1, layer2], user: @carto_user1)
+      map, table, table_visualization, visualization = create_full_visualization(@carto_user1,
+                                                                                 map: map,
+                                                                                 table: table1,
+                                                                                 data_layer: layer1)
+
+      fake_carto_http_client_toucher = FakeCartoHttpClientFileToucher.new
+
+      exported_file = Carto::VisualizationExport.new.export(
+        visualization,
+        @carto_user1,
         user_tables_ids: [table1.id],
         base_dir: base_dir,
         data_exporter: Carto::DataExporter.new(fake_carto_http_client_toucher))
@@ -142,9 +173,26 @@ describe Carto::VisualizationExport do
   end
 
   describe '#run_export!' do
+    # run_export! is called from the job, but the core of the logic is in `#export`, this makes sure its usage
+    it 'calls #export' do
+      visualization = FactoryGirl.create(:carto_visualization, user: @carto_user1)
+      ve = FactoryGirl.create(:visualization_export, user: @carto_user1, visualization: visualization)
+
+      fake_path = "/tmp/fakepath"
+      touch(fake_path)
+      ve.expects(:export).returns(fake_path)
+      file_upload_helper_mock = mock
+      file_upload_helper_mock.expects(:upload_file_to_storage)
+
+      ve.run_export!(file_upload_helper: file_upload_helper_mock)
+
+      visualization.destroy
+      File.delete(fake_path) if File.exists?(fake_path)
+    end
+
     describe 'with S3' do
       before(:each) do
-        @visualization = FactoryGirl.create(:carto_visualization, user: @carto_user)
+        @visualization = FactoryGirl.create(:carto_visualization, user: @carto_user1)
       end
 
       after(:each) do
@@ -155,7 +203,7 @@ describe Carto::VisualizationExport do
       let(:fake_path) { "#{test_dir}/fake_export.carto" }
 
       it 'runs export creating a log trace' do
-        ve = Carto::VisualizationExport.new(visualization: @visualization, user: @carto_user)
+        ve = Carto::VisualizationExport.new(visualization: @visualization, user: @carto_user1)
 
         FileUtils.mkdir_p test_dir
         FileUtils.touch(fake_path).first


### PR DESCRIPTION
This closes #7315.

@gfiorav CR this, please. In addition, I think that this migration is 100% safe and can be run within the PR, don't you agree?