### PR TITLE
[Metrics] Adds 'Exported map' events

### DIFF
--- a/app/controllers/carto/api/visualization_exports_controller.rb
+++ b/app/controllers/carto/api/visualization_exports_controller.rb
@@ -77,10 +77,13 @@ module Carto
                               }
           Cartodb::EventTracker.new.send_event(user, 'Exported map', custom_properties)
         rescue => e
-          Rollbar.report_message('EventTracker: segment event tracking error', 'error', { user_id: user_id, 
-                                                                                          event: 'Exported map',
-                                                                                          properties: custom_properties, 
-                                                                                          error_message: e.inspect })
+          Rollbar.report_message('EventTracker: segment event tracking error', 
+                                 'error', 
+                                 { user_id: user_id, 
+                                   event: 'Exported map',
+                                   properties: custom_properties, 
+                                   error_message: e.inspect
+                                 })
         end
       end
     end

--- a/app/controllers/carto/api/visualization_exports_controller.rb
+++ b/app/controllers/carto/api/visualization_exports_controller.rb
@@ -44,7 +44,7 @@ module Carto
 
         Resque.enqueue(Resque::ExporterJobs, job_id: visualization_export.id)
 
-        Cartodb::EventTracker.new.track_exported_map(user, @visualization)
+        Cartodb::EventTracker.new.track_exported_map(current_user, @visualization)
 
         render_jsonp(VisualizationExportPresenter.new(visualization_export).to_poro, 201)
       end

--- a/app/controllers/carto/api/visualization_exports_controller.rb
+++ b/app/controllers/carto/api/visualization_exports_controller.rb
@@ -44,9 +44,9 @@ module Carto
 
         Resque.enqueue(Resque::ExporterJobs, job_id: visualization_export.id)
 
+	Cartodb::EventTracker.new.track_exported_map(user, @visualization)
+
         render_jsonp(VisualizationExportPresenter.new(visualization_export).to_poro, 201)
- 
-        track_export_event(user, @visualization)
       end
 
       def show
@@ -67,24 +67,6 @@ module Carto
         raise Carto::LoadError.new("Visualization export not found: #{id}") unless @visualization_export
         export_user_id = @visualization_export.user_id
         raise Carto::UnauthorizedError.new unless export_user_id.nil? || export_user_id == current_user.id
-      end
-
-      def track_export_event(user, vis)
-        begin
-          custom_properties = { privacy: vis.privacy,
-                                type: vis.type,
-                                vis_id: vis.id
-                              }
-          Cartodb::EventTracker.new.send_event(user, 'Exported map', custom_properties)
-        rescue => e
-          Rollbar.report_message('EventTracker: segment event tracking error', 
-                                 'error', 
-                                 { user_id: user_id, 
-                                   event: 'Exported map',
-                                   properties: custom_properties, 
-                                   error_message: e.inspect
-                                 })
-        end
       end
     end
   end

--- a/app/controllers/carto/api/visualization_exports_controller.rb
+++ b/app/controllers/carto/api/visualization_exports_controller.rb
@@ -44,7 +44,7 @@ module Carto
 
         Resque.enqueue(Resque::ExporterJobs, job_id: visualization_export.id)
 
-	Cartodb::EventTracker.new.track_exported_map(user, @visualization)
+        Cartodb::EventTracker.new.track_exported_map(user, @visualization)
 
         render_jsonp(VisualizationExportPresenter.new(visualization_export).to_poro, 201)
       end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -314,8 +314,7 @@ class DataImport < Sequel::Model
     end
     notify(results)
 
-    Cartodb::EventTracker.new.track_import(current_user, self.id, results, self.visualization_id, 
-                                           self.from_common_data?)
+    Cartodb::EventTracker.new.track_import(current_user, id, results, visualization_id, from_common_data?)
 
     self
   end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -941,30 +941,4 @@ class DataImport < Sequel::Model
       datasource.set_audit_to_failed
     end
   end
