### PR TITLE
Refresh map when widgets order changes

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -432,6 +432,14 @@ module.exports = function (params) {
       });
     },
 
+    moveWidget: function (w) {
+      var layerId = w.get('layer_id');
+      var movingLayer = layerDefinitionsCollection.get(layerId);
+      if (movingLayer) {
+        layerDefinitionsCollection.trigger('layerMoved', movingLayer);
+      }
+    },
+
     deleteLayer: function (id) {
       var layerToDelete = layerDefinitionsCollection.get(id);
       if (!layerToDelete.canBeDeletedByUser()) return;

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
@@ -58,7 +58,16 @@ module.exports = CoreView.extend({
     }
   },
 
-  _onSortableFinish: function () {
+  _onSortableFinish: function (event, ui) {
+    var widgetDefModel;
+    var $draggedWidgetElement = ui.item;
+    var widgetId = $draggedWidgetElement.data('model-cid');
+
+    if (widgetId) {
+      widgetDefModel = this._widgetDefinitionsCollection.get(widgetId);
+      this._userActions.moveWidget(widgetDefModel);
+    }
+
     var self = this;
     this.$('.js-widgets > .js-widgetItem').each(function (index, item) {
       var modelCid = $(item).data('model-cid');

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -1908,7 +1908,7 @@ describe('cartodb3/data/user-actions', function () {
 
     describe('when given a widget which is not tied to a layer', function () {
       beforeEach(function () {
-        this.userActions.moveWidget({from: 1, to: 0});
+        this.userActions.moveWidget(this.wa1);
       });
 
       it('should not move layers', function () {
@@ -1918,7 +1918,7 @@ describe('cartodb3/data/user-actions', function () {
 
     describe('when given a widget which is tied to a layer', function () {
       beforeEach(function () {
-        this.userActions.moveWidget({from: 0, to: 1});
+        this.userActions.moveWidget(this.wa0);
       });
 
       it('should move layers', function () {

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -1807,7 +1807,6 @@ describe('cartodb3/data/user-actions', function () {
     });
   });
 
-
   describe('.saveWidget', function () {
     beforeEach(function () {
       this.A = this.layerDefinitionsCollection.add({
@@ -1909,7 +1908,7 @@ describe('cartodb3/data/user-actions', function () {
 
     describe('when given a widget which is not tied to a layer', function () {
       beforeEach(function () {
-        this.userActions.moveWidget(this.wa1);
+        this.userActions.moveWidget({from: 1, to: 0});
       });
 
       it('should not move layers', function () {
@@ -1919,7 +1918,7 @@ describe('cartodb3/data/user-actions', function () {
 
     describe('when given a widget which is tied to a layer', function () {
       beforeEach(function () {
-        this.userActions.moveWidget(this.wa0);
+        this.userActions.moveWidget({from: 0, to: 1});
       });
 
       it('should move layers', function () {

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -1807,6 +1807,7 @@ describe('cartodb3/data/user-actions', function () {
     });
   });
 
+
   describe('.saveWidget', function () {
     beforeEach(function () {
       this.A = this.layerDefinitionsCollection.add({
@@ -1867,6 +1868,62 @@ describe('cartodb3/data/user-actions', function () {
 
       it('should save analysis', function () {
         expect(this.analysisDefinitionsCollection.pluck('node_id')).toEqual(['a0']);
+      });
+    });
+  });
+
+  describe('.moveWidget', function () {
+    beforeEach(function () {
+      this.A = this.layerDefinitionsCollection.add({
+        id: 'A',
+        kind: 'carto',
+        options: {
+          letter: 'a',
+          table_name: 'alice'
+        }
+      });
+      this.B = this.layerDefinitionsCollection.add({
+        id: 'B',
+        kind: 'carto',
+        options: {
+          letter: 'b',
+          table_name: 'bob'
+        }
+      });
+
+      spyOn(this.layerDefinitionsCollection, 'trigger');
+
+      this.wa0 = this.widgetDefinitionsCollection.add({
+        id: 'wa0',
+        layer_id: 'A',
+        type: 'formula',
+        source: {id: 'a0'}
+      });
+
+      this.wa1 = this.widgetDefinitionsCollection.add({
+        id: 'wa1',
+        type: 'formula',
+        source: {id: 'a1'}
+      });
+    });
+
+    describe('when given a widget which is not tied to a layer', function () {
+      beforeEach(function () {
+        this.userActions.moveWidget(this.wa1);
+      });
+
+      it('should not move layers', function () {
+        expect(this.layerDefinitionsCollection.trigger).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when given a widget which is tied to a layer', function () {
+      beforeEach(function () {
+        this.userActions.moveWidget(this.wa0);
+      });
+
+      it('should move layers', function () {
+        expect(this.layerDefinitionsCollection.trigger).toHaveBeenCalledWith('layerMoved', this.A);
       });
     });
   });

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
@@ -34,6 +34,7 @@ describe('editor/widgets/widgets-view', function () {
       widgetDefinitionsCollection: {}
     });
     this.promise = $.Deferred();
+    spyOn(this.userActions, 'moveWidget');
     spyOn(this.userActions, 'saveWidget').and.returnValue(this.promise);
 
     this.view = new EditorWidgetsView({
@@ -87,12 +88,13 @@ describe('editor/widgets/widgets-view', function () {
 
       // Impossible to fake sortable behaviour so...
       this.view.$('.js-widgetItem:eq(1)').insertBefore(this.view.$('.js-widgetItem:eq(0)'));
-      this.view._onSortableFinish();
+      this.view._onSortableFinish('event', { item: this.view.$('.js-widgetItem:eq(1)') });
 
       // End of fake sortable
       expect(this.widgetDefModel2.get('order')).toBe(0);
       expect(this.widgetDefModel1.get('order')).toBe(1);
       expect(this.userActions.saveWidget).toHaveBeenCalled();
+      expect(this.userActions.moveWidget).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This PR fixes #8892.

When moving a widget, we force a new map triggering the movedLayer event of the associated layer of the widget, if anyone.

I think this is the easy way to achieve it the goal, but not completely sure about the approach @xavijam @viddo @alonsogarciapablo 