### PR TITLE
Allow 2 invocations to the same method

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -1,5 +1,10 @@
 IrresponsibleModule:
   enabled: false
+DuplicateMethodCall:
+  enabled: true
+  exclude: []
+  max_calls: 2
+  allow_calls: []
 UncommunicativeVariableName:
   enabled: true
   exclude: []


### PR DESCRIPTION
At least 2 is really useful for common scenarios of doing something with
a value if that value is present:

`my_hash['xxx'] = something.value if something.value`