### PR TITLE
Added superadmin method to get database FS usage

### DIFF
--- a/app/controllers/superadmin/platform_controller.rb
+++ b/app/controllers/superadmin/platform_controller.rb
@@ -67,7 +67,7 @@ class Superadmin::PlatformController < Superadmin::SuperadminController
 
   def database_host_fs_usage
     unless params[:database_host]
-      respond_with({ error: %q|Parameter 'database_host' must be supplied| },
+      respond_with({ error: "Parameter 'database_host' must be supplied" },
                    status: 400)
       return
     end

--- a/app/controllers/superadmin/platform_controller.rb
+++ b/app/controllers/superadmin/platform_controller.rb
@@ -67,15 +67,15 @@ class Superadmin::PlatformController < Superadmin::SuperadminController
 
   def database_host_fs_usage
     unless params[:database_host]
-      respond_with({ error: %Q|Parameter 'database_host' must be supplied| },
-                     status: 400)
+      respond_with({ error: %q|Parameter 'database_host' must be supplied| },
+                   status: 400)
       return
     end
 
     connection_params = ::Rails::Sequel.configuration.environment_for(Rails.env)
-      .merge('host' => params[:database_host],
-             'database' => 'postgres'
-      ) { |_, o, n| n.nil? ? o : n }
+                                       .merge('host' => params[:database_host],
+                                              'database' => 'postgres'
+                                             ) { |_, o, n| n.nil? ? o : n }
     conn = ::Sequel.connect(connection_params)
     disk_space = conn.fetch('SELECT * FROM cartodb.cdb_get_avail_disk_space();').first
     close_sequel_connection(conn)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -617,6 +617,7 @@ CartoDB::Application.routes.draw do
     get '/superadmin/stats/total_maps' => 'platform#total_maps'
     get '/superadmin/stats/total_active_users' => 'platform#total_active_users'
     get '/superadmin/stats/total_likes' => 'platform#total_likes'
+    get '/superadmin/stats/database_host_fs_usage' => 'platform#database_host_fs_usage'
   end
 
 end


### PR DESCRIPTION
This method assumes that the following function has to be installed in the database hosts:

``` sql
DROP FUNCTION cartodb.cdb_get_avail_disk_space();
DROP TYPE cartodb.cdb_fs_stats_info;
CREATE TYPE cartodb.cdb_fs_stats_info AS (avail bigint, total bigint);
CREATE FUNCTION cartodb.cdb_get_avail_disk_space()
  RETURNS cartodb.cdb_fs_stats_info
AS $$
  import os

  rv = plpy.execute("select current_setting('data_directory') AS data_directory")
  directory = rv[0]['data_directory']

  if directory:
    vfs = os.statvfs(directory)
    avail = vfs.f_bsize * vfs.f_bavail
    total = vfs.f_bsize * vfs.f_blocks
    return [avail, total]
  else:
    return [-1,-1]
$$ LANGUAGE plpythonu;
```

A bit unsure about how to test this. I guess the best way would be to make sure that the `cartodb.cdb_get_avail_disk_space()` is added to the test database and then create a new spec for superadmin platform controller (I'd rather do this than mocking the call to the db)

@luisbosque: please review
