### PR TITLE
Removed commas from transition arguments

### DIFF
--- a/app/assets/stylesheets/editor-3/block-list.css.scss
+++ b/app/assets/stylesheets/editor-3/block-list.css.scss
@@ -7,8 +7,8 @@
 }
 .BlockList-item {
   @include display-flex();
-  @include transition(border, 200ms, ease-in);
-  @include transition(box-shadow, 300ms, ease-in);
+  @include transition(border 200ms ease-in);
+  @include transition(box-shadow 300ms ease-in);
   margin-bottom: $baseSize;
   padding: $baseSize * 2;
   border: 1px solid $cSecondaryLine;
@@ -24,7 +24,7 @@
   border-style: dashed;
 }
 .BlockList-item:hover {
-  @include transition(border, 200ms, ease-in);
+  @include transition(border 200ms ease-in);
   border: 1px solid $cHoverLine;
 }
 .BlockList-item.BlockList-item--noAction {

--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -19,7 +19,7 @@
   background: $cSecondaryBackground;
 }
 .Editor-ListLayer-item:hover {
-  @include transition(border, 200ms, ease-in);
+  @include transition(border 200ms ease-in);
   border: 1px solid $cHoverLine;
 }
 .Editor-ListLayer-item.last-child {
@@ -39,7 +39,7 @@
   z-index: 1000;
 }
 .Editor-ListLayer-dragIcon {
-  @include transition(opacity, 200ms, ease-in);
+  @include transition(opacity 200ms ease-in);
   position: absolute;
   top: 28px;
   left: -20px;
@@ -156,7 +156,7 @@
   border: 1px solid $cSecondaryLine;
   border-radius: $halfBaseSize;
   &:hover {
-    @include transition(border, 200ms, ease-in);
+    @include transition(border 200ms ease-in);
     border: 1px solid $cHoverLine;
     cursor: pointer;
   }


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/7612.

![layers-shaking](https://cloud.githubusercontent.com/assets/390398/15717134/e5e05bb2-2825-11e6-91ad-fefd8d99630c.gif)

@javierarce can you please review?

BTW: We seem to be using `@include transition(property, duration, effect);` (arguments separated by commas) and I don't think that has the desired outcome (seems to be applying the transtion to `all` properties). I think we should change those to `@include transition(property duration effect);` (no commas) cc: @xavijam @viddo @javierarce @nobuti.