### PR TITLE
Adding 'opacity' to labels text and halo

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var camshaftReference = require('../../data/camshaft-reference');
+var Utils = require('../../helpers/utils');
 
 var CONFIG = {
   HEATMAP_IMAGE: 'url(http://s3.amazonaws.com/com.cartodb.assets.static/alphamarker.png)',
@@ -186,12 +187,22 @@ function _labels (props) {
     css['text-face-name'] = "'" + props.font + "'";
     if (props.fill) {
       css['text-size'] = props.fill.size.fixed;
-      css['text-fill'] = props.fill.color.fixed;
+
+      if (props.fill.color.opacity && props.fill.color.opacity < 1) {
+        css['text-fill'] = Utils.hexToRGBA(props.fill.color.fixed, props.fill.color.opacity);
+      } else {
+        css['text-fill'] = props.fill.color.fixed;
+      }
     }
     css['text-label-position-tolerance'] = 0;
     if (props.halo) {
       css['text-halo-radius'] = props.halo.size.fixed;
-      css['text-halo-fill'] = props.halo.color.fixed;
+
+      if (props.halo.color.opacity && props.halo.color.opacity < 1) {
+        css['text-halo-fill'] = Utils.hexToRGBA(props.halo.color.fixed, props.halo.color.opacity);
+      } else {
+        css['text-halo-fill'] = props.halo.color.fixed;
+      }
     }
     css['text-dy'] = props.offset === undefined ? -10 : props.offset;
     css['text-allow-overlap'] = props.overlap === undefined ? true : props.overlap;

--- a/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
@@ -188,7 +188,7 @@ function _labels (props) {
     if (props.fill) {
       css['text-size'] = props.fill.size.fixed;
 
-      if (props.fill.color.opacity && props.fill.color.opacity < 1) {
+      if (props.fill.color.opacity != null && props.fill.color.opacity < 1) {
         css['text-fill'] = Utils.hexToRGBA(props.fill.color.fixed, props.fill.color.opacity);
       } else {
         css['text-fill'] = props.fill.color.fixed;
@@ -198,7 +198,7 @@ function _labels (props) {
     if (props.halo) {
       css['text-halo-radius'] = props.halo.size.fixed;
 
-      if (props.halo.color.opacity && props.halo.color.opacity < 1) {
+      if (props.halo.color.opacity != null && props.halo.color.opacity < 1) {
         css['text-halo-fill'] = Utils.hexToRGBA(props.halo.color.fixed, props.halo.color.opacity);
       } else {
         css['text-halo-fill'] = props.halo.color.fixed;

--- a/lib/assets/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
@@ -284,7 +284,7 @@ module.exports = [
             },
             'color': {
               fixed: '#FFF',
-              opacity: 0.1
+              opacity: 0
             }
           },
           offset: -10,
@@ -295,13 +295,13 @@ module.exports = [
     },
     result: {
       point: {
-        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: rgba(255, 255, 255, 0.1);\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: rgba(255, 255, 255, 0);\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
       },
       line: {
-        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: rgba(255, 255, 255, 0.1);\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: rgba(255, 255, 255, 0);\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
       },
       polygon: {
-        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: #111;\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: rgba(255, 255, 255, 0);\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
       }
     }
   },

--- a/lib/assets/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
@@ -221,6 +221,94 @@ module.exports = [
     style: {
       type: 'simple',
       properties: {
+        labels: {
+          enabled: true,
+          attribute: 'test',
+          font: 'DejaVu Sans Book',
+          fill: {
+            'size': {
+              fixed: 10
+            },
+            'color': {
+              fixed: '#000',
+              opacity: 0.5
+            }
+          },
+          halo: {
+            'size': {
+              fixed: 1
+            },
+            'color': {
+              fixed: '#111',
+              opacity: 1
+            }
+          },
+          offset: -10,
+          overlap: true,
+          placement: 'point'
+        }
+      }
+    },
+    result: {
+      point: {
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: rgba(0, 0, 0, 0.5);\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: #111;\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+      },
+      line: {
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: rgba(0, 0, 0, 0.5);\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: #111;\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+      },
+      polygon: {
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: rgba(0, 0, 0, 0.5);\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: #111;\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+      }
+    }
+  },
+  {
+    style: {
+      type: 'simple',
+      properties: {
+        labels: {
+          enabled: true,
+          attribute: 'test',
+          font: 'DejaVu Sans Book',
+          fill: {
+            'size': {
+              fixed: 10
+            },
+            'color': {
+              fixed: '#000',
+              opacity: 1
+            }
+          },
+          halo: {
+            'size': {
+              fixed: 1
+            },
+            'color': {
+              fixed: '#FFF',
+              opacity: 0.1
+            }
+          },
+          offset: -10,
+          overlap: true,
+          placement: 'point'
+        }
+      }
+    },
+    result: {
+      point: {
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: rgba(255, 255, 255, 0.1);\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+      },
+      line: {
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: rgba(255, 255, 255, 0.1);\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+      },
+      polygon: {
+        cartocss: "#layer {\n}\n#layer::labels {\ntext-name: [test];\ntext-face-name: 'DejaVu Sans Book';\ntext-size: 10;\ntext-fill: #000;\ntext-label-position-tolerance: 0;\ntext-halo-radius: 1;\ntext-halo-fill: #111;\ntext-dy: -10;\ntext-allow-overlap: true;\ntext-placement: point;\ntext-placement-type: dummy;\n}"
+      }
+    }
+  },
+  {
+    style: {
+      type: 'simple',
+      properties: {
         fill: {
           size: {
             range: [1, 20],


### PR DESCRIPTION
AFAIK (please @rochoa correct me if so) there is no opacity attribution for labels (in fact in the old editor we didn't let the user change the opacity in the form), but the good thing is we can make use of the RGBA property, so the result would be:

![screen shot 2016-08-04 at 12 21 28](https://cloud.githubusercontent.com/assets/132146/17398792/e5bb2004-5a3e-11e6-8eb7-3e8ee46b48e7.png)
![screen shot 2016-08-04 at 12 27 01](https://cloud.githubusercontent.com/assets/132146/17398793/e5c88820-5a3e-11e6-9e10-c107ef8fa9ff.png)

CR: @javierarce
Fixes #9289.

Sounds ok?
cc @saleiva @noguerol 

Any possible problem I haven't seen @rochoa? 