### PR TITLE
Set avoidNotification on analysis nodes when removing a layer.

### DIFF
--- a/lib/assets/javascripts/cartodb3/analysis-notifications.js
+++ b/lib/assets/javascripts/cartodb3/analysis-notifications.js
@@ -19,6 +19,10 @@ var AnalysisNotifications = {
   },
 
   _addRemovedNotification: function (analysisNode) {
+    if (analysisNode.get('avoidNotification') === true) {
+      return;
+    }
+
     var nodeId = analysisNode.get('id');
     var notificationAttrs = {
       status: 'success',

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -559,6 +559,7 @@ module.exports = function (params) {
           }, [])
           .unique()
           .map(function (m) {
+            m.set({avoidNotification: true}, {silent: true});
             return m.destroy();
           })
           .value());

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -71,6 +71,7 @@ var F = function (opts) {
 F.prototype._onAnalysisDefinitionNodeRemoved = function (m) {
   var node = this._analysis().findNodeById(m.id);
   if (node) {
+    node.set({avoidNotification: !!m.get('avoidNotification')}, {silent: true});
     node.remove();
   }
 };

--- a/lib/assets/test/jasmine/cartodb3/analysis-notifications.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/analysis-notifications.spec.js
@@ -70,6 +70,12 @@ describe('AnalysisNotifications.track', function () {
           'delay': Notifier.DEFAULT_DELAY
         });
       });
+
+      it('should not update the notification if avoidNotification', function () {
+        this.analysisNode.set({avoidNotification: true}, {silent: true});
+        this.analysisNode.trigger('destroy', this.analysisNode);
+        expect(this.notification.set).not.toHaveBeenCalled();
+      });
     });
   });
 


### PR DESCRIPTION
This PR fixes #9124.

![analysis-layer-deletion](https://cloud.githubusercontent.com/assets/1366843/17623693/924a2a6e-60a1-11e6-8a87-e24d1b443548.gif)

cc @xavijam 