### PR TITLE
Fixes titles of analysis

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/analyses.js
+++ b/lib/assets/javascripts/cartodb3/data/analyses.js
@@ -7,91 +7,87 @@ var UnknownTypeFormModel = require('../editor/layers/layer-content-views/analyse
 
 var MAP = {
   'aggregate-intersection': {
-    title: _t('analyses.aggregate-intersection'),
+    title: _t('analyses.aggregate-intersection.short-title'),
     FormModel: IntersectionFormModel
   },
   'buffer': {
-    title: _t('analyses.area-of-influence'),
+    title: _t('analyses.area-of-influence.short-title'),
     FormModel: AreaOfInfluenceFormModel
   },
   'centroid': {
-    title: _t('analyses.centroid'),
+    title: _t('analyses.centroid.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/centroid-form-model')
   },
   'filter-by-node-column': {
-    title: _t('analyses.filter-by-node-column'),
+    title: _t('analyses.filter-by-node-column.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/filter-by-node-column')
   },
   'filter-category': {
-    title: _t('analyses.filter'),
+    title: _t('analyses.filter.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/filter-form-model')
   },
   'filter-range': {
-    title: _t('analyses.filter'),
+    title: _t('analyses.filter.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/filter-form-model')
   },
   'georeference-city': {
-    title: _t('analyses.georeference'),
+    title: _t('analyses.georeference.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model')
   },
   'georeference-ip-address': {
-    title: _t('analyses.georeference'),
+    title: _t('analyses.georeference.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model')
   },
   'georeference-long-lat': {
-    title: _t('analyses.georeference'),
+    title: _t('analyses.georeference.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model')
   },
   'georeference-postal-code': {
-    title: _t('analyses.georeference'),
+    title: _t('analyses.georeference.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model')
   },
   'georeference-street-address': {
-    title: _t('analyses.georeference'),
+    title: _t('analyses.georeference.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model')
   },
   'georeference-admin-region': {
-    title: _t('analyses.georeference'),
+    title: _t('analyses.georeference.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model')
   },
   'intersection': {
-    title: _t('analyses.intersection'),
+    title: _t('analyses.intersection.short-title'),
     FormModel: IntersectionFormModel
   },
   'kmeans': {
-    title: _t('analyses.cluster'),
+    title: _t('analyses.kmeans.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/kmeans-form-model')
   },
   'sampling': {
-    title: _t('analyses.sampling'),
+    title: _t('analyses.sampling.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/sampling-form-model')
   },
   'merge': {
-    title: _t('analyses.merge'),
+    title: _t('analyses.merge.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model')
   },
   'moran': {
-    title: _t('analyses.cluster'),
+    title: _t('analyses.moran-cluster.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/moran-form-model')
   },
-  // 'point-in-polygon': {
-  //   title: _t('analyses.point-in-polygon'),
-  //   FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/point-in-polygon-form-model')
-  // },
   'trade-area': {
-    title: _t('analyses.area-of-influence'),
+    title: _t('analyses.area-of-influence.short-title'),
     FormModel: AreaOfInfluenceFormModel
   },
   'weighted-centroid': {
-    title: _t('analyses.centroid'),
+    title: _t('analyses.centroid.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/centroid-form-model')
   },
   'spatial-markov-trend': {
-    title: _t('analyses.spatial-markov-trend'),
+    title: _t('analyses.spatial-markov-trend.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/spatial-markov-trend-model')
   },
   'data-observatory-measure': {
-    title: _t('analyses.data-observatory'),
+    title: _t('analyses.data-observatory.short-title'),
     FormModel: require('../editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model')
   }
 };

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/area-of-influence-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/area-of-influence-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.area-of-influence') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.area-of-influence.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.reference-layer-pluralize', { smart_count: 1 }) %></p>
       <div class="u-tSpace-xl CDB-Text CDB-Fieldset">

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/centroid-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/centroid-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.centroid') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.centroid.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.input-layer') %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model.js
@@ -76,7 +76,7 @@ module.exports = BaseAnalysisFormModel.extend({
       },
       segments: {
         type: 'Select',
-        title: '',
+        title: _t('editor.layers.analysis-form.data-observatory-measurement-segments'),
         options: this.doMetadata.columns(this.get('area'), this.get('measurement')).sort()
       }
     };

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source,final_column">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.data-observatory-measurement') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.data-observatory-measurement.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.data-observatory-measurement-desc') %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-by-node-column.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-by-node-column.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source,filter_source">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.filter-by-node-column') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.filter-by-node-column.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.link-layer-desc') %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.filter') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.filter.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.select-column') %></p>
       <div class="u-tSpace-xl CDB-Text CDB-Fieldset">

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.georeference') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.georeference.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.select-column') %></p>
       <div class="u-tSpace-xl CDB-Text CDB-Fieldset">

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/intersection-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/intersection-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source,target">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.intersection') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.intersection.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.input-layer') %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/kmeans-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/kmeans-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.kmeans') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.kmeans.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.input-layer') %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="left_source,right_source,join_operator">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.merge') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.merge.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.define-two-layers') %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/moran-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/moran-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.moran-cluster') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.moran-cluster.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.input-layer') %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/point-in-polygon-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/point-in-polygon-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="points_source,polygons_source">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.point-in-polygon') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.point-in-polygon.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.reference-layer-pluralize', { smart_count: 2 }) %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/sampling-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/sampling-form.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source,percent">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.sampling') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.sampling.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.sampling-desc') %></p>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/spatial-markov-trend.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/spatial-markov-trend.tpl
@@ -3,7 +3,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source,time_columns">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.spatial-markov-trend') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.spatial-markov-trend.title') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--m"><%- _t('editor.layers.analysis-form.spatial-markov-trend-desc') %></p>
     </div>

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1082,7 +1082,8 @@
         "data-observatory-measurement-column-help": "Adds a new column to your layer to store result",
         "data-observatory-measurement-measurement": "Measurement",
         "data-observatory-measurement-desc": "enrich your data",
