### PR TITLE
8356 builder features warning modal

### DIFF
--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -63,7 +63,8 @@ module Carto
           synchronization: Carto::Api::SynchronizationPresenter.new(@visualization.synchronization).to_poro,
           children: @visualization.children.map { |v| children_poro(v) },
           liked: @current_viewer ? @visualization.is_liked_by_user_id?(@current_viewer.id) : false,
-          url: url
+          url: url,
+          uses_builder_features: @visualization.uses_builder_features?
         }
         poro.merge!( { related_tables: related_tables } ) if @options.fetch(:related, true)
         poro

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -368,7 +368,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def uses_builder_features?
-    analyses.any? || widgets.any? || mapcaps.any?
+    analyses.any? || widgets.any? || mapcapped?
   end
 
   private

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -367,6 +367,10 @@ class Carto::Visualization < ActiveRecord::Base
     mapcaps.first
   end
 
+  def uses_builder_features?
+    analyses.any? || widgets.any? || mapcaps.any?
+  end
+
   private
 
   def named_maps_api

--- a/lib/assets/javascripts/cartodb/common/dialogs/builder_features_warning/builder_features_warning_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/builder_features_warning/builder_features_warning_view.js
@@ -1,0 +1,27 @@
+var cdb = require('cartodb.js-v3');
+var BaseDialog = require('../../views/base_dialog/view');
+var _ = require('underscore-cdb-v3');
+
+module.exports = BaseDialog.extend({
+
+  events: function() {
+    return _.extend({}, BaseDialog.prototype.events, {
+      'click .js-ok' : '_continue'
+    });
+  },
+
+  initialize: function() {
+    this.elder('initialize');
+    this.template = cdb.templates.getTemplate('common/dialogs/builder_features_warning/template');
+  },
+
+  render_content: function() {
+    return this.template({
+
+    });
+  },
+
+  _continue: function() {
+    this.close();
+  }
+});

