### PR TITLE
Allows entering a custom text in the text select view of the filter analysis form

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
+++ b/lib/assets/javascripts/cartodb3/components/custom-list/custom-view.js
@@ -61,6 +61,10 @@ module.exports = CoreView.extend({
     }
     this._renderList();
     this._setListMaxSize();
+
+    if (this.options.showSearch) {
+      this._focusSearch();
+    }
     return this;
   },
 
@@ -78,13 +82,18 @@ module.exports = CoreView.extend({
   },
 
   _renderSearch: function () {
-    var searchView = new SearchView({
+    this._searchView = new SearchView({
       typeLabel: this.options.typeLabel,
       model: this.model
     });
-    this.$el.prepend(searchView.render().el);
-    this.addView(searchView);
-    searchView.focus();
+    this.$el.prepend(this._searchView.render().el);
+    this.addView(this._searchView);
+  },
+
+  _focusSearch: function () {
+    setTimeout(function () {
+      this._searchView.focus();
+    }.bind(this), 0);
   },
 
   _renderList: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-form-model.js
@@ -131,7 +131,8 @@ module.exports = BaseAnalysisFormModel.extend({
           return { label: d, val: d };
         }),
         editorAttrs: {
-          showSearch: true
+          showSearch: true,
+          allowFreeTextInput: true
         }
       },
       accept_reject: {


### PR DESCRIPTION
This PR allows users to enter a free text in the text select view of the filter analysis form. 

![screen shot 2016-08-16 at 12 58 51](https://cloud.githubusercontent.com/assets/4933/17696794/07b8caaa-63b1-11e6-8e8d-e22e398ee62a.png)

Because we are showing a selection of the rows for a given column, in some cases users couldn't find the row they were looking for. With this fix, they'll be able to write the desired value.

This PR also fixes an issue with the focusing of the search input field of the custom lists (#9442).

Closes #9247 
Closes #9442

CR: @viddo 