### PR TITLE
Dataset view issues

### DIFF
--- a/app/assets/stylesheets/editor-3/dataset.css.scss
+++ b/app/assets/stylesheets/editor-3/dataset.css.scss
@@ -36,7 +36,7 @@
   position: relative;
   width: 100%;
 }
-.Dataset-viewTable .Table--relative {
+.Dataset-viewTable .Table-wrapper {
   top: 40px;
 }
 .Dataset-options,
@@ -89,4 +89,3 @@
 .is-dark .Dataset-tablePreview {
   color: $cWhite;
 }
-

--- a/app/assets/stylesheets/editor-3/table.css.scss
+++ b/app/assets/stylesheets/editor-3/table.css.scss
@@ -10,6 +10,14 @@ $elementWidthShort: 120px;
 $elementPadding: 14px 14px 18px;
 $tableBorderColor: $cSecondaryLine;
 
+.Table-wrapper {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: $cMainBg;
+}
 .Table {
   @include display-flex();
   @include flex-direction(column);
@@ -18,9 +26,9 @@ $tableBorderColor: $cSecondaryLine;
   right: $baseSize * 2;
   bottom: $baseSize * 2;
   left: $baseSize * 2;
+  background: $cWhite;
   overflow-x: auto;
   overflow-y: hidden;
-  background: $cThirdBackground;
   z-index: 2;
 }
 .Table--relative {
@@ -28,6 +36,7 @@ $tableBorderColor: $cSecondaryLine;
   right: 0;
   bottom: 0;
   left: 0;
+  padding: 0;
   border-top: 1px solid $cMainLine;
 }
 .Table-head {
@@ -109,7 +118,7 @@ $tableBorderColor: $cSecondaryLine;
   position: absolute;
   width: 100%;
   height: 100%;
-  background: #FFF;
+  background: $cWhite;
 }
 .Table-body tbody {
   @include display-flex();

--- a/app/assets/stylesheets/editor-3/table.css.scss
+++ b/app/assets/stylesheets/editor-3/table.css.scss
@@ -223,6 +223,7 @@ $tableBorderColor: $cSecondaryLine;
   color: $cAltText;
 }
 // Disabled state color
+.Table.is-disabled .Table-headItemName,
 .Table.is-disabled .Table-cell .CDB-Text,
 .Table.is-disabled .Table-cell .CDB-Text.is-number,
 .Table.is-disabled .Table-cell .CDB-Text.is-cartodbId {

--- a/lib/assets/javascripts/cartodb3/components/table/paginator/table-paginator-view.js
+++ b/lib/assets/javascripts/cartodb3/components/table/paginator/table-paginator-view.js
@@ -28,6 +28,7 @@ module.exports = CoreView.extend({
         this._isLoading = true;
       }
     }, this);
+    this._rowsCollection.bind('add remove', this.render, this);
     this._tableViewModel.bind('change:page', this._onTablePageChange, this);
     this.add_related_model(this._tableViewModel);
     this.add_related_model(this._rowsCollection);

--- a/lib/assets/javascripts/cartodb3/components/table/paginator/table-paginator.tpl
+++ b/lib/assets/javascripts/cartodb3/components/table/paginator/table-paginator.tpl
@@ -15,7 +15,7 @@
   <% if (!size) {%>
    <span class="u-mainTextColor">…</span>
   <% } else { %>
-    <span class="u-mainTextColor"><%- page * 40 %></span>
+    <span class="u-mainTextColor"><%- (page * 40) + 1 %></span>
     <span class="u-altTextColor u-lSpace u-rSpace"><%- _t('components.table.rows.paginator.to') %></span>
     <span class="u-mainTextColor"><%- (page * 40) + size %></span>
   <% } %>

--- a/lib/assets/javascripts/cartodb3/components/table/table-view.js
+++ b/lib/assets/javascripts/cartodb3/components/table/table-view.js
@@ -18,7 +18,7 @@ module.exports = CoreView.extend({
     readonly: false
   },
 
-  className: 'Table',
+  className: 'Table-wrapper',
   tagName: 'div',
 
   initialize: function (opts) {
@@ -53,10 +53,12 @@ module.exports = CoreView.extend({
   render: function () {
     this.clearSubViews();
     this.$el.empty();
+    var tableElement = $('<div>').addClass('Table js-table');
+    this.$el.append(tableElement);
     this._initViews();
 
-    this.$el.toggleClass('Table--relative', !!this._tableViewModel.get('relativePositionated'));
-    this.$el.toggleClass('is-disabled', !!this._tableViewModel.isDisabled());
+    this.$('.js-table').toggleClass('Table--relative', !!this._tableViewModel.get('relativePositionated'));
+    this.$('.js-table').toggleClass('is-disabled', !!this._tableViewModel.isDisabled());
     return this;
   },
 
@@ -91,7 +93,7 @@ module.exports = CoreView.extend({
     });
 
     this.addView(tableHeadView);
-    this.$el.append(tableHeadView.render().el);
+    this.$('.js-table').append(tableHeadView.render().el);
 
     var tableBodyView = new TableBodyView({
       modals: this._modals,
@@ -102,7 +104,7 @@ module.exports = CoreView.extend({
     });
 
     this.addView(tableBodyView);
-    this.$el.append(tableBodyView.render().el);
+    this.$('.js-table').append(tableBodyView.render().el);
   },
 
   _onChangeQueryOrStatus: function () {

--- a/lib/assets/javascripts/cartodb3/components/table/table-view.js
+++ b/lib/assets/javascripts/cartodb3/components/table/table-view.js
@@ -58,16 +58,22 @@ module.exports = CoreView.extend({
     this._initViews();
 
     this.$('.js-table').toggleClass('Table--relative', !!this._tableViewModel.get('relativePositionated'));
-    this.$('.js-table').toggleClass('is-disabled', !!this._tableViewModel.isDisabled());
+    this._setDisableState();
     return this;
   },
 
   _initBinds: function () {
     this._querySchemaModel.bind('change:query change:status', _.debounce(this._onChangeQueryOrStatus.bind(this), 100), this);
+    this._querySchemaModel.bind('change:status', this._setDisableState, this);
     this._querySchemaModel.bind('change:query', this._onQueryChanged, this);
     this._querySchemaModel.bind('change:status', this._fetchRowsData, this);
     this._tableViewModel.bind('change:sort_order change:order_by', this._fetchRowsData, this);
     this.add_related_model(this._querySchemaModel);
+    this.add_related_model(this._tableViewModel);
+  },
+
+  _setDisableState: function () {
+    this.$('.js-table').toggleClass('is-disabled', !!this._tableViewModel.isDisabled());
   },
 
   _fetchRowsData: function () {

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-actions-edition-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-actions-edition-view.js
@@ -8,6 +8,7 @@ var REQUIRED_OPTS = [
   'previewAction',
   'trackModel',
   'editorModel',
+  'querySchemaModel',
   'onApply',
   'onClear',
   'clearSQLModel'
@@ -26,11 +27,20 @@ module.exports = CoreView.extend({
       if (!opts[item]) throw new Error(item + ' is required');
       this['_' + item] = opts[item];
     }, this);
+
+    this._querySchemaModel.bind('change:status', this.render, this);
+    this.add_related_model(this._querySchemaModel);
   },
 
   render: function () {
     this.clearSubViews();
-    this.$el.html(template());
+    var geom = this._querySchemaModel.getGeometry();
+    var geomWebmercator = this._querySchemaModel.columnsCollection.findWhere({ name: 'the_geom_webmercator' });
+    this.$el.html(
+      template({
+        hasGeometry: geom && geomWebmercator
+      })
+    );
     this._initViews();
     return this;
   },

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-actions-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-actions-view.js
@@ -4,7 +4,8 @@ var template = require('./dataset-actions.tpl');
 
 var REQUIRED_OPTS = [
   'mapAction',
-  'previewAction'
+  'previewAction',
+  'querySchemaModel'
 ];
 
 module.exports = CoreView.extend({
@@ -20,11 +21,20 @@ module.exports = CoreView.extend({
       if (!opts[item]) throw new Error(item + ' is required');
       this['_' + item] = opts[item];
     }, this);
+
+    this._querySchemaModel.bind('change:status', this.render, this);
+    this.add_related_model(this._querySchemaModel);
   },
 
   render: function () {
     this.clearSubViews();
-    this.$el.html(template());
+    var geom = this._querySchemaModel.getGeometry();
+    var geomWebmercator = this._querySchemaModel.columnsCollection.findWhere({ name: 'the_geom_webmercator' });
+    this.$el.html(
+      template({
+        hasGeometry: geom && geomWebmercator
+      })
+    );
     return this;
   },
 

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-actions.tpl
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-actions.tpl
@@ -1,6 +1,8 @@
-<button class="u-rSpace--xl Dataset-tablePreview js-previewMap">
-  <span class="u-upperCase CDB-Button-Text CDB-Text CDB-Size-small"><%- _t('dataset.preview-map.preview') %></span>
-</button>
+<% if (hasGeometry) { %>
+  <button class="u-rSpace--xl Dataset-tablePreview js-previewMap">
+    <span class="u-upperCase CDB-Button-Text CDB-Text CDB-Size-small"><%- _t('dataset.preview-map.preview') %></span>
+  </button>
+<% } %>
 <button class="CDB-Button CDB-Button--primary u-upperCase js-createMap">
   <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small"><%- _t('dataset.create-map.title') %></span>
 </button>

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -119,7 +119,7 @@ module.exports = CoreView.extend({
       createControlView: function () {
         return new Toggler({
           editorModel: self._editorModel,
-          labels: ['Metadata', 'SQL']
+          labels: [_t('dataset.data'), _t('dataset.sql')]
         });
       },
       createActionView: function () {
@@ -151,6 +151,7 @@ module.exports = CoreView.extend({
       },
       createActionView: function () {
         return new ActionView({
+          querySchemaModel: self._querySchemaModel,
           mapAction: self._createMap.bind(self),
           previewAction: self._previewMap.bind(self)
         });
@@ -169,6 +170,7 @@ module.exports = CoreView.extend({
           clearSQLModel: self._clearSQLModel,
           trackModel: self._sqlModel,
           editorModel: self._editorModel,
+          querySchemaModel: self._querySchemaModel,
           onApply: self._parseSQL.bind(self),
           mapAction: self._createMap.bind(self),
           previewAction: self._previewMap.bind(self),

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
@@ -278,10 +278,7 @@ module.exports = {
     var filterFunction = function (item) {
       var columnName = item.get('name');
       var columnType = item.get('type');
-      if (columnName !== 'the_geom' && columnName !== 'the_geom_webmercator' && columnType !== 'date') {
-        return true;
-      }
-      return false;
+      return (columnName !== 'the_geom' && columnName !== 'the_geom_webmercator' && columnType !== 'date');
     };
     return generateSelectByStyleType('labels-attribute', querySchemaModel, filterFunction, styleType);
   },

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
@@ -275,7 +275,15 @@ module.exports = {
   },
 
   'labels-attribute': function (querySchemaModel, styleType) {
-    return generateSelectByStyleType('labels-attribute', querySchemaModel, null, styleType);
+    var filterFunction = function (item) {
+      var columnName = item.get('name');
+      var columnType = item.get('type');
+      if (columnName !== 'the_geom' && columnName !== 'the_geom_webmercator' && columnType !== 'date') {
+        return true;
+      }
+      return false;
+    };
+    return generateSelectByStyleType('labels-attribute', querySchemaModel, filterFunction, styleType);
   },
 
   'labels-fill': function () {

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
@@ -459,7 +459,7 @@ module.exports = {
       validators: ['required', {
         type: 'interval',
         min: 0,
-        max: 10
+        max: 50
       }]
     };
   },

--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
@@ -459,7 +459,7 @@ module.exports = {
       validators: ['required', {
         type: 'interval',
         min: 0,
-        max: 50
+        max: 30
       }]
     };
   },

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -804,6 +804,7 @@
   },
   "dataset": {
     "sql": "SQL",
+    "data": "Metadata",
     "updated": "Updated %{ago}",
     "options": {
       "add-row": "Add row",

--- a/lib/assets/test/jasmine/cartodb3/data/analysis-definition-node-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/analysis-definition-node-model.spec.js
@@ -34,8 +34,7 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
           kind: 'walk',
           time: 300,
           dissolved: true,
-          isolines: 3,
-          provider: 'heremaps'
+          isolines: 3
         },
         options: {
           optional: 'goes separately'
@@ -85,8 +84,7 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
       time: 300,
       dissolved: true,
       isolines: 3,
-      optional: 'goes separately',
-      provider: 'heremaps'
+      optional: 'goes separately'
     });
     expect(this.b1.attributes).toEqual({
       id: 'b1',
@@ -200,8 +198,7 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
             kind: 'walk',
             time: 300,
             dissolved: true,
-            isolines: 3,
-            provider: 'heremaps'
+            isolines: 3
           }
         }));
 
@@ -249,8 +246,7 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
             kind: 'walk',
             time: 300,
             dissolved: true,
-            isolines: 3,
-            provider: 'heremaps'
+            isolines: 3
           }
         });
 

--- a/lib/assets/test/jasmine/cartodb3/data/analysis-definition-node-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/analysis-definition-node-model.spec.js
@@ -34,7 +34,8 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
           kind: 'walk',
           time: 300,
           dissolved: true,
-          isolines: 3
+          isolines: 3,
+          provider: 'heremaps'
         },
         options: {
           optional: 'goes separately'
@@ -84,7 +85,8 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
       time: 300,
       dissolved: true,
       isolines: 3,
-      optional: 'goes separately'
+      optional: 'goes separately',
+      provider: 'heremaps'
     });
     expect(this.b1.attributes).toEqual({
       id: 'b1',
@@ -198,7 +200,8 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
             kind: 'walk',
             time: 300,
             dissolved: true,
-            isolines: 3
+            isolines: 3,
+            provider: 'heremaps'
           }
         }));
 
@@ -246,7 +249,8 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
             kind: 'walk',
             time: 300,
             dissolved: true,
-            isolines: 3
+            isolines: 3,
+            provider: 'heremaps'
           }
         });
 

--- a/lib/assets/test/spec/cartodb3/components/table/paginator/table-paginator-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/table/paginator/table-paginator-view.spec.js
@@ -29,6 +29,7 @@ describe('components/table/paginator/table-paginator-view', function () {
       configModel: this.configModel
     });
     spyOn(this.rowsCollection, 'sync');
+    spyOn(TablePaginatorView.prototype, 'render').and.callThrough();
     this.view = new TablePaginatorView({
       rowsCollection: this.rowsCollection,
       tableViewModel: this.tableViewModel
@@ -69,6 +70,18 @@ describe('components/table/paginator/table-paginator-view', function () {
       var mdl = this.rowsCollection.at(0);
       mdl.trigger('loading', mdl);
       expect(this.view._isLoading).toBeFalsy();
+    });
+
+    it('should render again when a new row is added', function () {
+      TablePaginatorView.prototype.render.calls.reset();
+      this.rowsCollection.add({ cartodb_id: 2 });
+      expect(TablePaginatorView.prototype.render).toHaveBeenCalled();
+    });
+
+    it('should render again when an old row is removed', function () {
+      TablePaginatorView.prototype.render.calls.reset();
+      this.rowsCollection.remove(this.rowsCollection.at(0));
+      expect(TablePaginatorView.prototype.render).toHaveBeenCalled();
     });
   });
 

--- a/lib/assets/test/spec/cartodb3/components/table/table-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/table/table-view.spec.js
@@ -98,7 +98,7 @@ describe('components/table/table-view', function () {
     it('should add relative class if table view model has it', function () {
       this.view._tableViewModel.set('relativePositionated', true);
       this.view.render();
-      expect(this.view.$el.hasClass('Table--relative')).toBeTruthy();
+      expect(this.view.$('.js-table').hasClass('Table--relative')).toBeTruthy();
     });
   });
 

--- a/lib/assets/test/spec/cartodb3/components/table/table-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/table/table-view.spec.js
@@ -39,6 +39,7 @@ describe('components/table/table-view', function () {
       querySchemaModel: this.querySchemaModel
     });
 
+    spyOn(TableView.prototype, '_setDisableState').and.callThrough();
     this.view = new TableView({
       modals: this.modals,
       rowsCollection: this.rowsCollection,
@@ -113,6 +114,14 @@ describe('components/table/table-view', function () {
       expect(this.view._tableViewModel.get('page')).toBe(0);
       expect(this.view._tableViewModel.get('order_by')).toBe('');
       expect(this.view._tableViewModel.get('sort_order')).toBe('asc');
+    });
+
+    it('should check disabled state each time query schema model changes', function () {
+      this.querySchemaModel.set('status', 'fetched');
+      expect(TableView.prototype._setDisableState).toHaveBeenCalled();
+      TableView.prototype._setDisableState.calls.reset();
+      this.querySchemaModel.set('status', 'fetching');
+      expect(TableView.prototype._setDisableState).toHaveBeenCalled();
     });
 
     it('should fetch query-schema-model if query has changed and it is possible', function () {

--- a/lib/assets/test/spec/cartodb3/dataset/dataset-options-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/dataset/dataset-options-view.spec.js
@@ -40,13 +40,13 @@ describe('dataset/dataset-options-view', function () {
       configModel: configModel
     });
 
-    var querySchemaModel = new QuerySchemaModel({
+    this.querySchemaModel = new QuerySchemaModel({
       status: 'unfetched',
       query: 'SELECT * FROM table_1'
     }, {
       configModel: configModel
     });
-    spyOn(querySchemaModel, 'fetch');
+    spyOn(this.querySchemaModel, 'fetch');
 
     editorModel = new EditorModel();
 
@@ -73,7 +73,7 @@ describe('dataset/dataset-options-view', function () {
       tableModel: tableModel,
       visModel: visModel,
       syncModel: syncModel,
-      querySchemaModel: querySchemaModel,
+      querySchemaModel: this.querySchemaModel,
       layerDefinitionModel: layerDefinitionModel
     });
 
@@ -84,16 +84,24 @@ describe('dataset/dataset-options-view', function () {
     expect(view.$('.Options-bar').length).toBe(1);
     expect(view.$('.js-input').length).toBe(1);
     expect(view.$('.js-input:checked').length).toBe(0);
-    expect(view.$('.js-previewMap').length).toBe(1);
+    expect(view.$('.js-previewMap').length).toBe(0);
     expect(view.$('.js-createMap').length).toBe(1);
   });
 
   it('should render properly when edition', function () {
     var content = view._codemirrorModel.get('content');
-
     editorModel.set('edition', true);
     expect(view.$('.Dataset-codemirror').length).toBe(1);
     expect(content).toContain('table_1');
+  });
+
+  it('should render preview button if geometry exists', function () {
+    spyOn(this.querySchemaModel, 'getGeometry').and.returnValue({});
+    this.querySchemaModel.columnsCollection.reset([{
+      name: 'the_geom_webmercator'
+    }]);
+    view.render();
+    expect(view.$('.js-previewMap').length).toBe(1);
   });
 
   it('should respond to change dataset name', function () {

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/area-of-influence-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/area-of-influence-form-model.spec.js
@@ -140,8 +140,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/area-o
           kind: 'walk',
           isolines: 1,
           time: 100,
-          dissolved: false,
-          provider: 'heremaps'
+          dissolved: false
         });
       });
     });
@@ -166,8 +165,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/area-o
           isolines: 1,
           time: 100,
           dissolved: false,
-          persisted: true,
-          provider: 'heremaps'
+          persisted: true
         });
       });
     });
