### PR TITLE
Add weight to pipe delimiter

### DIFF
--- a/services/importer/lib/importer/csv_normalizer.rb
+++ b/services/importer/lib/importer/csv_normalizer.rb
@@ -15,7 +15,7 @@ module CartoDB
       LINES_FOR_DETECTION   = 100       # How many lines to read?
       SAMPLE_READ_LIMIT     = 500000   # Read big enough sample bytes for the encoding sampling
       COMMON_DELIMITERS     = [',', "\t", ' ', ';', '|'].freeze
-      DELIMITER_WEIGHTS     = {','=>2, "\t"=>2, ' '=>1, ';'=>2}
+      DELIMITER_WEIGHTS     = {','=>2, "\t"=>2, ' '=>1, ';'=>2, '|'=>2}
       DEFAULT_DELIMITER     = ','
       DEFAULT_ENCODING      = 'UTF-8'
       DEFAULT_QUOTE         = '"'

--- a/services/importer/lib/importer/csv_normalizer.rb
+++ b/services/importer/lib/importer/csv_normalizer.rb
@@ -15,7 +15,7 @@ module CartoDB
       LINES_FOR_DETECTION   = 100       # How many lines to read?
       SAMPLE_READ_LIMIT     = 500000   # Read big enough sample bytes for the encoding sampling
       COMMON_DELIMITERS     = [',', "\t", ' ', ';', '|'].freeze
-      DELIMITER_WEIGHTS     = {','=>2, "\t"=>2, ' '=>1, ';'=>2, '|'=>2}
+      DELIMITER_WEIGHTS     = { ',' => 2, "\t" => 2, ' ' => 1, ';' => 2, '|' => 2 }.freeze
       DEFAULT_DELIMITER     = ','
       DEFAULT_ENCODING      = 'UTF-8'
       DEFAULT_QUOTE         = '"'


### PR DESCRIPTION
Delimiters should also have a weight associated to them for the scenario in which the CSV only has a single row of data, according to the comment at: https://github.com/CartoDB/cartodb/blob/4ee5dad91e023e15e23e04e7fff8bd0328076139/services/importer/lib/importer/csv_normalizer.rb#L103


The trace:

````
 TypeError: nil can't be coerced into Fixnum
 true: ---------------------------------------------------- false: ["/home/ubuntu/www/production.cartodb.com/releases//services/importer/lib/importer/csv_normalizer.rb:104:in `*'", 
"/home/ubuntu/www/production.cartodb.com/releases//services/importer/lib/importer/csv_normalizer.rb:104:in `block in detect_delimiter'", 
"/home/ubuntu/www/production.cartodb.com/releases//services/importer/lib/importer/csv_normalizer.rb:99:in `each'", 
"/home/ubuntu/www/production.cartodb.com/releases//services/importer/lib/importer/csv_normalizer.rb:99:in `detect_delimiter'", 

```