### PR TITLE
Apply default style when a new analysis has been added and it is ready

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -74,10 +74,13 @@ F.prototype._onAnalysisAdded = function (nodeDefModel) {
           if (nodeDefModel.querySchemaModel.get('status') === 'fetched') {
             var geom = nodeDefModel.querySchemaModel.getGeometry();
             var simpleType = geom && geom.getSimpleType();
+            var layer = _.first(this._layerDefinitionsCollection.where({ source: node.get('id') }));
 
-            setTimeout(function () {
-              this._layerDefinitionsCollection.at(1).styleModel.setDefaultPropertiesByType('simple', simpleType);
-            }.bind(this), 1000);
+            if (layer && simpleType) {
+              setTimeout(function () {
+                layer.styleModel.setDefaultPropertiesByType('simple', simpleType);
+              }, 1000);
+            }
             nodeDefModel.querySchemaModel.unbind('change:status', onChangeStatus, this);
           }
         };

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -16,7 +16,7 @@ var F = function (opts) {
   this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
   this._analysisDefinitionsCollection = opts.analysisDefinitionsCollection;
 
-  this._analysisDefinitionNodesCollection.on('add', this._analyseDefinitionNode, this);
+  this._analysisDefinitionNodesCollection.on('add', this._onAnalysisAdded, this);
   this._analysisDefinitionNodesCollection.on('change', this._analyseDefinitionNode, this);
   this._analysisDefinitionNodesCollection.on('remove', this._onAnalysisDefinitionNodeRemoved, this);
   this._analysisDefinitionsCollection.on('add change:node_id sync', this._analyseDefinition, this);
@@ -31,6 +31,8 @@ var F = function (opts) {
     linkLayerInfowindow(layerDefModel, this.visMap());
     linkLayerTooltip(layerDefModel, this.visMap());
   }, this);
+
+  this._layerDefinitionsCollection = opts.layerDefinitionsCollection;
 
   opts.widgetDefinitionsCollection.on('add', this._onWidgetDefinitionAdded, this);
   opts.widgetDefinitionsCollection.on('sync', this._onWidgetDefinitionSynced, this);
@@ -52,6 +54,45 @@ F.prototype._analyseDefinition = function (m) {
   var id = m.get('node_id');
   var nodeDefModel = this._analysisDefinitionNodesCollection.get(id);
   this._analyseDefinitionNode(nodeDefModel);
+};
+
+F.prototype._onAnalysisAdded = function (nodeDefModel) {
+  var attrs = nodeDefModel.toJSON({skipOptions: true});
+  this._analysis().analyse(attrs);
+  var node = this._analysis().findNodeById(nodeDefModel.id);
+  if (!node) return;
+
+  if (node.get('type') !== 'source') {
+    var styleOnReady = function () {
+      if (node.get('status') === 'ready') {
+        nodeDefModel.querySchemaModel.set({
+          query: node.get('query'),
+          may_have_rows: true
+        });
+
+        var onChangeStatus = function () {
+          if (nodeDefModel.querySchemaModel.get('status') === 'fetched') {
+            var geom = nodeDefModel.querySchemaModel.getGeometry();
+            var simpleType = geom && geom.getSimpleType();
+
+            setTimeout(function () {
+              this._layerDefinitionsCollection.at(1).styleModel.setDefaultPropertiesByType('simple', simpleType);
+            }.bind(this), 1000);
+            nodeDefModel.querySchemaModel.unbind('change:status', onChangeStatus, this);
+          }
+        };
+
+        nodeDefModel.querySchemaModel.bind('change:status', onChangeStatus, this);
+        nodeDefModel.querySchemaModel.fetch();
+        node.stopListening(node, 'change', styleOnReady);
+      }
+    }.bind(this);
+
+    node.listenTo(node, 'change', styleOnReady);
+  }
+
+  // Unfortunately have to try to setup sync until this point, since a node doesn't exist until after analyse call
+  this._analysisDefinitionNodesCollection.each(this._tryToSetupDefinitionNodeSync, this);
 };
 
 F.prototype._analyseDefinitionNode = function (nodeDefModel) {


### PR DESCRIPTION
This is a rudimentary option to set the style when a new analysis has finished. Bad things:

- We have to wait until the analysis is ready.
- Then we need to get the geometry in order to apply a proper style, so query-schema-model should be fetched.
- And finally, map will be reloaded, yes or yes, when a new analysis is ready, so we need to make another map instantiation with that new style.

**This is a first approach**, what do you think?

@javisantana @viddo @saleiva @alonsogarciapablo 