### PR TITLE
add check for visualization_id

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -1003,8 +1003,11 @@ class DataImport < Sequel::Model
       Carto::Tracking::Events::CreatedDataset.new(current_user, vis, origin: origin).report
     end
 
-    Carto::Tracking::Events::CreatedMap.new(current_user, Carto::Visualization.find(visualization_id), origin: 'import')
-                                       .report
+    if visualization_id
+      visualization = Carto::Visualization.find(visualization_id)
+
+      Carto::Tracking::Events::CreatedMap.new(current_user, visualization, origin: 'import').report
+    end
   rescue ActiveRecord::ActiveRecordError => exception
     CartoDB::Logger.warning(message: 'SegmentWrapper: could not report',
                             event: 'Created map',


### PR DESCRIPTION
Previous behaviour checked for `visualization_id` presence. I thought it was overkill. It's not. There are a lot of `data_imports` with no `visualization_id` (only data imports?).

Anyway, this restores the previous behaviour and stops Rollbar verbosity.

CR please @javitonino 