### PR TITLE
Prevent errors on overquota checking for organizations without owner

### DIFF
--- a/app/helpers/data_services_metrics_helper.rb
+++ b/app/helpers/data_services_metrics_helper.rb
@@ -11,7 +11,7 @@ module DataServicesMetricsHelper
   end
 
   def get_organization_geocoding_data(organization, from, to)
-    return if organization.owner.nil?
+    organization.require_organization_owner_presence!
     get_geocoding_data(organization.owner, from, to)
   end
 
@@ -20,7 +20,7 @@ module DataServicesMetricsHelper
   end
 
   def get_organization_here_isolines_data(organization, from, to)
-    return if organization.owner.nil?
+    organization.require_organization_owner_presence!
     get_here_isolines_data(organization.owner, from, to)
   end
 
@@ -29,7 +29,7 @@ module DataServicesMetricsHelper
   end
 
   def get_organization_obs_snapshot_data(organization, from, to)
-    return if organization.owner.nil?
+    organization.require_organization_owner_presence!
     get_obs_snapshot_data(organization.owner, from, to)
   end
 
@@ -38,7 +38,7 @@ module DataServicesMetricsHelper
   end
 
   def get_organization_obs_general_data(organization, from, to)
-    return if organization.owner.nil?
+    organization.require_organization_owner_presence!
     get_obs_general_data(organization.owner, from, to)
   end
 

--- a/app/models/carto/organization.rb
+++ b/app/models/carto/organization.rb
@@ -18,6 +18,7 @@ module Carto
     end
 
     def get_geocoding_calls(options = {})
+      require_organization_owner_presence!
       date_to = (options[:to] ? options[:to].to_date : Date.today)
       date_from = (options[:from] ? options[:from].to_date : owner.last_billing_cycle)
       if owner.has_feature_flag?('new_geocoder_quota')
@@ -32,34 +33,39 @@ module Carto
     end
 
     def period_end_date
-      owner.period_end_date
+      owner && owner.period_end_date
     end
 
     def get_new_system_geocoding_calls(options = {})
+      require_organization_owner_presence!
       date_to = (options[:to] ? options[:to].to_date : Date.current)
       date_from = (options[:from] ? options[:from].to_date : owner.last_billing_cycle)
       get_organization_geocoding_data(self, date_from, date_to)
     end
 
     def get_here_isolines_calls(options = {})
+      require_organization_owner_presence!
       date_to = (options[:to] ? options[:to].to_date : Date.today)
       date_from = (options[:from] ? options[:from].to_date : owner.last_billing_cycle)
       get_organization_here_isolines_data(self, date_from, date_to)
     end
 
     def get_obs_snapshot_calls(options = {})
+      require_organization_owner_presence!
       date_to = (options[:to] ? options[:to].to_date : Date.today)
       date_from = (options[:from] ? options[:from].to_date : owner.last_billing_cycle)
       get_organization_obs_snapshot_data(self, date_from, date_to)
     end
 
     def get_obs_general_calls(options = {})
+      require_organization_owner_presence!
       date_to = (options[:to] ? options[:to].to_date : Date.today)
       date_from = (options[:from] ? options[:from].to_date : owner.last_billing_cycle)
       get_organization_obs_general_data(self, date_from, date_to)
     end
 
     def twitter_imports_count(options = {})
+      require_organization_owner_presence!
       date_to = (options[:to] ? options[:to].to_date : Date.today)
       date_from = (options[:from] ? options[:from].to_date : owner.last_billing_cycle)
       Carto::SearchTweet.twitter_imports_count(users.joins(:search_tweets), date_from, date_to)
@@ -115,6 +121,12 @@ module Carto
 
     def get_auth_token
       auth_token.present? ? auth_token : generate_auth_token
+    end
+
+    def require_organization_owner_presence!
+      if owner.nil?
+        raise ::Organization::OrganizationWithoutOwner.new(self)
+      end
     end
 
     private

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -7,6 +7,14 @@ require_relative './permission'
 
 class Organization < Sequel::Model
 
+  class OrganizationWithoutOwner < StandardError
+    attr_reader :organization
+
+    def initialize(organization)
+      @organization = organization
+      super "Organization #{organization.name} has no owner"
+    end
+  end
 
   include CartoDB::OrganizationDecorator
   include Concerns::CartodbCentralSynchronizable
@@ -131,7 +139,7 @@ class Organization < Sequel::Model
   end
 
   def non_owner_users
-    self.users.select { |u| u.id != self.owner.id }
+    users.select { |u| owner && u.id != owner.id }
   end
 
   ##
@@ -141,36 +149,27 @@ class Organization < Sequel::Model
   #
   def self.overquota(delta = 0)
     Organization.all.select do |o|
-        next unless o.check_consistency
-
+      begin
         limit = o.geocoding_quota.to_i - (o.geocoding_quota.to_i * delta)
         over_geocodings = o.get_geocoding_calls > limit
-
         limit = o.here_isolines_quota.to_i - (o.here_isolines_quota.to_i * delta)
         over_here_isolines = o.get_here_isolines_calls > limit
-
         limit = o.obs_snapshot_quota.to_i - (o.obs_snapshot_quota.to_i * delta)
         over_obs_snapshot = o.get_obs_snapshot_calls > limit
-
         limit = o.obs_general_quota.to_i - (o.obs_general_quota.to_i * delta)
         over_obs_general = o.get_obs_general_calls > limit
-
-        limit =  o.twitter_datasource_quota.to_i - (o.twitter_datasource_quota.to_i * delta)
+        limit = o.twitter_datasource_quota.to_i - (o.twitter_datasource_quota.to_i * delta)
         over_twitter_imports = o.get_twitter_imports_count > limit
-
         over_geocodings || over_twitter_imports || over_here_isolines || over_obs_snapshot || over_obs_general
-    end
-  end
-
-  def check_consistency
-    if owner.nil?
-      CartoDB::Logger.error(
-        message: 'Organization without owner',
-        organization: name
-      )
-      false
-    else
-      true
+      rescue OrganizationWithoutOwner => error
+        # Avoid aborting because of inconistent organizations; just omit them
+        CartoDB::Logger.error(
+          message: 'Skipping organization without owner in overquota report',
+          organization: name,
+          exception: error
+        )
+        false
+      end
     end
   end
 
@@ -179,7 +178,7 @@ class Organization < Sequel::Model
   end
 
   def get_geocoding_calls(options = {})
-    return if owner.nil?
+    require_organization_owner_presence!
     date_from, date_to = quota_dates(options)
     if owner.has_feature_flag?('new_geocoder_quota')
       get_organization_geocoding_data(self, date_from, date_to)
@@ -189,7 +188,7 @@ class Organization < Sequel::Model
   end
 
   def get_new_system_geocoding_calls(options = {})
-    return if owner.nil?
+    require_organization_owner_presence! if !options[:from]
     date_to = (options[:to] ? options[:to].to_date : Date.current)
     date_from = (options[:from] ? options[:from].to_date : owner.last_billing_cycle)
     get_organization_geocoding_data(self, date_from, date_to)
@@ -382,6 +381,12 @@ class Organization < Sequel::Model
       'google_maps_client_id', google_maps_key,
       'google_maps_api_key', google_maps_private_key,
       'period_end_date', period_end_date
+  end
+
+  def require_organization_owner_presence!
+    if owner.nil?
+      raise Organization::OrganizationWithoutOwner.new(self)
+    end
   end
 
   private


### PR DESCRIPTION
Fixes #8017 

Note that the methods of DataServicesMetricsHelper were already checking for nil owners. For consistency with existing methods, nil is return in case of lack of owner in all cases.


