### PR TITLE
Op545 test ldap rake task

### DIFF
--- a/app/models/carto/ldap/configuration.rb
+++ b/app/models/carto/ldap/configuration.rb
@@ -45,16 +45,16 @@ class Carto::Ldap::Configuration < ActiveRecord::Base
   attr_readonly :user_id_field
 
   validates :organization, :host, :port, :connection_user, :connection_password, :user_id_field, :username_field,
-  :email_field, :user_object_class, :group_object_class, :presence => true
+            :email_field, :user_object_class, :group_object_class, presence: true
 
-  validates :ca_file, :length => { :minimum => 0, :allow_nil => true }
+  validates :ca_file, length: { minimum: 0, allow_nil: true }
 
-  validates :encryption, :inclusion => { :in => [ ENCRYPTION_SIMPLE_TLS, ENCRYPTION_START_TLS ], :allow_nil => true }
-  validates :ssl_version, :inclusion => { :in => [ ENCRYPTION_SSL_VERSION_TLSV1_1 ], :allow_nil => true }
+  validates :encryption,  inclusion: { in: [ENCRYPTION_SIMPLE_TLS, ENCRYPTION_START_TLS], allow_nil: true }
+  validates :ssl_version, inclusion: { in: [ENCRYPTION_SSL_VERSION_TLSV1_1], allow_nil: true }
   validate :domain_bases_not_empty
 
   def domain_bases_list
-    self.domain_bases.split(DOMAIN_BASES_SEPARATOR)
+    domain_bases.split(DOMAIN_BASES_SEPARATOR) if domain_bases
   end
 
   def domain_bases_list=(list)
@@ -121,8 +121,8 @@ class Carto::Ldap::Configuration < ActiveRecord::Base
   private
 
   def domain_bases_not_empty
-    errors.add(:domain_bases, "No domain bases set") if self.domain_bases.to_s.length == 0
-    errors.add(:domain_bases_list, "Domain bases list empty") if domain_bases_list.length < 1
+    errors.add(:domain_bases, "No domain bases set") unless domain_bases.present?
+    errors.add(:domain_bases_list, "Domain bases list empty") unless domain_bases_list.present?
   end
 
   def search_in_domain_bases(filter)

--- a/lib/tasks/ldap.rake
+++ b/lib/tasks/ldap.rake
@@ -1,40 +1,68 @@
 namespace :cartodb do
   namespace :ldap do
-    desc "Tests an LDAP connection"
-    task :test_ldap_connection, [] => :environment do |t, args|
+    desc "Tests an LDAP connection. Returns a summary of all tests ran, with success status and error messages."
+    task :test_ldap_connection, [:from_database] => :environment do |_t, args|
+      args.with_defaults(from_database: false)
 
-      raise "Missing HOST" if ENV['HOST'].blank?
-      host = ENV['HOST']
+      test_user     = ENV['TEST_USER']
+      test_password = ENV['TEST_PASSWORD']
+      ldap = args.from_database ? Carto::Ldap::Configuration.first : ldap_configuration_from_environment
 
-      raise "Missing PORT" if ENV['PORT'].blank?
-      port = ENV['PORT']
+      # Test configuration
+      config_result = if ldap.valid?
+                        { success: true }
+                      else
+                        { success: false, error: ldap.errors.to_h }
+                      end
 
-      encryption = ENV['ENCRYPTION'].blank? ? nil : ENV['ENCRYPTION']
+      result = { config: config_result }
 
-      ssl_version = ENV['SSL_VERSION'].blank? ? nil : ENV['SSL_VERSION']
-
-      raise "Missing CONNECTION_USER" if ENV['CONNECTION_USER'].blank?
-      connection_user = ENV['CONNECTION_USER']
-
-      raise "Missing CONNECTION_PASSWORD" if ENV['CONNECTION_PASSWORD'].blank?
-      connection_password = ENV['CONNECTION_PASSWORD']
-
-      ldap = Carto::Ldap::Configuration.new({
-          host:                 host,
-          port:                 port,
-          encryption:           encryption,
-          ssl_version:          ssl_version,
-          connection_user:      connection_user,
-          connection_password:  connection_password,
-        })
-
-      result = ldap.test_connection
-
-      if result[:success]
-        puts "OK"
-      else
-        puts "ERROR:\n#{result[:error]}"
+      REQUIRED_FIELDS = [:host, :port, :connection_user, :connection_password].freeze
+      if !config_result[:success] && config_result[:error].keys.any? { |k| REQUIRED_FIELDS.include?(k) }
+        result[:connection] = { success: false, error: 'Configuration not valid' }
       end
+
+      # Test connection
+      result[:connection] = ldap.test_connection unless result[:connection]
+
+      CONNECTION_DEPENDENT_TESTS = [:login, :user_search, :group_search].freeze
+      if result[:connection][:success]
+        result[:connection].delete(:connection)
+        if ldap.domain_bases
+          result[:login] = if ldap.user_id_field && test_user && test_password
+                             if ldap.authenticate(test_user, test_password)
+                               { success: true }
+                             else
+                               { success: false, error: 'Cannot log in with test credentials' }
+                             end
+                           else
+                             { success: false, error: 'Test credentials not provided' }
+                           end
+
+          result[:user_search] = if ldap.user_object_class
+                                   user_count = ldap.users.count
+                                   { success: user_count > 0, count: user_count }
+                                 else
+                                   { success: false, error: 'User class not provided' }
+                                 end
+
+          result[:group_search] = if ldap.group_object_class
+                                    group_count = ldap.groups.count
+                                    { success: group_count > 0, count: group_count }
+                                  else
+                                    { success: false, error: 'Group class not provided' }
+                                  end
+        else
+          CONNECTION_DEPENDENT_TESTS.each do |test|
+            result[test] = { success: false, error: 'Domain bases not provided' }
+          end
+        end
+      else
+        CONNECTION_DEPENDENT_TESTS.each do |test|
+          result[test] = { success: false, error: 'Connection failed' }
+        end
+      end
+      puts JSON.pretty_generate(result)
     end
 
     # INFO: Separate multiple domain names by commas
