### PR TITLE
Fixing problem adding a shared datasets in a map within the builder

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -81,16 +81,22 @@ module.exports = Backbone.Collection.extend({
 
       // Create source attr if it does not already exist
       var sourceId = nodeIds.next(o.letter);
-      var tableNameWithOwner = self._configModel.get('user_name') !== o.user_name ? (o.user_name + '.' + o.table_name) : o.table_name;
 
       if (o.table_name && (!o.source || o.source === sourceId)) {
+        o.table_name = o.table_name && o.table_name.replace(/"/g, '');
+        var tableName = o.table_name;
+
+        if (o.table_name.search(/\./i) === -1) {
+          tableName = o.user_name && self._configModel.get('user_name') !== o.user_name ? (o.user_name + '.' + o.table_name) : tableName;
+        }
+
         o.source = o.source || sourceId;
-        o.query = o.query || 'SELECT * FROM ' + tableNameWithOwner;
+        o.query = o.query || 'SELECT * FROM ' + tableName;
 
         // Add analysis definition unless already existing
         self._analysisDefinitionNodesCollection.createSourceNode({
           id: sourceId,
-          tableName: tableNameWithOwner,
+          tableName: tableName,
           query: o.query
         });
       }

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -86,8 +86,8 @@ module.exports = Backbone.Collection.extend({
         o.table_name = o.table_name && o.table_name.replace(/"/g, '');
         var tableName = o.table_name;
 
-        if (o.table_name.search(/\./i) === -1) {
-          tableName = o.user_name && self._configModel.get('user_name') !== o.user_name ? (o.user_name + '.' + o.table_name) : tableName;
+        if (o.table_name.search(/\./i) === -1 && o.user_name && self._configModel.get('user_name') !== o.user_name) {
+          tableName = o.user_name + '.' + o.table_name;
         }
 
         o.source = o.source || sourceId;

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -11,15 +11,14 @@ var layerTypesAndKinds = require('./layer-types-and-kinds');
  */
 module.exports = Backbone.Collection.extend({
 
-  initialize: function (models, options) {
-    if (!options.configModel) throw new Error('configModel is required');
-    if (!options.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
-    if (!options.mapId) throw new Error('mapId is required');
+  initialize: function (models, opts) {
+    if (!opts.configModel) throw new Error('configModel is required');
+    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
+    if (!opts.mapId) throw new Error('mapId is required');
 
-    this._configModel = options.configModel;
-    this._analysisDefinitionNodesCollection = options.analysisDefinitionNodesCollection;
-
-    this.mapId = options.mapId;
+    this._configModel = opts.configModel;
+    this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
+    this.mapId = opts.mapId;
   },
 
   url: function () {
@@ -82,15 +81,16 @@ module.exports = Backbone.Collection.extend({
 
       // Create source attr if it does not already exist
       var sourceId = nodeIds.next(o.letter);
+      var tableNameWithOwner = self._configModel.get('user_name') !== o.user_name ? (o.user_name + '.' + o.table_name) : o.table_name;
 
       if (o.table_name && (!o.source || o.source === sourceId)) {
         o.source = o.source || sourceId;
-        o.query = o.query || 'SELECT * FROM ' + o.table_name;
+        o.query = o.query || 'SELECT * FROM ' + tableNameWithOwner;
 
         // Add analysis definition unless already existing
         self._analysisDefinitionNodesCollection.createSourceNode({
           id: sourceId,
-          tableName: o.table_name,
+          tableName: tableNameWithOwner,
           query: o.query
         });
       }

--- a/lib/assets/test/jasmine/cartodb3/data/analysis-definitions-collection.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/analysis-definitions-collection.spec.js
@@ -6,18 +6,18 @@ var AnalysisDefinitionNodesCollection = require('../../../../javascripts/cartodb
 
 describe('cartodb3/data/analysis-definitions-collection', function () {
   beforeEach(function () {
-    var configModel = new ConfigModel({
+    this.configModel = new ConfigModel({
       base_url: '/u/pepe'
     });
 
     this.analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
-      configModel: {}
+      configModel: this.configModel
     });
 
     this.collection = new AnalysisDefinitionsCollection(null, {
       vizId: 'v-123',
       analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
-      configModel: configModel
+      configModel: this.configModel
     });
 
     this.A = this.collection.add({
@@ -122,7 +122,7 @@ describe('cartodb3/data/analysis-definitions-collection', function () {
       });
 
       this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
-        configModel: {},
+        configModel: this.configModel,
         analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
         mapId: '123'
       });

--- a/lib/assets/test/jasmine/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/layer-definitions-collection.spec.js
@@ -117,6 +117,28 @@ describe('data/layer-definitions-collection', function () {
     expect(this.collection.pluck('color')).toEqual([layerColors.COLORS[0], layerColors.COLORS[1]]);
   });
 
+  it('should create a layer with the owner of the table in the query', function () {
+    var layer1 = this.collection.add({
+      kind: 'carto',
+      options: {
+        table_name: 'table_name',
+        user_name: 'paco'
+      }
+    });
+
+    expect(layer1.get('sql').toLowerCase()).toBe('select * from paco.table_name');
+
+    var layer2 = this.collection.add({
+      kind: 'carto',
+      options: {
+        table_name: 'table_name',
+        user_name: 'pepe'
+      }
+    });
+
+    expect(layer2.get('sql').toLowerCase()).toBe('select * from table_name');
+  });
+
   describe('when there are some layers', function () {
     beforeEach(function () {
       this.collection.reset([{

--- a/lib/assets/test/jasmine/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/layer-definitions-collection.spec.js
@@ -137,6 +137,16 @@ describe('data/layer-definitions-collection', function () {
     });
 
     expect(layer2.get('sql').toLowerCase()).toBe('select * from table_name');
+
+    var layer3 = this.collection.add({
+      kind: 'carto',
+      options: {
+        table_name: '"paco".table_name',
+        user_name: ''
+      }
+    });
+
+    expect(layer3.get('sql').toLowerCase()).toBe('select * from paco.table_name');
   });
 
   describe('when there are some layers', function () {

--- a/lib/assets/test/jasmine/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/layer-definitions-collection.spec.js
@@ -7,6 +7,7 @@ var layerColors = require('../../../../javascripts/cartodb3/data/layer-colors');
 describe('data/layer-definitions-collection', function () {
   beforeEach(function () {
     var configModel = new ConfigModel({
+      user_name: 'pepe',
       base_url: '/u/pepe'
     });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/composite-layers-analysis-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/composite-layers-analysis-view.spec.js
@@ -44,7 +44,7 @@ describe('editor/layers/analysis-views/composite-layer-analysis-view', function 
     var model = this.analysisDefinitionNodesCollection.get('a1');
 
     this.layerDefinitionsCollection = new LayerDefinitionsCollection(null, {
-      configModel: {},
+      configModel: configModel,
       analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
       mapId: 'map-123'
     });


### PR DESCRIPTION
So, if a user add a shared dataset, it will work in the new builder.
But if the user creates a new map with any shared dataset, map will not work due to a bug in the vizJSON generation (https://github.com/CartoDB/cartodb/issues/8974).
In any case, fixing this problem, and the other is being managed by @juanignaciosl. 

Fixes #8954
CR: @javierarce 