### PR TITLE
Do not edit users that already have a quota set

### DIFF
--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -1307,13 +1307,13 @@ namespace :cartodb do
       users.each do |u|
         begin
           if u.organization_owner? && !u.organization.nil?
-            u.organization.obs_general_quota = do_quota
-            u.organization.obs_snapshot_quota = do_quota
+            u.organization.obs_general_quota = do_quota if u.organization.obs_general_quota.to_i = 0
+            u.organization.obs_snapshot_quota = do_quota if u.organization.obs_snapshot_quota.to_i = 0
             u.organization.save
             puts "Organization #{u.organization.name} processed OK"
           else
-            u.obs_general_quota = do_quota
-            u.obs_snapshot_quota = do_quota
+            u.obs_general_quota = do_quota if u.obs_general_quota.to_i = 0
+            u.obs_snapshot_quota = do_quota if u.obs_snapshot_quota.to_i = 0
             u.save
             puts "User #{u.username} processed OK"
           end


### PR DESCRIPTION
If there have been manual editions to the users affected by the Rake, they would be overwritten. By checking if the quota is 0 we avoid overwriting the quota to them, and otherwise we edit them.