### PR TITLE
7307 send vector flag true in the editor when number of features is less than 10k

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ WORKING_SPECS_1 = \
 	spec/helpers/url_validator_spec.rb \
 	spec/models/carto/bi_dataset_spec.rb \
 	spec/models/carto/bi_visualization_spec.rb \
+	spec/models/carto/layer_spec.rb \
 	spec/models/carto/visualization_spec.rb \
 	spec/requests/superadmin/feature_flag_spec.rb \
 	spec/models/carto/template_spec.rb \

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -42,10 +42,10 @@ module Carto
 
       private
 
-      MAX_FEATURES_LIMIT_FOR_VECTOR = 10000
+      MAX_FEATURES_FOR_VECTOR = 10000
 
       def enable_vector?(visualization, vector)
-        vector.nil? ? visualization.number_of_features < MAX_FEATURES_LIMIT_FOR_VECTOR : vector
+        vector.nil? ? visualization.number_of_features(MAX_FEATURES_FOR_VECTOR) < MAX_FEATURES_FOR_VECTOR : vector
       end
 
       def generate_vizjson(https_request:, vector: nil, forced_privacy_version:)

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -28,23 +28,29 @@ module Carto
         @redis_vizjson_cache = redis_vizjson_cache
       end
 
-      def to_vizjson(https_request: false, vector: false)
+      def to_vizjson(https_request: false, vector: nil)
         generate_vizjson(https_request: https_request, vector: vector, forced_privacy_version: nil)
       end
 
-      def to_named_map_vizjson(https_request: false, vector: false)
+      def to_named_map_vizjson(https_request: false, vector: nil)
         generate_vizjson(https_request: https_request, vector: vector, forced_privacy_version: :force_named)
       end
 
-      def to_anonymous_map_vizjson(https_request: false, vector: false)
+      def to_anonymous_map_vizjson(https_request: false, vector: nil)
         generate_vizjson(https_request: https_request, vector: vector, forced_privacy_version: :force_anonymous)
       end
 
       private
 
-      def generate_vizjson(https_request:, vector:, forced_privacy_version:)
+      MAX_FEATURES_LIMIT_FOR_VECTOR = 10000
+
+      def enable_vector?(visualization, vector)
+        vector.nil? ? visualization.number_of_features < MAX_FEATURES_LIMIT_FOR_VECTOR : vector
+      end
+
+      def generate_vizjson(https_request:, vector: nil, forced_privacy_version:)
         https_request ||= false
-        vector ||= false
+        vector = enable_vector?(@visualization, vector)
         version = case forced_privacy_version
                   when :force_named
                     '3n'

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -91,16 +91,20 @@ module VisualizationsControllerHelper
 
   def generate_vizjson3(visualization, params)
     Carto::Api::VizJSON3Presenter.new(visualization)
-                                 .to_vizjson(https_request: is_https?, vector: params[:vector] == 'true')
+                                 .to_vizjson(https_request: is_https?, vector: param_to_boolean(params[:vector]))
   end
 
   def generate_named_map_vizjson3(visualization, params)
     Carto::Api::VizJSON3Presenter.new(visualization)
-                                 .to_named_map_vizjson(https_request: is_https?, vector: params[:vector] == 'true')
+                                 .to_named_map_vizjson(https_request: is_https?, vector: param_to_boolean(params[:vector]))
   end
 
   def generate_anonymous_map_vizjson3(visualization, params)
     Carto::Api::VizJSON3Presenter.new(visualization)
-                                 .to_anonymous_map_vizjson(https_request: is_https?, vector: params[:vector] == 'true')
+                                 .to_anonymous_map_vizjson(https_request: is_https?, vector: param_to_boolean(params[:vector]))
+  end
+
+  def param_to_boolean(param)
+    param.nil? ? nil : param == 'true'
   end
 end

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -100,8 +100,7 @@ module Carto
     end
 
     def number_of_features
-      # WIP
-      10
+      affected_tables.map(&:estimated_row_count).reduce(0, :+)
     end
 
     private

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -100,7 +100,7 @@ module Carto
     end
 
     def number_of_features
-      affected_tables.map(&:estimated_row_count).reduce(0, :+)
+      affected_tables.map(&:estimated_row_count).map(&:to_i).reduce(0, :+)
     end
 
     private

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -99,8 +99,13 @@ module Carto
       basemap? && options["labels"] && options["labels"]["url"]
     end
 
