### PR TITLE
Fix HUE color selection area of the colorpicker

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
@@ -37,8 +37,8 @@ module.exports = cdb.core.View.extend({
                   '</div>',
       slidersHorz: {
         saturation: {
-          maxLeft: 218,
-          maxTop: 105,
+          maxLeft: 206,
+          maxTop: 95,
           callLeft: 'setSaturation',
           callTop: 'setBrightness'
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.88",
+  "version": "3.23.90",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes the area of the HUE component, so the color selector won't fall out of bounds.

Closes #7453 

![screen shot 2016-05-23 at 11 35 10](https://cloud.githubusercontent.com/assets/4933/15466533/6b94b2e2-20da-11e6-935e-441474e20a98.png)
![screen shot 2016-05-23 at 11 35 00](https://cloud.githubusercontent.com/assets/4933/15466532/6b9302bc-20da-11e6-8752-f849a6b4f7a4.png)
