### PR TITLE
Add widget source id validation

### DIFF
--- a/app/models/carto/widget.rb
+++ b/app/models/carto/widget.rb
@@ -11,7 +11,7 @@ class Carto::Widget < ActiveRecord::Base
 
   belongs_to :layer, class_name: Carto::Layer
 
-  validates :layer, :order, :type, :options, presence: true
+  validates :layer, :order, :type, :options, :analysis_node, presence: true
   validate :validate_user_not_viewer
 
   before_destroy :validate_user_not_viewer

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -34,6 +34,10 @@ module Carto
         FactoryGirl.create(:carto_zoom_overlay, visualization: visualization)
         FactoryGirl.create(:carto_search_overlay, visualization: visualization)
 
+        visualization.map.data_layers.each do |data_layer|
+          FactoryGirl.create(:source_analysis, user_id: carto_user.id, visualization_id: visualization.id)
+        end
+
         # Need to mock the nonexistant table because factories use Carto::* models
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_name_to).returns(true)
         CartoDB::Visualization::Member.any_instance.stubs(:propagate_privacy_to).returns(true)

--- a/spec/factories/widgets.rb
+++ b/spec/factories/widgets.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     ignore do
       column_name 'pop_max'
     end
+
     order 1
     type 'formula'
     title 'The Title'

--- a/spec/models/carto/widget_spec.rb
+++ b/spec/models/carto/widget_spec.rb
@@ -2,25 +2,9 @@ require 'json'
 require_relative '../../spec_helper'
 
 describe Carto::Widget do
-  include Carto::Factories::Visualizations
-
-  before(:all) do
-    @user = FactoryGirl.create(:carto_user)
-    @map, @table, @table_visualization, @visualization = create_full_visualization(@user)
-
-    @analysis = FactoryGirl.create(:source_analysis, visualization_id: @visualization.id, user_id: @user.id)
-  end
-
-  after(:all) do
-    destroy_full_visualization(@map, @table, @table_visualization, @visualization)
-    @user.destroy
-  end
-
   describe 'Storage' do
     it 'can be stored and retrieved keeping the data' do
-      widget = FactoryGirl.create(:widget_with_layer,
-                                  layer: @map.data_layers.first,
-                                  source_id: @analysis.analysis_definition[:id])
+      widget = FactoryGirl.create(:widget_with_layer)
       loaded_widget = Carto::Widget.find(widget.id)
       loaded_widget.order.should == widget.order
       loaded_widget.type.should == widget.type
@@ -31,28 +15,20 @@ describe Carto::Widget do
     end
 
     it 'is deleted if layer is deleted' do
-      layer = FactoryGirl.create(:carto_layer, kind: 'carto', maps: [@map])
-      @map.reload
-
-      layer = Carto::Layer.find(layer.id)
-
-      widget = FactoryGirl.create(:widget_with_layer,
-                                  layer: layer,
-                                  source_id: @analysis.analysis_definition[:id])
-      layer.destroy
+      widget = FactoryGirl.create(:widget_with_layer)
+      widget.layer.destroy
       Carto::Widget.where(id: widget.id).first.should be_nil
     end
 
     describe '#save' do
       before(:each) do
-        @widget = FactoryGirl.create(:widget_with_layer,
-                                     layer: @map.data_layers.first,
-                                     source_id: @analysis.analysis_definition[:id])
+        @map = FactoryGirl.create(:carto_map_with_layers)
+        @widget = FactoryGirl.create(:widget, layer: @map.data_layers.first)
       end
 
       after(:each) do
         @widget.destroy
-        @map.reload
+        @map.destroy
       end
 
       it 'triggers notify_map_change on related map(s)' do
@@ -68,15 +44,8 @@ describe Carto::Widget do
   end
 
   describe 'Format and validation' do
-    before(:all) do
-      @widget = FactoryGirl.create(:widget_with_layer,
-                                   layer: @map.data_layers.first,
-                                   source_id: @analysis.analysis_definition[:id])
-    end
-
-    after(:all) do
-      @widget.destroy
-      @map.reload
+    before(:each) do
+      @widget = FactoryGirl.build(:widget_with_layer, options: { valid: 'format' })
     end
 
     it 'validates correct options format' do
