### PR TITLE
Trim when joining results of geocoding #7988

### DIFF
--- a/services/table-geocoder/lib/internal-geocoder/admin0_text_polygons.rb
+++ b/services/table-geocoder/lib/internal-geocoder/admin0_text_polygons.rb
@@ -27,7 +27,7 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = trim(orig.geocode_string) AND dest.cartodb_georef_status IS NULL
         }
       end
 

--- a/services/table-geocoder/lib/internal-geocoder/admin1_column_polygons.rb
+++ b/services/table-geocoder/lib/internal-geocoder/admin1_column_polygons.rb
@@ -30,8 +30,8 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = orig.geocode_string
-            AND trim(dest.#{@internal_geocoder.country_column}::text) = orig.country
+          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = trim(orig.geocode_string)
+            AND trim(dest.#{@internal_geocoder.country_column}::text) = trim(orig.country)
             AND dest.cartodb_georef_status IS NULL
         }
       end

--- a/services/table-geocoder/lib/internal-geocoder/admin1_text_polygons.rb
+++ b/services/table-geocoder/lib/internal-geocoder/admin1_text_polygons.rb
@@ -27,7 +27,7 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = trim(orig.geocode_string) AND dest.cartodb_georef_status IS NULL
         }
       end
 

--- a/services/table-geocoder/lib/internal-geocoder/cities_column_column_points.rb
+++ b/services/table-geocoder/lib/internal-geocoder/cities_column_column_points.rb
@@ -32,9 +32,9 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = orig.geocode_string
-            AND trim(dest.#{@internal_geocoder.country_column}::text) = orig.country
-            AND trim(dest.#{@internal_geocoder.region_column}::text) = orig.region
+          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = trim(orig.geocode_string)
+            AND trim(dest.#{@internal_geocoder.country_column}::text) = trim(orig.country)
+            AND trim(dest.#{@internal_geocoder.region_column}::text) = trim(orig.region)
             AND dest.cartodb_georef_status IS NULL
         }
       end

--- a/services/table-geocoder/lib/internal-geocoder/cities_column_text_points.rb
+++ b/services/table-geocoder/lib/internal-geocoder/cities_column_text_points.rb
@@ -30,8 +30,8 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = orig.geocode_string
-            AND trim(dest.#{@internal_geocoder.country_column}::text) = orig.country
+          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = trim(orig.geocode_string)
+            AND trim(dest.#{@internal_geocoder.country_column}::text) = trim(orig.country)
             AND dest.cartodb_georef_status IS NULL
         }
       end

--- a/services/table-geocoder/lib/internal-geocoder/cities_text_column_points.rb
+++ b/services/table-geocoder/lib/internal-geocoder/cities_text_column_points.rb
@@ -30,8 +30,8 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = orig.geocode_string
-            AND trim(dest.#{@internal_geocoder.region_column}::text) = orig.region
+          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = trim(orig.geocode_string)
+            AND trim(dest.#{@internal_geocoder.region_column}::text) = trim(orig.region)
             AND dest.cartodb_georef_status IS NULL
         }
       end

--- a/services/table-geocoder/lib/internal-geocoder/cities_text_text_points.rb
+++ b/services/table-geocoder/lib/internal-geocoder/cities_text_text_points.rb
@@ -27,7 +27,7 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = orig.geocode_string
+          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = trim(orig.geocode_string)
             AND dest.cartodb_georef_status IS NULL
         }
       end

--- a/services/table-geocoder/lib/internal-geocoder/ipaddress_text_point.rb
+++ b/services/table-geocoder/lib/internal-geocoder/ipaddress_text_point.rb
@@ -27,7 +27,7 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = trim(orig.geocode_string) AND dest.cartodb_georef_status IS NULL
         }
       end
 

--- a/services/table-geocoder/lib/internal-geocoder/postalcode_column_points.rb
+++ b/services/table-geocoder/lib/internal-geocoder/postalcode_column_points.rb
@@ -30,7 +30,7 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = trim(orig.geocode_string) AND dest.cartodb_georef_status IS NULL
         }
       end
 

--- a/services/table-geocoder/lib/internal-geocoder/postalcode_column_polygon.rb
+++ b/services/table-geocoder/lib/internal-geocoder/postalcode_column_polygon.rb
@@ -30,7 +30,7 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest.#{@internal_geocoder.column_name}::text) = trim(orig.geocode_string) AND dest.cartodb_georef_status IS NULL
         }
       end
 

--- a/services/table-geocoder/lib/internal-geocoder/postalcode_text_points.rb
+++ b/services/table-geocoder/lib/internal-geocoder/postalcode_text_points.rb
@@ -27,7 +27,7 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = trim(orig.geocode_string) AND dest.cartodb_georef_status IS NULL
         }
       end
 

--- a/services/table-geocoder/lib/internal-geocoder/postalcode_text_polygon.rb
+++ b/services/table-geocoder/lib/internal-geocoder/postalcode_text_polygon.rb
@@ -27,7 +27,7 @@ module CartoDB
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM #{@internal_geocoder.temp_table_name} AS orig
-          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+          WHERE trim(dest."#{@internal_geocoder.column_name}"::text) = trim(orig.geocode_string) AND dest.cartodb_georef_status IS NULL
         }
       end
 

--- a/services/table-geocoder/spec/internal-geocoder/query_generator_factory_spec.rb
+++ b/services/table-geocoder/spec/internal-geocoder/query_generator_factory_spec.rb
@@ -81,7 +81,7 @@ describe CartoDB::InternalGeocoder::QueryGeneratorFactory do
         SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
             cartodb_georef_status = orig.cartodb_georef_status
         FROM any_temp_table AS orig
-        WHERE trim(dest."any_column_name"::text) = orig.geocode_string AND dest.cartodb_georef_status IS NULL
+        WHERE trim(dest."any_column_name"::text) = trim(orig.geocode_string) AND dest.cartodb_georef_status IS NULL
       }.squish
     end
   end
@@ -120,8 +120,8 @@ describe CartoDB::InternalGeocoder::QueryGeneratorFactory do
           SET the_geom = CASE WHEN orig.cartodb_georef_status THEN orig.the_geom ELSE dest.the_geom END,
               cartodb_georef_status = orig.cartodb_georef_status
           FROM any_temp_tablename AS orig
-          WHERE trim(dest.region_column_name::text) = orig.geocode_string
-            AND trim(dest.country_column_name::text) = orig.country
+          WHERE trim(dest.region_column_name::text) = trim(orig.geocode_string)
+            AND trim(dest.country_column_name::text) = trim(orig.country)
             AND dest.cartodb_georef_status IS NULL
         }.squish
     end


### PR DESCRIPTION
Turns out we were trimming strings before sending to the geocoder and
the geocoder was getting results for them, but when updating the
original table there was an inconsistency causing some results not to be
added.

@iriberri can you please review?