### PR TITLE
Check if notifier collection is available before removing the notifier model

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/components/notifier/notifier-item-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/components/notifier/notifier-item-view.js
@@ -88,9 +88,10 @@ module.exports = CoreView.extend({
   _closeHandler: function () {
     var status = this._notifierModel.getStatus();
     var action = this._notifierModel.getAction();
+    var collection = this._notifierModel.collection;
     this._notifierModel.trigger('notification:close', action || status);
     clearTimeout(this._timeout);
-    this._notifierModel.collection.remove(this._notifierModel);
+    collection && collection.remove(this._notifierModel);
   },
 
   _actionHandler: function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.27.30",
+  "version": "3.27.31",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is the case that the notification was included through a collection, isn't it?

CR: @nobuti 