### PR TITLE
Replace cdb.core.{Model,View} usages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ vendor/bundle/*
 vendor/cache/*
 .vagrant
 Vagrantfile
-node_modules
+/node_modules
 .grunt/*
 vendor/assets/javascripts/cartodb.*
 vendor/assets/stylesheets/cartodb.*

--- a/lib/assets/javascripts/cartodb/models/export_map_model.js
+++ b/lib/assets/javascripts/cartodb/models/export_map_model.js
@@ -1,3 +1,5 @@
+/* global cdb */
+
 cdb.admin.ExportMapModel = cdb.core.Model.extend({
   /*
    * Creates an export_visualization job and polls until it finishes.

--- a/lib/assets/javascripts/cartodb/organization/organization_user_form.js
+++ b/lib/assets/javascripts/cartodb/organization/organization_user_form.js
@@ -1,5 +1,6 @@
-/* Organization user form */
+/* global cdb */
 
+/* Organization user form */
 module.exports = cdb.core.View.extend({
   events: {
     'submit': '_validateFormSubmit'

--- a/lib/assets/javascripts/cartodb3/components/background-importer/background-geocoding-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/background-geocoding-item-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var Utils = require('cdb.Utils');
 var GeocodingResultDetailsView = require('../geocoding/geocoding-result-details-view');
@@ -8,7 +8,7 @@ var template = require('./background-geocoding-item.tpl');
  *  Geocoding item within background polling
  *
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'ImportItem',
   tagName: 'li',

--- a/lib/assets/javascripts/cartodb3/components/background-importer/background-import-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/background-import-item-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var UploadConfig = require('../../config/upload-config');
 var ErrorDetailsView = require('./error-details-view');
 var WarningsDetailsView = require('./warnings-details-view');
@@ -10,7 +10,7 @@ var template = require('./background-import-item.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'ImportItem',
   tagName: 'li',

--- a/lib/assets/javascripts/cartodb3/components/background-importer/background-import-limit-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/background-import-limit-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./background-import-limit.tpl');
 
 /**
@@ -6,7 +6,7 @@ var template = require('./background-import-limit.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'ImportItem ImportItem--sticky',
   tagName: 'li',

--- a/lib/assets/javascripts/cartodb3/components/background-importer/background-polling-header-title-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/background-polling-header-title-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./background-polling-header-title.tpl');
 
 /**
@@ -7,7 +7,7 @@ var template = require('./background-polling-header-title.tpl');
  *  It will contain only the title
  *
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'h3',
   className: 'BackgroundPolling-headerTitle CDB-Text CDB-Size-large u-mainTextColor',

--- a/lib/assets/javascripts/cartodb3/components/background-importer/background-polling-header-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/background-polling-header-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var $ = require('jquery');
 var BackgroundPollingHeaderTitleView = require('./background-polling-header-title-view');
 var template = require('./background-polling-header.tpl');
@@ -12,7 +12,7 @@ var template = require('./background-polling-header.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'BackgroundPolling-header',
 

--- a/lib/assets/javascripts/cartodb3/components/background-importer/background-polling-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/background-polling-view.js
@@ -1,4 +1,5 @@
 var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var ImportItemView = require('./background-import-item-view');
 var GeocodingItemView = require('./background-geocoding-item-view');
 var ImportLimitItemView = require('./background-import-limit-view');
@@ -15,7 +16,7 @@ var template = require('./background-polling.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'BackgroundPolling',
 
@@ -184,6 +185,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this.disable();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/components/background-importer/error-details-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/error-details-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js-v3');
+var CoreView = require('backbone/core-view');
 var defaultTemplate = require('./error-details.tpl');
 var upgradeErrorTemplate = require('./upgrade-errors.tpl');
 
@@ -7,7 +7,7 @@ var upgradeErrorTemplate = require('./upgrade-errors.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.userModel) throw new Error('userModel is required');
     if (!opts.configModel) throw new Error('configModel is required');

--- a/lib/assets/javascripts/cartodb3/components/background-importer/warnings-details-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/warnings-details-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js-v3');
+var CoreView = require('backbone/core-view');
 var partialImportDetailsTemplate = require('./warning-partial-import-details.tpl');
 var tooManyFilesDetailsTemplate = require('./warning-too-many-files-details.tpl');
 
@@ -7,7 +7,7 @@ var tooManyFilesDetailsTemplate = require('./warning-too-many-files-details.tpl'
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.userModel) throw new Error('userModel is required');

--- a/lib/assets/javascripts/cartodb3/components/carousel-form-view.js
+++ b/lib/assets/javascripts/cartodb3/components/carousel-form-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var CarouselView = require('./custom-carousel/custom-carousel-view');
 
 /**
  *  Carousel form view
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.collection) throw new Error('Carousel collection is required');

--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -1,6 +1,7 @@
 var $ = require('jquery');
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var CustomListView = require('../custom-list/custom-list-view');
 var CustomListItemView = require('../custom-list/custom-list-item-view');
 var itemTemplate = require('../custom-list/custom-list-item.tpl');
@@ -8,7 +9,7 @@ var itemTemplate = require('../custom-list/custom-list-item.tpl');
 /*
  *  A context menu
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   options: {
     offset: {},
@@ -26,7 +27,7 @@ module.exports = cdb.core.View.extend({
 
     this._triggerElementID = opts.triggerElementID;
 
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       visible: false
     });
 
@@ -121,6 +122,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._destroyDocumentBinds();
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/components/custom-carousel/custom-carousel-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-carousel/custom-carousel-item-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./custom-carousel-item.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Carousel-item',
   tagName: 'li',

--- a/lib/assets/javascripts/cartodb3/components/custom-carousel/custom-carousel-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-carousel/custom-carousel-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var Ps = require('perfect-scrollbar');
 var template = require('./custom-carousel.tpl');
 var CarouselCollection = require('./custom-carousel-collection');
@@ -20,7 +20,7 @@ var _ = require('underscore');
  *  });
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Carousel',
   tagName: 'div',
@@ -114,7 +114,7 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._destroyCustomScroll();
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   },
 
   initScroll: function () {

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-item-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   options: {
     template: require('./custom-list-item.tpl')

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-search-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-search-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./custom-list-search.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'CustomList-form CDB-Box-modalHeader',
   tagName: 'form',

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var Ps = require('perfect-scrollbar');
 var emptyTemplate = require('./custom-list-empty.tpl');
@@ -7,7 +7,7 @@ var ARROW_DOWN_KEY_CODE = 40;
 var ARROW_UP_KEY_CODE = 38;
 var ENTER_KEY_CODE = 13;
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'CDB-Text CDB-Size-medium CustomList-listWrapper',
   tagName: 'div',
@@ -141,7 +141,7 @@ module.exports = cdb.core.View.extend({
   clean: function () {
     this._removeArrowBinds();
     this._destroyCustomScroll();
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   },
 
   highlight: function () {

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var CustomListCollection = require('./custom-list-collection');
 var SearchView = require('./custom-list-search-view');
 var CustomListView = require('./custom-list-view');
@@ -24,7 +25,7 @@ var CustomListItemView = require('./custom-list-item-view');
  *  });
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   options: {
     showSearch: true,
@@ -43,7 +44,7 @@ module.exports = cdb.core.View.extend({
     }
 
     this.options = _.extend({}, this.options, opts);
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       query: '',
       visible: false
     });

--- a/lib/assets/javascripts/cartodb3/components/date-picker/calendar-dropdown-view.js
+++ b/lib/assets/javascripts/cartodb3/components/date-picker/calendar-dropdown-view.js
@@ -1,4 +1,5 @@
 var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var $ = require('jquery');
 var moment = require('moment');
@@ -8,7 +9,7 @@ var template = require('./calendar-dropdown.tpl');
  * Dropdown for a calendar selector.
  * Uses the DatePicker plugin internally to render the calendar and view behaviour.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Dropdown',
 
   // defaults, used for
@@ -67,7 +68,7 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._$calendar().DatePickerHide();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/components/date-picker/date-picker-range-view.js
+++ b/lib/assets/javascripts/cartodb3/components/date-picker/date-picker-range-view.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var moment = require('moment');
 var $ = require('jquery');
-var Backbone = require('backbone');
 var Utils = require('../../helpers/utils');
 require('../form-components/index');
 require('datepicker');
@@ -13,7 +13,7 @@ var MAX_RANGE = 30;
 /**
  * Custom picer for a dates range.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'DatePicker',
 
@@ -34,7 +34,7 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function (opts) {
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       fromDate: '',
       fromHour: 0,
       fromMin: 0,
@@ -258,7 +258,7 @@ module.exports = cdb.core.View.extend({
     this._destroyBinds();
     this.closeCalendar();
     this.$('.DatePicker-calendar').DatePickerHide();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/components/error/error-view.js
+++ b/lib/assets/javascripts/cartodb3/components/error/error-view.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var template = require('./error.tpl');
 
 /**
@@ -8,7 +9,7 @@ var template = require('./error.tpl');
  * @param {String} options.title If not provided will use a generic text as fallback
  * @param {String} options.desc If not provied will use a generic text as fallback
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'IntermediateInfo',
 
@@ -20,7 +21,7 @@ module.exports = cdb.core.View.extend({
         desc: _t('components.error.default-desc')
       }
     );
-    this.model = new cdb.core.Model(attrs);
+    this.model = new Backbone.Model(attrs);
   },
 
   render: function () {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
@@ -1,12 +1,13 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 require('bootstrap-colorpicker');
 var template = require('./template.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       hex: opts.value,
       opacity: opts.opacity || 1
     });
@@ -110,4 +111,3 @@ module.exports = cdb.core.View.extend({
     this.$('.js-colorPicker').colorpicker('setValue', color);
   }
 });
-

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/column-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/column-list-view.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var CustomListView = require('../../../custom-list/custom-view');
 var CustomListCollection = require('../../../custom-list/custom-list-collection');
 var template = require('./column-list-view.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   defaults: {
     headerTitle: ''
   },

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/fill-dialog-model.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/fill-dialog-model.js
@@ -1,14 +1,15 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 
 /**
  * View model of the fill dialog
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     visible: true,
     createContentView: function () {
-      return new cdb.core.View();
+      return new CoreView();
     }
   },
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/fill-dialog.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/fill-dialog.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Editor-boxModal Editor-FormDialog js-formDialog is-opening',
 
   initialize: function () {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/fill-tab.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/fill-tab.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./fill-tab.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.stackLayoutModel) throw new Error('stackLayoutModel is required');
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-view.js
@@ -1,11 +1,11 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var CustomListView = require('../../../../../custom-list/custom-view');
 var CustomListCollection = require('../../../../../custom-list/custom-list-collection');
 var template = require('./input-color-categories-list-view.tpl');
 var itemTemplate = require('./input-color-categories-list-item.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     this._showSearch = opts.showSearch || false;
     this._typeLabel = opts.typeLabel;

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./input-color-categories.tpl');
 var StackLayoutView = require('../../../../../../components/stack-layout/stack-layout-view');
 var InputColorPickerView = require('../input-color-picker/input-color-picker-view');
@@ -11,7 +11,7 @@ var DEFAULT_COLORS = ['#A6CEE3', '#1F78B4', '#B2DF8A', '#33A02C', '#FB9A99', '#E
 var CATEGORY_QUERY = 'SELECT <%= column %>, count(<%= column %>) FROM (<%= sql %>) _table_sql GROUP BY <%= column %> ORDER BY count DESC LIMIT <%= max_values %>';
 var MAX_VALUES = 9;
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_onClickBack'
   },

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-dialog-content.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-dialog-content.js
@@ -1,11 +1,11 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var tabPaneTemplate = require('../fill-tab-pane.tpl');
 var createTextLabelsTabPane = require('../../../../../components/tab-pane/create-text-labels-tab-pane');
 var ColorPicker = require('../color-picker/color-picker');
 var InputColorValueContentView = require('./input-color-value-content-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.configModel) throw new Error('configModel param is required');
     if (!opts.query) throw new Error('query param is required');

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-header.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-header.js
@@ -1,8 +1,8 @@
 var $ = require('jquery');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./input-color-picker-header.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-color': '_onClickColor'
   },

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-view.js
@@ -1,10 +1,11 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var ColorPicker = require('../../color-picker/color-picker');
 var template = require('./input-color-picker-view.tpl');
 var InputColorPickerHeader = require('./input-color-picker-header');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_onClickBack'
   },
@@ -12,7 +13,7 @@ module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     if (!opts.ramp) throw new Error('ramp param is required');
 
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       index: this.options.index,
       ramp: opts.ramp
     });

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
@@ -1,12 +1,12 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var StackLayoutView = require('../../../../../components/stack-layout/stack-layout-view');
 var ColumnListView = require('../column-list-view');
 var InputColorRamps = require('./input-ramps/input-color-ramps');
 var InputColorCategories = require('./input-categories/input-color-categories');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.columns) throw new Error('columns param is required');
     if (!opts.configModel) throw new Error('configModel param is required');

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color.js
@@ -1,9 +1,9 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./input-color.tpl');
 var InputDialogContent = require('./input-color-dialog-content');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   tagName: 'li',
   className: 'CDB-OptionInput-item',
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var StackLayoutView = require('../../../../../../components/stack-layout/stack-layout-view');
 var ColumnListView = require('../../column-list-view');
 var quantificationMethodItemTemplate = require('./quantification-method-item.tpl');
@@ -10,7 +10,7 @@ var rampList = require('./ramps');
 var QUANTIFICATION_METHODS = ['jenks', 'equal', 'headtails', 'quantiles'];
 var BINS = ['3', '4', '5', '6', '7'];
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     this._setupModel();
     this._initBinds();

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-content-view.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./input-ramp-content-view.tpl');
 var RampListView = require('./input-ramp-list-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_onClickBack',
     'click .js-quantification': '_onClickQuantification',

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
@@ -1,11 +1,11 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var CustomListView = require('../../../../../custom-list/custom-view');
 var CustomListCollection = require('../../../../../custom-list/custom-list-collection');
 var rampItemTemplate = require('./input-ramp-list-item-template.tpl');
 var rampList = require('./ramps');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.bins) throw new Error('bins is required');
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var template = require('./input-number-value-content-view.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_onClickBack',
     'click .js-quantification': '_onClickQuantification'
@@ -85,6 +85,6 @@ module.exports = cdb.core.View.extend({
   clean: function () {
     // Backbone.Form removes the view with the following method
     this._formView.remove();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-dialog-content.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-dialog-content.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var tabPaneTemplate = require('../fill-tab-pane.tpl');
 var createTextLabelsTabPane = require('../../../../../components/tab-pane/create-text-labels-tab-pane');
 var InputNumberFixedContentView = require('./input-number-fixed-content-view');
@@ -9,7 +9,7 @@ var DEFAULT_INPUT_MIN_VALUE = 0;
 var DEFAULT_INPUT_MAX_VALUE = 100;
 var DEFAULT_INPUT_STEP_VALUE = 1;
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.columns) throw new Error('columns param is required');
     this._columns = opts.columns;

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-fixed-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-fixed-content-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     this._initViews();
   },
@@ -48,6 +48,6 @@ module.exports = cdb.core.View.extend({
   clean: function () {
     // Backbone.Form removes the view with the following method
     this._formView.remove();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
@@ -1,5 +1,5 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var StackLayoutView = require('../../../../../components/stack-layout/stack-layout-view');
 var ColumnListView = require('../column-list-view');
 var quantificationMethodItemTemplate = require('./quantification-method-item.tpl');
@@ -7,7 +7,7 @@ var InputNumberContentView = require('./input-number-content-view');
 
 var QUANTIFICATION_METHODS = ['jenks', 'equal', 'headtails', 'quantiles'];
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_onClickBack'
   },

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./input-number.tpl');
 var InputDialogContent = require('./input-number-dialog-content');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   tagName: 'li',
   className: 'CDB-OptionInput-item',
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/operators/operators-list-model.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/operators/operators-list-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     visible: false,

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/operators/operators-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/operators/operators-list-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var $ = require('jquery');
 var CustomListView = require('../../../custom-list/custom-view');
@@ -6,7 +6,7 @@ var OperatorsListModel = require('./operators-list-model');
 var emptyTemplate = require('./operators-list-count.tpl');
 var template = require('./operators-list.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Editor-dropdown Editor-boxModal',
   tagName: 'div',

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/select/select-layer-list-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/select/select-layer-list-item-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   options: {
     template: require('./select-layer-list-item.tpl')

--- a/lib/assets/javascripts/cartodb3/components/infobox/infobox-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/infobox/infobox-item-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./infobox.tpl');
 var templateButton = require('./infobox-button.tpl');
 
@@ -8,7 +8,7 @@ var INFOBOX_TYPE = {
   default: ''
 };
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-primary .js-action': '_onMainClick',
     'click .js-secondary .js-action': '_onSecondClick'

--- a/lib/assets/javascripts/cartodb3/components/infobox/infobox-model.js
+++ b/lib/assets/javascripts/cartodb3/components/infobox/infobox-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var INFOBOX_DEFAULT_STATE = '';
 
 /**
@@ -6,7 +6,7 @@ var INFOBOX_DEFAULT_STATE = '';
  *
  */
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     state: INFOBOX_DEFAULT_STATE

--- a/lib/assets/javascripts/cartodb3/components/infobox/infobox-view.js
+++ b/lib/assets/javascripts/cartodb3/components/infobox/infobox-view.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.infoboxModel) throw new Error('infoboxModel is required');

--- a/lib/assets/javascripts/cartodb3/components/likes/likes-model.js
+++ b/lib/assets/javascripts/cartodb3/components/likes/likes-model.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 
-var LikeModel = cdb.core.Model.extend({
+var LikeModel = Backbone.Model.extend({
   defaults: {
     likeable: true
   },

--- a/lib/assets/javascripts/cartodb3/components/likes/likes-view.js
+++ b/lib/assets/javascripts/cartodb3/components/likes/likes-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./likes.tpl');
 
 /**
  * Responsible for likes (♥ 123) and its toggling behaviour.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   tagName: 'a',
 
   events: {

--- a/lib/assets/javascripts/cartodb3/components/loading/render-loading.js
+++ b/lib/assets/javascripts/cartodb3/components/loading/render-loading.js
@@ -1,3 +1,4 @@
+var cdb = require('cartodb.js');
 var template = require('./loading.tpl');
 var randomQuote = require('./random-quote');
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/add-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/add-analysis-view.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var CoreView = require('backbone/core-view');
 var AnalysisOptionsCollection = require('./analysis-options-collection');
 var renderLoading = require('../../../components/loading/render-loading');
 var template = require('./add-analysis-view.tpl');
@@ -9,7 +10,7 @@ var AnalysisCategoryView = require('./analysis-category-view');
  * View to add a new analysis node.
  * Expected to be rendered in a modal.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Dialog-content Dialog-content--expanded',
 
   events: {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-category-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-category-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var AnalysisOptionView = require('./analysis-option-view');
 var template = require('./analysis-category.tpl');
 
 /**
  * View to render an individual analysis category and its analysis options
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   options: {
     category: '',

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-option-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-option-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./analysis-option.tpl');
 
 /**
  * View for an individual analysis option.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'li',
   className: 'ModalBlockList-item',

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/add-layer-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/add-layer-model.js
@@ -10,7 +10,7 @@ var TableModel = require('../../../data/table-model');
  *
  * "Implements" the CreateListingModel.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   defaults: {
     type: 'addLayer',
     contentPane: 'listing', // [listing, loading]

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/add-layer-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/add-layer-view.js
@@ -1,4 +1,5 @@
 var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var template = require('./add-layer.tpl');
 var FooterView = require('./footer/footer-view');
@@ -13,7 +14,7 @@ var ErrorView = require('../../error/error-view');
 /**
  * Add layer dialog, typically used from editor
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Dialog-content Dialog-content--expanded',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/content-result-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/content-result-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var randomQuote = require('../../../../loading/random-quote');
 
 /*
  *  Content result default view
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-connect': '_onConnectClick'
   },

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/dataset-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/dataset-item-view.js
@@ -1,4 +1,5 @@
 var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var $ = require('jquery');
 var _ = require('underscore');
 var moment = require('moment');
@@ -10,7 +11,7 @@ var LikesView = require('../../../../likes/likes-view');
 /**
  * View representing an item in the list under datasets route.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   tagName: 'li',
   className: 'ModalBlockList-item ModalBlockList-item--full',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/datasets-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/datasets-list-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var DATASETS_ITEMS = {
   'datasets': require('./dataset-item-view'),
   'remotes': require('./remote-dataset-item-view')
@@ -7,7 +7,7 @@ var DATASETS_ITEMS = {
 /**
  * View representing the list of datasets
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'ul',
   className: 'DatasetsList',

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/datasets-pagination-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/datasets-pagination-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var PaginationModel = require('../../../../pagination/pagination-model');
 var PaginationView = require('../../../../pagination/pagination-view');
 
@@ -11,7 +11,7 @@ var PaginationView = require('../../../../pagination/pagination-view');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'DatasetsPaginator',
 
   initialize: function (opts) {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/datasets-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/datasets/datasets-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var ContentResultView = require('./content-result-view');
 var DatasetsListView = require('./datasets-list-view');
@@ -16,7 +16,7 @@ var datasetsLoaderTemplate = require('./datasets-loader.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.createModel) throw new Error('createModel is required');
     if (!opts.userModel) throw new Error('userModel is required');

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-data/import-data-form-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-data/import-data-form-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var $ = require('jquery');
 require('dragster');
 var Dropzone = require('dropzone');
@@ -13,7 +13,7 @@ var template = require('./import-data-form.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   options: {
     template: '',
     fileEnabled: false
@@ -211,7 +211,7 @@ module.exports = cdb.core.View.extend({
   clean: function () {
     this._destroyDropzone();
     this.$('.js-fileInput').unbind('change');
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-data/import-data-header-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-data/import-data-header-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./import-data-header.tpl');
 
 /**
@@ -9,7 +9,7 @@ var template = require('./import-data-header.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_goToStart'
   },

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-selected-dataset-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-selected-dataset-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var Utils = require('../../../../../helpers/utils');
 var template = require('./import-selected-dataset.tpl');
@@ -12,7 +12,7 @@ var template = require('./import-selected-dataset.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'DatasetSelected',
 
   _FORMATTERS: {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-header-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-header-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./import-service-header.tpl');
 
 /**
@@ -9,7 +9,7 @@ var template = require('./import-service-header.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_goToList'
   },

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-item-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-item-model.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  *  Service item model
  *
  */
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   defaults: {
     id: '',
     filename: '',

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-list-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-list-item-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var Utils = require('../../../../../../helpers/utils');
 var ServiceUtilsFormat = require('./import-service-item-description-format');
 var template = require('./import-service-list-item.tpl');
@@ -12,7 +12,7 @@ var _ = require('underscore');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   options: {
     title: '',
     fileAttrs: {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-list-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var ServiceListItemView = require('./import-service-list-item-view');
 var template = require('./import-service-list.tpl');
 
@@ -11,7 +11,7 @@ var template = require('./import-service-list.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   options: {
     title: 'service',
     fileAttrs: {}

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-loader-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-loader-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./import-service-loader.tpl');
 
 /**
@@ -8,7 +8,7 @@ var template = require('./import-service-loader.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-connect': '_checkToken'
   },

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-oauth-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-oauth-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  *  Get oauth url from the service requested
@@ -8,7 +8,7 @@ var cdb = require('cartodb.js');
  *  new ServiceOauthModel({ datasourceName: 'dropbox', configModel: configModel })
  */
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   _DATASOURCE_NAME: 'dropbox',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-token-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-service/import-service-token-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  *  Model to check if oAuth token is valid or not
@@ -8,7 +8,7 @@ var cdb = require('cartodb.js');
  *  new ServiceTokenModel({ datasourceName: 'dropbox', configModel: configModel })
  */
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   _DATASOURCE_NAME: 'dropbox',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/credits-info-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/credits-info-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var Utils = require('../../../../../../helpers/utils');
 var template = require('./credits-info.tpl');
 
@@ -10,7 +10,7 @@ var template = require('./credits-info.tpl');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     this._userModel = opts.userModel;

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/credits-usage-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/credits-usage-view.js
@@ -1,4 +1,5 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 require('jquery-ui/slider');
 var CreditsInfoView = require('./credits-info-view');
@@ -14,12 +15,12 @@ var MIN_PER_VALUE = 1;
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.userModel) throw new Error('userModel is required');
     this._userModel = opts.userModel;
-    this.model = new cdb.core.Model();
+    this.model = new Backbone.Model();
     this._initBinds();
     this._setModel();
   },
@@ -95,7 +96,7 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._destroySlider();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/twitter-categories/twitter-categories-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/twitter-categories/twitter-categories-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var $ = require('jquery');
 var TwitterCategoriesCollection = require('./twitter-categories-collection');
@@ -11,7 +11,7 @@ var TwitterCategoryView = require('./twitter-category-view');
  *    terms added.
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   _MAX_CATEGORIES: 4,
   _MAX_TERMS: 29,
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/twitter-categories/twitter-category-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/twitter-categories/twitter-category-model.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js-v3');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var TERMS_CHARS = 4;
 
 // Twitter category model
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   _MAX_COUNTER: 1014,
 
   _CHAR_MAP: {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/twitter-categories/twitter-category-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-twitter/twitter-categories/twitter-category-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var $ = require('jquery');
 var template = require('./twitter-category.tpl');
@@ -8,7 +8,7 @@ var template = require('./twitter-category.tpl');
  *  - It just needs a twitter category model
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'TwitterCategory',
 
   _MAX_CATEGORIES: 4,

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var UploadModel = require('../../../../../data/upload-model');
 
 /**
@@ -9,7 +9,7 @@ var UploadModel = require('../../../../../data/upload-model');
  *  - It returns their data if it is requested with a method.
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.userModel) throw new Error('userModel is required');

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/imports-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/imports-view.js
@@ -1,4 +1,6 @@
 var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var ViewFactory = require('../../../../view-factory');
 var importViewTemplate = require('./imports.tpl');
 var importTabViewTemplate = require('./import-tab.tpl');
@@ -28,7 +30,7 @@ var ROW_WIDTH = 800;
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'ImportOptions',
 
   events: {
@@ -44,7 +46,7 @@ module.exports = cdb.core.View.extend({
     this._userModel = opts.userModel;
     this._configModel = opts.configModel;
     this._createModel = opts.createModel;
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       page: 1,
       maxPages: 0
     });
@@ -319,7 +321,7 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._destroyBinds();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/listing-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/listing-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var DatasetsView = require('./datasets/datasets-view');
 var ImportsView = require('./imports/imports-view');
@@ -12,7 +12,7 @@ var TabPaneCollection = require('../../../tab-pane/tab-pane-collection');
  *  any of your current datasets or connect a new dataset.
  *
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'CreateDialog-listing CreateDialog-listing--noPaddingTop',
 
   initialize: function (opts) {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/navigation-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/navigation-view.js
@@ -1,4 +1,6 @@
 var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var $ = require('jquery');
 var _ = require('underscore');
 var template = require('./navigation.tpl');
@@ -10,7 +12,7 @@ var template = require('./navigation.tpl');
  *  - 'Search' any pattern within dataset collection.
  *
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'submit .js-search-form': '_submitSearch',
     'keydown .js-search-form': '_onSearchKeyDown',
@@ -34,7 +36,7 @@ module.exports = cdb.core.View.extend({
     this._createModel = opts.createModel;
     this._userModel = opts.userModel;
     this._tablesCollection = opts.tablesCollection;
-    this.model = new cdb.core.Model();
+    this.model = new Backbone.Model();
 
     this._preRender();
     this._initBinds();

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/footer/footer-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/footer/footer-view.js
@@ -1,4 +1,5 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var GuessingTogglerView = require('./guessing-toggler-view');
 var PrivacyTogglerView = require('./privacy-toggler-view');
 var template = require('./footer.tpl');
@@ -6,7 +7,7 @@ var template = require('./footer.tpl');
 /**
  * Footer view for the add layer modal.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-ok': '_finish'
   },
@@ -19,10 +20,10 @@ module.exports = cdb.core.View.extend({
     this._createModel = opts.createModel;
     this._userModel = opts.userModel;
     this._configModel = opts.configModel;
-    this._guessingModel = new cdb.core.Model({
+    this._guessingModel = new Backbone.Model({
       guessing: true
     });
-    this._privacyModel = new cdb.core.Model({
+    this._privacyModel = new Backbone.Model({
       privacy: this._userModel.canCreatePrivateDatasets() ? 'PRIVATE' : 'PUBLIC'
     });
     this._initBinds();

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/footer/guessing-toggler-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/footer/guessing-toggler-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./guessing-toggler.tpl');
 
 /**
@@ -6,7 +6,7 @@ var template = require('./guessing-toggler.tpl');
  * Expected to be rendered in the footer of a create dialog.
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-toggle': '_toggle'

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/footer/privacy-toggler-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/footer/privacy-toggler-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var $ = require('jquery');
 var template = require('./privacy-toggler.tpl');
 var TipsyTooltipView = require('../../../tipsy-tooltip-view');
@@ -12,7 +12,7 @@ var privatePrivacy = 'PRIVATE';
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click': '_onClick'
   },

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/add-widgets-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/add-widgets-view.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var createTuplesItems = require('./create-tuples-items');
 var widgetsTypes = require('./widgets-types');
 var BodyView = require('./body-view');
@@ -11,7 +11,7 @@ var renderLoading = require('../../../components/loading/render-loading');
  * View to add new widgets.
  * Expected to be rendered in a modal.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Dialog-content Dialog-content--expanded',
 
   events: {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/body-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/body-view.js
@@ -1,12 +1,12 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var createTextLabelsTabPane = require('../../tab-pane/create-text-labels-tab-pane');
 var tabPaneTemplate = require('./tab-pane-template.tpl');
 
 /**
  * View to select widget options to create.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.optionsCollection) throw new Error('optionsCollection is required');

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/category/category-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/category/category-option-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     type: 'category',

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/category/category-option-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/category/category-option-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var LayerSelectorView = require('../layer-selector-view');
 var template = require('./category-option.tpl');
 
 /**
  * View for an individual category option.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-checkbox': '_onSelect'

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/category/category-options-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/category/category-options-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var CategoryOptionView = require('./category-option-view.js');
 
 /**
  * View to select category widget options
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'WidgetList',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/formula/formula-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/formula/formula-option-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     type: 'formula',

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/formula/formula-option-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/formula/formula-option-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var LayerSelectorView = require('../layer-selector-view');
 var template = require('./formula-option.tpl');
 
 /**
  * View for an individual formula option.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-checkbox': '_onSelect'

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/formula/formula-options-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/formula/formula-options-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var FormulaOptionView = require('./formula-option-view.js');
 
 /**
  * View to select formula widget options
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'WidgetList',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/histogram/histogram-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/histogram/histogram-option-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     type: 'histogram',

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/histogram/histogram-option-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/histogram/histogram-option-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var LayerSelectorView = require('../layer-selector-view');
 var template = require('./histogram-option.tpl');
 
 /**
  * View for an individual histogram option.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-checkbox': '_onSelect'

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/histogram/histogram-options-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/histogram/histogram-options-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var HistogramOptionView = require('./histogram-option-view.js');
 
 /**
  * View to select histogram widget options
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'WidgetList',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/layer-selector-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/layer-selector-view.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 require('../../form-components/index');
 var CustomListItemView = require('../../form-components/editors/select/select-layer-list-item-view');
 var itemListTemplate = require('../../form-components/editors/select/select-layer-item.tpl');
@@ -9,7 +9,7 @@ var selectedItemTemplate = require('../../form-components/editors/select/select-
 /**
  * View for selecting the layer through which to load the column data.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'SelectorLayer',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-none-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-none-option-model.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  * Special case for the time-series type, when if selected it deletes an existing time-series if there is one,
  * otherwise it does nothing.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     type: 'time-series'

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-none-option-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-none-option-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./time-series-none-option.tpl');
 
 /**
  * Represents the (default) no-option view, i.e. since time-series options only can have one selection,
  * this serves as the "unselect" option.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-radio': '_onSelect'

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-option-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     type: 'time-series',

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-option-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-option-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var LayerSelectorView = require('../layer-selector-view');
 var template = require('./time-series-option.tpl');
 
 /**
  * View for an individual time-series option.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-radio': '_onSelect'

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-options-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-options-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var TimeSeriesOptionView = require('./time-series-option-view.js');
 var TimeSeriesNoneOptionView = require('./time-series-none-option-view.js');
 
 /**
  * View to select time-series widget options
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'WidgetList',
 

--- a/lib/assets/javascripts/cartodb3/components/modals/modal-view-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/modal-view-model.js
@@ -1,14 +1,15 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 
 /**
  * View model of a modal
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     show: true,
     createContentView: function () {
-      return new cdb.core.View();
+      return new CoreView();
     }
   },
 

--- a/lib/assets/javascripts/cartodb3/components/modals/modal-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/modal-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./modal.tpl');
 
 // Ought to match the duration of the .Dialog.is-closing animation.
 var CLOSE_DELAY_MS = 120;
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Dialog is-opening is-white',
 
   events: {
@@ -37,7 +37,7 @@ module.exports = cdb.core.View.extend({
   },
 
   destroy: function () {
-    // 'remove' would be a better name ofc, but there is already an internal method with that name in cdb.core.View
+    // 'remove' would be a better name ofc, but there is already an internal method with that name in CoreView
     this.model.destroy();
   },
 

--- a/lib/assets/javascripts/cartodb3/components/modals/modals-service-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/modals-service-model.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var ModalView = require('./modal-view');
 var ModalViewModel = require('./modal-view-model');
 
@@ -19,7 +19,7 @@ var DESTROYED_MODAL_EVENT = 'destroyedModal';
  *
  * You will probably see the name of "Dialog" here and there, it's the old nomenclature for the concept of Modal.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   /**
    * Creates a new modal view

--- a/lib/assets/javascripts/cartodb3/components/mosaic-form-view.js
+++ b/lib/assets/javascripts/cartodb3/components/mosaic-form-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var MosaicView = require('./mosaic/mosaic-view');
 
 /**
  *  Mosaic form view
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.collection) throw new Error('Mosaic collection is required');

--- a/lib/assets/javascripts/cartodb3/components/mosaic/mosaic-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/mosaic/mosaic-item-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./mosaic-item.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Mosaic-item',
   tagName: 'li',

--- a/lib/assets/javascripts/cartodb3/components/mosaic/mosaic-view.js
+++ b/lib/assets/javascripts/cartodb3/components/mosaic/mosaic-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./mosaic.tpl');
 var MosaicCollection = require('./mosaic-collection');
 var MosaicItemView = require('./mosaic-item-view');
@@ -18,7 +18,7 @@ var MosaicItemView = require('./mosaic-item-view');
  *  });
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Mosaic',
   tagName: 'div',

--- a/lib/assets/javascripts/cartodb3/components/pagination/pagination-model.js
+++ b/lib/assets/javascripts/cartodb3/components/pagination/pagination-model.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 
 /**
  * View model intended to be responsible for pagination logic, and to be used in conjunction with a Pagination view.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   defaults: {
     total_count: 0,
     per_page: 10,

--- a/lib/assets/javascripts/cartodb3/components/pagination/pagination-view.js
+++ b/lib/assets/javascripts/cartodb3/components/pagination/pagination-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var $ = require('jquery');
 var navigateThroughRouter = require('../../helpers/navigate-through-router');
 var template = require('./pagination.tpl');
@@ -17,7 +17,7 @@ var template = require('./pagination.tpl');
  *     })
  *   });
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Pagination',
 
   events: {

--- a/lib/assets/javascripts/cartodb3/components/scroll/scroll-view.js
+++ b/lib/assets/javascripts/cartodb3/components/scroll/scroll-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var Ps = require('perfect-scrollbar');
 var template = require('./scroll.tpl');
 
 var OFFSET = 20;
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   tagName: 'div',
   className: 'ScrollView',
 
@@ -104,6 +104,6 @@ module.exports = cdb.core.View.extend({
   clean: function () {
     this.destroyScroll();
     this._destroyDOMRefs();
-    cdb.core.View.prototype.clean.apply(this, arguments);
+    CoreView.prototype.clean.apply(this, arguments);
   }
 });

--- a/lib/assets/javascripts/cartodb3/components/stack-layout/stack-layout-model.js
+++ b/lib/assets/javascripts/cartodb3/components/stack-layout/stack-layout-model.js
@@ -1,12 +1,12 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  *  Stack layout model checks and decides if next or previous
  *  positions are possible.
  */
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     position: 0

--- a/lib/assets/javascripts/cartodb3/components/stack-layout/stack-layout-view.js
+++ b/lib/assets/javascripts/cartodb3/components/stack-layout/stack-layout-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var StackLayoutModel = require('./stack-layout-model');
 var _ = require('underscore');
 
@@ -7,7 +7,7 @@ var _ = require('underscore');
  *  They can go forward or backward.
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!this.collection || !this.collection.size()) {

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/create-editor-menu-tab-pane.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/create-editor-menu-tab-pane.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var TabPaneView = require('./tab-pane-view.js');
 var TabPaneCollection = require('./tab-pane-collection');
 var IconView = require('./tab-pane-icon-view');
@@ -11,7 +11,7 @@ var IconView = require('./tab-pane-icon-view');
  * Example usage:
  * {
  *   icon: 'my-icon',
- *   createContentView: cdb.core.View(),
+ *   createContentView: CoreView(),
  *   selected: false
  * }
  * @param {Array} paneItems
@@ -36,7 +36,7 @@ module.exports = function (paneItems, options) {
         return new IconView(_.extend({ model: this }, tabPaneItemIconOptions));
       },
       createContentView: function () {
-        return paneItem.createContentView && paneItem.createContentView() || new cdb.core.View();
+        return paneItem.createContentView && paneItem.createContentView() || new CoreView();
       }
     };
   });

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/create-text-labels-tab-pane.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/create-text-labels-tab-pane.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var TabPaneView = require('./tab-pane-view.js');
 var TabPaneCollection = require('./tab-pane-collection');
 var LabelView = require('./tab-pane-label-view');
@@ -10,13 +10,13 @@ var LabelView = require('./tab-pane-label-view');
  * Example usage:
  * {
  *   label: 'My label',
- *   createContentView: cdb.core.View(),
+ *   createContentView: CoreView(),
  *   selected: false
  * }
  *
  * @param {Array} paneItems
  * @param {Object} options
- * @return {Object} instance of cdb.core.View
+ * @return {Object} instance of CoreView
  */
 module.exports = function (paneItems, options) {
   options = options || {};
@@ -37,7 +37,7 @@ module.exports = function (paneItems, options) {
         return new LabelView(_.extend({ model: this }, tabPaneItemLabelOptions));
       },
       createContentView: function () {
-        return paneItem.createContentView && paneItem.createContentView() || new cdb.core.View();
+        return paneItem.createContentView && paneItem.createContentView() || new CoreView();
       }
     };
   });

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-icon-view.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-icon-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var Template = require('./tab-pane-icon.tpl');
 
 /**
  *  Icon component
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   tagName: 'i',
 
   className: 'CDB-IconFont',

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-item-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 
 /**
  *  TabPaneItem component
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   tagName: 'button',
 
   events: {

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-label-view.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-label-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 
 /**
  *  Label component
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Label',
 
   initialize: function () {

--- a/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-view.js
+++ b/lib/assets/javascripts/cartodb3/components/tab-pane/tab-pane-view.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var TabPaneItem = require('./tab-pane-item-view.js');
 var Template = require('./tab-pane.tpl');
 
@@ -7,7 +7,7 @@ var Template = require('./tab-pane.tpl');
  *  TabPane component
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Tab-pane',
 
   initialize: function (options) {

--- a/lib/assets/javascripts/cartodb3/components/tipsy-tooltip-view.js
+++ b/lib/assets/javascripts/cartodb3/components/tipsy-tooltip-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 require('tipsy');
 
 /**
@@ -10,7 +10,7 @@ require('tipsy');
  *
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   options: {
     gravity: 's',
     opacity: 1,

--- a/lib/assets/javascripts/cartodb3/components/view-factory.js
+++ b/lib/assets/javascripts/cartodb3/components/view-factory.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 
 /**
  * Convenient factory to create views without having to create new files.
@@ -9,10 +9,10 @@ module.exports = {
   /**
    * @param {String} html e.g. '<div>whatever</div>'
    * @param {Object,undefined} viewOpts view options, .e.g {className: 'Whatever'}
-   * @return {Object} instance of cdb.core.View, which takes two params of template and templateData
+   * @return {Object} instance of CoreView, which takes two params of template and templateData
    */
   createByHTML: function (html, viewOpts) {
-    var view = new cdb.core.View(viewOpts);
+    var view = new CoreView(viewOpts);
     view.render = function () {
       this.$el.html(html);
       return this;
@@ -25,10 +25,10 @@ module.exports = {
    * @param {Function} template e.g. from a `require('./my-template.tpl')`
    * @param {Object,undefined} templatedata
    * @param {Object,undefined} viewOpts view options, .e.g {className: 'Whatever'}
-   * @return {Object} instance of cdb.core.View, which takes two params of template and templateData
+   * @return {Object} instance of CoreView, which takes two params of template and templateData
    */
   createByTemplate: function (template, templateData, viewOpts) {
-    var view = new cdb.core.View(viewOpts);
+    var view = new CoreView(viewOpts);
     view.render = function () {
       this.$el.html(
         template(templateData)
@@ -59,7 +59,7 @@ module.exports = {
     if (!(createViewFns && createViewFns.forEach)) throw new Error('createViewFns is required as an iterable list');
     if (!_.all(createViewFns, _.isFunction)) throw new Error('createViewFns must only contain functions');
 
-    var listView = new cdb.core.View(viewOpts);
+    var listView = new CoreView(viewOpts);
 
     listView.render = function () {
       this.clearSubViews();

--- a/lib/assets/javascripts/cartodb3/data/acl-item-model.js
+++ b/lib/assets/javascripts/cartodb3/data/acl-item-model.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var PermissionModel = require('./permission-model');
 var OWN_ATTR_NAMES = ['id', 'username', 'avatar_url', 'name'];
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   defaults: {
     access: 'r'
   },

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
@@ -1,12 +1,12 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var syncAbort = require('./backbone/sync-abort');
 
 /**
  * Analysis definition model.
  * Points to a node that is the head of the particular analysis.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   /**
    * @override {Backbone.prototype.sync} abort ongoing request if there is any

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var camshaftReference = require('./camshaft-reference');
 var QuerySchemaModel = require('./query-schema-model');
 
@@ -7,7 +7,7 @@ var QuerySchemaModel = require('./query-schema-model');
  * Base model for an analysis definition node.
  * May point to one or multiple nodes in turn (referenced by ids).
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function (attrs, opts) {
     if (!this.id) throw new Error('id is required');
@@ -99,7 +99,7 @@ module.exports = cdb.core.Model.extend({
       this.querySchemaModel = null;
     }
 
-    return cdb.core.Model.prototype.destroy.apply(this, arguments);
+    return Backbone.Model.prototype.destroy.apply(this, arguments);
   },
 
   /**

--- a/lib/assets/javascripts/cartodb3/data/backbone/sync-abort.js
+++ b/lib/assets/javascripts/cartodb3/data/backbone/sync-abort.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  * Custom sync method to only allow a single request at a time,
  * any prev ongoing request at a time of a sync call will be aborted.
  *
  * @example
- *   var MyModel = cdb.core.Model.extend({
+ *   var MyModel = Backbone.Model.extend({
  *     // …
  *     sync: syncAbort,
  */
@@ -13,7 +13,7 @@ module.exports = function (method, self, opts) {
   if (this._xhr) {
     this._xhr.abort();
   }
-  this._xhr = cdb.core.Model.prototype.sync.apply(this, arguments);
+  this._xhr = Backbone.Model.prototype.sync.apply(this, arguments);
   this._xhr.always(function () {
     self._xhr = null;
   });

--- a/lib/assets/javascripts/cartodb3/data/background-importer/background-polling-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/background-polling-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var ImportsCollection = require('./background-importer-imports-collection');
 var GeocodingsCollection = require('./background-importer-geocodings-collection');
 
@@ -9,7 +9,7 @@ var POLLINGS_TIMER = 3000;
  *
  */
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     showGeocodingDatasetURLButton: false,

--- a/lib/assets/javascripts/cartodb3/data/background-importer/geocoding-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/geocoding-model.js
@@ -1,11 +1,12 @@
 var _ = require('underscore');
+var Backbone = require('backbone');
 var GeocodingModelPoller = require('./geocoding-model-poller');
 
 /**
  *  Geocoding model
  *
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   options: {
     startPollingAutomatically: true

--- a/lib/assets/javascripts/cartodb3/data/background-importer/import-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/import-model.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var ImportModelPoller = require('./import-model-poller');
 var SynchronizationModel = require('../synchronization-model');
 
@@ -8,7 +8,7 @@ var SynchronizationModel = require('../synchronization-model');
  *  the state of an import
  *
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   idAttribute: 'item_queue_id',
 

--- a/lib/assets/javascripts/cartodb3/data/background-importer/imports-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/imports-model.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var ImportModel = require('./import-model');
 var UploadModel = require('../upload-model');
 var VisDefinitionModel = require('../vis-definition-model');
@@ -17,7 +17,7 @@ var PermissionModel = require('../permission-model');
  *
  */
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     step: 'upload',
@@ -227,7 +227,7 @@ module.exports = cdb.core.Model.extend({
       return this._importModel.toJSON();
     }
 
-    return cdb.core.Model.prototype.get.call(this, attr);
+    return Backbone.Model.prototype.get.call(this, attr);
   },
 
   toJSON: function () {

--- a/lib/assets/javascripts/cartodb3/data/background-importer/lon-lat-geocoding-model.js
+++ b/lib/assets/javascripts/cartodb3/data/background-importer/lon-lat-geocoding-model.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 
 /**
  * A special case of a geocoding model, since lon/lat geocoding is not actually going through the common async processing
  * as the rest.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function (attrs) {
     if (!attrs.table) throw new Error('table is required');

--- a/lib/assets/javascripts/cartodb3/data/column-model.js
+++ b/lib/assets/javascripts/cartodb3/data/column-model.js
@@ -1,5 +1,5 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   idAttribute: 'name'
 });

--- a/lib/assets/javascripts/cartodb3/data/config-model.js
+++ b/lib/assets/javascripts/cartodb3/data/config-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  * Model for general frontend configuration.
@@ -10,7 +10,7 @@ var cdb = require('cartodb.js');
  *   configModel: configModel
  * })
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     base_url: '/CHANGEME' // expected to be set when model is created

--- a/lib/assets/javascripts/cartodb3/data/editor-model.js
+++ b/lib/assets/javascripts/cartodb3/data/editor-model.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  * Model for general editor configuration.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   defaults: {
     edition: false
   },

--- a/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var $ = require('jquery');
 var fs = require('fs');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   SYSTEM_COLUMNS: ['the_geom', 'the_geom_webmercator', 'created_at', 'updated_at', 'cartodb_id', 'cartodb_georef_status'],
 

--- a/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definition-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var syncAbort = require('./backbone/sync-abort');
 var StyleDefinitionModel = require('../editor/style/style-definition-model');
@@ -15,7 +15,7 @@ var OWN_ATTR_NAMES = ['id', 'order', 'color', 'table_name_alias', 'infowindow', 
  * Model to edit a layer definition.
  * Should always exist as part of a LayerDefinitionsCollection, so its URL is given from there.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   defaults: {
     'color': '#ff6600'
   },

--- a/lib/assets/javascripts/cartodb3/data/map-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/map-definition-model.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  * Model that represents a visualization's Map
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function (attrs, opts) {
     if (!opts.configModel) throw new Error('configModel is required');

--- a/lib/assets/javascripts/cartodb3/data/organization-model.js
+++ b/lib/assets/javascripts/cartodb3/data/organization-model.js
@@ -1,12 +1,11 @@
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
 var _ = require('underscore');
 
 /**
  *  Organization info model
  *
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   url: function () {
     var baseUrl = this._configModel.get('base_url');
@@ -19,7 +18,7 @@ module.exports = cdb.core.Model.extend({
     this._configModel = opts.configModel;
 
     if (!_.isEmpty(this.get('owner'))) {
-      this._ownerModel = new cdb.core.Model(
+      this._ownerModel = new Backbone.Model(
         _.omit(this.get('owner'), 'organization')
       );
     }

--- a/lib/assets/javascripts/cartodb3/data/permission-model.js
+++ b/lib/assets/javascripts/cartodb3/data/permission-model.js
@@ -1,4 +1,3 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var _ = require('underscore');
 var Utils = require('../helpers/utils');
@@ -20,7 +19,7 @@ var READ_WRITE = 'rw';
  *   an object like visualization table
  *
  */
-var PermissionModel = module.exports = cdb.core.Model.extend({
+var PermissionModel = module.exports = Backbone.Model.extend({
   url: function () {
     var baseUrl = this._configModel.get('base_url');
     return baseUrl + '/api/v1/perm';

--- a/lib/assets/javascripts/cartodb3/data/query-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-schema-model.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var syncAbort = require('./backbone/sync-abort');
 var createGeometry = require('../value-objects/geometry');
@@ -15,7 +14,7 @@ var PARAMS = {
 /**
  * Model to represent a schema of a SQL query.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     query: '',
@@ -67,7 +66,7 @@ module.exports = cdb.core.Model.extend({
       this.set('status', 'unavailable');
     }.bind(this);
 
-    return cdb.core.Model.prototype.fetch.call(this, opts);
+    return Backbone.Model.prototype.fetch.call(this, opts);
   },
 
   parse: function (r) {

--- a/lib/assets/javascripts/cartodb3/data/synchronization-model.js
+++ b/lib/assets/javascripts/cartodb3/data/synchronization-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var $ = require('jquery');
 var MULTIPLIER = 1.2; // Multiply current interval for this number
@@ -8,7 +8,7 @@ var INTERVAL = 1500; // Interval time between poll checkings
  *  Synced table model
  */
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   defaults: {
     name: '',
     url: '',

--- a/lib/assets/javascripts/cartodb3/data/table-model.js
+++ b/lib/assets/javascripts/cartodb3/data/table-model.js
@@ -1,12 +1,12 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var TableColumnsCollection = require('./table-columns-collection');
 var getSimpleGeometryType = require('./get-simple-geometry-type');
 
 /**
  * Model representing a table.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   idAttribute: 'name',
 

--- a/lib/assets/javascripts/cartodb3/data/upload-model.js
+++ b/lib/assets/javascripts/cartodb3/data/upload-model.js
@@ -8,7 +8,7 @@ require('backbone-model-file-upload');
 /**
  * Model that allows uploading files to CartoDB endpoints.
  *
- * NOTE: this model extends Backbone.Model instead of cdb.core.Model, because
+ * NOTE: this model extends Backbone.Model instead of Backbone.Model, because
  * it's required for the vendor/backbone-model-file-upload.
  */
 module.exports = Backbone.Model.extend({

--- a/lib/assets/javascripts/cartodb3/data/user-model.js
+++ b/lib/assets/javascripts/cartodb3/data/user-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var OrganizationModel = require('./organization-model');
 
@@ -7,7 +7,7 @@ var OrganizationModel = require('./organization-model');
  *
  */
 
-var UserModel = cdb.core.Model.extend({
+var UserModel = Backbone.Model.extend({
   url: function () {
     var baseUrl = this._configModel.get('base_url');
     return baseUrl + '/api/v1/users';

--- a/lib/assets/javascripts/cartodb3/data/vis-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/vis-definition-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  * Model that represents a visualization (v3)
@@ -6,7 +6,7 @@ var cdb = require('cartodb.js');
  * Even though a table might be represented as a Visualization in some cases, please use TableModel if you want to work
  * with the table data instead of adding table-specific methods here.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function (attrs, opts) {
     if (!opts.configModel) throw new Error('configModel is required');

--- a/lib/assets/javascripts/cartodb3/data/visualization-table-model.js
+++ b/lib/assets/javascripts/cartodb3/data/visualization-table-model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var TableModel = require('./table-model');
 var PermissionModel = require('./permission-model');
@@ -9,7 +9,7 @@ var LikesModel = require('../components/likes/likes-model');
  * Model that represents a table visualization (v3)
  *
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   urlRoot: function () {
     var baseUrl = this._configModel.get('base_url');

--- a/lib/assets/javascripts/cartodb3/data/visualizations-fetch-model.js
+++ b/lib/assets/javascripts/cartodb3/data/visualizations-fetch-model.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  * Model that encapsulates params for fetching data in a cdb.admin.Visualizations collection.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
   defaults: {
     content_type: '',
     page: 1,

--- a/lib/assets/javascripts/cartodb3/data/widget-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/widget-definition-model.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var syncAbort = require('./backbone/sync-abort');
 
 var ATTRS_AT_TOP_LEVEL = ['id', 'layer_id', 'source', 'title', 'type', 'order'];
@@ -7,7 +7,7 @@ var ATTRS_AT_TOP_LEVEL = ['id', 'layer_id', 'source', 'title', 'type', 'order'];
 /**
  * Widget definition Model
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     sync_on_data_change: true,

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -12,6 +12,7 @@ window._t = polyglot.t.bind(polyglot);
 
 var $ = require('jquery');
 var _ = require('underscore');
+var Backbone = require('backbone');
 var cdb = require('cartodb.js');
 var deepInsights = require('cartodb-deep-insights.js');
 var ConfigModel = require('./data/config-model');
@@ -42,7 +43,7 @@ var layersData = window.layersData;
 var analysesData = window.analysesData;
 var basemaps = window.basemaps;
 
-cdb.god = new cdb.core.Model(); // To be replaced
+cdb.god = new Backbone.Model(); // To be replaced
 
 var configModel = new ConfigModel(
   _.defaults(

--- a/lib/assets/javascripts/cartodb3/editor/components/code-mirror/code-mirror-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/components/code-mirror/code-mirror-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var CodeMirror = require('codemirror');
 var template = require('./code-mirror.tpl');
@@ -7,7 +7,7 @@ var errorTemplate = require('./code-mirror-error.tpl');
 require('./cartocss.code-mirror')(CodeMirror);
 require('./scroll.code-mirror')(CodeMirror);
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'Editor-content',
 
   initialize: function (opts) {
@@ -133,6 +133,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this.destroyEditor();
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/components/overlay/overlay-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/components/overlay/overlay-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./overlay.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.overlayModel) throw new Error('overlayModel is required');
     this.overlayModel = opts.overlayModel;

--- a/lib/assets/javascripts/cartodb3/editor/components/toggler/toggler-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/components/toggler/toggler-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./toggler.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Toggle',
 

--- a/lib/assets/javascripts/cartodb3/editor/components/undo-redo/undo-redo-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/components/undo-redo/undo-redo-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./undo-redo.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-redo': '_onRedoClick',
     'click .js-undo': '_onUndoClick',

--- a/lib/assets/javascripts/cartodb3/editor/components/view-options/panel-with-options-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/components/view-options/panel-with-options-view.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./panel-with-options.tpl');
 var InfoboxView = require('../../../components/infobox/infobox-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.createContentView) throw new Error('createContentView factory function is mandatory');
     if (!opts.editorModel) throw new Error('editorModel is required');

--- a/lib/assets/javascripts/cartodb3/editor/editor-header.js
+++ b/lib/assets/javascripts/cartodb3/editor/editor-header.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var template = require('./editor-header.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.title) throw new Error('title is required');
     if (!opts.editorModel) throw new Error('editorModel is required');

--- a/lib/assets/javascripts/cartodb3/editor/editor-map-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/editor-map-view.js
@@ -1,5 +1,5 @@
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var EditorView = require('./editor-view');
 var AddAnalysisView = require('../components/modals/add-analysis/add-analysis-view');
 var StackLayoutView = require('../components/stack-layout/stack-layout-view');
@@ -7,7 +7,7 @@ var BasemapContentView = require('./layers/basemap-content-view');
 var LayerContentView = require('./layers/layer-content-view');
 var WidgetsFormContentView = require('./widgets/widgets-form/widgets-form-content-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   className: 'MapEditor',
 
   events: {

--- a/lib/assets/javascripts/cartodb3/editor/editor-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/editor-view.js
@@ -1,5 +1,5 @@
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var createTextLabelsTabPane = require('../components/tab-pane/create-text-labels-tab-pane');
 var AddWidgetsView = require('../components/modals/add-widgets/add-widgets-view');
 var AddLayerView = require('../components/modals/add-layer/add-layer-view');
@@ -11,7 +11,7 @@ var EditorWidgetsView = require('./widgets/widgets-view');
 var LayersView = require('./layers/layers-view');
 var ScrollView = require('../components/scroll/scroll-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-add': '_addItem'
   },
@@ -81,7 +81,7 @@ module.exports = cdb.core.View.extend({
       label: _t('editor.tab-pane.elements.title-label'),
       selected: this.options.selectedTabItem === 'elements',
       createContentView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       }
     }, {
       name: 'widgets',

--- a/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/base-layer-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/base-layer-analysis-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var LayerAnalysisDraggableHelperView = require('../layer-analysis-draggable-helper-view');
 
 /**
  *  Base layer analysis view.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'li',
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var BasemapHeaderView = require('./basemap-content-views/basemap-header-view');
 var BasemapCategoryView = require('./basemap-content-views/basemap-category-view');
 var BasemapSelectView = require('./basemap-content-views/basemap-select-view');
@@ -7,7 +7,7 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var template = require('./basemap-content.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-back': '_onClickBack'

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-category-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-category-view.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./basemap-category.tpl');
 var CarouselFormView = require('../../../components/carousel-form-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.categoriesCollection) throw new Error('categoriesCollection is required');

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-header-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-header-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./basemap-header.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.category) throw new Error('category is required');

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-select-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-select-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./basemap-select.tpl');
 var MosaicFormView = require('../../../components/mosaic-form-view');
 var MosaicCollection = require('../../../components/mosaic/mosaic-collection');
 var _ = require('underscore-cdb-v3');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.layerDefinitionsCollection) throw new Error('layerDefinitionsCollection is required');

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-layer-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./basemap-layer.tpl');
 
 /**
  * View for an individual layer definition model.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'li',
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-analyses-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-analyses-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 
 /**
  * View of analyses within a layer
  * this.model is the layer-definition-model
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'ul',
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-analysis-draggable-helper-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-analysis-draggable-helper-view.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var CoreView = require('backbone/core-view');
 
 require('jquery-ui/draggable');
 
@@ -7,7 +8,7 @@ var Template = '<li class="<%- className %>"><%= html %></li>';
 var DEFAULT_DRAGGABLE_SCOPE = 'analysis';
 var DEFAULT_REVERT_DURATION = 100;
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click': '_onClick'
   },
@@ -53,6 +54,6 @@ module.exports = cdb.core.View.extend({
     if (this.$el.data('ui-draggable')) {
       this.$el.draggable('destroy');
     }
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-analysis-view-factory.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-analysis-view-factory.js
@@ -14,7 +14,7 @@ var LayerAnalysisViewFactory = function (analysisDefinitionNodesCollection, anal
 /**
  * @param {Object} layerAnalysisDefinitionNodeModel
  * @param {Object} layerDefinitionModel
- * @return {Object} instance of cdb.core.View
+ * @return {Object} instance of CoreView
  * @throws {Error} if node model can not be found, or view can not be found for the given mode
  */
 LayerAnalysisViewFactory.prototype.createView = function (layerAnalysisDefinitionNodeModel, layerDefinitionModel) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var createTextLabelsTabPane = require('../../components/tab-pane/create-text-labels-tab-pane');
 var TabPaneTemplate = require('./layer-tab-pane.tpl');
 var Header = require('./layer-header-view.js');
@@ -10,7 +10,7 @@ var TablesCollection = require('../../data/tables-collection');
 var AnalysisSourceOptionsModel = require('./layer-content-views/analyses/analysis-source-options-model');
 var AnalysisFormsCollection = require('./layer-content-views/analyses/analysis-forms-collection');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_onClickBack'
   },
@@ -53,7 +53,7 @@ module.exports = cdb.core.View.extend({
       name: 'data',
       selected: !analysisPayload,
       createContentView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       }
     }, {
       label: _t('editor.layers.menu-tab-pane-labels.analyses'),
@@ -127,7 +127,7 @@ module.exports = cdb.core.View.extend({
       label: _t('editor.layers.menu-tab-pane-labels.legends'),
       name: 'legends',
       createContentView: function () {
-        return new cdb.core.View({
+        return new CoreView({
           className: 'Editor-content'
         });
       }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./analyses-workflow-item.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'li',
   className: 'HorizontalBlockList-item',

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var AnalysesWorkflowItemView = require('./analyses-workflow-item-view');
 var template = require('./analyses-workflow.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-delete': '_deleteAnalysis'

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./analysis-controls.tpl');
 
 /**
  * View representing the apply button for a form
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Options-bar',
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
@@ -1,11 +1,11 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var camshaftReference = require('../../../../../data/camshaft-reference');
 
 /**
  * Base model for all analysis form models.
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function (attrs, opts) {
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
@@ -58,7 +58,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   /**
-   * @override {cdb.core.Model.prototype.set} see inline comment below for motivation
+   * @override {Backbone.Model.prototype.set} see inline comment below for motivation
    */
   set: function (key, val, options) {
     if (key == null) return this;
@@ -75,10 +75,10 @@ module.exports = cdb.core.Model.extend({
 
     var persisted = attrs.persisted || this.get('persisted');
 
-    cdb.core.Model.prototype.set.call(this, attrs, options);
+    Backbone.Model.prototype.set.call(this, attrs, options);
 
     if (persisted !== undefined) {
-      cdb.core.Model.prototype.set.call(this, 'persisted', persisted, {silent: true});
+      Backbone.Model.prototype.set.call(this, 'persisted', persisted, {silent: true});
     }
 
     return this;

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-view.js
@@ -1,5 +1,5 @@
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 require('../../../../components/form-components/index');
 
 var CHECK_FORM_VALIDATION_TOO = {validate: true};
@@ -7,7 +7,7 @@ var CHECK_FORM_VALIDATION_TOO = {validate: true};
 /**
  * This view is required because a schema change require the Backbone.Form object to be re-created to update the view as expected.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.formModel) throw new Error('formModel is required');
@@ -40,14 +40,14 @@ module.exports = cdb.core.View.extend({
   },
 
   /**
-   * @override cdb.core.View.prototype.clearSubViews
+   * @override CoreView.prototype.clearSubViews
    */
   clearSubViews: function () {
     if (this._analysisFormView) {
       this._analysisFormView.remove(); // the Backbone.Form equivalent to "view.clean()"
     }
 
-    return cdb.core.View.prototype.clearSubViews.apply(this, arguments);
+    return CoreView.prototype.clearSubViews.apply(this, arguments);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-source-options-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-source-options-model.js
@@ -1,13 +1,13 @@
 var _ = require('underscore');
 var queueAsync = require('queue-async');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
 /**
  * Analysis source options are not trivial to get and requires some coordination of events.
  *
  * It's intended to be fetched
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     fetching: false,

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-content-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var InfowindowSelectView = require('./infowindow-select-view');
 var InfowindowItemsView = require('./infowindow-items-view');
 var CarouselCollection = require('../../../../components/custom-carousel/custom-carousel-collection');
@@ -7,7 +7,7 @@ var _ = require('underscore');
 /**
  * Select for an Infowindow select type.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-description-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-description-view.js
@@ -1,7 +1,7 @@
 var template = require('./infowindow-description.tpl');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-toggle': '_toggle'

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-field-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-field-view.js
@@ -1,10 +1,11 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var template = require('./infowindow-field.tpl');
 
 /**
  * View for an individual column model.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'li',
 
@@ -27,7 +28,7 @@ module.exports = cdb.core.View.extend({
 
     this._layerInfowindowModel.bind('change:fields', this.render, this);
 
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       title: this._layerInfowindowModel.getAlternativeName(this.fieldName) || this.fieldName,
       selected: !!this._layerInfowindowModel.containsField(this.fieldName)
     });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
@@ -1,13 +1,13 @@
 var FieldView = require('./infowindow-field-view.js');
 var InfowindowDescriptionView = require('./infowindow-description-view.js');
 var template = require('./infowindow-fields.tpl');
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var $ = require('jquery');
 require('jquery-ui/sortable');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
@@ -229,6 +229,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._destroySortable();
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-form-model.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var DEBOUNCE_TIME = 350;
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function (attrs, opts) {
     if (!opts.layerInfowindowModel) throw new Error('layerInfowindowModel is required');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-form-view.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var template = require('./infowindow-form.tpl');
 var InfowindowFormModel = require('./infowindow-form-model');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   render: function () {
     this.clearSubViews();

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-items-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-items-view.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./infowindow-items.tpl');
 var InfowindowFieldsView = require('./infowindow-fields-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-select-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-select-view.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./infowindow-select.tpl');
 var CarouselFormView = require('../../../../components/carousel-form-view');
 var InfowindowFormView = require('./infowindow-form-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.templatesCollection) throw new Error('templatesCollection is required');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
@@ -1,4 +1,5 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var PanelWithOptionsView = require('../../../../editor/components/view-options/panel-with-options-view');
 var CodeMirrorView = require('../../../../editor/components/code-mirror/code-mirror-view');
@@ -8,7 +9,7 @@ var TabPaneView = require('../../../../components/tab-pane/tab-pane-view');
 var TabPaneCollection = require('../../../../components/tab-pane/tab-pane-collection');
 var Toggler = require('../../../../editor/components/toggler/toggler-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
@@ -34,11 +35,11 @@ module.exports = cdb.core.View.extend({
     var self = this;
 
     // CodeMirror placeholder
-    var CodeMirrorModel = new cdb.core.Model({
+    var CodeMirrorModel = new Backbone.Model({
       content: 'Hola mundo'
     });
 
-    var Dummy = cdb.core.View.extend({
+    var Dummy = CoreView.extend({
       render: function () {
         this.$el.html(this.options.content);
         return this;
@@ -99,6 +100,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this.model.unbind('change', null, this.model);
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindows-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindows-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var InfowindowView = require('./infowindow/infowindow-click-view');
 var TooltipView = require('./infowindow/infowindow-hover-view');
 var createTextLabelsTabPane = require('../../../components/tab-pane/create-text-labels-tab-pane');
 var TabPaneTemplate = require('../../tab-pane-submenu.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.layerDefinitionModel) throw new Error('Layer definition is required');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/layer-content-analyses-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/layer-content-analyses-view.js
@@ -1,4 +1,5 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var ScrollView = require('../../../components/scroll/scroll-view');
 var ViewFactory = require('../../../components/view-factory');
 var analysisPlaceholderTemplate = require('./analyses/analyses-placeholder.tpl');
@@ -14,7 +15,7 @@ var AnalysisControlsView = require('./analyses/analysis-controls-view');
  *   |       └── FormTypeView
  *   └── ControlsView
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   options: {
     selectedNodeId: false // or an id, e.g. 'a1'
@@ -29,7 +30,7 @@ module.exports = cdb.core.View.extend({
     this._analysisFormsCollection = opts.analysisFormsCollection;
     this._layerDefinitionModel = opts.layerDefinitionModel;
 
-    this._viewModel = new cdb.core.Model({selectedNodeId: this.options.selectedNodeId});
+    this._viewModel = new Backbone.Model({selectedNodeId: this.options.selectedNodeId});
 
     // Init listeners
     this._viewModel.on('change:selectedNodeId', this.render, this);
@@ -61,7 +62,7 @@ module.exports = cdb.core.View.extend({
   },
 
   clean: function () {
-    cdb.core.View.prototype.clean.apply(this, arguments);
+    CoreView.prototype.clean.apply(this, arguments);
     this._selectedNodeId(null, {silent: true});
     this.viewModel = null;
   },

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-header-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-header-view.js
@@ -1,8 +1,8 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var template = require('./layer-header.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
     this.layerDefinitionModel = opts.layerDefinitionModel;

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-view.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./layer.tpl');
 var ContextMenuView = require('../../components/context-menu/context-menu-view');
 var CustomListCollection = require('../../components/custom-list/custom-list-collection');
@@ -7,7 +7,7 @@ var CustomListCollection = require('../../components/custom-list/custom-list-col
 /**
  * View for an individual layer definition model.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'li',
 
@@ -102,6 +102,6 @@ module.exports = cdb.core.View.extend({
   },
 
   clean: function () {
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layers-view.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var LayerAnalysisViewFactory = require('./layer-analysis-view-factory');
 var LayerAnalysesView = require('./layer-analyses-view');
 var template = require('./layers.tpl');
@@ -12,7 +12,7 @@ var BasemapLayerView = require('./basemap-layer-view');
 /**
  * View to render layer definitions list
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.stackLayoutModel) throw new Error('stackLayoutModel is required');
@@ -113,6 +113,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._destroySortable();
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/style/style-cartocss-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-cartocss-model.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var UndoManager = require('../../data/undo-manager.js');
 var _ = require('underscore');
 
 /**
  *  CartoCSS Undo-redo model
  */
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     content: ''

--- a/lib/assets/javascripts/cartodb3/editor/style/style-cartocss-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-cartocss-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var CodeMirrorView = require('../../editor/components/code-mirror/code-mirror-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Editor-styleContentCartoCSS Editor-content',
 

--- a/lib/assets/javascripts/cartodb3/editor/style/style-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-content-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var StyleFormView = require('./style-form/style-form-view');
 var StylesFactory = require('./styles-factory');
@@ -7,7 +7,7 @@ var CarouselCollection = require('../../components/custom-carousel/custom-carous
 var styleFormNotReadyTemplate = require('./style-form-not-ready.tpl');
 var OverlayView = require('../components/overlay/overlay-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Editor-styleContent',
 

--- a/lib/assets/javascripts/cartodb3/editor/style/style-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-definition-model.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var StylesFactory = require('./styles-factory');
 var UndoManager = require('../../data/undo-manager');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   parse: function (r) {
     r = r || {};

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-aggregation-form/style-aggregation-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-aggregation-form/style-aggregation-form-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 require('../../../../components/form-components/index');
 var StyleShapeFormModel = require('./style-aggregation-properties-form-model');
 var template = require('./style-aggregation-form.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
@@ -50,7 +50,7 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._removeFormView();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-default-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-default-model.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 var StyleFormComponents = require('./style-form-components-dictionary');
 var DEBOUNCE_TIME = 350;
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   _FORM_NAME: '',
 

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-view.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var StylePropertiesFormView = require('./style-properties-form/style-properties-form-view');
 var StyleAggregationFormView = require('./style-aggregation-form/style-aggregation-form-view');
 var noneFormMessage = require('./none-form-message.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'Editor-formView',
 

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-animated-properties-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-animated-properties-form-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
-var _ = require('underscore');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
+var _ = require('underscore');
 require('../../../../components/form-components/index');
 var StyleAnimatedFormModel = require('./style-animated-properties-form-model');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'u-tSpace--m',
 
@@ -114,6 +114,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._removeAnimatedFormView();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-labels-properties-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-labels-properties-form-view.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 require('../../../../components/form-components/index');
 var StyleLabelsFormModel = require('./style-labels-properties-form-model');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'u-tSpace--m',
 
@@ -101,6 +101,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._removeLabelsFormView();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-properties-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-properties-form-view.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var StyleLabelsPropertiesFormView = require('./style-labels-properties-form-view');
 var StyleAnimatedPropertiesFormView = require('./style-animated-properties-form-view');
 var StyleShapePropertiesFormView = require('./style-shape-properties-form-view');
 var template = require('./style-properties-form.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.layerDefinitionsCollection) throw new Error('layerDefinitionsCollection is required');

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-shape-properties-form-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-shape-properties-form-view.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 require('../../../../components/form-components/index');
 var StyleShapeFormModel = require('./style-shape-properties-form-model');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   className: 'u-tSpace--m',
 
@@ -61,6 +61,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._removeFormView();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/style/style-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-view.js
@@ -1,4 +1,5 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var PanelWithOptionsView = require('../../editor/components/view-options/panel-with-options-view');
 var StyleContentView = require('./style-content-view');
 var StyleCartoCSSView = require('./style-cartocss-view');
@@ -12,7 +13,7 @@ var Infobox = require('../../components/infobox/infobox-factory');
 var InfoboxModel = require('../../components/infobox/infobox-model');
 var InfoboxCollection = require('../../components/infobox/infobox-collection');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.layerDefinitionsCollection) throw new Error('layersDefinitionCollection is required');
@@ -30,7 +31,7 @@ module.exports = cdb.core.View.extend({
     this._querySchemaModel = opts.querySchemaModel;
     this._editorModel = opts.editorModel;
     this._cartocssModel = this._layerDefinitionModel.cartocssModel;
-    this._codemirrorModel = new cdb.core.Model({
+    this._codemirrorModel = new Backbone.Model({
       content: this._layerDefinitionModel.get('cartocss')
     });
 
@@ -43,7 +44,7 @@ module.exports = cdb.core.View.extend({
       state: ''
     });
 
-    this._overlayModel = new cdb.core.Model({
+    this._overlayModel = new Backbone.Model({
       visible: false
     });
 

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widget-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widget-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./widget-view.tpl');
 
 var widgetIconTemplateMap = {
@@ -11,7 +11,7 @@ var widgetIconTemplateMap = {
 /**
  * View for an individual widget definition model.
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   tagName: 'li',
 

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     schema: {}

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-formula-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-formula-data-schema-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   defaults: {
     schema: {}

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-histogram-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-histogram-data-schema-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function (attrs, opts) {
     if (!opts.columnOptionsFactory) throw new Error('columnOptionsFactory is required');

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-time-series-data-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-time-series-data-schema-model.js
@@ -1,6 +1,6 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function (attrs, opts) {
     if (!opts.columnOptionsFactory) throw new Error('columnOptionsFactory is required');

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/style/widgets-form-style-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/style/widgets-form-style-schema-model.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 
-module.exports = cdb.core.Model.extend({
+module.exports = Backbone.Model.extend({
 
   initialize: function () {
     var o = [

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widget-header.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widget-header.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var template = require('./widget-header.tpl');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.title) throw new Error('title is required');
 

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-data-view.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var CarouselFormView = require('../../../components/carousel-form-view');
 var CarouselCollection = require('../../../components/custom-carousel/custom-carousel-collection');
 var WidgetFormFactory = require('./widgets-form-factory');
 var WidgetsDataFormView = require('./widgets-form-data-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.widgetDefinitionModel) throw new Error('widgetDefinitionModel is required');

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-style-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-style-view.js
@@ -1,7 +1,7 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var WidgetsStyleFormView = require('./widgets-form-style-view');
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!opts.widgetDefinitionModel) throw new Error('widgetDefinitionModel is required');
     this._widgetDefinitionModel = opts.widgetDefinitionModel;

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-content-view.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var WidgetsFormContentDataView = require('./widgets-form-content-data-view');
 var WidgetsFormContentStyleView = require('./widgets-form-content-style-view');
 var createTextLabelsTabPane = require('../../../components/tab-pane/create-text-labels-tab-pane');
@@ -10,7 +10,7 @@ var ScrollView = require('../../../components/scroll/scroll-view');
  * View to render all necessary for the widget form
  */
 
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
   events: {
     'click .js-back': '_onClickBack'
   },

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-data-view.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
-var WidgetFormFactory = require('./widgets-form-factory');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
+var WidgetFormFactory = require('./widgets-form-factory');
 var Template = require('./widgets-form-data.tpl');
 require('../../../components/form-components/index');
 
@@ -9,7 +9,7 @@ require('../../../components/form-components/index');
  *  View of form to edit a widget definition's data
  *
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.widgetDefinitionModel) throw new Error('widgetDefinitionModel is required');
@@ -55,7 +55,7 @@ module.exports = cdb.core.View.extend({
   clean: function () {
     // Backbone.Form removes the view with the following method
     this._widgetFormView.remove();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   },
 
   _onFormChange: function () {

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-style-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-style-view.js
@@ -1,14 +1,14 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
-var WidgetFormFactory = require('./widgets-form-factory');
 var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
+var WidgetFormFactory = require('./widgets-form-factory');
 var Template = require('./widgets-form-style.tpl');
 require('../../../components/form-components/index');
 
 /**
  * View of form to edit a widget definition's style
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   initialize: function (opts) {
     if (!opts.widgetDefinitionModel) throw new Error('widgetDefinitionModel is required');
@@ -51,7 +51,7 @@ module.exports = cdb.core.View.extend({
   clean: function () {
     // Backbone.Form removes the view with the following method
     this._widgetFormView.remove();
-    cdb.core.View.prototype.clean.call(this);
+    CoreView.prototype.clean.call(this);
   },
 
   _onFormChange: function () {

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
@@ -2,7 +2,7 @@ var EditorWidgetView = require('./widget-view');
 var AddWidgetsView = require('../../components/modals/add-widgets/add-widgets-view');
 var template = require('./widgets-view.tpl');
 var widgetPlaceholderTemplate = require('./widgets-placeholder.tpl');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var $ = require('jquery');
 
 require('jquery-ui/sortable');
@@ -10,7 +10,7 @@ require('jquery-ui/sortable');
 /**
  * View to render widgets definitions overview
  */
-module.exports = cdb.core.View.extend({
+module.exports = CoreView.extend({
 
   events: {
     'click .js-add-widget': '_addWidget'
@@ -93,6 +93,6 @@ module.exports = cdb.core.View.extend({
 
   clean: function () {
     this._destroySortable();
-    cdb.core.View.prototype.clean.apply(this);
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/helpers/navigate-through-router.js
+++ b/lib/assets/javascripts/cartodb3/helpers/navigate-through-router.js
@@ -41,7 +41,7 @@ function isCtrlKeyPressed (ev) {
  *
  *   - In the view file:
  *     var navigateThroughRouter = require('../../common/view_helpers/navigateThroughRouter');
- *     module.exports = new cdb.core.View.extend({
+ *     module.exports = new CoreView.extend({
  *       events: {
  *         'click a#my-link': navigateThroughRouter
  *         'click a#my-special-link': this._myCustomRoute

--- a/lib/assets/javascripts/cartodb3/helpers/parser-css.js
+++ b/lib/assets/javascripts/cartodb3/helpers/parser-css.js
@@ -1,3 +1,4 @@
+var cdb = require('cartodb.js');
 var carto = require('carto');
 var torque = require('torque.js');
 var _ = require('underscore');

--- a/lib/assets/node_modules/README.md
+++ b/lib/assets/node_modules/README.md
@@ -1,0 +1,4 @@
+utilizes https://github.com/substack/browserify-handbook#how-node_modules-works,
+to avoid annoying `require('../../../../../')` for both source and test environment
+
+Was migrated as-is from https://github.com/CartoDB/cartodb.js/blob/470399abb12b40d5476ab6bbfd792d95aa819f50/src/core/ on May 3rd 2016

--- a/lib/assets/node_modules/backbone/core-view.js
+++ b/lib/assets/node_modules/backbone/core-view.js
@@ -1,0 +1,160 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+
+/**
+ * NOTE! Migrated as-is from https://github.com/CartoDB/cartodb.js/blob/470399abb12b40d5476ab6bbfd792d95aa819f50/src/core/view.js 2016-06-03
+ * Base View for all CartoDB views.
+ * DO NOT USE Backbone.View directly
+ */
+var View = Backbone.View.extend({
+  classLabel: 'cdb.core.View',
+
+  constructor: function (options) {
+    this.options = _.defaults(options, this.options);
+    this._models = [];
+    this._subviews = {};
+    Backbone.View.call(this, options);
+    View.viewCount++;
+    View.views[this.cid] = this;
+    this._created_at = new Date();
+  },
+
+  add_related_model: function (m) {
+    if (!m) throw new Error('added non valid model');
+    this._models.push(m);
+  },
+
+  addView: function (v) {
+    this._subviews[v.cid] = v;
+    v._parent = this;
+  },
+
+  removeView: function (v) {
+    delete this._subviews[v.cid];
+  },
+
+  clearSubViews: function () {
+    _(this._subviews).each(function (v) {
+      v.clean();
+    });
+    this._subviews = {};
+  },
+
+  /**
+   * this methid clean removes the view
+   * and clean and events associated. call it when
+   * the view is not going to be used anymore
+   */
+  clean: function () {
+    var self = this;
+    this.trigger('clean');
+    this.clearSubViews();
+    // remove from parent
+    if (this._parent) {
+      this._parent.removeView(this);
+      this._parent = null;
+    }
+    this.remove();
+    this.unbind();
+    // remove this model binding
+    if (this.model && this.model.unbind) this.model.unbind(null, null, this);
+    // remove model binding
+    _(this._models).each(function (m) {
+      m.unbind(null, null, self);
+    });
+    this._models = [];
+    View.viewCount--;
+    delete View.views[this.cid];
+    return this;
+  },
+
+  show: function () {
+    this.$el.show();
+  },
+
+  hide: function () {
+    this.$el.hide();
+  },
+
+  /**
+  * Listen for an event on another object and triggers on itself, with the same name or a new one
+  * @method retrigger
+  * @param ev {String} event who triggers the action
+  * @param obj {Object} object where the event happens
+  * @param obj {Object} [optional] name of the retriggered event
+  */
+  retrigger: function (ev, obj, retrigEvent) {
+    if (!retrigEvent) {
+      retrigEvent = ev;
+    }
+    var self = this;
+    obj.bind && obj.bind(ev, function () {
+      self.trigger(retrigEvent);
+    }, self);
+    // add it as related model//object
+    this.add_related_model(obj);
+  },
+  /**
+  * Captures an event and prevents the default behaviour and stops it from bubbling
+  * @method killEvent
+  * @param event {Event}
+  */
+  killEvent: function (ev) {
+    if (ev && ev.preventDefault) {
+      ev.preventDefault();
+    }
+    if (ev && ev.stopPropagation) {
+      ev.stopPropagation();
+    }
+  },
+
+  /**
+  * Remove all the tipsy tooltips from the document
+  * @method cleanTooltips
+  */
+  cleanTooltips: function () {
+    this.$('.tipsy').remove();
+  }
+
+}, {
+  viewCount: 0,
+  views: {},
+
+  /**
+   * when a view with events is inherit and you want to add more events
+   * this helper can be used:
+   * var MyView = new core.View({
+   *  events: View.extendEvents({
+   *      'click': 'fn'
+   *  })
+   * })
+   */
+  extendEvents: function (newEvents) {
+    return function () {
+      return _.extend(newEvents, this.constructor.__super__.events);
+    };
+  },
+
+  /**
+   * search for views in a view and check if they are added as subviews
+   */
+  runChecker: function () {
+    _.each(View.views, function (view) {
+      _.each(view, function (prop, k) {
+        if (k !== '_parent' &&
+          view.hasOwnProperty(k) &&
+          prop instanceof View &&
+          view._subviews[prop.cid] === undefined) {
+          console.log('=========');
+          console.log('untracked view: ');
+          console.log(prop.el);
+          console.log('parent');
+          console.log(view.el);
+          console.log(' ');
+        }
+      });
+    });
+  }
+});
+
+module.exports = View;

--- a/lib/assets/test/spec/cartodb/common/dialogs/export_map/export_map_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/export_map/export_map_view.spec.js
@@ -1,3 +1,4 @@
+/* global cdb */
 var ExportMapView = require('../../../../../../javascripts/cartodb/common/dialogs/export_map/export_map_view');
 
 // Just duplicated from old modal to maintain the exiting tests at least.

--- a/lib/assets/test/spec/cartodb/table/infowindow.spec.js
+++ b/lib/assets/test/spec/cartodb/table/infowindow.spec.js
@@ -1,3 +1,5 @@
+/* global cdb */
+
 describe('MapInfowindow', function () {
   describe('leaflet', function () {
     GroupLayerSpecs(cdb.admin.LeafletMapView);

--- a/lib/assets/test/spec/cartodb3/components/background-importer/background-polling-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/background-importer/background-polling-view.spec.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var Backbone = require('backbone');
 var cdb = require('cartodb.js');
 var ImportsModel = require('../../../../../javascripts/cartodb3/data/background-importer/imports-model.js');
 var BackgroundPollingView = require('../../../../../javascripts/cartodb3/components/background-importer/background-polling-view.js');
@@ -23,7 +24,7 @@ describe('common/background-polling/background-polling-view', function () {
       base_url: '/u/pepe'
     });
 
-    cdb.god = new cdb.core.Model();
+    cdb.god = new Backbone.Model();
     spyOn(cdb.god, 'bind').and.callThrough();
 
     this.importsCollection = new ImportsCollection(undefined, {

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color.spec.js
@@ -1,8 +1,9 @@
+var Backbone = require('backbone');
 var InputColor = require('../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color');
 
 describe('components/form-components/editors/fill/input-color', function () {
   beforeEach(function () {
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       bins: 5,
       range: ['#FFF', '#FABADA', '#00FF00', '#000', '#99999'],
       attribute: 'column1',
@@ -42,7 +43,7 @@ describe('components/form-components/editors/fill/input-color', function () {
 
   describe('fixed value', function () {
     beforeEach(function () {
-      this.model = new cdb.core.Model({
+      this.model = new Backbone.Model({
         fixed: '#FF0000'
       });
       this.view = new InputColor(({
@@ -70,7 +71,7 @@ describe('components/form-components/editors/fill/input-color', function () {
 
   describe('range', function () {
     beforeEach(function () {
-      this.model = new cdb.core.Model({
+      this.model = new Backbone.Model({
         bins: 5,
         range: ['#FFFFFF', '#FABADA', '#00FF00', '#000000', '#999999'],
         attribute: 'column1',

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
@@ -1,9 +1,10 @@
+var Backbone = require('backbone');
 var InputColorRamps = require('../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps');
 
 describe('components/form-components/editors/fill/input-color/input-ramps/input-color-ramps', function () {
   describe('on model with a range', function () {
     beforeEach(function () {
-      this.model = new cdb.core.Model({
+      this.model = new Backbone.Model({
         bins: 7,
         range: ['#F1EEF6', '#D4B9DA', '#C994C7', '#DF65B0', '#E7298A', '#CE1256', '#91003F'],
         attribute: 'column1',
@@ -40,7 +41,7 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
 
   describe('model without previous range', function () {
     beforeEach(function () {
-      this.model = new cdb.core.Model({
+      this.model = new Backbone.Model({
         fixed: '#FF0000'
       });
 
@@ -62,7 +63,7 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
 
   describe('model with previous bins', function () {
     beforeEach(function () {
-      this.model = new cdb.core.Model({
+      this.model = new Backbone.Model({
         bins: 12
       });
 

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-number.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-number.spec.js
@@ -1,8 +1,9 @@
+var Backbone = require('backbone');
 var InputNumber = require('../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number');
 
 describe('components/form-components/editors/fill/input-number', function () {
   beforeEach(function () {
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       range: [1, 30],
       attribute: 'the_geom',
       quantification: 'Quantile'
@@ -34,7 +35,7 @@ describe('components/form-components/editors/fill/input-number', function () {
 
   describe('fixed value', function () {
     beforeEach(function () {
-      this.model = new cdb.core.Model({
+      this.model = new Backbone.Model({
         fixed: 128
       });
       this.view = new InputNumber(({
@@ -56,7 +57,7 @@ describe('components/form-components/editors/fill/input-number', function () {
 
   describe('range', function () {
     beforeEach(function () {
-      this.model = new cdb.core.Model({
+      this.model = new Backbone.Model({
         range: [1, 30],
         attribute: 'the_geom',
         quantification: 'Quantile'

--- a/lib/assets/test/spec/cartodb3/components/modals/add-analysis/add-analysis-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-analysis/add-analysis-view.spec.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var createGeometry = require('../../../../../../javascripts/cartodb3/value-objects/geometry');
 var AnalysisDefinitionNodeSourceModel = require('../../../../../../javascripts/cartodb3/data/analysis-definition-node-source-model');
 var AddAnalysisView = require('../../../../../../javascripts/cartodb3/components/modals/add-analysis/add-analysis-view');
 
 describe('components/modals/add-analysis/add-analysis-view', function () {
   beforeEach(function () {
-    this.modalModel = new cdb.core.Model();
+    this.modalModel = new Backbone.Model();
     spyOn(this.modalModel, 'destroy');
 
     this.analysisDefinitionNodeModel = new AnalysisDefinitionNodeSourceModel({
@@ -13,7 +13,7 @@ describe('components/modals/add-analysis/add-analysis-view', function () {
       type: 'source',
       query: 'SELECT * from somewhere'
     }, {
-      configModel: new cdb.core.Model(),
+      configModel: new Backbone.Model(),
       collection: {}
     });
     this.querySchemaModel = this.analysisDefinitionNodeModel.querySchemaModel;

--- a/lib/assets/test/spec/cartodb3/components/modals/add-layer/add-layer-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-layer/add-layer-model.spec.js
@@ -13,7 +13,7 @@ describe('components/modals/add-layer/add-layer-model', function () {
       base_url: '/u/pepe'
     });
 
-    cdb.god = new cdb.core.Model();
+    cdb.god = new Backbone.Model();
 
     this.userModel = new UserModel({
       username: 'pepe'
@@ -78,7 +78,7 @@ describe('components/modals/add-layer/add-layer-model', function () {
 
   describe('.canSelect', function () {
     beforeEach(function () {
-      this.dataset = new cdb.core.Model({
+      this.dataset = new Backbone.Model({
         selected: false
       });
     });

--- a/lib/assets/test/spec/cartodb3/components/modals/add-layer/guessing-toggler-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-layer/guessing-toggler-view.spec.js
@@ -1,4 +1,3 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var GuessingTogglerView = require('../../../../../../javascripts/cartodb3/components/modals/add-layer/footer/guessing-toggler-view');
 var CreateModel = require('../../../../../../javascripts/cartodb3/components/modals/add-layer/add-layer-model');
@@ -29,7 +28,7 @@ describe('components/modals/add-layer/footer/guessing-toggler-view', function ()
       layerDefinitionsCollection: new Backbone.Collection()
     });
 
-    this.guessingModel = new cdb.core.Model({ guessing: true });
+    this.guessingModel = new Backbone.Model({ guessing: true });
     this.view = new GuessingTogglerView({
       userModel: this.userModel,
       guessingModel: this.guessingModel,

--- a/lib/assets/test/spec/cartodb3/components/modals/add-layer/privacy-toggler-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-layer/privacy-toggler-view.spec.js
@@ -1,4 +1,3 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var PrivacyTogglerView = require('../../../../../../javascripts/cartodb3/components/modals/add-layer/footer/privacy-toggler-view');
 var CreateModel = require('../../../../../../javascripts/cartodb3/components/modals/add-layer/add-layer-model');
@@ -28,7 +27,7 @@ describe('components/modals/add-layer/footer/privacy-toggler-view', function () 
       layerDefinitionsCollection: new Backbone.Collection()
     });
 
-    this.privacyModel = new cdb.core.Model({ privacy: 'PUBLIC' });
+    this.privacyModel = new Backbone.Model({ privacy: 'PUBLIC' });
     this.view = new PrivacyTogglerView({
       userModel: this.userModel,
       privacyModel: this.privacyModel,

--- a/lib/assets/test/spec/cartodb3/components/modals/add-layer/shared-for-create-listing-view-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-layer/shared-for-create-listing-view-model.spec.js
@@ -1,3 +1,5 @@
+var Backbone = require('backbone');
+
 /**
  * Common test cases for a create listing view model.
  * Expected to be called in the context of the top-describe closure of an option model, e.g.:
@@ -21,7 +23,7 @@ module.exports = function () {
 
   describe('.canSelect', function () {
     it('should return a boolean for if user can select an item (more)', function () {
-      var datasetModel = new cdb.core.Model();
+      var datasetModel = new Backbone.Model();
       expect(this.model.canSelect(datasetModel)).toEqual(jasmine.any(Boolean));
     });
   });

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/add-widgets-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/add-widgets-view.spec.js
@@ -1,4 +1,3 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var ConfigModel = require('../../../../../../javascripts/cartodb3/data/config-model');
 var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
@@ -55,7 +54,7 @@ describe('components/modals/add-widgets/add-widgets-view', function () {
     spyOn(this.querySchemaModel1, 'fetch');
     spyOn(this.querySchemaModel2, 'fetch');
 
-    this.modalModel = new cdb.core.Model();
+    this.modalModel = new Backbone.Model();
 
     this.view = new AddWidgetsView({
       modalModel: this.modalModel,

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/body-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/body-view.spec.js
@@ -1,19 +1,18 @@
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var BodyView = require('../../../../../../javascripts/cartodb3/components/modals/add-widgets/body-view');
 var widgetsTypes = require('../../../../../../javascripts/cartodb3/components/modals/add-widgets/widgets-types');
 
 describe('components/modals/add-widgets/body-view', function () {
   beforeEach(function () {
-    var layerDefinitionModel = new cdb.core.Model();
+    var layerDefinitionModel = new Backbone.Model();
     layerDefinitionModel.getName = function () { return 'layer'; };
 
-    var analysisDefinitionModel = new cdb.core.Model({
+    var analysisDefinitionModel = new Backbone.Model({
       id: 'a1'
     });
 
     var tuples = [{
-      columnModel: new cdb.core.Model(),
+      columnModel: new Backbone.Model(),
       analysisDefinitionModel: analysisDefinitionModel,
       layerDefinitionModel: layerDefinitionModel
     }];

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/layer-selector-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/layer-selector-view.spec.js
@@ -1,24 +1,24 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var LayerSelectorView = require('../../../../../../javascripts/cartodb3/components/modals/add-widgets/layer-selector-view');
 
 describe('components/modals/add-widgets/layer-selector-view', function () {
   beforeEach(function () {
-    this.columnModel1 = new cdb.core.Model({
+    this.columnModel1 = new Backbone.Model({
       name: 'col',
       type: 'string'
     });
-    this.analysisDefinitionModel1 = new cdb.core.Model({ id: 'a1' });
-    this.analysisDefinitionModel2 = new cdb.core.Model({ id: 'a2' });
-    this.layerDefinitionModel1 = new cdb.core.Model({});
+    this.analysisDefinitionModel1 = new Backbone.Model({ id: 'a1' });
+    this.analysisDefinitionModel2 = new Backbone.Model({ id: 'a2' });
+    this.layerDefinitionModel1 = new Backbone.Model({});
     this.layerDefinitionModel1.getName = function () { return 'layer1'; };
-    this.columnModel2 = new cdb.core.Model({
+    this.columnModel2 = new Backbone.Model({
       name: 'col',
       type: 'string'
     });
-    this.layerDefinitionModel2 = new cdb.core.Model({});
+    this.layerDefinitionModel2 = new Backbone.Model({});
     this.layerDefinitionModel2.getName = function () { return 'layer2'; };
 
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       layer_index: 0,
       tuples: [{
         columnModel: this.columnModel1,

--- a/lib/assets/test/spec/cartodb3/components/modals/modal-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/modal-view.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var ModalViewModel = require('../../../../../javascripts/cartodb3/components/modals/modal-view-model');
 var ModalView = require('../../../../../javascripts/cartodb3/components/modals/modal-view');
 
@@ -6,7 +6,7 @@ describe('components/modals/modal-view', function () {
   var contentView;
 
   beforeEach(function () {
-    contentView = new cdb.core.View();
+    contentView = new CoreView();
     spyOn(contentView, 'render').and.callThrough();
     this.model = new ModalViewModel({
       createContentView: function () { return contentView; }

--- a/lib/assets/test/spec/cartodb3/components/modals/modals-service-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/modals-service-model.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var ModalsServiceModel = require('../../../../../javascripts/cartodb3/components/modals/modals-service-model');
 
 describe('components/modals/modals-service-model', function () {
@@ -16,7 +16,7 @@ describe('components/modals/modals-service-model', function () {
     beforeEach(function () {
       spyOn(document.body, 'appendChild');
 
-      contentView = new cdb.core.View();
+      contentView = new CoreView();
       spyOn(contentView, 'render').and.callThrough();
 
       this.modalView = this.modals.create(function () {
@@ -50,7 +50,7 @@ describe('components/modals/modals-service-model', function () {
 
     describe('subsequent calls', function () {
       beforeEach(function () {
-        contentView2 = new cdb.core.View();
+        contentView2 = new CoreView();
         spyOn(contentView2, 'render').and.callThrough();
 
         this.modalView2 = this.modals.create(function () {

--- a/lib/assets/test/spec/cartodb3/components/stack-layout/stack-layout-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/stack-layout/stack-layout-model.spec.js
@@ -1,13 +1,12 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var StackLayoutModel = require('../../../../../javascripts/cartodb3/components/stack-layout/stack-layout-model');
 
 describe('stack-layout/model', function () {
   beforeEach(function () {
     this.collection = new Backbone.Collection([
-      new cdb.core.Model(),
-      new cdb.core.Model()
+      new Backbone.Model(),
+      new Backbone.Model()
     ]);
     this.model = new StackLayoutModel({}, {
       stackLayoutItems: this.collection

--- a/lib/assets/test/spec/cartodb3/components/stack-layout/stack-layout-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/stack-layout/stack-layout-view.spec.js
@@ -1,11 +1,11 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var StackLayoutView = require('../../../../../javascripts/cartodb3/components/stack-layout/stack-layout-view');
 var StackLayoutModel = require('../../../../../javascripts/cartodb3/components/stack-layout/stack-layout-model');
-var Backbone = require('backbone');
 
 describe('stack-layout/view', function () {
   beforeEach(function () {
-    var SubView1 = cdb.core.View.extend({
+    var SubView1 = CoreView.extend({
       events: {
         'click': '_onClickNext'
       },
@@ -14,7 +14,7 @@ describe('stack-layout/view', function () {
       }
     });
 
-    var SubView2 = cdb.core.View.extend({
+    var SubView2 = CoreView.extend({
       events: {
         'click': '_onClickPrev'
       },
@@ -23,7 +23,7 @@ describe('stack-layout/view', function () {
       }
     });
 
-    var model1 = new cdb.core.Model({
+    var model1 = new Backbone.Model({
       createStackView: function (stackLayoutModel) {
         return new SubView1({
           stackLayoutModel: stackLayoutModel
@@ -31,7 +31,7 @@ describe('stack-layout/view', function () {
       }
     });
 
-    var model2 = new cdb.core.Model({
+    var model2 = new Backbone.Model({
       createStackView: function (stackLayoutModel, whatever) {
         return new SubView2({
           stackLayoutModel: stackLayoutModel

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/create-editor-menu-tab-pane.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/create-editor-menu-tab-pane.spec.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var createEditorMenuTabPane = require('../../../../../javascripts/cartodb3/components/tab-pane/create-editor-menu-tab-pane');
 
 describe('components/tab-pane/create-editor-menu-tab-pane', function () {
@@ -9,13 +9,13 @@ describe('components/tab-pane/create-editor-menu-tab-pane', function () {
         selected: false,
         icon: 'myFirstIcon',
         createContentView: function () {
-          return new cdb.core.View();
+          return new CoreView();
         }
       }, {
         selected: false,
         icon: 'mySecondIcon',
         createContentView: function () {
-          return new cdb.core.View();
+          return new CoreView();
         }
       }
     ];
@@ -23,7 +23,7 @@ describe('components/tab-pane/create-editor-menu-tab-pane', function () {
 
   it('should create view', function () {
     var view = createEditorMenuTabPane(this.items);
-    expect(view).toEqual(jasmine.any(cdb.core.View));
+    expect(view).toEqual(jasmine.any(CoreView));
     expect(view.collection.size()).toEqual(2);
 
     view.render();

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/create-text-labels-tab-pane.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/create-text-labels-tab-pane.spec.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var createTextLabelsTabPane = require('../../../../../javascripts/cartodb3/components/tab-pane/create-text-labels-tab-pane');
 
 describe('components/tab-pane/create-text-labels-tab-pane', function () {
@@ -8,20 +8,20 @@ describe('components/tab-pane/create-text-labels-tab-pane', function () {
       selected: false,
       label: 'label one',
       createContentView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       }
     }, {
       selected: false,
       label: 'label two',
       createContentView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       }
     }];
   });
 
   it('should create view', function () {
     var view = createTextLabelsTabPane(this.items);
-    expect(view).toEqual(jasmine.any(cdb.core.View));
+    expect(view).toEqual(jasmine.any(CoreView));
     expect(view.collection.size()).toEqual(2);
 
     view.render();

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-collection.spec.js
@@ -1,11 +1,11 @@
 var TabPaneCollection = require('../../../../../javascripts/cartodb3/components/tab-pane/tab-pane-collection');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var _ = require('underscore');
 
 describe('components/tab-pane-collection', function () {
   beforeEach(function () {
     this.collection = new TabPaneCollection();
-    this.collection.reset([new cdb.core.Model(), new cdb.core.Model()]);
+    this.collection.reset([new Backbone.Model(), new Backbone.Model()]);
   });
 
   it('should select one item by default', function () {
@@ -18,7 +18,7 @@ describe('components/tab-pane-collection', function () {
   it('should trigger reset event', function () {
     spyOn(TabPaneCollection.prototype, 'trigger').and.callThrough();
 
-    this.collection = new TabPaneCollection([new cdb.core.Model(), new cdb.core.Model()]);
+    this.collection = new TabPaneCollection([new Backbone.Model(), new Backbone.Model()]);
     var calls = TabPaneCollection.prototype.trigger.calls;
     var resetWasCalled = _.find(calls.allArgs(), function (e) { return e[0] === 'reset'; });
 

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-item-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-item-view.spec.js
@@ -1,11 +1,12 @@
 var TabPaneItemView = require('../../../../../javascripts/cartodb3/components/tab-pane/tab-pane-item-view');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 
 describe('components/tab-pane-item-view', function () {
   beforeEach(function () {
-    this.model = new cdb.core.Model({
+    this.model = new Backbone.Model({
       createButtonView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       }
     });
 
@@ -27,10 +28,10 @@ describe('components/tab-pane-item-view', function () {
 
   it('should add the selected class on the start', function () {
     var view = new TabPaneItemView({
-      model: new cdb.core.Model({
+      model: new Backbone.Model({
         selected: true,
         createButtonView: function () {
-          return new cdb.core.View();
+          return new CoreView();
         }
       })
     }).render();

--- a/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/tab-pane/tab-pane-view.spec.js
@@ -1,27 +1,28 @@
 var TabPaneView = require('../../../../../javascripts/cartodb3/components/tab-pane/tab-pane-view');
 var TabPaneCollection = require('../../../../../javascripts/cartodb3/components/tab-pane/tab-pane-collection');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 
 describe('components/tab-pane-view', function () {
   beforeEach(function () {
     this.collection = new TabPaneCollection();
 
-    var model = new cdb.core.Model({
+    var model = new Backbone.Model({
       createContentView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       },
       createButtonView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       }
     });
 
-    var model2 = new cdb.core.Model({
+    var model2 = new Backbone.Model({
       createContentView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       },
       createButtonView: function () {
-        return new cdb.core.View();
+        return new CoreView();
       }
     });
 

--- a/lib/assets/test/spec/cartodb3/components/view-factory.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/view-factory.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var ViewFactory = require('../../../../javascripts/cartodb3/components/view-factory');
 
 describe('components/view-factory', function () {
@@ -51,7 +51,7 @@ describe('components/view-factory', function () {
     describe('when given proper input', function () {
       beforeEach(function () {
         var createItemView = function (id) {
-          var view = new cdb.core.View({tagName: 'li'});
+          var view = new CoreView({tagName: 'li'});
           view.render = function () {
             this.$el.html('<div id="' + id + '"></div>');
             return this;

--- a/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/background-importer/geocoding-collection.spec.js
@@ -1,3 +1,4 @@
+var cdb = require('cartodb.js');
 var Backbone = require('backbone');
 var ConfigModel = require('../../../../../javascripts/cartodb3/data/config-model');
 var GeocodingsCollection = require('../../../../../javascripts/cartodb3/data/background-importer/background-importer-geocodings-collection.js');

--- a/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/layer-definition-model.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var ConfigModel = require('../../../../javascripts/cartodb3/data/config-model');
 var LayerDefinitionsCollection = require('../../../../javascripts/cartodb3/data/layer-definitions-collection');
 var LayerDefinitionModel = require('../../../../javascripts/cartodb3/data/layer-definition-model');
@@ -11,8 +11,8 @@ describe('data/layer-definition-model', function () {
 
     this.collection = new LayerDefinitionsCollection(null, {
       configModel: this.configModel,
-      analysisDefinitionsCollection: new cdb.Backbone.Collection(),
-      analysisDefinitionNodesCollection: new cdb.Backbone.Collection(),
+      analysisDefinitionsCollection: new Backbone.Collection(),
+      analysisDefinitionNodesCollection: new Backbone.Collection(),
       mapId: 'm123',
       basemaps: {}
     });
@@ -94,7 +94,7 @@ describe('data/layer-definition-model', function () {
 
   describe('.isOwnerOfAnalysisNode', function () {
     beforeEach(function () {
-      this.nodeModel = new cdb.core.Model({
+      this.nodeModel = new Backbone.Model({
         id: 'b3'
       });
     });
@@ -288,7 +288,7 @@ describe('data/layer-definition-model', function () {
         type: 'buffer'
       };
 
-      this.nodeDefModel = new cdb.core.Model(this.nodeAttrs);
+      this.nodeDefModel = new Backbone.Model(this.nodeAttrs);
       spyOn(this.collection, 'createNewAnalysisNode').and.returnValue(this.nodeDefModel);
       spyOn(this.model, 'save').and.callThrough();
 

--- a/lib/assets/test/spec/cartodb3/data/query-schema-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/query-schema-model.spec.js
@@ -1,12 +1,12 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var ConfigModel = require('../../../../javascripts/cartodb3/data/config-model');
 var QuerySchemaModel = require('../../../../javascripts/cartodb3/data/query-schema-model');
 
 describe('data/query-schema-model', function () {
   beforeEach(function () {
     this.xhrSpy = jasmine.createSpyObj('xhr', ['abort', 'always', 'fail']);
-    spyOn(cdb.core.Model.prototype, 'sync').and.returnValue(this.xhrSpy);
-    spyOn(cdb.core.Model.prototype, 'fetch').and.callThrough();
+    spyOn(Backbone.Model.prototype, 'sync').and.returnValue(this.xhrSpy);
+    spyOn(Backbone.Model.prototype, 'fetch').and.callThrough();
 
     var configModel = new ConfigModel({
       base_url: '/u/pepe',
@@ -27,7 +27,7 @@ describe('data/query-schema-model', function () {
 
     it('should not allow to fetch', function () {
       expect(this.model.fetch());
-      expect(cdb.core.Model.prototype.fetch).not.toHaveBeenCalled();
+      expect(Backbone.Model.prototype.fetch).not.toHaveBeenCalled();
     });
   });
 
@@ -57,18 +57,18 @@ describe('data/query-schema-model', function () {
       });
 
       it('should fetch with a wrapped query', function () {
-        expect(cdb.core.Model.prototype.fetch).toHaveBeenCalled();
-        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.q).toMatch(/select \* from \(.+\) /);
+        expect(Backbone.Model.prototype.fetch).toHaveBeenCalled();
+        expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.q).toMatch(/select \* from \(.+\) /);
       });
 
       it('should add order, rows and page', function () {
-        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.rows_per_page).toBe(40);
-        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.page).toBe(0);
-        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.sort_order).toBe('asc');
+        expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.rows_per_page).toBe(40);
+        expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.page).toBe(0);
+        expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.sort_order).toBe('asc');
       });
 
       it('should fetch using an API key', function () {
-        expect(cdb.core.Model.prototype.fetch.calls.argsFor(0)[0].data.api_key).toEqual('xyz123');
+        expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.api_key).toEqual('xyz123');
       });
 
       it('should change status', function () {
@@ -85,13 +85,13 @@ describe('data/query-schema-model', function () {
         });
 
         it('should fetch again', function () {
-          expect(cdb.core.Model.prototype.fetch.calls.count()).toEqual(2);
+          expect(Backbone.Model.prototype.fetch.calls.count()).toEqual(2);
         });
       });
 
       describe('when request succeeds', function () {
         beforeEach(function () {
-          cdb.core.Model.prototype.sync.calls.argsFor(0)[2].success({
+          Backbone.Model.prototype.sync.calls.argsFor(0)[2].success({
             fields: {
               cartodb_id: 'number',
               title: 'string',
@@ -120,7 +120,7 @@ describe('data/query-schema-model', function () {
 
       describe('when request fails', function () {
         beforeEach(function () {
-          cdb.core.Model.prototype.sync.calls.argsFor(0)[2].error({
+          Backbone.Model.prototype.sync.calls.argsFor(0)[2].error({
             error: 'meh'
           });
         });

--- a/lib/assets/test/spec/cartodb3/editor/components/view-options/panel-with-options-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/components/view-options/panel-with-options-view.spec.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var PanelWithOptions = require('../../../../../../javascripts/cartodb3/editor/components/view-options/panel-with-options-view.js');
 var EditorModel = require('../../../../../../javascripts/cartodb3/data/editor-model');
 
 describe('editor/components/view-options/panel-with-options-view', function () {
   beforeEach(function () {
-    var Dummy = cdb.core.View.extend({
+    var Dummy = CoreView.extend({
       render: function () {
         this.$el.html(this.options.content);
         return this;

--- a/lib/assets/test/spec/cartodb3/editor/editor-map-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/editor-map-view.spec.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var $ = require('jquery');
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var UserModel = require('../../../../javascripts/cartodb3/data/user-model');
 var LayerDefinitionModel = require('../../../../javascripts/cartodb3/data/layer-definition-model');
 var AddAnalysisView = require('../../../../javascripts/cartodb3/components/modals/add-analysis/add-analysis-view');
@@ -34,7 +34,7 @@ describe('editor/editor-map-view', function () {
     this.modals = new ModalsService();
 
     this.view = new EditorMapView({
-      visDefinitionModel: new cdb.core.Model({
+      visDefinitionModel: new Backbone.Model({
         name: 'My super fun vis'
       }),
       modals: this.modals,
@@ -73,7 +73,7 @@ describe('editor/editor-map-view', function () {
   describe('._onAddAnalysisClicked', function () {
     beforeEach(function () {
       jasmine.clock().install();
-      this.mockView = new cdb.core.View();
+      this.mockView = new CoreView();
       spyOn(AddAnalysisView.prototype, 'initialize');
       spyOn(AddAnalysisView.prototype, 'render').and.returnValue(this.mockView);
       spyOn(this.layerDefinitionModel, 'getAnalysisDefinitionNodeModel').and.returnValue(this.model);

--- a/lib/assets/test/spec/cartodb3/editor/editor-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/editor-view.spec.js
@@ -1,4 +1,3 @@
-var cdb = require('cartodb.js');
 var _ = require('underscore');
 var Backbone = require('backbone');
 var LayerDefinitionModel = require('../../../../javascripts/cartodb3/data/layer-definition-model');
@@ -21,7 +20,7 @@ describe('editor/editor-view', function () {
     this.widgetDefinitionsCollection = new Backbone.Collection();
 
     this.view = new EditorView({
-      visDefinitionModel: new cdb.core.Model({
+      visDefinitionModel: new Backbone.Model({
         name: 'My super fun vis'
       }),
       modals: {},

--- a/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/composite-layers-analysis-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/composite-layers-analysis-view.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var CompositeLayerAnalysisView = require('../../../../../../javascripts/cartodb3/editor/layers/analysis-views/composite-layer-analysis-view');
 var LayerDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/layer-definitions-collection');
 var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
@@ -62,7 +62,7 @@ describe('editor/layers/analysis-views/composite-layer-analysis-view', function 
     this.layerDefinitionModel = this.layerDefinitionsCollection.at(0);
     this.layerDefinitionModel.set({ source: model.id });
 
-    this.analysisNode = new cdb.core.Model({
+    this.analysisNode = new Backbone.Model({
       status: 'ready'
     });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/default-layers-analysis-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/default-layers-analysis-view.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var AnalysisDefinitionNodeModel = require('../../../../../../javascripts/cartodb3/data/analysis-definition-node-model');
 var DefaultLayerAnalysisView = require('../../../../../../javascripts/cartodb3/editor/layers/analysis-views/default-layer-analysis-view');
 
@@ -15,12 +15,12 @@ describe('editor/layers/analysis-views/default-layer-analysis-view', function ()
       sqlAPI: {}
     });
 
-    this.analysisNode = new cdb.core.Model();
+    this.analysisNode = new Backbone.Model();
 
     this.view = new DefaultLayerAnalysisView({
       model: this.model,
       analysisNode: this.analysisNode,
-      layerDefinitionModel: new cdb.core.Model()
+      layerDefinitionModel: new Backbone.Model()
     });
 
     this.view.render();
@@ -55,7 +55,7 @@ describe('editor/layers/analysis-views/default-layer-analysis-view', function ()
       var view = new DefaultLayerAnalysisView({
         model: this.model,
         analysisNode: this.analysisNode,
-        layerDefinitionModel: new cdb.core.Model()
+        layerDefinitionModel: new Backbone.Model()
       });
       view.render();
       expect(view.draggableHelperView).toBeDefined();
@@ -64,7 +64,7 @@ describe('editor/layers/analysis-views/default-layer-analysis-view', function ()
       var view = new DefaultLayerAnalysisView({
         model: this.model,
         analysisNode: this.analysisNode,
-        layerDefinitionModel: new cdb.core.Model(),
+        layerDefinitionModel: new Backbone.Model(),
         isDraggable: false
       });
       view.render();

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-draggable-helper-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-draggable-helper-view.spec.js
@@ -1,9 +1,9 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var LayerAnalysisDraggableHelperView = require('../../../../../javascripts/cartodb3/editor/layers/layer-analysis-draggable-helper-view');
 
 describe('editor/layers/layer-analysis-draggable-helper-view', function () {
   beforeEach(function () {
-    var v = new cdb.core.View();
+    var v = new CoreView();
 
     this.view = new LayerAnalysisDraggableHelperView({
       el: v.el

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-views.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-analysis-views.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var AnalysisDefinitionNodesCollection = require('../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var LayerDefinitionsCollection = require('../../../../../javascripts/cartodb3/data/layer-definitions-collection');
 var LayerAnalysesView = require('../../../../../javascripts/cartodb3/editor/layers/layer-analyses-view');
@@ -17,7 +17,7 @@ describe('editor/layers/layer-analyses-view', function () {
       basemaps: {}
     });
 
-    var analysisNode = new cdb.core.Model({
+    var analysisNode = new Backbone.Model({
       status: 'ready'
     });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var camshaftReference = require('../../../../../../../../javascripts/cartodb3/data/camshaft-reference');
 var LayerDefinitionModel = require('../../../../../../../../javascripts/cartodb3/data/layer-definition-model');
 var BaseAnalysisFormModel = require('../../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model');
@@ -48,7 +48,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/base-a
 
   describe('.save', function () {
     beforeEach(function () {
-      this.nodeDefModel = new cdb.core.Model({id: 'a1'});
+      this.nodeDefModel = new Backbone.Model({id: 'a1'});
       spyOn(this.nodeDefModel, 'set');
       spyOn(this.nodeDefModel, 'save');
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-workflow-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-workflow-view.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var LayerDefinitionModel = require('../../../../../../../javascripts/cartodb3/data/layer-definition-model');
 var AnalysisFormsCollection = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-forms-collection');
 var AnalysesWorkflowView = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view');
@@ -15,18 +15,18 @@ describe('editor/layers/layer-content-view/analyses/analyses-workflow-view', fun
       }
     }, {
       parse: true,
-      collection: new cdb.Backbone.Collection(),
+      collection: new Backbone.Collection(),
       configModel: {}
     });
     spyOn(this.layerDefModel, 'getAnalysisDefinitionNodeModel');
 
-    this.viewModel = new cdb.core.Model({
+    this.viewModel = new Backbone.Model({
       selectedNodeId: 'a2'
     });
 
     var analysis = jasmine.createSpyObj('vis.analysis', ['findNodeById']);
     analysis.findNodeById.and.callFake(function (id) {
-      return new cdb.core.Model({
+      return new Backbone.Model({
         id: id,
         status: 'ready'
       });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/layer-content-analyses-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/layer-content-analyses-view.spec.js
@@ -1,5 +1,4 @@
 var Backbone = require('backbone');
-var cdb = require('cartodb.js');
 var AnalysisDefinitionNodeModel = require('../../../../../../javascripts/cartodb3/data/analysis-definition-node-model');
 var LayerDefinitionModel = require('../../../../../../javascripts/cartodb3/data/layer-definition-model');
 var BaseAnalysisFormModel = require('../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model');
@@ -43,9 +42,9 @@ describe('editor/layers/layer-content-view/layer-content-analyses-view', functio
     }.bind(this));
 
     this.analysis = jasmine.createSpyObj('vis.analysis', ['findNodeById']);
-    this.analysis.findNodeById.and.returnValue(new cdb.core.Model());
+    this.analysis.findNodeById.and.returnValue(new Backbone.Model());
 
-    this.analysisSourceOptionsModel = new cdb.core.Model();
+    this.analysisSourceOptionsModel = new Backbone.Model();
     spyOn(this.analysisSourceOptionsModel, 'fetch');
     this.analysisFormsCollection = new AnalysisFormsCollection(null, {
       layerDefinitionModel: this.layerDefinitionModel,
@@ -82,7 +81,7 @@ describe('editor/layers/layer-content-view/layer-content-analyses-view', functio
         source: 'a0'
       }, {
         configModel: this.configModel,
-        collection: new cdb.Backbone.Collection()
+        collection: new Backbone.Collection()
       });
       this.layerDefinitionModel.getAnalysisDefinitionNodeModel.and.returnValue(this.a1);
       spyOn(this.a1, 'getPrimarySource').and.returnValue(this.a0);

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-view.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var StackLayoutModel = require('../../../../../javascripts/cartodb3/components/stack-layout/stack-layout-model');
 var LayerDefinitionModel = require('../../../../../javascripts/cartodb3/data/layer-definition-model');
 var LayerView = require('../../../../../javascripts/cartodb3/editor/layers/layer-view');
@@ -14,7 +14,7 @@ describe('editor/layers/layer-view', function () {
       configModel: {}
     });
     this.newAnalysesViewSpy = jasmine.createSpy('newAnalysesView').and.callFake(function (el) {
-      var view = new cdb.core.View({
+      var view = new CoreView({
         el: el
       });
       view.render = function () {

--- a/lib/assets/test/spec/cartodb3/editor/style/style-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-content-view.spec.js
@@ -6,7 +6,7 @@ var QuerySchemaModel = require('../../../../../javascripts/cartodb3/data/query-s
 
 describe('editor/style/style-content-view', function () {
   beforeEach(function () {
-    this.overlayModel = new cdb.core.Model();
+    this.overlayModel = new Backbone.Model();
     this.model = new StyleDefinitionModel();
     this.querySchemaModel = new QuerySchemaModel({
       query: 'SELECT * FROM table',

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model.spec.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var WidgetsFormColumnOptionsFactory = require('../../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-column-options-factory');
 var WidgetsFormCategoryDataSchemaModel = require('../../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/data/widgets-form-category-data-schema-model');
 
 describe('editor/widgets/widgets-form/data/widgets-form-category-data-schema-model', function () {
   beforeEach(function () {
-    var querySchemaModel = new cdb.core.Model();
+    var querySchemaModel = new Backbone.Model();
     this.widgetsFormColumnOptionsFactory = new WidgetsFormColumnOptionsFactory(querySchemaModel);
     spyOn(this.widgetsFormColumnOptionsFactory, 'create').and.returnValue([{
       val: 'col',

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/widget-form-style-schema-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/widget-form-style-schema-model.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var WidgetsFormStyleSchemaModel = require('../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/style/widgets-form-style-schema-model');
 
 describe('editor/widgets/widgets-form/widgets-form-style-schema-model', function () {
@@ -20,7 +20,7 @@ describe('editor/widgets/widgets-form/widgets-form-style-schema-model', function
 
   describe('.updateWidgetDefinitionModel', function () {
     beforeEach(function () {
-      this.widgetDefinitionModel = new cdb.core.Model();
+      this.widgetDefinitionModel = new Backbone.Model();
       spyOn(this.widgetDefinitionModel, 'save');
     });
 

--- a/lib/assets/test/spec/cartodb3/helpers/utils.spec.js
+++ b/lib/assets/test/spec/cartodb3/helpers/utils.spec.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var Utils = require('../../../../javascripts/cartodb3/helpers/utils');
 
 describe('helpers/utils', function () {
@@ -36,7 +36,7 @@ describe('helpers/utils', function () {
 
   describe('.result', function () {
     beforeEach(function () {
-      this.model = new cdb.core.Model({
+      this.model = new Backbone.Model({
         something: 'yay'
       });
       this.model.myProp = 123;

--- a/lib/assets/test/spec/node_modules/backbone/core-view.spec.js
+++ b/lib/assets/test/spec/node_modules/backbone/core-view.spec.js
@@ -1,0 +1,163 @@
+var $ = require('jquery');
+var _ = require('underscore');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
+
+describe('backbone/core-view', function () {
+  var TestView;
+  var view;
+
+  beforeEach(function () {
+    TestView = CoreView.extend({
+      initialize: function () {
+        this.init_called = true;
+      },
+      test_method: function () {}
+    });
+
+    CoreView.viewCount = 0;
+    view = new TestView({el: $('<div>')});
+  });
+
+  it('should call initialize', function () {
+    expect(view.init_called).toEqual(true);
+  });
+
+  it('should increment refCount', function () {
+    expect(CoreView.viewCount).toEqual(1);
+    expect(CoreView.views[view.cid]).toBeTruthy();
+  });
+
+  it('should decrement refCount', function () {
+    view.clean();
+    expect(CoreView.viewCount).toEqual(0);
+    expect(CoreView.views[view.cid]).toBeFalsy();
+  });
+
+  it('clean should remove view from dom', function () {
+    var dom = $('<div>');
+    dom.append(view.el);
+    expect(dom.children().length).toEqual(1);
+    view.clean();
+    expect(dom.children().length).toEqual(0);
+  });
+
+  it('clean should unbind all events', function () {
+    view.bind('meh', function () {});
+    expect(_.size(view._events)).toEqual(1);
+    view.clean();
+    expect(view._events).toEqual(undefined);
+  });
+
+  it('should unlink the view model', function () {
+    var called = false;
+    var new_view = new TestView({ el: $('<div>'), model: new Backbone.Model() });
+
+    spyOn(new_view, 'test_method');
+    new_view.model.bind('change', new_view.test_method, new_view);
+    new_view.model.bind('change', function () { called = true; });
+
+    new_view.model.trigger('change');
+    expect(called).toEqual(true);
+    expect(new_view.test_method).toHaveBeenCalled();
+    expect(new_view.test_method.calls.count()).toEqual(1);
+    called = false;
+    new_view.clean();
+    // trigger again
+    new_view.model.trigger('change');
+    expect(called).toEqual(true);
+    expect(new_view.test_method.calls.count()).toEqual(1);
+  });
+
+  it('should unlink linked models', function () {
+    var called = false;
+    var model = new Backbone.Model();
+    spyOn(view, 'test_method');
+    model.bind('change', view.test_method, view);
+    model.bind('change', function () { called = true; });
+    view.add_related_model(model);
+
+    model.trigger('change');
+    expect(called).toEqual(true);
+    expect(view.test_method).toHaveBeenCalled();
+    expect(view.test_method.calls.count()).toEqual(1);
+    called = false;
+    view.clean();
+    expect(_.size(view._models)).toEqual(0);
+    // trigger again
+    model.trigger('change');
+    expect(called).toEqual(true);
+    expect(view.test_method.calls.count()).toEqual(1);
+  });
+
+  it('should add and remove subview', function () {
+    var v1 = new CoreView();
+    view.addView(v1);
+    expect(view._subviews[v1.cid]).toEqual(v1);
+    expect(v1._parent).toEqual(view);
+    view.removeView(v1);
+    expect(view._subviews[v1.cid]).toEqual(undefined);
+  });
+
+  it('should remove and clean subviews', function () {
+    var v1 = new CoreView();
+    spyOn(v1, 'clean');
+    view.addView(v1);
+    expect(view._subviews[v1.cid]).toEqual(v1);
+    view.clean();
+    expect(view._subviews[v1.cid]).toEqual(undefined);
+    expect(v1.clean).toHaveBeenCalled();
+  });
+
+  it('subview shuould be removed from its parent', function () {
+    var v1 = new CoreView();
+    view.addView(v1);
+    expect(view._subviews[v1.cid]).toEqual(v1);
+    v1.clean();
+    expect(view._subviews[v1.cid]).toEqual(undefined);
+  });
+
+  it('extendEvents should extend events', function () {
+    var V1 = CoreView.extend({
+      events: CoreView.extendEvents({
+        'click': 'hide'
+      })
+    });
+    var v1 = new V1();
+    expect(v1.el.style.display).not.toEqual('none');
+    v1.$el.trigger('click');
+    expect(v1.el.style.display).toEqual('none');
+  });
+
+  it('should retrigger an event when launched on a descendant object', function (done) {
+    var launched = false;
+    view.child = new TestView({});
+    view.retrigger('cachopo', view.child);
+    view.bind('cachopo', function () {
+      launched = true;
+    });
+    view.child.trigger('cachopo');
+    setTimeout(function () {
+      expect(launched).toBeTruthy();
+      done();
+    }, 25);
+  });
+
+  it('should kill an event', function () {
+    var ev = {
+      stopPropagation: function () {},
+      preventDefault: function () {}
+    };
+    var ev2 = 'thisisnotanevent';
+
+    spyOn(ev, 'stopPropagation');
+    spyOn(ev, 'preventDefault');
+
+    view.killEvent(ev);
+    view.killEvent(ev2);
+    view.killEvent();
+
+    expect(ev.stopPropagation).toHaveBeenCalled();
+    expect(ev.preventDefault).toHaveBeenCalled();
+  });
+});

--- a/lib/build/files/browserify_files.js
+++ b/lib/build/files/browserify_files.js
@@ -167,7 +167,8 @@ module.exports = {
       'lib/build/source-map-support.js',
 
       // Add specs for browserify module code here:
-      'lib/assets/test/spec/cartodb3/**/*.spec.js'
+      'lib/assets/test/spec/cartodb3/**/*.spec.js',
+      'lib/assets/test/spec/node_modules/**/*.spec.js'
     ],
     dest: '.grunt/cartodb3-specs.js'
   }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "globals": [
       "alert",
       "cartodb",
-      "cdb",
       "_t",
       "jasmine",
       "describe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.25.7",
+  "version": "3.25.8",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
While working on #7691 I discovered some things I wanted to highlight:

1. [`cdb.core.Model`](https://github.com/CartoDB/cartodb.js/blob/2a84dd87ed202ae188fd58865d9b8e96a4791d35/src/core/model.js) contains code that's not actually used anywhere for the new code, so might as well just use `Backbone.Model`.
2. [`cdb.core.View`](https://github.com/CartoDB/cartodb.js/blob/2a84dd87ed202ae188fd58865d9b8e96a4791d35/src/core/view.js) do contain logic that's also used here (but not all)

Previously (in current/old editor) models and views were created in the context of the editor and passed to cartodb.js, since that's no the case anymore there's no reason to depend on those objects anymore.

So, I ported cdb.core.View here. The main benefit of 1 and 2 is that we can make a "clean cut" with cartodb.js, not having to require on common models/views anymore. Less complexity, and will enable both cartodb.js and the editor to change and improve w/o having to worry about one another.

Also, since we now have the `lib/assets/node_modules` dir, through how require calls are looked up we could finally fix those nasty `require('../../../../` calls, that's why `var CoreView = require('browserify/core-view')` works in all contexts. See [browserify-handbook#how-node_modules-works](https://github.com/substack/browserify-handbook#how-node_modules-works) for more details.

@xavijam @javier @alonsogarciapablo @javisantana I'd like to hear your opinions on this.

It's deployed on _ded03_ if you want to have a look, things works just like before.