### PR TITLE
Add new storage quota exception for geocoding and remove premature fail status

### DIFF
--- a/services/table-geocoder/lib/exceptions.rb
+++ b/services/table-geocoder/lib/exceptions.rb
@@ -9,7 +9,7 @@ module Carto
     GEOCODER_TIMED_OUT_WHAT_ABOUT = %q{
       Your geocoding request timed out.
       Please <a href='mailto:support@cartob.com?subject=The geocoder timed out'>contact us</a>
-      and we'll try to fix it quickly.
+      if you need further help.
     }.squish
 
     class AdditionalInfo
@@ -65,7 +65,16 @@ module Carto
       GeocoderBaseError.get_info(error_code)
     end
 
-
+    class OverStorageQuotaError < GeocoderBaseError
+      register_additional_info(
+        1801,
+        'Over account storage limit',
+        %q{Over account storage limit: The geocoding process was not able to finish because you ran out of quota.
+          To upgrade your account, go to your Dashboard and click Settings. Click
+          'Upgrade your server'. Follow the directions for choosing a larger size and setting up your payment information.}.squish,
+        AdditionalInfo::SOURCE_USER
+        )
+    end
 
     class MisconfiguredGmeGeocoderError < GeocoderBaseError
       register_additional_info(
@@ -73,7 +82,7 @@ module Carto
         'Google for Work account misconfigured',
         %q{Your Google for Work account seems to be incorrectly configured.
            Please <a href='mailto:sales@cartob.com?subject=Google for Work account misconfigured'>contact us</a>
-           and we'll try to fix it quickly.}.squish,
+           for further assistance.}.squish,
         AdditionalInfo::SOURCE_USER
         )
     end

--- a/services/table-geocoder/lib/exceptions.rb
+++ b/services/table-geocoder/lib/exceptions.rb
@@ -6,7 +6,7 @@ module Carto
   module GeocoderErrors
 
     GEOCODER_TIMED_OUT_TITLE = 'The geocoder timed out'
-    GEOCODER_TIMED_OUT_WHAT_ABOUT = %q{
+    GEOCODER_TIMED_OUT_WHAT_ABOUT = %{
       Your geocoding request timed out.
       Please <a href='mailto:support@cartob.com?subject=The geocoder timed out'>contact us</a>
       if you need further help.
@@ -69,34 +69,35 @@ module Carto
       register_additional_info(
         1801,
         'Over account storage limit',
-        %q{Over account storage limit: The geocoding process was not able to finish because you ran out of quota.
+        %{Over account storage limit: The geocoding process was not able to finish because you ran out of quota.
           To upgrade your account, go to your Dashboard and click Settings. Click
-          'Upgrade your server'. Follow the directions for choosing a larger size and setting up your payment information.}.squish,
+          'Upgrade your server'. Follow the directions for choosing a larger size
+          and setting up your payment information.}.squish,
         AdditionalInfo::SOURCE_USER
-        )
+      )
     end
 
     class MisconfiguredGmeGeocoderError < GeocoderBaseError
       register_additional_info(
         1000,
         'Google for Work account misconfigured',
-        %q{Your Google for Work account seems to be incorrectly configured.
+        %{Your Google for Work account seems to be incorrectly configured.
            Please <a href='mailto:sales@cartob.com?subject=Google for Work account misconfigured'>contact us</a>
            for further assistance.}.squish,
         AdditionalInfo::SOURCE_USER
-        )
+      )
     end
 
     class GmeGeocoderTimeoutError < GeocoderBaseError
       register_additional_info(
         1010,
         'Google geocoder timed out',
-        %q{Your geocoding request timed out after several attempts.
+        %{Your geocoding request timed out after several attempts.
            Please check your quota usage in the <a href='https://console.developers.google.com/'>Google Developers Console</a>
            and <a href='mailto:support@cartodb.com?subject=Google geocoder timed out'>contact us</a>
            if you are within the usage limits.}.squish,
         AdditionalInfo::SOURCE_USER
-        )
+      )
     end
 
     class AddGeorefStatusColumnDbTimeoutError < GeocoderBaseError
@@ -105,7 +106,7 @@ module Carto
         GEOCODER_TIMED_OUT_TITLE,
         GEOCODER_TIMED_OUT_WHAT_ABOUT,
         AdditionalInfo::SOURCE_CARTODB
-        )
+      )
     end
 
     class GeocoderCacheDbTimeoutError < GeocoderBaseError
