### PR TITLE
Fix invalid analyses

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/carousel-form-view.js
+++ b/lib/assets/javascripts/cartodb3/components/carousel-form-view.js
@@ -43,12 +43,12 @@ module.exports = CoreView.extend({
   },
 
   _onChangeHighlighted: function () {
-    var selected = this.collection.getSelected();
-    var highlighted = this.collection.getHighlighted();
-    var $el = this.$('.js-highlight');
-
-    if ($el) {
-      $el.text((highlighted || selected).getName());
+    var item = this.collection.getHighlighted() || this.collection.getSelected();
+    if (item) {
+      var $el = this.$('.js-highlight');
+      if ($el) {
+        $el.text(item.getName());
+      }
     }
   }
 

--- a/lib/assets/javascripts/cartodb3/components/mosaic-form-view.js
+++ b/lib/assets/javascripts/cartodb3/components/mosaic-form-view.js
@@ -44,12 +44,12 @@ module.exports = CoreView.extend({
   },
 
   _onChangeHighlighted: function () {
-    var selected = this.collection.getSelected();
-    var highlighted = this.collection.getHighlighted();
-    var $el = this.$('.js-highlight');
-
-    if ($el && (highlighted || selected)) {
-      $el.text((highlighted || selected).getName());
+    var item = this.collection.getHighlighted() || this.collection.getSelected();
+    if (item) {
+      var $el = this.$('.js-highlight');
+      if ($el) {
+        $el.text(item.getName());
+      }
     }
   }
 

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
@@ -33,15 +33,16 @@ module.exports = Backbone.Model.extend({
   toJSON: function () {
     return {
       id: this.id,
-      analysis_definition: this._getNodeDefinitionModel().toJSON()
+      analysis_definition: this.getNodeDefinitionModel().toJSON()
     };
   },
 
   containsNode: function (other) {
-    return this._getNodeDefinitionModel().containsNode(other);
+    var nodeDefModel = this.getNodeDefinitionModel();
+    return !!(nodeDefModel && nodeDefModel.containsNode(other));
   },
 
-  _getNodeDefinitionModel: function () {
+  getNodeDefinitionModel: function () {
     return this._analysisDefinitionNodesCollection.get(this.get('node_id'));
   }
 

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -42,17 +42,22 @@ module.exports = function (params) {
     };
   };
 
-  var deleteOrphanedNodes = function () {
-    _.clone(analysisDefinitionNodesCollection.models).forEach(function (nodeDefModel) {
-      if (!layerDefinitionsCollection.anyContainsNode(nodeDefModel)) {
-        // Also delete it's analysis if it's persisted
-        var analysisDefModel = analysisDefinitionsCollection.findWhere({node_id: nodeDefModel.id});
-        if (analysisDefModel) {
+  var deleteOrphanedAnalyses = function () {
+    analysisDefinitionNodesCollection
+      .toArray()
+      .forEach(function (nodeDefModel) {
+        if (!layerDefinitionsCollection.anyContainsNode(nodeDefModel)) {
+          nodeDefModel.destroy();
+        }
+      });
+
+    analysisDefinitionsCollection
+      .toArray()
+      .forEach(function (analysisDefModel) {
+        if (!analysisDefModel.getNodeDefinitionModel()) {
           analysisDefModel.destroy();
         }
-        nodeDefModel.destroy();
-      }
-    });
+      });
   };
 
   return {
@@ -194,7 +199,7 @@ module.exports = function (params) {
       layerDefModel.save({source: primarySourceNode.id});
       analysisDefinitionsCollection.saveAnalysisForLayer(layerDefModel);
 
-      deleteOrphanedNodes();
+      deleteOrphanedAnalyses();
     },
 
     /**
@@ -411,7 +416,7 @@ module.exports = function (params) {
         nodeDefModel.destroy(); // replaced by new node
       }
 
-      deleteOrphanedNodes();
+      deleteOrphanedAnalyses();
     },
 
     moveLayer: function (d) {
@@ -556,7 +561,7 @@ module.exports = function (params) {
       if (parentLayer) {
         analysisDefinitionsCollection.saveAnalysisForLayer(parentLayer);
       }
-      deleteOrphanedNodes();
+      deleteOrphanedAnalyses();
 
       return promise;
     },
@@ -571,6 +576,8 @@ module.exports = function (params) {
       if (layerDefModel.isDataLayer()) {
         analysisDefinitionsCollection.saveAnalysisForLayer(layerDefModel);
       }
+
+      deleteOrphanedAnalyses();
 
       return layerDefModel.save();
     }

--- a/lib/assets/test/jasmine/cartodb3/data/analysis-definition-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/analysis-definition-model.spec.js
@@ -44,9 +44,21 @@ describe('data/analysis-definition-model', function () {
   });
 
   describe('.containsNode', function () {
+    beforeEach(function () {
+      this.containedNode = this.analysisDefinitionNodesCollection.get('a0');
+      this.otherNode = this.analysisDefinitionNodesCollection.get('b0');
+    });
+
     it('should return true if given node is contained in the analysis', function () {
-      expect(this.model.containsNode(this.analysisDefinitionNodesCollection.get('a0'))).toBe(true);
-      expect(this.model.containsNode(this.analysisDefinitionNodesCollection.get('b0'))).toBe(false);
+      expect(this.model.containsNode(this.containedNode)).toBe(true);
+      expect(this.model.containsNode(this.otherNode)).toBe(false);
+      expect(this.model.containsNode()).toBe(false);
+    });
+
+    it('should return false if the analysis has no node', function () {
+      this.model.set('node_id', 'x0');
+      expect(this.model.containsNode(this.containedNode)).toBe(false);
+      expect(this.model.containsNode(this.otherNode)).toBe(false);
       expect(this.model.containsNode()).toBe(false);
     });
   });


### PR DESCRIPTION
Make sure to delete orphaned analyses, that does not any longer contain any node.

@xavijam Not entirely sure about the root cause still since I have not been able to reproduce the reported errors, but nevertheless invalid analyses are not worth keeping around, so using the cleanup method to delete this ones too. Added a guard check for the containsNode call to return false for this case instead of throwing an exception.