### PR TITLE
Fix font in invalid format message when importing dataset

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/map/image_picker/file_upload_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/map/image_picker/file_upload_template.jst.ejs
@@ -10,14 +10,14 @@
       <div class="Form-rowData Form-rowData--med Form-rowData--noMargin js-dropzone">
         <div class="Form-upload">
           <label class="Form-fileLabel js-fileLabel">Drag & drop your file</label>
-          <label class="Form-fileLabel Form-fileLabel--error js-fileError"></label>
+          <label class="Form-fileLabel Form-fileLabel--error CDB-Text CDB-Size-small js-fileError"></label>
           <div class="Form-file">
             <input type="file" class="js-fileInput" accept=".jpg,.gif,.png,.svg" />
             <span class="Button Button--main Form-fileButton js-fileButton">browse</span>
           </div>
         </div>
       </div>
-      <span class="Form-separator Form-separator--or">or</span>
+      <span class="u-lSpace--xl u-rSpace--xl u-flex u-alignCenter CDB-Text CDB-Size-medium u-altTextColor">or</span>
     <% } %>
     <div class="Form-rowData Form-rowData--noMargin Form-rowData--med">
       <input type="text" class="Form-input Form-input--med has-submit js-textInput" placeholder="https://carto.com/logo.png" />

--- a/lib/assets/javascripts/cartodb/common/views/create/listing/import_types/data_form.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/create/listing/import_types/data_form.jst.ejs
@@ -4,7 +4,7 @@
       <div class="Form-rowData Form-rowData--med Form-rowData--noMargin js-dropzone">
         <div class="Form-upload">
           <label class="Form-fileLabel js-fileLabel CDB-Text CDB-Size-medium">Drag & drop your file</label>
-          <label class="Form-fileLabel Form-fileLabel--error js-fileError"></label>
+          <label class="Form-fileLabel Form-fileLabel--error CDB-Text CDB-Size-small js-fileError"></label>
           <div class="Form-file">
             <input type="file" class="js-fileInput" />
             <span class="CDB-Button CDB-Button--primary Form-fileButton CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase  Form-fileButton js-fileButton">browse</span>

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-data/import-data-form.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-data/import-data-form.tpl
@@ -13,7 +13,7 @@
           </div>
         </div>
       </div>
-      <span class="Form-separator Form-separator--or"><%- _t('components.modals.add-layer.imports.form-import.or') %></span>
+      <span class="u-lSpace--xl u-rSpace--xl u-flex u-alignCenter CDB-Text CDB-Size-medium u-altTextColor"><%- _t('components.modals.add-layer.imports.form-import.or') %></span>
     <% } %>
     <div class="Form-rowData Form-rowData--noMargin Form-rowData--med">
       <input type="text" class="Form-input Form-input--med has-submit js-textInput CDB-Text CDB-Size-medium" value="" placeholder="https://carto.com/data-library" />

--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-data/import-data-form.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/import-data/import-data-form.tpl
@@ -4,7 +4,7 @@
       <div class="Form-rowData Form-rowData--med Form-rowData--noMargin js-dropzone">
         <div class="Form-upload">
           <label class="Form-fileLabel js-fileLabel CDB-Text CDB-Size-medium"><%- _t('components.modals.add-layer.imports.form-import.drag-and-drop') %></label>
-          <label class="Form-fileLabel Form-fileLabel--error js-fileError"></label>
+          <label class="Form-fileLabel Form-fileLabel--error CDB-Text CDB-Size-small js-fileError"></label>
           <div class="Form-file">
             <input type="file" class="js-fileInput" />
             <span class="CDB-Button CDB-Button--primary Form-fileButton CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase js-fileButton">


### PR DESCRIPTION
Before:
![screenshot_20160715_164110](https://cloud.githubusercontent.com/assets/7569673/16878579/56096fd8-4aad-11e6-976f-a813e2066b14.png)

After:
![screenshot_20160715_165625](https://cloud.githubusercontent.com/assets/7569673/16878588/5a609c32-4aad-11e6-9b6b-faf4d9f8daf1.png)

Alternative font size:
![screenshot_20160715_165707](https://cloud.githubusercontent.com/assets/7569673/16878608/76d0cff4-4aad-11e6-8fbd-cee5e759877f.png)

This PR comes with the small size (middle screenshot) because it wrapped better, but easy to change it.

--

Also fixes or separator in marker image upload.

Before:
![screenshot_20160715_170702](https://cloud.githubusercontent.com/assets/7569673/16878916/a6a73fd2-4aae-11e6-993b-1b6deeb5c197.png)

After:
![screenshot_20160715_170719](https://cloud.githubusercontent.com/assets/7569673/16878918/aa779210-4aae-11e6-9043-4838b113c963.png)
