### PR TITLE
Fixing translation for infowindow none template

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/link-layer-infowindow.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/link-layer-infowindow.js
@@ -1,5 +1,4 @@
-var fs = require('fs');
-var INFOWINDOW_NONE = fs.readFileSync(__dirname + '/../mustache-templates/infowindows/infowindow_none.jst.mustache', 'utf8');
+var infowindowNoneTemplate = require('../mustache-templates/infowindows/infowindow_none.tpl');
 
 module.exports = function linkLayerInfowindow (layerDef, visMap) {
   if (!layerDef.infowindowModel) return;
@@ -20,9 +19,11 @@ module.exports = function linkLayerInfowindow (layerDef, visMap) {
           title: true,
           position: 0
         }];
-        attrs.template = INFOWINDOW_NONE
-          .replace('{{{ select-fields }}}', _t('editor.layers.infowindow.select-fields'))
-          .replace('{{{ no-fields }}}', _t('editor.layers.infowindow.no-fields'));
+
+        attrs.template = infowindowNoneTemplate({
+          title: _t('editor.layers.infowindow.no-fields'),
+          subtitle: _t('editor.layers.infowindow.select-fields')
+        });
       }
     }
 

--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/link-layer-infowindow.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/link-layer-infowindow.js
@@ -10,17 +10,19 @@ module.exports = function linkLayerInfowindow (layerDef, visMap) {
     if (infowindowModel.isEmptyTemplate()) {
       var node = layerDef.getAnalysisDefinitionNodeModel();
 
-      var cartdb_id = node && node.querySchemaModel.columnsCollection.find(function (m) {
+      var cartodb_id = node && node.querySchemaModel.columnsCollection.find(function (m) {
         return m.get('name') === 'cartodb_id';
       });
 
-      if (cartdb_id) {
+      if (cartodb_id) {
         attrs.fields = [{
           name: 'cartodb_id',
           title: true,
           position: 0
         }];
-        attrs.template = INFOWINDOW_NONE;
+        attrs.template = INFOWINDOW_NONE
+          .replace('{{{ select-fields }}}', _t('editor.layers.infowindow.select-fields'))
+          .replace('{{{ no-fields }}}', _t('editor.layers.infowindow.no-fields'));
       }
     }
 

--- a/lib/assets/javascripts/cartodb3/mustache-templates/infowindows/infowindow_none.jst.mustache
+++ b/lib/assets/javascripts/cartodb3/mustache-templates/infowindows/infowindow_none.jst.mustache
@@ -5,8 +5,8 @@
       <div class="CDB-infowindow-inner">
         <ul class="CDB-infowindow-list">
           <li class="CDB-infowindow-listItem">
-            <h5 class="CDB-infowindow-subtitle"><%- _t('editor.layers.infowindow.select-fields') %></h5>
-            <h4 class="CDB-infowindow-title"><%- _t('editor.layers.infowindow.no-fields') %></h4>
+            <h5 class="CDB-infowindow-subtitle">{{{ select-fields }}}</h5>
+            <h4 class="CDB-infowindow-title">{{{ no-fields }}}</h4>
           </li>
         </ul>
       </div>

--- a/lib/assets/javascripts/cartodb3/mustache-templates/infowindows/infowindow_none.tpl
+++ b/lib/assets/javascripts/cartodb3/mustache-templates/infowindows/infowindow_none.tpl
@@ -5,8 +5,8 @@
       <div class="CDB-infowindow-inner">
         <ul class="CDB-infowindow-list">
           <li class="CDB-infowindow-listItem">
-            <h5 class="CDB-infowindow-subtitle">{{{ select-fields }}}</h5>
-            <h4 class="CDB-infowindow-title">{{{ no-fields }}}</h4>
+            <h5 class="CDB-infowindow-subtitle"><%- subtitle %></h5>
+            <h4 class="CDB-infowindow-title"><%- title %></h4>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Mustache templates don't know anything about `_t` functionality, and also interpolation was not correct. Do you think @alonsogarciapablo we could pass variables to the fields array? Any better idea?

CR: @alonsogarciapablo
cc @matallo

Fixes #9199.