### PR TITLE
Reset analysis payload once it has been used

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -105,6 +105,7 @@ module.exports = CoreView.extend({
         } else {
           selectedNodeId = self.layerDefinitionModel.get('source');
         }
+        analysisPayload = null; // remove payload once we have used it, to not have it being invoked again when switching tabs
 
         return new LayerContentAnalysesView({
           className: 'Editor-content',


### PR DESCRIPTION
Fixes #7826 

Navigating between the tabs caused the payload from the creation to be reused (due to the lifecycle closure of the parent render), causing the analysis view to create a new form model for the payload, instead of creating it from the persisted node of the layer as expected.

cc @xavijam not much to review, but oh well