### PR TITLE
Remove query-schema-model cachebust

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/query-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-schema-model.js
@@ -60,7 +60,6 @@ module.exports = Backbone.Model.extend({
     opts.data = _.extend(
       opts.data || {},
       {
-        cachebust: new Date().getTime(),
         api_key: this._configModel.get('api_key'),
         q: this._getSqlApiQueryParam()
       },

--- a/lib/assets/test/jasmine/cartodb3/data/query-schema-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/query-schema-model.spec.js
@@ -73,10 +73,6 @@ describe('data/query-schema-model', function () {
         expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.q).toMatch(/select \* from \(.+\) /);
       });
 
-      it('should contain a cache bust', function () {
-        expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.cachebust).toMatch(/\d+/);
-      });
-
       it('should add order, rows and page', function () {
         expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.rows_per_page).toBe(40);
         expect(Backbone.Model.prototype.fetch.calls.argsFor(0)[0].data.page).toBe(0);


### PR DESCRIPTION
Fixes #9217

Since no longer necessary as of
https://github.com/CartoDB/CartoDB-SQL-API/pull/330

@xavijam ping
cc @rochoa 