-        "data-observatory-measurement-refine": "Choose a measure"
+        "data-observatory-measurement-refine": "Choose a measure",
+        "data-observatory-measurement-segments": "Segments"
       },
       "infowindow": {
         "placeholder-interactivity-text": "Popups are disabled because interactivity is not available for this layer.",

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -16,20 +16,62 @@
     "november": "November",
     "december": "December"
   },
+
   "analyses": {
-    "georeference": "Georeference",
-    "data-observatory-measurement": "Enrich from Data Observatory",
-    "merge": "Join columns from 2nd layer",
-    "filter-by-node-column": "Link two layers",
-    "centroid": "Centroid from geometries",
-    "area-of-influence": "Create areas of influence",
-    "intersection": "Intersection",
-    "filter": "Filter by column value",
-    "sampling": "Subsample percent of rows",
-    "kmeans": "Calculate clusters of points",
-    "moran-cluster": "Detect outliers and clusters",
-    "spatial-markov-trend": "Predict trends and volatility"
+    "georeference": {
+      "title": "Georeference",
+      "short-title": "Georeference"
+    },
+    "data-observatory-measurement": {
+      "title": "Enrich from Data Observatory",
+      "short-title": "Data observatory"
+    },
+    "merge": {
+      "title": "Join columns from 2nd layer",
+      "short-title": "Merge"
+    },
+    "filter-by-node-column": {
+      "title": "Link two layers",
+      "short-title": "Link"
+    },
+    "centroid": {
+      "title": "Centroid from geometries",
+      "short-title": "Centroid"
+    },
+    "area-of-influence": {
+      "title": "Create areas of influence",
+      "short-title": "Area of influence"
+    },
+    "intersection": {
+      "title": "Intersection",
+      "short-title": "Intersection"
+    },
+    "aggregate-intersection": {
+      "title": "Intersection",
+      "short-title": "Intersection"
+    },
+    "filter": {
+      "title": "Filter by column value",
+      "short-title": "Filter"
+    },
+    "sampling": {
+      "title": "Subsample percent of rows",
+      "short-title": "Sampling"
+    },
+    "kmeans": {
+      "title": "Calculate clusters of points",
+      "short-title": "Clusters"
+    },
+    "moran-cluster": {
+      "title": "Detect outliers and clusters",
+      "short-title": "Outliers & clusters",
+    },
+    "spatial-markov-trend": {
+      "title": "Predict trends and volatility",
+      "short-title": "Trends"
+    },
   },
+
   "analysis-category": {
     "create-clean": "Create and clean",
     "data-transformation": "Transform",

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -28,11 +28,11 @@
     },
     "merge": {
       "title": "Join columns from 2nd layer",
-      "short-title": "Merge"
+      "short-title": "Join columns"
     },
     "filter-by-node-column": {
       "title": "Link two layers",
-      "short-title": "Link"
+      "short-title": "Link to layer"
     },
     "centroid": {
       "title": "Centroid from geometries",
@@ -40,7 +40,7 @@
     },
     "area-of-influence": {
       "title": "Create areas of influence",
-      "short-title": "Area of influence"
+      "short-title": "AOI"
     },
     "intersection": {
       "title": "Intersection",


### PR DESCRIPTION
This PR separates the titles of the analysis that appear inside the forms (`analyses.[ANALYSIS_NAME].title`) and the short titles that appear in each analysis item (`analyses.[ANALYSIS_NAME].short-title`):

```
  "analyses": {
    "georeference": {
      "title": "Georeference",
      "short-title": "Georeference"
    },
```
![screen shot 2016-07-07 at 12 30 10](https://cloud.githubusercontent.com/assets/4933/16650608/5fba48d2-443f-11e6-956c-d88cfd5ceb75.png)

![screen shot 2016-07-07 at 12 45 42](https://cloud.githubusercontent.com/assets/4933/16650882/bf08b3cc-4440-11e6-8f82-f84ae3707599.png)

CR: @viddo 
CR: @saleiva, please, check specially the names of the short versions that appear at https://github.com/CartoDB/cartodb/blob/a9800e001b25758626d7b95f8304224d6e2e49af/lib/assets/locale/en.json#L23


Closes #8317 