### PR TITLE
9179 add default source to all layers

### DIFF
--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -15,8 +15,10 @@ module Carto
       before_filter :redirect_to_editor_if_forced,
                     :load_derived_visualization, only: :show
       before_filter :authors_only
-      before_filter :editable_visualizations_only,
-                    :ensure_source_analyses, only: :show # TODO: remove this when analysis logic lives in the backend
+      before_filter :editable_visualizations_only, only: :show
+
+      # TODO: remove this when analysis logic lives in the backend
+      before_filter :ensure_source_analyses, if: :has_analyses?
 
       after_filter :update_user_last_activity,
                    :track_builder_visit, only: :show
@@ -52,8 +54,13 @@ module Carto
         render_404 unless @visualization.editable?
       end
 
+      def has_analyses?
+        @visualization.analyses.empty?
+      end
+
       def ensure_source_analyses
-        @visualization.add_source_analyses if @visualization.analyses.empty?
+        @visualization.add_source_analyses
+        @visualization.reload
       end
 
       def unauthorized

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -18,7 +18,7 @@ module Carto
       before_filter :editable_visualizations_only, only: :show
 
       # TODO: remove this when analysis logic lives in the backend
-      before_filter :ensure_source_analyses, if: :has_analyses?
+      before_filter :ensure_source_analyses, unless: :has_analyses?
 
       after_filter :update_user_last_activity,
                    :track_builder_visit, only: :show
@@ -55,7 +55,7 @@ module Carto
       end
 
       def has_analyses?
-        @visualization.analyses.empty?
+        @visualization.analyses.any?
       end
 
       def ensure_source_analyses

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -12,13 +12,14 @@ module Carto
 
       ssl_required :show
 
-      before_filter :redirect_to_editor_if_forced, only: :show
-      before_filter :load_derived_visualization, only: :show
+      before_filter :redirect_to_editor_if_forced,
+                    :load_derived_visualization, only: :show
       before_filter :authors_only
-      before_filter :editable_visualizations_only, only: :show
+      before_filter :editable_visualizations_only,
+                    :ensure_source_analyses, only: :show # TODO: remove this when analysis logic lives in the backend
 
-      after_filter :update_user_last_activity, only: :show
-      after_filter :track_builder_visit, only: :show
+      after_filter :update_user_last_activity,
+                   :track_builder_visit, only: :show
 
       layout 'application_builder'
 
@@ -49,6 +50,10 @@ module Carto
 
       def editable_visualizations_only
         render_404 unless @visualization.editable?
+      end
+
+      def ensure_source_analyses
+        @visualization.add_source_analyses if @visualization.analyses.empty?
       end
 
       def unauthorized

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -29,6 +29,26 @@ class Carto::Analysis < ActiveRecord::Base
     analysis
   end
 
+  def self.source_analysis_for_layer(layer, index)
+    map = layer.map
+    visualization = map.visualization if map
+    user = visualization.user if visualization
+
+    visualization_id = visualization.id if visualization
+    user_id = user.id if user
+
+    layer_options = layer.options
+
+    analysis_definition = {
+      id: 'abcdefghijklmnopqrstuv'[index],
+      type: 'source',
+      params: { query: layer.default_query(user) },
+      options: { table_name: layer_options[:table_name] }
+    }
+
+    new(visualization_id: visualization_id, user_id: user_id, analysis_definition: analysis_definition)
+  end
+
   def analysis_definition_for_api
     filter_valid_properties(analysis_node)
   end

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -35,13 +35,21 @@ class Carto::Analysis < ActiveRecord::Base
 
   def self.source_analysis_for_layer(layer, index)
     map = layer.map
-    visualization = map.visualization if map
-    user = visualization.user if visualization
+    visualization = map.visualization
+    user = visualization.user
 
-    visualization_id = visualization.id if visualization
-    user_id = user.id if user
+    visualization_id = visualization.id
+    user_id = user.id
 
