### PR TITLE
Internal geocoder - Fix queries to avoid column name conflict

### DIFF
--- a/services/table-geocoder/lib/internal-geocoder/cities_column_text_points.rb
+++ b/services/table-geocoder/lib/internal-geocoder/cities_column_text_points.rb
@@ -30,13 +30,13 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(#{@internal_geocoder.column_name}::text) = orig.geocode_string
+          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = orig.geocode_string
             AND trim(dest.#{@internal_geocoder.country_column}::text) = orig.country
             AND dest.cartodb_georef_status IS NULL
         }
       end
 
-    end # CitiesColumnTextPoints
+    end
 
-  end # InternalGeocoder
-end # CartoDB
+  end
+end

--- a/services/table-geocoder/lib/internal-geocoder/postalcode_column_points.rb
+++ b/services/table-geocoder/lib/internal-geocoder/postalcode_column_points.rb
@@ -30,11 +30,11 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(#{@internal_geocoder.column_name}::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
         }
       end
 
-    end # PostalcodeColumnPoints
+    end
 
-  end # InternalGeocoder
-end # CartoDB
+  end
+end

--- a/services/table-geocoder/lib/internal-geocoder/postalcode_column_polygon.rb
+++ b/services/table-geocoder/lib/internal-geocoder/postalcode_column_polygon.rb
@@ -30,11 +30,11 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(#{@internal_geocoder.column_name}::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
         }
       end
 
-    end # PostalcodeColumnPolygon
+    end
 
-  end # InternalGeocoder
-end # CartoDB
+  end
+end


### PR DESCRIPTION
Fixes #5899 

In several scenarios (Postal codes + city names) in which the first target column was named `region`, a missing specification for the table which the column belongs to was raising an error when geocoding:

```
Sequel::DatabaseError: PG::Error: ERROR: column reference "region" is ambiguous LINE 6: WHERE trim(region::text) = orig.geocode_string
```

Internally, for each geocoding process, we're creating a temporary table with the following schema:

````
 geocode_string | country | region |                      the_geom                      | cartodb_georef_status 
----------------+---------+--------+----------------------------------------------------+-----------------------
 madrid         | spain   |        | 0101000020E610000074D2FBC6D79E0DC05A643BDF4F354440 | t
 barcelona      | spain   |        | 0101000020E6100000DA20938C9C4501408481E7DEC3B14440 | t
(2 rows)


 geocode_string | country | region |                      the_geom                      | cartodb_georef_status 
----------------+---------+--------+----------------------------------------------------+-----------------------
 8.8.8.8        |         |        | 0101000020E610000000000000004058C00000000000004340 | t
 1.1.1.1        |         |        | 0101000020E61000000000000000A060400000000000003BC0 | t
(2 rows)
````

Then, if not specified in the query, names as `country` or `region` would exist both in the original user table and in the temporary table.

I reviewed all the query generators and found three occurrences of this issue, which I fixed here.

This is an example of query built **before** the fix:

```
          UPDATE \"public\".\"untitled_table\" AS dest
          SET the_geom =
          CASE
          WHEN orig.cartodb_georef_status THEN orig.the_geom
          ELSE dest.the_geom
          END,
          cartodb_georef_status = orig.cartodb_georef_status
          FROM \"public\".internal_geocoding_1464686281 AS orig
          WHERE **trim(region::text) = orig.geocode_string**
          AND trim(dest.country::text) = orig.country
          AND dest.cartodb_georef_status IS NULL
```

This is an example **after** the fix:

```
          UPDATE \"public\".\"untitled_table_copy\" AS dest
          SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom 
          ELSE dest.the_geom
          END,
          cartodb_georef_status = orig.cartodb_georef_status
          FROM \"public\".internal_geocoding_1464689353 AS orig
          WHERE **trim(dest.region::text) = orig.geocode_string**
          AND trim(dest.country::text) = orig.country
          AND dest.cartodb_georef_status IS NULL
```

Related: RB/16024