### PR TITLE
Several improvements for the fill component

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
@@ -5,6 +5,7 @@ var StackLayoutView = require('../../../../../components/stack-layout/stack-layo
 var ColumnListView = require('../column-list-view');
 var InputColorRamps = require('./input-ramps/input-color-ramps');
 var InputColorCategories = require('./input-categories/input-color-categories');
+var EXCLUDED_COLUMNS = ['the_geom', 'the_geom_webmercator'];
 
 module.exports = CoreView.extend({
   initialize: function (opts) {
@@ -107,9 +108,13 @@ module.exports = CoreView.extend({
   },
 
   _createColumnListView: function (stackLayoutModel, opts) {
+    var columns = _.reject(this._columns, function (column) {
+      return column.type === 'geometry' || _.contains(EXCLUDED_COLUMNS, column.label);
+    }, this);
+
     var view = new ColumnListView({
       stackLayoutModel: stackLayoutModel,
-      columns: this._columns,
+      columns: columns,
       showSearch: true,
       typeLabel: 'column'
     });

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
@@ -103,6 +103,8 @@ module.exports = CoreView.extend({
 
     if (this.model.get('attribute')) {
       this._stackLayoutView.model.set('position', 1);
+    } else if (this.model.get('quantification')) {
+      this._stackLayoutView.model.set('position', 2);
     }
   },
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.tpl
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.tpl
@@ -7,7 +7,7 @@
       <%- attribute %>
     </li>
     <li class="CDB-ListDecoration-item CDB-ListDecoration-itemPadding--vertical CDB-Text CDB-Size-medium u-secondaryTextColor u-flex">
-      <%- quantification %>
+      <%- _t('form-components.editors.fill.quantification.methods.' + quantification) %>
       <button class="CDB-Shape u-lSpace js-quantification">
         <div class="CDB-Shape-threePoints is-horizontal is-blue is-small">
           <div class="CDB-Shape-threePointsItem"></div>


### PR DESCRIPTION
Closes #7910

- [x] For the panel color > By value we shouldn't show several columns like: the_geom, the_geom_webmercator,... (https://github.com/CartoDB/cartodb/pull/7920/commits/7c93087c3572b80a611ba0464de4f2ff525a8a2d)
- [x] Only show number columns in the size > By value panel. (already done: https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js#L44) 
- [x] When user selects Size > By value, it should not go to quantification panel, it should select one by default (or leave what it was selected) and go to MIN-MAX state/panel (https://github.com/CartoDB/cartodb/pull/7920/commits/d661cfb63d4994560603d774fac04787c7ffd1cc)
- [x] Fixes capitalization of the quantification name in the value dialog (https://github.com/CartoDB/cartodb/pull/7920/commits/2ac31e06cf8431d8b61ce852da71bf352d32185c)

CR: @xavijam 