### PR TITLE
Filter category analysis; Split by comma instead of ||

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/fallback-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/fallback-form-model.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var camshaftReference = require('../../../../../data/camshaft-reference');
 var BaseAnalysisFormModel = require('./base-analysis-form-model');
 
-var ARRAY_SPLIT_COMBO = '||';
+var ARRAY_SPLIT_COMBO = ',';
 
 /**
  * A fallback form model in case the type is not supported (yet).

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/fallback-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/fallback-form-model.js
@@ -34,13 +34,16 @@ module.exports = BaseAnalysisFormModel.extend({
     var params = camshaftReference.paramsForType(this.get('type'));
     for (var name in params) {
       var param = params[name];
-
       if (param.type === 'array') {
-        attrs[name] = (attrs[name] || '')
-          .split(ARRAY_SPLIT_COMBO)
-          .map(function (val) {
-            return val.trim();
-          });
+        if (!_.isString(attrs[name]) || attrs[name].trim() === '') {
+          attrs[name] = null;
+        } else {
+          attrs[name] = attrs[name]
+            .split(ARRAY_SPLIT_COMBO)
+            .map(function (val) {
+              return val.trim();
+            });
+        }
       }
     }
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/fallback-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/fallback-form-model.spec.js
@@ -66,7 +66,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/fallba
 
           var attrs = this.layerDefinitionModel.createNewAnalysisNode.calls.argsFor(0)[0];
           expect(attrs.accept).toEqual(jasmine.any(Array));
-          expect(attrs.accept).toEqual(['a', 'b | b', 'c', 'd, e, and f']);
+          expect(attrs.accept).toEqual(['a', 'b | b', 'c', 'd', 'e', 'and f']);
         });
       });
     });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/fallback-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/fallback-form-model.spec.js
@@ -51,7 +51,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/fallba
           type: 'filter-category',
           source: 'a1',
           column: 'col',
-          accept: 'a || b | b || c || d, e, and f'
+          accept: 'a, b | b, c, d, e, and f'
         });
       });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/fallback-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/fallback-form-model.spec.js
@@ -50,23 +50,32 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/fallba
         this.model.set({
           type: 'filter-category',
           source: 'a1',
-          column: 'col',
-          accept: 'a, b | b, c, d, e, and f'
+          column: 'col'
         });
       });
 
       describe('when saved', function () {
         beforeEach(function () {
           expect(this.model.isValid()).toBe(true, 'the model should be valid to be saved');
-          this.model.save();
         });
 
-        it('should split array params', function () {
+        it('should split array params for values', function () {
+          this.model.set('accept', 'a, b | b, c, d, e, and f');
+          this.model.save();
           expect(this.layerDefinitionModel.createNewAnalysisNode).toHaveBeenCalled();
 
           var attrs = this.layerDefinitionModel.createNewAnalysisNode.calls.argsFor(0)[0];
           expect(attrs.accept).toEqual(jasmine.any(Array));
           expect(attrs.accept).toEqual(['a', 'b | b', 'c', 'd', 'e', 'and f']);
+        });
+
+        it('should set a null value if there is no value', function () {
+          this.model.set('accept', '');
+          this.model.save();
+          expect(this.layerDefinitionModel.createNewAnalysisNode).toHaveBeenCalled();
+
+          var attrs = this.layerDefinitionModel.createNewAnalysisNode.calls.argsFor(0)[0];
+          expect(attrs.accept).toBe(null);
         });
       });
     });


### PR DESCRIPTION
Fixes #7705

> The client should not send an empty array for accept.

cc @rochoa 