### PR TITLE
Boolean or string restriction for category widget.

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/widgets-types.js
@@ -21,7 +21,7 @@ module.exports = [
         if (type === 'string' || type === 'boolean') {
           m = new CategoryOptionModel({
             tuples: tuples,
-            title: 'Category ' + columnModel.get('name'),
+            title: _t('editor.widgets.widgets-types.category') + ' ' + columnModel.get('name'),
             name: columnModel.get('name'),
             aggregation: 'count' // or sum
           });
@@ -50,7 +50,7 @@ module.exports = [
         if (columnModel.get('type') === 'number') {
           var m = new HistogramOptionModel({
             tuples: tuples,
-            title: 'Histogram ' + columnModel.get('name'),
+            title: _t('editor.widgets.widgets-types.histogram') + ' ' + columnModel.get('name'),
             name: columnModel.get('name'),
             bins: 10
           });
@@ -79,7 +79,7 @@ module.exports = [
         if (columnModel.get('type') === 'number') {
           var m = new FormulaOptionModel({
             tuples: tuples,
-            title: 'Formula ' + columnModel.get('name'),
+            title: _t('editor.widgets.widgets-types.formula') + ' ' + columnModel.get('name'),
             operation: 'avg',
             name: columnModel.get('name')
           });
@@ -113,7 +113,7 @@ module.exports = [
         if (columnModel.get('type') === 'date') {
           var attrs = {
             tuples: tuples,
-            title: 'Time-series ' + columnName,
+            title: _t('editor.widgets.widgets-types.time-series') + ' ' + columnName,
             bins: 256
           };
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/widgets-types.js
@@ -14,15 +14,21 @@ module.exports = [
   {
     type: 'category',
     createOptionModels: function (tuplesItems) {
-      return _.map(tuplesItems, function (tuples) {
+      return _.reduce(tuplesItems, function (memo, tuples) {
         var columnModel = tuples[0].columnModel;
-        return new CategoryOptionModel({
-          tuples: tuples,
-          title: 'Category ' + columnModel.get('name'),
-          name: columnModel.get('name'),
-          aggregation: 'count' // or sum
-        });
-      });
+        var type = columnModel.get('type');
+        var m;
+        if (type === 'string' || type === 'boolean') {
+          m = new CategoryOptionModel({
+            tuples: tuples,
+            title: 'Category ' + columnModel.get('name'),
+            name: columnModel.get('name'),
+            aggregation: 'count' // or sum
+          });
+          memo.push(m);
+        }
+        return memo;
+      }, []);
     },
     createTabPaneItem: function (optionsCollection) {
       return {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/stat-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/stat-view.js
@@ -101,7 +101,7 @@ module.exports = CoreView.extend({
   _renderTemplate: function () {
     this.$el.append(template({
       column: this._statModel.get('name'),
-      type: this._statModel.get('type'),
+      type: this._statModel.get('column'),
       isSelected: this._statModel.get('selected')
     }));
   },

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/widgets-types.js
@@ -8,18 +8,24 @@ module.exports = [
   {
     type: 'category',
     createOptionModels: function (tuplesItems) {
-      return _.map(tuplesItems, function (tuples) {
+      return _.reduce(tuplesItems, function (memo, tuples) {
         var columnModel = tuples[0].columnModel;
         var table = tuples[0].layerDefinitionModel.getTableName();
-        return new CategoryOptionModel({
-          tuples: tuples,
-          table: table,
-          title: 'Category ' + columnModel.get('name'),
-          name: columnModel.get('name'),
-          column: columnModel.get('type'),
-          aggregation: 'count' // or sum
-        });
-      });
+        var type = columnModel.get('type');
+        var m;
+        if (type === 'string' || type === 'boolean') {
+          m = new CategoryOptionModel({
+            tuples: tuples,
+            table: table,
+            title: 'Category ' + columnModel.get('name'),
+            name: columnModel.get('name'),
+            column: columnModel.get('type'),
+            aggregation: 'count' // or sum
+          });
+          memo.push(m);
+        }
+        return memo;
+      }, []);
     }
   },
   {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/widgets-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/widgets-types.js
@@ -17,7 +17,7 @@ module.exports = [
           m = new CategoryOptionModel({
             tuples: tuples,
             table: table,
-            title: 'Category ' + columnModel.get('name'),
+            title: _t('editor.widgets.widgets-types.category') + ' ' + columnModel.get('name'),
             name: columnModel.get('name'),
             column: columnModel.get('type'),
             aggregation: 'count' // or sum
@@ -38,7 +38,7 @@ module.exports = [
           var m = new HistogramOptionModel({
             tuples: tuples,
             table: table,
-            title: 'Histogram ' + columnModel.get('name'),
+            title: _t('editor.widgets.widgets-types.histogram') + ' ' + columnModel.get('name'),
             name: columnModel.get('name'),
             column: columnModel.get('type'),
             bins: 10
@@ -59,7 +59,7 @@ module.exports = [
           var m = new FormulaOptionModel({
             tuples: tuples,
             table: table,
-            title: 'Formula ' + columnModel.get('name'),
+            title: _t('editor.widgets.widgets-types.formula') + ' ' + columnModel.get('name'),
             operation: 'avg',
             name: columnModel.get('name'),
             column: columnModel.get('type')

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -524,7 +524,7 @@
       "layer": {
         "analysis": "Analysis",
         "add-analysis": "Add analysis",
-        "analyses-count": "(%{smart_count}) Analysis |||| (%{smart_count}) Analyses", 
+        "analyses-count": "(%{smart_count}) Analysis |||| (%{smart_count}) Analyses",
         "add-layer": "Add layer",
         "delete": "Delete"
       },
@@ -754,6 +754,12 @@
     "widgets": {
       "widgets-view": {
         "add_widget": "Add widget"
+      },
+      "widgets-types": {
+        "histogram": "Histogram",
+        "category": "Category",
+        "formula": "Formula",
+        "time-series": "Time-series"
       },
       "widgets-form": {
         "placeholder-text": "You have not added any widgets yet. Add new widgets to discover new things.",

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/stat-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/stat-view.spec.js
@@ -27,6 +27,7 @@ describe('editor/layers/layers-content-view/data/stat-view', function () {
 
     var statModel = new Backbone.Model({
       type: 'formula',
+      column: 'number',
       name: 'location',
       layer_index: 0,
       table: 'marias',
@@ -85,7 +86,7 @@ describe('editor/layers/layers-content-view/data/stat-view', function () {
     expect(view.$('.js-checkbox').length).toBe(1);
     expect(view.$('.js-stat').length).toBe(1);
     expect(view.$('.StatsList-details h2').text()).toBe('location');
-    expect(view.$('.StatsList-tag').text()).toBe('formula');
+    expect(view.$('.StatsList-tag').text()).toBe('number');
     expect(view.$('.js-formula-stat').text()).toContain('937');
   });
 


### PR DESCRIPTION
This PR fixes #7932.

- It prevents number columns to be used for category stats and widgets
- It added the column's type as a tag in the stat for the data panel.

cc @javisantana @xavijam @fdansv 