### PR TITLE
Show all analysis nodes in the source options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,8 +21,6 @@
       throw grunt.util.error(env +' file is missing! See '+ env +'.sample for how it should look like');
     }
 
-    env.tape_tests = 'lib/assets/test/tape/**/*-test.js';
-
     var aws = {};
     if (grunt.file.exists('./lib/build/grunt-aws.json')) {
       aws = grunt.file.readJSON('./lib/build/grunt-aws.json');

--- a/lib/assets/javascripts/cartodb3/data/query-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-schema-model.js
@@ -44,8 +44,12 @@ module.exports = Backbone.Model.extend({
     return this._configModel.getSqlApiUrl();
   },
 
+  isFetched: function () {
+    return this.get('status') === 'fetched';
+  },
+
   canFetch: function () {
-    return this.get('query') && !this._isFetched();
+    return this.get('query') && !this.isFetched();
   },
 
   fetch: function (opts) {
@@ -98,6 +102,16 @@ module.exports = Backbone.Model.extend({
     return true;
   },
 
+  /**
+   * @return {Geom} value object or null if not available
+   */
+  getGeometry: function () {
+    var row = this.rowsSampleCollection.find(this._getRawGeomFromRow);
+    return row
+      ? createGeometry(this._getRawGeomFromRow(row))
+      : null;
+  },
+
   _onChange: function () {
     if (!this.hasChanged('status') && this.get('status') === 'fetching') {
       // If is already fetching just redo the fetch with latest attrs
@@ -115,16 +129,6 @@ module.exports = Backbone.Model.extend({
     }
   },
 
-  /**
-   * @return {Geom} value object or null if not available
-   */
-  getGeometry: function () {
-    var row = this.rowsSampleCollection.find(this._getRawGeomFromRow);
-    return row
-      ? createGeometry(this._getRawGeomFromRow(row))
-      : null;
-  },
-
   _getRawGeomFromRow: function (m) {
     return m.get('the_geom') || m.get('the_geom_webmercator');
   },
@@ -139,10 +143,6 @@ module.exports = Backbone.Model.extend({
     return this.get('query').length > MAX_GET_LENGTH
       ? 'POST'
       : 'GET';
-  },
-
-  _isFetched: function () {
-    return this.get('status') === 'fetched';
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-source-options-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-source-options-model.js
@@ -11,15 +11,13 @@ module.exports = Backbone.Model.extend({
 
   defaults: {
     fetching: false,
-    layer_source_select_options: []
+    nodes_options: []
   },
 
   initialize: function (attrs, opts) {
     if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
-    if (!opts.layerDefinitionsCollection) throw new Error('layerDefinitionsCollection is required');
-    if (!opts.tablesCollection) throw new Error('layerDefinitionsCollection is required');
+    if (!opts.tablesCollection) throw new Error('tablesCollection is required');
 
-    this._layerDefinitionsCollection = opts.layerDefinitionsCollection;
     this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
     this._tablesCollection = opts.tablesCollection;
   },
@@ -27,13 +25,13 @@ module.exports = Backbone.Model.extend({
   fetch: function () {
     this.set({
       fetching: true,
-      layer_source_select_options: []
+      nodes_options: []
     });
 
     var queue = queueAsync();
 
     this._fetchTables(queue);
-    this._createLayerSourceOptions(queue);
+    this._createOptionsFromNodes(queue);
 
     queue.awaitAll(function () {
       this.set('fetching', false);
@@ -50,15 +48,16 @@ module.exports = Backbone.Model.extend({
       requiredSimpleGeometryTypes = [requiredSimpleGeometryTypes];
     }
 
-    var layerSourceOpts = this
-      .get('layer_source_select_options')
-      .filter(function (d) {
-        return this._isValidGeometry(requiredSimpleGeometryTypes, d.simpleGeometryType);
-      }, this)
-      .map(function (d) {
-        return _.extend({ type: 'node' }, d);
-      });
-    return layerSourceOpts.concat(this._getTablesSelectOptions(requiredSimpleGeometryTypes));
+    return _.flatten([
+      this.get('nodes_options')
+        .filter(function (d) {
+          return this._isValidGeometry(requiredSimpleGeometryTypes, d.simpleGeometryType);
+        }, this)
+        .map(function (d) {
+          return _.extend({ type: 'node' }, d);
+        }),
+      this._getTablesSelectOptions(requiredSimpleGeometryTypes)
+    ]);
   },
 
   /**
@@ -96,44 +95,45 @@ module.exports = Backbone.Model.extend({
     }.bind(this));
   },
 
-  _createLayerSourceOptions: function (queue) {
-    var layerSourceSelectOptions = this.get('layer_source_select_options');
+  _createOptionsFromNodes: function (queue) {
+    var self = this;
 
-    this._layerDefinitionsCollection
-      .each(function (m) {
-        var nodeDefModel = m.getAnalysisDefinitionNodeModel();
-        var layerName = m.getName();
+    this._analysisDefinitionNodesCollection
+      .each(function (nodeDefModel) {
+        var querySchemaModel = nodeDefModel.querySchemaModel;
 
-        if (nodeDefModel) {
-          var querySchemaModel = nodeDefModel.querySchemaModel;
+        queue.defer(function (cb) {
+          if (querySchemaModel.isFetched()) {
+            self._appendNodeOption(nodeDefModel);
+            return cb();
+          }
 
-          queue.defer(function (cb) {
-            if (!querySchemaModel.canFetch()) {
-              cb();
-              return;
-            }
+          if (!querySchemaModel.canFetch()) {
+            return cb();
+          }
 
-            var onStatusChange = function () {
-              if (querySchemaModel.get('status') === 'fetching') return;
-              querySchemaModel.off('change:status', onStatusChange);
+          var onStatusChange = function () {
+            if (querySchemaModel.get('status') === 'fetching') return;
+            querySchemaModel.off('change:status', onStatusChange);
+            self._appendNodeOption(nodeDefModel);
+            cb();
+          };
+          querySchemaModel.on('change:status', onStatusChange);
+          querySchemaModel.fetch();
+        });
+      });
+  },
 
-              var geom = querySchemaModel.getGeometry();
+  _appendNodeOption: function (nodeDefModel) {
+    var geom = nodeDefModel.querySchemaModel.getGeometry();
+    if (!geom) return;
 
-              if (geom) {
-                layerSourceSelectOptions.push({
-                  simpleGeometryType: geom.getSimpleType(),
-                  val: nodeDefModel.id,
-                  label: nodeDefModel.id + ' (' + layerName + ')'
-                });
-              }
-
-              cb();
-            };
-            querySchemaModel.on('change:status', onStatusChange);
-            querySchemaModel.fetch();
-          });
-        }
-      }, this);
+    this.get('nodes_options')
+      .push({
+        simpleGeometryType: geom.getSimpleType(),
+        val: nodeDefModel.id,
+        label: nodeDefModel.id
+      });
   },
 
   _getTablesSelectOptions: function (requiredSimpleGeometryTypes) {

--- a/lib/assets/test/jasmine/cartodb3/editor/layers/layer-content-view/analyses/analysis-source-options-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/editor/layers/layer-content-view/analyses/analysis-source-options-model.spec.js
@@ -3,9 +3,8 @@ var geometry = require('../../../../../../../javascripts/cartodb3/value-objects/
 var AnalysisDefinitionNodesCollection = require('../../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var TablesCollection = require('../../../../../../../javascripts/cartodb3/data/tables-collection');
 var AnalysisSourceOptionsModel = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-source-options-model');
-var LayerDefinitionsCollection = require('../../../../../../../javascripts/cartodb3/data/layer-definitions-collection');
 
-describe('editor/layers/layer-content-views/analyses/analysis-source-options-model', function () {
+describe('cartodb3/editor/layers/layer-content-views/analyses/analysis-source-options-model', function () {
   beforeEach(function () {
     var configModel = new ConfigModel({
       base_url: '/u/pepe'
@@ -15,20 +14,11 @@ describe('editor/layers/layer-content-views/analyses/analysis-source-options-mod
       configModel: configModel
     });
 
-    this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
-      configModel: configModel,
-      analysisDefinitionsCollection: {},
-      analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
-      mapId: 'map-123',
-      basemaps: {}
-    });
-    this.layerDefinitionModel = this.layerDefinitionsCollection.add({
-      id: 'l-1',
-      kind: 'carto',
-      options: {
-        table_name: 'foo',
-        cartocss: 'asd',
-        source: 'a0'
+    this.analysisDefinitionNodesCollection.add({
+      id: 'a0',
+      type: 'source',
+      params: {
+        query: 'SELECT * FROM first'
       }
     });
 
@@ -38,7 +28,6 @@ describe('editor/layers/layer-content-views/analyses/analysis-source-options-mod
 
     this.model = new AnalysisSourceOptionsModel(null, {
       analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
-      layerDefinitionsCollection: this.layerDefinitionsCollection,
       tablesCollection: this.tablesCollection
     });
   });
@@ -48,6 +37,30 @@ describe('editor/layers/layer-content-views/analyses/analysis-source-options-mod
     expect(this.model.getSelectOptions('polygon')).toEqual([]);
   });
 
+  describe('when analysis are already fetched', function () {
+    beforeEach(function () {
+      spyOn(this.tablesCollection, 'fetch');
+      spyOn(this.analysisDefinitionNodesCollection.first().querySchemaModel, 'fetch');
+      spyOn(this.analysisDefinitionNodesCollection.first().querySchemaModel, 'getGeometry').and.returnValue(geometry('0106000020E61000000100000001030000000100000016000000000000C0D4211740000000A07DC34840000000C0285C1740000000E0AEC6484000000000BF98174000000060D5D44840000000A03F48174000000020E4DF48400000000096FC164000000060CBE54840000000C06903174000000000B1EC484000000060A8EC16400000008073F2484000000060BB3B17400000006005FB48400000000065471740000000203E0149400000002085EB1740000000000B16494000000080826D1840000000207915494000000040FF861840000000601110494000000040138F18400000004092FF484000000080814E1940000000A07BEB484000000060C1161A4000000020D2E74840000000E0CE0A1A40000000A06ADA484000000060707D1940000000A08DCB484000000000EA721940000000A0E0BA4840000000603EA91840000000609AC0484000000000F1EC17400000008062B948400000000074DA17400000004081BE4840000000C0D4211740000000A07DC34840'));
+      this.analysisDefinitionNodesCollection.first().querySchemaModel.set('status', 'fetched');
+
+      this.model.fetch();
+
+      this.tablesCollection.trigger('sync');
+      expect(this.model.get('fetching')).toBe(false);
+    });
+
+    it('should populate nodes from already fetched nodes', function () {
+      expect(this.model.getSelectOptions('polygon')).toEqual([
+        jasmine.objectContaining({
+          val: 'a0',
+          label: 'a0',
+          type: 'node'
+        })
+      ]);
+    });
+  });
+
   describe('when analysis nodes are fetched', function () {
     beforeEach(function () {
       spyOn(this.tablesCollection, 'fetch');
@@ -55,7 +68,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-source-options-mod
       this.model.fetch();
     });
 
-    it('should is fetching', function () {
+    it('should be in fetching state', function () {
       expect(this.model.get('fetching')).toBe(true);
     });
 
@@ -80,7 +93,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-source-options-mod
         expect(this.model.getSelectOptions('polygon')).toEqual([
           jasmine.objectContaining({
             val: 'a0',
-            label: 'a0 (foo)',
+            label: 'a0',
             type: 'node'
           })
         ]);
@@ -98,7 +111,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-source-options-mod
         expect(this.model.getSelectOptions(['polygon', 'point'])).toEqual([
           jasmine.objectContaining({
             val: 'a0',
-            label: 'a0 (foo)',
+            label: 'a0',
             type: 'node'
           }),
           jasmine.objectContaining({
@@ -113,7 +126,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-source-options-mod
         expect(this.model.getSelectOptions(['*'])).toEqual([
           jasmine.objectContaining({
             val: 'a0',
-            label: 'a0 (foo)',
+            label: 'a0',
             type: 'node'
           }),
           jasmine.objectContaining({

--- a/lib/build/tasks/watch.js
+++ b/lib/build/tasks/watch.js
@@ -14,14 +14,14 @@ exports.task = function() {
   js.push(['lib/assets/javascripts/cdb/src/**/*.js']);
 
   return {
-    tape: {
+    jasmine: {
       files: [
         'lib/assets/javascripts/cartodb3/**/*.js',
         'lib/assets/test/jasmine/**/*.js'
       ],
       tasks: ['npm-test'],
       options: {
-        spawn: true, // don't share context with others watchers, only want to rerun the tape tests separately
+        spawn: true, // don't share context with others watchers, only want to rerun the jasmine tests separately
         interrupt: true,
         atBegin: false
       }


### PR DESCRIPTION
Fixes #8265 

At the time of implementation it was only allowed to select layers' head nodes as input sources, this changes the options to include _all_ nodes (except for the self). 
Also fixed the bug where source options weren’t shown in the options if the query-schema was already fetched. 

E.g.

![screen shot 2016-06-28 at 11 30 59](https://cloud.githubusercontent.com/assets/978461/16410837/9e345462-3d24-11e6-8efc-70322cb6dbc1.png) ![screen shot 2016-06-28 at 11 30 53](https://cloud.githubusercontent.com/assets/978461/16410836/9e2f5944-3d24-11e6-95ac-9827632517a0.png)

@javisantana @saleiva  Right now only the input source is filtered out (A2 in the example above), but we could potentially have trouble if we don't filter out nodes that creates cycles (e.g. a node in layer A, which has a node that points to a node in B…), but we can solve that separately…

@xavijam review, please