### PR TITLE
tooltip: fix empty template

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
@@ -144,12 +144,15 @@ module.exports = Backbone.Model.extend({
   },
 
   setTemplate: function (templateName) {
-    var template = (typeof (this.TEMPLATES[templateName]) === 'undefined') ? '' : this.TEMPLATES[templateName];
+    var template = this.TEMPLATES[templateName];
 
     var attrs = {
-      'template_name': templateName,
-      'template': template
+      'template_name': templateName
     };
+
+    if (template) {
+      attrs.template = template;
+    }
 
     if (templateName === '') {
       attrs.fields = [];

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
@@ -34,64 +34,64 @@ module.exports = CoreView.extend({
 
     var self = this;
 
-    // // CodeMirror placeholder
-    // var CodeMirrorModel = new Backbone.Model({
-    //   content: 'Hola mundo'
-    // });
+    // CodeMirror placeholder
+    var CodeMirrorModel = new Backbone.Model({
+      content: 'Hola mundo'
+    });
 
-    // var Dummy = CoreView.extend({
-    //   render: function () {
-    //     this.$el.html(this.options.content);
-    //     return this;
-    //   }
-    // });
+    var Dummy = CoreView.extend({
+      render: function () {
+        this.$el.html(this.options.content);
+        return this;
+      }
+    });
 
-    // var tabPaneTabs = [{
-    //   selected: true,
-    //   createContentView: function () {
-    //     return new ScrollView({
-    //       createContentView: function () {
-    //         return new InfowindowContentView(_.extend(self.options, { templates: self._templates }));
-    //       }
-    //     });
-    //   }
-    // }, {
-    //   selected: false,
-    //   createContentView: function () {
-    //     return new ScrollView({
-    //       createContentView: function () {
-    //         return new CodeMirrorView({
-    //           model: CodeMirrorModel
-    //         });
-    //       }
-    //     });
-    //   }
-    // }];
+    var tabPaneTabs = [{
+      selected: true,
+      createContentView: function () {
+        return new ScrollView({
+          createContentView: function () {
+            return new InfowindowContentView(_.extend(self.options, { templates: self._templates }));
+          }
+        });
+      }
+    }, {
+      selected: false,
+      createContentView: function () {
+        return new ScrollView({
+          createContentView: function () {
+            return new CodeMirrorView({
+              model: CodeMirrorModel
+            });
+          }
+        });
+      }
+    }];
 
-    // var collectionPane = new TabPaneCollection(tabPaneTabs);
+    var collectionPane = new TabPaneCollection(tabPaneTabs);
 
-    // var panelWithOptionsView = new PanelWithOptionsView({
-    //   className: 'Editor-content',
-    //   editorModel: self._editorModel,
-    //   createContentView: function () {
-    //     return new TabPaneView({
-    //       collection: collectionPane
-    //     });
-    //   },
-    //   createControlView: function () {
-    //     return new Toggler({
-    //       editorModel: self._editorModel,
-    //       collection: collectionPane,
-    //       labels: ['VALUES', 'HTML']
-    //     });
-    //   },
-    //   createActionView: function () {
-    //     return new Dummy({
-    //       content: ''
-    //     });
-    //   }
-    // });
-    var panelWithOptionsView = new InfowindowContentView(_.extend(self.options, { templates: self._templates }));
+    var panelWithOptionsView = new PanelWithOptionsView({
+      className: 'Editor-content',
+      editorModel: self._editorModel,
+      createContentView: function () {
+        return new TabPaneView({
+          collection: collectionPane
+        });
+      },
+      createControlView: function () {
+        return new Toggler({
+          editorModel: self._editorModel,
+          collection: collectionPane,
+          labels: ['VALUES', 'HTML']
+        });
+      },
+      createActionView: function () {
+        return new Dummy({
+          content: ''
+        });
+      }
+    });
+
     this.$el.append(panelWithOptionsView.render().el);
     this.addView(panelWithOptionsView);
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
@@ -34,64 +34,64 @@ module.exports = CoreView.extend({
 
     var self = this;
 
-    // CodeMirror placeholder
-    var CodeMirrorModel = new Backbone.Model({
-      content: 'Hola mundo'
-    });
+    // // CodeMirror placeholder
+    // var CodeMirrorModel = new Backbone.Model({
+    //   content: 'Hola mundo'
+    // });
 
-    var Dummy = CoreView.extend({
-      render: function () {
-        this.$el.html(this.options.content);
-        return this;
-      }
-    });
+    // var Dummy = CoreView.extend({
+    //   render: function () {
+    //     this.$el.html(this.options.content);
+    //     return this;
+    //   }
+    // });
 
-    var tabPaneTabs = [{
-      selected: true,
-      createContentView: function () {
-        return new ScrollView({
-          createContentView: function () {
-            return new InfowindowContentView(_.extend(self.options, { templates: self._templates }));
-          }
-        });
-      }
-    }, {
-      selected: false,
-      createContentView: function () {
-        return new ScrollView({
-          createContentView: function () {
-            return new CodeMirrorView({
-              model: CodeMirrorModel
-            });
-          }
-        });
-      }
-    }];
+    // var tabPaneTabs = [{
+    //   selected: true,
+    //   createContentView: function () {
+    //     return new ScrollView({
+    //       createContentView: function () {
+    //         return new InfowindowContentView(_.extend(self.options, { templates: self._templates }));
+    //       }
+    //     });
+    //   }
+    // }, {
+    //   selected: false,
+    //   createContentView: function () {
+    //     return new ScrollView({
+    //       createContentView: function () {
+    //         return new CodeMirrorView({
+    //           model: CodeMirrorModel
+    //         });
+    //       }
+    //     });
+    //   }
+    // }];
 
-    var collectionPane = new TabPaneCollection(tabPaneTabs);
+    // var collectionPane = new TabPaneCollection(tabPaneTabs);
 
-    var panelWithOptionsView = new PanelWithOptionsView({
-      className: 'Editor-content',
-      editorModel: self._editorModel,
-      createContentView: function () {
-        return new TabPaneView({
-          collection: collectionPane
-        });
-      },
-      createControlView: function () {
-        return new Toggler({
-          editorModel: self._editorModel,
-          collection: collectionPane,
-          labels: ['VALUES', 'HTML']
-        });
-      },
-      createActionView: function () {
-        return new Dummy({
-          content: ''
-        });
-      }
-    });
-
+    // var panelWithOptionsView = new PanelWithOptionsView({
+    //   className: 'Editor-content',
+    //   editorModel: self._editorModel,
+    //   createContentView: function () {
+    //     return new TabPaneView({
+    //       collection: collectionPane
+    //     });
+    //   },
+    //   createControlView: function () {
+    //     return new Toggler({
+    //       editorModel: self._editorModel,
+    //       collection: collectionPane,
+    //       labels: ['VALUES', 'HTML']
+    //     });
+    //   },
+    //   createActionView: function () {
+    //     return new Dummy({
+    //       content: ''
+    //     });
+    //   }
+    // });
+    var panelWithOptionsView = new InfowindowContentView(_.extend(self.options, { templates: self._templates }));
     this.$el.append(panelWithOptionsView.render().el);
     this.addView(panelWithOptionsView);
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
@@ -102,4 +102,5 @@ module.exports = CoreView.extend({
     this.model.unbind('change', null, this.model);
     CoreView.prototype.clean.apply(this);
   }
+
 });

--- a/lib/assets/javascripts/cartodb3/infowindow-manager.js
+++ b/lib/assets/javascripts/cartodb3/infowindow-manager.js
@@ -36,8 +36,10 @@ function InfowindowLink (layerDef, visMap) {
 function TooltipLink (layerDef, visMap) {
   if (!layerDef.tooltipModel) return;
 
-  function onChange (attrs) {
-    visMap.getLayerById(layerDef.id).tooltip.update(attrs.toJSON());
+  function onChange (tooltipModel) {
+    var attrs = JSON.parse(JSON.stringify(tooltipModel.attributes));
+
+    visMap.getLayerById(layerDef.id).tooltip.update(attrs);
   }
 
   layerDef.tooltipModel.bind('change', onChange);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.25.26",
+  "version": "3.25.27",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.25.27",
+  "version": "3.25.28",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
close https://github.com/CartoDB/cartodb/issues/7736

it was setting an empty template (i.e. `''`) thus not rendering properly the tooltips, this is needed for the click infowindows, but not really for the tooltips at this point

CR @gfiorav 