### PR TITLE
Do not raise exception when there's no map #7707

### DIFF
--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -155,7 +155,7 @@ module CartoDB
         end
       end
 
-      if !errors.emtpy?
+      if !errors.empty?
         CartoDB.notify_error("Errors reverting Table privacy", user_id: metadata_table.user_id,
                                                                table_id: metadata_table.id,
                                                                errors: errors)

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -28,14 +28,16 @@ module CartoDB
         end
 
       rescue NoMethodError => exception
-        CartoDB.notify_debug("#{exception.message} #{exception.backtrace}", {
-          table_id: @table.id,
-          table_name: @table.name,
-          user_id: @table.user_id,
-          data_import_id: @table.data_import_id
-          })
-
-        raise exception
+        if @table.map.nil? && exception.message =~ /undefined method `save' for nil:NilClass/
+          CartoDB.notify_debug("#{exception.message} #{exception.backtrace}", {
+              table_id: @table.id,
+              table_name: @table.name,
+              user_id: @table.user_id,
+              data_import_id: @table.data_import_id
+            })
+        else
+          raise exception
+        end
       end
     end
 

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -28,11 +28,12 @@ module CartoDB
 
     rescue NoMethodError => exception
       if @table.map.nil? && exception.message =~ /undefined method `save' for nil:NilClass/
-        CartoDB.notify_debug("#{exception.message} #{exception.backtrace}",
-                             table_id: @table.id,
-                             table_name: @table.name,
-                             user_id: @table.user_id,
-                             data_import_id: @table.data_import_id)
+        CartoDB::Logger.debug(message: 'Privacy change of table with no map',
+                              exception: exception,
+                              table_id: @table.id,
+                              table_name: @table.name,
+                              user: User.where(id: @table.user_id),
+                              data_import_id: @table.data_import_id)
       else
         raise exception
       end


### PR DESCRIPTION
Go back to previous behavior but refining it:
- capture specific exception
- check for @table.map and exception message

then log the exception for debugging purposes (in case the sync has no
map for any reason) but do not stop the whole process just because of
it.

@gfiorav and @iriberri can you please review? there's a bit more historic info in the issue and previous commits.