### PR TITLE
Better wrap and break.

### DIFF
--- a/app/assets/stylesheets/editor-3/notifier.css.scss
+++ b/app/assets/stylesheets/editor-3/notifier.css.scss
@@ -3,9 +3,12 @@
 @import 'cdb-variables/sizes';
 
 .Notifier {
+  @include css3-prefix(hyphens, auto);
   margin: 0 -25px;
   padding: 0 $baseSize * 3;
   border-top: 1px solid $cSecondaryLine;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 
   &.is-dark {
     border-color: #3A484E;
@@ -41,7 +44,6 @@
   @include flex(1);
   min-width: 0; // To prevent firefox screw up
   padding-right: $baseSize * 2;
-  word-break: break-all;
 }
 
 .Notifier-actions {


### PR DESCRIPTION
This PR fixes #8798.

I made some tests and the issue has no optimal solution that works everywhere, because there are too much inconsistencies between vendors, even the hyphens are inconsistent within the same browser (Firefox doesn't hyphen words with underscores) . IMO this is the best approach: http://codepen.io/nobuti/pen/kXxyxO/

<img width="1215" alt="screen shot 2016-07-12 at 17 37 57" src="https://cloud.githubusercontent.com/assets/1366843/16773318/d73f0ac0-4857-11e6-9853-8343125c1861.png">

Even applying this, we can't assure no weirdos will appear.

cc @piensaenpixel