### PR TITLE
POC/WIP moving side-effects to each corresponding model

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/category/category-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/category/category-option-model.js
@@ -5,7 +5,7 @@ module.exports = WidgetOptionModel.extend({
 
   defaults: _.defaults({type: 'category'}, WidgetOptionModel.defaults),
 
-  createUpdateOrSimilar: function (widgetDefinitionsCollection) {
+  _createUpdateOrSimilar: function (widgetDefinitionsCollection) {
     var columnName = this.columnName();
 
     var attrs = {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/formula/formula-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/formula/formula-option-model.js
@@ -5,7 +5,7 @@ module.exports = WidgetOptionModel.extend({
 
   defaults: _.defaults({type: 'formula'}, WidgetOptionModel.defaults),
 
-  createUpdateOrSimilar: function (widgetDefinitionsCollection) {
+  _createUpdateOrSimilar: function (widgetDefinitionsCollection) {
     var attrs = {
       type: 'formula',
       layer_id: this.layerDefinitionModel().id,

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/histogram/histogram-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/histogram/histogram-option-model.js
@@ -5,7 +5,7 @@ module.exports = WidgetOptionModel.extend({
 
   defaults: _.defaults({type: 'histogram'}, WidgetOptionModel.defaults),
 
-  createUpdateOrSimilar: function (widgetDefinitionsCollection) {
+  _createUpdateOrSimilar: function (widgetDefinitionsCollection) {
     var attrs = {
       type: 'histogram',
       layer_id: this.layerDefinitionModel().id,

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-none-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-none-option-model.js
@@ -9,7 +9,7 @@ module.exports = WidgetOptionModel.extend({
 
   defaults: _.defaults({type: 'time-series'}, WidgetOptionModel.defaults),
 
-  createUpdateOrSimilar: function (widgetDefinitionsCollection) {
+  _createUpdateOrSimilar: function (widgetDefinitionsCollection) {
     var m = widgetDefinitionsCollection.find(this._isTimesSeries);
     if (m) {
       m.destroy({ wait: true });

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/time-series/time-series-option-model.js
@@ -5,7 +5,7 @@ module.exports = WidgetOptionModel.extend({
 
   defaults: _.defaults({type: 'time-series'}, WidgetOptionModel.defaults),
 
-  createUpdateOrSimilar: function (widgetDefinitionsCollection) {
+  _createUpdateOrSimilar: function (widgetDefinitionsCollection) {
     var columnName = this.columnName();
     var layerId = this.layerDefinitionModel().id;
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/widget-option-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/widget-option-model.js
@@ -19,8 +19,27 @@ module.exports = Backbone.Model.extend({
     return this._selectedItem().columnModel.get('name');
   },
 
-  createUpdateOrSimilar: function () {
-    throw new Error('createUpdateOrSimilar should be implemented by child');
+  save: function (attrs, opts) {
+    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
+    if (!opts.widgetDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
+
+    var nodeDefModel = this.analysisDefinitionNodeModel();
+
+    // Might not always have a node-definition, e.g. time-series none-option
+    if (nodeDefModel) {
+      var analysisDefinitionModel = opts.analysisDefinitionsCollection.findAnalysisThatContainsNode(nodeDefModel);
+
+      if (!analysisDefinitionModel) {
+        opts.analysisDefinitionsCollection.create({analysis_definition: nodeDefModel.toJSON()});
+        this.layerDefinitionModel().save();
+      }
+    }
+
+    this._createUpdateOrSimilar(opts.widgetDefinitionsCollection);
+  },
+
+  _createUpdateOrSimilar: function () {
+    throw new Error('_createUpdateOrSimilar should be implemented by child');
   },
 
   _selectedItem: function () {

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
@@ -94,7 +94,52 @@ module.exports = Backbone.Model.extend({
     return true;
   },
 
-  destroy: function () {
+  destroy: function (opts) {
+    if (!opts.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
+    if (!opts.layerDefinitionsCollection) throw new Error('layerDefinitionsCollection is required');
+    if (!opts.widgetDefinitionsCollection) throw new Error('widgetDefinitionsCollection is required');
+
+    var analysisDefModel;
+    var primarySourceNode = this.getPrimarySource();
+
+    if (primarySourceNode) {
+      // If deleted node had an analysis, update it to point to its primary source instead
+      analysisDefModel = opts.analysisDefinitionsCollection.findByNodeId(this.id);
+      if (analysisDefModel) {
+        analysisDefModel.save({node_id: primarySourceNode.id});
+      }
+
+      // If deleted node was a head of a layer change the source to be its primary source instead
+      opts.layerDefinitionsCollection.each(function (m) {
+        if (m.get('source') === this.id) {
+          m.save({source: primarySourceNode.id});
+        }
+      });
+    }
+
+    var containsNode = function (m) {
+      return m.id !== this.id && m.containsNode(this);
+    };
+    _
+      .flatten([
+        this.collection.filter(containsNode),
+        opts.analysisDefinitionsCollection.filter(containsNode),
+        opts.layerDefinitionsCollection.filter(containsNode),
+        opts.widgetDefinitionsCollection.filter(containsNode),
+        this
+      ], true)
+      .forEach(function (m) {
+        m.destroy();
+      });
+
+    // If there were a primary source, make sure it's not orphaned afterwards
+    if (primarySourceNode && !analysisDefModel) {
+      analysisDefModel = opts.analysisDefinitionsCollection.find(containsNode);
+      if (!analysisDefModel) {
+        opts.analysisDefinitionsCollection.create({analysis_definition: primarySourceNode.toJSON()});
+      }
+    }
+
     if (this.querySchemaModel) {
       this.querySchemaModel.destroy();
       this.querySchemaModel = null;

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-source-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-source-model.js
@@ -15,6 +15,22 @@ module.exports = AnalysisDefinitionNodeModel.extend({
       query: this.get('query'),
       may_have_rows: true
     });
+  },
+
+  saveQuery: function (d) {
+    if (!d.query) throw new Error('query is required');
+    if (!d.analysisDefinitionsCollection) throw new Error('analysisDefinitionsCollection is required');
+    if (!d.layerDefModel) throw new Error('layerDefModel is required');
+
+    this.set('query', d.query || '');
+
+    var analysisDefinitionModel = d.analysisDefinitionsCollection.findAnalysisThatContainsNode(this);
+    if (analysisDefinitionModel) {
+      analysisDefinitionModel.save();
+    } else {
+      d.analysisDefinitionsCollection.create({analysis_definition: this.toJSON()});
+      d.layerDefModel.save();
+    }
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -1,8 +1,7 @@
-var _ = require('underscore');
-var camshaftReference = require('./camshaft-reference');
-
 /**
- * Coordinate side-effects done on explicit interactions.
+ * Adapter for CRUD operations that require various collections,
+ * to not have to pass them all around various view hierarchies.
+ *
  * @param {Object} collections
  * @param {Object} collections.analysisDefinitionsCollection
  * @param {Object} collections.analysisDefinitionNodesCollection
@@ -22,121 +21,37 @@ module.exports = function (collections) {
 
   return {
 
-    /**
-     * Creates a new analysis node on a particular layer.
-     * It's assumed to be created on top of an existing node.
-     * @param {Object} nodeAttrs
-     * @param {Object} layerDefModel - instance of layer-definition-model
-     * @return {Object} instance of analysis-definition-node-model
-     */
-    createAnalysisNode: function (nodeAttrs, layerDefmodel) {
-      var nodeDefModel = analysisDefinitionNodesCollection.add(nodeAttrs, {parse: false});
-      var sourceNode = nodeDefModel.getPrimarySource();
-
-      var analysisDefinitionModel = analysisDefinitionsCollection.findByNodeId(sourceNode.id);
-      if (analysisDefinitionModel) {
-        analysisDefinitionModel.save({node_id: nodeDefModel.id});
-      } else {
-        analysisDefinitionsCollection.create({analysis_definition: nodeDefModel.toJSON()});
-      }
-
-      layerDefmodel.save({
-        cartocss: camshaftReference.getDefaultCartoCSSForType(nodeDefModel.get('type')),
-        source: nodeDefModel.id
+    saveAnalysis: function (analysisFormModel) {
+      analysisFormModel.save(null, {
+        analysisDefinitionsCollection: analysisDefinitionsCollection,
+        analysisDefinitionNodesCollection: analysisDefinitionNodesCollection
       });
-
-      return nodeDefModel;
     },
 
-    updateOrCreateAnalysis: function (analysisFormModel) {
-      if (!analysisFormModel.isValid()) return;
-
-      var nodeDefModel = analysisDefinitionNodesCollection.get(analysisFormModel.id);
-
-      if (nodeDefModel) {
-        analysisFormModel.updateNodeDefinition(nodeDefModel);
-        var analysisDefinitionModel = analysisDefinitionsCollection.findAnalysisThatContainsNode(nodeDefModel);
-        analysisDefinitionModel.save();
-      } else {
-        analysisFormModel.createNodeDefinition(this); // delegates creation to the form
-      }
+    saveAnalysisSourceQuery: function (query, nodeDefModel, layerDefModel) {
+      nodeDefModel.saveQuery({
+        query: query,
+        analysisDefinitionsCollection: analysisDefinitionsCollection,
+        layerDefModel: layerDefModel
+      });
     },
 
-    updateAnalysisSourceQuery: function (query, nodeDefModel, layerDefModel) {
-      if (!nodeDefModel) throw new Error('nodeDefModel is required');
-      if (nodeDefModel.get('type') !== 'source') throw new Error('nodeDefModel must be a source node');
-
-      nodeDefModel.set('query', query || '');
-
-      var analysisDefinitionModel = analysisDefinitionsCollection.findAnalysisThatContainsNode(nodeDefModel);
-      if (analysisDefinitionModel) {
-        analysisDefinitionModel.save();
-      } else {
-        analysisDefinitionsCollection.create({analysis_definition: nodeDefModel.toJSON()});
-        layerDefModel.save();
-      }
-    },
-
-    updateOrCreateWidget: function (widgetOptionModel) {
-      var nodeDefModel = widgetOptionModel.analysisDefinitionNodeModel();
-
-      // Might not always have a node-definition, e.g. time-series none-option
-      if (nodeDefModel) {
-        var analysisDefinitionModel = analysisDefinitionsCollection.findAnalysisThatContainsNode(nodeDefModel);
-
-        if (!analysisDefinitionModel) {
-          analysisDefinitionsCollection.create({analysis_definition: nodeDefModel.toJSON()});
-          widgetOptionModel.layerDefinitionModel().save();
-        }
-      }
-
-      widgetOptionModel.createUpdateOrSimilar(widgetDefinitionsCollection); // delegate back depending on use-case
+    saveWidget: function (widgetOptionModel) {
+      widgetOptionModel.save(null, {
+        analysisDefinitionsCollection: analysisDefinitionsCollection,
+        widgetDefinitionsCollection: widgetDefinitionsCollection
+      });
     },
 
     deleteAnalysisNode: function (nodeId) {
       var nodeDefModel = analysisDefinitionNodesCollection.get(nodeId);
       if (!nodeDefModel) return false; // abort if there is no node-definition; nothing to delete/change
 
-      var analysisDefModel;
-      var primarySourceNode = nodeDefModel.getPrimarySource();
-
-      if (primarySourceNode) {
-        // If deleted node had an analysis, update it to point to its primary source instead
-        analysisDefModel = analysisDefinitionsCollection.findByNodeId(nodeId);
-        if (analysisDefModel) {
-          analysisDefModel.save({node_id: primarySourceNode.id});
-        }
-
-        // If deleted node was a head of a layer change the source to be its primary source instead
-        layerDefinitionsCollection.each(function (m) {
-          if (m.get('source') === nodeId) {
-            m.save({source: primarySourceNode.id});
-          }
-        });
-      }
-
-      var containsNode = function (m) {
-        return m.id !== nodeDefModel.id && m.containsNode(nodeDefModel);
-      };
-      _
-        .flatten([
-          analysisDefinitionNodesCollection.filter(containsNode),
-          analysisDefinitionsCollection.filter(containsNode),
-          layerDefinitionsCollection.filter(containsNode),
-          widgetDefinitionsCollection.filter(containsNode),
-          nodeDefModel
-        ], true)
-        .forEach(function (m) {
-          m.destroy();
-        });
-
-      // If there were a primary source, make sure it's not orphaned afterwards
-      if (primarySourceNode && !analysisDefModel) {
-        analysisDefModel = analysisDefinitionsCollection.find(containsNode);
-        if (!analysisDefModel) {
-          analysisDefinitionsCollection.create({analysis_definition: primarySourceNode.toJSON()});
-        }
-      }
+      nodeDefModel.destroy({
+        analysisDefinitionsCollection: analysisDefinitionsCollection,
+        layerDefinitionsCollection: layerDefinitionsCollection,
+        widgetDefinitionsCollection: widgetDefinitionsCollection
+      });
     }
   };
 };

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -38,9 +38,7 @@ module.exports = CoreView.extend({
   },
 
   _onSaveClicked: function () {
-    if (this._formModel.isValid()) {
-      this._userActions.updateOrCreateAnalysis(this._formModel);
-    }
+    this._userActions.saveAnalysis(this._formModel);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
@@ -46,6 +46,40 @@ module.exports = Backbone.Model.extend({
     }
   },
 
+  save: function (attrs, opts) {
+    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
+    if (!opts.analysisDefinitionCollection) throw new Error('analysisDefinitionCollection is required');
+    if (!this.isValid()) return;
+
+    var nodeDefModel = opts.analysisDefinitionNodesCollection.get(this.id);
+    var analysisDefinitionModel;
+
+    if (nodeDefModel) {
+      this._updateNodeDefinition(nodeDefModel);
+      analysisDefinitionModel = opts.analysisDefinitionsCollection.findAnalysisThatContainsNode(nodeDefModel);
+      analysisDefinitionModel.save();
+    } else {
+      // Create a new analysis
+      var nodeAttrs = this._formatAttrs(this.attributes);
+      this.set('persisted', true);
+
+      nodeDefModel = opts.analysisDefinitionNodesCollection.add(nodeAttrs, {parse: false});
+      var sourceNode = nodeDefModel.getPrimarySource();
+      analysisDefinitionModel = opts.analysisDefinitionsCollection.findByNodeId(sourceNode.id);
+
+      if (analysisDefinitionModel) {
+        analysisDefinitionModel.save({node_id: nodeDefModel.id});
+      } else {
+        opts.analysisDefinitionsCollection.create({analysis_definition: nodeDefModel.toJSON()});
+      }
+
+      this._layerDefinitionModel.save({
+        cartocss: camshaftReference.getDefaultCartoCSSForType(nodeDefModel.get('type')),
+        source: nodeDefModel.id
+      });
+    }
+  },
+
   /**
    * @override {Backbone.Model.prototype.set} Maintain persisted attr if model is clear'ed
    */
@@ -73,15 +107,9 @@ module.exports = Backbone.Model.extend({
     return this;
   },
 
-  updateNodeDefinition: function (nodeDefModel) {
+  _updateNodeDefinition: function (nodeDefModel) {
     var nodeAttrs = this._formatAttrs(this.attributes);
     nodeDefModel.set(nodeAttrs);
-  },
-
-  createNodeDefinition: function (userActions) {
-    var nodeAttrs = this._formatAttrs(this.attributes);
-    this.set('persisted', true);
-    return userActions.createAnalysisNode(nodeAttrs, this._layerDefinitionModel);
   },
 
   _formatAttrs: function (formAttrs) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -56,7 +56,7 @@ module.exports = CoreView.extend({
     if (model.get('selected') === true) {
       candidate = this._columnsModel.findWidget(model);
       if (!candidate) {
-        m = model.createUpdateOrSimilar(this._widgetDefinitionsCollection);
+        m = model._createUpdateOrSimilar(this._widgetDefinitionsCollection);
         model.set({widget: m});
       } else {
         model.set({widget: candidate});

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -139,7 +139,7 @@ module.exports = CoreView.extend({
   _saveSQL: function () {
     var query = this._codemirrorModel.get('content');
     this._sqlModel.set('content', query);
-    this._userActions.updateAnalysisSourceQuery(query, this._nodeModel, this._layerDefinitionModel);
+    this._userActions.saveAnalysisSourceQuery(query, this._nodeModel, this._layerDefinitionModel);
     this._querySchemaModel.set('query_errors', []);
     this._checkClearButton();
   },


### PR DESCRIPTION
@alonsogarciapablo addressing some of the concerns from previous PR (and offline conversation), it's a POC so have only migrated the code quickly to discuss some different points. 
If we finally agree this PR is not the wrong road to take I'll just close it.

The primary goal to solve in #7881 is to get rid of the indirect CRUD operations done in listener callbacks, secondary to know have the things easily maintainable. While it can be convenient to have side-effects in one place (like we have with the deep-insights-integration) I'm not sure if that should be a goal in itself.

That said, on specific things from prev PR:

> (re: `updateOrCreateAnalysis`) [Why this indirection here? Makes this method harder to understand...](https://github.com/CartoDB/cartodb/pull/8042#discussion_r68192171)

Like I responded in the thread there, it ~~is~~ was necessary due use-cases have different side-effects, by keeping the ~~`updateOrCreateAnalysis`~~ `analysisForm.save` logic internal (in the form model) the indirection is no longer there. A bonus consequence is that `userActions.userActions.createAnalysisNode` could be removed.

> (re: userActions methods' params signatures) [One of the things that might be a bit confusing about this is the fact that each method takes some arguments and they are not very "uniform" (eg: one method takes a nodeAttrs object while another takes an analysisFormModel object). Do you think we could somehow homogenise this? (for example: only pass layer, analysis or widget models + attr objects for updates + options).](https://github.com/CartoDB/cartodb/pull/8042#discussion_r68194177)

> the good thing about your current approach is being able to have everything in the same place

I agreed with this sentiment, but the only thing in common between the various methods are really only the collections, so there is really no benefit of having the logic in the same place afterall. The important thing is to have the side-effects in the same place however (which is resolved by this).

This is resolved, by having the model encapsulating its own state and only require the collections they need to do the necessary side-effects. For now I kept userActions to not have to pass around the individual collections in all views (although some are already passed around), but what goes for me could even 🔥 it (to remove indirection).

Thoughts?

edit: addressing more concerns from offline conversation