### PR TITLE
Invitation token

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ ghost tables, importing common data and automatic index creation.
 ### Bug Fixes
 * Incorrect error message when password validation failed
 * Fix visualization not found error when exporting maps created from datasets
+* Fixes for organization invitations
 
 3.13.0 (2016-XX-XX)
 -------------------

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -155,9 +155,11 @@ class SignupController < ApplicationController
   end
 
   def valid_email_invitation_token?
-    if (params[:user] && params[:user][:email]) || params[:email] && params[:invitation_token]
-      invitation = Carto::Invitation.find_by_seed(params[:invitation_token])
-      invitation.present? && invitation.users_emails.include?(params[:email] || params[:user][:email]) ? true : false
+    email = (params[:user] && params[:user][:email]) || params[:email]
+    token = params[:invitation_token]
+    if email && token
+      invitation = Carto::Invitation.query_with_valid_email(email).where(organization_id: @organization.id).all
+      invitation.any? { |i| i.token(email) == token }
     end
   end
 

--- a/app/views/signup/signup.html.erb
+++ b/app/views/signup/signup.html.erb
@@ -48,7 +48,7 @@
                     </div>
 
                     <div class="Sessions-field">
-                      <%= f.email_field :email, class: "Sessions-input", placeholder: 'email' %>
+                      <%= f.email_field :email, class: "Sessions-input", placeholder: 'email', readonly: params[:invitation_token].present? %>
                       <% if !@user.errors[:email].blank? %>
                         <div class="Sessions-fieldError js-Sessions-fieldError" data-content="<%= @user.errors[:email] %>">!</div>
                       <% end %>

--- a/spec/requests/signup_controller_spec.rb
+++ b/spec/requests/signup_controller_spec.rb
@@ -21,17 +21,26 @@ describe SignupController do
     end
 
     it 'returns 200 for organizations with signup_page_enabled' do
-      @fake_organization = FactoryGirl.create(:organization, whitelisted_email_domains: ['cartodb.com'] )
+      @fake_organization = FactoryGirl.create(:organization, whitelisted_email_domains: ['cartodb.com'])
       Organization.stubs(:where).returns([@fake_organization])
       get signup_url
       response.status.should == 200
     end
 
     it 'returns 404 for organizations without signup_page_enabled' do
-      @fake_organization = FactoryGirl.create(:organization, whitelisted_email_domains: [] )
+      @fake_organization = FactoryGirl.create(:organization, whitelisted_email_domains: [])
       Organization.stubs(:where).returns([@fake_organization])
       get signup_url
       response.status.should == 404
+    end
+
+    it 'returns 200 for organizations without signup_page_enabled but with a valid invitation' do
+      @fake_organization = FactoryGirl.create(:organization_with_users, whitelisted_email_domains: [])
+      owner = Carto::User.find(@fake_organization.owner.id)
+      invitation = Carto::Invitation.create_new(owner, ['wadus@wad.us'], 'Welcome!')
+      Organization.stubs(:where).returns([@fake_organization])
+      get signup_url(invitation_token: invitation.token('wadus@wad.us'), email: 'wadus@wad.us')
+      response.status.should == 200
     end
 
     it 'returns user error with admin mail if organization has not enough seats' do


### PR DESCRIPTION
Fixes #7402.

Current code already checks return for Central and displays errors accordingly. But the problem was that a filter to check if the signup form is enabled was run first and was flawed, so it returned 404 even though the invitation was correct. Also, blocked email field, as changing it won't work with an invitation (it won't match the token).