### PR TITLE
Fixes related with SQL panel

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -152,6 +152,7 @@ module.exports = CoreView.extend({
     } else {
       // Parser errors SQL here and saving
       this._querySchemaModel.set({
+        status: 'unfetched',
         query: query
       });
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -210,16 +210,16 @@ module.exports = CoreView.extend({
     this._querySchemaModel.resetDueToAlteredData();
   },
 
+  _clearSQL: function () {
+    var sql = this._defaultSQL();
+    this._codemirrorModel.set({content: sql});
+    this._parseSQL();
+  },
+
   _checkClearButton: function () {
     var custom_sql = this._codemirrorModel.get('content').toLowerCase();
     var default_sql = this._defaultSQL().toLowerCase();
     this._clearSQLModel.set({visible: custom_sql !== default_sql});
-  },
-
-  _clearSQL: function () {
-    var sql = this._defaultSQL();
-    this._codemirrorModel.set({content: sql});
-    this._saveSQL();
   },
 
   _defaultSQL: function () {

--- a/lib/assets/javascripts/cartodb3/helpers/sql-utils.js
+++ b/lib/assets/javascripts/cartodb3/helpers/sql-utils.js
@@ -6,7 +6,14 @@ module.exports = {
 
   // return true if the sql query alters table schema in some way
   altersSchema: function (sql) {
-    sql = sql.trim();
+    if (!sql) {
+      return false;
+    }
+
+    // Remove all line breaks in order to prevent
+    // search pattern problems
+    sql = this._removeLineBreaks(sql.trim());
+
     return sql.search(/alter\s+[\w\."]+\s+/i) !== -1 ||
       sql.search(/drop\s+[\w\.\"]+/i) !== -1 ||
       sql.search(/^vacuum\s+[\w\.\"]+/i) !== -1 ||
@@ -21,12 +28,24 @@ module.exports = {
 
   // return true if the sql query alters table data
   altersData: function (sql) {
+    if (!sql) {
+      return false;
+    }
+
+    // Remove all line breaks in order to prevent
+    // search pattern problems
+    sql = this._removeLineBreaks(sql.trim());
+
     return this.altersSchema(sql) ||
       sql.search(/^refresh\s+materialized\s+view\s+[\w\.\"]+/i) !== -1 ||
       sql.search(/^truncate\s+[\w\.\"]+/i) !== -1 ||
       sql.search(/insert\s+into/i) !== -1 ||
       sql.search(/update\s+[\w\.\-"]+\s+.*set/i) !== -1 ||
       sql.search(/delete\s+from/i) !== -1;
+  },
+
+  _removeLineBreaks: function (sql) {
+    return sql.replace(/\r?\n|\r/g, ' ');
   }
 
 };

--- a/lib/assets/test/jasmine/cartodb3/helpers/sql-utils.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/helpers/sql-utils.spec.js
@@ -47,5 +47,6 @@ describe('helpers/sql-utils', function () {
     expect(SQLUtils.altersData('update  "schema"."table"  set a = 1')).toEqual(true);
     expect(SQLUtils.altersData('update  "schema-dash".table  set a = 1')).toEqual(true);
     expect(SQLUtils.altersData('update  "schema-dash"."table"  set a = 1')).toEqual(true);
+    expect(SQLUtils.altersData('update  "schema-dash"."table" as at \n set a = 1')).toEqual(true);
   });
 });


### PR DESCRIPTION
- update statements with alias fail (Fixes #8928): We were not taking into account \r or \n in the sql-utils parser. CR: @javisantana 
- Table view does not update after clicking on "CLEAR" (Fixes #8966): Missing changing status of the query-schema-model as we do in the dataset view. CR: @nobuti 