### PR TITLE
Return escaped user/schema in table names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,7 @@ which should be fixed manually.
 * Fix broken syncs after setting sync options to "Never"
 * Fix broken visualizations due to invalid permissions
 * Check layer limits server-side
+* Fixed error duplicating datasets from the dashboard if the owner had hyphens in the name
 * Fix URL generations in some views, to correctly include the subdomain
 * Make `layers.kind` not null. Run `bundle exec rake db:migrate` to update your database
 * Remove unused and broken tool for migration of the visualization table

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -98,7 +98,7 @@ module Carto
     private
 
     def fully_qualified_name
-      "#{user.database_schema}.#{name}"
+      "\"#{user.database_schema}\".#{name}"
     end
 
     def is_owner?(user)

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -767,7 +767,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 3
         body['total_likes'].should eq 0
         body['total_shared'].should eq 2
-        body['visualizations'][0]['table']['name'].should == "#{@org_user_2.database_schema}.#{u2_t_2.name}"
+        body['visualizations'][0]['table']['name'].should == "\"#{@org_user_2.database_schema}\".#{u2_t_2.name}"
 
         post api_v1_visualizations_add_like_url(user_domain: @org_user_1.username, id: u1_t_1_id, api_key: @org_user_1.api_key)
 


### PR DESCRIPTION
Fixes #7466 

The problem was that the table name `user-1.table` was generated without escaping. This solves it from the backend, by automatically escaping the schema name.