### PR TITLE
Parse error correctly if it's an object.

### DIFF
--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -1,6 +1,5 @@
 var Backbone = require('backbone');
 var $ = require('jquery');
-var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var VisDefinitionModel = require('../../data/vis-definition-model');
 var CreationModalView = require('../../components/modals/creation/modal-creation-view');
@@ -206,6 +205,7 @@ module.exports = CoreView.extend({
         }.bind(this),
         error: function (errors) {
           Notifier.removeNotification(notification);
+          errors = errors.responseJSON.error;
           this._codemirrorModel.set('errors', this._parseErrors(errors));
         }.bind(this)
       });
@@ -228,10 +228,6 @@ module.exports = CoreView.extend({
   },
 
   _parseErrors: function (errors) {
-    if (_.isObject(errors) && errors.responseJSON) {
-      errors = errors.responseJSON.error;
-    }
-
     return errors.map(function (error) {
       return {
         message: error

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -1,5 +1,6 @@
 var Backbone = require('backbone');
 var $ = require('jquery');
+var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var VisDefinitionModel = require('../../data/vis-definition-model');
 var CreationModalView = require('../../components/modals/creation/modal-creation-view');
@@ -227,6 +228,10 @@ module.exports = CoreView.extend({
   },
 
   _parseErrors: function (errors) {
+    if (_.isObject(errors) && errors.responseJSON) {
+      errors = errors.responseJSON.error;
+    }
+
     return errors.map(function (error) {
       return {
         message: error

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -1,4 +1,5 @@
 var Backbone = require('backbone');
+var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var PanelWithOptionsView = require('../../../../components/view-options/panel-with-options-view');
 var ScrollView = require('../../../../components/scroll/scroll-view');
@@ -175,6 +176,10 @@ module.exports = CoreView.extend({
   },
 
   _parseErrors: function (errors) {
+    if (_.isObject(errors) && errors.responseJSON) {
+      errors = errors.responseJSON.error;
+    }
+
     return errors.map(function (error) {
       return {
         message: error

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -1,5 +1,4 @@
 var Backbone = require('backbone');
-var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var PanelWithOptionsView = require('../../../../components/view-options/panel-with-options-view');
 var ScrollView = require('../../../../components/scroll/scroll-view');
@@ -146,6 +145,7 @@ module.exports = CoreView.extend({
         }.bind(this),
         error: function (errors) {
           Notifier.removeNotification(notification);
+          errors = errors.responseJSON.error;
           this._codemirrorModel.set('errors', this._parseErrors(errors));
         }.bind(this)
       });
@@ -176,10 +176,6 @@ module.exports = CoreView.extend({
   },
 
   _parseErrors: function (errors) {
-    if (_.isObject(errors) && errors.responseJSON) {
-      errors = errors.responseJSON.error;
-    }
-
     return errors.map(function (error) {
       return {
         message: error


### PR DESCRIPTION
This PR fixes #8842.

If the query alters data, the error comes from an ajax request directly, not from query schema model, so we need to handle it properly.

cc @xavijam 