### PR TITLE
Add pipe delimiter to CSV normalizer

### DIFF
--- a/services/importer/lib/importer/csv_normalizer.rb
+++ b/services/importer/lib/importer/csv_normalizer.rb
@@ -14,7 +14,7 @@ module CartoDB
       LINE_SIZE_FOR_CLEANING = 5000
       LINES_FOR_DETECTION   = 100       # How many lines to read?
       SAMPLE_READ_LIMIT     = 500000   # Read big enough sample bytes for the encoding sampling
-      COMMON_DELIMITERS     = [',', "\t", ' ', ';', '|']
+      COMMON_DELIMITERS     = [',', "\t", ' ', ';', '|'].freeze
       DELIMITER_WEIGHTS     = {','=>2, "\t"=>2, ' '=>1, ';'=>2}
       DEFAULT_DELIMITER     = ','
       DEFAULT_ENCODING      = 'UTF-8'

--- a/services/importer/lib/importer/csv_normalizer.rb
+++ b/services/importer/lib/importer/csv_normalizer.rb
@@ -14,7 +14,7 @@ module CartoDB
       LINE_SIZE_FOR_CLEANING = 5000
       LINES_FOR_DETECTION   = 100       # How many lines to read?
       SAMPLE_READ_LIMIT     = 500000   # Read big enough sample bytes for the encoding sampling
-      COMMON_DELIMITERS     = [',', "\t", ' ', ';']
+      COMMON_DELIMITERS     = [',', "\t", ' ', ';', '|']
       DELIMITER_WEIGHTS     = {','=>2, "\t"=>2, ' '=>1, ';'=>2}
       DEFAULT_DELIMITER     = ','
       DEFAULT_ENCODING      = 'UTF-8'


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/8097