### PR TITLE
Fixes autostyling using an older version of the original style

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -106,7 +106,8 @@ F.prototype._onLayerChangeCheckWidgetAutoStyling = function (model, style) {
   var self = this;
   var currentLayerId = model.get('id');
   var layer = this._getLayer(model);
-  layer.set('initialStyle', style);
+  if (!layer) return;
+  layer.attributes.initialStyle = style;
   var widgetsToInvalidate = this.widgetDefinitionsCollection.where({'layer_id': currentLayerId});
   widgetsToInvalidate.forEach(function (widget) {
     var widgetModel = self._diDashboard.getWidget(widget.id);

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -105,6 +105,8 @@ F.prototype._onWidgetDefinitionSynced = function (m) {
 F.prototype._onLayerChangeCheckWidgetAutoStyling = function (model, style) {
   var self = this;
   var currentLayerId = model.get('id');
+  var layer = this._getLayer(model);
+  layer.set('initialStyle', style);
   var widgetsToInvalidate = this.widgetDefinitionsCollection.where({'layer_id': currentLayerId});
   widgetsToInvalidate.forEach(function (widget) {
     var widgetModel = self._diDashboard.getWidget(widget.id);


### PR DESCRIPTION
Before:
![bef](https://cloud.githubusercontent.com/assets/3707222/16545752/d3aae912-4134-11e6-9c4c-59640bba84aa.gif)
After:
![aft](https://cloud.githubusercontent.com/assets/3707222/16545753/d75eddfc-4134-11e6-923a-039785fe6f8b.gif)

@javisantana cc @makella 