### PR TITLE
changing default point outline from yellow to white

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/default-cartography.json
+++ b/lib/assets/javascripts/cartodb3/data/default-cartography.json
@@ -13,10 +13,10 @@
       },
       "stroke": {
         "size": {
-          "fixed": 1.5
+          "fixed": 1
         },
         "color": {
-          "fixed": "#ffda8d",
+          "fixed": "#fff",
           "opacity": 1
         }
       }


### PR DESCRIPTION
@saleiva @javisantana 

Please look and merge if it is OK!!

Just please get the yellow outline off of everything.

I don't know why point outline goes to other geometries, but here, I changed the basic default.