### PR TITLE
force_s3_upload for exports fixes #7560

### DIFF
--- a/app/helpers/file_upload.rb
+++ b/app/helpers/file_upload.rb
@@ -20,12 +20,14 @@ module CartoDB
       @uploads_path
     end
 
+    # force_s3_upload uploads file to S3 even if size is greater than `MAX_SYNC_UPLOAD_S3_FILE_SIZE`
     def upload_file_to_storage(filename_param: nil,
                                file_param: nil,
                                request_body: nil,
                                s3_config: nil,
                                timestamp: Time.now,
-                               allow_spaces: false)
+                               allow_spaces: false,
+                               force_s3_upload: false)
       results = {
         file_uri: nil,
         enqueue:  true
@@ -64,7 +66,7 @@ module CartoDB
       do_long_upload = s3_config && s3_config['async_long_uploads'].present? && s3_config['async_long_uploads'] &&
         File.size(filepath) > MAX_SYNC_UPLOAD_S3_FILE_SIZE
 
-      if use_s3 && !do_long_upload
+      if use_s3 && (!do_long_upload || force_s3_upload)
         file_url = upload_file_to_s3(filepath, filename, random_token, s3_config)
 
         if load_file_from_request_body

--- a/app/models/carto/visualization_export.rb
+++ b/app/models/carto/visualization_export.rb
@@ -48,7 +48,8 @@ module Carto
       results = file_upload_helper.upload_file_to_storage(
         file_param: file,
         s3_config: s3_config,
-        allow_spaces: true
+        allow_spaces: true,
+        force_s3_upload: true
       )
 
       if results[:file_uri].present?


### PR DESCRIPTION
This is a quick & dirty change that fixes #7560.

@gfiorav , could you CR this, please?

cc @rafatower : it's dirty but I think that it makes sense for exports, which should always place the file in S3. `FileUpload` screams for a refactor, but I need a quick fix.