@@ -114,7 +115,7 @@ module Carto
         GEOCODER_TIMED_OUT_TITLE,
         GEOCODER_TIMED_OUT_WHAT_ABOUT,
         AdditionalInfo::SOURCE_CARTODB
-        )
+      )
     end
 
     class TableGeocoderDbTimeoutError < GeocoderBaseError
@@ -123,7 +124,7 @@ module Carto
         GEOCODER_TIMED_OUT_TITLE,
         GEOCODER_TIMED_OUT_WHAT_ABOUT,
         AdditionalInfo::SOURCE_CARTODB
-        )
+      )
     end
 
   end

--- a/services/table-geocoder/lib/exceptions.rb
+++ b/services/table-geocoder/lib/exceptions.rb
@@ -72,7 +72,8 @@ module Carto
         %{Over account storage limit: The geocoding process was not able to finish because you ran out of quota.
           To upgrade your account, go to your Dashboard and click Settings. Click
           'Upgrade your server'. Follow the directions for choosing a larger size
-          and setting up your payment information.}.squish,
+          and setting up your payment information.
+        }.squish,
         AdditionalInfo::SOURCE_USER
       )
     end
@@ -83,7 +84,8 @@ module Carto
         'Google for Work account misconfigured',
         %{Your Google for Work account seems to be incorrectly configured.
            Please <a href='mailto:sales@cartob.com?subject=Google for Work account misconfigured'>contact us</a>
-           for further assistance.}.squish,
+           for further assistance.
+        }.squish,
         AdditionalInfo::SOURCE_USER
       )
     end
@@ -95,7 +97,8 @@ module Carto
         %{Your geocoding request timed out after several attempts.
            Please check your quota usage in the <a href='https://console.developers.google.com/'>Google Developers Console</a>
            and <a href='mailto:support@cartodb.com?subject=Google geocoder timed out'>contact us</a>
-           if you are within the usage limits.}.squish,
+           if you are within the usage limits.
+        }.squish,
         AdditionalInfo::SOURCE_USER
       )
     end

--- a/services/table-geocoder/lib/internal_geocoder.rb
+++ b/services/table-geocoder/lib/internal_geocoder.rb
@@ -51,7 +51,6 @@ module CartoDB
         copy_results_to_table
         change_status('completed')
       rescue => e
-        change_status('failed')
         raise e
       ensure
         drop_temp_table
@@ -133,6 +132,10 @@ module CartoDB
             @query_generator.copy_results_to_table_query,
             @table_schema, @table_name
           )
+      rescue => e
+        if e.is_a?(Sequel::DatabaseError) && e.message =~ /.*quota exceeded.*/i
+          raise Carto::GeocoderErrors::OverStorageQuotaError
+        end
       end
 
       def drop_temp_table


### PR DESCRIPTION
Closes #5230 and helps with https://github.com/CartoDB/cartodb/issues/7338

While working on adding an exception for quota issues, I realised about a problem in the current flow.

Whenever an exception was raised, the status was automatically set to failed. The polling of the frontend was detecting the failed status and setting the geocoding as failed, but with an unknown error because the error is detected afterwards by `handle_geocoding_failure`. The current `handle_geocoding_failure` changes the status to failed (again), so I removed the initial failure setup, which is hiding the real exceptions.

The flow was something like:

* Editor starts geocoding process
* Geocoding fails
* Status is set to failure in the backend
* The Editor detects the new failure state and shows a modal about the error
* The backend keeps working on handling the failure and sets the error code accordingly, which is not shown to the user