### PR TITLE
Fix wrong cursor on analysis icon

### DIFF
--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -161,9 +161,17 @@
   display: block;
   margin-right: 0;
 }
+.Editor-ListAnalysis-item.ui-draggable .CDB-Shape, // override default cursor for shape
+.Editor-ListAnalysis-item.ui-draggable {
+  cursor: move;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
+}
 .Editor-ListAnalysis-item.ui-draggable-dragging {
   width: 100%;
   cursor: move;
+  cursor: -webkit-grabbing;
+  cursor: -moz-grabbing;
   z-index: 1000;
 }
 .Editor-ListAnalysis-inner {
@@ -277,7 +285,3 @@
   text-align: center;
   z-index: -1;
 }
-
-
-
-

--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -163,11 +163,13 @@
 }
 .Editor-ListAnalysis-item.ui-draggable .CDB-Shape, // override default cursor for shape
 .Editor-ListAnalysis-item.ui-draggable {
+   // scss-lint:disable VendorPrefix
   cursor: move;
   cursor: -webkit-grab;
   cursor: -moz-grab;
 }
 .Editor-ListAnalysis-item.ui-draggable-dragging {
+   // scss-lint:disable VendorPrefix
   width: 100%;
   cursor: move;
   cursor: -webkit-grabbing;


### PR DESCRIPTION
Fixes #9254

Make sure the nested CDB-Shape gets its cursor overriden in the case of a draggable item.

@xavijam