### PR TITLE
Move test from CLI to browser-based test suite

### DIFF
--- a/lib/assets/test/spec/cartodb3/data/analyses.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/analyses.spec.js
@@ -1,6 +1,3 @@
-/*
-this was commented because some imported module is importing cartodb.js and these tests don't allow to have DOM code
-
 var Backbone = require('backbone');
 var analyses = require('../../../../javascripts/cartodb3/data/analyses');
 var UnknownTypeFormModel = require('../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/unknown-type-form-model');
@@ -81,4 +78,3 @@ describe('cartodb3/data/analyses', function () {
     });
   });
 });
-*/


### PR DESCRIPTION
Due to the implicit require of cartodb.js that makes it fail in the non-browser env.

cc @javisantana 