### PR TITLE
Don't run the same applied query

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -126,8 +126,13 @@ module.exports = CoreView.extend({
   },
 
   _parseSQL: function () {
-    var query = this._codemirrorModel.get('content');
-    var altersData = SQLUtils.altersData(query);
+    var appliedQuery = this._querySchemaModel.get('query').toLowerCase();
+    var currentQuery = this._codemirrorModel.get('content').toLowerCase();
+    var altersData = SQLUtils.altersData(currentQuery);
+
+    if (currentQuery === appliedQuery) {
+      return false;
+    }
 
     if (altersData) {
       var notification = Notifier.addNotification({
@@ -136,9 +141,9 @@ module.exports = CoreView.extend({
         closable: false
       });
 
-      this._sqlModel.set('content', query);
+      this._sqlModel.set('content', currentQuery);
 
-      this._SQL.execute(query, null, {
+      this._SQL.execute(currentQuery, null, {
         success: function () {
           notification.set({
             status: 'success',
@@ -157,7 +162,7 @@ module.exports = CoreView.extend({
       // Parser errors SQL here and saving
       this._querySchemaModel.set({
         status: 'unfetched',
-        query: query
+        query: currentQuery
       });
 
       this._querySchemaModel.fetch({

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -126,11 +126,11 @@ module.exports = CoreView.extend({
   },
 
   _parseSQL: function () {
-    var appliedQuery = this._querySchemaModel.get('query').toLowerCase();
-    var currentQuery = this._codemirrorModel.get('content').toLowerCase();
+    var appliedQuery = this._querySchemaModel.get('query');
+    var currentQuery = this._codemirrorModel.get('content');
     var altersData = SQLUtils.altersData(currentQuery);
 
-    if (currentQuery === appliedQuery) {
+    if (currentQuery.toLowerCase() === appliedQuery.toLowerCase()) {
       return false;
     }
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
@@ -123,6 +123,18 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
     expect(this.node.querySchemaModel.resetDueToAlteredData).toHaveBeenCalled();
   });
 
+  it('should not let run the same query that is applied', function () {
+    var originalQuery = 'SELECT * FROM table';
+    spyOn(this.node.querySchemaModel, 'fetch');
+    this.node.querySchemaModel.set('query', originalQuery);
+    this.view._codemirrorModel.set('content', originalQuery);
+    this.view._parseSQL();
+    expect(this.node.querySchemaModel.fetch).not.toHaveBeenCalled();
+    this.view._codemirrorModel.set('content', originalQuery.toUpperCase());
+    this.view._parseSQL();
+    expect(this.node.querySchemaModel.fetch).not.toHaveBeenCalled();
+  });
+
   it('should listen vis reload to show success notification', function () {
     var query = 'SELECT * FROM table';
     spyOn(this.editorModel, 'isEditing').and.returnValue(true);


### PR DESCRIPTION
Seems like #9184 is due to the fact that the sql notification disappear when the vis is reloaded. Trying to run the same query that is applied, query is applied but event about `viz:reload` is not sent (I feel it makes sense, because nothing has changed).

Fixes #9184.

CR @alonsogarciapablo @nobuti (both), you were changing this and know better than me the internals.