### PR TITLE
Disables the opacity selection for categories

### DIFF
--- a/app/assets/stylesheets/editor-3/color-picker.css.scss
+++ b/app/assets/stylesheets/editor-3/color-picker.css.scss
@@ -25,6 +25,11 @@
   padding: 3px 4px;
   text-align: center;
 }
+
+.ColorPicker-input.is-disabled {
+  opacity: 0.5;
+}
+
 .ColorPicker-input.is-color {
   width: 52px;
 }
@@ -82,6 +87,10 @@
   margin-bottom: $baseSize;
   border-radius: 2px;
   background-image: image-url('layout/colorpicker/alpha-horizontal.png');
+}
+
+.ColorPicker.colorpicker.colorpicker-horizontal .colorpicker-alpha.is-hidden {
+  visibility: hidden;
 }
 
 .ColorPicker.colorpicker.colorpicker-horizontal .colorpicker-alpha::before {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
@@ -64,7 +64,6 @@ module.exports = cdb.core.View.extend({
 
     if (this.options.disableOpacity) {
       this.$('.js-colorPicker .js-alpha').addClass('is-hidden');
-      this.$('.js-a').addClass('is-disabled');
     }
 
     var self = this;

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
@@ -8,7 +8,7 @@ module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     this.model = new cdb.core.Model({
       hex: opts.value,
-      opacity: opts.opacity
+      opacity: opts.opacity || 1
     });
 
     this._initBinds();
@@ -19,7 +19,8 @@ module.exports = cdb.core.View.extend({
 
     var color = _.extend(rgb, {
       hex: this.model.get('hex'),
-      opacity: this.model.get('opacity')
+      opacity: this.model.get('opacity') || 1,
+      opacityDisabled: this.options.disableOpacity
     });
 
     this.$el.append(template(color));
@@ -60,6 +61,11 @@ module.exports = cdb.core.View.extend({
         }
       }
     });
+
+    if (this.options.disableOpacity) {
+      this.$('.js-colorPicker .js-alpha').addClass('is-hidden');
+      this.$('.js-a').addClass('is-disabled');
+    }
 
     var self = this;
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/template.tpl
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/template.tpl
@@ -18,7 +18,7 @@
       <span class="ColorPicker-inputLabel u-upperCase">B</span>
     </div>
     <div class="ColorPicker-inputWrapper">
-      <input type="text" class="CDB-InputText ColorPicker-input js-a" value="<%- opacity %>" <% if (opacityDisabled) { %>disabled<% } %> />
+      <input type="text" class="CDB-InputText ColorPicker-input js-a<% if (opacityDisabled) { %> is-disabled<% } %>" value="<%- opacity %>" <% if (opacityDisabled) { %>disabled<% } %> />
       <span class="ColorPicker-inputLabel u-upperCase">A</span>
     </div>
   </div>

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/template.tpl
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/template.tpl
@@ -18,7 +18,7 @@
       <span class="ColorPicker-inputLabel u-upperCase">B</span>
     </div>
     <div class="ColorPicker-inputWrapper">
-      <input type="text" class="CDB-InputText ColorPicker-input js-a" value="<%- opacity %>" />
+      <input type="text" class="CDB-InputText ColorPicker-input js-a" value="<%- opacity %>" <% if (opacityDisabled) { %>disabled<% } %> />
       <span class="ColorPicker-inputLabel u-upperCase">A</span>
     </div>
   </div>

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-view.js
@@ -40,7 +40,8 @@ module.exports = cdb.core.View.extend({
 
     this._colorPicker = new ColorPicker({
       value: this._getColor(),
-      opacity: 1
+      opacity: 1,
+      disableOpacity: true
     });
 
     this.addView(this._colorPicker);

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color.js
@@ -104,10 +104,12 @@ module.exports = cdb.core.View.extend({
   },
 
   _getRGBA: function (color, opacity) {
-    return 'rgba(' + parseInt(color.slice(-6, -4), 16) + ',' +
-     parseInt(color.slice(-4, -2), 16) + ',' +
-    parseInt(color.slice(-2), 16) + ',' +
-    opacity + ')';
+    var r = parseInt(color.slice(-6, -4), 16);
+    var g = parseInt(color.slice(-4, -2), 16);
+    var b = parseInt(color.slice(-2), 16);
+    var a = opacity || 1;
+
+    return 'rgba(' + [r, g, b, a].join(',') + ')';
   },
 
   _onToggleSelected: function () {

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/color-picker/color-picker.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/color-picker/color-picker.spec.js
@@ -1,0 +1,48 @@
+var ColorPicker = require('../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker');
+
+describe('components/form-components/editors/fill/color-picker/color-picker', function () {
+  describe('with opacity', function () {
+    beforeEach(function () {
+      this.view = new ColorPicker({
+        value: '#A6CEE3',
+        opacity: 0.5
+      });
+
+      this.view.render();
+    });
+
+    it('should get render', function () {
+      expect(this.view.$('.js-hex').val()).toBe('#A6CEE3');
+      expect(this.view.$('.js-r').val()).toBe('166');
+      expect(this.view.$('.js-g').val()).toBe('206');
+      expect(this.view.$('.js-b').val()).toBe('227');
+      expect(this.view.$('.js-a').val()).toBe('0.5');
+    });
+
+    afterEach(function () {
+      this.view.remove();
+    });
+  });
+
+  describe('withouth opacity', function () {
+    beforeEach(function () {
+      this.view = new ColorPicker({
+        value: '#A6CEE3',
+        opacity: 0.5,
+        disableOpacity: true
+      });
+
+      this.view.render();
+    });
+
+    it('should disable the opacity selector', function () {
+      expect(this.view.$('.js-a').val()).toBe('0.5');
+      expect(this.view.$('.js-a').hasClass('is-disabled')).toBe(true);
+      expect(this.view.$('.js-colorPicker .js-alpha').hasClass('is-hidden')).toBe(true);
+    });
+
+    afterEach(function () {
+      this.view.remove();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.25.3",
+  "version": "3.25.5",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since category ramps are just a list of opaque colors, the color picker shouldn't give the option to change the opacity. This PR does that.

This PR also sets the default opacity to 1 in case it's not defined.

![screen shot 2016-06-06 at 13 20 25](https://cloud.githubusercontent.com/assets/4933/15820372/5c25d452-2be9-11e6-9e7b-e1cb5a7dd79c.png)

Closes #7667
