### PR TITLE
Sync tables - Check if results exist before drop in rescue

### DIFF
--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -44,7 +44,7 @@ module CartoDB
         puts exception.to_s
         puts exception.backtrace
         puts '=================='
-        drop(result.table_name) if exists?(result.table_name)
+        drop(result.table_name) if result && exists?(result.table_name)
         raise exception
       end
 


### PR DESCRIPTION
If `result.nil?`, the code raises an exception that end ups in the rescue. The rescue was trying to drop the stale table, but `result` is nil, so you can't access to `result.table_name`.