### PR TITLE
8571 add query schema model cachebust

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/query-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-schema-model.js
@@ -61,6 +61,7 @@ module.exports = Backbone.Model.extend({
     opts.data = _.extend(
       opts.data || {},
       {
+        cachebust: new Date().getTime(),
         api_key: this._configModel.get('api_key'),
         q: this._getSqlApiQueryParam()
       },

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -111,15 +111,14 @@ module.exports = function (collections) {
             return; // wait until fetched
           }
 
-          var geometry;
-
           if ( // Only apply changes if:
             layerDefinitionsCollection.contains(layerDefModel) && // layer still exist
             layerDefModel.get('source') === nodeDefModel.id && // node is still the head of layer
-            layerDefModel.styleModel.get('type') === 'none' && // layer have no styles applied
-            (geometry = querySchemaModel.getGeometry()) // nodes contains a geometry
+            layerDefModel.styleModel.get('type') === 'none' // layer have no styles applied
           ) {
-            layerDefModel.styleModel.setDefaultPropertiesByType('simple', geometry.getSimpleType());
+            var geometry = querySchemaModel.getGeometry();
+            var simpleGeometryType = geometry && geometry.getSimpleType();
+            layerDefModel.styleModel.setDefaultPropertiesByType('simple', simpleGeometryType || 'point'); // fallback on point styling for points if there's no geometry
             layerDefModel.save();
           }
         };

--- a/lib/assets/test/jasmine/cartodb3/data/query-schema-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/query-schema-model.spec.js
@@ -61,6 +61,10 @@ describe('data/query-schema-model', function () {
         expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.q).toMatch(/select \* from \(.+\) /);
       });
 
+      it('should contain a cache bust', function () {
+        expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.cachebust).toMatch(/\d+/);
+      });
+
       it('should add order, rows and page', function () {
         expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.rows_per_page).toBe(40);
         expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.page).toBe(0);

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -165,7 +165,25 @@ describe('cartodb3/data/user-actions', function () {
           expect(this.querySchemaModel.fetch).toHaveBeenCalled();
         });
 
-        describe('when query-schema is fetched', function () {
+        describe('when query-schema is fetched w/ some geometry', function () {
+          beforeEach(function () {
+            this.layerDefModel.save.calls.reset();
+            spyOn(this.layerDefModel.styleModel, 'setDefaultPropertiesByType').and.callThrough();
+            spyOn(this.querySchemaModel, 'getGeometry').and.returnValue(geometry.ex('polygon'));
+
+            this.querySchemaModel.set({status: 'fetched'});
+          });
+
+          it('should set default style on layer model', function () {
+            expect(this.layerDefModel.styleModel.setDefaultPropertiesByType).toHaveBeenCalledWith('simple', 'polygon');
+          });
+
+          it('should have been saved again', function () {
+            expect(this.layerDefModel.save).toHaveBeenCalled();
+          });
+        });
+
+        describe('when query-schema is fetched but could not find any geometry', function () {
           beforeEach(function () {
             this.layerDefModel.save.calls.reset();
             spyOn(this.layerDefModel.styleModel, 'setDefaultPropertiesByType').and.callThrough();
@@ -174,7 +192,7 @@ describe('cartodb3/data/user-actions', function () {
             this.querySchemaModel.set({status: 'fetched'});
           });
 
-          it('should set default style on layer model', function () {
+          it('should set default style w/ points as fallback', function () {
             expect(this.layerDefModel.styleModel.setDefaultPropertiesByType).toHaveBeenCalledWith('simple', 'point');
           });
 


### PR DESCRIPTION
Fixes #8571 with a tmp solution until this can be fixed on the maps API.  Requests will have an additional query string param that will change value for every request, e.g. `?cachebust=1468243056998&…`

edit: also set default style as _points_ if could not find any geometry

cc @javisantana @rochoa 

