### PR TITLE
Replaces label title in the georeference form

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model.js
@@ -174,7 +174,7 @@ module.exports = BaseAnalysisFormModel.extend({
       },
       type: {
         type: 'Select',
-        title: _t('editor.layers.analysis-form.mode'),
+        title: _t('editor.layers.analysis-form.type'),
         options: [
           { val: 'georeference-long-lat', label: _t('editor.layers.analysis-form.georeference-long-lat') },
           { val: 'georeference-city', label: _t('editor.layers.analysis-form.georeference-city') },

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form.tpl
@@ -11,7 +11,7 @@
         <div class="Editor-formInput" data-editors="source"></div>
       </div>
       <div class="u-tSpace-xl CDB-Text CDB-Fieldset">
-        <p class="CDB-Legend u-upperCase u-iBlock CDB-Text is-semibold CDB-Size-small u-rSpace--m"><%- _t('editor.layers.analysis-form.column') %></p>
+        <p class="CDB-Legend u-upperCase u-iBlock CDB-Text is-semibold CDB-Size-small u-rSpace--m"><%- _t('editor.layers.analysis-form.type') %></p>
         <div class="Editor-formInput" data-editors="type"></div>
       </div>
     </div>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/intersection-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/intersection-form-model.js
@@ -95,7 +95,7 @@ module.exports = BaseAnalysisFormModel.extend({
       },
       type: {
         type: 'Radio',
-        title: _t('editor.layers.analysis-form.type'),
+        title: _t('editor.layers.analysis-form.measure-by'),
         options: [
           { label: 'Filter', val: 'intersection' },
           { label: 'Aggregate', val: 'aggregate-intersection' }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/intersection-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/intersection-form.tpl
@@ -12,7 +12,7 @@
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">3</div>
     <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="<%- dataFields %>">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('editor.layers.analysis-form.type') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('editor.layers.analysis-form.measure-by') %></h2>
       </div>
       <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--xl"><%- _t('editor.layers.analysis-form.filter-aggregate') %></p>
     </div>

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1147,7 +1147,7 @@
         "tune-analysis": "Tune your analysis",
         "tune-centroid": "Tune your centroid",
         "tune-clusters": "Tune your clusters",
-        "type": "Measure by",
+        "measure-by": "Measure by",
         "value": "Value",
         "weight": "Weight",
         "weight-column": "Weight column",


### PR DESCRIPTION
Replaces 'Column' label with 'Type'. 

It also creates a "measure-by" entry in the localization file that was needed.