### PR TITLE
Display a notification when map instantiation fails

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -4,8 +4,6 @@ var linkLayerTooltip = require('./deep-insights-integration/link-layer-tooltip')
 var AnalysisNotifications = require('./analysis-notifications');
 var VisNotifications = require('./vis-notifications');
 
-var Notifier = require('./components/notifier/notifier');
-
 /**
  * Integration between various data collections/models with cartodb.js and deep-insights.
  */

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -4,6 +4,8 @@ var linkLayerTooltip = require('./deep-insights-integration/link-layer-tooltip')
 var AnalysisNotifications = require('./analysis-notifications');
 var VisNotifications = require('./vis-notifications');
 
+var Notifier = require('./components/notifier/notifier');
+
 /**
  * Integration between various data collections/models with cartodb.js and deep-insights.
  */

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var linkLayerInfowindow = require('./deep-insights-integration/link-layer-infowindow');
 var linkLayerTooltip = require('./deep-insights-integration/link-layer-tooltip');
 var AnalysisNotifications = require('./analysis-notifications');
+var VisNotifications = require('./vis-notifications');
 
 /**
  * Integration between various data collections/models with cartodb.js and deep-insights.
@@ -49,6 +50,8 @@ var F = function (opts) {
 
   this._analysisDefinitionsCollection.each(this._analyseDefinition, this);
   this._vis().on('reload', this._recordChange, this);
+
+  VisNotifications.track(this._vis());
 };
 
 F.prototype._onAnalysisDefinitionNodeRemoved = function (m) {

--- a/lib/assets/javascripts/cartodb3/vis-notifications.js
+++ b/lib/assets/javascripts/cartodb3/vis-notifications.js
@@ -1,0 +1,41 @@
+var Notifier = require('./components/notifier/notifier');
+
+var NOTIFICATION_ID = 'visNotification';
+
+var VisNotifications = {
+
+  track: function (vis) {
+    vis.on('change:error', this._toggleVisErrorNotification, this);
+    this._toggleVisErrorNotification(vis);
+  },
+
+  _toggleVisErrorNotification: function (vis) {
+    var error = vis.get('error');
+    if (error) {
+      this._showVisErrorNotification();
+    } else {
+      this._hideVisErrorNotification();
+    }
+  },
+
+  _showVisErrorNotification: function () {
+    Notifier.addNotification(this._getNotificationAttrs());
+  },
+
+  _hideVisErrorNotification: function () {
+    if (Notifier.getNotification(NOTIFICATION_ID)) {
+      Notifier.removeNotification(NOTIFICATION_ID);
+    }
+  },
+
+  _getNotificationAttrs: function () {
+    return {
+      id: NOTIFICATION_ID,
+      status: 'error',
+      info: _t('notifications.vis.failed'),
+      closable: false
+    };
+  }
+};
+
+module.exports = VisNotifications;

--- a/lib/assets/javascripts/cartodb3/vis-notifications.js
+++ b/lib/assets/javascripts/cartodb3/vis-notifications.js
@@ -1,6 +1,8 @@
+var _ = require('underscore');
 var Notifier = require('./components/notifier/notifier');
 
 var NOTIFICATION_ID = 'visNotification';
+var NOTIFICATION_TEMPLATE = _.template("<span class='CDB-Text is-semibold u-errorTextColor'><%= title %></span>&nbsp;<%= body %>");
 
 var VisNotifications = {
 
@@ -32,7 +34,10 @@ var VisNotifications = {
     return {
       id: NOTIFICATION_ID,
       status: 'error',
-      info: _t('notifications.vis.failed'),
+      info: NOTIFICATION_TEMPLATE({
+        title: _t('notifications.vis.failed.title'),
+        body: _t('notifications.vis.failed.body')
+      }),
       closable: false
     };
   }

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1475,7 +1475,10 @@
   },
   "notifications": {
     "vis": {
-      "failed": "This map couldn't be rendered. Please try to refresh the page and contact us if the error persists."
+      "failed": {
+        "title": "This map couldn't be rendered.",
+        "body": "Please refresh the page and contact us if the error persists."
+      }
     },
     "analysis": {
       "pending": "Analysis %{nodeId} waiting",

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1474,6 +1474,9 @@
     }
   },
   "notifications": {
+    "vis": {
+      "failed": "This map couldn't be rendered. Please try to refresh the page and contact us if the error persists."
+    },
     "analysis": {
       "pending": "Analysis %{nodeId} waiting",
       "waiting": "Analysis %{nodeId} enqueued",

--- a/lib/assets/test/jasmine/cartodb3/vis-notifications.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/vis-notifications.spec.js
@@ -1,0 +1,47 @@
+var Backbone = require('backbone');
+var VisNotifications = require('../../../javascripts/cartodb3/vis-notifications');
+var Notifier = require('../../../javascripts/cartodb3/components/notifier/notifier');
+
+describe('VisNotifications.track', function () {
+  beforeEach(function () {
+    this.visModel = new Backbone.Model();
+    this.notification = new Backbone.Model();
+    spyOn(Notifier, 'addNotification').and.callThrough();
+    spyOn(Notifier, 'removeNotification').and.callThrough();
+  });
+
+  describe('if vis has errors', function () {
+    it('should display a notification', function () {
+      this.visModel.set('error', 'whatever');
+      VisNotifications.track(this.visModel);
+      expect(Notifier.addNotification).toHaveBeenCalledWith({
+        id: 'visNotification',
+        status: 'error',
+        info: 'notifications.vis.failed',
+        closable: false
+      });
+    });
+  });
+
+  describe('if error attribute changes', function () {
+    beforeEach(function () {
+      VisNotifications.track(this.visModel);
+    });
+
+    it("should display a notification if there's an error", function () {
+      this.visModel.set('error', 'whatever');
+      expect(Notifier.addNotification).toHaveBeenCalledWith({
+        id: 'visNotification',
+        status: 'error',
+        info: 'notifications.vis.failed',
+        closable: false
+      });
+    });
+
+    it('should hide the notification when the error is removed', function () {
+      this.visModel.set('error', 'whatever');
+      this.visModel.unset('error');
+      expect(Notifier.removeNotification).toHaveBeenCalledWith('visNotification');
+    });
+  });
+});

--- a/lib/assets/test/jasmine/cartodb3/vis-notifications.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/vis-notifications.spec.js
@@ -17,7 +17,7 @@ describe('VisNotifications.track', function () {
       expect(Notifier.addNotification).toHaveBeenCalledWith({
         id: 'visNotification',
         status: 'error',
-        info: 'notifications.vis.failed',
+        info: "<span class='CDB-Text is-semibold u-errorTextColor'>notifications.vis.failed.title</span>&nbsp;notifications.vis.failed.body",
         closable: false
       });
     });
@@ -33,7 +33,7 @@ describe('VisNotifications.track', function () {
       expect(Notifier.addNotification).toHaveBeenCalledWith({
         id: 'visNotification',
         status: 'error',
-        info: 'notifications.vis.failed',
+        info: "<span class='CDB-Text is-semibold u-errorTextColor'>notifications.vis.failed.title</span>&nbsp;notifications.vis.failed.body",
         closable: false
       });
     });

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -1,4 +1,5 @@
 var $ = require('jquery');
+var _ = require('underscore');
 var Backbone = require('backbone');
 var ConfigModel = require('../../../javascripts/cartodb3/data/config-model');
 var deepInsights = require('cartodb-deep-insights.js');
@@ -7,6 +8,36 @@ var AnalysisDefinitionsCollection = require('../../../javascripts/cartodb3/data/
 var DeepInsightsIntegrations = require('../../../javascripts/cartodb3/deep-insights-integrations');
 var LayerDefinitionsCollection = require('../../../javascripts/cartodb3/data/layer-definitions-collection');
 var VisDefinitionModel = require('../../../javascripts/cartodb3/data/vis-definition-model');
+
+var createFakeDashboard = function (layers) {
+  var allLayersHaveIds = _.all(layers, function (layer) {
+    return layer.get('id');
+  });
+  if (!allLayersHaveIds) {
+    throw new Error('all layers in createFakeDashboard need to have an id');
+  }
+
+  var fakeMap = new Backbone.Model();
+  fakeMap.getLayerById = function (layerId) {
+    return _.find(layers, function (layer) {
+      return layer.get('id') === layerId;
+    });
+  };
+  var fakeVis = new Backbone.Model();
+  fakeVis.map = fakeMap;
+
+  return {
+    getMap: function () {
+      return fakeVis;
+    }
+  };
+};
+
+var createFakeLayer = function (attrs) {
+  var layer = new Backbone.Model(attrs);
+  layer.isVisible = function () { return true; };
+  return layer;
+};
 
 describe('deep-insights-integrations', function () {
   beforeEach(function (done) {
@@ -540,26 +571,11 @@ describe('deep-insights-integrations', function () {
 
   describe('.infowindow', function () {
     beforeEach(function () {
-      var self = this;
-
-      this.cdbLayer = new Backbone.Model({});
+      this.cdbLayer = createFakeLayer({ id: 'layer-id' });
       this.cdbLayer.infowindow = jasmine.createSpyObj('infowindow', ['update']);
 
-      var fakeDashboard = {
-        getMap: function () {
-          return {
-            map: {
-              getLayerById: function () {
-                return self.cdbLayer;
-              }
-            },
-            on: function () {}
-          };
-        }
-      };
-
       this.layerDefinitionsCollection.resetByLayersData({
-        id: 'test-infowindow',
+        id: 'layer-id',
         kind: 'carto',
         options: {
           table_name: 'infowindow_stuff',
@@ -582,7 +598,7 @@ describe('deep-insights-integrations', function () {
       });
 
       this.integrations2 = new DeepInsightsIntegrations({
-        deepInsightsDashboard: fakeDashboard,
+        deepInsightsDashboard: createFakeDashboard([ this.cdbLayer ]),
         analysisDefinitionsCollection: this.analysisDefinitionsCollection,
         analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
         layerDefinitionsCollection: this.layerDefinitionsCollection,
@@ -752,8 +768,8 @@ describe('deep-insights-integrations', function () {
 
   describe('"syncing" of errors coming from cartodb.js models', function () {
     beforeEach(function () {
-      var self = this;
-      this.cdbLayer = new Backbone.Model({
+      this.cdbLayer = createFakeLayer({
+        id: 'layer-id',
         error: {
           type: 'turbo-carto',
           context: {
@@ -768,21 +784,8 @@ describe('deep-insights-integrations', function () {
       });
       this.cdbLayer.infowindow = jasmine.createSpyObj('infowindow', ['update']);
 
-      var fakeDashboard = {
-        getMap: function () {
-          return {
-            map: {
-              getLayerById: function () {
-                return self.cdbLayer;
-              }
-            },
-            on: function () {}
-          };
-        }
-      };
-
       this.layerDefinitionsCollection.resetByLayersData({
-        id: 'test-infowindow',
+        id: 'layer-id',
         kind: 'carto',
         options: {
           table_name: 'infowindow_stuff',
@@ -805,7 +808,7 @@ describe('deep-insights-integrations', function () {
       });
 
       this.integrations2 = new DeepInsightsIntegrations({
-        deepInsightsDashboard: fakeDashboard,
+        deepInsightsDashboard: createFakeDashboard([ this.cdbLayer ]),
         analysisDefinitionsCollection: this.analysisDefinitionsCollection,
         analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
         layerDefinitionsCollection: this.layerDefinitionsCollection,


### PR DESCRIPTION
Part of https://github.com/CartoDB/cartodb/issues/7985. This implements notifications for "map instantiation error".

Basically, when there's an unknown error, the following notification is displayed:

<img width="372" alt="screen shot 2016-07-13 at 18 08 15" src="https://cloud.githubusercontent.com/assets/390398/16811235/a882edf2-4927-11e6-8ff5-e220f5f0909d.png">

Right now, the notification is not closable, but I can change this. The notification will be automatically closed when the next request to the Maps API succeeds. (cc: @saleiva, makes sense? how do you like the copy?)

@nobuti can you CR please? Thx!


