### PR TITLE
8070 builder redirects

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -42,6 +42,7 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def account
+    @user.builder_enabled = 'force-builder' if @user.builder_enabled.nil?
     @can_be_deleted, @cant_be_deleted_reason = can_be_deleted?(@user)
     respond_to do |format|
       format.html { render 'account' }
@@ -64,6 +65,10 @@ class Admin::UsersController < Admin::AdminController
 
     if @user.can_change_email? && attributes[:email].present?
       @user.set_fields(attributes, [:email])
+    end
+
+    if attributes[:builder_enabled].present?
+      @user.set_fields(attributes, [:builder_enabled])
     end
 
     raise Sequel::ValidationFailed.new('Validation failed') unless @user.valid?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -42,7 +42,6 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def account
-    @user.builder_enabled = 'force-builder' if @user.builder_enabled.nil?
     @can_be_deleted, @cant_be_deleted_reason = can_be_deleted?(@user)
     respond_to do |format|
       format.html { render 'account' }

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -58,8 +58,9 @@ class Admin::VisualizationsController < Admin::AdminController
   end
 
   def show
+    table_action = request.original_fullpath =~ %r{/tables/}
     unless current_user.present?
-      if request.original_fullpath =~ %r{/tables/}
+      if table_action
         return(redirect_to CartoDB.url(self, 'public_table_map', {id: request.params[:id]}))
       else
         return(redirect_to CartoDB.url(self, 'public_visualizations_public_map', {id: request.params[:id]}))
@@ -70,10 +71,18 @@ class Admin::VisualizationsController < Admin::AdminController
     @basemaps = @visualization.user.basemaps
 
     unless @visualization.has_write_permission?(current_user)
-      if request.original_fullpath =~ %r{/tables/}
+      if table_action
         return redirect_to CartoDB.url(self, 'public_table_map', {id: request.params[:id], redirected:true})
       else
         return redirect_to CartoDB.url(self, 'public_visualizations_public_map', {id: request.params[:id], redirected:true})
+      end
+    end
+
+    if current_user.force_builder?
+      if table_action
+        return redirect_to CartoDB.url(self, 'builder_dataset', id: request.params[:id])
+      else
+        return redirect_to CartoDB.url(self, 'builder_visualization', id: request.params[:id])
       end
     end
 

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -61,9 +61,9 @@ class Admin::VisualizationsController < Admin::AdminController
     table_action = request.original_fullpath =~ %r{/tables/}
     unless current_user.present?
       if table_action
-        return(redirect_to CartoDB.url(self, 'public_table_map', {id: request.params[:id]}))
+        return(redirect_to CartoDB.url(self, 'public_table_map', id: request.params[:id]))
       else
-        return(redirect_to CartoDB.url(self, 'public_visualizations_public_map', {id: request.params[:id]}))
+        return(redirect_to CartoDB.url(self, 'public_visualizations_public_map', id: request.params[:id]))
       end
     end
 
@@ -72,9 +72,10 @@ class Admin::VisualizationsController < Admin::AdminController
 
     unless @visualization.has_write_permission?(current_user)
       if table_action
-        return redirect_to CartoDB.url(self, 'public_table_map', {id: request.params[:id], redirected:true})
+        return redirect_to CartoDB.url(self, 'public_table_map', id: request.params[:id], redirected: true)
       else
-        return redirect_to CartoDB.url(self, 'public_visualizations_public_map', {id: request.params[:id], redirected:true})
+        return redirect_to CartoDB.url(self, 'public_visualizations_public_map',
+                                       id: request.params[:id], redirected: true)
       end
     end
 

--- a/app/controllers/carto/builder/builder_users_module.rb
+++ b/app/controllers/carto/builder/builder_users_module.rb
@@ -4,24 +4,7 @@ module Carto
   module Builder
     module BuilderUsersModule
       def builder_users_only
-        render_404 unless current_user && builder_user?(current_user)
-      end
-
-      def builder_user?(user)
-        manager_user(user).has_feature_flag?('editor-3')
-      end
-
-      def forced_builder?(user)
-        manager_user(user).force_builder?
-      end
-
-      def forced_editor?(user)
-        manager_user(user).forced_editor?
-      end
-
-      def manager_user(user)
-        org = user.organization
-        org ? org.owner : user
+        render_404 unless current_user && current_user.builder_enabled?
       end
     end
   end

--- a/app/controllers/carto/builder/builder_users_module.rb
+++ b/app/controllers/carto/builder/builder_users_module.rb
@@ -11,6 +11,14 @@ module Carto
         manager_user(user).has_feature_flag?('editor-3')
       end
 
+      def forced_builder?(user)
+        manager_user(user).force_builder?
+      end
+
+      def forced_editor?(user)
+        manager_user(user).forced_editor?
+      end
+
       def manager_user(user)
         org = user.organization
         org ? org.owner : user