-    qualified_table_name = safe_schema_and_table_quoting(layer.options[:user_name], layer.options[:table_name])
+    layer_options = layer.options
+    username = layer_options[:user_name]
+    table_name = layer_options[:table_name]
+
+    qualified_table_name = if username && username != user.username
+                             safe_schema_and_table_quoting(username, table_name)
+                           else
+                             table_name
+                           end
 
     analysis_definition = {
       id: 'abcdefghijklmnopqrstuvwxyz'[index] + '0',

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -6,7 +6,7 @@ require_relative './carto_json_serializer'
 require_dependency 'carto/table_utils'
 
 class Carto::Analysis < ActiveRecord::Base
-  include Carto::TableUtils
+  extend Carto::TableUtils
 
   serialize :analysis_definition, ::Carto::CartoJsonSymbolizerSerializer
   validates :analysis_definition, carto_json_symbolizer: true

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -3,7 +3,11 @@
 require 'json'
 require_relative './carto_json_serializer'
 
+require_dependency 'carto/table_utils'
+
 class Carto::Analysis < ActiveRecord::Base
+  include Carto::TableUtils
+
   serialize :analysis_definition, ::Carto::CartoJsonSymbolizerSerializer
   validates :analysis_definition, carto_json_symbolizer: true
   validate :validate_user_not_viewer
@@ -37,11 +41,13 @@ class Carto::Analysis < ActiveRecord::Base
     visualization_id = visualization.id if visualization
     user_id = user.id if user
 
+    qualified_table_name = safe_schema_and_table_quoting(layer.options[:user_name], layer.options[:table_name])
+
     analysis_definition = {
       id: 'abcdefghijklmnopqrstuvwxyz'[index] + '0',
       type: 'source',
       params: { query: layer.default_query(user) },
-      options: { table_name: layer.options[:table_name] }
+      options: { table_name: qualified_table_name }
     }
 
     new(visualization_id: visualization_id, user_id: user_id, analysis_definition: analysis_definition)

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -38,7 +38,7 @@ class Carto::Analysis < ActiveRecord::Base
     user_id = user.id if user
 
     analysis_definition = {
-      id: 'abcdefghijklmnopqrstuv'[index],
+      id: 'abcdefghijklmnopqrstuvwxyz'[index] + '0',
       type: 'source',
       params: { query: layer.default_query(user) },
       options: { table_name: layer.options[:table_name] }

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -37,13 +37,11 @@ class Carto::Analysis < ActiveRecord::Base
     visualization_id = visualization.id if visualization
     user_id = user.id if user
 
-    layer_options = layer.options
-
     analysis_definition = {
       id: 'abcdefghijklmnopqrstuv'[index],
       type: 'source',
       params: { query: layer.default_query(user) },
-      options: { table_name: layer_options[:table_name] }
+      options: { table_name: layer.options[:table_name] }
     }
 
     new(visualization_id: visualization_id, user_id: user_id, analysis_definition: analysis_definition)

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -202,7 +202,7 @@ module Carto
         if table_name.present? && !table_name.include?('.') && user_name.present? && user_username != user_name
           %{ select * from "#{user_name}".#{safe_table_name_quoting(table_name)} }
         else
-          "SELECT * FROM #{qualified_table_name(user)}"
+          "SELECT * FROM #{qualified_table_name}"
         end
       end
     end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -371,6 +371,17 @@ class Carto::Visualization < ActiveRecord::Base
     analyses.any? || widgets.any? || mapcapped?
   end
 
+  def add_source_analyses
+    return unless analyses.empty?
+
+    carto_and_torque_layers.each_with_index do |layer, index|
+      analysis = Carto::Analysis.source_analysis_for_layer(layer, index)
+      layer.options[:source] = analysis.natural_id if analysis.save
+      layer.options[:letter] = analysis.natural_id.first
+      layer.save
+    end
+  end
+
   private
 
   def named_maps_api

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -376,6 +376,7 @@ class Carto::Visualization < ActiveRecord::Base
 
     carto_and_torque_layers.each_with_index do |layer, index|
       analysis = Carto::Analysis.source_analysis_for_layer(layer, index)
+
       layer.options[:source] = analysis.natural_id if analysis.save
       layer.options[:letter] = analysis.natural_id.first
       layer.save

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -377,9 +377,13 @@ class Carto::Visualization < ActiveRecord::Base
     carto_and_torque_layers.each_with_index do |layer, index|
       analysis = Carto::Analysis.source_analysis_for_layer(layer, index)
 
-      layer.options[:source] = analysis.natural_id if analysis.save
-      layer.options[:letter] = analysis.natural_id.first
-      layer.save
+      if analysis.save
+        layer.options[:source] = analysis.natural_id
+        layer.options[:letter] = analysis.natural_id.first
+        layer.save
+      else
+        CartoDB::Logger.warning(message: 'Couldn\'t add source analysis for layer', user: user, layer: layer)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #9179 

This achieves that Builder maps (Builder maps only) are ensured to have a source analysis per layer if the don't have any other type analysis already.

This should be wiped from the face of the code once the analysis logic has been ported to the backend.

Please CR, @javitonino 