### PR TITLE
8284 apply default style on analysis added

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-source-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-source-model.js
@@ -14,7 +14,7 @@ module.exports = AnalysisDefinitionNodeModel.extend({
 
     this.querySchemaModel.set({
       query: this.get('query'),
-      may_have_rows: true
+      ready: true
     });
 
     this.tableModel = new TableModel({

--- a/lib/assets/javascripts/cartodb3/data/query-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-schema-model.js
@@ -20,7 +20,7 @@ module.exports = Backbone.Model.extend({
   defaults: {
     query: '',
     status: 'unavailable', //, unfetched, fetching, fetched
-    may_have_rows: false // this flag indicate if there _may_ be data available on the given query (but there's no guarantee)
+    ready: false // if ready there _may_ be data available on the given query (but there's no guarantee)
   },
 
   /**
@@ -120,10 +120,10 @@ module.exports = Backbone.Model.extend({
     }
 
     var hasChangedQuery = this.hasChanged('query');
-    if (hasChangedQuery || this.hasChanged('may_have_rows')) {
-      if (hasChangedQuery) {
-        this.columnsCollection.reset();
-      }
+    if (hasChangedQuery) {
+      this.columnsCollection.reset();
+    }
+    if (hasChangedQuery || this.hasChanged('ready')) {
       this.rowsSampleCollection.reset();
       this.set('status', this.get('query') ? 'unfetched' : 'unavailable');
     }

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -76,7 +76,7 @@ module.exports = function (collections) {
      * @param {Object} layerDefModel - instance of layer-definition-model
      * @return {Object} instance of analysis-definition-node-model
      */
-    createAnalysisNode: function (nodeAttrs, layerDefmodel) {
+    createAnalysisNode: function (nodeAttrs, layerDefModel) {
       var nodeDefModel = analysisDefinitionNodesCollection.add(nodeAttrs, {parse: false});
       var sourceNode = nodeDefModel.getPrimarySource();
 
@@ -87,7 +87,7 @@ module.exports = function (collections) {
         analysisDefinitionsCollection.createAnalysisForNode(nodeDefModel);
       }
 
-      layerDefmodel.save({
+      layerDefModel.save({
         cartocss: camshaftReference.getDefaultCartoCSSForType(nodeDefModel.get('type')),
         source: nodeDefModel.id
       });

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -92,6 +92,44 @@ module.exports = function (collections) {
         source: nodeDefModel.id
       });
 
+      var CHANGE_READY = 'change:ready';
+      var onQuerySchemaReady;
+      onQuerySchemaReady = function () {
+        var querySchemaModel = nodeDefModel.querySchemaModel;
+        if (querySchemaModel.get('ready')) {
+          querySchemaModel.off(CHANGE_READY, onQuerySchemaReady);
+        } else {
+          return; // wait until ready
+        }
+
+        var CHANGE_STATUS = 'change:status';
+        var saveDefaultStylesIfStillRelevant;
+        saveDefaultStylesIfStillRelevant = function () {
+          if (querySchemaModel.get('status') === 'fetched') {
+            querySchemaModel.off(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
+          } else {
+            return; // wait until fetched
+          }
+
+          var geometry;
+
+          if ( // Only apply changes if:
+            layerDefinitionsCollection.contains(layerDefModel) && // layer still exist
+            layerDefModel.get('source') === nodeDefModel.id && // node is still the head of layer
+            layerDefModel.styleModel.get('type') === 'none' && // layer have no styles applied
+            (geometry = querySchemaModel.getGeometry()) // nodes contains a geometry
+          ) {
+            layerDefModel.styleModel.setDefaultPropertiesByType('simple', geometry.getSimpleType());
+            layerDefModel.save();
+          }
+        };
+        saveDefaultStylesIfStillRelevant();
+        querySchemaModel.on(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
+        querySchemaModel.fetch();
+      };
+      nodeDefModel.querySchemaModel.on(CHANGE_READY, onQuerySchemaReady);
+      onQuerySchemaReady();
+
       return nodeDefModel;
     },
 

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -88,7 +88,7 @@ F.prototype._tryToSetupDefinitionNodeSync = function (m) {
     var updateAnalysisQuerySchema = function () {
       m.querySchemaModel.set({
         query: node.get('query'),
-        may_have_rows: node.get('status') === 'ready'
+        ready: node.get('status') === 'ready'
       });
     };
     updateAnalysisQuerySchema();

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var ConfigModel = require('../../../../javascripts/cartodb3/data/config-model');
 var LayerDefinitionModel = require('../../../../javascripts/cartodb3/data/layer-definition-model');
+var QuerySchemaModel = require('../../../../javascripts/cartodb3/data/query-schema-model');
 var AnalysisDefinitionNodesCollection = require('../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var AnalysisDefinitionsCollection = require('../../../../javascripts/cartodb3/data/analysis-definitions-collection');
 var LayerDefinitionsCollection = require('../../../../javascripts/cartodb3/data/layer-definitions-collection');
@@ -14,6 +15,7 @@ var AreaOfInfluenceFormModel = require('../../../../javascripts/cartodb3/editor/
 var CategoryWidgetOptionModel = require('../../../../javascripts/cartodb3/components/modals/add-widgets/category/category-option-model');
 var FilterByNodeColumnFormModel = require('../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-by-node-column');
 var AnalysisSourceOptionsModel = require('../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-source-options-model');
+var geometry = require('../../../../javascripts/cartodb3/value-objects/geometry');
 
 describe('cartodb3/data/user-actions', function () {
   var interceptAjaxCall;
@@ -87,8 +89,14 @@ describe('cartodb3/data/user-actions', function () {
 
     describe('when given a node w/o analysis', function () {
       beforeEach(function () {
-        this.layerDefModel = new Backbone.Model();
-        spyOn(this.layerDefModel, 'save');
+        this.layerDefModel = this.layerDefinitionsCollection.add({
+          id: 'layerA',
+          kind: 'carto',
+          options: {
+            table_name: 'alice'
+          }
+        });
+        spyOn(this.layerDefModel, 'save').and.callThrough();
 
         var nodeAttrs = {
           id: 'a1',
@@ -98,6 +106,7 @@ describe('cartodb3/data/user-actions', function () {
           time: 123
         };
 
+        spyOn(QuerySchemaModel.prototype, 'on').and.callThrough();
         this.nodeDefModel = this.userActions.createAnalysisNode(nodeAttrs, this.layerDefModel);
       });
 
@@ -120,6 +129,59 @@ describe('cartodb3/data/user-actions', function () {
       it('should return a new node', function () {
         expect(this.nodeDefModel).toBeDefined();
         expect(this.nodeDefModel.id).toEqual('a1');
+      });
+
+      it('should listen to query-schema-model changes', function () {
+        expect(QuerySchemaModel.prototype.on).toHaveBeenCalled();
+        expect(QuerySchemaModel.prototype.on.calls.count()).toEqual(2);
+        expect(QuerySchemaModel.prototype.on.calls.argsFor(1)[0]).toEqual('change:ready');
+        expect(QuerySchemaModel.prototype.on.calls.argsFor(1)[1]).toEqual(jasmine.any(Function));
+      });
+
+      describe('when query-schema-model ready attr is changed', function () {
+        beforeEach(function () {
+          this.querySchemaModel = this.analysisDefinitionNodesCollection.get('a1').querySchemaModel;
+          spyOn(this.querySchemaModel, 'off').and.callThrough();
+          spyOn(this.querySchemaModel, 'fetch');
+
+          this.querySchemaModel.set({
+            query: 'SELECT * FROM alice_results',
+            ready: true
+          });
+        });
+
+        it('should remove listener', function () {
+          expect(this.querySchemaModel.off).toHaveBeenCalledWith('change:ready', jasmine.any(Function));
+          expect(this.querySchemaModel.off.calls.argsFor(0)[1]).toBe(QuerySchemaModel.prototype.on.calls.argsFor(1)[1]);
+        });
+
+        it('should listen to status attr', function () {
+          expect(QuerySchemaModel.prototype.on.calls.count()).toEqual(3);
+          expect(QuerySchemaModel.prototype.on.calls.argsFor(2)[0]).toEqual('change:status');
+          expect(QuerySchemaModel.prototype.on.calls.argsFor(2)[1]).toEqual(jasmine.any(Function));
+        });
+
+        it('should fetch model', function () {
+          expect(this.querySchemaModel.fetch).toHaveBeenCalled();
+        });
+
+        describe('when query-schema is fetched', function () {
+          beforeEach(function () {
+            this.layerDefModel.save.calls.reset();
+            spyOn(this.layerDefModel.styleModel, 'setDefaultPropertiesByType').and.callThrough();
+            spyOn(this.querySchemaModel, 'getGeometry').and.returnValue(geometry.ex('point'));
+
+            this.querySchemaModel.set({status: 'fetched'});
+          });
+
+          it('should set default style on layer model', function () {
+            expect(this.layerDefModel.styleModel.setDefaultPropertiesByType).toHaveBeenCalledWith('simple', 'point');
+          });
+
+          it('should have been saved again', function () {
+            expect(this.layerDefModel.save).toHaveBeenCalled();
+          });
+        });
       });
     });
 

--- a/lib/assets/test/spec/cartodb3/data/query-schema-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/query-schema-model.spec.js
@@ -132,10 +132,10 @@ describe('data/query-schema-model', function () {
     });
   });
 
-  describe('when may_have_rows flag is changed', function () {
+  describe('when ready flag is changed', function () {
     describe('when there is no query', function () {
       beforeEach(function () {
-        this.model.set('may_have_rows', true);
+        this.model.set('ready', true);
       });
 
       it('should reset rows sample', function () {
@@ -151,7 +151,7 @@ describe('data/query-schema-model', function () {
       beforeEach(function () {
         this.model.set({
           query: 'SELECT * FROM something',
-          may_have_rows: false
+          ready: false
         });
       });
 

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -432,7 +432,7 @@ describe('deep-insights-integrations', function () {
 
       it('should setup query schema model of node-definition', function () {
         expect(this.a0.querySchemaModel.get('query')).toEqual('SELECT * FROM foobar');
-        expect(this.a0.querySchemaModel.get('may_have_rows')).toBe(true);
+        expect(this.a0.querySchemaModel.get('ready')).toBe(true);
       });
 
       describe('when analysis node has finished executing', function () {
@@ -474,7 +474,7 @@ describe('deep-insights-integrations', function () {
 
       it('should setup query schema model of node-definition', function () {
         expect(this.a1.querySchemaModel.get('query')).toEqual(undefined);
-        expect(this.a1.querySchemaModel.get('may_have_rows')).toBe(false);
+        expect(this.a1.querySchemaModel.get('ready')).toBe(false);
       });
 
       describe('when analysis node has finished executing', function () {
@@ -487,7 +487,7 @@ describe('deep-insights-integrations', function () {
 
         it('should update the query-schema-model', function () {
           expect(this.a1.querySchemaModel.get('query')).toEqual('SELECT buffer FROM tmp_result_table_123');
-          expect(this.a1.querySchemaModel.get('may_have_rows')).toBe(true);
+          expect(this.a1.querySchemaModel.get('ready')).toBe(true);
         });
       });
     });


### PR DESCRIPTION
Resolves #7827 ~~#8284~~ 

When a new node is created we listen to change to the query-schema-model and apply defaults styles as soon as possible, if the layer+node is still considered "still valid" (to avoid overwriting changes done by the user while looking up the geometry)

@xavijam please review