### PR TITLE
Fixing problem with fill-component in Firefox

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-header.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-header.js
@@ -33,13 +33,13 @@ module.exports = CoreView.extend({
     return ramp[this.model.get('index')];
   },
 
-  _onClickColor: function (e) {
-    this.killEvent(e);
-    this.model.set('index', $(e.toElement).index());
+  _onClickColor: function (ev) {
+    this.killEvent(ev);
+    this.model.set('index', $(ev.target).index());
   },
 
-  _onClickBack: function (e) {
-    this.killEvent(e);
+  _onClickBack: function (ev) {
+    this.killEvent(ev);
     this.trigger('back', this);
   }
 });


### PR DESCRIPTION
Firefox doesn't understand what `event.toElement` mean (using the older and beloved `event.target`) and the index was always giving -1, that was the reason of the problem.

Fixes #8905.

CR: @javierarce 
cc @javitonino 