### PR TITLE
fix title and large labels

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/field.tpl
+++ b/lib/assets/javascripts/cartodb3/components/form-components/field.tpl
@@ -2,7 +2,7 @@
   <label class="CDB-Legend u-upperCase u-ellipsis CDB-Text is-semibold CDB-Size-small u-rSpace--m" for="<%- editorId %>">
     <% if (title || help) { %>
       <div class="u-flex u-alignCenter">
-        <%- title %>
+        <span class="u-ellipsis" title="<%- title %>"><%- title %></span>
         <% if (help) { %>
           <span class="js-help is-underlined u-lSpace" data-tooltip="<%- help %>">?</span>
         <% } %>


### PR DESCRIPTION
@javierarce could you take a look?
Now when the label is very long the text is hidden, talking with @urbanphes we decided add and ellipsis and a title 

![labels](https://cloud.githubusercontent.com/assets/1214201/16836738/4cf1f4ae-49bf-11e6-8fa8-cd55f37dad9a.gif)
