### PR TITLE
min-height: 0 to everything.

### DIFF
--- a/app/assets/stylesheets/editor-3/editor.css.scss
+++ b/app/assets/stylesheets/editor-3/editor.css.scss
@@ -20,18 +20,20 @@
   @include display-flex();
   position: relative;
   height: 100%;
+  min-height: 450px;
 }
 .Editor-panel {
   @include transition(width, 300ms, ease-in-out);
   @include display-flex();
   @include flex-direction(column);
+  @include flex(1);
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 100vh;
+  min-height: 0;
   padding: 18px 25px 0;
   box-sizing: border-box;
 }
@@ -42,6 +44,7 @@
   @include display-flex();
   @include flex(1);
   @include flex-direction(column);
+  min-height: 0;
 }
 .Editor-panelWrapper {
   position: relative;

--- a/app/assets/stylesheets/editor-3/scroll-view.css.scss
+++ b/app/assets/stylesheets/editor-3/scroll-view.css.scss
@@ -8,12 +8,15 @@
 
   &,
   .ScrollView-wrapper {
+    @include display-flex();
+    @include flex-direction(column);
     @include flex(1);
     position: relative;
     margin-right: -24px;
     margin-left: -24px;
     padding-right: 24px;
     padding-left: 24px;
+    min-height: 0;
   }
 
   .ScrollView-content {

--- a/app/assets/stylesheets/editor-3/stats-list.css.scss
+++ b/app/assets/stylesheets/editor-3/stats-list.css.scss
@@ -8,7 +8,6 @@
 
 .StatsList-item {
   @include display-flex;
-  @include align-items(baseline);
   width: 294px;
   margin: 0 0 $baseSize * 3;
   box-sizing: border-box;

--- a/app/assets/stylesheets/editor-3/tab-pane.css.scss
+++ b/app/assets/stylesheets/editor-3/tab-pane.css.scss
@@ -5,4 +5,5 @@
   @include display-flex();
   @include flex(1);
   @include flex-direction(column);
+  min-height: 0;
 }


### PR DESCRIPTION
This PR fixes #7946.

Whenever you've got an element with overflow: [hidden|scroll|auto] inside of a flex item, you need to give its ancestor flex item min-width:0 (in a horizontal flex container) or min-height:0 (in a vertical flex container), to disable this min-sizing behavior, or else the flex item will refuse to shrink smaller than the child's min-content size. 

See https://bugzilla.mozilla.org/show_bug.cgi?id=1043520

cc @piensaenpixel @xavijam @javierarce @javitonino 