### PR TITLE
xor and source-over become multiply and torque marker-width support

### DIFF
--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -406,6 +406,11 @@ module Carto
         "line-comp-op" => "blending"
       }.freeze
 
+      BLENDING_ALIAS = {
+        'xor' => 'multiply',
+        'source-over' => 'multiply'
+      }.freeze
+
       def wizard_properties_properties_to_style_properties_properties(wizard_properties_properties)
         spp = {}
         wpp = wizard_properties_properties
@@ -413,7 +418,11 @@ module Carto
 
         apply_direct_mapping(spp, wpp, PROPERTIES_DIRECT_MAPPING)
 
-        spp['blending'] = 'none' if spp['blending'].blank?
+        if spp['blending'].blank?
+          spp['blending'] = 'none'
+        else
+          spp['blending'] = BLENDING_ALIAS.fetch(spp['blending'], spp['blending'])
+        end
 
         merge_into_if_present(spp, 'stroke', generate_stroke(wpp))
 
@@ -459,7 +468,7 @@ module Carto
         merge_into_if_present(fill, @source_type == 'bubble' ? 'size' : 'color', generate_dimension_properties(wpp))
 
         case @source_type
-        when 'polygon'
+        when 'polygon', 'torque', 'torque_cat'
           fill['size'] = { 'fixed' => wpp['marker-width'] }.merge(fill['size'] || {})
         when 'choropleth', 'category'
           fill['size'] = { 'fixed' => 10 }.merge(fill['size'] || {})

--- a/spec/requests/carto/api/layer_presenter_spec.rb
+++ b/spec/requests/carto/api/layer_presenter_spec.rb
@@ -705,6 +705,7 @@ describe Carto::Api::LayerPresenter do
 
         let(:torque_blend_mode) { "lighter" }
         let(:property) { "fecha_date" }
+        let(:marker_width) { 6 }
         let(:torque_cumulative) { false }
         let(:torque_duration) { 30 }
         let(:torque_frame_count) { 256 }
@@ -719,7 +720,7 @@ describe Carto::Api::LayerPresenter do
                 "property" => property,
                 "marker-type" => "ellipse",
                 "layer-type" => "torque",
-                "marker-width" => 6,
+                "marker-width" => marker_width,
                 "marker-fill" => "#0F3B82",
                 "marker-opacity" => 0.9,
                 "marker-line-width" => 0,
@@ -748,6 +749,28 @@ describe Carto::Api::LayerPresenter do
 
         it 'torque-cumulative becomes overlap' do
           expect(@animated).to include('overlap' => torque_cumulative)
+        end
+
+        it 'marker-width becomes fill size fixed' do
+          expect(@fill_size).to include('fixed' => marker_width)
+        end
+
+        describe 'torque-blend-mode' do
+          it 'turns xor into multiply' do
+            xor_torque_wizard_properties = torque_wizard_properties
+            xor_torque_wizard_properties['properties']['torque-blend-mode'] = 'xor'
+            layer = build_layer_with_wizard_properties(xor_torque_wizard_properties)
+            options = presenter_with_style_properties(layer).to_poro['options']
+            options['style_properties']['properties']['blending'].should eq 'multiply'
+          end
+
+          it 'turns source-over into multiply' do
+            source_over_torque_wizard_properties = torque_wizard_properties
+            source_over_torque_wizard_properties['properties']['torque-blend-mode'] = 'source-over'
+            layer = build_layer_with_wizard_properties(source_over_torque_wizard_properties)
+            options = presenter_with_style_properties(layer).to_poro['options']
+            options['style_properties']['properties']['blending'].should eq 'multiply'
+          end
         end
       end
     end


### PR DESCRIPTION
This fixes #8465.

@xavijam CR this, please. I still have to confirm that canvas composite models are xor and source-over as I didn't manage to break the map as @saleiva mentioned. See the issue for more details.