### PR TITLE
Be more lenient validating email addresses

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/utils.js
+++ b/lib/assets/javascripts/cartodb/old_common/utils.js
@@ -268,7 +268,7 @@
   };
 
   cdb.Utils.isValidEmail = function(str) {
-    var re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
+    var re = /^([^@]+)@([^@]+)\.([^@\.]+)$/i;
     return re.test(str);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.25.26",
+  "version": "3.25.27",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is only used in the invitations view. Old code did not allow email addresses with + or with the new longer TLDs. This allows pretty much anything. Worst case, the invitation email is wrong and the invitation is not received, so no harm done.

Pending package bump