### PR TITLE
Uses underscore instead of math max

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/tablestats.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/tablestats.js
@@ -199,6 +199,10 @@ ColumnGraph.prototype = {
       histogram = this._getHistogramFromBounds(bins);
     } else return;
 
+    if (!histogram || _.isEmpty(histogram)) {
+      return;
+    }
+
     if (this.normalize) {
       var max = _.max(histogram);
       histogram = histogram.map(function (bin) {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/tablestats.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/tablestats.js
@@ -200,7 +200,7 @@ ColumnGraph.prototype = {
     } else return;
 
     if (this.normalize) {
-      var max = Math.max.apply(null, histogram);
+      var max = _.max(histogram);
       histogram = histogram.map(function (bin) {
         return bin / max;
       });


### PR DESCRIPTION
Was using way too many arguments in `Math.max`. Using underscore's implementation instead.

Fixes #8159 

cr @nobuti ?