### PR TITLE
Problems related with context-menu cleaning fixed

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -22,9 +22,9 @@ module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     opts = opts || {};
     if (!opts.collection) throw new Error('collection option is required');
-    if (!opts.triggerElementID) throw new Error('element id is required');
+    if (!opts.targetElement) throw new Error('targetElement is required');
 
-    this._triggerElementID = opts.triggerElementID;
+    this._targetElement = opts.targetElement;
 
     this.model = new cdb.core.Model({
       visible: false
@@ -86,7 +86,7 @@ module.exports = cdb.core.View.extend({
 
   _onDocumentElementClicked: function (ev) {
     var $el = $(ev.target);
-    if ($el.closest(this.$el).length === 0 && $el.attr('id') !== this._triggerElementID) {
+    if ($el.closest(this.$el).length === 0 && (ev.target !== this._targetElement)) {
       this.hide();
     }
   },

--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -22,9 +22,9 @@ module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     opts = opts || {};
     if (!opts.collection) throw new Error('collection option is required');
-    if (!opts.targetElement) throw new Error('targetElement is required');
+    if (!opts.triggerElementID) throw new Error('element id is required');
 
-    this._targetElement = opts.targetElement;
+    this._triggerElementID = opts.triggerElementID;
 
     this.model = new cdb.core.Model({
       visible: false
@@ -86,7 +86,7 @@ module.exports = cdb.core.View.extend({
 
   _onDocumentElementClicked: function (ev) {
     var $el = $(ev.target);
-    if ($el.closest(this.$el).length === 0 && (ev.target !== this._targetElement)) {
+    if ($el.closest(this.$el).length === 0 && $el.attr('id') !== this._triggerElementID) {
       this.hide();
     }
   },

--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -86,7 +86,7 @@ module.exports = cdb.core.View.extend({
 
   _onDocumentElementClicked: function (ev) {
     var $el = $(ev.target);
-    if ($el.closest(this.$el).length === 0 && $el.attr('id') !== this._triggerElementID) {
+    if ($el.closest(this.$el).length === 0 && $el.closest($('#' + this._triggerElementID)).length === 0) {
       this.hide();
     }
   },

--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -20,55 +20,43 @@ module.exports = cdb.core.View.extend({
   tagName: 'div',
 
   initialize: function (opts) {
-    _.bindAll(this, '_onEscapePressed', '_onDocumentElementClicked');
-
     opts = opts || {};
-    if (!opts.collection) {
-      throw new Error('collection option is required');
-    }
+    if (!opts.collection) throw new Error('collection option is required');
+    if (!opts.triggerElementID) throw new Error('element id is required');
 
-    if (!opts.triggerElementID) {
-      throw new Error('triggerElementID option is required');
-    }
-
-    this.options = _.extend({}, this.options, opts);
+    this._triggerElementID = opts.triggerElementID;
 
     this.model = new cdb.core.Model({
       visible: false
     });
 
+    this._onEscapePressed = this._onEscapePressed.bind(this);
+    this._onDocumentElementClicked = this._onDocumentElementClicked.bind(this);
+
     this._initBinds();
-
-    $(document).bind('keydown', this._onEscapePressed);
-    $(document).bind('click', this._onDocumentElementClicked);
-  },
-
-  _onEscapePressed: function (ev) {
-    if (ev.which === $.ui.keyCode.ESCAPE) {
-      this.hide();
-    }
-  },
-
-  _onDocumentElementClicked: function (e) {
-    var clickedElement = e.target;
-    var triggerElement = $('#' + this.options.triggerElementID)[0];
-    if (triggerElement === clickedElement || $.contains(triggerElement, clickedElement)) {
-      this.toggle();
-    } else {
-      this.hide();
-    }
-  },
-
-  clean: function () {
-    $(document).unbind('keydown', this._onEscapePressed);
-    $(document).unbind('click', this._onDocumentElementClicked);
-
-    cdb.core.View.prototype.clean.apply(this);
   },
 
   _initBinds: function () {
-    this.model.on('change:visible', this.render, this);
+    this.model.on('change:visible', function (mdl, isVisible) {
+      this.render();
+      if (isVisible) {
+        this._initDocumentBinds();
+      } else {
+        this._destroyDocumentBinds();
+      }
+    }, this);
     this.collection.on('change:selected', this.hide, this);
+    this.add_related_model(this.collection);
+  },
+
+  _initDocumentBinds: function () {
+    $(document).on('keydown', this._onEscapePressed);
+    $(document).on('click', this._onDocumentElementClicked);
+  },
+
+  _destroyDocumentBinds: function () {
+    $(document).off('keydown', this._onEscapePressed);
+    $(document).off('click', this._onDocumentElementClicked);
   },
 
   render: function () {
@@ -88,6 +76,19 @@ module.exports = cdb.core.View.extend({
     this.$el.toggle(this.isVisible());
 
     return this;
+  },
+
+  _onEscapePressed: function (ev) {
+    if (ev.which === $.ui.keyCode.ESCAPE) {
+      this.hide();
+    }
+  },
+
+  _onDocumentElementClicked: function (ev) {
+    var $el = $(ev.target);
+    if ($el.closest(this.$el).length === 0 && $el.attr('id') !== this._triggerElementID) {
+      this.hide();
+    }
   },
 
   _renderList: function () {
@@ -116,5 +117,10 @@ module.exports = cdb.core.View.extend({
 
   isVisible: function () {
     return this.model.get('visible');
+  },
+
+  clean: function () {
+    this._destroyDocumentBinds();
+    cdb.core.View.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/editor-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/editor-view.js
@@ -99,6 +99,9 @@ module.exports = cdb.core.View.extend({
       title: this._visDefinitionModel.get('name')
     });
 
+    this.$el.append(header.render().$el);
+    this.addView(header);
+
     var tabPaneOptions = {
       tabPaneOptions: {
         template: EditorTabPaneTemplate,
@@ -116,8 +119,8 @@ module.exports = cdb.core.View.extend({
     this._mapTabPaneView = createTextLabelsTabPane(tabPaneTabs, tabPaneOptions);
     this._mapTabPaneView.collection.bind('change:selected', this._updateAddButtonState, this);
 
-    this.$el.append(header.render().$el);
     this.$el.append(this._mapTabPaneView.render().$el);
+    this.addView(this._mapTabPaneView);
 
     this._updateAddButtonState();
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
@@ -21,6 +21,7 @@ module.exports = cdb.core.View.extend({
 
   events: {
     'click .js-add-analysis': '_onAddAnalysisClick',
+    'click .js-show-menu': '_onOpenContextMenu',
     'click .js-title': '_onEditLayer'
   },
 
@@ -121,6 +122,10 @@ module.exports = cdb.core.View.extend({
     this._stackLayoutModel.nextStep(this.model, 'layers', selectedNode);
   },
 
+  _onOpenContextMenu: function () {
+    this._menuView.toggle();
+  },
+
   _onDestroy: function () {
     this.clean();
   },
@@ -147,8 +152,8 @@ module.exports = cdb.core.View.extend({
     ]);
 
     var triggerElementID = 'context-menu-trigger-' + this.model.cid;
-    this.$el.find('.js-show-menu').attr('id', triggerElementID);
-    var menuView = new ContextMenuView({
+    this.$('.js-show-menu').attr('id', triggerElementID);
+    this._menuView = new ContextMenuView({
       collection: menuItems,
       triggerElementID: triggerElementID,
       offset: { top: '47px', right: '12px' }
@@ -160,8 +165,8 @@ module.exports = cdb.core.View.extend({
       }
     }, this);
 
-    this.$el.append(menuView.render().el);
-    this.addView(menuView);
+    this.$el.append(this._menuView.render().el);
+    this.addView(this._menuView);
   },
 
   clean: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
@@ -151,11 +151,9 @@ module.exports = cdb.core.View.extend({
       }
     ]);
 
-    var triggerElementID = 'context-menu-trigger-' + this.model.cid;
-    this.$('.js-show-menu').attr('id', triggerElementID);
     this._menuView = new ContextMenuView({
       collection: menuItems,
-      triggerElementID: triggerElementID,
+      targetElement: this.$('.js-show-menu').get(0),
       offset: { top: '47px', right: '12px' }
     });
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
@@ -151,9 +151,11 @@ module.exports = cdb.core.View.extend({
       }
     ]);
 
+    var triggerElementID = 'context-menu-trigger-' + this.model.cid;
+    this.$('.js-show-menu').attr('id', triggerElementID);
     this._menuView = new ContextMenuView({
       collection: menuItems,
-      targetElement: this.$('.js-show-menu').get(0),
+      triggerElementID: triggerElementID,
       offset: { top: '47px', right: '12px' }
     });
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
@@ -34,6 +34,7 @@ module.exports = cdb.core.View.extend({
     this._layerAnalysisViewFactory = new LayerAnalysisViewFactory(opts.analysisDefinitionNodesCollection, opts.analysis);
 
     this.listenTo(this._layerDefinitionsCollection, 'add', this.render);
+    this.add_related_model(this._layerDefinitionsCollection);
   },
 
   render: function () {
@@ -48,7 +49,8 @@ module.exports = cdb.core.View.extend({
 
   _addLayerView: function (m) {
     var view;
-    if (m.get('order') === 0) {
+
+    if (m.get('type') === 'Tiled') {
       view = new BasemapLayerView({
         model: m
       });

--- a/lib/assets/javascripts/cartodb3/editor/map/map-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/map/map-view.js
@@ -82,6 +82,7 @@ module.exports = cdb.core.View.extend({
     });
 
     this.$el.append(stackLayoutView.render().$el);
+    this.addView(stackLayoutView);
     return this;
   }
 });

--- a/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
@@ -126,12 +126,12 @@ describe('components/context-menu/context-menu-view', function () {
     expect(this.view.$el.css('wadus')).toBeUndefined();
   });
 
-  describe('binds on unvisible', function () {
+  describe('document binds when item is not visible', function () {
     beforeEach(function () {
       spyOn(this.view, 'hide');
     });
 
-    it('should not bind outside click', function () {
+    it('should not check outside click', function () {
       $('body').click();
       expect(this.view.hide).not.toHaveBeenCalled();
       this.$button.click();
@@ -139,7 +139,7 @@ describe('components/context-menu/context-menu-view', function () {
       expect(this.view.hide).toHaveBeenCalled();
     });
 
-    it('should not bind ESC keypress', function () {
+    it('should not check ESC keypress', function () {
       simulateEscapeKeyPress();
       expect(this.view.hide).not.toHaveBeenCalled();
       this.$button.click();

--- a/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
@@ -22,16 +22,19 @@ describe('components/context-menu/context-menu-view', function () {
       }
     ]);
 
-    this.$button = $('<button class="js-show-menu" id="something"></button>');
+    this.triggerElement = $('<div id="something"></div>');
+    this.button = $('<button class="js-show-menu"></button>');
+    this.triggerElement.append(this.button);
 
-    $('body').append(this.$button);
+    $('body').append(this.triggerElement);
 
     this.view = new ContextMenuView({
       collection: this.collection,
-      triggerElementID: this.$button.attr('id')
+      triggerElementID: this.triggerElement[0].id
     });
 
-    this.$button.on('click', function () {
+    this.triggerElement.on('click', function (ev) {
+      console.log("paco", ev.target);
       self.view.toggle();
     });
 
@@ -42,7 +45,7 @@ describe('components/context-menu/context-menu-view', function () {
   });
 
   afterEach(function () {
-    this.$button.remove();
+    this.triggerElement.remove();
     this.view.clean();
   });
 
@@ -51,20 +54,33 @@ describe('components/context-menu/context-menu-view', function () {
     expect(this.view.$el.find('button[title="Label 2"]')).toBeDefined();
   });
 
-  it('should be toggled when clicking on the button', function () {
+  it('should be toggled when clicking on the triggerElement', function () {
     expect(this.view.$el.css('display')).toEqual('none');
 
-    this.$button.click();
+    this.triggerElement.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
 
-    this.$button.click();
+    this.triggerElement.click();
+
+    expect(this.view.$el.css('display')).toEqual('none');
+  });
+
+  it('should be toggled when clicking on an element inside of the triggerElement', function () {
+    expect(this.view.$el.css('display')).toEqual('none');
+
+    this.button.click();
+
+    console.log(this.view.isVisible());
+    expect(this.view.$el.css('display')).toEqual('block');
+
+    this.button.click();
 
     expect(this.view.$el.css('display')).toEqual('none');
   });
 
   it('should be hidden when clicking on the document', function () {
-    this.$button.click();
+    this.triggerElement.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
 
@@ -75,7 +91,7 @@ describe('components/context-menu/context-menu-view', function () {
   });
 
   it('should be hidden when hitting ESCAPE', function () {
-    this.$button.click();
+    this.triggerElement.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
 
@@ -85,7 +101,7 @@ describe('components/context-menu/context-menu-view', function () {
   });
 
   it('should be hidden when clicking on one of the items', function () {
-    this.$button.click();
+    this.triggerElement.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
     expect(this.collection.at(0).get('selected')).toBe(false);
@@ -101,7 +117,7 @@ describe('components/context-menu/context-menu-view', function () {
   it('should apply the given offset', function () {
     this.view = new ContextMenuView({
       collection: this.collection,
-      triggerElementID: this.$button.attr('id'),
+      triggerElementID: this.triggerElement.attr('id'),
       offset: { top: '0px', right: '1px', bottom: '2px', left: '3px', wadus: 'wadus' }
     });
 

--- a/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
@@ -28,7 +28,7 @@ describe('components/context-menu/context-menu-view', function () {
 
     this.view = new ContextMenuView({
       collection: this.collection,
-      targetElement: this.$button.get(0)
+      triggerElementID: this.$button.attr('id')
     });
 
     this.$button.on('click', function () {
@@ -101,7 +101,7 @@ describe('components/context-menu/context-menu-view', function () {
   it('should apply the given offset', function () {
     this.view = new ContextMenuView({
       collection: this.collection,
-      targetElement: this.$button[0],
+      triggerElementID: this.$button.attr('id'),
       offset: { top: '0px', right: '1px', bottom: '2px', left: '3px', wadus: 'wadus' }
     });
 

--- a/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
@@ -10,6 +10,8 @@ var simulateEscapeKeyPress = function () {
 
 describe('components/context-menu/context-menu-view', function () {
   beforeEach(function () {
+    var self = this;
+
     this.collection = new CustomListCollection([
       {
         label: 'Label 1',
@@ -20,14 +22,17 @@ describe('components/context-menu/context-menu-view', function () {
       }
     ]);
 
-    this.triggerElement = $('<div id="something"></div>');
-    this.button = $('<button class="js-show-menu"></button>');
-    this.triggerElement.append(this.button);
-    $('body').append(this.triggerElement);
+    this.$button = $('<button class="js-show-menu" id="something"></button>');
+
+    $('body').append(this.$button);
 
     this.view = new ContextMenuView({
       collection: this.collection,
-      triggerElementID: this.triggerElement[0].id
+      triggerElementID: this.$button[0].id
+    });
+
+    this.$button.on('click', function () {
+      self.view.toggle();
     });
 
     this.view.render();
@@ -37,7 +42,7 @@ describe('components/context-menu/context-menu-view', function () {
   });
 
   afterEach(function () {
-    this.triggerElement.remove();
+    this.$button.remove();
     this.view.clean();
   });
 
@@ -46,32 +51,32 @@ describe('components/context-menu/context-menu-view', function () {
     expect(this.view.$el.find('button[title="Label 2"]')).toBeDefined();
   });
 
-  it('should be toggled when clicking on the triggerElement', function () {
+  it('should be toggled when clicking on the button', function () {
     expect(this.view.$el.css('display')).toEqual('none');
 
-    this.triggerElement.click();
+    this.$button.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
 
-    this.triggerElement.click();
+    this.$button.click();
 
     expect(this.view.$el.css('display')).toEqual('none');
   });
 
-  it('should be toggled when clicking on an element inside of the triggerElement', function () {
+  it('should be toggled when clicking on an element inside of the button', function () {
     expect(this.view.$el.css('display')).toEqual('none');
 
-    this.button.click();
+    this.$button.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
 
-    this.button.click();
+    this.$button.click();
 
     expect(this.view.$el.css('display')).toEqual('none');
   });
 
   it('should be hidden when clicking on the document', function () {
-    this.triggerElement.click();
+    this.$button.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
 
@@ -82,7 +87,7 @@ describe('components/context-menu/context-menu-view', function () {
   });
 
   it('should be hidden when hitting ESCAPE', function () {
-    this.triggerElement.click();
+    this.$button.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
 
@@ -92,7 +97,7 @@ describe('components/context-menu/context-menu-view', function () {
   });
 
   it('should be hidden when clicking on one of the items', function () {
-    this.triggerElement.click();
+    this.$button.click();
 
     expect(this.view.$el.css('display')).toEqual('block');
     expect(this.collection.at(0).get('selected')).toBe(false);
@@ -108,7 +113,7 @@ describe('components/context-menu/context-menu-view', function () {
   it('should apply the given offset', function () {
     this.view = new ContextMenuView({
       collection: this.collection,
-      triggerElementID: this.triggerElement[0].id,
+      triggerElementID: this.$button[0].id,
       offset: { top: '0px', right: '1px', bottom: '2px', left: '3px', wadus: 'wadus' }
     });
 
@@ -121,7 +126,33 @@ describe('components/context-menu/context-menu-view', function () {
     expect(this.view.$el.css('wadus')).toBeUndefined();
   });
 
+  describe('binds on unvisible', function () {
+    beforeEach(function () {
+      spyOn(this.view, 'hide');
+    });
+
+    it('should not bind outside click', function () {
+      $('body').click();
+      expect(this.view.hide).not.toHaveBeenCalled();
+      this.$button.click();
+      $('body').click();
+      expect(this.view.hide).toHaveBeenCalled();
+    });
+
+    it('should not bind ESC keypress', function () {
+      simulateEscapeKeyPress();
+      expect(this.view.hide).not.toHaveBeenCalled();
+      this.$button.click();
+      simulateEscapeKeyPress();
+      expect(this.view.hide).toHaveBeenCalled();
+    });
+  });
+
   describe('.clean', function () {
+    beforeEach(function () {
+      this.$button.click();
+    });
+
     it('should unbind document clicks', function () {
       spyOn(this.view, 'hide');
 

--- a/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
@@ -34,7 +34,6 @@ describe('components/context-menu/context-menu-view', function () {
     });
 
     this.triggerElement.on('click', function (ev) {
-      console.log("paco", ev.target);
       self.view.toggle();
     });
 
@@ -71,7 +70,6 @@ describe('components/context-menu/context-menu-view', function () {
 
     this.button.click();
 
-    console.log(this.view.isVisible());
     expect(this.view.$el.css('display')).toEqual('block');
 
     this.button.click();

--- a/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/context-menu/context-menu-view.spec.js
@@ -28,7 +28,7 @@ describe('components/context-menu/context-menu-view', function () {
 
     this.view = new ContextMenuView({
       collection: this.collection,
-      triggerElementID: this.$button[0].id
+      targetElement: this.$button.get(0)
     });
 
     this.$button.on('click', function () {
@@ -52,18 +52,6 @@ describe('components/context-menu/context-menu-view', function () {
   });
 
   it('should be toggled when clicking on the button', function () {
-    expect(this.view.$el.css('display')).toEqual('none');
-
-    this.$button.click();
-
-    expect(this.view.$el.css('display')).toEqual('block');
-
-    this.$button.click();
-
-    expect(this.view.$el.css('display')).toEqual('none');
-  });
-
-  it('should be toggled when clicking on an element inside of the button', function () {
     expect(this.view.$el.css('display')).toEqual('none');
 
     this.$button.click();
@@ -113,7 +101,7 @@ describe('components/context-menu/context-menu-view', function () {
   it('should apply the given offset', function () {
     this.view = new ContextMenuView({
       collection: this.collection,
-      triggerElementID: this.$button[0].id,
+      targetElement: this.$button[0],
       offset: { top: '0px', right: '1px', bottom: '2px', left: '3px', wadus: 'wadus' }
     });
 
@@ -126,31 +114,27 @@ describe('components/context-menu/context-menu-view', function () {
     expect(this.view.$el.css('wadus')).toBeUndefined();
   });
 
-  describe('document binds when item is not visible', function () {
-    beforeEach(function () {
-      spyOn(this.view, 'hide');
-    });
+  it('should not try to hide the context menu when clicking somewhere else', function () {
+    spyOn(this.view, 'hide');
+    $('body').click();
+    expect(this.view.hide).not.toHaveBeenCalled();
+    this.view.show();
+    $('body').click();
+    expect(this.view.hide).toHaveBeenCalled();
+  });
 
-    it('should not check outside click', function () {
-      $('body').click();
-      expect(this.view.hide).not.toHaveBeenCalled();
-      this.$button.click();
-      $('body').click();
-      expect(this.view.hide).toHaveBeenCalled();
-    });
-
-    it('should not check ESC keypress', function () {
-      simulateEscapeKeyPress();
-      expect(this.view.hide).not.toHaveBeenCalled();
-      this.$button.click();
-      simulateEscapeKeyPress();
-      expect(this.view.hide).toHaveBeenCalled();
-    });
+  it('should not try to hide the context menu when ESC key is pressed', function () {
+    spyOn(this.view, 'hide');
+    simulateEscapeKeyPress();
+    expect(this.view.hide).not.toHaveBeenCalled();
+    this.view.show();
+    simulateEscapeKeyPress();
+    expect(this.view.hide).toHaveBeenCalled();
   });
 
   describe('.clean', function () {
     beforeEach(function () {
-      this.$button.click();
+      this.view.show();
     });
 
     it('should unbind document clicks', function () {

--- a/lib/assets/test/spec/cartodb3/editor/editor-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/editor-view.spec.js
@@ -1,4 +1,5 @@
 var cdb = require('cartodb.js');
+var _ = require('underscore');
 var Backbone = require('backbone');
 var LayerDefinitionModel = require('../../../../javascripts/cartodb3/data/layer-definition-model');
 var EditorView = require('../../../../javascripts/cartodb3/editor/editor-view');
@@ -42,6 +43,10 @@ describe('editor/editor-view', function () {
 
   it('should render correctly', function () {
     expect(this.view.$el.text()).toContain('editor.button_add');
+  });
+
+  it('should have two subviews', function () {
+    expect(_.size(this.view._subviews)).toBe(2);
   });
 
   describe('add button', function () {

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-view.spec.js
@@ -43,6 +43,12 @@ describe('editor/layers/layer-view', function () {
     expect(this.view.$el.text()).toContain('thename');
   });
 
+  it('should open context-menu box when option is clicked', function () {
+    spyOn(this.view._menuView, 'toggle');
+    this.view.$('.js-show-menu').click();
+    expect(this.view._menuView.toggle).toHaveBeenCalled();
+  });
+
   it('should render analysis views', function () {
     expect(this.view.$el.text()).toContain('ANALYSES');
 

--- a/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/map/map-view.spec.js
@@ -1,4 +1,5 @@
 var cdb = require('cartodb.js');
+var _ = require('underscore');
 var Backbone = require('backbone');
 var LayerDefinitionModel = require('../../../../../javascripts/cartodb3/data/layer-definition-model');
 var EditorMapView = require('../../../../../javascripts/cartodb3/editor/map/map-view');
@@ -31,6 +32,10 @@ describe('editor/map/map-view', function () {
 
   it('should have no leaks', function () {
     expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should have one subview', function () {
+    expect(_.size(this.view._subviews)).toBe(1);
   });
 
   it('should render correctly', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.88",
+  "version": "3.23.89",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #7457.

So, from my point of view, only external views should open the context-menu, not the proper view.
And also, document binds should not be enabled until the view is visible.
What do you think mate?

CR: @alonsogarciapablo 