@@ -93,19 +62,22 @@ describe Carto::Widget do
   end
 
   describe '#from_visualization_id' do
+    before(:each) do
+      @map = FactoryGirl.create(:carto_map_with_layers)
+      @visualization = FactoryGirl.create(:carto_visualization, map: @map)
+    end
+
+    after(:each) do
+      @visualization.destroy
+      @map.destroy
+    end
+
     it 'retrieves all visualization widgets' do
-      map2, table2, table_visualization2, visualization2 = create_full_visualization(@user)
-
-      # Twice expectation: 2x (creation + destroy) + analysis2 create
-      Map.any_instance.expects(:update_related_named_maps).times(5).returns(true)
-      widget = FactoryGirl.create(:widget_with_layer,
-                                  layer: @map.data_layers.first,
-                                  source_id: @analysis.analysis_definition[:id])
-
-      analysis2 = FactoryGirl.create(:source_analysis, visualization_id: visualization2.id, user_id: @user.id)
-      widget2 = FactoryGirl.create(:widget_with_layer,
-                                   layer: map2.data_layers.first,
-                                   source_id: analysis2.analysis_definition[:id])
+      # Twice expectation: creation + destroy
+      Map.any_instance.expects(:update_related_named_maps).times(2).returns(true)
+      layer = @visualization.data_layers.first
+      widget = FactoryGirl.create(:widget, layer: layer)
+      widget2 = FactoryGirl.create(:widget_with_layer)
 
       widgets = Carto::Widget.from_visualization_id(@visualization.id)
       widgets.length.should == 1
@@ -114,48 +86,48 @@ describe Carto::Widget do
 
       widget2.destroy
       widget.destroy
-      @map.reload
-
-      destroy_full_visualization(map2, table2, table_visualization2, visualization2)
     end
   end
 
   context 'viewer users' do
-    before(:all) do
-      widget = FactoryGirl.create(:widget_with_layer,
-                                  layer: @map.data_layers.first,
-                                  source_id: @analysis.analysis_definition[:id])
-      @widget = Carto::Widget.find(widget.id)
-
-      @user.update_attributes(viewer: true)
-      @map.reload
-    end
-
     before(:each) do
       Map.any_instance.stubs(:update_related_named_maps)
+      @user = FactoryGirl.create(:carto_user)
+      @map = FactoryGirl.create(:carto_map_with_layers, user: @user)
+      @visualization = FactoryGirl.create(:carto_visualization, map: @map, user: @user)
+      @layer = @visualization.data_layers.first
     end
 
-    after(:all) do
-      @user.update_attributes(viewer: false)
-      @widget.destroy
-      @map.reload
-
-      @map.reload
+    after(:each) do
+      @visualization.destroy
+      @map.destroy
+      @user.destroy
     end
 
     it "can't create a new widget" do
-      widget = FactoryGirl.build(:widget_with_layer,
-                                 layer: @map.data_layers.first,
-                                 source_id: @analysis.analysis_definition[:id])
+      user = @visualization.user
+      user.viewer = true
+      user.save
+      @visualization.reload
+      @layer.reload
 
+      widget = FactoryGirl.build(:widget, layer: @layer)
       widget.save.should be_false
       widget.errors[:layer].should eq(["Viewer users can't edit widgets"])
     end
 
     it "can't delete widgets" do
-      @widget.destroy.should eq false
-      Carto::Widget.exists?(@widget.id).should eq true
-      @widget.errors[:layer].should eq(["Viewer users can't edit widgets"])
+      widget = FactoryGirl.create(:widget, layer: @layer)
+
+      user = @visualization.user
+      user.viewer = true
+      user.save
+      @visualization.reload
+      widget = Carto::Widget.find(widget.id)
+
+      widget.destroy.should eq false
+      Carto::Widget.exists?(widget.id).should eq true
+      widget.errors[:layer].should eq(["Viewer users can't edit widgets"])
     end
   end
 end


### PR DESCRIPTION
This adds validation so that `source_id` has to be a proper node `natural_id`.


There are 441 legacy widgets without them. They're fixed by visiting the dashboard.