### PR TITLE
Adds missing headers for buckets and quantification methods

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/column-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/column-list-view.js
@@ -1,8 +1,17 @@
 var cdb = require('cartodb.js');
 var CustomListView = require('../../../custom-list/custom-view');
 var CustomListCollection = require('../../../custom-list/custom-list-collection');
+var template = require('./column-list-view.tpl');
 
 module.exports = cdb.core.View.extend({
+  defaults: {
+    headerTitle: ''
+  },
+
+  events: {
+    'click .js-back': '_onClickBack'
+  },
+
   initialize: function (opts) {
     if (!opts.stackLayoutModel) throw new Error('stackLayoutModel is required');
     if (!opts.columns) throw new Error('columns param is required');
@@ -24,8 +33,18 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
-    this.$el.append(this._listView.render().$el);
+    this.$el.append(template({
+      headerTitle: this.options.headerTitle
+    }));
+
+    this.$('.js-content').append(this._listView.render().$el);
+
     return this;
+  },
+
+  _onClickBack: function (e) {
+    this.killEvent(e);
+    this.trigger('back', this);
   },
 
   _initBinds: function () {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/column-list-view.tpl
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/column-list-view.tpl
@@ -1,0 +1,13 @@
+<% if (headerTitle) { %>
+<div class="CDB-Box-modalHeader">
+  <ul class="CDB-Box-modalHeaderItem CDB-Box-modalHeaderItem--block CDB-Box-modalHeaderItem--paddingHorizontal">
+    <li class="CDB-ListDecoration-item CDB-ListDecoration-itemPadding--vertical CDB-Text CDB-Size-medium u-secondaryTextColor">
+      <button class="u-rSpace--xl u-actionTextColor js-back">
+        <i class="CDB-IconFont CDB-IconFont-arrowPrev Size-large"></i>
+      </button>
+      <%- headerTitle%>
+    </li>
+  </ul>
+</div>
+<% } %>
+<div class="js-content"></div>

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
@@ -114,6 +114,7 @@ module.exports = cdb.core.View.extend({
 
   _createBinsListView: function (stackLayoutModel, opts) {
     var view = new ColumnListView({
+      headerTitle: _t('form-components.editors.fill.bins'),
       stackLayoutModel: stackLayoutModel,
       columns: BINS
     });
@@ -123,11 +124,16 @@ module.exports = cdb.core.View.extend({
       stackLayoutModel.goToStep(1);
     }, this);
 
+    view.bind('back', function (value) {
+      stackLayoutModel.goToStep(1);
+    }, this);
+
     return view;
   },
 
   _createQuantificationListView: function (stackLayoutModel, opts) {
     var view = new ColumnListView({
+      headerTitle: _t('form-components.editors.fill.quantification'),
       stackLayoutModel: stackLayoutModel,
       columns: QUANTIFICATION_METHODS
     });
@@ -135,6 +141,10 @@ module.exports = cdb.core.View.extend({
     view.bind('selectItem', function (value) {
       this.model.set('quantification', value);
       stackLayoutModel.prevStep();
+    }, this);
+
+    view.bind('back', function (value) {
+      stackLayoutModel.goToStep(1);
     }, this);
 
     return view;

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
@@ -74,6 +74,7 @@ module.exports = cdb.core.View.extend({
     }, {
       createStackView: function (stackLayoutModel, opts) {
         var view = new ColumnListView({
+          headerTitle: _t('form-components.editors.fill.quantification'),
           stackLayoutModel: stackLayoutModel,
           columns: QUANTIFICATION_METHODS,
           showSearch: false
@@ -81,6 +82,10 @@ module.exports = cdb.core.View.extend({
 
         view.bind('selectItem', function (value) {
           self.model.set('quantification', value);
+          stackLayoutModel.prevStep();
+        }, self);
+
+        view.bind('back', function (value) {
           stackLayoutModel.prevStep();
         }, self);
 

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -9,6 +9,8 @@
   "form-components": {
     "editors": {
       "fill": {
+        "quantification": 'Quantification',
+        "bins": 'Buckets',
         "input-color": {
           "solid": "Solid",
           "value": "By value"

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -9,8 +9,8 @@
   "form-components": {
     "editors": {
       "fill": {
-        "quantification": 'Quantification',
-        "bins": 'Buckets',
+        "quantification": "Quantification",
+        "bins": "Buckets",
         "input-color": {
           "solid": "Solid",
           "value": "By value"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.89",
+  "version": "3.23.91",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.91",
+  "version": "3.23.92",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds missing headers to go back from the buckets and quantification panes of the Fill component:

![screen shot 2016-05-23 at 12 37 29](https://cloud.githubusercontent.com/assets/4933/15468195/1e63539e-20e3-11e6-8132-2b9c5bfddd00.png)
![screen shot 2016-05-23 at 12 37 23](https://cloud.githubusercontent.com/assets/4933/15468196/1e898afa-20e3-11e6-873d-47cad81151b0.png)

Closes #7456 