### PR TITLE
8864 inherit permissions old model

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -18,9 +18,10 @@ module CartoDB
 
     @old_acl = nil
 
-    ACCESS_READONLY   = 'r'
-    ACCESS_READWRITE  = 'rw'
-    ACCESS_NONE       = 'n'
+    ACCESS_READONLY   = 'r'.freeze
+    ACCESS_READWRITE  = 'rw'.freeze
+    ACCESS_NONE       = 'n'.freeze
+    SORTED_ACCESSES   = [ACCESS_READWRITE, ACCESS_READONLY, ACCESS_NONE].freeze
 
     TYPE_USER         = 'user'
     TYPE_ORGANIZATION = 'org'
@@ -331,31 +332,24 @@ module CartoDB
     # @param subject ::User
     # @return String Permission::ACCESS_xxx
     def permission_for_user(subject)
-      permission = nil
-
       # Common scenario
       return ACCESS_READWRITE if is_owner?(subject)
 
-      acl.map { |entry|
-        if entry[:type] == TYPE_USER && entry[:id] == subject.id
-          permission = entry[:access]
-        end
+      permission_entries = acl.select do |entry|
+        (entry[:type] == TYPE_USER && entry[:id] == subject.id) ||
+          (entry[:type] == TYPE_GROUP && !subject.groups.nil? && subject.groups.map(&:id).include?(entry[:id])) ||
+          (entry[:type] == TYPE_ORGANIZATION && !subject.organization.nil? && subject.organization.id == entry[:id])
+      end
 
-        if entry[:type] == TYPE_GROUP && permission == nil
-          if !subject.groups.nil? && subject.groups.collect(&:id).include?(entry[:id])
-            permission = entry[:access]
-          end
-        end
+      higher_access(permission_entries.map { |entry| entry[:access] })
+    end
 
-        # Organization has lower precedence than user, if set leave as it is
-        if entry[:type] == TYPE_ORGANIZATION && permission == nil
-          if !subject.organization.nil? && subject.organization.id == entry[:id]
-            permission = entry[:access]
-          end
-        end
-      }
-      permission = ACCESS_NONE if permission.nil?
-      permission
+    def higher_access(accesses)
+      return ACCESS_NONE if accesses.empty?
+      index = SORTED_ACCESSES.index do |access|
+        accesses.include?(access)
+      end
+      SORTED_ACCESSES[index]
     end
 
     def permission_for_org

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -505,7 +505,7 @@ describe CartoDB::Permission do
       permission.permitted?(user2_mock, Permission::ACCESS_READONLY).should eq true
       permission.permitted?(user2_mock, Permission::ACCESS_READWRITE).should eq true
 
-      # Organization has more permissions than user. Should get overriden (user prevails)
+      # Organization has more permissions than user. Should get inherited (RW prevails)
       permission.acl = [
           {
               type: Permission::TYPE_USER,
@@ -526,30 +526,7 @@ describe CartoDB::Permission do
       ]
       permission.save
       permission.permitted?(user2_mock, Permission::ACCESS_READONLY).should eq true
-      permission.permitted?(user2_mock, Permission::ACCESS_READWRITE).should eq false
-
-      # User has revoked permissions, org has permissions. User revoked should prevail
-      permission.acl = [
-          {
-              type: Permission::TYPE_USER,
-              entity: {
-                  id: user2_mock.id,
-                  username: user2_mock.username
-              },
-              access: Permission::ACCESS_NONE
-          },
-          {
-              type: Permission::TYPE_ORGANIZATION,
-              entity: {
-                  id: org_mock.id,
-                  username: org_mock.name
-              },
-              access: Permission::ACCESS_READWRITE
-          }
-      ]
-      permission.save
-      permission.permitted?(user2_mock, Permission::ACCESS_READONLY).should eq false
-      permission.permitted?(user2_mock, Permission::ACCESS_READWRITE).should eq false
+      permission.permitted?(user2_mock, Permission::ACCESS_READWRITE).should eq true
 
       # Organization permission only
       permission.acl = [


### PR DESCRIPTION
Fixes #8864

This changes the permission model so it behaves like it is implied in the frontend (org permissions are inherited to all users) and makes it consistent with the Carto::Permission model.