### PR TITLE
6901 reduce named map calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ ghost tables, importing common data and automatic index creation.
 ### Bug Fixes
 * Incorrect error message when password validation failed
 * Fix visualization not found error when exporting maps created from datasets
+* Performance improvements updating visualizations
 * Fixes for organization invitations
 
 3.13.0 (2016-XX-XX)

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -98,12 +98,18 @@ class Map < Sequel::Model
   end
 
   def recalculate_bounds!
-    result = get_map_bounds
-    # switch to (lat,lon) for the frontend
-    update(
-      view_bounds_ne: "[#{result[:maxy]}, #{result[:maxx]}]",
-      view_bounds_sw: "[#{result[:miny]}, #{result[:minx]}]"
-    )
+    set_boundaries(get_map_bounds)
+    save
+  rescue Sequel::DatabaseError => exception
+    CartoDB::notify_exception(exception, user: user)
+  end
+
+  def set_default_boundaries!
+    bounds = get_map_bounds
+    set_boundaries(bounds)
+    recenter_using_bounds(bounds)
+    recalculate_zoom(bounds)
+    save
   rescue Sequel::DatabaseError => exception
     CartoDB::notify_exception(exception, user: user)
   end
@@ -160,17 +166,13 @@ class Map < Sequel::Model
     (center.nil? || center == '') ? DEFAULT_OPTIONS[:center] : center.gsub(/\[|\]|\s*/, '').split(',')
   end
 
-  def recenter_using_bounds!
-    bounds = get_map_bounds
+  def recenter_using_bounds(bounds)
     x = (bounds[:maxx] + bounds[:minx]) / 2
     y = (bounds[:maxy] + bounds[:miny]) / 2
-    update(center: "[#{y},#{x}]")
-  rescue Sequel::DatabaseError => exception
-    CartoDB::notify_exception(exception, user: user)
+    self.center = "[#{y},#{x}]"
   end
 
-  def recalculate_zoom!
-    bounds = get_map_bounds
+  def recalculate_zoom(bounds)
     latitude_size = bounds[:maxy] - bounds[:miny]
     longitude_size = bounds[:maxx] - bounds[:minx]
 
@@ -180,9 +182,7 @@ class Map < Sequel::Model
     zoom = -1 * ((Math.log([longitude_size, latitude_size].max) / Math.log(2)) - (Math.log(360) / Math.log(2)))
     zoom = [[zoom.round, 1].max, MAXIMUM_ZOOM].min
 
-    update(zoom: zoom)
-  rescue Sequel::DatabaseError => exception
-    CartoDB::notify_exception(exception, user: user)
+    self.zoom = zoom
   end
 
   def view_bounds_data
@@ -214,6 +214,12 @@ class Map < Sequel::Model
   def get_map_bounds
     # (lon,lat) as comes out from postgis
     BoundingBoxHelper.get_table_bounds(user.in_database, table_name)
+  end
+
+  def set_boundaries(bounds)
+    # switch to (lat,lon) for the frontend
+    self.view_bounds_ne = "[#{result[:maxy]}, #{result[:maxx]}]"
+    self.view_bounds_sw = "[#{result[:miny]}, #{result[:minx]}]"
   end
 
   def get_the_last_time_tiles_have_changed_to_render_it_in_vizjsons

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -218,8 +218,8 @@ class Map < Sequel::Model
 
   def set_boundaries(bounds)
     # switch to (lat,lon) for the frontend
-    self.view_bounds_ne = "[#{result[:maxy]}, #{result[:maxx]}]"
-    self.view_bounds_sw = "[#{result[:miny]}, #{result[:minx]}]"
+    self.view_bounds_ne = "[#{bounds[:maxy]}, #{bounds[:maxx]}]"
+    self.view_bounds_sw = "[#{bounds[:miny]}, #{bounds[:minx]}]"
   end
 
   def get_the_last_time_tiles_have_changed_to_render_it_in_vizjsons

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -539,9 +539,7 @@ class Table
     )
 
     member.store
