### PR TITLE
Size options for custom list.

### DIFF
--- a/app/assets/stylesheets/editor-3/custom-list.css.scss
+++ b/app/assets/stylesheets/editor-3/custom-list.css.scss
@@ -12,6 +12,7 @@
   right: 0;
   min-width: 246px;
   max-width: 272px;
+  visibility: hidden;
   z-index: 100;
 }
 .CustomList--small {

--- a/app/assets/stylesheets/editor-3/custom-list.css.scss
+++ b/app/assets/stylesheets/editor-3/custom-list.css.scss
@@ -14,6 +14,10 @@
   max-width: 272px;
   visibility: hidden;
   z-index: 100;
+
+  &.has-visibility {
+    visibility: visible;
+  }
 }
 .CustomList--small {
   width: 215px;

--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -76,7 +76,7 @@ module.exports = CoreView.extend({
     this.$el.toggle(this.isVisible());
 
     $('body').append(this.el);
-
+    this._setListMaxSize();
     this.$el.css('top', this.options.position.y + this.options.offset.y);
     this.$el.css('left', this.options.position.x + this.options.offset.x - this.$el.outerWidth());
 
@@ -97,15 +97,23 @@ module.exports = CoreView.extend({
   },
 
   _renderList: function () {
-    var listView = new CustomListView({
+    this._listView = new CustomListView({
       model: this.model,
       collection: this.collection,
       typeLabel: '',
       ItemView: this.options.itemView,
-      itemTemplate: this.options.itemTemplate
+      itemTemplate: this.options.itemTemplate,
+      size: 5
     });
-    this.$el.append(listView.render().el);
-    this.addView(listView);
+    this.$el.append(this._listView.render().el);
+    this.addView(this._listView);
+  },
+
+  _setListMaxSize: function () {
+    setTimeout(function () {
+      this._listView.setMaxSize();
+      this.$el.css('visibility', 'visible');
+    }.bind(this), 0);
   },
 
   show: function () {

--- a/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
+++ b/lib/assets/javascripts/cartodb3/components/context-menu/context-menu-view.js
@@ -112,7 +112,7 @@ module.exports = CoreView.extend({
   _setListMaxSize: function () {
     setTimeout(function () {
       this._listView.setMaxSize();
-      this.$el.css('visibility', 'visible');
+      this.$el.addClass('has-visibility');
     }.bind(this), 0);
   },
 
@@ -122,6 +122,7 @@ module.exports = CoreView.extend({
 
   hide: function () {
     this.model.set('visible', false);
+    this.$el.removeClass('has-visibility');
   },
 
   toggle: function () {

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
@@ -25,6 +25,7 @@ module.exports = CoreView.extend({
   initialize: function (opts) {
     this.options = _.extend({}, this.options, opts);
     this._onKeyDownBinded = this._onKeyDown.bind(this);
+    this._needsMaxSize = true;
     this._initBinds();
   },
 
@@ -68,10 +69,15 @@ module.exports = CoreView.extend({
   },
 
   setMaxSize: function () {
-    var height = this.$('.js-listItem:first').outerHeight();
+    if (!this._needsMaxSize) {
+      return;
+    }
+
+    var height = this.$('.CustomList-list').children(':first').outerHeight();
     this.$('.js-list').css({
       'max-height': height * this.options.size
     });
+    this._needsMaxSize = false;
   },
 
   _renderItem: function (mdl) {

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-list-view.js
@@ -10,7 +10,12 @@ var ARROW_UP_KEY_CODE = 38;
 var ENTER_KEY_CODE = 13;
 
 module.exports = CoreView.extend({
+  options: {
+    size: 3
+  },
+
   className: 'CDB-Text CDB-Size-medium CustomList-listWrapper',
+
   tagName: 'div',
 
   events: {
@@ -60,6 +65,13 @@ module.exports = CoreView.extend({
     }
 
     return this;
+  },
+
+  setMaxSize: function () {
+    var height = this.$('.js-listItem:first').outerHeight();
+    this.$('.js-list').css({
+      'max-height': height * this.options.size
+    });
   },
 
   _renderItem: function (mdl) {

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
@@ -105,7 +105,7 @@ module.exports = CoreView.extend({
   _setListMaxSize: function () {
     setTimeout(function () {
       this._listView.setMaxSize();
-      this.$el.css('visibility', 'visible');
+      this.$el.addClass('has-visibility');
     }.bind(this), 0);
   },
 
@@ -124,6 +124,7 @@ module.exports = CoreView.extend({
   hide: function () {
     this.trigger('hidden', this);
     this.model.set('visible', false);
+    this.$el.removeClass('has-visibility');
   },
 
   toggle: function () {

--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
@@ -60,6 +60,7 @@ module.exports = CoreView.extend({
       this._renderSearch();
     }
     this._renderList();
+    this._setListMaxSize();
     return this;
   },
 
@@ -93,11 +94,19 @@ module.exports = CoreView.extend({
       collection: this.collection,
       typeLabel: this.options.typeLabel,
       ItemView: this.options.itemView,
-      itemTemplate: this.options.itemTemplate
+      itemTemplate: this.options.itemTemplate,
+      size: this.options.size
     });
     this.$el.append(this._listView.render().el);
     this._listView.highlight();
     this.addView(this._listView);
+  },
+
+  _setListMaxSize: function () {
+    setTimeout(function () {
+      this._listView.setMaxSize();
+      this.$el.css('visibility', 'visible');
+    }.bind(this), 0);
   },
 
   highlight: function () {


### PR DESCRIPTION
This PR fixes #9077.

I found this issue tricky because it could affect a lot of elements in the UI. For instance, a lot of form components use this custom list internally. 

The custom max height of the list view should depend on the inner item's height, and how many items we want to show without scrolling. So I'm introducing a size option for the custom list, that it handles how many items are visible at first sight. This is customizable for every custom view.

![custom-list-size](https://cloud.githubusercontent.com/assets/1366843/17077110/885971fa-50c4-11e6-8fd6-fb1f18a60193.gif)

In the screencast above you can see the context menu has a custom size of 5, to fix the issue. And I set the default size to 3, because TBH, those huge form controls bugged me up and I want to save some vertical space. In any case, now we can show some of them with different sizes.

Thoughts @xavijam @piensaenpixel @saleiva?