### PR TITLE
Connect user to aggregation tables

### DIFF
--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -1269,6 +1269,16 @@ namespace :cartodb do
       end
     end
 
+    # usage:
+    #   bundle exec rake cartodb:db:connect_aggregation_fdw_tables[username]
+    desc 'Connect aggregation tables through FDW to user'
+    task :connect_aggregation_fdw_tables, [:username] => [:environment] do |task, args|
+      args.with_defaults(:username => nil)
+      raise 'Not a valid username' if args[:username].blank?
+      user = ::User.find(username: args[:username])
+      user.db_service.connect_to_aggregation_tables
+    end
+
     def update_user_metadata(user)
       begin
         user.save_metadata


### PR DESCRIPTION
This is the first iteration of the [styling available datasets](https://github.com/CartoDB/cartodb/issues/7329).

In this PR I've added the capability to connect admin0 and admin1 tables to the user database using Foreign Data Wrappers. All the needed info comes from the app_config file.

Also I've added one rake task to empower some selected users with this capability

// @rafatower @javisantana 