@@ -103,5 +131,43 @@ namespace :cartodb do
       puts "LDAP configuration created with id: #{ldap.id}"
     end
 
+  end
+
+  private
+
+  def ldap_configuration_from_environment
+    # Mandatory: connection parameters
+    host = ENV['HOST']
+    port = ENV['PORT']
+    ssl_version = ENV['SSL_VERSION'].blank? ? nil : ENV['SSL_VERSION']
+    encryption = ENV['ENCRYPTION'].blank? ? nil : ENV['ENCRYPTION']
+    connection_user = ENV['CONNECTION_USER']
+    connection_password = ENV['CONNECTION_PASSWORD']
+
+    # Optional: for testing auth/searches
+    user_id_field = ENV['USER_ID_FIELD']
+    domain_bases  = ENV['DOMAIN_BASES']
+
+    # Optional: for testing searches
+    username_field     = ENV['USERNAME_FIELD']
+    email_field        = ENV['EMAIL_FIELD']
+    user_object_class  = ENV['USER_OBJECT_CLASS']
+    group_object_class = ENV['GROUP_OBJECT_CLASS']
+
+    Carto::Ldap::Configuration.new(
+      organization:         Carto::Organization.new,
+      host:                 host,
+      port:                 port,
+      encryption:           encryption,
+      ssl_version:          ssl_version,
+      connection_user:      connection_user,
+      connection_password:  connection_password,
+      user_id_field:        user_id_field,
+      username_field:       username_field,
+      email_field:          email_field,
+      domain_bases:         domain_bases,
+      user_object_class:    user_object_class,
+      group_object_class:   group_object_class
+    )
   end
 end

--- a/lib/tasks/ldap.rake
+++ b/lib/tasks/ldap.rake
@@ -67,7 +67,7 @@ namespace :cartodb do
 
     # INFO: Separate multiple domain names by commas
     desc "Creates an LDAP Configuration entry"
-    task :create_ldap_configuration, [] => :environment do |t, args|
+    task :create_ldap_configuration, [] => :environment do |_t, _args|
 
       if ENV['ORGANIZATION_ID'].blank?
         if ENV['ORGANIZATION_NAME'].blank?
@@ -75,9 +75,9 @@ namespace :cartodb do
         else
           organization_id = ::Organization.where(name: ENV['ORGANIZATION_NAME']).first.id
         end
-       else
+      else
         organization_id = ENV['ORGANIZATION_ID']
-       end
+      end
 
       raise "Missing HOST" if ENV['HOST'].blank?
       host = ENV['HOST']
@@ -112,21 +112,21 @@ namespace :cartodb do
       raise "Missing GROUP_OBJECT_CLASS" if ENV['GROUP_OBJECT_CLASS'].blank?
       group_object_class = ENV['GROUP_OBJECT_CLASS']
 
-      ldap = Carto::Ldap::Configuration.create({
-          organization_id:      organization_id,
-          host:                 host,
-          port:                 port,
-          encryption:           encryption,
-          ssl_version:          ssl_version,
-          connection_user:      connection_user,
-          connection_password:  connection_password,
-          user_id_field:        user_id_field,
-          username_field:       username_field,
-          email_field:          email_field,
-          domain_bases_list:    domain_bases,
-          user_object_class:    user_object_class,
-          group_object_class:   group_object_class
-        })
+      ldap = Carto::Ldap::Configuration.create(
+        organization_id:      organization_id,
+        host:                 host,
+        port:                 port,
+        encryption:           encryption,
+        ssl_version:          ssl_version,
+        connection_user:      connection_user,
+        connection_password:  connection_password,
+        user_id_field:        user_id_field,
+        username_field:       username_field,
+        email_field:          email_field,
+        domain_bases_list:    domain_bases,
+        user_object_class:    user_object_class,
+        group_object_class:   group_object_class
+      )
 
       puts "LDAP configuration created with id: #{ldap.id}"
     end

--- a/lib/tasks/ldap.rake
+++ b/lib/tasks/ldap.rake
@@ -131,6 +131,10 @@ namespace :cartodb do
       puts "LDAP configuration created with id: #{ldap.id}"
     end
 
+    desc "Deletes existing LDAP Configuration entries"
+    task :reset_ldap_configuration, [] => :environment do |_t, _args|
+      Carto::Ldap::Configuration.delete_all
+    end
   end
 
   private


### PR DESCRIPTION
- Extracts create/test ldap parameter parsing code to `ldap_configuration_from_environment`
- Improves test ldap task with more checks (searches, login) and returns a JSON for automatic testing
- Adds a small `reset_ldap_configuration` task to reset configuration/disabling LDAP