### PR TITLE
add template_type in vizjson presenter

### DIFF
--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -447,7 +447,7 @@ module Carto
       ).freeze
 
       INFOWINDOW_AND_TOOLTIP_KEYS = %w(
-        fields template_name template alternative_names width maxHeight headerColor
+        fields template_name template template_type alternative_names width maxHeight headerColor
       ).freeze
 
       def initialize(layer, options = {}, configuration = {}, decoration_data = {})


### PR DESCRIPTION
close template compile issue in embeds described in https://github.com/CartoDB/cartodb/issues/8558

rather than change the default `template_type` in cartodb.js for the new embeds (which for some reason was underscore, instead of moustache, as in old embeds) we are now exposing the template_type (updated at the time it's changed in the builder) for namedmaps

CR @gfiorav (thanks mate) /cc @alonsogarciapablo 