-    def number_of_features
-      affected_tables.map(&:estimated_row_count).map(&:to_i).reduce(0, :+)
+    def number_of_features(max = nil)
+      n = 0
+      affected_tables.each do |at|
+        n += at.estimated_row_count.to_i
+        break if max.present? && n >= max
+      end
+      n
     end
 
     private

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -99,6 +99,11 @@ module Carto
       basemap? && options["labels"] && options["labels"]["url"]
     end
 
+    def number_of_features
+      # WIP
+      10
+    end
+
     private
 
     def tables_from_query_option

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -43,7 +43,7 @@ module Carto
     end
 
     def service
-      @service ||= ::Table.new(user_table: self)
+      table
     end
 
     def set_service(table)

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -329,7 +329,7 @@ class Carto::Visualization < ActiveRecord::Base
   def number_of_features(max = nil)
     n = 0
     layers.each do |layer|
-      n += layer.number_of_features
+      n += layer.number_of_features(max)
       break if max.present? && n >= max
     end
     n

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -328,9 +328,7 @@ class Carto::Visualization < ActiveRecord::Base
 
   # TODO: improve performance not counting beyond limit
   def number_of_features
-    # WIP
-    # layers.number_of_features
-    10
+    layers.map(&:number_of_features).reduce(0, :+)
   end
 
   private

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -326,9 +326,13 @@ class Carto::Visualization < ActiveRecord::Base
     related_canonical_visualizations.map(&:attributions).reject(&:blank?)
   end
 
-  # TODO: improve performance not counting beyond limit
-  def number_of_features
-    layers.map(&:number_of_features).reduce(0, :+)
+  def number_of_features(max = nil)
+    n = 0
+    layers.each do |layer|
+      n += layer.number_of_features
+      break if max.present? && n >= max
+    end
+    n
   end
 
   private

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -326,6 +326,13 @@ class Carto::Visualization < ActiveRecord::Base
     related_canonical_visualizations.map(&:attributions).reject(&:blank?)
   end
 
+  # TODO: improve performance not counting beyond limit
+  def number_of_features
+    # WIP
+    # layers.number_of_features
+    10
+  end
+
   private
 
   def get_named_map

--- a/spec/models/carto/layer_spec.rb
+++ b/spec/models/carto/layer_spec.rb
@@ -1,0 +1,21 @@
+# encoding: UTF-8
+
+require 'spec_helper_min'
+
+describe Carto::Layer do
+  describe '#number_of_features' do
+    it 'returns the sum of number of rows of its affected tables' do
+      T1_FEATURES = 111
+      T2_FEATURES = 222
+      user_table_1 = FactoryGirl.create(:carto_user_table)
+      user_table_2 = FactoryGirl.create(:carto_user_table)
+      user_table_1.stubs(:estimated_row_count).returns(T1_FEATURES)
+      user_table_2.stubs(:estimated_row_count).returns(T2_FEATURES)
+
+      layer = FactoryGirl.create(:carto_layer)
+      layer.stubs(:affected_tables).returns([user_table_1, user_table_2])
+
+      layer.number_of_features.should eq T1_FEATURES + T2_FEATURES
+    end
+  end
+end

--- a/spec/models/carto/layer_spec.rb
+++ b/spec/models/carto/layer_spec.rb
@@ -4,9 +4,10 @@ require 'spec_helper_min'
 
 describe Carto::Layer do
   describe '#number_of_features' do
+    T1_FEATURES = 111
+    T2_FEATURES = 222
+
     it 'returns the sum of number of rows of its affected tables' do
-      T1_FEATURES = 111
-      T2_FEATURES = 222
       user_table_1 = FactoryGirl.create(:carto_user_table)
       user_table_2 = FactoryGirl.create(:carto_user_table)
       user_table_1.stubs(:estimated_row_count).returns(T1_FEATURES)
@@ -16,6 +17,32 @@ describe Carto::Layer do
       layer.stubs(:affected_tables).returns([user_table_1, user_table_2])
 
       layer.number_of_features.should eq T1_FEATURES + T2_FEATURES