-    member.map.recalculate_bounds!
-    member.map.recenter_using_bounds!
-    member.map.recalculate_zoom!
+    member.map.set_default_boundaries!
 
     CartoDB::Visualization::Overlays.new(member).create_default_overlays
   end

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -652,6 +652,7 @@ module CartoDB
           end
           @updating_named_maps = true
         end
+        true
       end
 
       def get_named_map

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -849,7 +849,7 @@ module CartoDB
       end
 
       def relator
-        Relator.new(attributes)
+        @relator ||= Relator.new(attributes)
       end
 
       def name_checker

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -645,8 +645,12 @@ module CartoDB
       def save_named_map
         return if type == TYPE_REMOTE
 
-        Rails::Sequel.connection.after_commit do
-          (get_named_map ? update_named_map : create_named_map) if carto_visualization
+        unless @updating_named_maps
+          Rails::Sequel.connection.after_commit do
+            @updating_named_maps = false
+            (get_named_map ? update_named_map : create_named_map) if carto_visualization
+          end
+          @updating_named_maps = true
         end
       end
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -670,6 +670,10 @@ module CartoDB
         related_canonical_visualizations.map(&:attributions).reject {|attribution| attribution.blank?}
       end
 
+      def map
+        @map ||= ::Map.where(id: map_id).first
+      end
+
       private
 
       attr_reader   :repository, :name_checker, :validator
@@ -849,7 +853,7 @@ module CartoDB
       end
 
       def relator
-        @relator ||= Relator.new(attributes)
+        Relator.new(map, attributes)
       end
 
       def name_checker

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -8,20 +8,20 @@ require_relative '../layer'
 module CartoDB
   module Visualization
     class Relator
-      LAYER_SCOPES  = {
-                        base:             :user_layers,
-                        cartodb:          :data_layers,
-                        carto_and_torque: :carto_and_torque_layers,
-                        others:           :other_layers,
-                        named_map:        :named_maps_layers
-                      }
+      LAYER_SCOPES = {
+        base:             :user_layers,
+        cartodb:          :data_layers,
+        carto_and_torque: :carto_and_torque_layers,
+        others:           :other_layers,
+        named_map:        :named_maps_layers
+      }.freeze
 
-      INTERFACE     = %w{ overlays user table related_templates related_tables related_canonical_visualizations
-                          layers stats mapviews total_mapviews single_data_layer? synchronization is_synced? permission
-                          parent children support_tables prev_list_item next_list_item likes likes_count reload_likes
-                          estimated_row_count actual_row_count }
+      INTERFACE = %w{ overlays user table related_templates related_tables related_canonical_visualizations
+                      layers stats mapviews total_mapviews single_data_layer? synchronization is_synced? permission
+                      parent children support_tables prev_list_item next_list_item likes likes_count reload_likes
+                      estimated_row_count actual_row_count }.freeze
 
-      def initialize(map, attributes={})
+      def initialize(map, attributes = {})
         @id             = attributes.fetch(:id)
         @map_id         = attributes.fetch(:map_id)
         @user_id        = attributes.fetch(:user_id)

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -16,12 +16,12 @@ module CartoDB
                         named_map:        :named_maps_layers
                       }
 
