### PR TITLE
Dataset view issues

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/table/table-view-model.js
+++ b/lib/assets/javascripts/cartodb3/components/table/table-view-model.js
@@ -58,8 +58,11 @@ module.exports = Backbone.Model.extend({
   },
 
   isCustomQueryApplied: function () {
+    var sanitizeName = function (str) {
+      return str.replace(/"/g, '').toLowerCase();
+    };
     var query = this._querySchemaModel.get('query');
-    return query.toLowerCase() !== 'select * from ' + this.get('tableName');
+    return sanitizeName(query) !== sanitizeName('select * from ' + this.get('tableName'));
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-content/dataset-content-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-content/dataset-content-view.js
@@ -45,11 +45,15 @@ module.exports = CoreView.extend({
   },
 
   _initViews: function () {
+    var permissionModel = this._tableModel._permissionModel;
+    var hasWriteAccess = permissionModel.isOwner(this._userModel) || permissionModel.hasWriteAccess(this._userModel);
+    var isReadOnly = this._syncModel.isSync() || !hasWriteAccess;
+
     var tableView = TableManager.create({
       relativePositionated: true,
       querySchemaModel: this._querySchemaModel,
       tableName: this._tableModel.get('name'),
-      readonly: this._syncModel.isSync() || !this._tableModel.isOwner(this._userModel),
+      readonly: isReadOnly,
       modals: this._modals,
       configModel: this._configModel
     });

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -105,7 +105,6 @@ module.exports = CoreView.extend({
     var re = new RegExp(oldName, 'gi');
     var newContent = content.replace(re, newName);
     this._codemirrorModel.set('content', newContent);
-    this._parseSQL();
   },
 
   _initViews: function () {

--- a/lib/assets/test/spec/cartodb3/components/table/table-view-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/table/table-view-model.spec.js
@@ -110,5 +110,14 @@ describe('components/table/table-view-model', function () {
       this.querySchemaModel.set('query', 'SELECT * FROM paco');
       expect(this.model.isCustomQueryApplied()).toBeFalsy();
     });
+
+    it('should not consider custom query if table name is from another org user', function () {
+      this.querySchemaModel.set('query', 'select * from hey.hello');
+      this.model.set('tableName', '"hey".hello');
+      expect(this.model.isCustomQueryApplied()).toBeFalsy();
+      this.querySchemaModel.set('query', 'select * from "hey".hello');
+      this.model.set('tableName', 'hey.hello');
+      expect(this.model.isCustomQueryApplied()).toBeFalsy();
+    });
   });
 });

--- a/lib/assets/test/spec/cartodb3/dataset/dataset-options-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/dataset/dataset-options-view.spec.js
@@ -105,8 +105,10 @@ describe('dataset/dataset-options-view', function () {
   });
 
   it('should respond to change dataset name', function () {
+    spyOn(view, '_parseSQL');
     visModel.set('name', 'foo');
     expect(DatasetOptionsView.prototype._onChangeName).toHaveBeenCalled();
+    expect(view._parseSQL).not.toHaveBeenCalled();
 
     var content = view._codemirrorModel.get('content');
     expect(content).toContain('foo');

--- a/lib/assets/test/spec/cartodb3/dataset/dataset-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/dataset/dataset-view.spec.js
@@ -21,9 +21,11 @@ describe('dataset/dataset-view', function () {
       configModel: configModel
     });
 
-    var tableModel = new TableModel({
-      name: 'table_1'
+    this.tableModel = new TableModel({
+      name: 'table_1',
+      permission: {}
     }, {
+      parse: true,
       configModel: configModel
     });
 
@@ -40,7 +42,7 @@ describe('dataset/dataset-view', function () {
     this.view = new DatasetView({
       modals: new Backbone.Model(),
       userModel: userModel,
-      tableModel: tableModel,
+      tableModel: this.tableModel,
       syncModel: syncModel,
       configModel: configModel,
       querySchemaModel: querySchemaModel
@@ -60,14 +62,14 @@ describe('dataset/dataset-view', function () {
     });
 
     it('should render the table as disabled if table belongs to other user', function () {
-      spyOn(this.view._tableModel, 'isOwner').and.returnValue(false);
+      spyOn(this.tableModel._permissionModel, 'isOwner').and.returnValue(false);
       this.view.render();
       expect(this.view.$('.Table').hasClass('is-disabled')).toBeTruthy();
     });
 
     it('should render the table as disabled if it is sync', function () {
       this.view._syncModel.isSync.and.returnValue(true);
-      spyOn(this.view._tableModel, 'isOwner').and.returnValue(true);
+      spyOn(this.tableModel._permissionModel, 'isOwner').and.returnValue(true);
       this.view.render();
       expect(this.view.$('.Table').hasClass('is-disabled')).toBeTruthy();
       expect(this.view.$('.SyncInfo').length).toBe(1);
@@ -75,7 +77,7 @@ describe('dataset/dataset-view', function () {
 
     it('should not render sync info if table doesn\'t belong to the user', function () {
       this.view._syncModel.isSync.and.returnValue(true);
-      spyOn(this.view._tableModel, 'isOwner').and.returnValue(false);
+      spyOn(this.tableModel._permissionModel, 'isOwner').and.returnValue(false);
       this.view.render();
       expect(this.view.$('.Table').hasClass('is-disabled')).toBeTruthy();
       expect(this.view.$('.SyncInfo').length).toBe(0);


### PR DESCRIPTION
- Cannot edit shared datasets in the builder (fixes #8865).
- An error pops up after dataset renaming, but the renaming succeed (fixes #9161): we were fetching 2 times the query-schema-model. It was not necessary to fetch when it is renamed in the sql editor.

CR: @nobuti 