### PR TITLE
Fixes retried_times increments

### DIFF
--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -1,4 +1,3 @@
-
 # encoding: utf-8
 require 'virtus'
 require_relative 'adapter'

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -1,3 +1,4 @@
+
 # encoding: utf-8
 require 'virtus'
 require_relative 'adapter'
@@ -379,7 +380,7 @@ module CartoDB
           default_message = CartoDB::IMPORTER_ERROR_CODES.fetch(self.error_code, {})
           self.error_message = default_message.fetch(:title, '')
         end
-        if self.retried_times < MAX_RETRIES - 1
+        if self.retried_times < MAX_RETRIES
           self.retried_times  += 1
           self.run_at         = Time.now + interval
         else
@@ -394,8 +395,7 @@ module CartoDB
         self.state          = STATE_FAILURE
         self.error_code     = error_code
         self.error_message  = error_message
-        self.retried_times  += 1 unless self.retried_times >= MAX_RETRIES
-        if self.retried_times < MAX_RETRIES - 1
+        if self.retried_times < MAX_RETRIES
           self.retried_times  += 1
           self.run_at         = Time.now + interval
         else


### PR DESCRIPTION
Fixes #7649 

====

Description copied from the issue:


It's been a couple of times that I have been receiving *a lot* (33, but I've tested up to 1K emails...) of emails of "Your sync has reached the max retries attempts".

I've been taking a look at the code and found [this](https://github.com/CartoDB/cartodb/blob/2656a6e3ff496a65eee8e9aec732d020aef26cf8/app/models/synchronization/member.rb#L382-L388):

```ruby
def set_failure_state_from(importer)
        log.append_and_store     '******** synchronization failed ********'
        self.log_trace      = importer.runner_log_trace
        log.append     "*** Runner log: #{self.log_trace} \n***" unless self.log_trace.nil?
        self.state          = STATE_FAILURE
        self.error_code     = importer.error_code.blank? ? 9999 : importer.error_code
        self.error_message  = importer.error_message
        # Try to fill empty messages with the list
        if self.error_message.blank? && !self.error_code.nil?
          default_message = CartoDB::IMPORTER_ERROR_CODES.fetch(self.error_code, {})
          self.error_message = default_message.fetch(:title, '')
        end
        if self.retried_times < MAX_RETRIES - 1
          self.retried_times  += 1
          self.run_at         = Time.now + interval
        else
          ::Resque.enqueue(::Resque::UserJobs::Mail::Sync::MaxRetriesReached, self.user_id,
                           self.visualization_id, self.name, self.error_code, self.error_message)
        end
      end
````

This method is called whenever there's an error rescued in the Sync process not related with the import. In the case of import, the method `set_general_failure_state_from ` is used.

`MAX_RETRIES` = 10, so from the code above I'm seeing that when `self.retried_times` is equal to 9, it will never go through the if block that increments the retried time up to 10, the maximum, and it will *always* go through the else block that sends a mail to the user.

The task that enqueues the Sync Tables to be run again checks that `self.retried_times < MAX_RETRIES`, so this scenario is going to be enqueued always as `9 < 10` and `self.run_at         = Time.now + interval` does never get updated. The cron that runs the rake for enqueueing syncs will always see a sync in this state as something that needs to be enqueued every time.

In short, when there are (at least) 9 sync failures due to the sync code -- usually malformed synchronizations (model) or inconsistent data due to source table deletions -- the mailer will flood the user inbox with emails.


The issue seems to come from https://github.com/CartoDB/cartodb/commit/c995a60e63133b8bdcac59591565d708f86fe4d5