### PR TITLE
Fix checking for visualization extension

### DIFF
--- a/lib/carto/visualization_exporter.rb
+++ b/lib/carto/visualization_exporter.rb
@@ -77,7 +77,7 @@ module Carto
     VISUALIZATION_EXTENSIONS = [Carto::VisualizationExporter::EXPORT_EXTENSION].freeze
 
     def self.has_visualization_extension?(filename)
-      VISUALIZATION_EXTENSIONS.any? { |extension| filename =~ /#{extension}$/ }
+      VISUALIZATION_EXTENSIONS.any? { |extension| filename =~ /#{Regexp.escape(extension)}$/ }
     end
 
     def export(visualization, user,


### PR DESCRIPTION
The extension wasn't being escaped, so dots matched any character

Fixes #9053