### PR TITLE
Fix some tests in parallel by removing hidden Rails dependency

### DIFF
--- a/services/importer/spec/unit/excel2csv_spec.rb
+++ b/services/importer/spec/unit/excel2csv_spec.rb
@@ -11,6 +11,10 @@ require_relative '../doubles/csv_normalizer'
 include Mocha::ParameterMatchers
 
 describe CartoDB::Importer2::Excel2Csv do
+  before(:each) do
+    CartoDB.stubs(:python_path).returns('')
+    CartoDB.stubs(:python_bin_path).returns(`which python`.strip)
+  end
 
   describe '#excel2csv' do
     before(:each) do

--- a/services/importer/spec/unit/shp_normalizer_spec.rb
+++ b/services/importer/spec/unit/shp_normalizer_spec.rb
@@ -10,6 +10,9 @@ include CartoDB::Importer2::Doubles
 describe CartoDB::Importer2::ShpNormalizer do
 
   describe '#shape_encoding' do
+    before(:each) do
+      CartoDB.stubs(:python_bin_path).returns(`which python`.strip)
+    end
 
     it 'guesses UTF-8 encoding for USA counties common data unzipped with cpg file' do
       job = CartoDB::Importer2::Doubles::Job.new
@@ -19,7 +22,7 @@ describe CartoDB::Importer2::ShpNormalizer do
 
       shp_normalizer.shape_encoding.should eq 'UTF-8'
     end
-  
+
     it 'guesses LATIN1 encoding for a "greek", unsupported encoding' do
       job = CartoDB::Importer2::Doubles::Job.new
       job.stubs(:table_name).returns('greek')


### PR DESCRIPTION
These two tests did fail in the parallel execution and required a second try. This is because they depend on function on a Rails initializer, while Rails is not loaded for unit tests. Solved by stubbing.