### PR TITLE
Define "carto" dependency as git branch to freeze it at shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1087,8 +1087,8 @@
     },
     "carto": {
       "version": "0.15.1-cdb1",
-      "from": "https://github.com/CartoDB/carto/archive/master.tar.gz",
-      "resolved": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+      "from": "cartodb/carto#master",
+      "resolved": "git://github.com/cartodb/carto.git#f17aea8657ea27f2a660db15dd13b57127e823f9",
       "dependencies": {
         "mapnik-reference": {
           "version": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "backbone-model-file-upload": "^1.0.0",
     "browserify-shim": "3.8.12",
     "camshaft-reference": "<2.0",
-    "carto": "https://github.com/CartoDB/carto/archive/master.tar.gz",
+    "carto": "cartodb/carto#master",
     "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "cartodb/cartodb.js#v4",


### PR DESCRIPTION
Using a URL like `https://github.com/CartoDB/carto/archive/master.tar.gz` means it will get downloaded each time `npm install` happens, even if `carto` dependency is frozen at `npm-shrinkwrap.json` file it will redownload whatever is on `master` branch.

However using a `"username/repo#branch"` (or `git://...`)  pattern allows npm to freeze the commit at `npm-shrinkwrap.json` so you get the same version afterwards.

Just to let you know: we also have `cartocolor` development dependency declared as we had `carto` dependency. But I'm not that familiar with the usage of that dev dependency, so please, consider reviewing that situation.

cc @xavijam @javisantana 