### PR TITLE
Insert cdb.js layers at the right position

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -310,7 +310,6 @@ module.exports = function (params) {
         tableName = prevLayer.get('table_name');
         tableNameAlias = prevLayer.get('table_name_alias');
         attrs = createDefaultCartoDBAttrs();
-        attrs.order = prevOrder;
         attrs.options = _.extend({}, attrs.options, {
           sql: 'SELECT * FROM ' + tableName,
           table_name: tableName,
@@ -407,7 +406,7 @@ module.exports = function (params) {
       $.when.apply($, saveAnalysisPromises).done(function () { // http://api.jquery.com/jQuery.when/
         layerDefinitionsCollection.save({
           success: function () {
-            layerDefinitionsCollection.trigger('layerMoved', movingLayer, to, layerDefinitionsCollection);
+            layerDefinitionsCollection.trigger('layerMoved', movingLayer);
           }
         });
       });

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -223,7 +223,6 @@ module.exports = function (params) {
 
       var attrs = createDefaultCartoDBAttrs();
       attrs.letter = newLetter;
-      attrs.order = at;
       attrs.options.table_name = tableName;
       attrs.options.query = 'SELECT * FROM ' + tableName;
 
@@ -362,7 +361,6 @@ module.exports = function (params) {
         tableName = ownerLayer.get('table_name');
         tableNameAlias = ownerLayer.get('table_name_alias');
         attrs = createDefaultCartoDBAttrs();
-        attrs.order = newPosition;
         attrs.options = _.extend({}, attrs.options, {
           sql: 'SELECT * FROM ' + tableName,
           table_name: tableName,

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -288,25 +288,14 @@ F.prototype._onLayerDefinitionRemoved = function (m) {
   }
 };
 
-F.prototype._onLayerDefinitionMoved = function (m, at, c) {
+F.prototype._onLayerDefinitionMoved = function (m) {
   this.visMap().layers.remove(m, { silent: true });
-  this._createLayer(m, {
-    at: at
-  });
+  this._createLayer(m);
 };
 
 var LAYER_TYPE_TO_LAYER_CREATE_METHOD;
-F.prototype._createLayer = function (layerDefModel, opts) {
-  opts = _.extend({
-    at: layerDefModel.get('order')
-  }, opts);
+F.prototype._createLayer = function (layerDefModel) {
   var attrs = JSON.parse(JSON.stringify(layerDefModel.attributes)); // deep clone;
-
-  if (attrs.source) {
-    // Make sure to analysis is created first
-    var nodeDefModel = this._analysisDefinitionNodesCollection.get(attrs.source);
-    this._analyseDefinitionNode(nodeDefModel);
-  }
 
   LAYER_TYPE_TO_LAYER_CREATE_METHOD = LAYER_TYPE_TO_LAYER_CREATE_METHOD || {
     'cartodb': 'createCartoDBLayer',
@@ -319,8 +308,17 @@ F.prototype._createLayer = function (layerDefModel, opts) {
   var createMethodName = LAYER_TYPE_TO_LAYER_CREATE_METHOD[attrs.type.toLowerCase()];
   if (!createMethodName) throw new Error('no create method name found for type ' + attrs.type);
 
+  if (attrs.source) {
+    // Make sure the analysis is created first
+    var nodeDefModel = this._analysisDefinitionNodesCollection.get(attrs.source);
+    this._analyseDefinitionNode(nodeDefModel);
+  }
+
   var visMap = this.visMap();
-  visMap[createMethodName](attrs, opts);
+  var layerPosition = this._layerDefinitionsCollection.indexOf(layerDefModel);
+  visMap[createMethodName](attrs, {
+    at: layerPosition
+  });
 
   linkLayerInfowindow(layerDefModel, visMap);
   linkLayerTooltip(layerDefModel, visMap);

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -1297,8 +1297,6 @@ describe('cartodb3/data/user-actions', function () {
       expect(onRemoveCallback).not.toHaveBeenCalled();
       expect(onLayerMovedCallback).toHaveBeenCalled();
       expect(onLayerMovedCallback.calls.argsFor(0)[0].id).toEqual('layer4');
-      expect(onLayerMovedCallback.calls.argsFor(0)[1]).toEqual(1);
-      expect(onLayerMovedCallback.calls.argsFor(0)[2]).toBe(this.layerDefinitionsCollection);
     });
 
     it('should create analysis for layers that have a source', function () {

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -228,23 +228,39 @@ describe('deep-insights-integrations', function () {
       expect(l).toBeDefined();
       expect(l.get('color')).toEqual('blue');
       expect(l.get('type')).toEqual('Plain');
+      expect(l.get('order')).toEqual(0);
     });
 
     it('should insert the layer at the given position (order)', function () {
       this.layerDefinitionModel = this.layerDefinitionsCollection.add({
         id: 'integration-test-2',
-        kind: 'background',
+        kind: 'carto',
         options: {
-          color: 'blue',
-          order: 99 // order is actually reset after being added to the collection
+          sql: 'SELECT * FROM foo',
+          cartocss: '...'
         }
-      }, { at: 0 }); // <- this is what actually determines the right order
+      }, { at: 1 }); // <- this is what actually determines the right order
 
-      expect(this.layerDefinitionModel.get('order')).toEqual(0);
+      expect(this.layerDefinitionModel.get('order')).toEqual(1);
 
       var l = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
-      expect(this.integrations.visMap().layers.indexOf(l)).toEqual(0);
-      expect(l.get('order')).toEqual(0);
+      expect(this.integrations.visMap().layers.indexOf(l)).toEqual(1);
+      expect(l.get('order')).toEqual(1);
+
+      this.layerDefinitionModel = this.layerDefinitionsCollection.add({
+        id: 'integration-test-3',
+        kind: 'carto',
+        options: {
+          sql: 'SELECT * FROM foo',
+          cartocss: '...'
+        }
+      }, { at: 2 }); // <- this is what actually determines the right order
+
+      expect(this.layerDefinitionModel.get('order')).toEqual(2);
+
+      l = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
+      expect(this.integrations.visMap().layers.indexOf(l)).toEqual(2);
+      expect(l.get('order')).toEqual(2);
     });
 
     describe('when update some layer attrs', function () {
@@ -508,7 +524,7 @@ describe('deep-insights-integrations', function () {
 
     it('should remove model and create a new one with the same id', function () {
       var currentModel = this.integrations._getLayer(this.newLayer);
-      this.layerDefinitionsCollection.trigger('layerMoved', this.newLayer, 0);
+      this.layerDefinitionsCollection.trigger('layerMoved', this.newLayer);
       var newModel = this.integrations._getLayer(this.newLayer);
       expect(newModel.cid).not.toBe(currentModel.cid);
       expect(newModel.attributes.source).toEqual('a0');


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb/issues/8784.

Use the actual position of the layerDefModel in the layerDefinitionsCollection instead of using the `order` attribute to determine where the layer should be inserted.

@viddo can you please review? Thx!