### PR TITLE
basemaps: link infowindows with labelsontop

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/link-layer-infowindow.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/link-layer-infowindow.js
@@ -8,7 +8,7 @@ module.exports = function linkLayerInfowindow (layerDef, visMap) {
     var attrs = JSON.parse(JSON.stringify(infowindowModel.attributes));
 
     if (infowindowModel.isEmptyTemplate()) {
-      var cartdb_id = layerDef.getAnalysisDefinitionNodeModel().querySchemaModel.columnsCollection.find(function (m) {
+      var cartdb_id = layerDef.getAnalysisDefinitionNodeModel() && layerDef.getAnalysisDefinitionNodeModel().querySchemaModel.columnsCollection.find(function (m) {
         return m.get('name') === 'cartodb_id';
       });
 

--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/link-layer-infowindow.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/link-layer-infowindow.js
@@ -8,7 +8,9 @@ module.exports = function linkLayerInfowindow (layerDef, visMap) {
     var attrs = JSON.parse(JSON.stringify(infowindowModel.attributes));
 
     if (infowindowModel.isEmptyTemplate()) {
-      var cartdb_id = layerDef.getAnalysisDefinitionNodeModel() && layerDef.getAnalysisDefinitionNodeModel().querySchemaModel.columnsCollection.find(function (m) {
+      var node = layerDef.getAnalysisDefinitionNodeModel();
+
+      var cartdb_id = node && node.querySchemaModel.columnsCollection.find(function (m) {
         return m.get('name') === 'cartodb_id';
       });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.27.38",
+  "version": "3.27.40",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
close https://github.com/CartoDB/cartodb/issues/8188

- prevent basemaps with labels on top to fail when `layerDef.getAnalysisDefinitionNodeModel()` is undefined

CR @viddo /cc @gfiorav 