### PR TITLE
Allow dashes at downloaded filenames fixes #9229

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -107,7 +107,7 @@ module CartoDB
       end
 
       def self.url_filename_regex
-        @url_filename_regex ||= Regexp.new("[[:word:]]+#{Regexp.union(supported_extensions_match)}+", Regexp::IGNORECASE)
+        @url_filename_regex ||= Regexp.new("[[:word:]-]+#{Regexp.union(supported_extensions_match)}+", Regexp::IGNORECASE)
       end
 
       def initialize(url, http_options = {}, options = {}, seed = nil, repository = nil)


### PR DESCRIPTION
@rafatower CR this, please. It makes sense and, as far as I've tested, fixes the issue. Nevertheless I haven't been able to trace this change back. This regex is being used for many months now.

cc @rafatower @iriberri 