### PR TITLE
7306 auto indexing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ WORKING_SPECS_9 = \
 # Tests using spec_helper_min instead of spec_helper
 SPEC_HELPER_MIN_SPECS = \
 	spec/models/carto/analysis_spec.rb \
+	spec/models/carto/analysis_node_spec.rb \
 	spec/models/carto/mobile_app_presenter_spec.rb \
 	spec/models/carto/overlay_spec.rb \
 	spec/models/table_registrar_spec.rb \

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/requests/carto/api/visualization_exports_controller_spec.rb \
 	spec/requests/carto/api/vizjson3_presenter_spec.rb \
 	spec/requests/admin/users_controller_spec.rb \
+	spec/services/carto/user_table_index_service_spec.rb \
 	spec/lib/carto/strong_password_validator_spec.rb \
 	spec/lib/initializers/zz_patch_reconnect_spec.rb \
 	spec/lib/cartodb/redis_vizjson_cache_spec.rb \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 3.14.0 (2016-XX-XX)
 -------------------
 
+### NOTICE
+This release introduces a new Resque queue: `user_dbs`. It is needed for operation on user databases, i.e: linking
+ghost tables, importing common data and automatic index creation.
+
+### Features
+* Automatic creation of indexes on columns affected by a widget
+
 ### Bug Fixes
 * Incorrect error message when password validation failed
 

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -66,7 +66,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
     @user.save(raise_on_failure: true)
     @user.create_in_central
     common_data_url = CartoDB::Visualization::CommonDataService.build_url(self)
-    ::Resque.enqueue(::Resque::UserJobs::CommonData::LoadCommonData, @user.id, common_data_url)
+    ::Resque.enqueue(::Resque::UserDBJobs::CommonData::LoadCommonData, @user.id, common_data_url)
     @user.notify_new_organization_user
     @user.organization.notify_if_seat_limit_reached
     redirect_to CartoDB.url(self, 'organization', {}, current_user), flash: { success: "New user created successfully" }

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -457,7 +457,7 @@ class Admin::VisualizationsController < Admin::AdminController
     return true unless current_user.present?
     begin
       visualizations_api_url = CartoDB::Visualization::CommonDataService.build_url(self)
-      ::Resque.enqueue(::Resque::UserJobs::CommonData::LoadCommonData, current_user.id, visualizations_api_url) if current_user.should_load_common_data?
+      ::Resque.enqueue(::Resque::UserDBJobs::CommonData::LoadCommonData, current_user.id, visualizations_api_url) if current_user.should_load_common_data?
     rescue Exception => e
       # We don't block the load of the dashboard because we aren't able to load common dat
       CartoDB.notify_exception(e, {user:current_user})

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -41,7 +41,7 @@ class Carto::Analysis < ActiveRecord::Base
   end
 
   def analysis_node
-    Carto::AnalysisNode.new(self, analysis_definition)
+    Carto::AnalysisNode.new(analysis_definition)
   end
 
   private

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -26,7 +26,7 @@ class Carto::Analysis < ActiveRecord::Base
   end
 
   def analysis_definition_for_api
-    filter_valid_properties(analysis_definition)
+    filter_valid_properties(analysis_node)
   end
 
   def natural_id
@@ -50,10 +50,11 @@ class Carto::Analysis < ActiveRecord::Base
   # This methods extract the needed ones.
   VALID_ANALYSIS_PROPERTIES = [:id, :type, :params].freeze
 
-  def filter_valid_properties(definition)
-    valid = definition.select { |property, _| VALID_ANALYSIS_PROPERTIES.include?(property) }
-    if valid[:params] && valid[:params][:source]
-      valid[:params][:source] = filter_valid_properties(valid[:params][:source])
+  def filter_valid_properties(node)
+    valid = node.definition.select { |property, _| VALID_ANALYSIS_PROPERTIES.include?(property) }
+    node.children_and_location.each do |location, child|
+      child_in_hash = location.reduce(valid, :[])
+      child_in_hash.replace(filter_valid_properties(child))
     end
     valid
   end

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -40,6 +40,10 @@ class Carto::Analysis < ActiveRecord::Base
     visualization.map
   end
 
+  def analysis_node
+    Carto::AnalysisNode(self, analysis_definition)
+  end
+
   private
 
   # Analysis definition contains attributes not needed by Analysis API (see #7128).

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -41,7 +41,7 @@ class Carto::Analysis < ActiveRecord::Base
   end
 
   def analysis_node
-    Carto::AnalysisNode(self, analysis_definition)
+    Carto::AnalysisNode.new(self, analysis_definition)
   end
 
   private

--- a/app/models/carto/analysis_node.rb
+++ b/app/models/carto/analysis_node.rb
@@ -1,0 +1,31 @@
+# encoding: UTF-8
+
+class Carto::AnalysisNode
+  def initialize(analysis, definition, parent: nil)
+    @analysis = analysis
+    @definition = definition
+    @parent = parent
+  end
+
+  attr_reader :analysis, :definition, :parent
+
+  def children
+    @children ||= get_children(@definition)
+  end
+
+  private
+
+  MANDATORY_KEYS_FOR_ANALYSIS_NODE = [:id, :type, :params, :options].freeze
+  def get_children(definition)
+    children = definition.map do |_, v|
+      if v.is_a?(Hash)
+        if (MANDATORY_KEYS_FOR_ANALYSIS_NODE - v.keys).empty?
+          Carto::AnalysisNode.new(analysis, v, parent: self)
+        else
+          get_children(v)
+        end
+      end
+    end
+    children.flatten.compact
+  end
+end

--- a/app/models/carto/analysis_node.rb
+++ b/app/models/carto/analysis_node.rb
@@ -1,13 +1,11 @@
 # encoding: UTF-8
 
 class Carto::AnalysisNode
-  def initialize(analysis, definition, parent: nil)
-    @analysis = analysis
+  def initialize(definition)
     @definition = definition
-    @parent = parent
   end
 
-  attr_reader :analysis, :definition, :parent
+  attr_reader :definition
 
   def id
     definition[:id]
@@ -59,7 +57,7 @@ class Carto::AnalysisNode
       if v.is_a?(Hash)
         this_path = path + [k]
         if (MANDATORY_KEYS_FOR_ANALYSIS_NODE - v.keys).empty?
-          { this_path => Carto::AnalysisNode.new(analysis, v, parent: self) }
+          { this_path => Carto::AnalysisNode.new(v) }
         else
           get_children(v, this_path)
         end

--- a/app/models/carto/analysis_node.rb
+++ b/app/models/carto/analysis_node.rb
@@ -33,11 +33,7 @@ class Carto::AnalysisNode
 
   def find_by_id(node_id)
     return self if node_id == id
