### PR TITLE
Update GIS StackExchange tag names to CARTO

### DIFF
--- a/lib/assets/javascripts/cartodb/common/views/dashboard_header/user_support_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/dashboard_header/user_support_template.jst.ejs
@@ -3,5 +3,5 @@
 <% } else if (userType === 'client' || userType === 'internal') { %>
   <a href="mailto:support@carto.com" class="Header-navigationLink u-hideOnMobile">Support</a>
 <% } else { %>
-  <a href="http://gis.stackexchange.com/questions/tagged/cartodb" class="Header-navigationLink u-hideOnMobile">Support</a>
+  <a href="http://gis.stackexchange.com/questions/tagged/carto" class="Header-navigationLink u-hideOnMobile">Support</a>
 <% } %>

--- a/lib/assets/javascripts/cartodb/common/views/support_banner.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/support_banner.jst.ejs
@@ -18,9 +18,9 @@
         <% if (isViewer) { %>
           You will be able to create your own maps!
         <% } else if (userType === 'org' || userType === 'org_admin' || userType === 'client') { %>
-          Remember that there is a lot of information in our <a href="http://gis.stackexchange.com/questions/tagged/cartodb" target="_blank">community forums</a>.
+          Remember that there is a lot of information in our <a href="http://gis.stackexchange.com/questions/tagged/carto" target="_blank">community forums</a>.
         <% } else if (userType === "internal") { %>
-          Don't forget to share your knowledge in our <a href="http://gis.stackexchange.com/questions/tagged/cartodb"  target="_blank">community forums</a>.
+          Don't forget to share your knowledge in our <a href="http://gis.stackexchange.com/questions/tagged/carto"  target="_blank">community forums</a>.
         <% } else { %>
           If you experience any problems with the CARTO service, feel free to <a href="mailto:support@carto.com">contact us</a>.
         <% } %>
@@ -39,7 +39,7 @@
         <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-medium u-upperCase">Contact us</span>
       </a>
     <% } else { %>
-      <a href="http://gis.stackexchange.com/questions/tagged/cartodb" class="SupportBanner-link CDB-Button CDB-Button--secondary" target="_blank">
+      <a href="http://gis.stackexchange.com/questions/tagged/carto" class="SupportBanner-link CDB-Button CDB-Button--secondary" target="_blank">
         <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-medium u-upperCase">Community support</span>
       </a>
     <% } %>

--- a/lib/assets/javascripts/cartodb/common/views/support_banner.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/support_banner.jst.ejs
@@ -20,7 +20,7 @@
         <% } else if (userType === 'org' || userType === 'org_admin' || userType === 'client') { %>
           Remember that there is a lot of information in our <a href="http://gis.stackexchange.com/questions/tagged/carto" target="_blank">community forums</a>.
         <% } else if (userType === "internal") { %>
-          Don't forget to share your knowledge in our <a href="http://gis.stackexchange.com/questions/tagged/carto"  target="_blank">community forums</a>.
+          Don&#39;t forget to share your knowledge in our <a href="http://gis.stackexchange.com/questions/tagged/carto"  target="_blank">community forums</a>.
         <% } else { %>
           If you experience any problems with the CARTO service, feel free to <a href="mailto:support@carto.com">contact us</a>.
         <% } %>


### PR DESCRIPTION
We updated the tag in GIS SE and made `cartodb` and `carto` synonyms.

http://gis.stackexchange.com/questions/tagged/carto


cc @xavijam 