-      INTERFACE     = %w{ overlays map user table related_templates related_tables related_canonical_visualizations
+      INTERFACE     = %w{ overlays user table related_templates related_tables related_canonical_visualizations
                           layers stats mapviews total_mapviews single_data_layer? synchronization is_synced? permission
                           parent children support_tables prev_list_item next_list_item likes likes_count reload_likes
                           estimated_row_count actual_row_count }
 
-      def initialize(attributes={})
+      def initialize(map, attributes={})
         @id             = attributes.fetch(:id)
         @map_id         = attributes.fetch(:map_id)
         @user_id        = attributes.fetch(:user_id)
@@ -32,6 +32,7 @@ module CartoDB
         @likes          = nil
         @prev_id        = attributes.fetch(:prev_id)
         @next_id        = attributes.fetch(:next_id)
+        @map            = map
       end
 
       # @return []
@@ -72,10 +73,6 @@ module CartoDB
 
       def overlays
         @overlays ||= Carto::Overlay.where(visualization_id: id).all
-      end
-
-      def map
-        @map ||= ::Map.where(id: map_id).first
       end
 
       def user
@@ -157,7 +154,7 @@ module CartoDB
         likes
       end
 
-      attr_reader :id, :map_id
+      attr_reader :id, :map_id, :map
 
       private
 

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -23,7 +23,6 @@ module CartoDB
 
       def initialize(map, attributes = {})
         @id             = attributes.fetch(:id)
-        @map_id         = attributes.fetch(:map_id)
         @user_id        = attributes.fetch(:user_id)
         @permission_id  = attributes.fetch(:permission_id)
         @parent_id      = attributes.fetch(:parent_id)
@@ -80,8 +79,8 @@ module CartoDB
       end
 
       def table
-        return nil if map_id.nil?
-        @table ||= ::UserTable.from_map_id(map_id).try(:service)
+        return nil if map.nil?
+        @table ||= ::UserTable.from_map_id(map.id).try(:service)
       end
 
       def estimated_row_count
@@ -154,7 +153,7 @@ module CartoDB
         likes
       end
 
-      attr_reader :id, :map_id, :map
+      attr_reader :id, :map
 
       private
 

--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -164,9 +164,7 @@ describe Map do
       table.reload
       table.georeference_from!(:latitude_column => :latitude, :longitude_column => :longitude)
       table.optimize
-      table.map.recalculate_bounds!
-
-      table.map.recenter_using_bounds!
+      table.map.set_default_boundaries!
 
       # casting to string :_( but currently only used by frontend
       table.map.center_data.should == [ 60.0.to_s, 5.0.to_s ]
@@ -181,28 +179,28 @@ describe Map do
       # Out of usual bounds by being bigger than "full world bounding box"
       table.map.stubs(:get_map_bounds)
                .returns({ minx: -379, maxx: 379, miny: -285 , maxy: 285.0511})
-      table.map.recalculate_zoom!
+      table.map.set_default_boundaries!
       table.map.zoom.should == 1
 
       table.map.stubs(:get_map_bounds)
                .returns({ minx: -179, maxx: 179, miny: -85 , maxy: 85.0511})
-      table.map.recalculate_zoom!
+      table.map.set_default_boundaries!
       table.map.zoom.should == 1
 
       table.map.stubs(:get_map_bounds)
                .returns({ minx: 1, maxx: 2, miny: 1 , maxy: 2})
-      table.map.recalculate_zoom!
+      table.map.set_default_boundaries!
       table.map.zoom.should == 8
 
       table.map.stubs(:get_map_bounds)
                .returns({ minx: 0.025, maxx: 0.05, miny: 0.025 , maxy: 0.05})
-      table.map.recalculate_zoom!
+      table.map.set_default_boundaries!
       table.map.zoom.should == 14
 
       # Smaller than our max zoom level
       table.map.stubs(:get_map_bounds)
                .returns({ minx: 0.000001, maxx: 0.000002, miny: 0.000001 , maxy: 0.000002})
-      table.map.recalculate_zoom!
+      table.map.set_default_boundaries!
       table.map.zoom.should == 18
 
     end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -208,7 +208,7 @@ describe Table do
       }
 
       # To forget about internals of zooming
-      ::Map.any_instance.stubs(:recalculate_zoom!).returns(nil)
+      ::Map.any_instance.stubs(:recalculate_zoom).returns(nil)
 
       visualizations = CartoDB::Visualization::Collection.new.fetch.to_a.length
       table = create_table(name: "epaminondas_pantulis", user_id: @user.id)


### PR DESCRIPTION
See #6901

Reduces number of named map saves during import 13->3 (two are actually needed, so just one extra).

I had to move map from the Relator to Member itself. Although Relator appears to memoize the relations, don't let it fool you, as a new Relator is created for each relation access. This appears to be a bug when extracting those methods to the Relator (2013) but a lot of code depends on this behaviour, specially visualization creation stuff.

Anyway, as I need map to be memoized (so `member.map.visualization` always refers to the same visualization instance) to be able to check if a named map update is already scheduled, I extracted it to Member. This is not a problem as Viz<->Map is 1:1 and never modified.