### PR TITLE
adds restricted options for ff rakes

### DIFF
--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -135,7 +135,7 @@ namespace :cartodb do
         ff.restricted = restricted
         ff.save
 
-        puts "[INFO]\tFeature flag '#{args[:feature]}' restricted set to '#{restricted}'"
+        puts "[INFO]\tFeature flag '#{args[:feature]}' restricted set to '#{ff.restricted}'"
       else
         raise "[ERROR]\tFeature '#{args[:feature]}' doesn't exist"
       end

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -142,7 +142,7 @@ namespace :cartodb do
 
         puts "[INFO]\tFeature flag '#{args[:feature]}' restricted set to '#{restricted}'"
       else
-        raise "[ERROR]\tFeature '#{args[:feature]}' doesn't exists"
+        raise "[ERROR]\tFeature '#{args[:feature]}' doesn't exist"
       end
     end
 

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -108,7 +108,7 @@ namespace :cartodb do
 
     # WARNING: For use only at development, opensource and custom installs.
     # Refer to https://github.com/CartoDB/cartodb-management/wiki/Feature-Flags
-    desc "add feature flag"
+    desc "add feature flag and optionally set restricted (default is true)"
     task :add_feature_flag, [:feature, :restricted] => :environment do |_task, args|
       restricted = args[:restricted] ? args[:restricted].casecmp('false') != 0 : true
 

--- a/lib/tasks/enable_feature.rake
+++ b/lib/tasks/enable_feature.rake
@@ -118,14 +118,9 @@ namespace :cartodb do
         ff.id = FeatureFlag.order(:id).last.id + 1
         ff.save
 
-        puts "[INFO]\tFeature flag '#{args[:feature]}' created and restricted set to '#{restricted}'"
-      elsif ff.restricted != restricted
-        ff.restricted = restricted
-        ff.save
-
-        puts "[INFO]\tFeature flag '#{args[:feature]}' already existed, its restricted is now '#{restricted}'"
+        puts "[INFO]\tFeature flag '#{args[:feature]}' created and restricted set to '#{ff.restricted}'"
       else
-        puts "[INFO]\tFeature '#{args[:feature]}' already exists and is set to '#{restricted}'"
+        raise "[ERROR]\tFeature '#{args[:feature]}' already exists and its restricted set to '#{ff.restricted}'"
       end
     end
 


### PR DESCRIPTION
This adds an optional param to `add_feature_flag` to make it unrestricted or restricted:

```
rake cartodb:features:add_feature_flag[feature,restricted]  # add feature flag and optionally set restricted (default is true)
```

~~If the feature already exists, it will change the restricted if needed.~~
If the feature already exists, an error is raised.

It also adds another task only to change restricted of an existing feature flag (also nice to have):

```
rake cartodb:features:change_feature_restricted[feature,restricted]  # change feature flag to restricted or unrestricted
```


Please CR @javitonino 

cc/ @santisaez 