### PR TITLE
Exporter sql api ssl configuration m

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,7 @@ be exectuded daily
 * Removing Bitly shortener.
 * Several XSS fixes in organization accounts
 * API fixes that allows.
+* API fixes that allows 
 
 3.12.2 (2016-05-15)
 -------------------

--- a/lib/carto/http/client.rb
+++ b/lib/carto/http/client.rb
@@ -48,9 +48,10 @@ module Carto
         perform_request(__method__, url, options)
       end
 
-      def get_file(url, file_path)
+      # `options` are Typhoeus options. Example: { ssl_verifypeer: false, ssl_verifyhost: 0 }
+      def get_file(url, file_path, options = {})
         downloaded_file = File.open file_path, 'wb'
-        request = request(url)
+        request = request(url, options)
         request.on_headers do |response|
           if response.code != 200
             raise "Request failed. URL: #{url}. File path: #{file_path}. Code: #{response.code}. Body: #{response.body}"

--- a/lib/carto/visualization_exporter.rb
+++ b/lib/carto/visualization_exporter.rb
@@ -15,7 +15,7 @@ module Carto
       query = %{select * from "#{table_name}"}
       url = sql_api_query_url(query, table_name, user_table.user, privacy(user_table), format)
       exported_file = "#{folder}/#{table_name}.#{format}"
-      @http_client.get_file(url, exported_file)
+      @http_client.get_file(url, exported_file, ssl_verifypeer: false, ssl_verifyhost: 0)
     end
 
     def export_visualization_tables(visualization, user, dir, format, user_tables_ids: nil)

--- a/spec/models/carto/visualization_export_spec.rb
+++ b/spec/models/carto/visualization_export_spec.rb
@@ -46,7 +46,8 @@ describe Carto::VisualizationExport do
       @touched_files = []
     end
 
-    def get_file(url, exported_file)
+    # Mock needs not url nor Typhoeus options
+    def get_file(_, exported_file, _)
       @touched_files << exported_file
       touch(exported_file)
     end


### PR DESCRIPTION
@javitonino this is the merge of `exporter_sql_api_ssl_configuration` branch, which comes from `3.13.x`, into `exporter_sql_api_ssl_configuration_m` for master. It shows too many commits but changes are accurate (everything but a NEWS change that I prefer to keep to avoid merging issues).

I'll merge & deploy this tomorrow unless you have complaints :-)