-    children.each do |child|
-      found = child.find_by_id(node_id)
-      return found unless found.nil?
-    end
-    nil
+    children.lazy.map { |child| child.find_by_id(node_id) }.find { |child| child }
   end
 
   def source?

--- a/app/models/carto/analysis_node.rb
+++ b/app/models/carto/analysis_node.rb
@@ -42,6 +42,15 @@ class Carto::AnalysisNode
     nil
   end
 
+  def source?
+    type == 'source'
+  end
+
+  def table_source?(table_name)
+    # Maybe check params[:query]
+    source? && options && options[:table_name] == table_name
+  end
+
   private
 
   MANDATORY_KEYS_FOR_ANALYSIS_NODE = [:id, :type, :params, :options].freeze

--- a/app/models/carto/analysis_node.rb
+++ b/app/models/carto/analysis_node.rb
@@ -9,8 +9,33 @@ class Carto::AnalysisNode
 
   attr_reader :analysis, :definition, :parent
 
+  def id
+    @definition[:id]
+  end
+
+  def type
+    @definition[:type]
+  end
+
+  def params
+    @definition[:params]
+  end
+
+  def options
+    @definition[:options]
+  end
+
   def children
     @children ||= get_children(@definition)
+  end
+
+  def find_by_id(node_id)
+    return self if node_id == id
+    children.each do |child|
+      found = child.find_by_id(node_id)
+      return found unless found.nil?
+    end
+    nil
   end
 
   private

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -99,6 +99,14 @@ module Carto
       basemap? && options["labels"] && options["labels"]["url"]
     end
 
+    def map
+      maps.first
+    end
+
+    def visualization
+      map.visualization
+    end
+
     private
 
     def tables_from_query_option

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -13,7 +13,7 @@ module Carto
     has_many :layers_user
     has_many :users, through: :layers_user
 
-    has_many :layers_user_table, foreign_key: :layer_id
+    has_many :layers_user_table
     has_many :user_tables, through: :layers_user_table, class_name: Carto::UserTable
 
     has_many :widgets, class_name: Carto::Widget, order: '"order"'

--- a/app/models/carto/layers_user_table.rb
+++ b/app/models/carto/layers_user_table.rb
@@ -6,7 +6,7 @@ module Carto
   class LayersUserTable < ActiveRecord::Base
 
     belongs_to :layer, class_name: Carto::Layer
-    belongs_to :user_table, class_name: Carto::UserTable, foreign_key: :table_id
+    belongs_to :user_table, class_name: Carto::UserTable
 
   end
 end

--- a/app/models/carto/map.rb
+++ b/app/models/carto/map.rb
@@ -116,6 +116,10 @@ class Carto::Map < ActiveRecord::Base
     map.notify_map_change if map
   end
 
+  def visualization
+    visualizations.first
+  end
+
   private
 
   def get_the_last_time_tiles_have_changed_to_render_it_in_vizjsons

--- a/app/models/carto/widget.rb
+++ b/app/models/carto/widget.rb
@@ -42,7 +42,7 @@ class Carto::Widget < ActiveRecord::Base
   end
 
   def visualization
-    layer.maps.first.visualizations.first
+    layer.visualization
   end
 
   def analysis_node

--- a/app/models/carto/widget.rb
+++ b/app/models/carto/widget.rb
@@ -41,6 +41,19 @@ class Carto::Widget < ActiveRecord::Base
     layer.maps { |l| l.writable_by_user?(user) }.select { |writable| !writable }.empty?
   end
 
+  def visualization
+    layer.maps.first.visualizations.first
+  end
+
+  def analysis_node
+    return nil unless source_id
+    visualization.analyses.map(&:analysis_node).each do |node|
+      found = node.find_by_id(source_id)
+      return found if found
+    end
+    nil
+  end
+
   private
 
   def notify_maps_change

--- a/app/models/carto/widget.rb
+++ b/app/models/carto/widget.rb
@@ -47,11 +47,8 @@ class Carto::Widget < ActiveRecord::Base
 
   def analysis_node
     return nil unless source_id
-    visualization.analyses.map(&:analysis_node).each do |node|
-      found = node.find_by_id(source_id)
-      return found if found
-    end
-    nil
+    analysis_nodes = visualization.analyses.map(&:analysis_node)
+    analysis_nodes.lazy.map { |node| node.find_by_id(source_id) }.find { |node| node }
   end
 
   def column

--- a/app/models/carto/widget.rb
+++ b/app/models/carto/widget.rb
@@ -54,6 +54,10 @@ class Carto::Widget < ActiveRecord::Base
     nil
   end
 
+  def column
+    options[:column]
+  end
+
   private
 
   def notify_maps_change

--- a/app/models/carto/widget.rb
+++ b/app/models/carto/widget.rb
@@ -13,8 +13,8 @@ class Carto::Widget < ActiveRecord::Base
 
   validates :layer, :order, :type, :options, presence: true
 
-  after_save :notify_maps_change
-  after_destroy :notify_maps_change
+  after_save    :notify_maps_change, :auto_generate_indices
+  after_destroy :notify_maps_change, :auto_generate_indices
 
   def self.from_visualization_id(visualization_id)
     visualization = Carto::Visualization.where(id: visualization_id).first
@@ -64,6 +64,12 @@ class Carto::Widget < ActiveRecord::Base
     layer.maps.each do |m|
       map = Map.where(id: m.id).first
       map.notify_map_change if map
+    end
+  end
+
+  def auto_generate_indices
+    layer.user_tables.each do |ut|
+      ::Resque.enqueue(::Resque::UserDBJobs::UserDBMaintenance::AutoIndexTable, ut.id)
     end
   end
 end

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1322,6 +1322,11 @@ class Table
     sequel.count
   end
 
+  def pg_stats
+    owner.in_database.fetch('SELECT * FROM pg_stats where schemaname = ? AND tablename = ?',
+                            owner.database_schema, name).all
+  end
+
   def beautify_name(name)
     return name unless name
     name.tr('_', ' ').split.map(&:capitalize).join(' ')

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1105,7 +1105,7 @@ class Table
   def pg_indexes
     owner.in_database(as: :superuser).fetch(%{
       SELECT
-        a.attname as column, i.relname as name,
+        a.attname as column, i.relname as name
       FROM
         pg_class t, pg_class i, pg_index ix, pg_attribute a
       WHERE

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1099,7 +1099,7 @@ class Table
   end
 
   def has_index?(column_name)
-    pg_indexes.map { |i| i[:column] }.include? column_name
+    pg_indexes.any? { |i| i[:column] == column_name }
   end
 
   def pg_indexes

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1118,8 +1118,9 @@ class Table
     }).all
   end
 
