### PR TITLE
Allows to specify the count operation without a column

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/intersection-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/intersection-form-model.js
@@ -3,12 +3,26 @@ var BaseAnalysisFormModel = require('./base-analysis-form-model');
 var template = require('./intersection-form.tpl');
 var ColumnOptions = require('../column-options');
 
-var AGGREGATE_INTERSECTION_FIELDS = 'type,aggregate_function,aggregate_column';
+var AGGREGATE_INTERSECTION_FIELDS = 'type,aggregate';
 var INTERSECTION_FIELDS = 'type';
 /**
  * Form model for the intersection analysis
  */
 module.exports = BaseAnalysisFormModel.extend({
+  parse: function (attrs) {
+    if (!attrs.aggregate_column) {
+      attrs.aggregate_column = 'cartodb_id';
+    }
+    if (!attrs.aggregate_function) {
+      attrs.aggregate_function = 'count';
+    }
+    attrs.aggregate = {
+      operator: attrs.aggregate_function,
+      attribute: attrs.aggregate_function === 'count' ? '' : attrs.aggregate_column
+    };
+    return attrs;
+  },
+
   initialize: function () {
     BaseAnalysisFormModel.prototype.initialize.apply(this, arguments);
 
@@ -20,8 +34,8 @@ module.exports = BaseAnalysisFormModel.extend({
     this.listenTo(this._columnOptions, 'columnsFetched', this._setSchema);
 
     this.on('change:type', this._setSchema, this);
+    this.on('change:aggregate', this._onChangeAggregate, this);
     this.on('change:target', this._onChangeTarget, this);
-    this.on('change', this._onChange, this);
 
     this._setSchema();
     this._fetchColumns();
@@ -35,8 +49,17 @@ module.exports = BaseAnalysisFormModel.extend({
     }
   },
 
+  _getFormatFieldNames: function () {
+    if (this.get('type') === 'aggregate-intersection') {
+      return 'type,aggregate_column,aggregate_function';
+    } else {
+      return INTERSECTION_FIELDS;
+    }
+  },
+
   _formatAttrs: function (formAttrs) {
-    var customFormattedFormAttrs = _.pick(formAttrs, ['id', 'source', 'target'].concat(this._getFormFieldNames().split(',')));
+    var customFormattedFormAttrs = _.pick(formAttrs, ['id', 'source', 'target'].concat(this._getFormatFieldNames().split(',')));
+
     return BaseAnalysisFormModel.prototype._formatAttrs.call(this, customFormattedFormAttrs);
   },
 
@@ -83,28 +106,28 @@ module.exports = BaseAnalysisFormModel.extend({
           { label: 'Aggregate', val: 'aggregate-intersection' }
         ]
       },
-      aggregate_function: {
-        type: 'Select',
-        title: _t('editor.layers.analysis-form.operation'),
-        options: [
-          { label: _t('editor.layers.aggregate-functions.count'), val: 'count' },
-          { label: _t('editor.layers.aggregate-functions.sum'), val: 'sum' },
-          { label: _t('editor.layers.aggregate-functions.avg'), val: 'avg' },
-          { label: _t('editor.layers.aggregate-functions.min'), val: 'min' },
-          { label: _t('editor.layers.aggregate-functions.max'), val: 'max' }
-        ],
-        validators: ['required']
-      },
-      aggregate_column: {
-        type: 'Select',
+      aggregate: {
+        type: 'Operators',
         title: _t('editor.layers.analysis-form.column'),
         options: this._columnOptions.filterByType('number')
       }
     }));
   },
 
+  _onChangeAggregate: function () {
+    var aggregate = this.get('aggregate');
+    this.set({
+      aggregate_column: aggregate.attribute || 'cartodb_id',
+      aggregate_function: aggregate.operator
+    });
+  },
+
   _onChangeTarget: function () {
-    this.set('aggregate_column', null);
+    this.set('aggregate', {
+      operator: 'count',
+      attribute: ''
+    });
+    this._analysisSourceOptionsModel.createSourceNodeUnlessExisting(this.get('target'));
     this._fetchColumns();
   },
 
@@ -155,8 +178,5 @@ module.exports = BaseAnalysisFormModel.extend({
   },
 
   _onChange: function () {
-    if (this.changed.target) {
-      this._analysisSourceOptionsModel.createSourceNodeUnlessExisting(this.changed.target);
-    }
   }
 });


### PR DESCRIPTION
Closes #8235

This PR replaces the `aggregate_column` and ``aggregate_function` fields with a single field that allows selecting both things.

CR: @xavijam 

![animation](https://cloud.githubusercontent.com/assets/4933/16496609/150611c8-3ef3-11e6-998c-6760c36d4b69.gif)


PS: Despite the fact that the user is no longer required to specify a column, due to https://github.com/CartoDB/camshaft/issues/102 we still need to send a string (which is why we are sending `cartodb_id` behind curtains).