### PR TITLE
No tile_style key resistant named map templates

### DIFF
--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -140,11 +140,12 @@ module Carto
       end
 
       def common_options_for_carto_and_torque_layers(layer, index)
-        layer_options = layer.options
+        layer_options = layer.options.with_indifferent_access
+        tile_style = layer_options[:tile_style].strip if layer_options[:tile_style]
 
         options = {
           id: layer.id,
-          cartocss: layer_options.fetch('tile_style').strip.empty? ? EMPTY_CSS : layer_options.fetch('tile_style'),
+          cartocss: tile_style.present? ? tile_style : EMPTY_CSS,
           cartocss_version: layer_options.fetch('style_version')
         }
 


### PR DESCRIPTION
This should fix traces like: https://rollbar.com/vizzuality/CartoDB/items/19500/

As @javitonino noted, this happens when you apply a manual CartoCSS style and it's empty. Maybe the frontend shouldn't send layer options without the `tile_style` key, but it doesn't hurt with this fix (it looks like this was foreseen looking at the `EMPYT_CSS` code we coalesce when `tile_style` is empty). Just to be clear: there is no problem with an empty `tile_style`, it's the lack of a `tile_style` key.

Worth changing in the frontend @xavijam ? My current position is no.

Please CR, @javitonino 

cc/ @juanignaciosl