-  def create_index(column, prefix = '')
-    owner.in_database[%{CREATE INDEX "#{index_name(column, prefix)}" ON "#{name}"("#{column}")}]
+  def create_index(column, prefix = '', concurrent: false)
+    concurrently = concurrent ? 'CONCURRENTLY' : ''
+    owner.in_database[%{CREATE INDEX #{concurrently} "#{index_name(column, prefix)}" ON "#{name}"("#{column}")}]
   end
 
   def drop_index(column, prefix = '')

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1120,11 +1120,11 @@ class Table
 
   def create_index(column, prefix = '', concurrent: false)
     concurrently = concurrent ? 'CONCURRENTLY' : ''
-    owner.in_database[%{CREATE INDEX #{concurrently} "#{index_name(column, prefix)}" ON "#{name}"("#{column}")}]
+    owner.in_database.execute(%{CREATE INDEX #{concurrently} "#{index_name(column, prefix)}" ON "#{name}"("#{column}")})
   end
 
   def drop_index(column, prefix = '')
-    owner.in_database[%{DROP INDEX "#{index_name(column, prefix)}"}]
+    owner.in_database.execute(%{DROP INDEX "#{index_name(column, prefix)}"})
   end
 
   def cartodbfy

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -24,13 +24,19 @@ module Carto
 
       indexed_columns = indices.map { |i| i[:column] }
       create_index_on = columns_to_index - indexed_columns
-      create_index_on.each { |col| @table.create_index(col, AUTO_INDEX_PREFIX, concurrent: true) }
+      create_index_on.each do |col|
+        CartoDB::Logger.debug(message: 'Auto index', action: 'create', table: @user_table, column: col)
+        @table.create_index(col, AUTO_INDEX_PREFIX, concurrent: true)
+      end
 
       auto_indexed_columns = auto_indices.map { |i| i[:column] }
       drop_index_on = auto_indexed_columns - columns_to_index
-      drop_index_on.each { |col| @table.drop_index(col, AUTO_INDEX_PREFIX) }
+      drop_index_on.each do |col|
+        CartoDB::Logger.debug(message: 'Auto index', action: 'drop', table: @user_table, column: col)
+        @table.drop_index(col, AUTO_INDEX_PREFIX)
+      end
     rescue => e
-      CartoDB::Logger.error(exception: e, message: 'Error auto-indexing table', table: user_table)
+      CartoDB::Logger.error(exception: e, message: 'Error auto-indexing table', table: @user_table)
     end
 
     def indexable_column?(column)
@@ -99,7 +105,7 @@ module Carto
       if stats && !stats.empty?
         stats.map { |s| { s[:attname] => s } }.reduce(:merge)
       else
-        CartoDB::Logger.warning(message: 'Error retrieving stats for table', table: user_table)
+        CartoDB::Logger.warning(message: 'Error retrieving stats for table', table: @user_table)
         nil
       end
     end

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -24,7 +24,7 @@ module Carto
 
       indexed_columns = indices.map { |i| i[:column] }
       create_index_on = columns_to_index - indexed_columns
-      create_index_on.each { |col| @table.create_index(col, AUTO_INDEX_PREFIX) }
+      create_index_on.each { |col| @table.create_index(col, AUTO_INDEX_PREFIX, concurrent: true) }
 
       auto_indexed_columns = auto_indices.map { |i| i[:column] }
       drop_index_on = auto_indexed_columns - columns_to_index

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -2,8 +2,19 @@ module Carto
   class UserTableIndexService
     AUTO_INDEX_TTL_MS = 600000
     AUTO_INDEX_PREFIX = '_auto_idx_'.freeze
-    MINIMUM_ROW_COUNT_TO_INDEX = 10000
     INDEXABLE_WIDGET_TYPES = %w(histogram category time-series).freeze
+
+    # Not worth it to create indices on small tables, where a full scan is cheap.
+    # Maybe better to use number of pages instead of rows instead.
+    MINIMUM_ROW_COUNT_TO_INDEX = 10000
+    # Number of categories (most common) shown by default in widgets, used to determine the number
+    # of categories likely to be used for filtering.
+    CATEGORIES_SHOWN_IN_WIDGET = 5
+    # Number of different values in a column to consider indexing it, to avoid indexing boolean columns.
+    # Note: Also used to index columns with less values but an unbalanced probability distribution.
+    MINIMUM_COLUMN_VALUES_TO_INDEX = 5
+    # Regardless of anything, columns with high clustering factor (sorted in physical order) are also indexed.
+    MINIMUM_CORRELATION_TO_INDEX = 0.9
 
     def initialize(user_table)
       @user_table = user_table
@@ -48,19 +59,19 @@ module Carto
       # or with few but unbalanced values (e.g: boolean with 80/20 distribution)
       common_freqs = stats[:most_common_freqs] || stats[:most_common_elem_freqs]
       if common_freqs.present?
-        check_common_freq = common_freqs[4] || common_freqs.last
-        if check_common_freq < 0.25
+        check_common_freq = common_freqs[CATEGORIES_SHOWN_IN_WIDGET - 1] || common_freqs.last
+        if check_common_freq < (1.0 / MINIMUM_COLUMN_VALUES_TO_INDEX)
           return true
         end
       else
         # No histogram, rely on distinct values. Note: Values < 0 represent a proportion over the number of rows.
         # They are generated when the analyzer gives up counting or identifies the value as a continuous magnitude
         distinct = stats[:n_distinct]
-        return true if distinct < 0 || distinct > 4
+        return true if distinct < 0 || distinct > MINIMUM_COLUMN_VALUES_TO_INDEX
       end
 
       # Accept columns with high correlation (values related to physical row order)
-      if stats[:correlation].abs > 0.9
+      if stats[:correlation].abs > MINIMUM_CORRELATION_TO_INDEX
         return true
       end
 

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -6,12 +6,15 @@ module Carto
 
     private
 
-    def widgets
-      @user_table.layers.map(&:widgets).flatten
+    def table_widgets
+      widgets.select do |w|
+        node = w.analysis_node
+        node && node.table_source?(@user_table.name)
+      end
     end
 
-    def visualizations
-      @user_table.layers.map(&:maps).flatten.map(&:visualizations).map(&:first)
+    def widgets
+      @user_table.layers.map(&:widgets).flatten
     end
   end
 end

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -106,7 +106,7 @@ module Carto
         stats.map { |s| { s[:attname] => s } }.reduce(:merge)
       else
         CartoDB::Logger.warning(message: 'Error retrieving stats for table', table: @user_table)
-        nil
+        {}
       end
     end
   end

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -1,0 +1,17 @@
+module Carto
+  class UserTableIndexService
+    def initialize(user_table)
+      @user_table = user_table
+    end
+
+    private
+
+    def widgets
+      @user_table.layers.map(&:widgets).flatten
+    end
+
+    def visualizations
+      @user_table.layers.map(&:maps).flatten.map(&:visualizations).map(&:first)
+    end
+  end
+end

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -36,13 +36,17 @@ module Carto
       return false unless stats
 
       # Accept columns with several different values
+      # Checks common values and accepts cases with several value
+      # or with few but unbalanced values (e.g: boolean with 80/20 distribution)
       common_freqs = stats[:most_common_freqs] || stats[:most_common_elem_freqs]
       if common_freqs.present?
-        if common_freqs.last < 0.25
+        check_common_freq = common_freqs[4] || common_freqs.last
+        if check_common_freq < 0.25
           return true
         end
       else
-        # No histrogram, rely on distinct values
+        # No histogram, rely on distinct values. Note: Values < 0 represent a proportion over the number of rows.
+        # They are generated when the analyzer gives up counting or identifies the value as a continuous magnitude
         distinct = stats[:n_distinct]
         return true if distinct < 0 || distinct > 4
       end

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -10,7 +10,9 @@ module Carto
     end
 
     def generate_indices
-      columns_to_index = (@table.estimated_row_count > MINIMUM_ROW_COUNT_TO_INDEX) ? columns_with_widgets : []
+      widget_columns = (@table.estimated_row_count > MINIMUM_ROW_COUNT_TO_INDEX) ? columns_with_widgets : []
+      columns_to_index = widget_columns.select { |c| indexable_column?(c) }
+
       auto_indexed_columns = auto_indices.map { |i| i[:column] }
       indexed_columns = indices.map { |i| i[:column] }
 
@@ -23,9 +25,29 @@ module Carto
 
     private
 
-    def columns_with_widgets
-      column_widgets = widgets_by_column
-      column_widgets.keys
+    def indexable_column?(column)
+      stats = pg_stats_by_column[column]
+      return false unless stats
+
+      # Accept columns with several different values
+      common_freqs = stats[:most_common_freqs] || stats[:most_common_elem_freqs]
+      if common_freqs.present?
+        if common_freqs.last < 0.25
+          return true
+        end
+      else
+        # No histrogram, rely on distinct values
+        distinct = stats[:n_distinct]
+        return true if distinct < 0 || distinct > 4
+      end
+
+      # Accept columns with high correlation (values related to physical row order)
+      if stats[:correlation].abs > 0.9
+        return true
+      end
+
+      # Default
+      false
     end
 
     def auto_indices
@@ -36,12 +58,12 @@ module Carto
       @indices ||= @table.pg_indexes
     end
 
-    def widgets_by_column
-      column_widgets = {}
-      table_widgets.select { |w1| INDEXABLE_WIDGET_TYPES.include?(w1.type) }.each do |w2|
-        column_widgets.fetch(w2.column) { |k| column_widgets[k] = [] } << w2
+    def columns_with_widgets
+      columns = Set.new
+      table_widgets.select { |w| INDEXABLE_WIDGET_TYPES.include?(w.type) }.each do |w|
+        columns.add(w.column)
       end
-      column_widgets
+      columns
     end
 
     def table_widgets
@@ -53,6 +75,16 @@ module Carto
 
     def widgets
       @user_table.layers.map(&:widgets).flatten
+    end
+
+    def pg_stats_by_column
+      @stats ||= get_pg_stats_by_column
+    end
+
+    def get_pg_stats_by_column
+      @table.update_table_pg_stats
+      stats = @table.pg_stats
+      stats.map { |s| { s[:attname] => s } }.reduce(:merge)
     end
   end
 end

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -1,10 +1,48 @@
 module Carto
   class UserTableIndexService
+    AUTO_INDEX_PREFIX = '_auto_idx_'.freeze
+    MINIMUM_ROW_COUNT_TO_INDEX = 10000
+    INDEXABLE_WIDGET_TYPES = %w(histogram category time-series).freeze
+
     def initialize(user_table)
       @user_table = user_table
+      @table = user_table.service
+    end
+
+    def generate_indices
+      columns_to_index = (@table.estimated_row_count > MINIMUM_ROW_COUNT_TO_INDEX) ? columns_with_widgets : []
+      auto_indexed_columns = auto_indices.map { |i| i[:column] }
+      indexed_columns = indices.map { |i| i[:column] }
+
+      create_index_on = columns_to_index - indexed_columns
+      create_index_on.each { |col| @table.create_index(col, AUTO_INDEX_PREFIX) }
+
+      drop_index_on = auto_indexed_columns - columns_to_index
+      drop_index_on.each { |col| @table.drop_index(col, AUTO_INDEX_PREFIX) }
     end
 
     private
+
+    def columns_with_widgets
+      column_widgets = widgets_by_column
+      column_widgets.keys
+    end
+
+    def auto_indices
+      indices.select { |i| i[:name].starts_with?(AUTO_INDEX_PREFIX) }
+    end
+
+    def indices
+      @indices ||= @table.pg_indexes
+    end
+
+    def widgets_by_column
+      column_widgets = {}
+      table_widgets.select { |w1| INDEXABLE_WIDGET_TYPES.include?(w1.type) }.each do |w2|
+        column_widgets.fetch(w2.column) { |k| column_widgets[k] = [] } << w2
+      end
+      column_widgets
+    end
 
     def table_widgets
       widgets.select do |w|

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -11,7 +11,7 @@ module Carto
     end
 
     def update_auto_indices
-      bolt = Carto::Bolt.new("user_table:#{user_table.id}:auto_index", ttl_ms: AUTO_INDEX_TTL_MS)
+      bolt = Carto::Bolt.new("user_table:#{@user_table.id}:auto_index", ttl_ms: AUTO_INDEX_TTL_MS)
 
       bolt.run_locked { generate_indices }
     end

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -19,7 +19,7 @@ module Carto
       return if user_tables_synced_with_db?
 
       if safe_async?
-        ::Resque.enqueue(::Resque::UserJobs::SyncTables::LinkGhostTables, @user_id)
+        ::Resque.enqueue(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTables, @user_id)
       else
         link_ghost_tables_synchronously
       end

--- a/lib/resque/user_db_jobs.rb
+++ b/lib/resque/user_db_jobs.rb
@@ -1,0 +1,43 @@
+# encoding: utf-8
+require_relative './base_job'
+require 'resque-metrics'
+require_relative '../cartodb/metrics'
+
+module Resque
+  module UserDBJobs
+    module UserDBMaintenance
+      module LinkGhostTables
+        extend ::Resque::Metrics
+        @queue = :user_dbs
+
+        def self.perform(user_id)
+          Carto::GhostTablesManager.new(user_id).link_ghost_tables_synchronously
+        rescue => e
+          CartoDB.notify_exception(e)
+          raise e
+        end
+      end
+
+      module AutoIndexTable
+        @queue = :user_dbs
+
+        def self.perform(user_table_id)
+          user_table = Carto::UserTable.where(id: user_table_id).first
+          Carto::UserTableIndexService(Carto::UserTable.find(user_table_id)).generate_indices if user_table
+        rescue => e
+          CartoDB::Logger.error(message: 'Error auto-indexing table', exception: e, user_table_id: user_table_id)
+        end
+      end
+    end
+
+    module CommonData
+      module LoadCommonData
+        @queue = :user_dbs
+
+        def self.perform(user_id, visualizations_api_url)
+          ::User.where(id: user_id).first.load_common_data(visualizations_api_url)
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/user_db_jobs.rb
+++ b/lib/resque/user_db_jobs.rb
@@ -23,7 +23,7 @@ module Resque
 
         def self.perform(user_table_id)
           user_table = Carto::UserTable.where(id: user_table_id).first
-          Carto::UserTableIndexService(Carto::UserTable.find(user_table_id)).generate_indices if user_table
+          Carto::UserTableIndexService(Carto::UserTable.find(user_table_id)).update_auto_indices if user_table
         rescue => e
           CartoDB::Logger.error(message: 'Error auto-indexing table', exception: e, user_table_id: user_table_id)
         end

--- a/lib/resque/user_db_jobs.rb
+++ b/lib/resque/user_db_jobs.rb
@@ -23,7 +23,7 @@ module Resque
 
         def self.perform(user_table_id)
           user_table = Carto::UserTable.where(id: user_table_id).first
-          Carto::UserTableIndexService(Carto::UserTable.find(user_table_id)).update_auto_indices if user_table
+          Carto::UserTableIndexService.new(user_table).update_auto_indices if user_table
         rescue => e
           CartoDB::Logger.error(message: 'Error auto-indexing table', exception: e, user_table_id: user_table_id)
         end

--- a/lib/resque/user_jobs.rb
+++ b/lib/resque/user_jobs.rb
@@ -58,31 +58,6 @@ module Resque
 
     end
 
-    module SyncTables
-      module LinkGhostTables
-        extend ::Resque::Metrics
-        @queue = :users
-
-        def self.perform(user_id)
-          Carto::GhostTablesManager.new(user_id).link_ghost_tables_synchronously
-        rescue => e
-          CartoDB.notify_exception(e)
-          raise e
-        end
-      end
-    end
-
-    module CommonData
-      module LoadCommonData
-        @queue = :users
-
-        def self.perform(user_id, visualizations_api_url)
-          ::User.where(id: user_id).first.load_common_data(visualizations_api_url)
-        end
-      end
-
-    end
-
     module Mail
 
       module NewOrganizationUser

--- a/script/resque
+++ b/script/resque
@@ -1,2 +1,2 @@
 #!/bin/sh
-VVERBOSE=true QUEUE=imports,exports,users,geocodings,synchronizations,tracker rake environment resque:work
+VVERBOSE=true QUEUE=imports,exports,users,user_dbs,geocodings,synchronizations,tracker rake environment resque:work

--- a/spec/factories/analyses.rb
+++ b/spec/factories/analyses.rb
@@ -14,8 +14,15 @@ FactoryGirl.define do
   }.freeze
 
   factory :source_analysis, class: Carto::Analysis do
+    ignore do
+      source_table 'subway_stops'
+    end
 
-    analysis_definition { SOURCE_ANALYSIS_DEFINITION }
+    analysis_definition do
+      SOURCE_ANALYSIS_DEFINITION.merge(
+        params: { query: "select * from #{source_table}" }
+      )
+    end
 
     factory :analysis, class: Carto::Analysis do
       created_at { Time.now }
@@ -24,12 +31,18 @@ FactoryGirl.define do
   end
 
   factory :analysis_with_source, class: Carto::Analysis do
+    ignore do
+      source_table 'subway_stops'
+    end
+
     analysis_definition do
       {
         id: unique_string,
         type: "buffer",
         params: {
-          source: SOURCE_ANALYSIS_DEFINITION
+          source: SOURCE_ANALYSIS_DEFINITION.merge(
+            params: { query: "select * from #{source_table}" }
+          )
         }
       }
     end

--- a/spec/factories/analyses.rb
+++ b/spec/factories/analyses.rb
@@ -4,25 +4,24 @@ require 'helpers/unique_names_helper'
 
 include UniqueNamesHelper
 
-FactoryGirl.define do
-  SOURCE_ANALYSIS_DEFINITION = {
-    id: unique_string,
-    type: "source",
-    params: {
-      query: "select * from subway_stops"
+module AnalysisFactoryHelper
+  def self.source_analysis_for_table(table_name)
+    {
+      id:      unique_string,
+      type:    'source',
+      params:  { query: "select * from #{table_name}" },
+      options: { table_name: table_name }
     }
-  }.freeze
+  end
+end
 
+FactoryGirl.define do
   factory :source_analysis, class: Carto::Analysis do
     ignore do
       source_table 'subway_stops'
     end
 
-    analysis_definition do
-      SOURCE_ANALYSIS_DEFINITION.merge(
-        params: { query: "select * from #{source_table}" }
-      )
-    end
+    analysis_definition { AnalysisFactoryHelper.source_analysis_for_table(source_table) }
 
     factory :analysis, class: Carto::Analysis do
       created_at { Time.now }
@@ -40,9 +39,7 @@ FactoryGirl.define do
         id: unique_string,
         type: "buffer",
         params: {
-          source: SOURCE_ANALYSIS_DEFINITION.merge(
-            params: { query: "select * from #{source_table}" }
-          )
+          source: AnalysisFactoryHelper.source_analysis_for_table(source_table)
         }
       }
     end

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -19,7 +19,7 @@ module Carto
         data_layer: nil)
 
         table_visualization = table.visualization || create_table_visualization(carto_user, table)
-        visualization = FactoryGirl.create(:carto_visualization, user_id: carto_user.id, map: map)
+        visualization = FactoryGirl.create(:carto_visualization, user: carto_user, map: map)
 
         unless data_layer.present?
           data_layer = visualization.map.data_layers.first

--- a/spec/factories/layers.rb
+++ b/spec/factories/layers.rb
@@ -60,6 +60,19 @@ FactoryGirl.define do
 
       tooltip tooltip_light
     end
+
+    factory :carto_layer_with_sql do
+      ignore do
+        table_name 'default_table'
+      end
+      options do
+        {
+          table_name: table_name,
+          query:      "select * from #{table_name}",
+          sql_wrap:   "select * from (<%= sql %>) __wrap"
+        }
+      end
+    end
   end
 
 end

--- a/spec/factories/widgets.rb
+++ b/spec/factories/widgets.rb
@@ -2,16 +2,19 @@ require_relative '../../app/models/carto/widget'
 
 FactoryGirl.define do
   factory :widget, class: Carto::Widget do
+    ignore do
+      column_name 'pop_max'
+    end
     order 1
     type 'formula'
     title 'The Title'
-    options {
+    options do
       {
         type: "formula",
-        column: "pop_max",
+        column: column_name,
         operation: "min"
       }
-    }
+    end
     created_at { Time.now }
     updated_at { Time.now }
 

--- a/spec/lib/carto/ghost_tables_manager_spec.rb
+++ b/spec/lib/carto/ghost_tables_manager_spec.rb
@@ -36,7 +36,7 @@ module Carto
       @user.tables.count.should eq 0
       @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_false
 
-      ::Resque.expects(:enqueue).with(::Resque::UserJobs::SyncTables::LinkGhostTables, @user.id).never
+      ::Resque.expects(:enqueue).with(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTables, @user.id).never
 
       @ghost_tables_manager.link_ghost_tables_synchronously
       @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_true
@@ -126,7 +126,7 @@ module Carto
       @user.tables.count.should eq 0
       @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_false
 
-      ::Resque.expects(:enqueue).with(::Resque::UserJobs::SyncTables::LinkGhostTables, @user.id).never
+      ::Resque.expects(:enqueue).with(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTables, @user.id).never
 
       @ghost_tables_manager.link_ghost_tables_synchronously
       @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_true
@@ -171,7 +171,7 @@ module Carto
       @user.tables.count.should eq 0
       @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_false
 
-      ::Resque.expects(:enqueue).with(::Resque::UserJobs::SyncTables::LinkGhostTables, @user.id).never
+      ::Resque.expects(:enqueue).with(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTables, @user.id).never
 
       @ghost_tables_manager.link_ghost_tables_synchronously
       @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_true

--- a/spec/models/carto/analysis_node_spec.rb
+++ b/spec/models/carto/analysis_node_spec.rb
@@ -1,0 +1,87 @@
+# encoding: utf-8
+
+require 'spec_helper_min'
+
+describe Carto::AnalysisNode do
+  let(:analysis_definition) do
+    {
+      id: "a2",
+      type: "point-in-polygon",
+      options: { primary_source_name: "polygons_source" },
+      params: {
+        points_source: {
+          id: "paradas_metro_madrid",
+          type: "source",
+          params: { query: "SELECT * FROM paradas_metro_madrid" },
+          options: { table_name: "paradas_metro_madrid" }
+        },
+        polygons_source: {
+          id: "a1",
+          type: "buffer",
+          options: { kind: "car", time: "100", distance: "kilometers" },
+          params: {
+            source: {
+              id: "a0",
+              type: "source",
+              params: { query: "SELECT * FROM paradas_metro_madrid" },
+              options: { table_name: "paradas_metro_madrid" }
+            },
+            radius: 2000,
+            isolines: 1,
+            dissolved: false
+          }
+        }
+      }
+    }
+  end
+
+  before(:each) do
+    @node = Carto::AnalysisNode.new(nil, analysis_definition)
+  end
+
+  it 'returns definition values from accessors' do
+    @node.id.should eq analysis_definition[:id]
+    @node.type.should eq analysis_definition[:type]
+    @node.params.should eq analysis_definition[:params]
+    @node.options.should eq analysis_definition[:options]
+  end
+
+  describe '#children' do
+    it 'returns all children of a node' do
+      @node.children.count.should eq 2
+      @node.children[0].id.should eq 'paradas_metro_madrid'
+      @node.children[1].id.should eq 'a1'
+    end
+
+    it 'returns nodes with parent set' do
+      @node.children.each { |n| n.parent.should eq @node }
+    end
+
+    it 'returns an empty list when no childrens are found' do
+      @node.definition.delete(:params)
+      @node.children.should eq []
+    end
+  end
+
+  describe '#find_by_id' do
+    it 'finds root element' do
+      @node.find_by_id('a2').should eq @node
+    end
+
+    it 'finds direct children' do
+      found = @node.find_by_id('a1')
+      found.should be
+      found.parent.should eq @node
+    end
+
+    it 'finds indirect descendants' do
+      found = @node.find_by_id('a0')
+      found.should be
+      found.parent.parent.should eq @node
+    end
+
+    it 'returns nil if not found' do
+      @node.find_by_id('404').should be_nil
+    end
+  end
+end

--- a/spec/models/carto/analysis_node_spec.rb
+++ b/spec/models/carto/analysis_node_spec.rb
@@ -36,7 +36,7 @@ describe Carto::AnalysisNode do
   end
 
   before(:each) do
-    @node = Carto::AnalysisNode.new(nil, analysis_definition)
+    @node = Carto::AnalysisNode.new(analysis_definition)
   end
 
   it 'returns definition values from accessors' do
@@ -53,10 +53,6 @@ describe Carto::AnalysisNode do
       @node.children[1].id.should eq 'a1'
     end
 
-    it 'returns nodes with parent set' do
-      @node.children.each { |n| n.parent.should eq @node }
-    end
-
     it 'returns an empty list when no childrens are found' do
       @node.definition.delete(:params)
       @node.children.should eq []
@@ -71,13 +67,11 @@ describe Carto::AnalysisNode do
     it 'finds direct children' do
       found = @node.find_by_id('a1')
       found.should be
-      found.parent.should eq @node
     end
 
     it 'finds indirect descendants' do
       found = @node.find_by_id('a0')
       found.should be
-      found.parent.parent.should eq @node
     end
 
     it 'returns nil if not found' do

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -83,25 +83,22 @@ describe Carto::Analysis do
   end
 
   describe '#analysis_node' do
-    it 'returns an analysis node with analysis set' do
+    it 'returns an analysis node with the definition of the analysis' do
       analysis = Carto::Analysis.new(analysis_definition: definition_with_options)
       node = analysis.analysis_node
-      node.analysis.should eq analysis
-      node.parent.should be_nil
+      node.definition.should eq analysis.analysis_definition
       node.children.should be_empty
     end
 
-    it 'returns an analysis tree with analysis set' do
+    it 'returns an analysis tree' do
       analysis = Carto::Analysis.new(analysis_definition: nested_definition_with_options)
       root = analysis.analysis_node
-      root.analysis.should eq analysis
-      root.parent.should be_nil
+      root.definition.should eq analysis.analysis_definition
 
       children = root.children
       children.should_not be_empty
-      children[0].parent.should eq root
-      children[0].analysis.should eq analysis
       children[0].children.should be_empty
+      children[0].definition.should eq definition_with_options
     end
   end
 

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -27,6 +27,23 @@ describe Carto::Analysis do
     }
   end
 
+  let(:point_in_polygon_definition_with_options) do
+    {
+      id: "a2",
+      type: "point-in-polygon",
+      options: { primary_source_name: "polygons_source" },
+      params: {
+        polygon_source: definition_with_options,
+        points_source: {
+          id: "table",
+          type: "source",
+          params: { query: "SELECT * FROM table" },
+          options: { table_name: "table" }
+        }
+      }
+    }
+  end
+
   describe '#natural_id' do
     it 'returns nil if analysis definition has no id at the first level' do
       Carto::Analysis.new(analysis_definition: nil).natural_id.should eq nil
@@ -52,6 +69,16 @@ describe Carto::Analysis do
 
       nested_analysis = analysis.analysis_definition_for_api[:params][:source]
       nested_analysis.include?(:options).should be_false
+    end
+
+    it 'removes options from nested source analysis with multiple sources' do
+      analysis = Carto::Analysis.new(analysis_definition: point_in_polygon_definition_with_options)
+
+      polygon_analysis = analysis.analysis_definition_for_api[:params][:polygon_source]
+      polygon_analysis.include?(:options).should be_false
+
+      points_analysis = analysis.analysis_definition_for_api[:params][:points_source]
+      points_analysis.include?(:options).should be_false
     end
   end
 

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -55,6 +55,29 @@ describe Carto::Analysis do
     end
   end
 
+  describe '#analysis_node' do
+    it 'returns an analysis node with analysis set' do
+      analysis = Carto::Analysis.new(analysis_definition: definition_with_options)
+      node = analysis.analysis_node
+      node.analysis.should eq analysis
+      node.parent.should be_nil
+      node.children.should be_empty
+    end
+
+    it 'returns an analysis tree with analysis set' do
+      analysis = Carto::Analysis.new(analysis_definition: nested_definition_with_options)
+      root = analysis.analysis_node
+      root.analysis.should eq analysis
+      root.parent.should be_nil
+
+      children = root.children
+      children.should_not be_empty
+      children[0].parent.should eq root
+      children[0].analysis.should eq analysis
+      children[0].children.should be_empty
+    end
+  end
+
   describe '#save' do
     include Carto::Factories::Visualizations
     include HelperMethods

--- a/spec/services/carto/user_table_index_service_spec.rb
+++ b/spec/services/carto/user_table_index_service_spec.rb
@@ -256,6 +256,11 @@ describe Carto::UserTableIndexService do
       )
       @service.send(:indexable_column?, 'col').should be_true
     end
+
+    it 'returns false if no stats can be gathered' do
+      @service.stubs(:pg_stats_by_column).returns({})
+      @service.send(:indexable_column?, 'col').should be_false
+    end
   end
 
   private

--- a/spec/services/carto/user_table_index_service_spec.rb
+++ b/spec/services/carto/user_table_index_service_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper_min'
+
+describe Carto::UserTableIndexService do
+  include NamedMapsHelper
+  include Carto::Factories::Visualizations
+
+  before(:all) do
+    byebug
+    bypass_named_maps
+    @user = FactoryGirl.create(:carto_user)
+    @map1, @table1, @table_visualization1, @visualization1 = create_full_visualization(@user)
+    @map2, @table2, @table_visualization2, @visualization2 = create_full_visualization(@user)
+
+    @map12 = FactoryGirl.create(:carto_map, user_id: @user.id)
+    FactoryGirl.create(:carto_tiled_layer, maps: [@map12])
+    FactoryGirl.create(:carto_layer_with_sql, maps: [@map12], table_name: @table1.name)
+    FactoryGirl.create(:carto_layer_with_sql, maps: [@map12], table_name: @table2.name)
+    @map12.reload
+    @visualization12 = FactoryGirl.create(:carto_visualization, user: @user, map: @map12)
+
+    # Register table dependencies
+    [@map1, @map2, @map12].each do |map|
+      map.data_layers.each do |layer|
+        ::Layer[layer.id].register_table_dependencies
+      end
+    end
+
+    # Create analyses
+    FactoryGirl.create(:source_analysis, visualization: @visualization1,
+                                         user: @user, source_table: @table1.name)
+    FactoryGirl.create(:analysis_with_source, visualization: @visualization2,
+                                              user: @user, source_table: @table2.name)
+
+    FactoryGirl.create(:source_analysis, visualization: @visualization12,
+                                         user: @user, source_table: @table1.name)
+    FactoryGirl.create(:source_analysis, visualization: @visualization12,
+                                         user: @user, source_table: @table2.name)
+  end
+
+  after(:all) do
+    @visualization12.destroy if @visualization12
+    @map12.destroy if @map12
+    destroy_full_visualization(@map2, @table2, @table_visualization2, @visualization2)
+    destroy_full_visualization(@map1, @table1, @table_visualization1, @visualization1)
+    # This avoids connection leaking.
+    ::User[@user.id].destroy
+  end
+
+  after(:each) do
+    Carto::Widget.all.map(&:destroy)
+  end
+
+  it 'retrieves all visualizations of the user table' do
+    viz = Carto::UserTableIndexService.new(@table1).send(:visualizations)
+    viz.sort.should eq [@visualization1, @visualization12].sort
+  end
+end

--- a/spec/services/carto/user_table_index_service_spec.rb
+++ b/spec/services/carto/user_table_index_service_spec.rb
@@ -5,7 +5,6 @@ describe Carto::UserTableIndexService do
   include Carto::Factories::Visualizations
 
   before(:all) do
-    byebug
     bypass_named_maps
     @user = FactoryGirl.create(:carto_user)
     @map1, @table1, @table_visualization1, @visualization1 = create_full_visualization(@user)
@@ -26,18 +25,26 @@ describe Carto::UserTableIndexService do
     end
 
     # Create analyses
-    FactoryGirl.create(:source_analysis, visualization: @visualization1,
-                                         user: @user, source_table: @table1.name)
-    FactoryGirl.create(:analysis_with_source, visualization: @visualization2,
-                                              user: @user, source_table: @table2.name)
-
-    FactoryGirl.create(:source_analysis, visualization: @visualization12,
-                                         user: @user, source_table: @table1.name)
-    FactoryGirl.create(:source_analysis, visualization: @visualization12,
-                                         user: @user, source_table: @table2.name)
+    @analysis1 = FactoryGirl.create(:source_analysis,
+                                    visualization: @visualization1,
+                                    user: @user,
+                                    source_table: @table1.name)
+    @analysis2 = FactoryGirl.create(:analysis_with_source,
+                                    visualization: @visualization2,
+                                    user: @user,
+                                    source_table: @table2.name)
+    @analysis12_1 = FactoryGirl.create(:source_analysis,
+                                       visualization: @visualization12,
+                                       user: @user,
+                                       source_table: @table1.name)
+    @analysis12_2 = FactoryGirl.create(:source_analysis,
+                                       visualization: @visualization12,
+                                       user: @user,
+                                       source_table: @table2.name)
   end
 
   after(:all) do
+    bypass_named_maps
     @visualization12.destroy if @visualization12
     @map12.destroy if @map12
     destroy_full_visualization(@map2, @table2, @table_visualization2, @visualization2)
@@ -46,12 +53,46 @@ describe Carto::UserTableIndexService do
     ::User[@user.id].destroy
   end
 
-  after(:each) do
-    Carto::Widget.all.map(&:destroy)
+  describe '#table_widgets' do
+    before(:all) do
+      @widget1 = create_widget(@analysis1)
+      @widget2_analysis = create_widget(@analysis2)
+      @widget2_source = create_widget(@analysis2, child: true)
+      @widget12_1 = create_widget(@analysis12_1)
+      @widget12_2 = create_widget(@analysis12_2)
+    end
+
+    after(:all) do
+      Carto::Widget.all.map(&:destroy)
+    end
+
+    it 'retrieves all widgets related to the table' do
+      service = Carto::UserTableIndexService.new(@table1)
+      widgets = service.send(:table_widgets)
+      widgets.sort.should eq [@widget1, @widget12_1].sort
+    end
+
+    it 'does not retrieve widgets that operate on an analysis' do
+      service = Carto::UserTableIndexService.new(@table2)
+      widgets = service.send(:table_widgets)
+      widgets.sort.should eq [@widget2_source, @widget12_2].sort
+      widgets.should_not include @widget2_analysis
+    end
   end
 
-  it 'retrieves all visualizations of the user table' do
-    viz = Carto::UserTableIndexService.new(@table1).send(:visualizations)
-    viz.sort.should eq [@visualization1, @visualization12].sort
+  private
+
+  def create_widget(analysis, child = false)
+    root_node = analysis.analysis_node
+    child_node = root_node.children.first
+    widget_node = child ? child_node : root_node
+
+    # Locate the layer corresponding to this analysis (matches visualization and table name from source node)
+    source_node = child_node || root_node
+    layer = analysis.visualization.data_layers.find do |l|
+      l.user_tables.any? { |t| t.name == source_node.options[:table_name] }
+    end
+
+    FactoryGirl.create(:widget, layer: layer, source_id: widget_node.id)
   end
 end

--- a/spec/services/carto/user_table_index_service_spec.rb
+++ b/spec/services/carto/user_table_index_service_spec.rb
@@ -270,7 +270,7 @@ describe Carto::UserTableIndexService do
   end
 
   def stub_create_index(column)
-    @table1.service.stubs(:create_index).with(column, Carto::UserTableIndexService::AUTO_INDEX_PREFIX)
+    @table1.service.stubs(:create_index).with(column, Carto::UserTableIndexService::AUTO_INDEX_PREFIX, concurrent: true)
   end
 
   def stub_drop_index(column)

--- a/spec/services/carto/user_table_index_service_spec.rb
+++ b/spec/services/carto/user_table_index_service_spec.rb
@@ -96,7 +96,7 @@ describe Carto::UserTableIndexService do
 
       stub_create_index('number').once
       stub_create_index('date').once
-      Carto::UserTableIndexService.new(@table1).generate_indices
+      Carto::UserTableIndexService.new(@table1).send(:generate_indices)
     end
 
     it 'does not create indices for small tables' do
@@ -107,7 +107,7 @@ describe Carto::UserTableIndexService do
 
       stub_create_index('number').never
       stub_create_index('date').never
-      Carto::UserTableIndexService.new(@table1).generate_indices
+      Carto::UserTableIndexService.new(@table1).send(:generate_indices)
     end
 
     it 'does not create indices for formula widgets' do
@@ -116,7 +116,7 @@ describe Carto::UserTableIndexService do
       create_widget(@analysis1, column: 'number', type: 'formula')
 
       stub_create_index('number').never
-      Carto::UserTableIndexService.new(@table1).generate_indices
+      Carto::UserTableIndexService.new(@table1).send(:generate_indices)
     end
 
     it 'does not create indices for indexed columns' do
@@ -127,7 +127,7 @@ describe Carto::UserTableIndexService do
 
       stub_create_index('number').never
       stub_create_index('date').once
-      Carto::UserTableIndexService.new(@table1).generate_indices
+      Carto::UserTableIndexService.new(@table1).send(:generate_indices)
     end
 
     it 'does not create indices for indexed columns (in multi-column indexes)' do
@@ -138,7 +138,7 @@ describe Carto::UserTableIndexService do
 
       stub_create_index('number').never
       stub_create_index('date').never
-      Carto::UserTableIndexService.new(@table1).generate_indices
+      Carto::UserTableIndexService.new(@table1).send(:generate_indices)
     end
 
     it 'drops unneeded indices' do
@@ -146,7 +146,7 @@ describe Carto::UserTableIndexService do
       @table1.service.stubs(:estimated_row_count).returns(100000)
 
       stub_drop_index('number').once
-      Carto::UserTableIndexService.new(@table1).generate_indices
+      Carto::UserTableIndexService.new(@table1).send(:generate_indices)
     end
 
     it 'drops indices for small tables' do
@@ -155,7 +155,7 @@ describe Carto::UserTableIndexService do
       create_widget(@analysis1, column: 'number')
 
       stub_drop_index('number').once
-      Carto::UserTableIndexService.new(@table1).generate_indices
+      Carto::UserTableIndexService.new(@table1).send(:generate_indices)
     end
 
     it 'does not drop manual indices' do
@@ -164,7 +164,7 @@ describe Carto::UserTableIndexService do
       create_widget(@analysis1, column: 'number')
 
       @table1.service.stubs(:drop_index).never
-      Carto::UserTableIndexService.new(@table1).generate_indices
+      Carto::UserTableIndexService.new(@table1).send(:generate_indices)
     end
   end
 


### PR DESCRIPTION
Closes #7306

Some highlights:
 - Introduces a new Resque queue: `user_dbs`. It is used for this functionality as well as ghost tables and loading common data. It is intended for operations which cause high load on the user database.
 - It is necessary to parse analysis definitions in the backend, in order to determine if a widget operates on a table or an intermediate analysis. The new `AnalysisNode` model parses the analysis definition as a tree to make this easier.
 - Uses some basic heuristics to try to avoid creating unnecessary indices. It should create an index for almost all columns, but avoid creation on boolean/ternary categories. This is a quick first approximation that could/should be tuned.