### PR TITLE
Pass element ID instead of the DOM element itself

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -25,8 +25,8 @@ module.exports = cdb.core.View.extend({
       throw new Error('collection option is required');
     }
 
-    if (!opts.triggerElement) {
-      throw new Error('triggerElement option is required');
+    if (!opts.triggerElementID) {
+      throw new Error('triggerElementID option is required');
     }
 
     this.options = _.extend({}, this.options, opts);
@@ -49,7 +49,8 @@ module.exports = cdb.core.View.extend({
 
   _onDocumentElementClicked: function (e) {
     var clickedElement = e.target;
-    if (this.options.triggerElement === clickedElement || $.contains(this.options.triggerElement, clickedElement)) {
+    var triggerElement = $('#' + this.options.triggerElementID)[0];
+    if (triggerElement === clickedElement || $.contains(triggerElement, clickedElement)) {
       this.toggle();
     } else {
       this.hide();

--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -37,8 +37,8 @@ module.exports = cdb.core.View.extend({
 
     this._initBinds();
 
-    $(document).bind('keydown', this._onEscapePressed.bind(this));
-    $(document).bind('click', this._onDocumentElementClicked.bind(this));
+    $(document).bind('keydown', $.proxy(this._onEscapePressed, this));
+    $(document).bind('click', $.proxy(this._onDocumentElementClicked, this));
   },
 
   _onEscapePressed: function (ev) {
@@ -57,9 +57,11 @@ module.exports = cdb.core.View.extend({
     }
   },
 
-  remove: function () {
-    $(document).unbind('keydown', this._onEscapePressed.bind(this));
-    $(document).unbind('click', this._onDocumentElementClicked.bind(this));
+  clean: function () {
+    $(document).unbind('keydown', this._onEscapePressed);
+    $(document).unbind('click', this._onDocumentElementClicked);
+
+    cdb.core.View.prototype.clean.apply(this);
   },
 
   _initBinds: function () {

--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -20,6 +20,8 @@ module.exports = cdb.core.View.extend({
   tagName: 'div',
 
   initialize: function (opts) {
+    _.bindAll(this, '_onEscapePressed', '_onDocumentElementClicked');
+
     opts = opts || {};
     if (!opts.collection) {
       throw new Error('collection option is required');
@@ -37,8 +39,8 @@ module.exports = cdb.core.View.extend({
 
     this._initBinds();
 
-    $(document).bind('keydown', $.proxy(this._onEscapePressed, this));
-    $(document).bind('click', $.proxy(this._onDocumentElementClicked, this));
+    $(document).bind('keydown', this._onEscapePressed);
+    $(document).bind('click', this._onDocumentElementClicked);
   },
 
   _onEscapePressed: function (ev) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
@@ -146,9 +146,11 @@ module.exports = cdb.core.View.extend({
       }
     ]);
 
+    var triggerElementID = 'context-menu-trigger-' + this.model.cid;
+    this.$el.find('.js-show-menu').attr('id', triggerElementID);
     var menuView = new ContextMenuView({
       collection: menuItems,
-      triggerElement: this.$el.find('.js-show-menu')[0],
+      triggerElementID: triggerElementID,
       offset: { top: '47px', right: '12px' }
     });
 

--- a/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
@@ -2,6 +2,12 @@ var $ = require('jquery');
 var CustomListCollection = require('../../../../../javascripts/cartodb3/components/custom-list/custom-list-collection');
 var ContextMenuView = require('../../../../../javascripts/cartodb3/components/context-menu/context-menu-view');
 
+var simulateEscapeKeyPress = function () {
+  var e = $.Event('keydown');
+  e.keyCode = e.which = $.ui.keyCode.ESCAPE;
+  $(document).trigger(e);
+};
+
 describe('components/context-menu/context-menu-view', function () {
   beforeEach(function () {
     this.collection = new CustomListCollection([
@@ -64,12 +70,23 @@ describe('components/context-menu/context-menu-view', function () {
     expect(this.view.$el.css('display')).toEqual('none');
   });
 
-  it('should be hidden when clicking on the docuemnt', function () {
+  it('should be hidden when clicking on the document', function () {
     this.triggerElement.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
 
     $('body').click();
+    spyOn(this.view, '_onDocumentElementClicked');
+
+    expect(this.view.$el.css('display')).toEqual('none');
+  });
+
+  it('should be hidden when hitting ESCAPE', function () {
+    this.triggerElement.click();
+
+    expect(this.view.$el.css('display')).toEqual('block');
+
+    simulateEscapeKeyPress();
 
     expect(this.view.$el.css('display')).toEqual('none');
   });
@@ -102,5 +119,37 @@ describe('components/context-menu/context-menu-view', function () {
     expect(this.view.$el.css('bottom')).toEqual('2px');
     expect(this.view.$el.css('left')).toEqual('3px');
     expect(this.view.$el.css('wadus')).toBeUndefined();
+  });
+
+  describe('.clean', function () {
+    it('should unbind document clicks', function () {
+      spyOn(this.view, 'hide');
+
+      $('body').click();
+
+      expect(this.view.hide).toHaveBeenCalled();
+      this.view.hide.calls.reset();
+
+      this.view.clean();
+
+      $('body').click();
+
+      expect(this.view.hide).not.toHaveBeenCalled();
+    });
+
+    it('should unbind ESC key', function () {
+      spyOn(this.view, 'hide');
+
+      simulateEscapeKeyPress();
+
+      expect(this.view.hide).toHaveBeenCalled();
+      this.view.hide.calls.reset();
+
+      this.view.clean();
+
+      simulateEscapeKeyPress();
+
+      expect(this.view.hide).not.toHaveBeenCalled();
+    });
   });
 });

--- a/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
@@ -14,14 +14,14 @@ describe('components/context-menu/context-menu-view', function () {
       }
     ]);
 
-    this.triggerElement = $('<div></div>');
+    this.triggerElement = $('<div id="something"></div>');
     this.button = $('<button class="js-show-menu"></button>');
     this.triggerElement.append(this.button);
     $('body').append(this.triggerElement);
 
     this.view = new ContextMenuView({
       collection: this.collection,
-      triggerElement: this.triggerElement[0]
+      triggerElementID: this.triggerElement[0].id
     });
 
     this.view.render();
@@ -91,7 +91,7 @@ describe('components/context-menu/context-menu-view', function () {
   it('should apply the given offset', function () {
     this.view = new ContextMenuView({
       collection: this.collection,
-      triggerElement: this.triggerElement[0],
+      triggerElementID: this.triggerElement[0].id,
       offset: { top: '0px', right: '1px', bottom: '2px', left: '3px', wadus: 'wadus' }
     });
 


### PR DESCRIPTION
This PR changes the ContextMenu component so that is uses DOM ids instead of references to DOM elements, as suggested [in this comment](https://github.com/CartoDB/cartodb/pull/7420/files#r63733560).

@viddo better?

cc: @javisantana 