### PR TITLE
Data panel fixes

### DIFF
--- a/app/assets/stylesheets/editor-3/stats-list.css.scss
+++ b/app/assets/stylesheets/editor-3/stats-list.css.scss
@@ -34,3 +34,7 @@
   background-color: $cThirdBackground;
   color: $cAltText;
 }
+
+.StatsList-style.is-hidden {
+  display: none;
+}

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -69,6 +69,7 @@ module.exports = CoreView.extend({
           className: 'Editor-content',
           widgetDefinitionsCollection: self.widgetDefinitionsCollection,
           layerDefinitionModel: self.layerDefinitionModel,
+          stackLayoutModel: self.stackLayoutModel,
           configModel: self._configModel,
           editorModel: self._editorModel
         });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-not-ready.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-not-ready.tpl
@@ -1,0 +1,47 @@
+<div class="FormPlaceholder-paragraph u-tSpace-m u-flex">
+  <div class="FormPlaceholder-step u-rSpace--m"></div>
+  <div class="FormPlaceholder-inner">
+    <span class="FormPlaceholder-label FormPlaceholder-size--med u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--med u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--med"></span>
+    <span class="FormPlaceholder-label FormPlaceholder-size--short u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--long u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--long"></span>
+  </div>
+</div>
+
+<div class="FormPlaceholder-paragraph u-tSpace-m u-flex">
+  <div class="FormPlaceholder-step u-rSpace--m"></div>
+  <div class="FormPlaceholder-inner">
+    <span class="FormPlaceholder-label FormPlaceholder-size--med u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--med u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--med"></span>
+    <span class="FormPlaceholder-label FormPlaceholder-size--short u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--long u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--long"></span>
+  </div>
+</div>
+
+<div class="FormPlaceholder-paragraph u-tSpace-m u-flex">
+  <div class="FormPlaceholder-step u-rSpace--m"></div>
+  <div class="FormPlaceholder-inner">
+    <span class="FormPlaceholder-label FormPlaceholder-size--med u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--med u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--med"></span>
+    <span class="FormPlaceholder-label FormPlaceholder-size--short u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--long u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--long"></span>
+  </div>
+</div>
+
+<div class="FormPlaceholder-paragraph u-tSpace-m u-flex">
+  <div class="FormPlaceholder-step u-rSpace--m"></div>
+  <div class="FormPlaceholder-inner">
+    <span class="FormPlaceholder-label FormPlaceholder-size--med u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--med u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--med"></span>
+    <span class="FormPlaceholder-label FormPlaceholder-size--short u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--long u-tSpace-xl"></span>
+    <span class="FormPlaceholder-title FormPlaceholder-size--long"></span>
+  </div>
+</div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -61,6 +61,7 @@ module.exports = CoreView.extend({
     this._querySchemaModel.on('change', this._onQuerySchemaChange, this);
     this.add_related_model(this._querySchemaModel);
     this._optionsCollection.on('change:selected', this._handleWidget, this);
+    this.add_related_model(this._optionsCollection);
   },
 
   _handleWidget: function (model) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -13,30 +13,40 @@ module.exports = CoreView.extend({
     if (!opts.widgetDefinitionsCollection) throw new Error('widgetDefinitionsCollection is required');
     if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-    if (!opts.configModel) throw new Error('configModel is required');
+    if (!opts.tableStats) throw new Error('tableStats is required');
     if (!opts.moreStatsModel) throw new Error('moreStatsModel is required');
 
     this._querySchemaModel = opts.querySchemaModel;
-    this._configModel = opts.configModel;
     this._layerDefinitionModel = opts.layerDefinitionModel;
     this._moreStatsModel = opts.moreStatsModel;
     this._analysisDefinitionNode = this._layerDefinitionModel.getAnalysisDefinitionNodeModel();
     this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
+    this._tableStats = opts.tableStats;
 
     this._optionsCollection = new Backbone.Collection();
     this._initBinds();
+    this._initData();
   },
 
   render: function () {
     this.clearSubViews();
     this.$el.empty();
     if (this._hasFetchedQuerySchema()) {
-      this._createOptionsModels();
       this._renderStats();
     } else {
       this._showLoading();
     }
     return this;
+  },
+
+  _initData: function () {
+    if (this._querySchemaModel.get('status') !== 'fetching') {
+      this._querySchemaModel.fetch();
+    }
+
+    if (this._querySchemaModel.get('status') === 'fetched') {
+      this._createOptionsModels();
+    }
   },
 
   _showLoading: function () {
@@ -48,8 +58,6 @@ module.exports = CoreView.extend({
   _initBinds: function () {
     this._querySchemaModel.on('change', this._onQuerySchemaChange, this);
     this.add_related_model(this._querySchemaModel);
-    this._querySchemaModel.fetch();
-
     this._optionsCollection.on('change:selected', this._handleWidget, this);
   },
 
@@ -66,6 +74,7 @@ module.exports = CoreView.extend({
 
   _onQuerySchemaChange: function () {
     if (this._hasFetchedQuerySchema()) {
+      this._createOptionsModels();
       this.render();
     }
   },
@@ -86,9 +95,9 @@ module.exports = CoreView.extend({
 
     this._optionsCollection.forEach(function (stat) {
       var view = new StatView({
-        configModel: this._configModel,
         widgetDefinitionsCollection: this._widgetDefinitionsCollection,
         moreStatsModel: this._moreStatsModel,
+        tableStats: this._tableStats,
         statModel: stat
       });
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -15,6 +15,7 @@ module.exports = CoreView.extend({
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
     if (!opts.tableStats) throw new Error('tableStats is required');
     if (!opts.moreStatsModel) throw new Error('moreStatsModel is required');
+    if (!opts.stackLayoutModel) throw new Error('StackLayoutModel is required');
 
     this._querySchemaModel = opts.querySchemaModel;
     this._layerDefinitionModel = opts.layerDefinitionModel;
@@ -22,6 +23,7 @@ module.exports = CoreView.extend({
     this._analysisDefinitionNode = this._layerDefinitionModel.getAnalysisDefinitionNodeModel();
     this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
     this._tableStats = opts.tableStats;
+    this._stackLayoutModel = opts.stackLayoutModel;
 
     this._optionsCollection = new Backbone.Collection();
     this._initBinds();
@@ -96,6 +98,7 @@ module.exports = CoreView.extend({
     this._optionsCollection.forEach(function (stat) {
       var view = new StatView({
         widgetDefinitionsCollection: this._widgetDefinitionsCollection,
+        stackLayoutModel: this._stackLayoutModel,
         moreStatsModel: this._moreStatsModel,
         tableStats: this._tableStats,
         statModel: stat

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -4,6 +4,7 @@ var CoreView = require('backbone/core-view');
 var StatView = require('./stat-view');
 var createTuplesItems = require('./create-tuples-items');
 var widgetsTypes = require('./widgets-types');
+var dataNotReadyTemplate = require('./data-content-not-ready.tpl');
 
 module.exports = CoreView.extend({
   className: 'Editor-dataContent',
@@ -32,8 +33,16 @@ module.exports = CoreView.extend({
     if (this._hasFetchedQuerySchema()) {
       this._createOptionsModels();
       this._renderStats();
+    } else {
+      this._showLoading();
     }
     return this;
+  },
+
+  _showLoading: function () {
+    this.$el.append(
+      dataNotReadyTemplate()
+    );
   },
 
   _initBinds: function () {
@@ -62,7 +71,7 @@ module.exports = CoreView.extend({
   },
 
   _hasFetchedQuerySchema: function () {
-    return this._querySchemaModel.get('status') !== 'fetching';
+    return this._querySchemaModel.get('status') === 'fetched';
   },
 
   _renderStats: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -21,12 +21,14 @@ module.exports = CoreView.extend({
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
     if (!opts.editorModel) throw new Error('editorModel is required');
     if (!opts.configModel) throw new Error('configModel is required');
+    if (!opts.stackLayoutModel) throw new Error('StackLayoutModel is required');
 
     this._layerDefinitionModel = opts.layerDefinitionModel;
     this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
 
     this._configModel = opts.configModel;
     this._editorModel = opts.editorModel;
+    this._stackLayoutModel = opts.stackLayoutModel;
     this._nodeModel = this._layerDefinitionModel.getAnalysisDefinitionNodeModel();
     this._querySchemaModel = this._nodeModel.querySchemaModel;
 
@@ -159,6 +161,7 @@ module.exports = CoreView.extend({
             return new DataContentView({
               className: 'Editor-content',
               tableStats: self._tableStats,
+              stackLayoutModel: self._stackLayoutModel,
               widgetDefinitionsCollection: self._widgetDefinitionsCollection,
               moreStatsModel: self._moreStatsModel,
               querySchemaModel: self._querySchemaModel,

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -68,7 +68,7 @@ module.exports = CoreView.extend({
   },
 
   _hasFetchedQuerySchema: function () {
-    return this._querySchemaModel.get('status') !== 'fetching';
+    return this._querySchemaModel.get('status') === 'fetched';
   },
 
   _updateCodeMirrorModel: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -12,6 +12,7 @@ var Infobox = require('../../../../components/infobox/infobox-factory');
 var InfoboxModel = require('../../../../components/infobox/infobox-model');
 var InfoboxCollection = require('../../../../components/infobox/infobox-collection');
 var ShowMoreView = require('./data-show-more-view');
+var TableStats = require('../../../../components/modals/add-widgets/tablestats');
 
 module.exports = CoreView.extend({
 
@@ -39,6 +40,10 @@ module.exports = CoreView.extend({
     this._sqlModel = this._layerDefinitionModel.sqlModel;
     this._infoboxModel = new InfoboxModel({
       state: ''
+    });
+
+    this._tableStats = new TableStats({
+      configModel: this._configModel
     });
 
     this._codemirrorModel = new Backbone.Model({
@@ -153,6 +158,7 @@ module.exports = CoreView.extend({
           createContentView: function () {
             return new DataContentView({
               className: 'Editor-content',
+              tableStats: self._tableStats,
               widgetDefinitionsCollection: self._widgetDefinitionsCollection,
               moreStatsModel: self._moreStatsModel,
               querySchemaModel: self._querySchemaModel,

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/stat-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/stat-view.js
@@ -10,7 +10,8 @@ module.exports = CoreView.extend({
   className: 'StatsList is-hidden',
 
   events: {
-    'click .js-checkbox': '_onSelect'
+    'click .js-checkbox': '_onSelect',
+    'click .js-style': '_onEdit'
   },
 
   initialize: function (opts) {
@@ -18,11 +19,13 @@ module.exports = CoreView.extend({
     if (!opts.statModel) throw new Error('statModel is required');
     if (!opts.moreStatsModel) throw new Error('moreStatsModel is required');
     if (!opts.tableStats) throw new Error('tableStats is required');
+    if (!opts.stackLayoutModel) throw new Error('StackLayoutModel is required');
 
     this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
     this._statModel = opts.statModel;
     this._moreStatsModel = opts.moreStatsModel;
     this._tableStats = opts.tableStats;
+    this._stackLayoutModel = opts.stackLayoutModel;
 
     this.model = new Backbone.Model({
       graph: null
@@ -104,6 +107,12 @@ module.exports = CoreView.extend({
 
   _onSelect: function () {
     this._statModel.set('selected', !this._statModel.get('selected'));
+    this.$('.js-style').toggleClass('is-hidden');
+  },
+
+  _onEdit: function (e) {
+    e.preventDefault();
+    this._stackLayoutModel.goToStep(1, this._statModel.get('widget'), 'widget-content');
   },
 
   _showFormula: function (graph, shown, limit) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/stat-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/stat-view.js
@@ -1,7 +1,6 @@
 var Backbone = require('backbone');
 var _ = require('underscore');
 var CoreView = require('backbone/core-view');
-var TableStats = require('../../../../components/modals/add-widgets/tablestats');
 var template = require('./stat.tpl');
 var templateCategory = require('./stat-category.tpl');
 var templateHistogram = require('./stat-histogram.tpl');
@@ -18,12 +17,12 @@ module.exports = CoreView.extend({
     if (!opts.widgetDefinitionsCollection) throw new Error('widgetDefinitionsCollection is required');
     if (!opts.statModel) throw new Error('statModel is required');
     if (!opts.moreStatsModel) throw new Error('moreStatsModel is required');
-    if (!opts.configModel) throw new Error('configModel is required');
+    if (!opts.tableStats) throw new Error('tableStats is required');
 
     this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
     this._statModel = opts.statModel;
     this._moreStatsModel = opts.moreStatsModel;
-    this._configModel = opts.configModel;
+    this._tableStats = opts.tableStats;
 
     this.model = new Backbone.Model({
       graph: null
@@ -69,12 +68,9 @@ module.exports = CoreView.extend({
 
   _initViews: function () {
     var self = this;
-    var ts = new TableStats({
-      configModel: this._configModel
-    });
     var table = this._statModel.get('table');
     var column = this._statModel.get('name');
-    ts.graphFor(table, column, function (graph) {
+    this._tableStats.graphFor(table, column, function (graph) {
       if (graph.stats) {
         self.model.set({graph: graph});
       }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/stat.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/stat.tpl
@@ -7,7 +7,7 @@
   <div class="WidgetList-inner js-inner">
     <div class="StatsList-header">
       <h3 class="u-ellipsis CDB-Text CDB-Size-medium u-bSpace--xl"><%- _t('editor.data.stats.add-widget') %></h3>
-      <a class="CDB-Text CDB-Size-small" href="#"><div class="StatsList-arrow CDB-Shape-Arrow is-blue u-iBlock  u-rSpace--m"></div> <%- _t('editor.data.stats.style') %></a>
+      <a class="StatsList-style CDB-Text CDB-Size-small js-style <% if (!isSelected) { %> is-hidden <% } %>" href="#"><div class="StatsList-arrow CDB-Shape-Arrow is-blue u-iBlock  u-rSpace--m"></div> <%- _t('editor.data.stats.style') %></a>
     </div>
     <div class="StatsList-details u-bSpace--xl">
       <h2 class="u-ellipsis CDB-Text CDB-Size-large u-rSpace--m"><%- column %></h2>

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
@@ -82,10 +82,13 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
       visible: false
     });
 
+    var stackLayoutModel = jasmine.createSpyObj('stackLayoutModel', ['goToStep']);
+
     view = new DataContentView({
       widgetDefinitionsCollection: widgetDefinitionsCollection,
       layerDefinitionModel: layerDefinitionModel,
       querySchemaModel: querySchemaModel,
+      stackLayoutModel: stackLayoutModel,
       configModel: configModel,
       tableStats: ts,
       moreStatsModel: moreStatsModel,

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
@@ -6,6 +6,7 @@ var QuerySchemaModel = require('../../../../../../../javascripts/cartodb3/data/q
 
 describe('editor/layers/layers-content-view/data/data-content-view', function () {
   var view;
+  var querySchemaModel;
 
   beforeEach(function () {
     var configModel = new ConfigModel({
@@ -14,12 +15,14 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
       api_key: 'foo'
     });
 
-    var querySchemaModel = new QuerySchemaModel({
+    querySchemaModel = new QuerySchemaModel({
       query: 'SELECT * FROM table',
-      status: 'fetched'
+      status: 'unfetched'
     }, {
       configModel: {}
     });
+
+    spyOn(QuerySchemaModel.prototype, 'fetch');
 
     var widgetDefinitionsCollection = new Backbone.Collection([
       {
@@ -30,6 +33,8 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
     ]);
 
     var layerDefinitionModel = new Backbone.Model();
+    spyOn(layerDefinitionModel, 'save');
+
     layerDefinitionModel.getAnalysisDefinitionNodeModel = function () {
       return new Backbone.Model();
     };
@@ -83,8 +88,6 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
 
     spyOn(view, '_handleWidget');
     spyOn(view, 'render').and.callThrough();
-
-    spyOn(view, '_hasFetchedQuerySchema').and.returnValue(true);
     spyOn(view, '_createOptionsModels').and.callFake(function () {
       view._optionsCollection = optionsCollection;
       view._initBinds(); // rebind because we are replacing the collection
@@ -92,12 +95,18 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
     view.render();
   });
 
+  it('should render "placeholder" if query schema model is not fetched', function () {
+    expect(view.$('.FormPlaceholder-paragraph').length).toBe(4);
+    expect(_.keys(view._subviews).length).toBe(0);
+  });
+
   it('should render properly', function () {
+    querySchemaModel.set('status', 'fetched');
     expect(_.keys(view._subviews).length).toBe(3);
   });
 
   it('should bind events properly', function () {
-    view._querySchemaModel.trigger('change');
+    querySchemaModel.set('status', 'fetched');
     expect(view.render).toHaveBeenCalled();
 
     view._optionsCollection.at(0).set({selected: true});

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var ConfigModel = require('../../../../../../../javascripts/cartodb3/data/config-model');
 var DataContentView = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view');
 var QuerySchemaModel = require('../../../../../../../javascripts/cartodb3/data/query-schema-model');
+var TableStats = require('../../../../../../../javascripts/cartodb3/components/modals/add-widgets/tablestats');
 
 describe('editor/layers/layers-content-view/data/data-content-view', function () {
   var view;
@@ -13,6 +14,10 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
       base_url: '/u/pepe',
       user_name: 'cdb',
       api_key: 'foo'
+    });
+
+    var ts = new TableStats({
+      configModel: configModel
     });
 
     querySchemaModel = new QuerySchemaModel({
@@ -82,6 +87,7 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
       layerDefinitionModel: layerDefinitionModel,
       querySchemaModel: querySchemaModel,
       configModel: configModel,
+      tableStats: ts,
       moreStatsModel: moreStatsModel,
       editorModel: new Backbone.Model()
     });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
@@ -17,6 +17,7 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
     }, {
       configModel: {}
     });
+    this.stackLayoutModel = jasmine.createSpyObj('stackLayoutModel', ['goToStep']);
 
     this.layerDefinitionModel = new Backbone.Model();
     this.layerDefinitionModel.getAnalysisDefinitionNodeModel = function () {
@@ -30,6 +31,7 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
 
     this.view = new DataView({
       layerDefinitionModel: this.layerDefinitionModel,
+      stackLayoutModel: this.stackLayoutModel,
       widgetDefinitionsCollection: new Backbone.Collection(),
       querySchemaModel: this.querySchemaModel,
       editorModel: this.editorModel,

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/stat-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/stat-view.spec.js
@@ -25,6 +25,10 @@ describe('editor/layers/layers-content-view/data/stat-view', function () {
       layerDefinitionModel: layerDefinitionModel
     }];
 
+    var ts = new TableStats({
+      configModel: configModel
+    });
+
     var statModel = new Backbone.Model({
       type: 'formula',
       column: 'number',
@@ -54,6 +58,7 @@ describe('editor/layers/layers-content-view/data/stat-view', function () {
       configModel: configModel,
       moreStatsModel: moreStatsModel,
       statModel: statModel,
+      tableStats: ts,
       widgetDefinitionsCollection: widgetDefinitionsCollection
     });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/stat-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/stat-view.spec.js
@@ -54,13 +54,18 @@ describe('editor/layers/layers-content-view/data/stat-view', function () {
       visible: false
     });
 
+    this.stackLayoutModel = jasmine.createSpyObj('stackLayoutModel', ['goToStep']);
+
     view = new StatView({
       configModel: configModel,
+      stackLayoutModel: this.stackLayoutModel,
       moreStatsModel: moreStatsModel,
       statModel: statModel,
       tableStats: ts,
       widgetDefinitionsCollection: widgetDefinitionsCollection
     });
+
+    spyOn(view, 'clean');
 
     var Graph = {
       stats: {
@@ -96,16 +101,25 @@ describe('editor/layers/layers-content-view/data/stat-view', function () {
   });
 
   it('should select/unselect the widget properly', function () {
-    view.$('.js-checkbox').get(0).click();
+    view.$('.js-checkbox').trigger('click');
     expect(view._statModel.get('selected')).toBe(true);
-    view.$('.js-checkbox').get(0).click();
+    expect(view.$('.js-style').hasClass('is-hidden')).toBe(false);
+    view.$('.js-checkbox').trigger('click');
     expect(view._statModel.get('selected')).toBe(false);
+    expect(view.$('.js-style').hasClass('is-hidden')).toBe(true);
   });
 
   it('should be selected when widget is added', function () {
     widgetDefinitionsCollection.at(0).set({type: 'formula'});
     view._locateWidget();
     expect(view._statModel.get('selected')).toBe(true);
+  });
+
+  it('should go to style widget when clicked on style link', function () {
+    view.$('.js-checkbox').trigger('click');
+    expect(view.$('.js-style').hasClass('is-hidden')).toBe(false);
+    view.$('.js-style').trigger('click');
+    expect(this.stackLayoutModel.goToStep).toHaveBeenCalled();
   });
 
   it('should not have any leaks', function () {


### PR DESCRIPTION
This PR fixes #7939.

When creating stat views, we only created an instance of Tablestats in order to take advantage of a persisted object in order to make queries to the sql api. This way only one request is made for the stats. Also, it adds the preload view and connect the style button to the proper view.

cc @xavijam 