### PR TITLE
Don't sync query changes for source nodes

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -63,21 +63,24 @@ F.prototype._analyseDefinitionNode = function (nodeDefModel) {
 };
 
 F.prototype._tryToSetupDefinitionNodeSync = function (m) {
-  // Only setup syncing between node-definition and node sync once
-  if (!m.__synced) {
-    var node = this._analysis().findNodeById(m.id);
-    if (node) {
-      m.__synced = true;
-      var updateAnalysisQuerySchema = function () {
-        m.querySchemaModel.set({
-          query: node.get('query'),
-          may_have_rows: node.get('status') === 'ready'
-        });
-      };
-      updateAnalysisQuerySchema();
-      m.listenTo(node, 'change', updateAnalysisQuerySchema);
-      m.listenToOnce(node, 'destroy', m.stopListening);
-    }
+  if (m.__syncSetup) return; // only setup once
+
+  var node = this._analysis().findNodeById(m.id);
+  if (!node) return; // might not exist when method is called, so do no thing to allow retries
+
+  m.__syncSetup = true;
+
+  // Don't need to sync source nodes
+  if (node.get('type') !== 'source') {
+    var updateAnalysisQuerySchema = function () {
+      m.querySchemaModel.set({
+        query: node.get('query'),
+        may_have_rows: node.get('status') === 'ready'
+      });
+    };
+    updateAnalysisQuerySchema();
+    m.listenTo(node, 'change', updateAnalysisQuerySchema);
+    m.listenToOnce(node, 'destroy', m.stopListening);
   }
 };
 

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -66,7 +66,7 @@ F.prototype._tryToSetupDefinitionNodeSync = function (m) {
   if (m.__syncSetup) return; // only setup once
 
   var node = this._analysis().findNodeById(m.id);
-  if (!node) return; // might not exist when method is called, so do no thing to allow retries
+  if (!node) return; // might not exist when method is called, so do nothing to allow retries
 
   m.__syncSetup = true;
 

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -408,7 +408,7 @@ describe('deep-insights-integrations', function () {
 
   describe('when analysis-definition-node is created', function () {
     beforeEach(function () {
-      this.nodeDefModel = this.analysisDefinitionNodesCollection.add({
+      this.a0 = this.analysisDefinitionNodesCollection.add({
         id: 'a0',
         type: 'source',
         params: {
@@ -430,7 +430,7 @@ describe('deep-insights-integrations', function () {
     describe('when changed', function () {
       beforeEach(function () {
         this.analysis.analyse.calls.reset();
-        this.nodeDefModel.set('query', 'SELECT * FROM foobar LIMIT 10');
+        this.a0.set('query', 'SELECT * FROM foobar LIMIT 10');
       });
 
       it('should analyse node again but with changed query', function () {
@@ -445,14 +445,15 @@ describe('deep-insights-integrations', function () {
       });
     });
 
-    describe('when an analysis-definition is added', function () {
+    describe('when an analysis-definition is added for source node', function () {
       beforeEach(function () {
-        this.analysisDefinitionsCollection.add({analysis_definition: this.nodeDefModel.toJSON()});
+        spyOn(this.a0.querySchemaModel, 'set');
+        this.analysisDefinitionsCollection.add({analysis_definition: this.a0.toJSON()});
       });
 
       it('should setup query schema model of node-definition', function () {
-        expect(this.nodeDefModel.querySchemaModel.get('query')).toEqual('SELECT * FROM foobar');
-        expect(this.nodeDefModel.querySchemaModel.get('may_have_rows')).toBe(false);
+        expect(this.a0.querySchemaModel.get('query')).toEqual('SELECT * FROM foobar');
+        expect(this.a0.querySchemaModel.get('may_have_rows')).toBe(true);
       });
 
       describe('when analysis node has finished executing', function () {
@@ -460,20 +461,54 @@ describe('deep-insights-integrations', function () {
           this.analysis.findNodeById('a0').set('status', 'ready');
         });
 
-        it('should update the query-schema-model', function () {
-          expect(this.nodeDefModel.querySchemaModel.get('query')).toEqual('SELECT * FROM foobar');
-          expect(this.nodeDefModel.querySchemaModel.get('may_have_rows')).toBe(true);
+        it('should not affect the query-schema-model if its a source', function () {
+          expect(this.a0.querySchemaModel.set).not.toHaveBeenCalled();
         });
       });
 
       describe('when analysis-definition-node is removed', function () {
         beforeEach(function () {
           expect(this.analysis.findNodeById('a0')).toBeDefined();
-          this.analysisDefinitionNodesCollection.remove(this.nodeDefModel);
+          this.analysisDefinitionNodesCollection.remove(this.a0);
         });
 
         it('should remove node', function () {
           expect(this.analysis.findNodeById('a0')).toBeUndefined();
+        });
+      });
+    });
+
+    describe('when an analysis definition is added for non-source node', function () {
+      beforeEach(function () {
+        this.analysisDefinitionsCollection.add({
+          analysis_definition: {
+            id: 'a1',
+            type: 'buffer',
+            params: {
+              radius: 10,
+              source: this.a0.toJSON()
+            }
+          }
+        });
+        this.a1 = this.analysisDefinitionNodesCollection.get('a1');
+      });
+
+      it('should setup query schema model of node-definition', function () {
+        expect(this.a1.querySchemaModel.get('query')).toEqual(undefined);
+        expect(this.a1.querySchemaModel.get('may_have_rows')).toBe(false);
+      });
+
+      describe('when analysis node has finished executing', function () {
+        beforeEach(function () {
+          this.analysis.findNodeById('a1').set({
+            query: 'SELECT buffer FROM tmp_result_table_123',
+            status: 'ready'
+          });
+        });
+
+        it('should update the query-schema-model', function () {
+          expect(this.a1.querySchemaModel.get('query')).toEqual('SELECT buffer FROM tmp_result_table_123');
+          expect(this.a1.querySchemaModel.get('may_have_rows')).toBe(true);
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.27.41",
+  "version": "3.27.42",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The query is always fixed and set from editor, so no need to listen to changes from analysis nodes in cartodb.js. So, with this a layer with a source node (i.e. no analysis) should allow modifying the styles w/o risking the geometry to be unknown.

@xavijam please review
cc @AbelVM 