### PR TITLE
Changed text "CartoDB logo" => "CARTO logo"

### DIFF
--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -913,7 +913,7 @@
             "fullscreen": "Fullscreen",
             "scrollwheel": "Scroll wheel zoom",
             "layer_selector": "Layer selector",
-            "logo": "CartoDB Logo",
+            "logo": "CARTO Logo",
             "widgets": "Widgets column"
           }
         }


### PR DESCRIPTION
This text appears in the builder map settings view as a checkbox to
select to show or not our logo in the map.

![screen shot 2016-07-14 at 16 17 21](https://cloud.githubusercontent.com/assets/2141690/16842646/7e1e5c06-49de-11e6-9e5f-455dde7011a7.png)

CR @xavijam 