### PR TITLE
Adapt to new odbc_fdw API

### DIFF
--- a/services/importer/lib/importer/connector.rb
+++ b/services/importer/lib/importer/connector.rb
@@ -128,17 +128,17 @@ module CartoDB
 
       def server_params
         params = @connection.select { |k, _v| k.downcase.in? SERVER_OPTIONS }
-        conection_options params
+        connection_options params
       end
 
       def user_params
         params = @connection.select { |k, _v| k.downcase.in? USER_OPTIONS }
-        conection_options params
+        connection_options params
       end
 
       def table_params
         params = @connection.reject { |k, _v| k.downcase.in? SERVER_OPTIONS + USER_OPTIONS }
-        conection_options(params).merge(@options)
+        connection_options(params).merge(@options)
       end
 
       # Parse @json_params and extract @params

--- a/services/importer/lib/importer/connector.rb
+++ b/services/importer/lib/importer/connector.rb
@@ -116,7 +116,7 @@ module CartoDB
 
       def fetch_ignoring_case(hash, key)
         if hash
-          k, _v = hash.find { |k, _v| k.to_s.downcase == key.to_s.downcase }
+          k, _v = hash.detect { |k, _v| k.to_s.casecmp(key.to_s) == 0 }
           k
         end
       end

--- a/services/importer/lib/importer/connector.rb
+++ b/services/importer/lib/importer/connector.rb
@@ -238,7 +238,8 @@ module CartoDB
           options = table_params.merge(prefix: foreign_prefix)
           schema = @options['schema'] ||
                    fetch_ignoring_case(@connection, 'schema') ||
-                   fetch_ignoring_case(@connection, 'database')
+                   fetch_ignoring_case(@connection, 'database') ||
+                   'public'
           %{
             IMPORT FOREIGN SCHEMA #{schema}
               FROM SERVER #{server_name}

--- a/services/importer/lib/importer/connector.rb
+++ b/services/importer/lib/importer/connector.rb
@@ -116,8 +116,8 @@ module CartoDB
 
       def fetch_ignoring_case(hash, key)
         if hash
-          k, _v = hash.detect { |k, _v| k.to_s.casecmp(key.to_s) == 0 }
-          k
+          _k, v = hash.find { |k, _v| k.to_s.casecmp(key.to_s) == 0 }
+          v
         end
       end
 

--- a/services/importer/lib/importer/connector.rb
+++ b/services/importer/lib/importer/connector.rb
@@ -267,7 +267,7 @@ module CartoDB
       end
 
       def escape_single_quotes(text)
-        text.gsub("'", "''")
+        text.to_s.gsub("'", "''")
       end
 
       def drop_server_command

--- a/services/importer/lib/importer/connector.rb
+++ b/services/importer/lib/importer/connector.rb
@@ -199,7 +199,7 @@ module CartoDB
       end
 
       def result_table_name
-        name = Carto::DB::Sanitize.sanitize_identifier @options['table']
+        Carto::DB::Sanitize.sanitize_identifier @options['table']
       end
 
       def foreign_table_name


### PR DESCRIPTION
See #9214 

Connection parameters must be now prefixed by `odbc_` in the odbc-fdw options and must
preserve the case (since some parameter names may be case-sensitive)