### PR TITLE
Add layer style issues

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/add-layer-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/add-layer-model.js
@@ -218,6 +218,8 @@ module.exports = cdb.core.Model.extend({
         tile_style: camshaftReference.getDefaultCartoCSSForType(),
         cartocss: camshaftReference.getDefaultCartoCSSForType(),
         style_version: '2.1.1',
+        tooltip: {},
+        infowindow: {},
         visible: true
       }
     };

--- a/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
@@ -41,14 +41,14 @@ module.exports = cdb.core.Model.extend({
       attrs.sql = r.options.query;
     }
 
-    if (r.infowindow) {
+    if (r.options.table_name) {
       if (!this.infowindowModel) {
         this.infowindowModel = new InfowindowDefinitionModel(r.infowindow, {
           configModel: opts.configModel || this._configModel
         });
       }
     }
-    if (r.tooltip) {
+    if (r.options.table_name) {
       if (!this.tooltip) {
         this.tooltipModel = new InfowindowDefinitionModel(r.tooltip, {
           configModel: opts.configModel || this._configModel
@@ -108,11 +108,13 @@ module.exports = cdb.core.Model.extend({
       options: options
     };
 
-    if (this.infowindowModel) {
+    var infowindowData = this.infowindowModel && this.infowindowModel.toJSON();
+    if (!_.isEmpty(infowindowData)) {
       d.infowindow = this.infowindowModel.toJSON();
     }
 
-    if (this.tooltipModel) {
+    var tooltipData = this.tooltipModel && this.tooltipModel.toJSON();
+    if (!_.isEmpty(tooltipData)) {
       d.tooltip = this.tooltipModel.toJSON();
     }
 

--- a/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
@@ -41,15 +41,15 @@ module.exports = cdb.core.Model.extend({
       attrs.sql = r.options.query;
     }
 
-    if (r.options.table_name) {
+    if (r.infowindow) {
       if (!this.infowindowModel) {
         this.infowindowModel = new InfowindowDefinitionModel(r.infowindow, {
           configModel: opts.configModel || this._configModel
         });
       }
     }
-    if (r.options.table_name) {
-      if (!this.tooltip) {
+    if (r.tooltip) {
+      if (!this.tooltipModel) {
         this.tooltipModel = new InfowindowDefinitionModel(r.tooltip, {
           configModel: opts.configModel || this._configModel
         });
@@ -122,9 +122,11 @@ module.exports = cdb.core.Model.extend({
       d.options.style_properties = this.styleModel.toJSON();
     }
 
+    var attributes = _.omit(this.attributes, 'infowindow', 'tooltip');
+
     return _.defaults(
       d,
-      _.pick(this.attributes, OWN_ATTR_NAMES)
+      _.pick(attributes, OWN_ATTR_NAMES)
     );
   },
 

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -128,8 +128,8 @@ module.exports = Backbone.Collection.extend({
   _onSync: function (layerDefModel) {
     // Create analysis definition if there is none yet
     var nodeDefModel = layerDefModel.getAnalysisDefinitionNodeModel();
-    var analysisDefinitionModel = this._analysisDefinitionsCollection.findByNodeId(nodeDefModel.id);
-    if (nodeDefModel && !analysisDefinitionModel) {
+    var analysisDefCollection = this._analysisDefinitionsCollection;
+    if (nodeDefModel && !analysisDefCollection.findByNodeId(nodeDefModel.id)) {
       this._createAnalysisDefinition(nodeDefModel);
     }
   },

--- a/lib/assets/javascripts/cartodb3/editor/style/style-manager.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-manager.js
@@ -27,7 +27,7 @@ StyleManager.prototype = {
 
     function _unbind (layerDef) {
       if (layerDef.styleModel) {
-        layerDef.styleModel.unbind(null, null, this);
+        layerDef.styleModel.unbind('change', _generate(layerDef), this);
       }
     }
 

--- a/lib/assets/javascripts/cartodb3/editor/style/style-manager.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-manager.js
@@ -12,19 +12,34 @@ function StyleManager (layerDefinitionsCollection) {
 StyleManager.prototype = {
   _initBinds: function () {
     var self = this;
-    function _bind () {
-      function _generate (layerDef) {
-        return function () { self.generate(layerDef); };
-      }
-      this.layerDefinitionsCollection.each(function (layerDef) {
-        // base layers don't have styles
-        if (layerDef.styleModel) {
-          layerDef.styleModel.bind('change', _generate(layerDef), self);
-        }
-      });
+
+    function _generate (layerDef) {
+      return function () {
+        self.generate(layerDef);
+      };
     }
-    this.layerDefinitionsCollection.bind('reset', _bind, this);
-    _bind.call(this);
+
+    function _bind (layerDef) {
+      if (layerDef && layerDef.styleModel) {
+        layerDef.styleModel.bind('change', _generate(layerDef), this);
+      }
+    }
+
+    function _unbind (layerDef) {
+      if (layerDef.styleModel) {
+        layerDef.styleModel.unbind(null, null, this);
+      }
+    }
+
+    function _bindAll () {
+      this.layerDefinitionsCollection.each(_bind, this);
+    }
+
+    this.layerDefinitionsCollection.bind('reset', _bindAll, this);
+    this.layerDefinitionsCollection.bind('add', _bind, this);
+    this.layerDefinitionsCollection.bind('remove', _unbind, this);
+
+    _bindAll.call(this);
   },
 
   generate: function (layerDef) {

--- a/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
@@ -241,6 +241,22 @@ describe('data/layer-definition-model', function () {
           }
         });
       });
+
+      it('should not provide infowindow data if model is empty', function () {
+        delete this.model.attributes.infowindow;
+        this.infowindowModel.clear();
+
+        expect(this.model.toJSON()).toEqual({
+          id: 'abc-123',
+          kind: 'carto',
+          options: {
+            type: 'CartoDB',
+            table_name: 'foo_table',
+            source: 'a1',
+            style_properties: jasmine.any(Object)
+          }
+        });
+      });
     });
   });
 

--- a/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
@@ -243,7 +243,6 @@ describe('data/layer-definition-model', function () {
       });
 
       it('should not provide infowindow data if model is empty', function () {
-        delete this.model.attributes.infowindow;
         this.infowindowModel.clear();
 
         expect(this.model.toJSON()).toEqual({

--- a/lib/assets/test/spec/cartodb3/editor/style/style-manager.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-manager.spec.js
@@ -49,14 +49,14 @@ describe('editor/style/style-manager', function () {
   });
 
   describe('track changes', function () {
-    it('it should track style changes', function () {
+    it('should track style changes', function () {
       // remove binding to onChange so the style changes are not sent to cartodb.js layers (which are not created in the test suite)
       this.collection.off('change', this.collection._onChange, this.collection);
       this.layerDefModel.styleModel.set({ fill: { color: { fixed: '#000', opacity: 0.4 } } });
       expect(this.layerDefModel.get('cartocss').indexOf('marker-fill: #000;')).not.toBe(-1);
     });
 
-    it('it should update sql when style changes', function () {
+    it('should update sql when style changes', function () {
       // remove binding to onChange so the style changes are not sent to cartodb.js layers (which are not created in the test suite)
       this.collection.off('change', this.collection._onChange, this.collection);
       this.layerDefModel.styleModel.set({ type: 'hexabins', dummy: 1 });
@@ -64,7 +64,7 @@ describe('editor/style/style-manager', function () {
       expect(this.layerDefModel.get('sql_wrap').indexOf('WITH hgrid')).not.toBe(-1);
     });
 
-    it('it should update layer type when style is animated', function () {
+    it('should update layer type when style is animated', function () {
       // remove binding to onChange so the style changes are not sent to cartodb.js layers (which are not created in the test suite)
       this.collection.off('change', this.collection._onChange, this.collection);
       this.layerDefModel.styleModel.set({ type: 'simple', dummy: 1 });
@@ -89,7 +89,7 @@ describe('editor/style/style-manager', function () {
       expect(this.layerDefModel.get('type')).toBe('torque');
     });
 
-    it('it should track style changes on add', function () {
+    it('should track style changes on add', function () {
       this.collection.add({
         id: 'l-101',
         order: 2,

--- a/lib/assets/test/spec/cartodb3/editor/style/style-manager.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-manager.spec.js
@@ -90,8 +90,25 @@ describe('editor/style/style-manager', function () {
     });
 
     it('it should track style changes on add', function () {
-      // this.layerDefModel._styleModel.set({ fill: { fixed: '#000', opacity: 0.4 } });
-      // expect(this.layerDefModel.get('cartocss')).toBe('#layer {\nmarker-fill: #000;\nmarker-fill-opacity: 0.4;\n}');
+      this.collection.add({
+        id: 'l-101',
+        order: 2,
+        options: {
+          type: 'CartoDB',
+          table_name: 'hey',
+          cartocss: 'after'
+        }
+      });
+      var layerDefModel = this.collection.at(1);
+      layerDefModel.styleModel.set({
+        fill: {
+          color: {
+            fixed: '#000',
+            opacity: 0.4
+          }
+        }
+      });
+      expect(layerDefModel.get('cartocss')).toBe('#layer {\nmarker-fill: #000;\nmarker-fill-opacity: 0.4;\nmarker-allow-overlap: true;\nmarker-line-width: 2;\nmarker-line-color: #FFFFFF;\nmarker-line-opacity: 1;\n}');
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.23.91",
+  "version": "3.23.92",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Three things about this PR:

1. If a new layer is added, infowindow and tooltip layer models are not initialized, because they don't have data about those things. From now on, both models will be created from the beginning, checking that the layer has a table_name, as we do with the style model.
Also, if infowindow models don't have any data, they will not be parsed in the layer-definition-model toJSON. -> CR: @alonsogarciapablo + @matallo

2. And, when a new layer is added, style-manager was not binding new layer changes -> CR: @javisantana.

3. If a layer changes (after saving it) and it doesn't have any source reference, it will not try to create the analysis definition. -> CR: @viddo 