-
-  def track_new_datasets(results)
-    return unless current_user
-
-    # Generate an event for every new imported dataset
-    results.each do |result|
-        if result.success?
-          if result.name != nil
-            map = UserTable.where(data_import_id: self.id, name: result.name).first
-            origin = self.from_common_data? ? 'common-data' : 'import'
-          else
-            map = UserTable.where(data_import_id: self.id).first
-            origin = 'copy'
-          end
-          vis = Carto::Visualization.where(map_id: map.map_id).first
-          custom_properties = { privacy: vis.privacy, type: vis.type,  vis_id: vis.id, origin: origin }
-          Cartodb::EventTracker.new.send_event(current_user, 'Created dataset', custom_properties)
-        end
-    end
-
-    unless self.visualization_id.nil?
-      vis = Carto::Visualization.where(id: self.visualization_id).first
-      custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id, origin: 'import' }
-      Cartodb::EventTracker.new.send_event(current_user, 'Created map', custom_properties)
-    end
-  end
 end

--- a/lib/cartodb/event_tracker.rb
+++ b/lib/cartodb/event_tracker.rb
@@ -2,12 +2,12 @@ module Cartodb
   class EventTracker
 
     def track_exported_map(user, vis)
-      unless vis.nil?
+      if !vis.nil?
         custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id }
         send_event(user, 'Exported map', custom_properties)
       else
         report_error('Exported map', user, type: 'Null visualization')
-      end      
+      end
     end
 
     def track_import(user, import_id, results, visualization_id, from_common_data)
@@ -15,7 +15,7 @@ module Cartodb
       results.each do |result|
         begin
           if result.success?
-            if result.name != nil
+            if !result.name.nil?
               map = UserTable.where(data_import_id: import_id, name: result.name).first
               origin = from_common_data ? 'common-data' : 'import'
             else
@@ -23,7 +23,7 @@ module Cartodb
               origin = 'copy'
             end
             vis = Carto::Visualization.where(map_id: map.map_id).first
-            custom_properties = { privacy: vis.privacy, type: vis.type,  vis_id: vis.id, origin: origin }
+            custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id, origin: origin }
             send_event(user, 'Created dataset', custom_properties)
           end
         rescue => e
@@ -34,9 +34,9 @@ module Cartodb
       # Generate an event if a map is imported as well
       begin
         if visualization_id
-           vis = Carto::Visualization.where(id: visualization_id).first
-           custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id, origin: 'import' }
-           send_event(user, 'Created map', custom_properties)
+          vis = Carto::Visualization.where(id: visualization_id).first
+          custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id, origin: 'import' }
+          send_event(user, 'Created map', custom_properties)
         end
       rescue => e
         report_error('Created map', user, type: 'Invalid import result', error: e.inspect)
@@ -58,7 +58,7 @@ module Cartodb
 
     def generate_event_properties(user)
       {
-        username:  user.username,
+        username: user.username,
         email: user.email,
         plan: user.account_type,
         organization: user.organization_user? ? user.organization.name : nil,
@@ -82,7 +82,7 @@ module Cartodb
 
     def report_error(event, user, type: 'Unknown', properties: {}, error: nil)
       Rollbar.log('error',
-                  "EventTracker: #{type} error",    
+                  "EventTracker: #{type} error",
                   user_id: user.nil? ? nil : user.id,
                   event: event,
                   properties: properties,

--- a/lib/cartodb/event_tracker.rb
+++ b/lib/cartodb/event_tracker.rb
@@ -1,5 +1,46 @@
 module Cartodb
   class EventTracker
+
+    def track_exported_map(user, vis)
+      unless vis.nil?
+        custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id }
+        send_event(user, 'Exported map', custom_properties)
+      else
+        report_error('Exported map', user, type: 'Null visualization')
+      end      
+    end
+
+    def track_import(user, import_id, results, visualization_id, from_common_data)
+      # Generate an event for every new imported dataset
+      results.each do |result|
+        begin
+          if result.success?
+            if result.name != nil
+              map = UserTable.where(data_import_id: import_id, name: result.name).first
+              origin = from_common_data ? 'common-data' : 'import'
+            else
+              map = UserTable.where(data_import_id: import_id).first
+              origin = 'copy'
+            end
+            vis = Carto::Visualization.where(map_id: map.map_id).first
+            custom_properties = { privacy: vis.privacy, type: vis.type,  vis_id: vis.id, origin: origin }
+            send_event(user, 'Created dataset', custom_properties)
+          end
+        rescue => e
+          report_error('Created dataset', user, type: 'Invalid import result', error: e.inspect)
+        end
+      end
+
+      # Generate an event if a map is imported as well
+      begin
+        vis = Carto::Visualization.where(id: visualization_id).first
+        custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id, origin: 'import' }
+        send_event(user, 'Created map', custom_properties)
+      rescue => e
+        report_error('Created map', user, type: 'Invalid import result', error: e.inspect)
+      end
+    end
+
     def send_event(user, event_name, custom_properties = {})
       return unless is_tracking_active?
       return unless user_valid?(user, event_name, custom_properties)
