### PR TITLE
Fix missing geometry type exceptions

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-option-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-option-view.js
@@ -14,9 +14,7 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    if (!opts.simpleGeometryTypeInput) throw new Error('simpleGeometryTypeInput is required');
-
-    this._simpleGeometryTypeInput = opts.simpleGeometryTypeInput;
+    this._simpleGeometryTypeInput = opts.simpleGeometryTypeInput; // might be undefined/null, so don't check
 
     this.listenTo(this.model, 'change:selected', this.render);
   },
@@ -45,7 +43,7 @@ module.exports = CoreView.extend({
 
   _disabledDesc: function (desc) {
     return _t('components.modals.add-analysis.disabled-option-desc', {
-      simpleGeometryType: this._simpleGeometryTypeInput,
+      simpleGeometryType: this._simpleGeometryTypeInput || _t('components.modals.add-analysis.unknown-geometry-type'),
       requiredInputGeometries: this.model.getValidInputGeometries()
     });
   },

--- a/lib/assets/javascripts/cartodb3/components/modals/modal-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/modal-view.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var template = require('./modal.tpl');
 
@@ -59,6 +60,7 @@ module.exports = CoreView.extend({
 
   _onDestroy: function () {
     this.hide();
+    _.invoke(this._subviews, 'allOff');
     this._delayDueToAnimation(function () {
       this.clean();
     });

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -207,6 +207,7 @@
         "loading-title": "Loading options",
         "add-btn": "Add analysis",
         "disabled-option-desc": "Your layer geometry is %{simpleGeometryType} and this analysis needs %{requiredInputGeometries}",
+        "unknown-geometry-type": "unknown",
         "option-types": {
           "buffer": {
             "title": "Buffer",

--- a/lib/assets/node_modules/backbone/core-view.js
+++ b/lib/assets/node_modules/backbone/core-view.js
@@ -46,7 +46,6 @@ var View = Backbone.View.extend({
    * the view is not going to be used anymore
    */
   clean: function () {
-    var self = this;
     this.trigger('clean');
     this.clearSubViews();
     // remove from parent
@@ -55,17 +54,25 @@ var View = Backbone.View.extend({
       this._parent = null;
     }
     this.remove();
-    this.unbind();
-    // remove this model binding
-    if (this.model && this.model.unbind) this.model.unbind(null, null, this);
-    // remove model binding
-    _(this._models).each(function (m) {
-      m.unbind(null, null, self);
-    });
-    this._models = [];
+    this.allOff();
     View.viewCount--;
     delete View.views[this.cid];
     return this;
+  },
+
+  /**
+   * Remove all event listeners on related models
+   */
+  allOff: function () {
+    this.off();
+
+    if (this.model && this.model.off) this.model.off(null, null, this);
+
+    var self = this;
+    _(this._models).each(function (m) {
+      m.off(null, null, self);
+    });
+    this._models = [];
   },
 
   show: function () {

--- a/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-option-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-option-view.spec.js
@@ -12,52 +12,69 @@ describe('components/modals/add-analysis/analysis-option-view', function () {
         type: 'buffer'
       }
     });
-
-    this.view = new AnalysisOptionView({
-      model: this.model,
-      simpleGeometryTypeInput: 'point'
-    });
-    this.view.render();
   });
 
-  it('should render the info', function () {
-    expect(this.view.$el.html()).toContain('Buffer');
-    expect(this.view.$el.html()).toContain('describes the buffer');
-    expect(this.view.$el.html()).toContain('area of influence');
-  });
-
-  it('should not have any leaks', function () {
-    expect(this.view).toHaveNoLeaks();
-  });
-
-  describe('when selected', function () {
+  describe('when given a simple geometry type', function () {
     beforeEach(function () {
-      this.model.set('selected', true);
-    });
-
-    it('should highlight the item', function () {
-      expect(this.view.el.className).toContain('is-selected');
-    });
-  });
-
-  describe('when geometry type does not match ', function () {
-    beforeEach(function () {
-      spyOn(this.model, 'acceptsGeometryTypeAsInput').and.returnValue(false);
+      this.view = new AnalysisOptionView({
+        model: this.model,
+        simpleGeometryTypeInput: 'point'
+      });
       this.view.render();
     });
 
-    it('should disable the view', function () {
-      expect(this.view.el.className).toContain('is-disabled');
+    it('should render the info', function () {
+      expect(this.view.$el.html()).toContain('Buffer');
+      expect(this.view.$el.html()).toContain('describes the buffer');
+      expect(this.view.$el.html()).toContain('area of influence');
     });
 
-    it('should show alternative desc', function () {
-      expect(this.view.$el.html()).toContain('disabled-option-desc');
-      expect(this.view.$el.html()).not.toContain('describes the buffer');
+    it('should not have any leaks', function () {
+      expect(this.view).toHaveNoLeaks();
     });
 
-    it('should not be able to select it', function () {
-      this.view.$el.click();
-      expect(this.view.el.className).not.toContain('selected');
+    describe('when selected', function () {
+      beforeEach(function () {
+        this.model.set('selected', true);
+      });
+
+      it('should highlight the item', function () {
+        expect(this.view.el.className).toContain('is-selected');
+      });
+    });
+
+    describe('when geometry type does not match ', function () {
+      beforeEach(function () {
+        spyOn(this.model, 'acceptsGeometryTypeAsInput').and.returnValue(false);
+        this.view.render();
+      });
+
+      it('should disable the view', function () {
+        expect(this.view.el.className).toContain('is-disabled');
+      });
+
+      it('should show alternative desc', function () {
+        expect(this.view.$el.html()).toContain('disabled-option-desc');
+        expect(this.view.$el.html()).not.toContain('describes the buffer');
+      });
+
+      it('should not be able to select it', function () {
+        this.view.$el.click();
+        expect(this.view.el.className).not.toContain('selected');
+      });
+    });
+  });
+
+  describe('when not given any geometry type', function () {
+    beforeEach(function () {
+      this.view = new AnalysisOptionView({
+        model: this.model
+      });
+      this.view.render();
+    });
+
+    it('should not have any leaks', function () {
+      expect(this.view).toHaveNoLeaks();
     });
   });
 });

--- a/lib/assets/test/spec/cartodb3/components/modals/modal-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/modal-view.spec.js
@@ -1,13 +1,23 @@
+var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 var ModalViewModel = require('../../../../../javascripts/cartodb3/components/modals/modal-view-model');
 var ModalView = require('../../../../../javascripts/cartodb3/components/modals/modal-view');
 
 describe('components/modals/modal-view', function () {
-  var contentView;
+  var contentView, contentViewEventSpy;
 
   beforeEach(function () {
-    contentView = new CoreView();
+    contentViewEventSpy = jasmine.createSpy('test');
+    var TestView = CoreView.extend({
+      initialize: function () {
+        this.model.on('test', contentViewEventSpy, this);
+      }
+    });
+
+    this.contentViewModel = new Backbone.Model();
+    contentView = new TestView({model: this.contentViewModel});
     spyOn(contentView, 'render').and.callThrough();
+
     this.model = new ModalViewModel({
       createContentView: function () { return contentView; }
     });
@@ -28,6 +38,10 @@ describe('components/modals/modal-view', function () {
 
   describe('when close is clicked', function () {
     beforeEach(function () {
+      this.contentViewModel.trigger('test', 'asd');
+      expect(contentViewEventSpy).toHaveBeenCalled();
+      contentViewEventSpy.calls.reset();
+
       jasmine.clock().install();
       spyOn(this.view, 'hide').and.callThrough();
       spyOn(this.view, 'clean').and.callThrough();
@@ -47,7 +61,12 @@ describe('components/modals/modal-view', function () {
       expect(this.view.hide).toHaveBeenCalled();
     });
 
-    it('should have cleaned the view', function () {
+    it('should not react to model bindings anymore', function () {
+      this.contentViewModel.trigger('test', 'asd');
+      expect(contentViewEventSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not clean the view right away', function () {
       expect(this.view.clean).not.toHaveBeenCalled();
     });
 
@@ -58,6 +77,15 @@ describe('components/modals/modal-view', function () {
 
       it('should have cleaned the view', function () {
         expect(this.view.clean).toHaveBeenCalled();
+      });
+
+      it('should not react to model bindings anymore', function () {
+        this.contentViewModel.trigger('test', 'asd');
+        expect(contentViewEventSpy).not.toHaveBeenCalled();
+      });
+
+      it('should have no leaks', function () {
+        expect(this.view).toHaveNoLeaks();
       });
     });
   });


### PR DESCRIPTION
Fixes #7728 

It had two origins:
1. Race-condition when the query-schema-model was updated while the
modal was closing, the model listeners weren’t removed until the modal
animation finished. Changed to be removed straight away.
2. Option view required geometry type, even though it might not be
available (yet, or due to failing node results), so relaxed the check

@alonsogarciapablo could you try this branch locally and confirm that it solves your problem, please?