### PR TITLE
Fix Cannot read property 'fixed' of undefined

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-shape-properties-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-shape-properties-form-model.js
@@ -15,11 +15,13 @@ module.exports = StyleFormDefaultModel.extend({
     var isAggregatedType = _.contains(StylesFactory.getAggregationTypes(), r.type);
 
     if (isAggregatedType || (geom && geom.getSimpleType() === 'polygon')) {
-      delete attrs.fill.size;
+      if (attrs.fill.size) {
+        attrs.fill = _.omit(attrs.fill, 'size');
+      }
     }
 
     if (geom && geom.getSimpleType() === 'line') {
-      delete attrs.fill;
+      attrs = _.omit(attrs.fill);
     }
 
     if (r.type === 'heatmap') {


### PR DESCRIPTION
Fixes #9285 (and a previous thesis that was wrong: https://github.com/CartoDB/cartodb/pull/9152#discussion_r72478756)

The problem was that the [style-properties-form/style-shape-properties-form-model.js](https://github.com/CartoDB/cartodb/blob/2ca338f73d40fb343699a4500e250197e0f57600/lib/assets/javascripts/cartodb3/editor/style/style-form/style-properties-form/style-shape-properties-form-model.js#L18) is given a _reference_ to the original `fill` object from [default-cartography object](https://github.com/CartoDB/cartodb/blob/605c2c76e3f140cb01b36387ad7cffca1d512899/lib/assets/javascripts/cartodb3/data/default-cartography.json#L6-L8), so by deleting the prop of course it modified the original `size` prop which is used in various places.

I've done the quick fix, because fixing the root problem will require more severe changes, basically avoiding passing objects by reference to prevent this kind of bugs.

@xavijam please review