### PR TITLE
Fixes opacity for points

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
@@ -93,7 +93,7 @@ function pointFill (props) {
     if (props.color.operation) {
       css['marker-comp-op'] = props.color.operation;
     }
-    if (props.color.opacity) {
+    if (_.isNumber(props.color.opacity)) {
       css['marker-fill-opacity'] = props.color.opacity;
     }
     if (props.image) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.0.29",
+  "version": "4.0.30",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It looks like [we are not sending the opacity when the value is zero](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb3/editor/style/style-converter.js#L96) like we are doing [for polygons](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb3/editor/style/style-converter.js#L118).

CR: @javisantana 

Closes #8817 