### PR TITLE
Fixed mobile apps form app_type input if it can't be changed

### DIFF
--- a/app/views/carto/admin/mobile_apps/_form.html.erb
+++ b/app/views/carto/admin/mobile_apps/_form.html.erb
@@ -109,7 +109,7 @@
         <%- app_type = app_types[@mobile_app.app_type.to_sym] %>
         <div class="FormAccount-rowData in-block u-vspace-s">
           <div class="RadioButton">
-            <input class="CDB-Radio" type="radio" name="mobile_app[app_type]" checked required>
+            <input class="CDB-Radio" type="radio" checked required disabled>
             <span class="CDB-Radio-face"></span>
             <label class="Ru-iBlock u-lSpace CDB-Text CDB-Size-medium is-semibold u-secondaryTextColor u-lSpace--xl"><%= @mobile_app.app_type.capitalize %></label>
           </div>


### PR DESCRIPTION
Fixes #9376

Set the input to `disabled` in case it cannot be changed, so it won't be sent to the controller.

CR @javitonino 

