### PR TITLE
Fix creation of mobile apps #8747

### DIFF
--- a/app/views/carto/admin/mobile_apps/_form.html.erb
+++ b/app/views/carto/admin/mobile_apps/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @mobile_app, as: :mobile_app, url: (@mobile_app.persisted? ? CartoDB.url(self, 'mobile_app', { id: @mobile_app.id }, current_user) : CartoDB.url(self, 'mobile_apps', {}, current_user)), :html => { :class => "js-MobileAppForm" } do |f| %>
+<%= form_for @mobile_app, as: :mobile_app, url: (@mobile_app.persisted? ? CartoDB.url(self, 'mobile_app', { id: @mobile_app.id }, current_user) : CartoDB.url(self, 'mobile_apps', {}, current_user)), html: { class: "js-MobileAppForm" } do |f| %>
   <%= csrf_meta_tags %>
 
   <span class="FormAccount-separator"></span>

--- a/app/views/carto/admin/mobile_apps/_form.html.erb
+++ b/app/views/carto/admin/mobile_apps/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @mobile_app, as: :mobile_app, url: (@mobile_app.persisted? ? CartoDB.url(self, 'mobile_app', { id: @mobile_app.id }) : CartoDB.url(self, 'mobile_apps')), :html => { :class => "js-MobileAppForm" } do |f| %>
+<%= form_for @mobile_app, as: :mobile_app, url: (@mobile_app.persisted? ? CartoDB.url(self, 'mobile_app', { id: @mobile_app.id }, current_user) : CartoDB.url(self, 'mobile_apps', {}, current_user)), :html => { :class => "js-MobileAppForm" } do |f| %>
   <%= csrf_meta_tags %>
 
   <span class="FormAccount-separator"></span>


### PR DESCRIPTION
Fixes #8747

Without passing the user, the URL generated is for the user (not the org), causing a redirection which fails.