### PR TITLE
8977 fix layer creation create missing analyses

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -231,6 +231,12 @@ module.exports = function (params) {
         at: at,
         error: options.error,
         success: function () {
+          layerDefinitionsCollection.each(function (layerDefModel) {
+            if (!layerDefModel.isDataLayer()) return;
+            if (analysisDefinitionsCollection.findAnalysisForLayer(layerDefModel)) return;
+
+            analysisDefinitionsCollection.saveAnalysisForLayer(layerDefModel);
+          });
           layerDefinitionsCollection.save();
           options.success && options.success();
         }

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -906,7 +906,9 @@ describe('cartodb3/data/user-actions', function () {
 
     it('should create analysis for all layers that lack one', function () {
       this.layerDefinitionsCollection.add({kind: 'tiled'});
-      this.layerDefinitionsCollection.add({
+
+      // Layers w/ analysis
+      this.layerA = this.layerDefinitionsCollection.add({
         id: 'layerA',
         kind: 'carto',
         options: {
@@ -914,7 +916,16 @@ describe('cartodb3/data/user-actions', function () {
           source: 'a0'
         }
       });
-      this.layerDefinitionsCollection.add({
+      this.analysisDefinitionsCollection.add({
+        analysis_definition: {
+          id: 'a0',
+          type: 'source',
+          params: {}
+        }
+      });
+
+      // Layer w/o analysis
+      this.layerB = this.layerDefinitionsCollection.add({
         id: 'layerB',
         kind: 'carto',
         options: {
@@ -927,8 +938,10 @@ describe('cartodb3/data/user-actions', function () {
 
       this.userActions.createLayerForTable('tableName');
 
+      // Should create an aalysis for layerB
       expect(this.analysisDefinitionsCollection.saveAnalysisForLayer).toHaveBeenCalled();
-      expect(this.analysisDefinitionsCollection.saveAnalysisForLayer.calls.count()).toEqual(2);
+      expect(this.analysisDefinitionsCollection.saveAnalysisForLayer.calls.count()).toEqual(1);
+      expect(this.analysisDefinitionsCollection.saveAnalysisForLayer.calls.argsFor(0)[0].id).toEqual('layerB');
     });
   });
 

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -768,6 +768,7 @@ describe('cartodb3/data/user-actions', function () {
         if (/layers/.test(params.url)) {
           params.success && params.success({
             id: undefined,
+            options: {},
             order: 2,
             infowindow: '',
             tooltip: '',
@@ -821,20 +822,17 @@ describe('cartodb3/data/user-actions', function () {
     });
 
     it('should place the layer below the "Tiled" layer on top', function () {
-      var TiledLayer = new Backbone.Model({
+      this.layerDefinitionsCollection.add({
         id: 'labels-on-top',
-        type: 'Tiled',
+        kind: 'tiled',
         order: 1
       });
-      var CartoDBLayer = new Backbone.Model({
+      this.layerDefinitionsCollection.add({
         id: 'cartodb-layer',
-        type: 'CartoDB',
+        kind: 'carto',
+        options: {table_name: 'carto'},
         order: 0
       });
-      this.layerDefinitionsCollection.reset([
-        CartoDBLayer,
-        TiledLayer
-      ]);
 
       spyOn(this.layerDefinitionsCollection, 'create').and.callThrough();
       spyOn(this.layerDefinitionsCollection, 'save').and.callThrough();
@@ -851,20 +849,18 @@ describe('cartodb3/data/user-actions', function () {
     });
 
     it('should place the layer below the "Torque" layer on top', function () {
-      var TorqueLayer = new Backbone.Model({
+      this.layerDefinitionsCollection.add({
         id: 'torque-layer',
-        type: 'torque',
+        kind: 'torque',
+        options: {table_name: 'torque'},
         order: 1
       });
-      var CartoDBLayer = new Backbone.Model({
+      this.layerDefinitionsCollection.add({
         id: 'cartodb-layer',
-        type: 'CartoDB',
+        kind: 'carto',
+        options: {table_name: 'carto'},
         order: 0
       });
-      this.layerDefinitionsCollection.reset([
-        CartoDBLayer,
-        TorqueLayer
-      ]);
 
       spyOn(this.layerDefinitionsCollection, 'create').and.callThrough();
       spyOn(this.layerDefinitionsCollection, 'save').and.callThrough();
@@ -879,25 +875,18 @@ describe('cartodb3/data/user-actions', function () {
     });
 
     it('should place the new layer above the "CartoDB" layer on top', function () {
-      var TiledLayer_1 = new Backbone.Model({
-        type: 'Tiled',
-        order: 1
-      });
-      spyOn(TiledLayer_1, 'save');
-      var CartoDBLayer_0 = new Backbone.Model({
+      this.layerDefinitionsCollection.add({
         id: 'layer-0',
-        type: 'CartoDB',
+        kind: 'carto',
+        options: {table_name: 'alice'},
         order: 0
       });
-      var CartoDBLayer_1 = new Backbone.Model({
+      this.layerDefinitionsCollection.add({
         id: 'layer-1',
-        type: 'CartoDB',
+        kind: 'carto',
+        options: {table_name: 'bob'},
         order: 1
       });
-      this.layerDefinitionsCollection.reset([
-        CartoDBLayer_0,
-        CartoDBLayer_1
-      ]);
 
       spyOn(this.layerDefinitionsCollection, 'create').and.callThrough();
       spyOn(this.layerDefinitionsCollection, 'save').and.callThrough();
@@ -913,6 +902,33 @@ describe('cartodb3/data/user-actions', function () {
 
       // Order of other layers has not been changed
       expect(this.layerDefinitionsCollection.save).toHaveBeenCalled();
+    });
+
+    it('should create analysis for all layers that lack one', function () {
+      this.layerDefinitionsCollection.add({kind: 'tiled'});
+      this.layerDefinitionsCollection.add({
+        id: 'layerA',
+        kind: 'carto',
+        options: {
+          letter: 'a',
+          source: 'a0'
+        }
+      });
+      this.layerDefinitionsCollection.add({
+        id: 'layerB',
+        kind: 'carto',
+        options: {
+          letter: 'b',
+          source: 'b0'
+        }
+      });
+
+      spyOn(this.analysisDefinitionsCollection, 'saveAnalysisForLayer');
+
+      this.userActions.createLayerForTable('tableName');
+
+      expect(this.analysisDefinitionsCollection.saveAnalysisForLayer).toHaveBeenCalled();
+      expect(this.analysisDefinitionsCollection.saveAnalysisForLayer.calls.count()).toEqual(2);
     });
   });
 

--- a/lib/build/tasks/watch.js
+++ b/lib/build/tasks/watch.js
@@ -14,18 +14,6 @@ exports.task = function() {
   js.push(['lib/assets/javascripts/cdb/src/**/*.js']);
 
   return {
-    jasmine: {
-      files: [
-        'lib/assets/javascripts/cartodb3/**/*.js',
-        'lib/assets/test/jasmine/**/*.js'
-      ],
-      tasks: ['npm-test'],
-      options: {
-        spawn: true, // don't share context with others watchers, only want to rerun the jasmine tests separately
-        interrupt: true,
-        atBegin: false
-      }
-    },
     js: {
       files: js,
       tasks: ['cdb', 'concat:js', 'jst'],


### PR DESCRIPTION
Fixes #8977 

Make sure the analysis are persisted for all existing layers/nodes at the time of creating the new layer, since saving the collection will persist the source references.

@alonsogarciapablo can you review, please?