### PR TITLE
Ensure `source` attribute is updated when layerDefinitionModel changes and layer in CartoDB.js didn't have a `source`

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -18,8 +18,8 @@ var F = function (opts) {
 
   this._analysisDefinitionNodesCollection.on('add', this._analyseDefinitionNode, this);
   this._analysisDefinitionNodesCollection.on('change', this._analyseDefinitionNode, this);
-  this._analysisDefinitionsCollection.on('add change:node_id sync', this._analyseDefinition, this);
   this._analysisDefinitionNodesCollection.on('remove', this._onAnalysisDefinitionNodeRemoved, this);
+  this._analysisDefinitionsCollection.on('add change:node_id sync', this._analyseDefinition, this);
 
   opts.layerDefinitionsCollection.on('add', this._onLayerDefinitionAdded, this);
   opts.layerDefinitionsCollection.on('sync', this._onLayerDefinitionSynced, this);
@@ -177,6 +177,9 @@ F.prototype._onLayerDefinitionChanged = function (m) {
         layer.remove();
         this._createLayer(m);
       } else {
+        if (m.get('source') && !layer.get('source')) {
+          attrs.source = m.get('source');
+        }
         layer.update(attrs);
       }
     }

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -243,6 +243,49 @@ describe('deep-insights-integrations', function () {
       });
     });
 
+    describe('when layer has a source attribute here and not in CartoDB.js', function () {
+      it('should set/update the source attribute', function () {
+        // Simulate what deep-insight.js/CartoDB.js does internally to reset the layers (eg: when
+        // creating a dashboard from a viz.json file using createDashboard) right after a map has been
+        // created. Notice that layers don't have a source attribute in these cases.
+        this.integrations.visMap().layers.reset({
+          'id': 'LAYER_ID',
+          'type': 'CartoDB',
+          'order': 1,
+          'visible': true,
+          'options': {
+            'cartocss': 'cartoCSS',
+            'cartocss_version': '2.1.1',
+            'sql': 'SELECT * FROM test'
+          }
+        });
+
+        this.layerDefinitionModel = this.layerDefinitionsCollection.add({
+          id: 'LAYER_ID',
+          kind: 'carto',
+          options: {
+            sql: 'SELECT * FROM test',
+            cartocss: 'cartoCSS',
+            table_name: 'infowindow_stuff'
+          }
+        });
+        expect(this.layerDefinitionModel.get('source')).not.toBeUndefined();
+
+        // Layer at the CartoDB.js level doesn't have a "source"
+        this.layerBefore = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
+        expect(this.layerBefore.get('source')).toBeUndefined();
+
+        // Change some attributes
+        this.layerDefinitionModel.set({
+          cartocss: 'a different CartoCSS'
+        });
+
+        // Layer in CartoDB.js now has the corresponding "source" attribute
+        this.layerAfter = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
+        expect(this.layerAfter.get('source')).toEqual(this.layerDefinitionModel.get('source'));
+      });
+    });
+
     describe('when removing layer', function () {
       beforeEach(function () {
         this.layerDefinitionsCollection.remove(this.layerDefinitionModel);


### PR DESCRIPTION
Fixes: https://github.com/CartoDB/cartodb/issues/7875.

This was the quickest way to fix ☝️ . It basically ensures that, when a layerDefinitionModel is saved, the `source` attribute is updated when it's present in an editor's model and not in the corresponding layer in CartoDB.js. 

It fixes the bug but only because the `sql_history` attribute is changed when the SQL of a layer is updated. This triggers the udpate of the CartoDB.js model, previously ensuring that the `source` is set. Bug fix is executed as a side-effect of something else, which makes it a bit fragile...

@viddo PTAL! Thanks!

cc: @nobuti 