--- a/app/controllers/carto/builder/builder_users_module.rb
+++ b/app/controllers/carto/builder/builder_users_module.rb
@@ -8,7 +8,12 @@ module Carto
       end
 
       def builder_user?(user)
-        user.has_feature_flag?('editor-3')
+        manager_user(user).has_feature_flag?('editor-3')
+      end
+
+      def manager_user(user)
+        org = user.organization
+        org ? org.owner : user
       end
     end
   end

--- a/app/controllers/carto/builder/datasets_controller.rb
+++ b/app/controllers/carto/builder/datasets_controller.rb
@@ -28,7 +28,7 @@ module Carto
       private
 
       def redirect_to_editor_if_forced
-        redirect_to CartoDB.url(self, 'public_visualizations_show', id: params[:id]) if current_user.force_editor?
+        redirect_to CartoDB.url(self, 'public_tables_show', id: params[:id]) if current_user.force_editor?
       end
 
       def load_canonical_visualization

--- a/app/controllers/carto/builder/datasets_controller.rb
+++ b/app/controllers/carto/builder/datasets_controller.rb
@@ -28,7 +28,7 @@ module Carto
       private
 
       def redirect_to_editor_if_forced
-        redirect_to CartoDB.url(self, 'public_visualizations_show', id: params[:id]) if forced_editor?(current_user)
+        redirect_to CartoDB.url(self, 'public_visualizations_show', id: params[:id]) if current_user.force_editor?
       end
 
       def load_canonical_visualization

--- a/app/controllers/carto/builder/datasets_controller.rb
+++ b/app/controllers/carto/builder/datasets_controller.rb
@@ -9,6 +9,7 @@ module Carto
 
       ssl_required :show
 
+      before_filter :redirect_to_editor_if_forced, only: [:show]
       before_filter :load_canonical_visualization, only: [:show]
       before_filter :authors_only
       before_filter :load_user_table, only: [:show]
@@ -25,6 +26,10 @@ module Carto
       end
 
       private
+
+      def redirect_to_editor_if_forced
+        redirect_to CartoDB.url(self, 'public_visualizations_show', id: params[:id]) if forced_editor?(current_user)
+      end
 
       def load_canonical_visualization
         @canonical_visualization = load_visualization_from_id_or_name(params[:id])

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -10,6 +10,7 @@ module Carto
 
       ssl_required :show
 
+      before_filter :redirect_to_editor_if_forced, only: [:show]
       before_filter :load_visualization, only: [:show]
       before_filter :authors_only
       before_filter :editable_visualizations_only, only: [:show]
@@ -29,6 +30,10 @@ module Carto
       end
 
       private
+
+      def redirect_to_editor_if_forced
+        redirect_to CartoDB.url(self, 'public_visualizations_show_map', id: params[:id]) if forced_editor?(current_user)
+      end
 
       def load_visualization
         @visualization = load_visualization_from_id_or_name(params[:id])

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -32,7 +32,7 @@ module Carto
       private
 
       def redirect_to_editor_if_forced
-        redirect_to CartoDB.url(self, 'public_visualizations_show_map', id: params[:id]) if forced_editor?(current_user)
+        redirect_to CartoDB.url(self, 'public_visualizations_show_map', id: params[:id]) if current_user.force_editor?
       end
 
       def load_visualization

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1565,11 +1565,16 @@ class User < Sequel::Model
     mobile_max_open_users > 0
   end
 
+  def builder_enabled?
+    user = has_organization? ? organization.owner : self
+    user.has_feature_flag?('editor-3')
+  end
+
   def force_builder?
     builder_enabled.nil? || builder_enabled == FORCE_BUILDER
   end
 
-  def forced_editor?
+  def force_editor?
     builder_enabled == FORCE_EDITOR
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,9 @@ class User < Sequel::Model
 
   COMMON_DATA_ACTIVE_DAYS = 31
 
+  FORCE_BUILDER = 'force-builder'.freeze
+  FORCE_EDITOR  = 'force-editor'.freeze
+
   self.raise_on_typecast_failure = false
   self.raise_on_save_failure = false
 
@@ -1560,6 +1563,14 @@ class User < Sequel::Model
 
   def open_apps_enabled?
     mobile_max_open_users > 0
+  end
+
+  def force_builder?
+    builder_enabled.nil? || builder_enabled == FORCE_BUILDER
+  end
+
+  def forced_editor?
+    builder_enabled == FORCE_EDITOR
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1574,6 +1574,7 @@ class User < Sequel::Model
   end
 
   def force_editor?
+    # Explicit test to false is necessary, as builder_enabled = nil, doesn't force anything
     builder_enabled == false
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,9 +91,6 @@ class User < Sequel::Model
 
   COMMON_DATA_ACTIVE_DAYS = 31
 
