### PR TITLE
Fix opacity selection

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var cdb = require('cartodb.js');
 require('bootstrap-colorpicker');
 var template = require('./template.tpl');
@@ -14,17 +15,20 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
-    var rgba = this._hexToRGB(this.model.get('hex'));
-    this.$el.append(template({
+    var rgb = this._hexToRGB(this.model.get('hex'));
+
+    var color = _.extend(rgb, {
       hex: this.model.get('hex'),
-      r: rgba.r,
-      g: rgba.g,
-      b: rgba.b,
       opacity: this.model.get('opacity')
-    }));
+    });
+
+    this.$el.append(template(color));
+
+    var rgbaTemplate = _.template('rgba(<%- r %>, <%- g %>, <%- b %>, <%- opacity %>)');
 
     this.$('.js-colorPicker').colorpicker({
-      color: this.model.get('hex'),
+      color: rgbaTemplate(color),
+      format: 'rgba',
       container: true,
       horizontal: true,
       inline: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.88",
+  "version": "3.23.89",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.89",
+  "version": "3.23.90",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The opacity of the `rgba` color that the user selected in the fill component is not reflected on the UI.

This PR fixes the issue passing a RGBA color (that is, a color with the opacity value) to the colorpicker component instead of a regular RGB.