### PR TITLE
Escape + and / symbols in Surrogate Keys on Varnish HTTP and Telnet invalidation - fixes #7868

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,10 +5,14 @@
 This release introduces a new Resque queue: `user_dbs`. It is needed for operation on user databases, i.e: linking
 ghost tables, importing common data and automatic index creation.
 
+There is also a fix on Varnish invalidation triggers in user databases to fix some edge cases where tables would not be properly invalidated on Varnish (see https://github.com/CartoDB/cartodb/issues/7868).
+This fix is loaded to newly created users, but it needs to be applied manually to all existing user databases by running: `rake cartodb:db:load_varnish_trigger`.
+
 ### Features
 * Automatic creation of indexes on columns affected by a widget
 
 ### Bug Fixes
+* Invalidations not being tagged properly when Surrogate-Key contained special regex characters (+, /)
 * Incorrect error message when password validation failed
 * Fix visualization not found error when exporting maps created from datasets
 * Fixes for organization invitations

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1260,6 +1260,7 @@ module CartoDB
 
                   try:
                     cache_key = "t:" + GD['base64'].b64encode(GD['hashlib'].sha256('#{@user.database_name}:%s' % table_name).digest())[0:6]
+                    cache_key = cache_key.replace('+', '\\\\\\\\+').replace('/', '\\\\\\\\/')
                     # We want to say \b here, but the Varnish telnet interface expects \\b, we have to escape that on Python to \\\\b and double that for SQL
                     client.fetch('#{purge_command} obj.http.Surrogate-Key ~ "\\\\\\\\b%s\\\\\\\\b"' % cache_key)
                     break
@@ -1308,6 +1309,7 @@ module CartoDB
                   try:
                     client = GD['httplib'].HTTPConnection('#{varnish_host}', #{varnish_port}, False, timeout)
                     cache_key = "t:" + GD['base64'].b64encode(GD['hashlib'].sha256('#{@user.database_name}:%s' % table_name).digest())[0:6]
+                    cache_key = cache_key.replace('+', '\\\\+').replace('/', '\\\\\/')
                     client.request('PURGE', '/key', '', {"Invalidation-Match": ('\\\\b%s\\\\b' % cache_key) })
                     response = client.getresponse()
                     assert response.status == 204


### PR DESCRIPTION
Fixes #7868.

I'm not entirely sure on how to make a spec for this, but I've tested manually (by crafting by brute force tables whose Surrogate-Key ends up containing + and /) and it works fine.

could you review @rochoa @luisico?   🙏😄