@@ -30,14 +71,21 @@ module Cartodb
 
     def user_valid?(user, event_name, custom_properties)
       if user.nil?
-        Rollbar.report_message('EventTracker: null user error', 'Error', { event: event_name,
-                                                                           custom_properties: custom_properties,
-                                                                           error_message: 'Provided user is null'})
+        report_error(event_name, user, type: 'Null user', properties: custom_properties)
         false
       else
         true
       end
     end
 
+    def report_error(event, user, type: 'Unknown', properties: {}, error: nil)
+      Rollbar.log('error',
+                  "EventTracker: #{type} error",    
+                  user_id: user.nil? ? nil : user.id,
+                  event: event,
+                  properties: properties,
+                  error_message: error
+                 )
+    end
   end
 end

--- a/lib/cartodb/event_tracker.rb
+++ b/lib/cartodb/event_tracker.rb
@@ -33,9 +33,11 @@ module Cartodb
 
       # Generate an event if a map is imported as well
       begin
-        vis = Carto::Visualization.where(id: visualization_id).first
-        custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id, origin: 'import' }
-        send_event(user, 'Created map', custom_properties)
+        if visualization_id
+           vis = Carto::Visualization.where(id: visualization_id).first
+           custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id, origin: 'import' }
+           send_event(user, 'Created map', custom_properties)
+        end
       rescue => e
         report_error('Created map', user, type: 'Invalid import result', error: e.inspect)
       end

--- a/lib/cartodb/event_tracker.rb
+++ b/lib/cartodb/event_tracker.rb
@@ -12,23 +12,23 @@ module Cartodb
 
     def track_import(user, import_id, results, visualization_id, from_common_data)
       # Generate an event for every new imported dataset
-      results.each do |result|
-        begin
+      begin
+        results.each do |result|
           if result.success?
             if !result.name.nil?
-              map = UserTable.where(data_import_id: import_id, name: result.name).first
+              user_table = UserTable.where(data_import_id: import_id, name: result.name).first
               origin = from_common_data ? 'common-data' : 'import'
             else
-              map = UserTable.where(data_import_id: import_id).first
+              user_table = UserTable.where(data_import_id: import_id).first
               origin = 'copy'
             end
-            vis = Carto::Visualization.where(map_id: map.map_id).first
+            vis = Carto::Visualization.where(map_id: user_table.map_id).first
             custom_properties = { privacy: vis.privacy, type: vis.type, vis_id: vis.id, origin: origin }
             send_event(user, 'Created dataset', custom_properties)
           end
-        rescue => e
-          report_error('Created dataset', user, type: 'Invalid import result', error: e.inspect)
         end
+      rescue => e
+        report_error('Created dataset', user, type: 'Invalid import result', error: e.inspect)
       end
 
       # Generate an event if a map is imported as well


### PR DESCRIPTION
Closes: #7434 

Adds:
 - launches new 'Exported map' event when map is exported by user (app/controllers/carto/api/visualization_exports_controller.rb)
 - launches new  'Created map' event when user imports a file with both datasets and map (app/models/data_import.rb)

Modifies:
- Encapsulates event generation functionality with exception catching (inside specific private function) (in app/models/data_import.rb) So, in case of any event-related error, app execution wouldn't be affected.

CR @juanignaciosl, @xavijam, please 