### PR TITLE
Using the same query from current editor in order to obtain geometry type

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/query-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-schema-model.js
@@ -5,7 +5,12 @@ var syncAbort = require('./backbone/sync-abort');
 var geometry = require('./geometry');
 
 var MAX_GET_LENGTH = 1024;
-var WRAP_SQL_TEMPLATE = 'select * from (<%= sql %>) __wrapped limit <%= rows_sample_size %>';
+var WRAP_SQL_TEMPLATE = 'select * from (<%= sql %>) __wrapped';
+var PARAMS = {
+  sort_order: 'asc',
+  rows_per_page: 40,
+  page: 0
+};
 
 /**
  * Model to represent a schema of a SQL query.
@@ -48,10 +53,15 @@ module.exports = cdb.core.Model.extend({
     this.set('status', 'fetching');
 
     opts = opts || {};
-    opts.data = {
-      api_key: this._configModel.get('api_key'),
-      q: this._getSqlApiQueryParam()
-    };
+    opts.data = _.extend(
+      opts.data || {},
+      {
+        api_key: this._configModel.get('api_key'),
+        q: this._getSqlApiQueryParam()
+      },
+      PARAMS
+    );
+
     opts.method = this._httpMethod();
     opts.error = function () {
       this.set('status', 'unavailable');
@@ -116,8 +126,7 @@ module.exports = cdb.core.Model.extend({
 
   _getSqlApiQueryParam: function () {
     return _.template(WRAP_SQL_TEMPLATE)({
-      sql: this.get('query'),
-      rows_sample_size: 10
+      sql: this.get('query')
     });
   },
 

--- a/lib/assets/test/spec/cartodb3/data/query-schema-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/query-schema-model.spec.js
@@ -61,8 +61,10 @@ describe('data/query-schema-model', function () {
         expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.q).toMatch(/select \* from \(.+\) /);
       });
 
-      it('should fetch a sample of rows only', function () {
-        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.q).toMatch(/ limit \d/);
+      it('should add order, rows and page', function () {
+        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.rows_per_page).toBe(40);
+        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.page).toBe(0);
+        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.sort_order).toBe('asc');
       });
 
       it('should fetch using an API key', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.24.11",
+  "version": "3.24.12",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Basically we are not getting the geometry type properly from several datasets in the new editor (reported by @AbelVM), but looks like old editor was doing it correctly so we have decided to follow the same thing in the new builder (:fingers_crossed:).

Fixes #7485.

CR: @viddo 

cc @AbelVM @javisantana 