### PR TITLE
[popups] custom, fix change select

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
@@ -178,6 +178,10 @@ module.exports = Backbone.Model.extend({
     return this.get('template_name') && this.TEMPLATES[this.get('template_name')];
   },
 
+  isCustomTemplate: function () {
+    return this.get('template_name') === '' && this.get('template') !== '';
+  },
+
   wrongTemplate: function () {
     return this.get('template_name') && !this.TEMPLATES[this.get('template_name')];
   }

--- a/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
@@ -180,10 +180,6 @@ module.exports = Backbone.Model.extend({
 
   isCustomTemplate: function () {
     return this.get('template_name') === '' && this.get('template') !== '';
-  },
-
-  wrongTemplate: function () {
-    return this.get('template_name') && !this.TEMPLATES[this.get('template_name')];
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
@@ -25,7 +25,7 @@ module.exports = CoreView.extend({
 
     // Set edition attribute in case custom html is applied
     this._editorModel.set({
-      edition: this.model.get('template_name') === ''
+      edition: this.model.isCustomTemplate()
     });
 
     // There is a case when creating an empty map, then adding a point
@@ -43,7 +43,7 @@ module.exports = CoreView.extend({
 
   _initModels: function () {
     var content;
-    if (this.model.get('template_name') === '') {
+    if (this.model.isCustomTemplate()) {
       content = this.model.get('template');
     } else {
       content = this._getTemplateContent();
@@ -172,7 +172,7 @@ module.exports = CoreView.extend({
   _configPanes: function () {
     var self = this;
     var tabPaneTabs = [{
-      selected: self.model.get('template_name') !== '',
+      selected: !self.model.isCustomTemplate(),
       createContentView: function () {
         return new ScrollView({
           createContentView: function () {
@@ -187,7 +187,7 @@ module.exports = CoreView.extend({
         return new CoreView();
       }
     }, {
-      selected: self.model.get('template_name') === '',
+      selected: self.model.isCustomTemplate(),
       createContentView: function () {
         return new InfoWindowHTMLView({
           onApplyEvent: self._saveInfowindowHTML.bind(self),
@@ -211,7 +211,7 @@ module.exports = CoreView.extend({
 
   _onChangeEdition: function () {
     var edition = this._editorModel.get('edition');
-    var html_custom = this.model.get('template_name') === '';
+    var html_custom = this.model.isCustomTemplate();
 
     if (!edition && html_custom) {
       this._infoboxModel.set({state: 'confirm'});

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
@@ -28,13 +28,6 @@ module.exports = CoreView.extend({
       edition: this.model.isCustomTemplate()
     });
 
-    // There is a case when creating an empty map, then adding a point
-    // and in the builder, the template_name is 'table/views/infowindow_light'
-    // In this case, we set the default template
-    if (this.model.wrongTemplate()) {
-      this.model.set({template_name: this.model.defaults.template_name});
-    }
-
     this._initModels();
     this._initBinds();
     this._configPanes();

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindows-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindows-view.js
@@ -109,10 +109,18 @@ module.exports = CoreView.extend({
 
     switch (this._layerTabPaneView.getSelectedTabPaneName()) {
       case 'click':
-        selectedChild = this._layerInfowindowModel.hasTemplate() ? _t('editor.layers.infowindow.style.' + this._layerInfowindowModel.get('template_name')) : _t('editor.layers.infowindow.style.none');
+        if (this._layerInfowindowModel.hasTemplate()) {
+          selectedChild = _t('editor.layers.infowindow.style.' + this._layerInfowindowModel.get('template_name'));
+        } else {
+          selectedChild = this._layerInfowindowModel.isCustomTemplate() ? _t('editor.layers.infowindow.style.custom') : _t('editor.layers.infowindow.style.none');
+        }
         break;
       case 'hover':
-        selectedChild = this._layerTooltipModel.hasTemplate() ? _t('editor.layers.tooltip.style.' + this._layerTooltipModel.get('template_name')) : _t('editor.layers.tooltip.style.none');
+        if (this._layerTooltipModel.hasTemplate()) {
+          selectedChild = _t('editor.layers.tooltip.style.' + this._layerTooltipModel.get('template_name'));
+        } else {
+          selectedChild = this._layerTooltipModel.isCustomTemplate() ? _t('editor.layers.tooltip.style.custom') : _t('editor.layers.tooltip.style.none');
+        }
         break;
     }
 
@@ -140,9 +148,6 @@ module.exports = CoreView.extend({
 
   _onChangeTemplate: function () {
     this._updateSelectedChild();
-
-    if (this._editorModel.get('edition') === false) {
-      this.render();
-    }
   }
+
 });

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -691,6 +691,7 @@
           "window-size": "Window size",
           "header-color": "Header color",
           "none": "None",
+          "custom": "Custom",
           "infowindow_light": "Light",
           "infowindow_dark": "Dark",
           "infowindow_color": "Color",
@@ -704,6 +705,7 @@
       "tooltip": {
         "style": {
           "none": "None",
+          "custom": "Custom",
           "tooltip_light": "Light",
           "tooltip_dark": "Dark"
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.27.41",
+  "version": "3.27.44",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
close #8228 

better use methods in the definition model than string checks (I should have spotted this in the review), the empty template name wasn't quite right as that can perfectly be a select option; the custom template is empty template name and template not empty

also, I removed that _wrong_ code as with the last mirgation we're not exposing that `table/views/infowindow_light` anymore (copying @juanignaciosl to confirm)

CR @nobuti /cc @juanignaciosl 