### PR TITLE
Fix an error in rescue from visualization renaming

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1230,10 +1230,12 @@ class Table
             layer.rename_table(@name_changed_from, name).save
           end
         end
-      rescue exception
-        CartoDB::report_exception(exception,
-                                  "Failed while renaming visualization #{@name_changed_from} to #{name}",
-                                  user: owner)
+      rescue => exception
+        CartoDB::Logger.error(exception: exception,
+                              message: "Failed while renaming visualization",
+                              user: owner,
+                              from_name: @name_changed_from,
+                              to_name: name)
         raise exception
       end
     end


### PR DESCRIPTION
Found this by chance, the rescue is wrong here. Fixed this and took the change to update to the new logger. CR @gfiorav 