### PR TITLE
7171 CartoDBfy tables before switching in Sync Tables

### DIFF
--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -202,7 +202,7 @@ module CartoDB
       def import_cleanup(schema_name, table_name)
         qualified_table_name = "\"#{schema_name}\".#{table_name}"
 
-        user.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
+        user.db_service.in_database_direct_connection(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
           # When tables are created using ogr2ogr they are added a ogc_fid or gid primary key
           # In that case:
           #  - If cartodb_id already exists, remove ogc_fid

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -149,6 +149,7 @@ module CartoDB
           WHERE attrelid = '#{qualified_table_name}'::regclass
           AND attname = '#{THE_GEOM}'
           AND a.atttypid = t.oid
+          AND a.attstattarget < 0
           LIMIT 1
         }].first
         return nil unless the_geom_data
@@ -213,6 +214,7 @@ module CartoDB
             WHERE attrelid = '#{qualified_table_name}'::regclass
             AND (a.attname = 'ogc_fid' OR a.attname = 'gid')
             AND a.atttypid = t.oid
+            AND a.attstattarget < 0
             LIMIT 1
           }].first
           aux_cartodb_id_column = aux_cartodb_id_column[:attname] unless aux_cartodb_id_column.nil?

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -103,6 +103,7 @@ module CartoDB
                               exception: exception,
                               user: user,
                               table: table_name)
+        drop(table_name) if exists?(table_name)
         raise exception
       end
 

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -42,6 +42,7 @@ module CartoDB
         puts exception.to_s
         puts exception.backtrace
         puts '=================='
+        raise exception
       end
 
       def overwrite(table_name, result)

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -135,11 +135,12 @@ module CartoDB
         fix_oid(table_name)
       end
 
+      # From Table#get_the_geom_type!, adapted to unregistered tables
+      # returns type to run Table#get_the_geom_type! afterwards again, which
+      # saves the type in table metadata
       def fix_the_geom_type!(schema_name, table_name)
         qualified_table_name = "\"#{schema_name}\".#{table_name}"
 
