### PR TITLE
Relax containsNode check for widget def model

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/widget-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/widget-definition-model.js
@@ -84,11 +84,14 @@ module.exports = Backbone.Model.extend({
     this.set(attrsForNewType);
   },
 
-  containsNode: function (nodeDefModel) {
-    if (!nodeDefModel) return false;
+  containsNode: function (otherNodeDefModel) {
+    if (!otherNodeDefModel) return false;
+
     var sourceId = this.get('source');
-    return sourceId === nodeDefModel.id ||
-      nodeDefModel.collection.get(sourceId).containsNode(nodeDefModel);
+    var nodeDefModel = otherNodeDefModel.collection.get(sourceId);
+
+    return !!(sourceId === otherNodeDefModel.id ||
+      nodeDefModel && nodeDefModel.containsNode(otherNodeDefModel));
   }
 
 });

--- a/lib/assets/test/jasmine/cartodb3/data/widget-definition-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/widget-definition-model.spec.js
@@ -154,5 +154,10 @@ describe('cartodb3/data/widget-definition-model', function () {
       expect(this.widgetDefModel.containsNode()).toBe(false);
       expect(this.widgetDefModel.containsNode(false)).toBe(false);
     });
+
+    it('should return false if widget source does not exist', function () {
+      this.widgetDefModel.set('source', 'y404');
+      expect(this.widgetDefModel.containsNode(this.a1)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Fixed the call throwing an error if the source defined for the widget does not exist (e.g. set to `undefined`).

Note that this only fixes a _symptom_ of a map is in an inconsistent state,  the reason for this state is still unknown. 😖 

@javierarce can you review please?