### PR TITLE
7368 missing sql embed backwards compatibility

### DIFF
--- a/app/models/layer/presenter.rb
+++ b/app/models/layer/presenter.rb
@@ -197,12 +197,17 @@ module CartoDB
           decorate_with_data(layer.options, @decoration_data)
         else
           data = {
-            sql:                wrap(sql_from(layer.options), layer.options),
             layer_name:         name_for(layer),
             cartocss:           css_from(layer.options),
             cartocss_version:   layer.options.fetch('style_version'),
             interactivity:      layer.options.fetch('interactivity')
           }
+          source = layer.options['source']
+          if options[:for_named_map] && source
+            data[:source] = { id: source }
+          else
+            data[:sql] = wrap(sql_from(layer.options), layer.options)
+          end
 
           data = decorate_with_data(data, @decoration_data)
 

--- a/app/models/layer/presenter.rb
+++ b/app/models/layer/presenter.rb
@@ -203,12 +203,9 @@ module CartoDB
             interactivity:      layer.options.fetch('interactivity')
           }
           source = layer.options['source']
-          if source
-            data[:source] = { id: source }
-            data.delete(:sql)
-          else
-            data[:sql] = wrap(sql_from(layer.options), layer.options)
-          end
+          data[:source] = { id: source } if source
+          data[:sql] = wrap(sql_from(layer.options), layer.options)
+
           data = decorate_with_data(data, @decoration_data)
 
           viewer = options[:viewer_user]

--- a/app/models/layer/presenter.rb
+++ b/app/models/layer/presenter.rb
@@ -197,14 +197,12 @@ module CartoDB
           decorate_with_data(layer.options, @decoration_data)
         else
           data = {
+            sql:                wrap(sql_from(layer.options), layer.options),
             layer_name:         name_for(layer),
             cartocss:           css_from(layer.options),
             cartocss_version:   layer.options.fetch('style_version'),
             interactivity:      layer.options.fetch('interactivity')
           }
-          source = layer.options['source']
-          data[:source] = { id: source } if source
-          data[:sql] = wrap(sql_from(layer.options), layer.options)
 
           data = decorate_with_data(data, @decoration_data)
 

--- a/app/models/visualization/vizjson.rb
+++ b/app/models/visualization/vizjson.rb
@@ -221,7 +221,8 @@ module CartoDB
           full: true,
           visualization_id: visualization.id,
           https_request: false,
-          attributions: visualization.attributions_from_derived_visualizations
+          attributions: visualization.attributions_from_derived_visualizations,
+          for_named_map: false
         }
       end
 

--- a/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
+++ b/services/named-maps-api-wrapper/lib/named-maps-wrapper/named_map.rb
@@ -125,7 +125,8 @@ module CartoDB
           presenter_options = {
             full: false,
             user_name: parent.username,
-            viewer_user: ::User.where(username: parent.username).first
+            viewer_user: ::User.where(username: parent.username).first,
+            for_named_map: true
           }
 
           # Layers are zero-based on the client

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -188,8 +188,8 @@ describe Carto::Api::VizJSON3Presenter do
       v2_vizjson = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata).send :calculate_vizjson
       v3_vizjson = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user).send :calculate_vizjson
 
-      v2_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should be_nil
-      v2_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should eq(id: source)
+      v2_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should eq query
+      v2_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should be_nil
       v3_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should be_nil
       v3_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should eq source
     end

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -172,11 +172,14 @@ describe Carto::Api::VizJSON3Presenter do
       layer.save
 
       # INFO: send :calculate_vizjson won't use cache
-      v2_vizjson = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata).send :calculate_vizjson
-      v3_vizjson = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user).send :calculate_vizjson
+      v2_vizjson = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata).send(:calculate_vizjson)
+      nm_vizjson = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata).send(:calculate_vizjson, for_named_map: true)
+      v3_vizjson = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user).send(:calculate_vizjson)
 
       v2_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should eq query
       v2_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should be_nil
+      nm_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should eq query
+      nm_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should be_nil
       v3_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should eq query
       v3_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should be_nil
 
@@ -185,11 +188,14 @@ describe Carto::Api::VizJSON3Presenter do
       layer.save
       @visualization.reload
 
-      v2_vizjson = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata).send :calculate_vizjson
-      v3_vizjson = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user).send :calculate_vizjson
+      v2_vizjson = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata).send(:calculate_vizjson)
+      nm_vizjson = Carto::Api::VizJSONPresenter.new(@visualization, $tables_metadata).send(:calculate_vizjson, for_named_map: true)
+      v3_vizjson = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user).send(:calculate_vizjson)
 
       v2_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should eq query
       v2_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should be_nil
+      nm_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should be_nil
+      nm_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should eq(id: source)
       v3_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:sql].should be_nil
       v3_vizjson[:layers][1][:options][:layer_definition][:layers][0][:options][:source].should eq source
     end


### PR DESCRIPTION
Fixes #7368 

Instead of trying to add the `query` when using the old embed with analyses, this modified the old embed to use named maps when showing a visualization with analyses.