### PR TITLE
9308 viz tokend in db

### DIFF
--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -3,9 +3,11 @@ require_relative '../visualization/stats'
 require_relative '../../helpers/embed_redis_cache'
 require_dependency 'cartodb/redis_vizjson_cache'
 require_dependency 'carto/named_maps/api'
+require_dependency 'carto/helpers/auth_token_generator'
 
 class Carto::Visualization < ActiveRecord::Base
   include CacheHelper
+  include Carto::AuthTokenGenerator
 
   AUTH_DIGEST = '1211b3e77138f6e1724721f1ab740c9c70e66ba6fec5e989bb6640c4541ed15d06dbd5fdcbd3052b'.freeze
 

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -225,7 +225,7 @@ module Carto
 
       def auth
         method, valid_tokens = if @visualization.password_protected?
-                                 [AUTH_TYPE_SIGNED, @visualization.user.get_auth_tokens]
+                                 [AUTH_TYPE_SIGNED, [@visualization.get_auth_token]]
                                elsif @visualization.organization?
                                  [AUTH_TYPE_SIGNED, @visualization.allowed_auth_tokens]
                                else

--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -137,6 +137,20 @@ namespace :cartodb do
       puts "Purge complete. Removed #{purged_count} items"
     end
 
+    desc "Updates visualizations auth tokens from named maps"
+    task update_auth_tokens: :environment do |_|
+      Carto::Visualization.find_each(conditions: "privacy = 'password'") do |visualization|
+        puts "Updating #{visualization.id}"
+        begin
+          tokens = visualization.get_auth_tokens
+          puts "  from #{visualization.auth_token} to #{tokens.first}"
+          visualization.update_column(:auth_token, tokens.first)
+        rescue => e
+          puts "ERROR #{e.inspect}"
+        end
+      end
+    end
+
     private
 
     def inconsistent?(viz)


### PR DESCRIPTION
See #9308

Plan is to deploy this, which makes newly generated tokens to be stored in the database. Then run the rake task to copy tokens from named map to database (~2400 maps) and then, do another PR to make the retrieval of auth_tokens to use the DB instead of the named map.

Please CR @gfiorav