+    end
+
+    it 'returns the sum of number of rows of its affected tables up to a max' do
+      user_table_1 = FactoryGirl.create(:carto_user_table)
+      user_table_2 = FactoryGirl.create(:carto_user_table)
+      user_table_1.stubs(:estimated_row_count).returns(T1_FEATURES)
+      user_table_2.stubs(:estimated_row_count).returns(T2_FEATURES)
+
+      layer = FactoryGirl.create(:carto_layer)
+      layer.stubs(:affected_tables).returns([user_table_1, user_table_2])
+
+      layer.number_of_features(T1_FEATURES + 1).should eq T1_FEATURES + T2_FEATURES
+      layer.number_of_features(T1_FEATURES).should eq T1_FEATURES
+      layer.number_of_features(1).should eq T1_FEATURES
+    end
+
+    it 'only calls the needed user_table#estimated_row_count' do
+      user_table_1 = FactoryGirl.create(:carto_user_table)
+      user_table_2 = FactoryGirl.create(:carto_user_table)
+      user_table_1.stubs(:estimated_row_count).once.returns(T1_FEATURES)
+      user_table_2.stubs(:estimated_row_count).never
+
+      layer = FactoryGirl.create(:carto_layer)
+      layer.stubs(:affected_tables).returns([user_table_1, user_table_2])
+
+      layer.number_of_features(1).should eq T1_FEATURES
     end
   end
 end

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -135,4 +135,21 @@ describe Carto::Visualization do
       destroy_full_visualization(map, table, table_visualization, visualization)
     end
   end
+
+  describe 'number_of_features' do
+    include Carto::Factories::Visualizations
+
+    it 'returns the sum of number of rows of its layers' do
+      L1_FEATURES = 111
+      L2_FEATURES = 222
+      layer_1 = FactoryGirl.create(:carto_layer)
+      layer_1.stubs(:number_of_features).returns(L1_FEATURES)
+      layer_2 =  FactoryGirl.create(:carto_layer)
+      layer_2.stubs(:number_of_features).returns(L2_FEATURES)
+
+      map = FactoryGirl.create(:carto_map, layers: [layer_1, layer_2], user: @carto_user)
+      _, _, _, visualization = create_full_visualization(@carto_user, map: map)
+      visualization.number_of_features.should eq L1_FEATURES + L2_FEATURES
+    end
+  end
 end

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -136,7 +136,7 @@ describe Carto::Visualization do
     end
   end
 
-  describe 'number_of_features' do
+  describe '#number_of_features' do
     include Carto::Factories::Visualizations
 
     it 'returns the sum of number of rows of its layers' do
@@ -163,10 +163,34 @@ describe Carto::Visualization do
       visualization.number_of_features.should eq features.reduce(0, :+)
     end
 
+    L1_FEATURES = 101
+    L2_FEATURES = 204
+    L3_FEATURES = 309
+
     it 'returns the sum of number of rows of its layers up to a max' do
-      L1_FEATURES = 101
-      L2_FEATURES = 204
-      L3_FEATURES = 309
+      layer_1 = FactoryGirl.create(:carto_layer)
+      layer_1.stubs(:number_of_features).returns(L1_FEATURES)
+      layer_2 = FactoryGirl.create(:carto_layer)
+      layer_2.stubs(:number_of_features).returns(L2_FEATURES)
+      layer_3 = FactoryGirl.create(:carto_layer)
+      layer_3.stubs(:number_of_features).returns(L3_FEATURES)
+
+      visualization = FactoryGirl.create(:carto_visualization, user: @carto_user)
+      visualization.stubs(:layers).returns([layer_1, layer_2, layer_3])
+
+      total = L1_FEATURES + L2_FEATURES + L3_FEATURES
+      visualization.number_of_features(total + 1).should eq total
+
+      max = L1_FEATURES + L2_FEATURES
+      visualization.number_of_features(max).should eq max
+
+      max2 = L1_FEATURES + (L2_FEATURES / 2)
+      visualization.number_of_features(max2).should eq max
+
+      visualization.number_of_features(1).should eq L1_FEATURES
+    end
+
+    it 'only calls the needed layer#number_of_features' do
       layer_1 = FactoryGirl.create(:carto_layer)
       layer_1.stubs(:number_of_features).once.returns(L1_FEATURES)
       layer_2 = FactoryGirl.create(:carto_layer)
@@ -176,8 +200,8 @@ describe Carto::Visualization do
 
       visualization = FactoryGirl.create(:carto_visualization, user: @carto_user)
       visualization.stubs(:layers).returns([layer_1, layer_2, layer_3])
-      max = L1_FEATURES + L2_FEATURES
-      visualization.number_of_features(max).should eq max
+
+      visualization.number_of_features(L1_FEATURES + L2_FEATURES)
     end
   end
 end

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1101,7 +1101,7 @@ describe Carto::Api::VisualizationsController do
 
       def get_vizjson3_url(user, visualization, vector: nil)
         args = { user_domain: user.username, id: visualization.id, api_key: user.api_key }
-        args[:vector] = vector if vector
+        args[:vector] = vector unless vector.nil?
         api_v3_visualizations_vizjson_url(args)
       end
 
