### PR TITLE
Only show columns with weight > 0 in analysis

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model.js
@@ -65,7 +65,7 @@ module.exports = BaseAnalysisFormModel.extend({
    * @override {BaseAnalysisFormModel._setSchema}
    */
   _setSchema: function () {
-    var areas = this.doMetadata ? this.doMetadata.areas() : [''];
+    var areas = this.doMetadata.areas();
     var schema = {
       source: this._primarySourceSchemaItem(),
       area: {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model.js
@@ -6,18 +6,29 @@ module.exports = BaseAnalysisFormModel.extend({
   initialize: function () {
     BaseAnalysisFormModel.prototype.initialize.apply(this, arguments);
 
-    var nodeDefModel = this._layerDefinitionModel.findAnalysisDefinitionNodeModel(this.get('source'));
+    this.nodeDefModel = this._layerDefinitionModel.findAnalysisDefinitionNodeModel(this.get('source'));
+
     this.doMetadata = new DataObservartoryMetadata(null, {
       configModel: this._configModel,
-      geometryType: nodeDefModel.querySchemaModel.getGeometry().getSimpleType()
+      geometryType: null
     });
-    this.listenTo(this.doMetadata, 'sync', this._setSchema);
-    this.doMetadata.fetch();
 
+    // check if the geometry type is available, if not wait until it's finished
+    if (this.nodeDefModel.querySchemaModel.isFetched()) {
+      this._fetchDOMetadata();
+    } else {
+      this.nodeDefModel.querySchemaModel.once('change:status', this._fetchDOMetadata, this);
+    }
+    this._setSchema();
+  },
+
+  _fetchDOMetadata: function () {
+    this.doMetadata.setGeometryType(this.nodeDefModel.querySchemaModel.getGeometry().getSimpleType());
+    this.listenTo(this.doMetadata, 'sync', this._setSchema);
     this.on('change:area', this._areaChanged, this);
     this.on('change:measurement', this._measurementChanged, this);
     this.on('change:segments', this._setSegment, this);
-    this._setSchema();
+    this.doMetadata.fetch();
   },
 
   _areaChanged: function () {
@@ -38,11 +49,11 @@ module.exports = BaseAnalysisFormModel.extend({
     var s = this.doMetadata.segment(this.get('area'), this.get('measurement'), this.get('segments'));
     if (s) {
       this.set('segment_name', s);
-      // this code changes the column name automatically
-      // if (this.get('final_column') === '') {
-      // this.set('final_column', this._normalizeSegment(s));
-      // this._setSchema();
-      // }
+    // this code changes the column name automatically
+    // if (this.get('final_column') === '') {
+    // this.set('final_column', this._normalizeSegment(s));
+    // this._setSchema();
+    // }
     }
   },
 
@@ -54,7 +65,7 @@ module.exports = BaseAnalysisFormModel.extend({
    * @override {BaseAnalysisFormModel._setSchema}
    */
   _setSchema: function () {
-    var areas = this.doMetadata.areas();
+    var areas = this.doMetadata ? this.doMetadata.areas() : [''];
     var schema = {
       source: this._primarySourceSchemaItem(),
       area: {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-measure-model.js
@@ -5,8 +5,11 @@ var DataObservartoryMetadata = require('../data-observatory-metadata');
 module.exports = BaseAnalysisFormModel.extend({
   initialize: function () {
     BaseAnalysisFormModel.prototype.initialize.apply(this, arguments);
+
+    var nodeDefModel = this._layerDefinitionModel.findAnalysisDefinitionNodeModel(this.get('source'));
     this.doMetadata = new DataObservartoryMetadata(null, {
-      configModel: this._configModel
+      configModel: this._configModel,
+      geometryType: nodeDefModel.querySchemaModel.getGeometry().getSimpleType()
     });
     this.listenTo(this.doMetadata, 'sync', this._setSchema);
     this.doMetadata.fetch();

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/data-observatory-metadata.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/data-observatory-metadata.js
@@ -13,6 +13,7 @@ var QUERY = [
   '  join obs_column_tag t on t.tag_id = o.id and t.column_id in (select ttt.column_id from obs_column_tag ttt where ttt.tag_id = tag.id)',
   '  join obs_column tt on tt.id = t.column_id',
   "  where o.type = 'subsection'",
+  '    and tt.weight > 0 '
   '  group by o.name, o.id',
   ')) as subsection',
   "from obs_tag tag where type = 'section'"

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/data-observatory-metadata.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/data-observatory-metadata.js
@@ -2,22 +2,31 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var cdb = require('cartodb.js');
 
-var QUERY = [
-  'select tag.name, to_json(ARRAY(',
-  '  select row_to_json(',
-  '    (select row(_) from (select o.name, o.id, array_agg(',
-  '      (select row(__) from (select tt.name, tt.id) as __)',
-  '    ) as columns) as _)',
-  '  )',
-  '  from obs_tag o ',
-  '  join obs_column_tag t on t.tag_id = o.id and t.column_id in (select ttt.column_id from obs_column_tag ttt where ttt.tag_id = tag.id)',
-  '  join obs_column tt on tt.id = t.column_id',
-  "  where o.type = 'subsection'",
-  '    and tt.weight > 0 '
-  '  group by o.name, o.id',
-  ')) as subsection',
-  "from obs_tag tag where type = 'section'"
-].join('\n');
+function getQueryForGeometryType (geometryType) {
+  var QUERY = [
+    'select tag.name, to_json(ARRAY(',
+    '  select row_to_json(',
+    '    (select row(_) from (select o.name, o.id, array_agg(',
+    '      (select row(__) from (select tt.name, tt.id) as __)',
+    '    ) as columns) as _)',
+    '  )',
+    '  from obs_tag o ',
+    '  join obs_column_tag t on t.tag_id = o.id and t.column_id in (select ttt.column_id from obs_column_tag ttt where ttt.tag_id = tag.id)',
+    '  join obs_column tt on tt.id = t.column_id',
+    "  where o.type = 'subsection'",
+    '    and tt.weight > 0 ',
+    '    {{aggregate_condition}}',
+    '  group by o.name, o.id',
+    ')) as subsection',
+    "from obs_tag tag where type = 'section'"
+  ].join('\n');
+
+  var replacement = '';
+  if (geometryType === 'polygon') {
+    replacement = "and tt.aggregate ILIKE 'sum'";
+  }
+  return QUERY.replace('{{aggregate_condition}}', replacement);
+}
 
 /**
  * this class fetches information from observatory metadata
@@ -25,12 +34,13 @@ var QUERY = [
 module.exports = Backbone.Model.extend({
   initialize: function (attrs, opts) {
     this._configModel = opts.configModel;
+    this._geometryType = opts.geometryType;
   },
 
   sync: function (method, model, options) {
     // TODO: use configuration for data observatory
     var sql = cdb.SQL({ user: 'observatory' });
-    sql.execute(QUERY).done(function (data) {
+    sql.execute(getQueryForGeometryType(this._geometryType)).done(function (data) {
       options.success && options.success(data);
     }).error(function (errors) {
       // console.log("errors:" + errors);

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/data-observatory-metadata.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/data-observatory-metadata.js
@@ -47,6 +47,10 @@ module.exports = Backbone.Model.extend({
     });
   },
 
+  setGeometryType: function (geometryType) {
+    this._geometryType = geometryType;
+  },
+
   parse: function (attrs) {
     var a = {};
     _.each(attrs.rows, function (r) {


### PR DESCRIPTION
This should solve issues with measures like "aggregate travel time to work", that should be hidden, from appearing in the Builder Analysis.

cc @rambo @saleiva