### PR TITLE
7652 fill default ramp

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
@@ -8,24 +8,13 @@ var InputRampContentView = require('./input-ramp-content-view');
 var rampList = require('./ramps');
 
 var QUANTIFICATION_METHODS = ['jenks', 'equal', 'headtails', 'quantiles'];
-
 var BINS = ['3', '4', '5', '6', '7'];
 
 module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     this._setupModel();
+    this._initBinds();
     this._initViews();
-
-    if (!this.model.get('range')) {
-      this.model.unset('fixed');
-      this.model.set('range', this._getDefaultRamp());
-    }
-  },
-
-  _getDefaultRamp: function () {
-    return _.map(rampList, function (ramp) {
-      return ramp[3];
-    }, this)[0];
   },
 
   render: function () {
@@ -44,6 +33,16 @@ module.exports = cdb.core.View.extend({
     if (!this.model.get('bins')) {
       this.model.set('bins', BINS[0]);
     }
+
+    this.model.unset('fixed');
+
+    if (!this.model.get('range')) {
+      this.model.set('range', this._getDefaultRamp());
+    }
+  },
+
+  _initBinds: function () {
+    this.model.bind('change:bins', this._updateRange, this);
   },
 
   _initViews: function () {
@@ -66,6 +65,20 @@ module.exports = cdb.core.View.extend({
     this._stackLayoutView = new StackLayoutView({
       collection: stackViewCollection
     });
+  },
+
+  _updateRange: function () {
+    var previousBins = this.model.previous('bins');
+
+    if (!previousBins) {
+      return;
+    }
+
+    var previousRamps = _.find(rampList, function (ramp) {
+      return ramp[previousBins] === this.model.get('range');
+    }, this);
+
+    this.model.set('range', previousRamps[this.model.get('bins')]);
   },
 
   _createInputRampContentView: function (stackLayoutModel, opts) {
@@ -132,5 +145,11 @@ module.exports = cdb.core.View.extend({
     }, this);
 
     return view;
+  },
+
+  _getDefaultRamp: function () {
+    return _.map(rampList, function (ramp) {
+      return ramp[this.model.get('bins')];
+    }, this)[0];
   }
 });

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
@@ -75,10 +75,11 @@ module.exports = cdb.core.View.extend({
     }
 
     var previousRamps = _.find(rampList, function (ramp) {
-      return ramp[previousBins] === this.model.get('range');
+      return ramp[previousBins].join('') === this.model.get('range').join('');
     }, this);
 
-    this.model.set('range', previousRamps[this.model.get('bins')]);
+    var bins = this.model.get('bins');
+    this.model.set('range', previousRamps[bins]);
   },
 
   _createInputRampContentView: function (stackLayoutModel, opts) {

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
@@ -1,7 +1,7 @@
 var InputColorRamps = require('../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps');
 var rampList = require('../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/ramps');
 
-fdescribe('components/form-components/editors/fill/input-color/input-ramps/input-color-ramps', function () {
+describe('components/form-components/editors/fill/input-color/input-ramps/input-color-ramps', function () {
   describe('on model with a range', function () {
     beforeEach(function () {
       this.model = new cdb.core.Model({

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
@@ -1,5 +1,4 @@
 var InputColorRamps = require('../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps');
-var rampList = require('../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/ramps');
 
 describe('components/form-components/editors/fill/input-color/input-ramps/input-color-ramps', function () {
   describe('on model with a range', function () {

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
@@ -1,0 +1,58 @@
+var InputColorRamps = require('../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps');
+var rampList = require('../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/ramps');
+
+fdescribe('components/form-components/editors/fill/input-color/input-ramps/input-color-ramps', function () {
+  describe('on model with a range', function () {
+    beforeEach(function () {
+      this.model = new cdb.core.Model({
+        bins: 7,
+        range: ['#F1EEF6', '#D4B9DA', '#C994C7', '#DF65B0', '#E7298A', '#CE1256', '#91003F'],
+        attribute: 'column1',
+        quantification: 'jenks'
+      });
+
+      this.view = new InputColorRamps(({
+        model: this.model
+      }));
+
+      this.view.render();
+    });
+
+    it('should render properly', function () {
+      expect(this.view.$el.html()).toContain('column1');
+      expect(this.view.$el.html()).toContain('7 form-components.editors.fill.input-ramp.buckets');
+      expect(this.view.$el.html()).toContain('form-components.editors.fill.quantification.methods.jenks');
+    });
+
+    it('should pick a similar ramp when changing bins', function () {
+      this.model.set('bins', 3);
+      expect(this.model.get('range').join(',')).toBe('#E7E1EF,#C994C7,#DD1C77');
+    });
+
+    afterEach(function () {
+      this.view.remove();
+    });
+  });
+
+  describe('model without previous range', function () {
+    beforeEach(function () {
+      this.model = new cdb.core.Model({
+        fixed: '#FF0000'
+      });
+
+      this.view = new InputColorRamps(({
+        model: this.model
+      }));
+    });
+
+    it('should initialize the model with default values', function () {
+      expect(this.model.get('quantification')).toBe('jenks');
+      expect(this.model.get('bins')).toBe('3');
+      expect(this.model.get('fixed')).toBe(undefined);
+    });
+
+    afterEach(function () {
+      this.view.remove();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.25.3",
+  "version": "3.25.4",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR picks a default color ramp when the user switches to the color ramp selector in the category fill. Also, when a user updates the number of bins, the ramp gets updated with the corresponding one based on the new chosen value.

Closes #7652 