-        # Partial duplication of Table#set_the_geom_column! to be able to
-        # operate with non-registered tables.
         type = nil
         the_geom_data = user.in_database[%Q{
           SELECT a.attname, t.typname
@@ -196,10 +197,10 @@ module CartoDB
         type
       end
 
+      # From Table#import_cleanup, with column schema checks adapted to unregistered tables
       def import_cleanup(schema_name, table_name)
         qualified_table_name = "\"#{schema_name}\".#{table_name}"
 
-        # From Table#import_cleanup, with column schema checks adapted to unregistered tables
         user.in_database_direct_connection(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
           # When tables are created using ogr2ogr they are added a ogc_fid or gid primary key
           # In that case:

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -202,7 +202,7 @@ module CartoDB
       def import_cleanup(schema_name, table_name)
         qualified_table_name = "\"#{schema_name}\".#{table_name}"
 
-        user.in_database_direct_connection(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
+        user.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
           # When tables are created using ogr2ogr they are added a ogc_fid or gid primary key
           # In that case:
           #  - If cartodb_id already exists, remove ogc_fid

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -211,7 +211,7 @@ module CartoDB
             SELECT a.attname, t.typname
             FROM pg_attribute a, pg_type t
             WHERE attrelid = '#{qualified_table_name}'::regclass
-            AND a.attname = 'ogc_fid' OR a.attname = 'gid'
+            AND (a.attname = 'ogc_fid' OR a.attname = 'gid')
             AND a.atttypid = t.oid
             LIMIT 1
           }].first

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -291,7 +291,7 @@ module CartoDB
 
       def move_to_schema(result, schema=DESTINATION_SCHEMA)
         # The new table to sync is moved to user schema to allow CartoDBfication.
-        # This temporal table should not be registered (check ghost_tables_manager.rb)
+        # This temporary table should not be registered (check ghost_tables_manager.rb)
         return self if schema == result.schema
         database.execute(%Q{
           ALTER TABLE "#{result.schema}"."#{result.table_name}"

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -4,6 +4,8 @@ module CartoDB
   module Synchronization
     class Adapter
       DESTINATION_SCHEMA = 'public'
+      STATEMENT_TIMEOUT = 1.hour * 1000
+      THE_GEOM = 'the_geom'.freeze
 
       attr_accessor :table
 
@@ -27,8 +29,10 @@ module CartoDB
           end
           copy_privileges(user.database_schema, table_name, result.schema, result.table_name)
           index_statements = generate_index_statements(user.database_schema, table_name)
+          move_to_schema(result)
+          geo_type = cartodbfy(result.table_name)
           overwrite(table_name, result)
-          cartodbfy(table_name)
+          setup_table(table_name, geo_type)
           run_index_statements(index_statements)
         end
         self
@@ -42,7 +46,6 @@ module CartoDB
 
       def overwrite(table_name, result)
         return false unless runner.remote_data_updated?
-
         temporary_name = temporary_name_for(result.table_name)
 
         # The relation might (and probably will) already exist in the user public schema
@@ -53,9 +56,9 @@ module CartoDB
         database.transaction do
           rename(table_name, temporary_name) if exists?(table_name)
           drop(temporary_name) if exists?(temporary_name)
-          move_to_schema(result)
           rename(result.table_name, table_name)
         end
+        update_cdb_tablemetadata(table_name)
         fix_oid(table_name)
       rescue => exception
         puts "Sync overwrite ERROR: #{exception.message}: #{exception.backtrace.join}"
@@ -69,6 +72,7 @@ module CartoDB
                               table: table_name,
                               result: result_hash)
         drop(result.table_name) if exists?(result.table_name)
+        raise exception
       end
 
       def fix_oid(table_name)
@@ -79,30 +83,185 @@ module CartoDB
       end
 
       def cartodbfy(table_name)
+        schema_name = user.database_schema
+        qualified_table_name = "\"#{schema_name}\".#{table_name}"
+
+        type = fix_the_geom_type!(schema_name, table_name)
+        import_cleanup(schema_name, table_name)
+
+        user.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_conn|
+          user_conn.run(%Q{
+            SELECT cartodb.CDB_CartodbfyTable('#{schema_name}'::TEXT,'#{qualified_table_name}'::REGCLASS);
+          })
+        end
+
+        update_table_pg_stats(qualified_table_name)
+        return type
+      rescue => exception
+        CartoDB::Logger.error(message: 'Error in sync cartodbfy',
+                              exception: exception,
+                              user: user,
+                              table: table_name)
+        raise exception
+      end
+
+      def update_table_pg_stats(qualified_table_name)
+        user.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_conn|
+          user_conn.run(%Q{
+            ANALYZE #{qualified_table_name};
+          })
+        end
+      end
+
+      def setup_table(table_name, geo_type)
         table = user.tables.where(name: table_name).first.service
 
         table.force_schema = true
 
         table.import_to_cartodb(table_name)
         table.schema(reload: true)
-
-        table.send :set_the_geom_column!
-        table.import_cleanup
-
-        table.send :cartodbfy
-        table.schema(reload: true)
         table.reload
 
-        table.send :update_table_pg_stats
+        # We send the detected geometry type to avoid manipulating geoms twice
+        # set_the_geom_column! should just edit the metadata with the specified type
+        table.send :set_the_geom_column!, geo_type
         table.save
       rescue => exception
-        CartoDB::Logger.error(message: 'Error in sync cartodbfy',
+        CartoDB::Logger.error(message: 'Error in setup cartodbfy',
                               exception: exception,
                               user: user,
                               table: table_name)
       ensure
         fix_oid(table_name)
-        update_cdb_tablemetadata(table_name)
+      end
+
+      def fix_the_geom_type!(schema_name, table_name)
+        qualified_table_name = "\"#{schema_name}\".#{table_name}"
+
+        # Partial duplication of Table#set_the_geom_column! to be able to
+        # operate with non-registered tables.
+        type = nil
+        the_geom_data = user.in_database[%Q{
+          SELECT a.attname, t.typname
+          FROM pg_attribute a, pg_type t
+          WHERE attrelid = '#{qualified_table_name}'::regclass
+          AND attname = '#{THE_GEOM}'
+          AND a.atttypid = t.oid
+          LIMIT 1
+        }].first
+        return nil unless the_geom_data
+
+        if the_geom_data[:typname] != 'geometry'
+          user.in_database.rename_column(qualified_table_name, THE_GEOM, :the_geom_str)
+          return nil
+        end
+
+        geom_type = user.in_database[%Q{
+          SELECT GeometryType(#{THE_GEOM})
+          FROM #{qualified_table_name}
+          WHERE #{THE_GEOM} IS NOT null
+          LIMIT 1
+        }].first
+
+        type = geom_type[:geometrytype].to_s.downcase if geom_type
+
+        # if the geometry is MULTIPOINT we convert it to POINT
+        if type == 'multipoint'
+          user.db_service.in_database_direct_connection(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
+            user_database.run("SELECT public.AddGeometryColumn('#{schema_name}', '#{table_name}','the_geom_simple',4326, 'GEOMETRY', 2);")
+            user_database.run(%Q{UPDATE #{qualified_table_name} SET the_geom_simple = ST_GeometryN(the_geom,1);})
+            user_database.run("SELECT DropGeometryColumn('#{schema_name}', '#{table_name}','the_geom');")
+            user_database.run(%Q{ALTER TABLE #{qualified_table_name} RENAME COLUMN the_geom_simple TO the_geom;})
+          end
+          type = 'point'
+        end
+
+        # if the geometry is LINESTRING or POLYGON we convert it to MULTILINESTRING or MULTIPOLYGON
+        if %w(linestring polygon).include?(type)
+          user.db_service.in_database_direct_connection(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
+            user_database.run("SELECT public.AddGeometryColumn('#{schema_name}', '#{table_name}','the_geom_simple',4326, 'GEOMETRY', 2);")
+            user_database.run(%Q{UPDATE #{qualified_table_name} SET the_geom_simple = ST_Multi(the_geom);})
+            user_database.run("SELECT DropGeometryColumn('#{schema_name}', '#{table_name}','the_geom');")
+            user_database.run(%Q{ALTER TABLE #{qualified_table_name} RENAME COLUMN the_geom_simple TO the_geom;})
+
+            type = user_database[%Q{
+              SELECT GeometryType(#{THE_GEOM})
+              FROM #{qualified_table_name}
+              WHERE #{THE_GEOM} IS NOT null
+              LIMIT 1
+            }].first[:geometrytype]
+          end
+        end
+
+        type
+      end
+
+      def import_cleanup(schema_name, table_name)
+        qualified_table_name = "\"#{schema_name}\".#{table_name}"
+
+        # From Table#import_cleanup, with column schema checks adapted to unregistered tables
+        user.in_database_direct_connection(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
+          # When tables are created using ogr2ogr they are added a ogc_fid or gid primary key
+          # In that case:
+          #  - If cartodb_id already exists, remove ogc_fid
+          #  - If cartodb_id does not exist, treat this field as the auxiliary column
+          aux_cartodb_id_column = user_database[%Q{
+            SELECT a.attname, t.typname
+            FROM pg_attribute a, pg_type t
+            WHERE attrelid = '#{qualified_table_name}'::regclass
+            AND a.attname = 'ogc_fid' OR a.attname = 'gid'
+            AND a.atttypid = t.oid
+            LIMIT 1
+          }].first
+          aux_cartodb_id_column = aux_cartodb_id_column[:attname] unless aux_cartodb_id_column.nil?
+
+          # Remove primary key
+          existing_pk = user_database[%Q{
+            SELECT c.conname AS pk_name
+            FROM pg_class r, pg_constraint c, pg_namespace n
+            WHERE r.oid = c.conrelid AND contype='p' AND relname = '#{table_name}'
+            AND r.relnamespace = n.oid and n.nspname= '#{schema_name}'
+          }].first
+          existing_pk = existing_pk[:pk_name] unless existing_pk.nil?
+          user_database.run(%Q{
+            ALTER TABLE #{qualified_table_name} DROP CONSTRAINT "#{existing_pk}"
+          }) unless existing_pk.nil?
+
+          # All normal fields casted to text
+          varchar_columns = user_database[%Q{
+            SELECT a.attname, t.typname
+            FROM pg_attribute a, pg_type t
+            WHERE attrelid = '#{qualified_table_name}'::regclass
+            AND typname = 'varchar'
+            AND a.atttypid = t.oid
+          }].all
+
+          varchar_columns.each do |column|
+            user_database.run(%Q{ALTER TABLE #{qualified_table_name} ALTER COLUMN "#{column[:attname]}" TYPE text})
+          end
+
+          # If there's an auxiliary column, copy to cartodb_id and restart the sequence to the max(cartodb_id)+1
+          if aux_cartodb_id_column.present?
+            begin
+              already_had_cartodb_id = false
+              user_database.run(%Q{ALTER TABLE #{qualified_table_name} ADD COLUMN cartodb_id SERIAL})
+            rescue
+              already_had_cartodb_id = true
+            end
+            unless already_had_cartodb_id
+              user_database.run(%Q{UPDATE #{qualified_table_name} SET cartodb_id = CAST(#{aux_cartodb_id_column} AS INTEGER)})
+              cartodb_id_sequence_name = user_database["SELECT pg_get_serial_sequence('#{schema_name}.#{table_name}', 'cartodb_id')"].first[:pg_get_serial_sequence]
+              max_cartodb_id = user_database[%Q{SELECT max(cartodb_id) FROM #{qualified_table_name}}].first[:max]
+              # only reset the sequence on real imports.
+
+              if max_cartodb_id
+                user_database.run("ALTER SEQUENCE #{cartodb_id_sequence_name} RESTART WITH #{max_cartodb_id + 1}")
+              end
+            end
+            user_database.run(%Q{ALTER TABLE #{qualified_table_name} DROP COLUMN #{aux_cartodb_id_column}})
+          end
+
+        end
       end
 
       def update_cdb_tablemetadata(name)
@@ -126,6 +285,8 @@ module CartoDB
       end
 
       def move_to_schema(result, schema=DESTINATION_SCHEMA)
+        # The new table to sync is moved to user schema to allow CartoDBfication.
+        # This temporal table should not be registered (check ghost_tables_manager.rb)
         return self if schema == result.schema
         database.execute(%Q{
           ALTER TABLE "#{result.schema}"."#{result.table_name}"

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -233,7 +233,7 @@ module CartoDB
 
       rescue => exception
         CartoDB.notify_exception(exception)
-        log.append exception.message, truncate = false
+        log.append_and_store exception.message, truncate = false
         log.append exception.backtrace.join('\n'), truncate = false
 
         if importer.nil?
@@ -349,7 +349,7 @@ module CartoDB
       end
 
       def set_success_state_from(importer)
-        log.append     '******** synchronization succeeded ********'
+        log.append_and_store     '******** synchronization succeeded ********'
         self.log_trace      = importer.runner_log_trace
         self.state          = STATE_SUCCESS
         self.etag           = importer.etag
@@ -368,7 +368,7 @@ module CartoDB
       end
 
       def set_failure_state_from(importer)
-        log.append     '******** synchronization failed ********'
+        log.append_and_store     '******** synchronization failed ********'
         self.log_trace      = importer.runner_log_trace
         log.append     "*** Runner log: #{self.log_trace} \n***" unless self.log_trace.nil?
         self.state          = STATE_FAILURE
@@ -389,7 +389,7 @@ module CartoDB
       end
 
       def set_general_failure_state_from(exception, error_code = 99999, error_message = 'Unknown error, please try again')
-        log.append     '******** synchronization raised exception ********'
+        log.append_and_store     '******** synchronization raised exception ********'
         self.log_trace      = exception.message + ' ' + exception.backtrace.join("\n")
         self.state          = STATE_FAILURE
         self.error_code     = error_code

--- a/db/migrate/20160516103200_drop_visualization_exports_user_id_null_constraint.rb
+++ b/db/migrate/20160516103200_drop_visualization_exports_user_id_null_constraint.rb
@@ -1,0 +1,16 @@
+Sequel.migration do
+  up do
+    Rails::Sequel.connection.run(%{
+      ALTER TABLE visualization_exports alter column user_id drop not null;
+    })
+  end
+
+  down do
+    # This is the symmetric action, but it's not safe (there could be null `user_id`s)
+    # and it's not needed for `up` to be safe (`up` code is idempotent).
+    #
+    # Rails::Sequel.connection.run(%{
+    #   ALTER TABLE visualization_exports alter column user_id set not null;
+    # })
+  end
+end

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -138,7 +138,7 @@ module Carto
                  count(column_name::text) cdb_columns_count
           FROM information_schema.columns c, pg_tables t, pg_trigger tg
           WHERE
-            t.tablename !~ 'importer_' AND
+            t.tablename !~ '^importer_' AND
             t.tablename = c.table_name AND
             t.schemaname = c.table_schema AND
             c.table_schema = '#{user.database_schema}' AND

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -138,6 +138,7 @@ module Carto
                  count(column_name::text) cdb_columns_count
           FROM information_schema.columns c, pg_tables t, pg_trigger tg
           WHERE
+            t.tablename !~ 'importer_' AND
             t.tablename = c.table_name AND
             t.schemaname = c.table_schema AND
             c.table_schema = '#{user.database_schema}' AND


### PR DESCRIPTION
Fixes #7171 

## The problem
Currently, the synchronization workflow is as follows:
  1. The new table is imported, it is never registered
  2. The old and the new tables are switched. The old table is dropped.
  3. CartoDBfication, import cleanups (cartodb_id) and geom checks (multi/simple geoms) are performed

And this provokes several problems:
  * When the switch is performed, the new table is not CartoDBfied (no cartodb_id, no the_geom) so any maps that contain this table as a layer will crash. See #7171 for a specific example.
  * If there's an error in the CartoDBfication or the rest of the checks, the synchronization will leave a broken table. The old table has been dropped so there's no possible rollback. The maps will be broken.
  * Also, if there's an error in the CartoDBfication, when the Ghost Tables are triggered they will unregister the table, breaking completely the synchronization. This would remove any layer in which the disconnected table was involved too.

When working in the issue, I noticed that the current flow is working due to the fact that when the switch between tables is performed, the new table gets automatically registered (it reuses the register of the old table) so the operations in the Table model that require the Table object can be performed on them.

As a side-effect, as the new table was not CartoDBfied it would not be captured when the ghost tables were triggered.

## The solution
We had to move the CartoDBfy process (and the rest of the checks) before the switch is performed to ensure that when it happens, the new table will be completely compatible with the maps and the Editor.

By "moving" these processes before the switch, we no longer have a registered table to work with. This is the reason why we duplicated code from Table (`cartodbfy`, `set_the_geom_column!` and `import_cleanup`) and adapted it to work with unregistered tables. Basically in this approach I am getting the column information via PostgreSQL queries, instead of checking the schema of the Table.

This code duplication is intended to be only part of a first iteration. Some parts of these methods can be directly removed with a correct configuration of Ogr2Ogr or the original methods can moved outside of Table.rb to create some kind of utility that can be used for both registered and unregistered tables.

To be able to CartoDBfy the table before switching, we had to move the table to the user schema. Some internal code of the CartoDBfication performs queries on CDB_UserQuotaSize and other functions that are expected to live in the schema in which the table lives, and `cdb_importer`, which is the default schema in which new tables are created does not contain these.

We also had to work with Ghost Tables. As the table is CartoDBfied and lives in the user schema, it would be visible for the Ghost Tables task. We're adding a commit to ignore tables in the User DB that are named as our `importer` tables.

Now the process is as follows:

  1. The new table is imported
  2. It is moved to the user schema
  3. It is CartoDBfied + import_cleanup + geom fixes(cartodb_id, the_geom)
  4. It is switched by the old table of the user

In this scenario, if something goes wrong while manipulating the table (incorrect CartoDB ID, or multiple geometry types issues, which were reported by Jaak) an exception will be raised and the sync will stop before any switch is made.

## Testing

Output of some tests: https://gist.github.com/iriberri/42a1a44a47f9ee5e428901dcd4a125d5


Other similar branches I created just for test purposes (see gist above):
* `7171-cdbfy_in_syncs_b`
* `cdbfy_master_with_sleep`

### Timing checks
I got some timings for the query edited in the `ghost_tables_manager` for my own production user with 2564 tables in the User DB.

* Original query, no name checks:
  * Time: 240.853 ms
* Adapted query 1: `t.tablename !~ 'importer_\\w{32}'`
  * Time: 364.519 ms
* Adapted query 2 (the one currently commited): `t.tablename !~ '^importer_'`
  * Time: 277.863 ms
* Adapted query 3: `t.tablename !~ '^importer_\\w{32}'`
  * Time: 278.990 ms

====

Pending: 
* [x] drop table in failure scenario to not leave stale tables
* [x] test thoroughly for cartodbfycation exceptions and special geom types (multipoint, simple linestrings) to check postgres queries flow
* [x] get some numbers on ghost tables query times