### PR TITLE
8286 forbid editing derived visualizations builder

### DIFF
--- a/app/controllers/carto/builder/datasets_controller.rb
+++ b/app/controllers/carto/builder/datasets_controller.rb
@@ -13,6 +13,7 @@ module Carto
       before_filter :load_canonical_visualization, only: [:show]
       before_filter :authors_only
       before_filter :load_user_table, only: [:show]
+      before_filter :editable_visualizations_only, only: [:show]
 
       after_filter :update_user_last_activity, only: [:show]
 
@@ -43,6 +44,10 @@ module Carto
       def load_user_table
         @user_table = @canonical_visualization.user_table
         render_404 unless @user_table
+      end
+
+      def editable_visualizations_only
+        render_404 unless @canonical_visualization.editable?
       end
     end
   end

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -45,7 +45,7 @@ module Carto
       end
 
       def editable_visualizations_only
-        render_403 unless @visualization.editable?
+        render_404 unless @visualization.editable?
       end
     end
   end

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -11,7 +11,7 @@ module Carto
       ssl_required :show
 
       before_filter :redirect_to_editor_if_forced, only: [:show]
-      before_filter :load_visualization, only: [:show]
+      before_filter :load_derived_visualization, only: [:show]
       before_filter :authors_only
       before_filter :editable_visualizations_only, only: [:show]
 
@@ -35,9 +35,9 @@ module Carto
         redirect_to CartoDB.url(self, 'public_visualizations_show_map', id: params[:id]) if current_user.force_editor?
       end
 
-      def load_visualization
+      def load_derived_visualization
         @visualization = load_visualization_from_id_or_name(params[:id])
-        render_404 unless @visualization
+        render_404 unless @visualization && @visualization.derived?
       end
 
       def authors_only

--- a/spec/requests/carto/builder/datasets_controller_spec.rb
+++ b/spec/requests/carto/builder/datasets_controller_spec.rb
@@ -72,5 +72,13 @@ describe Carto::Builder::DatasetsController do
 
       response.status.should == 404
     end
+
+    it 'does not show raster visualizations' do
+      Carto::Visualization.any_instance.stubs(:kind).returns(Carto::Visualization::KIND_RASTER)
+
+      get builder_dataset_url(id: @visualization.id)
+
+      response.status.should == 404
+    end
   end
 end

--- a/spec/requests/carto/builder/visualizations_controller_spec.rb
+++ b/spec/requests/carto/builder/visualizations_controller_spec.rb
@@ -68,7 +68,7 @@ describe Carto::Builder::VisualizationsController do
 
       get builder_visualization_url(id: @visualization.id)
 
-      response.status.should == 403
+      response.status.should == 404
     end
 
     it 'does not show slide type visualizations' do

--- a/spec/requests/carto/builder/visualizations_controller_spec.rb
+++ b/spec/requests/carto/builder/visualizations_controller_spec.rb
@@ -39,6 +39,14 @@ describe Carto::Builder::VisualizationsController do
       response.status.should == 404
     end
 
+    it 'returns 404 for non-derived visualizations' do
+      @visualization.type = Carto::Visualization::TYPE_CANONICAL
+      @visualization.save
+      get builder_visualization_url(id: UUIDTools::UUID.timestamp_create.to_s)
+
+      response.status.should == 404
+    end
+
     it 'returns 403 for visualizations not writable by user' do
       @other_visualization = FactoryGirl.create(:carto_visualization)
 
@@ -69,7 +77,7 @@ describe Carto::Builder::VisualizationsController do
 
       get builder_visualization_url(id: @visualization.id)
 
-      response.status.should == 403
+      response.status.should == 404
     end
 
     it 'defaults to generate vizjson with vector=false' do


### PR DESCRIPTION
Also, no raster editing in the dataset view (keeps current behaviour).