### PR TITLE
Set datasource auth error as error 1012, not 1011

### DIFF
--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -153,7 +153,7 @@ module CartoDB
       TableQuotaExceededError               => 8002,
       UnknownError                          => 99999,
       CartoDB::Datasources::DatasourceBaseError                   => 1012,
-      CartoDB::Datasources::AuthError                             => 1011,
+      CartoDB::Datasources::AuthError                             => 1012,
       CartoDB::Datasources::TokenExpiredOrInvalidError            => 1012,
       CartoDB::Datasources::InvalidServiceError                   => 1012,
       CartoDB::Datasources::DataDownloadError                     => 1011,


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/7538