### PR TITLE
9168 fix delete layer with high node ids

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -484,6 +484,13 @@ module.exports = function (params) {
 
         // Since will reassign ids from the start of list need to calculate which sequence id to start on
         var idSequence = newParentLinkedNodesList.length;
+        var firstSequence = nodeIds.sequence(newParentLinkedNodesList[0].id);
+
+        // If first node has a higher sequence start from that one to avoid issues on renaming nodes
+        if (idSequence <= firstSequence) {
+          idSequence = firstSequence;
+        }
+
         var lastNode = _.last(newParentLinkedNodesList);
         if (lastNode.get('type') !== 'source') {
           idSequence++; // to start on right id sequence, so last item in newParentLinkedNodesList gets assigned x1 as id, since its source will be a none-source node belong to another layer

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -313,7 +313,8 @@ F.prototype._createTimeseries = function (newLayer, animatedChanged, persist) {
 
 F.prototype._onLayerDefinitionRemoved = function (m) {
   if (!m.isNew()) {
-    this._getLayer(m).remove();
+    var layer = this._getLayer(m);
+    layer && layer.remove();
   }
 };
 

--- a/lib/assets/javascripts/cartodb3/value-objects/analysis-node-ids.js
+++ b/lib/assets/javascripts/cartodb3/value-objects/analysis-node-ids.js
@@ -47,6 +47,17 @@ module.exports = {
     return _.isArray(match) && match[0] || '';
   },
 
+  /**
+   * Get the sequence representation.
+   * @param {String, Object} sourceId or backbone model that have id. e.g. 'c2'
+   * @return {Number} e.g. 2 or undefined if there is no sequence
+   */
+  sequence: function (sourceId) {
+    if (!sourceId || !_.isString(sourceId)) return;
+    var match = sourceId.match(/(\d+$)/);
+    return _.isArray(match) && match[0] || undefined;
+  },
+
   changeLetter: function (id, newLetter) {
     var seq = id.match(/(\d+)$/)[0];
     return newLetter + seq;

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -1893,6 +1893,7 @@ describe('cartodb3/data/user-actions', function () {
         expect(this.layerDefinitionsCollection.pluck('id')).toEqual(['A', 'B'], 'layer C should be deleted');
         expect(this.analysisDefinitionNodesCollection.pluck('id')).toEqual(['a0', 'a1', 'b2', 'b3', 'b4'], 'c2 should not be b2');
         expect(this.analysisDefinitionNodesCollection.get('b3').get('source')).toEqual('b2', 'b3 should point on the renamed node');
+        expect(this.analysisDefinitionNodesCollection.get('b2').get('source')).toEqual('a1', 'b2 should still point to the same node');
         expect(this.analysisDefinitionNodesCollection.get('b2').get('type')).toEqual('centroid', 'b2 should be the prev c2');
       });
     });

--- a/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/user-actions.spec.js
@@ -1798,6 +1798,104 @@ describe('cartodb3/data/user-actions', function () {
         });
       });
     });
+
+    // https://github.com/CartoDB/cartodb/issues/9168
+    describe('when a layer has nodes with larger ids than there are nodes', function () {
+      beforeEach(function () {
+        this.analysisDefinitionNodesCollection.reset();
+        this.analysisDefinitionsCollection.reset();
+        this.analysisDefinitionsCollection.add({
+          id: '41ceca6d-1b59-45e1-ab9b-0b092fc5cb9d',
+          analysis_definition: {
+            id: 'a1',
+            type: 'kmeans',
+            params: {
+              source: {
+                id: 'a0',
+                type: 'source',
+                params: {
+                  query: 'SELECT * FROM crime_incidents_2016_5'
+                },
+                options: {
+                  table_name: 'crime_incidents_2016_5'
+                }
+              },
+              clusters: 3
+            }
+          }
+        });
+        this.analysisDefinitionsCollection.add({
+          id: '5fb42f6d-debb-4b0c-bf37-daac79639b57',
+          analysis_definition: {
+            id: 'b4',
+            type: 'intersection',
+            params: {
+              source: {
+                id: 'b3',
+                type: 'buffer',
+                params: {
+                  source: {
+                    id: 'c2',
+                    type: 'centroid',
+                    params: {
+                      source: {id: 'a1'},
+                      category_column: 'cluster_no'
+                    }
+                  },
+                  radius: 750,
+                  isolines: 1,
+                  dissolved: false
+                },
+                options: {
+                  kind: 'car',
+                  time: '300',
+                  distance: 'meters'
+                }
+              },
+              target: {id: 'a1'}
+            }
+          }
+        });
+        this.analysisDefinitionsCollection.add({
+          id: '312a9e2a-8c59-406b-bd77-588e7e98ebef',
+          analysis_definition: {id: 'c2'}
+        });
+        this.layerDefinitionsCollection.reset();
+        this.layerA = this.layerDefinitionsCollection.add({
+          id: 'A',
+          kind: 'carto',
+          options: {
+            letter: 'a',
+            source: 'a1'
+          }
+        });
+        this.layerB = this.layerDefinitionsCollection.add({
+          id: 'B',
+          kind: 'carto',
+          options: {
+            letter: 'b',
+            source: 'b4'
+          }
+        });
+        this.layerZ = this.layerDefinitionsCollection.add({
+          id: 'C',
+          kind: 'carto',
+          options: {
+            letter: 'c',
+            source: 'c2'
+          }
+        });
+
+        this.userActions.deleteLayer('C');
+      });
+
+      it('should fold node c2 under layer B', function () {
+        expect(this.layerDefinitionsCollection.pluck('id')).toEqual(['A', 'B'], 'layer C should be deleted');
+        expect(this.analysisDefinitionNodesCollection.pluck('id')).toEqual(['a0', 'a1', 'b2', 'b3', 'b4'], 'c2 should not be b2');
+        expect(this.analysisDefinitionNodesCollection.get('b3').get('source')).toEqual('b2', 'b3 should point on the renamed node');
+        expect(this.analysisDefinitionNodesCollection.get('b2').get('type')).toEqual('centroid', 'b2 should be the prev c2');
+      });
+    });
   });
 
   describe('.saveLayer', function () {


### PR DESCRIPTION
Fixes #9168 
Fixes #9178

E.g. (from the reported issue) deleting layer C will now make its node to be folded under another layer as expected.

Before delete:
<img src="https://cloud.githubusercontent.com/assets/978461/17254448/3872b00c-55b5-11e6-9f8f-ad0a5cfdf081.png" alt="screen shot 2016-07-29 at 17 52 18" width="30%"> 
After delete (`c2` moved to `b2`):
<img src="https://cloud.githubusercontent.com/assets/978461/17254423/1421834a-55b5-11e6-89b6-68f83ebe6a92.png" width="30%" />

The problem was that layer B's node already had a rather high sequence number (starting at `[b4, b3]`), so when reorganizing the nodes under the new layer (B) and only having 3 nodes `[b4,b3,c2]` the algorithm wasn't prepared for this and wanted to rename them to `[b3,b2,b1]`, which caused node b3 to point at itself (thus the infinite loop later in the code path). 

Changed the code to take this into account and instead start from the highest sequence instead (thus naming nodes `[b4,b3,b2]` instead). Test case is using data from the extracted carto file.

@alonsogarciapablo can your review?
cc @saleiva @xavijam 