### PR TITLE
Use userActions when widget is added from data view

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -143,7 +143,7 @@ module.exports = function (collections) {
         layerDefModel.save(); // to make sure layer's source ref is persisted
       }
 
-      widgetOptionModel.save(widgetDefinitionsCollection); // delegate back to form model to decide how to save
+      return widgetOptionModel.save(widgetDefinitionsCollection); // delegate back to form model to decide how to save
     },
 
     saveWidget: function (widgetDefModel) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -11,6 +11,7 @@ module.exports = CoreView.extend({
     if (!opts.columnsModel) throw new Error('columnsModel is required');
     if (!opts.stackLayoutModel) throw new Error('StackLayoutModel is required');
     if (!opts.infoboxModel) throw new Error('infoboxModel is required');
+    if (!opts.userActions) throw new Error('userActions is required');
 
     this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
 
@@ -18,6 +19,7 @@ module.exports = CoreView.extend({
     this._infoboxModel = opts.infoboxModel;
     this._columnsModel = opts.columnsModel;
     this._columnsCollection = this._columnsModel.getCollection();
+    this._userActions = opts.userActions;
 
     this._initBinds();
   },
@@ -56,7 +58,7 @@ module.exports = CoreView.extend({
     if (model.get('selected') === true) {
       candidate = this._columnsModel.findWidget(model);
       if (!candidate) {
-        m = model.save(this._widgetDefinitionsCollection);
+        m = this._userActions.saveWidgetOption(model);
         model.set({widget: m});
       } else {
         model.set({widget: candidate});

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -210,6 +210,7 @@ module.exports = CoreView.extend({
               stackLayoutModel: self._stackLayoutModel,
               widgetDefinitionsCollection: self._widgetDefinitionsCollection,
               columnsModel: self._columnsModel,
+              userActions: self._userActions,
               infoboxModel: self._infoboxModel
             });
           }

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
@@ -52,9 +52,12 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
     spyOn(DataContentView.prototype, '_renderStats');
     spyOn(DataContentView.prototype, '_columnsReady').and.returnValue(false);
 
+    var userActions = jasmine.createSpyObj('userActions', ['saveWidgetOption']);
+
     view = new DataContentView({
       widgetDefinitionsCollection: widgetDefinitionsCollection,
       stackLayoutModel: stackLayoutModel,
+      userActions: userActions,
       columnsNumberModel: columnModel,
       columnsModel: columnsModel,
       infoboxModel: new Backbone.Model()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.0.24",
+  "version": "4.0.26",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We were not using userActions within data-view panel and if you create a new map with one layer, and try to add a widget from that panel, map instantiation fails due to node is not saved before saving the widget.

CR: @viddo 

cc @saleiva @nobuti 