-  FORCE_BUILDER = 'force-builder'.freeze
-  FORCE_EDITOR  = 'force-editor'.freeze
-
   self.raise_on_typecast_failure = false
   self.raise_on_save_failure = false
 
@@ -1565,17 +1562,19 @@ class User < Sequel::Model
     mobile_max_open_users > 0
   end
 
+  # The builder is enabled/disabled based on a feature flag
+  # The builder_enabled is used to allow the user to turn it on/off
   def builder_enabled?
     user = has_organization? ? organization.owner : self
     user.has_feature_flag?('editor-3')
   end
 
   def force_builder?
-    builder_enabled.nil? || builder_enabled == FORCE_BUILDER
+    builder_enabled == true
   end
 
   def force_editor?
-    builder_enabled == FORCE_EDITOR
+    builder_enabled == false
   end
 
   private

--- a/app/views/admin/users/account.html.erb
+++ b/app/views/admin/users/account.html.erb
@@ -133,6 +133,25 @@
         </div>
       <% end %>
 
+      <% if (@user.has_feature_flag?('editor-3'))  %>
+      <span class="FormAccount-separator"></span>
+
+      <div class="FormAccount-row">
+        <div class="FormAccount-rowLabel">
+          <label class="FormAccount-label">Builder</label>
+        </div>
+        <div class="FormAccount-rowData">
+          <div class="Toggler">
+            <%= f.check_box :builder_enabled, { id: "builder_enabled" }, 'force-builder', 'force-editor' %>
+            <%= label_tag(:builder_enabled, '') %>
+          </div>
+          <div class="FormAccount-rowInfo FormAccount-rowInfo--marginLeft">
+            <p class="FormAccount-rowInfoText">Use the Builder for creating and updating maps</p>
+          </div>
+        </div>
+      </div>
+      <% end %>
+
       <%# if none of the services are activated, this block shouldn't appear %>
       <% if @services.size > 0 %>
         <div class="FormAccount-title">

--- a/app/views/admin/users/account.html.erb
+++ b/app/views/admin/users/account.html.erb
@@ -133,7 +133,7 @@
         </div>
       <% end %>
 
-      <% if (@user.has_feature_flag?('editor-3'))  %>
+      <% if (@user.builder_enabled?)  %>
       <span class="FormAccount-separator"></span>
 
       <div class="FormAccount-row">

--- a/app/views/admin/users/account.html.erb
+++ b/app/views/admin/users/account.html.erb
@@ -142,7 +142,7 @@
         </div>
         <div class="FormAccount-rowData">
           <div class="Toggler">
-            <%= f.check_box :builder_enabled, { id: "builder_enabled" }, 'force-builder', 'force-editor' %>
+            <%= f.check_box :builder_enabled, id: "builder_enabled" %>
             <%= label_tag(:builder_enabled, '') %>
           </div>
           <div class="FormAccount-rowInfo FormAccount-rowInfo--marginLeft">

--- a/db/migrate/20160624101145_add_builder_enabled_to_users.rb
+++ b/db/migrate/20160624101145_add_builder_enabled_to_users.rb
@@ -1,7 +1,7 @@
 Sequel.migration do
   change do
     alter_table :users do
-      add_column :builder_enabled, :text
+      add_column :builder_enabled, :boolean, null: true, default: true
     end
   end
 end

--- a/db/migrate/20160624101145_add_builder_enabled_to_users.rb
+++ b/db/migrate/20160624101145_add_builder_enabled_to_users.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :users do
+      add_column :builder_enabled, :text
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
     table_quota            5
     quota_in_bytes         5000000
     id                     { UUIDTools::UUID.timestamp_create.to_s }
+    builder_enabled        'no-redirect'
 
     trait :admin_privileges do
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,7 +14,6 @@ FactoryGirl.define do
     table_quota            5
     quota_in_bytes         5000000
     id                     { UUIDTools::UUID.timestamp_create.to_s }
-    builder_enabled        'no-redirect'
 
     trait :admin_privileges do
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
     table_quota            5
     quota_in_bytes         5000000
     id                     { UUIDTools::UUID.timestamp_create.to_s }
+    builder_enabled        nil
 
     trait :admin_privileges do
 


### PR DESCRIPTION
This add a new option for users to enable/disable the builder. It adds redirects between the editors based on that setting.

Migration notes:
 - Will be split to be merged separately after CR
 - Field is nullable to avoid rewriting the table. Also, to test if this avoids triggering errors while migrating.
 - The field is actually ternary, not boolean. You can put any othervalue to disable redirects altogether (for devs, so they have access to both editors).

![screenshot_20160624_142605](https://cloud.githubusercontent.com/assets/7569673/16337733/e9b1d186-3a17-11e6-8d0a-9adeb7a8ceaf.png)

Closes #8070 