### PR TITLE
Remove job table deletion notification

### DIFF
--- a/services/importer/lib/importer/job.rb
+++ b/services/importer/lib/importer/job.rb
@@ -64,7 +64,6 @@ module CartoDB
       end
 
       def delete_job_table
-        CartoDB.notify_debug('Dropping temp table', schema: @schema, table: table_name)
         delete_temp_table(table_name)
       end
 


### PR DESCRIPTION
We added this notification to trace the deletion of the import temporary table to supervise that these weren't being stuck in the user db in case of an import error.

After a couple of months, I don't think this trace is useful anymore, so I'm removing it to alleviate the big amount of notifications we raise.