### PR TITLE
Add map copier dependency

### DIFF
--- a/app/models/visualization/table_blender.rb
+++ b/app/models/visualization/table_blender.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require_dependency 'map/copier'
+
 module CartoDB
   module Visualization
     class TableBlender


### PR DESCRIPTION
Before it was taken implicitly from the controllers, and I removed it with the visualization copier refactor.

CR @gfiorav 
cc @matallo (thanks for reporting)