@@ -227,8 +225,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/area-o
         type: 'trade-area',
         id: 'a1',
         source: 'a0',
-        kind: 'walk',
-        provider: 'heremaps'
+        kind: 'walk'
       });
     });
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -100,9 +100,9 @@
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                 },
                                 "process-nextick-args": {
-                                  "version": "1.0.7",
-                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                                  "version": "1.0.6",
+                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
@@ -214,14 +214,14 @@
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                                   "dependencies": {
                                     "brace-expansion": {
-                                      "version": "1.1.4",
-                                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
+                                      "version": "1.1.3",
+                                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                                       "dependencies": {
                                         "balanced-match": {
-                                          "version": "0.4.1",
-                                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                                          "version": "0.3.0",
+                                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                                         },
                                         "concat-map": {
                                           "version": "0.0.1",
@@ -315,9 +315,9 @@
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                 },
                                 "process-nextick-args": {
-                                  "version": "1.0.7",
-                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                                  "version": "1.0.6",
+                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
@@ -366,14 +366,14 @@
                           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                         },
                         "mime-types": {
-                          "version": "2.1.11",
-                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                          "version": "2.1.10",
+                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
                           "dependencies": {
                             "mime-db": {
-                              "version": "1.23.0",
-                              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                              "version": "1.22.0",
+                              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
                             }
                           }
                         },
@@ -388,9 +388,9 @@
                           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
                         },
                         "tunnel-agent": {
-                          "version": "0.4.3",
-                          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+                          "version": "0.4.2",
+                          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
+                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
                         },
                         "tough-cookie": {
                           "version": "2.2.2",
@@ -430,29 +430,26 @@
                               }
                             },
                             "sshpk": {
-                              "version": "1.8.3",
-                              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+                              "version": "1.7.4",
+                              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
                               "dependencies": {
                                 "asn1": {
                                   "version": "0.2.3",
                                   "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                                 },
-                                "assert-plus": {
-                                  "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                                },
                                 "dashdash": {
-                                  "version": "1.13.1",
-                                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.1.tgz"
-                                },
-                                "getpass": {
-                                  "version": "0.1.6",
-                                  "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                                  "version": "1.13.0",
+                                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
+                                  "dependencies": {
+                                    "assert-plus": {
+                                      "version": "1.0.0",
+                                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                    }
+                                  }
                                 },
                                 "jsbn": {
                                   "version": "0.1.0",
@@ -460,9 +457,9 @@
                                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                                 },
                                 "tweetnacl": {
-                                  "version": "0.13.3",
-                                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                                  "version": "0.14.3",
+                                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                                 },
                                 "jodid25519": {
                                   "version": "1.0.2",
@@ -479,9 +476,9 @@
                           }
                         },
                         "oauth-sign": {
-                          "version": "0.8.2",
-                          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                          "version": "0.8.1",
+                          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz",
+                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                         },
                         "hawk": {
                           "version": "3.1.3",
@@ -668,9 +665,9 @@
                       }
                     },
                     "which": {
-                      "version": "1.2.7",
-                      "from": "https://registry.npmjs.org/which/-/which-1.2.7.tgz",
-                      "resolved": "https://registry.npmjs.org/which/-/which-1.2.7.tgz",
+                      "version": "1.2.4",
+                      "from": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+                      "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
                       "dependencies": {
                         "is-absolute": {
                           "version": "0.1.7",
@@ -1085,7 +1082,7 @@
     },
     "camshaft-reference": {
       "version": "0.22.0",
-      "from": "https://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.22.0.tgz",
+      "from": "camshaft-reference@0.22.0",
       "resolved": "https://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.22.0.tgz"
     },
     "carto": {
@@ -1120,12 +1117,12 @@
     "cartodb-deep-insights.js": {
       "version": "0.0.1",
       "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#cf39111439317409ca51c860e46bd1933d5a1c71",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#70c56cc6bc20fe10cf016563d9b437968db6522f",
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#1ead53d283ade853d899181cb057278b8670b5ac",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#c0c36f210db4e09e6ab0e7846959408d5b12e961",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1135,7 +1132,7 @@
             "d3.cartodb": {
               "version": "1.1.1",
               "from": "cartodb/d3.cartodb#gh-pages",
-              "resolved": "git://github.com/cartodb/d3.cartodb.git#1d0813a600a51951e86014c085f4b7dd57e75f86",
+              "resolved": "git://github.com/cartodb/d3.cartodb.git#ae986fc5bd6378b2e253cf90b048347b8f00700d",
               "dependencies": {
                 "crossfilter": {
                   "version": "1.3.12",
@@ -1256,7 +1253,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#1ead53d283ade853d899181cb057278b8670b5ac",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#c0c36f210db4e09e6ab0e7846959408d5b12e961",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1271,7 +1268,7 @@
         "d3.cartodb": {
           "version": "1.1.1",
           "from": "cartodb/d3.cartodb#gh-pages",
-          "resolved": "git://github.com/cartodb/d3.cartodb.git#1d0813a600a51951e86014c085f4b7dd57e75f86",
+          "resolved": "git://github.com/cartodb/d3.cartodb.git#ae986fc5bd6378b2e253cf90b048347b8f00700d",
           "dependencies": {
             "crossfilter": {
               "version": "1.3.12",


### PR DESCRIPTION
It fixes several problems reported in the table-view element and in the dataset page.

- Adding dark background for table view (only showed in the builder) - fixes #8860.
- Change table-paginator when a new row is added or an old row is removed - fixes #8658.
- Start table-paginator count from 1, not from 0 - commented by @urbanphes.
- Set `is-disabled` class properly when any change happens related with the table-view.
- Make read only state more explicit - fixes #6017.
- Don't display `preview` button in dataset page if there is no geometry and `the_geom_webmercator` is not present - fixes #8743.

Extra balls:
- Changed animated-trails limit to 30 - fixes  #8490.
- Don't let the user choose `the_geom` or `the_geom_webmercator` columns or date type columns in the label attribute, within the styles - fixes #8668.
- Updated dependencies.
- Fixed master frontend tests.

CR: @nobuti (I encourage you to follow commit by commit, each fix is done in a commit).