### PR TITLE
Fixes "Never show me this message" for certain analysis

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-launcher.js
+++ b/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-launcher.js
@@ -37,7 +37,7 @@ var launcher = (function () {
     },
 
     launch: function (type, model) {
-      var genericType = ANALYSES_TYPES[type] && ANALYSES_TYPES[type].genericType ? ANALYSES_TYPES[type].genericType : type;
+      var genericType = ANALYSES_TYPES[type] && ANALYSES_TYPES[type].genericType || type?;
 
       if (!LocalStorage.get(genericType) && genericType) {
         onboardings.create(function (modalModel) {

--- a/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-launcher.js
+++ b/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-launcher.js
@@ -37,7 +37,8 @@ var launcher = (function () {
     },
 
     launch: function (type, model) {
-      var genericType = ANALYSES_TYPES[type] ? ANALYSES_TYPES[type].genericType : type;
+      var genericType = ANALYSES_TYPES[type] && ANALYSES_TYPES[type].genericType ? ANALYSES_TYPES[type].genericType : type;
+
       if (!LocalStorage.get(genericType) && genericType) {
         onboardings.create(function (modalModel) {
           return new AnalysisOnboardingView({

--- a/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-launcher.js
+++ b/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-launcher.js
@@ -37,7 +37,7 @@ var launcher = (function () {
     },
 
     launch: function (type, model) {
-      var genericType = ANALYSES_TYPES[type] && ANALYSES_TYPES[type].genericType || type?;
+      var genericType = ANALYSES_TYPES[type] && ANALYSES_TYPES[type].genericType || type;
 
       if (!LocalStorage.get(genericType) && genericType) {
         onboardings.create(function (modalModel) {

--- a/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-launcher.js
+++ b/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-launcher.js
@@ -37,7 +37,8 @@ var launcher = (function () {
     },
 
     launch: function (type, model) {
-      if (!LocalStorage.get(type) && ANALYSES_TYPES[type]) {
+      var genericType = ANALYSES_TYPES[type] ? ANALYSES_TYPES[type].genericType : type;
+      if (!LocalStorage.get(genericType) && genericType) {
         onboardings.create(function (modalModel) {
           return new AnalysisOnboardingView({
             modalModel: modalModel,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.0.86",
+  "version": "4.0.86-dev",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.0.86-dev",
+  "version": "4.0.87-dev",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes an issue which caused the onboarding window for analysis to appear when users checked the "Never show me this message." box. 

The problem was that certain analyses share a common "generic type" and the analysis onboarding launcher wasn't using that generic type, but the analysis type (which is different for every kind of analysis).

Closes: #9284 

CR: @xavijam 
