### PR TITLE
Fixes format params for the merge analysis

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
@@ -64,17 +64,17 @@ module.exports = BaseAnalysisFormModel.extend({
     var customFormattedFormAttrs = _.pick(formAttrs, ['id', 'type', 'left_source', 'right_source'].concat(this._getFormatFieldNames().split(',')));
 
     if (this.get('left_source') === this.get('source_geometry_selector')) {
-      formAttrs.source_geometry = 'left_source';
+      customFormattedFormAttrs.source_geometry = 'left_source';
     } else {
-      formAttrs.source_geometry = 'right_source';
+      customFormattedFormAttrs.source_geometry = 'right_source';
     }
 
     if (!formAttrs.left_source_columns) {
-      formAttrs.left_source_columns = [];
+      customFormattedFormAttrs.left_source_columns = [];
     }
 
     if (!formAttrs.right_source_columns) {
-      formAttrs.right_source_columns = [];
+      customFormattedFormAttrs.right_source_columns = [];
     }
 
     return BaseAnalysisFormModel.prototype._formatAttrs.call(this, customFormattedFormAttrs);

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
@@ -69,6 +69,14 @@ module.exports = BaseAnalysisFormModel.extend({
       formAttrs.source_geometry = 'right_source';
     }
 
+    if (!formAttrs.left_source_columns) {
+      formAttrs.left_source_columns = [];
+    }
+
+    if (!formAttrs.right_source_columns) {
+      formAttrs.right_source_columns = [];
+    }
+
     return BaseAnalysisFormModel.prototype._formatAttrs.call(this, customFormattedFormAttrs);
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "3.28.37",
+  "version": "3.28.38",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes two params that weren't being correctly sent:

- `source_gometry` now correctly indicates if the user wants to use the left or right source in the analysis.
- `left_source_columns` and `right_source_columns` has a default empty value (`[]`) to indicate that the user doesn't want to include any column from those sources (not sending anything would mean that the user wants to include every column).

Closes #8572 