--- a/lib/assets/javascripts/cartodb/common/dialogs/builder_features_warning/builder_features_warning_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/builder_features_warning/builder_features_warning_view.js
@@ -4,24 +4,24 @@ var _ = require('underscore-cdb-v3');
 
 module.exports = BaseDialog.extend({
 
-  events: function() {
+  events: function () {
     return _.extend({}, BaseDialog.prototype.events, {
-      'click .js-ok' : '_continue'
+      'click .js-ok': '_continue'
     });
   },
 
-  initialize: function() {
+  initialize: function () {
     this.elder('initialize');
     this.template = cdb.templates.getTemplate('common/dialogs/builder_features_warning/template');
   },
 
-  render_content: function() {
+  render_content: function () {
     return this.template({
 
     });
   },
 
-  _continue: function() {
+  _continue: function () {
     this.close();
   }
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/builder_features_warning/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/builder_features_warning/template.jst.ejs
@@ -1,0 +1,21 @@
+<div class="Dialog-header u-inner">
+  <div class="Dialog-headerIcon Dialog-headerIcon--alert">
+    <i class="CDB-IconFont CDB-IconFont-question"></i>
+  </div>
+  <p class="Dialog-headerTitle">
+    This map uses features only available in the Builder
+  </p>
+  <p class="Dialog-headerText">
+    Editing Builder maps in the editor is not supported.<br />
+    The map may not display correctly and not all features will be available.<br />
+    It is recommended that you only edit this map using the Builder. It can be activated from your account settings.
+  </p>
+</div>
+<div class="Dialog-footer Dialog-footer--simple u-inner">
+  <button class="Button Button--secondary Dialog-footerBtn cancel">
+    <span>Back to dashboard</span>
+  </button>
+  <button class="js-ok Button Button--main">
+    <span>Continue (NOT RECOMMENDED)</span>
+  </button>
+</div>

--- a/lib/assets/javascripts/cartodb/common/dialogs/builder_features_warning/template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/builder_features_warning/template.jst.ejs
@@ -3,12 +3,12 @@
     <i class="CDB-IconFont CDB-IconFont-question"></i>
   </div>
   <p class="Dialog-headerTitle">
-    This map uses features only available in the Builder
+    WAIT! This map contains new Builder features that are not supported in the Editor
   </p>
   <p class="Dialog-headerText">
-    Editing Builder maps in the editor is not supported.<br />
-    The map may not display correctly and not all features will be available.<br />
-    It is recommended that you only edit this map using the Builder. It can be activated from your account settings.
+    If you continue, the map may not display correctly and some features will not be available.<br />
+    It is highly recommended that you use the Builder to edit and build maps.<br />
+    <b>Tip:</b> Activate the Builder as your default tool from your Account settings.
   </p>
 </div>
 <div class="Dialog-footer Dialog-footer--simple u-inner">
@@ -16,6 +16,6 @@
     <span>Back to dashboard</span>
   </button>
   <button class="js-ok Button Button--main">
-    <span>Continue (NOT RECOMMENDED)</span>
+    <span>Continue</span>
   </button>
 </div>

--- a/lib/assets/javascripts/cartodb/editor.js
+++ b/lib/assets/javascripts/cartodb/editor.js
@@ -35,6 +35,8 @@ cdb.editor = {
   ChangeLockViewModel: require('./common/dialogs/change_lock/change_lock_view_model'),
   ChangeLockView: require('./common/dialogs/change_lock/change_lock_view'),
 
+  BuilderFeaturesWarningDialog: require('./common/dialogs/builder_features_warning/builder_features_warning_view'),
+
   PecanView: require('./common/dialogs/pecan/pecan_view'),
 
   DuplicateVisView: require('./common/dialogs/duplicate_vis_view'),

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -168,6 +168,20 @@ $(function() {
         view.appendToBody();
       }
 
+      // *** Warning opening Builder maps in the old editor
+      if (this.vis.get('uses_builder_features')) {
+        var view = new cdb.editor.BuilderFeaturesWarningDialog({
+          //clean_on_hide: true,
+          enter_to_confirm: true
+        });
+        var self = this;
+        view.cancel = function() {
+          window.location = self.user.viewUrl().dashboard()[ self.vis.isVisualization() ? 'maps' : 'datasets' ]();
+        };
+
+        view.appendToBody();
+      }
+
       // ***  tabs
       this.tabs = new cdb.admin.Tabs({
         el: this.$('nav'),

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -171,7 +171,7 @@ $(function() {
       // *** Warning opening Builder maps in the old editor
       if (this.vis.get('uses_builder_features')) {
         var view = new cdb.editor.BuilderFeaturesWarningDialog({
-          //clean_on_hide: true,
+          clean_on_hide: true,
           enter_to_confirm: true
         });
         var self = this;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.28.21",
+  "version": "3.28.22",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.28.20",
+  "version": "3.28.21",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.28.19",
+  "version": "3.28.20",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -273,6 +273,9 @@ describe Carto::Api::VisualizationsController do
       expected_visualization = JSON.parse(table1_visualization_hash.to_json)
       expected_visualization = normalize_hash(expected_visualization)
 
+      # This is only in the Carto::Visualization presenter (not in old member presenter)
+      expected_visualization['uses_builder_features'] = false
+
       response = response_body(type: CartoDB::Visualization::Member::TYPE_CANONICAL)
       # INFO: old API won't support server side generated urls for visualizations. See #5250 and #5279
       response['visualizations'][0].delete('url')


### PR DESCRIPTION
Closes #8356

Checks for the presence of builder-only features(analyses, widgets and mapcaps) when opening a map, and displays this modal in case if it finds any:
![screenshot_20160630_165322](https://cloud.githubusercontent.com/assets/7569673/16492835/804d4470-3ee3-11e6-81e0-1f01639451a4.png)

