### PR TITLE
Add --quote-all-identifiers option to pg_dump during user export

### DIFF
--- a/services/user-mover/export_user.rb
+++ b/services/user-mover/export_user.rb
@@ -53,7 +53,7 @@ module CartoDB
           @database_host,
           CartoDB::DataMover::Config[:user_dbport],
           @database_name
-        )} -f #{@path}#{@database_schema}.schema.sql -n #{@database_schema} --verbose --no-tablespaces -Z 0")
+        )} -f #{@path}#{@database_schema}.schema.sql -n #{@database_schema} --verbose --no-tablespaces --quote-all-identifiers -Z 0")
       end
     end
   end


### PR DESCRIPTION
This is a workaround for a (currently on the moderation queue) bug in Postgres 9.5's pg_dump which does not treat "over" as a reserved keyword while dumping a 9.3 database.