### PR TITLE
9155 fix letter match

### DIFF
--- a/lib/assets/javascripts/cartodb3/value-objects/analysis-node-ids.js
+++ b/lib/assets/javascripts/cartodb3/value-objects/analysis-node-ids.js
@@ -43,7 +43,8 @@ module.exports = {
    */
   letter: function (sourceId) {
     if (!sourceId || !_.isString(sourceId)) return '';
-    return sourceId.match(/^([a-z]+)/)[0];
+    var match = sourceId.match(/^([a-z]+)/);
+    return _.isArray(match) && match[0] || '';
   },
 
   changeLetter: function (id, newLetter) {

--- a/lib/assets/test/jasmine/cartodb3/value-objects/analysis-node-ids.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/value-objects/analysis-node-ids.spec.js
@@ -68,6 +68,7 @@ describe('value-objects/analysis-node-ids', function () {
       expect(analysisDefinitionNodeIds.letter(undefined)).toEqual('');
       expect(analysisDefinitionNodeIds.letter(false)).toEqual('');
       expect(analysisDefinitionNodeIds.letter({})).toEqual('');
+      expect(analysisDefinitionNodeIds.letter('"other_username".secondary_table_that_might_look_like_this')).toEqual('');
     });
   });
 


### PR DESCRIPTION
Fixes #9155 

This bug only happens if there are secondary sources that have the format of `”other_user”.some_table_name”`, since the regex previously assumed the node ids to start with a letter.

@xavijam ping