### PR TITLE
Reverse order of layerDefs in layer-definitions-collection to match the order attribute

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -102,7 +102,7 @@ module.exports = Backbone.Collection.extend({
   createLayerForTable: function (tableName, options) {
     options = options || {};
     var order = 0;
-    var layerOnTop = this.first();
+    var layerOnTop = this.last();
     if (layerOnTop) {
       order = layerOnTop.get('order');
       if (layerTypesAndKinds.isCartoDBType(layerOnTop.get('type'))) {

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -26,7 +26,7 @@ module.exports = Backbone.Collection.extend({
   },
 
   comparator: function (m) {
-    return -m.get('order');
+    return m.get('order');
   },
 
   model: function (d, opts) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var cdb = require('cartodb.js');
 var LayerAnalysisViewFactory = require('./layer-analysis-view-factory');
 var LayerAnalysesView = require('./layer-analyses-view');
@@ -44,7 +45,7 @@ module.exports = cdb.core.View.extend({
 
     this.$el.html(template);
 
-    this._layerDefinitionsCollection.each(this._addLayerView, this);
+    _.each(this._layerDefinitionsCollection.toArray().reverse(), this._addLayerView, this);
 
     return this;
   },

--- a/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -60,8 +60,8 @@ describe('data/layer-definitions-collection', function () {
         order: 0
       });
       this.collection.reset([
-        TiledLayer,
-        CartoDBLayer
+        CartoDBLayer,
+        TiledLayer
       ]);
 
       spyOn(TiledLayer, 'save');
@@ -75,17 +75,17 @@ describe('data/layer-definitions-collection', function () {
     });
 
     it('should place the new layer above the "CartoDB" layer on top', function () {
-      var CartoDBLayer_1 = new Backbone.Model({
-        type: 'CartoDB',
-        order: 1
-      });
       var CartoDBLayer_0 = new Backbone.Model({
         type: 'CartoDB',
         order: 0
       });
+      var CartoDBLayer_1 = new Backbone.Model({
+        type: 'CartoDB',
+        order: 1
+      });
       this.collection.reset([
-        CartoDBLayer_1,
-        CartoDBLayer_0
+        CartoDBLayer_0,
+        CartoDBLayer_1
       ]);
 
       var newLayer = this.collection.createLayerForTable('tableName');
@@ -94,8 +94,8 @@ describe('data/layer-definitions-collection', function () {
       expect(newLayer.get('order')).toEqual(2);
 
       // Order of other layers has not been changed
-      expect(CartoDBLayer_1.get('order')).toEqual(1);
       expect(CartoDBLayer_0.get('order')).toEqual(0);
+      expect(CartoDBLayer_1.get('order')).toEqual(1);
     });
 
     it('should place the new layer below the "Tiled" layer on top (labels) and update the top most layer', function () {
@@ -109,8 +109,8 @@ describe('data/layer-definitions-collection', function () {
         order: 0
       });
       this.collection.reset([
-        TiledLayer_1,
-        CartoDBLayer_0
+        CartoDBLayer_0,
+        TiledLayer_1
       ]);
 
       var newLayer = this.collection.createLayerForTable('tableName');


### PR DESCRIPTION
Also, it now matches the order of the collection of layers in CartoDB.js.

cc: @matallo 