### PR TITLE
Redirect to waiting page on ongoing http header authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,7 +74,8 @@ class ApplicationController < ActionController::Base
       authenticator = Carto::HttpHeaderAuthentication.new
       if authenticator.autocreation_enabled?
         if authenticator.creation_in_progress?(request)
-          render_http_code(409, 500, 'Creation already in progress')
+          # render_http_code(409, 500, 'Creation already in progress')
+          redirect_to CartoDB.path(self, 'signup_http_authentication_in_progress')
         else
           redirect_to CartoDB.path(self, 'signup_http_authentication')
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,7 +74,6 @@ class ApplicationController < ActionController::Base
       authenticator = Carto::HttpHeaderAuthentication.new
       if authenticator.autocreation_enabled?
         if authenticator.creation_in_progress?(request)
-          # render_http_code(409, 500, 'Creation already in progress')
           redirect_to CartoDB.path(self, 'signup_http_authentication_in_progress')
         else
           redirect_to CartoDB.path(self, 'signup_http_authentication')

--- a/app/controllers/carto/api/user_creations_controller.rb
+++ b/app/controllers/carto/api/user_creations_controller.rb
@@ -6,6 +6,7 @@ module Carto
     class UserCreationsController < ::Api::ApplicationController
 
       skip_before_filter :api_authorization_required
+      skip_before_filter :http_header_authentication, only: [:show]
 
       ssl_required :show
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -13,7 +13,7 @@ class SignupController < ApplicationController
                      only: [:create_http_authentication, :create_http_authentication_in_progress]
 
   before_filter :load_organization, only: [:create_http_authentication, :create_http_authentication_in_progress]
-  before_filter :check_organization_quotas, only: [:create_http_authentication, :create_http_authentication_in_progress]
+  before_filter :check_organization_quotas, only: [:create_http_authentication]
   before_filter :load_mandatory_organization, only: [:signup, :create]
   before_filter :disable_if_ldap_configured
   before_filter :initialize_google_plus_config

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -100,8 +100,11 @@ class SignupController < ApplicationController
 
   def create_http_authentication_in_progress
     authenticator = Carto::HttpHeaderAuthentication.new
-    render_500 unless authenticator.autocreation_enabled? && authenticator.creation_in_progress?(request)
-    render 'shared/signup_confirmation'
+    if !authenticator.creation_in_progress?(request)
+      redirect_to CartoDB.url(self, 'login')
+    else
+      render 'shared/signup_confirmation'
+    end
   end
 
   private

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -9,7 +9,8 @@ class SignupController < ApplicationController
 
   ssl_required :signup, :create, :create_http_authentication, :create_http_authentication_in_progress
 
-  skip_before_filter :http_header_authentication, only: [:create_http_authentication, :create_http_authentication_in_progress]
+  skip_before_filter :http_header_authentication,
+                     only: [:create_http_authentication, :create_http_authentication_in_progress]
 
   before_filter :load_organization, only: [:create_http_authentication, :create_http_authentication_in_progress]
   before_filter :check_organization_quotas, only: [:create_http_authentication, :create_http_authentication_in_progress]

--- a/app/views/layouts/mail.html.erb
+++ b/app/views/layouts/mail.html.erb
@@ -75,7 +75,6 @@
                 <%= render partial: 'mailer_modules/message_title', locals: { subject: @subject } %>
 
                 <%= yield %>
-                <%= yield :body %>
 
               </table>
             </td>

--- a/app/views/layouts/mail.html.erb
+++ b/app/views/layouts/mail.html.erb
@@ -75,6 +75,7 @@
                 <%= render partial: 'mailer_modules/message_title', locals: { subject: @subject } %>
 
                 <%= yield %>
+                <%= yield :body %>
 
               </table>
             </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ CartoDB::Application.routes.draw do
   get   '/signup'           => 'signup#signup',     as: :signup
   post  '/signup'           => 'signup#create',  as: :signup_organization_user
   get   '(/user/:user_domain)(/u/:user_domain)/signup_http_authentication' => 'signup#create_http_authentication', as: :signup_http_authentication
+  get   '(/user/:user_domain)(/u/:user_domain)/signup_http_authentication_in_progress' => 'signup#create_http_authentication_in_progress', as: :signup_http_authentication_in_progress
 
   get   '(/user/:user_domain)(/u/:user_domain)/enable_account_token/:id' => 'account_tokens#enable',     as: :enable_account_token_show
   get   '(/user/:user_domain)(/u/:user_domain)/resend_validation_mail/:user_id' => 'account_tokens#resend',     as: :resend_validation_mail

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -187,12 +187,23 @@ describe ApplicationController do
           response.location.should match /#{signup_http_authentication_path}/
         end
 
-        # This behaviour avoids filling `user_creations` table with failed repetitions because of polling.
-        it 'returns 409 instead of redirecting to user creation if there is another user creation not finished for that email' do
+        # This behaviour avoids filling `user_creations` table with failed repetitions because of polling
+        # and makes frontend to redirect nicely to the dashboard on finish (failing stopped redirection from working)
+        it 'redirects to creation in progress instead of creation if that user has a not finished user creation' do
           email = 'unknown2@company.com'
           FactoryGirl.create(:user_creation, state: 'enqueuing', email: email)
           get dashboard_url, {}, authentication_headers(email)
-          response.status.should == 409
+          response.status.should eq 302
+          response.location.should match(/#{signup_http_authentication_in_progress_path}/)
+        end
+
+        it 'redirects to user creation for unknown emails if there is other enqueued user creation (for other user)' do
+          email1 = 'unknown1@company.com'
+          email2 = 'unknown2@company.com'
+          FactoryGirl.create(:user_creation, state: 'enqueuing', email: email1)
+          get dashboard_url, {}, authentication_headers(email2)
+          response.status.should eq 302
+          response.location.should match(/#{signup_http_authentication_path}/)
         end
       end
     end


### PR DESCRIPTION
This fixes #9362 and #9369 .

As depending on timing there might be redundant requests from frontend, instead of failing with a 409 user will be redirected to waiting screen.