### PR TITLE
Fixed hidden pagination in add dataset listing for IE and Firefox

### DIFF
--- a/app/assets/stylesheets/common/create/create_listing.css.scss
+++ b/app/assets/stylesheets/common/create/create_listing.css.scss
@@ -12,7 +12,8 @@
 .CreateDialog-listing.CreateDialog-listing--noPaddingTop { padding-top: 0 }
 .DatasetsPaginator {
   width: 940px;
-  margin: 30px auto 30px;
+  margin: 0 auto;
+  padding: 30px 0;
 }
 .DatasetsPaginator .Pagination {
   @include justify-content(flex-end, end);

--- a/app/assets/stylesheets/common/dialog.css.scss
+++ b/app/assets/stylesheets/common/dialog.css.scss
@@ -134,6 +134,7 @@ body.is-inDialog {
 }
 .Dialog-body .ListingContent {
   margin-bottom: 100px;
+  margin-top: 260px\9;
 }
 .Dialog-footer {
   padding: $sMargin-group 0;

--- a/app/assets/stylesheets/common/dialog.css.scss
+++ b/app/assets/stylesheets/common/dialog.css.scss
@@ -134,7 +134,6 @@ body.is-inDialog {
 }
 .Dialog-body .ListingContent {
   margin-bottom: 100px;
-  margin-top: 260px\9;
 }
 .Dialog-footer {
   padding: $sMargin-group 0;
@@ -374,5 +373,12 @@ $sNarrower-width: 620px;
   100% {
     @include opacity(0.0);
     @include transform(scale(2.0));
+  }
+}
+
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  /* IE10+ CSS styles go here */
+  .Dialog-body .ListingContent {
+    margin-bottom: 260px;
   }
 }

--- a/app/assets/stylesheets/common/dialog.css.scss
+++ b/app/assets/stylesheets/common/dialog.css.scss
@@ -103,7 +103,6 @@ body.is-inDialog {
 .Dialog-body.Dialog-body--create {
   position: relative;
   width: 100%;
-  padding-bottom: 100px;
   overflow: auto;
 }
 .Dialog-body.Dialog-body--share {
@@ -132,6 +131,9 @@ body.is-inDialog {
 .Filters.Dialog-bodyFilters {
   position: relative;
   background: none;
+}
+.Dialog-body .ListingContent {
+  margin-bottom: 100px;
 }
 .Dialog-footer {
   padding: $sMargin-group 0;

--- a/app/assets/stylesheets/common/dialog.css.scss
+++ b/app/assets/stylesheets/common/dialog.css.scss
@@ -379,6 +379,6 @@ $sNarrower-width: 620px;
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
   /* IE10+ CSS styles go here */
   .Dialog-body .ListingContent {
-    margin-bottom: 260px;
+    margin-bottom: 200px;
   }
 }


### PR DESCRIPTION
Fixes #9104

- Chrome:
<img width="1440" alt="screen shot 2016-08-09 at 15 39 54" src="https://cloud.githubusercontent.com/assets/2141690/17518462/451edb32-5e48-11e6-8812-b6c5bbdaaed7.png">
_Bad news: Chrome shows a bit more margin on the bottom._

- Microsoft Edge (_Microsoft recomended browser_):
![screen shot 2016-08-09 at 15 40 34 2](https://cloud.githubusercontent.com/assets/2141690/17518460/4518dfe8-5e48-11e6-842a-2c91872f4143.png)

- IE 11:
![screen shot 2016-08-09 at 17 18 17 2](https://cloud.githubusercontent.com/assets/2141690/17521905/64dd6148-5e55-11e6-8410-9aaa13d8cd5a.png)

- Firefox
![screen shot 2016-08-09 at 15 40 52 2](https://cloud.githubusercontent.com/assets/2141690/17518461/451bf3cc-5e48-11e6-8b29-31033f46c3e4.png)

 CR @piensaenpixel cc @xavijam 