@@ -1357,11 +1357,11 @@ describe Carto::Api::VisualizationsController do
         end
       end
 
-      it 'includes vector flag (default false)' do
+      it 'includes vector flag (default true for this fake visualization with 0 features)' do
         get_json get_vizjson3_url(@user_1, @visualization), @headers do |response|
           response.status.should == 200
           vizjson3 = response.body
-          vizjson3[:vector].should == false
+          vizjson3[:vector].should == true
         end
       end
 
@@ -1370,6 +1370,14 @@ describe Carto::Api::VisualizationsController do
           response.status.should == 200
           vizjson3 = response.body
           vizjson3[:vector].should == true
+        end
+      end
+
+      it 'includes vector flag (false if requested)' do
+        get_json get_vizjson3_url(@user_1, @visualization, vector: false), @headers do |response|
+          response.status.should == 200
+          vizjson3 = response.body
+          vizjson3[:vector].should == false
         end
       end
 

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -88,6 +88,22 @@ describe Carto::Api::VizJSON3Presenter do
       vizjson_b[:vector].should eq false
     end
 
+    it 'to_vizjson enables vector if visualization has less than 10k features without overriding the parameter' do
+      @visualization.stubs(:number_of_features).returns(10)
+      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization)
+      v3_presenter.to_vizjson[:vector].should eq true
+      v3_presenter.to_vizjson(vector: true)[:vector].should eq true
+      v3_presenter.to_vizjson(vector: false)[:vector].should eq false
+    end
+
+    it 'to_vizjson disables vector if visualization has equal or more than 10k features without overriding the parameter' do
+      @visualization.stubs(:number_of_features).returns(10000)
+      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization)
+      v3_presenter.to_vizjson[:vector].should eq false
+      v3_presenter.to_vizjson(vector: true)[:vector].should eq true
+      v3_presenter.to_vizjson(vector: false)[:vector].should eq false
+    end
+
     it 'to_named_map_vizjson uses the redis vizjson cache' do
       fake_vizjson = { fake: 'sure!', layers: [] }
 

--- a/spec/requests/carto/editor/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/editor/public/embeds_controller_spec.rb
@@ -28,11 +28,11 @@ describe Carto::Editor::Public::EmbedsController do
       response.body.include?(@visualization.name).should be true
     end
 
-    it 'defaults to generate vizjson with vector=false' do
+    it 'defaults to generate vizjson with vector (default true for this fake visualization with 0 features)' do
       get editor_visualization_public_embed_url(visualization_id: @visualization.id)
 
       response.status.should == 200
-      response.body.should include('\"vector\":false')
+      response.body.should include('\"vector\":true')
     end
 
     it 'generates vizjson with vector=true with flag' do
@@ -40,6 +40,13 @@ describe Carto::Editor::Public::EmbedsController do
 
       response.status.should == 200
       response.body.should include('\"vector\":true')
+    end
+
+    it 'generates vizjson with vector=false with flag' do
+      get editor_visualization_public_embed_url(visualization_id: @visualization.id, vector: false)
+
+      response.status.should == 200
+      response.body.should include('\"vector\":false')
     end
 
     it 'does not embed private visualizations' do

--- a/spec/requests/carto/editor/visualizations_controller_spec.rb
+++ b/spec/requests/carto/editor/visualizations_controller_spec.rb
@@ -63,11 +63,11 @@ describe Carto::Editor::VisualizationsController do
       response.status.should == 403
     end
 
-    it 'defaults to generate vizjson with vector=false' do
+    it 'defaults to generate vizjson with vector=true (default true for this fake visualization with 0 features)' do
       get editor_visualization_url(id: @visualization.id)
 
       response.status.should == 200
-      response.body.should include('\"vector\":false')
+      response.body.should include('\"vector\":true')
     end
 
     it 'generates vizjson with vector=true with flag' do
@@ -75,6 +75,13 @@ describe Carto::Editor::VisualizationsController do
 
       response.status.should == 200
       response.body.should include('\"vector\":true')
+    end
+
+    it 'generates vizjson with vector=false with false flag' do
+      get editor_visualization_url(id: @visualization.id, vector: false)
+
+      response.status.should == 200
+      response.body.should include('\"vector\":false')
     end
 
     it 'displays analysesData' do


### PR DESCRIPTION
This is the backend side of #7307. It enables vector based on the statistic of row number. Since it's an statistic it's not always up-to-date and might enable vector if the table has recently grown beyond the threshold.

We still need to disable vector if user adds a layer. @xavijam can any frontend take care of it or should I dive into it?

@javitonino CR this, please.

cc @javisantana 