### PR TITLE
Disable twitter imports for free accounts

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1014,6 +1014,8 @@ class User < Sequel::Model
   end
 
   def remaining_twitter_quota
+    # HOTFIX block remaining quota for free users
+    return 0 if self.account_type == 'FREE'
     if organization.present?
       remaining = organization.remaining_twitter_quota
     else


### PR DESCRIPTION
@ethervoid @iriberri  please review

About this: it is basically used in 2 particular places:
- in the decorator to inform user/ui about feature avail. https://github.com/CartoDB/cartodb/blob/4c141afc4f5617115901170c805c7c7499b88598/app/controllers/api/json/imports_controller.rb#L160-L167
- in the twitter datasource itself: https://github.com/CartoDB/cartodb/blob/4c141afc4f5617115901170c805c7c7499b88598/services/datasources/lib/datasources/search/twitter.rb#L129