### PR TITLE
use default style when type is none

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
@@ -1,32 +1,9 @@
 var _ = require('underscore');
+var camshaftReference = require('../../data/camshaft-reference');
 
 var CONFIG = {
   HEATMAP_IMAGE: 'url(http://s3.amazonaws.com/com.cartodb.assets.static/alphamarker.png)',
-  GENERIC_STYLE: [
-    '[mapnik-geometry-type=point] {',
-    'marker-width: 7;',
-    'marker-fill: #294bd7;',
-    'marker-fill-opacity: 0.9;',
-    'marker-line-width: 1;',
-    'marker-line-color: #fff;',
-    'marker-line-opacity: 1;',
-    'marker-allow-overlap: true;',
-    '}',
-    '',
-    '[mapnik-geometry-type=linestring] {',
-    'line-color:  #FFB927;',
-    'line-width: 2;',
-    'line-opacity: 1;',
-    '}',
-    '',
-    '//polygons',
-    '[mapnik-geometry-type=polygon] {',
-    'polygon-fill: #8DCCB8;',
-    'polygon-opacity: 0.7;',
-    'line-color: #fff;',
-    'line-width: 0.5;',
-    'line-opacity: 0.7;',
-    '}'].join('\n'),
+  GENERIC_STYLE: camshaftReference.getDefaultCartoCSSForType(),
   DEFAULT_HEATMAP_COLORS: ['blue', 'cyan', 'lightgreen', 'yellow', 'orange', 'red']
 };
 


### PR DESCRIPTION
fixes #9143

There is a problem. This fixed the default style applied but does not the fact that "none" style is applied when you remove all the analysis in a layer

cc @viddo 