### PR TITLE
Check if the query is already applied before show the notification.

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -131,6 +131,7 @@ module.exports = CoreView.extend({
     var altersData = SQLUtils.altersData(currentQuery);
 
     if (currentQuery.toLowerCase() === appliedQuery.toLowerCase()) {
+      this._sqlNotification && Notifier.removeNotification(this._sqlNotification);
       return false;
     }
 
@@ -195,19 +196,30 @@ module.exports = CoreView.extend({
 
   _saveSQL: function () {
     var query = this._codemirrorModel.get('content');
+    var alreadyApplied = this._isQueryAlreadyApplied(query);
+
     this._sqlModel.set('content', query);
     this._userActions.saveAnalysisSourceQuery(query, this._nodeModel, this._layerDefinitionModel);
     this._querySchemaModel.set('query_errors', []);
 
-    this._sqlNotification = Notifier.addNotification({
-      id: PREFIX_NOTIFICATION_ID + this.cid,
-      status: 'loading',
-      info: _t('editor.data.notifier.sql-applying'),
-      closable: false
-    });
+    if (!alreadyApplied) {
+      this._sqlNotification = Notifier.addNotification({
+        id: PREFIX_NOTIFICATION_ID + this.cid,
+        status: 'loading',
+        info: _t('editor.data.notifier.sql-applying'),
+        closable: false
+      });
 
-    this._sqlNotification.once('vis:reload', this._updateVisNotification, this);
+      this._sqlNotification.once('vis:reload', this._updateVisNotification, this);
+    }
+
     this._checkClearButton();
+  },
+
+  _isQueryAlreadyApplied: function (query) {
+    var history = this._sqlModel.getUndoHistory();
+    var last = _.last(history);
+    return last && last.content && last.content.toLowerCase() === query.toLowerCase();
   },
 
   _updateVisNotification: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -129,6 +129,7 @@ module.exports = CoreView.extend({
     var appliedQuery = this._querySchemaModel.get('query');
     var currentQuery = this._codemirrorModel.get('content');
     var altersData = SQLUtils.altersData(currentQuery);
+    var notification;
 
     if (currentQuery.toLowerCase() === appliedQuery.toLowerCase()) {
       this._sqlNotification && Notifier.removeNotification(this._sqlNotification);
@@ -136,7 +137,7 @@ module.exports = CoreView.extend({
     }
 
     if (altersData) {
-      var notification = Notifier.addNotification({
+      notification = Notifier.addNotification({
         status: 'loading',
         info: _t('editor.data.notifier.sql-alter-loading'),
         closable: false

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
@@ -63,6 +63,8 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
       visDefinitionModel: this.visDefinitionModel
     });
 
+    spyOn(Notifier, 'addNotification').and.callThrough();
+
     this.view = new DataView({
       layerDefinitionModel: this.layerDefinitionModel,
       stackLayoutModel: this.stackLayoutModel,
@@ -135,8 +137,21 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
     expect(this.node.querySchemaModel.fetch).not.toHaveBeenCalled();
   });
 
+  it('should not throw notification if same query that is applied', function () {
+    spyOn(this.node.querySchemaModel, 'fetch');
+    this.view._sqlModel.set('content', 'SELECT * FROM table');
+    this.view._codemirrorModel.set('content', 'SELECT * + FROM table');
+    this.view._parseSQL();
+    expect(this.node.querySchemaModel.fetch).toHaveBeenCalled();
+    this.node.querySchemaModel.set('query_errors', ['Syntax error']);
+    this.view._codemirrorModel.set('content', 'SELECT * FROM table');
+    this.node.querySchemaModel.set('query_errors', []);
+    this.view._saveSQL();
+    expect(Notifier.addNotification).toHaveBeenCalledTimes(1);
+  });
+
   it('should listen vis reload to show success notification', function () {
-    var query = 'SELECT * FROM table';
+    var query = 'SELECT * FROM table limit 10';
     spyOn(this.editorModel, 'isEditing').and.returnValue(true);
     this.view._codemirrorModel.set('content', query);
     this.view._saveSQL();


### PR DESCRIPTION
This PR fixes #9260.

Because the applying notification listens the vis reload event to change its state (and eventually autoclose it), we check if the query is already applied. In this case, no new map request is made, so no need to show the notification.

cc @xavijam 