### PR TITLE
Fixes analysis onboarding window

### DIFF
--- a/app/assets/stylesheets/common/onboarding.css.scss
+++ b/app/assets/stylesheets/common/onboarding.css.scss
@@ -20,7 +20,7 @@
   height: 100%;
 }
 
-.Onboarding-fake2 {
+.Onboarding-fake {
   @include flex(0 0 415px);
   height: 100%;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.0.96",
+  "version": "4.0.97",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The onboarding window for the analysis got broken (probably when I implemented the builder onboarding) and showed the content in fullscreen. This PR fixes this problem.

![screen shot 2016-08-10 at 10 58 55](https://cloud.githubusercontent.com/assets/4933/17547821/549a2142-5ee9-11e6-9faa-990015b645f7.png)

I've made sure that the builder onboarding is working fine after this fix.

CR: @xavijam 
Closes #9380 