### PR TITLE
Don't return id on EUMAPI user creation

### DIFF
--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -57,7 +57,7 @@ module Carto
           account_creator.with_soft_twitter_datasource_limit(create_params[:soft_twitter_datasource_limit])
         end
 
-        render_jsonp account_creator.validation_errors.full_messages, 410 && return unless account_creator.valid?
+        render_jsonp(account_creator.validation_errors.full_messages, 410) && return unless account_creator.valid?
 
         account_creator.enqueue_creation(self)
 

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -108,7 +108,7 @@ module Carto
       end
 
       def destroy
-        render_jsonp "Can't delete org owner", 401 && return if @organization.owner_id == @user.id
+        render_jsonp("Can't delete org owner", 401) && return if @organization.owner_id == @user.id
 
         unless @user.can_delete
           render_jsonp "Can't delete @user. #{'Has shared entities' if @user.has_shared_entities?}", 410

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -58,7 +58,13 @@ module Carto
 
         account_creator.enqueue_creation(self)
 
-        render_jsonp Carto::Api::UserPresenter.new(account_creator.user, current_viewer: current_viewer).to_poro, 200
+        presentation = Carto::Api::UserPresenter.new(account_creator.user,
+                                                     current_viewer: current_viewer)
+                                                .to_poro
+
+        presentation.delete(:id) # We don't return the id since this API uses usernames
+
+        render_jsonp presentation, 200
       rescue => e
         CartoDB.notify_exception(e, user: account_creator.user.inspect)
 

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -57,7 +57,7 @@ module Carto
           account_creator.with_soft_twitter_datasource_limit(create_params[:soft_twitter_datasource_limit])
         end
 
-        render_jsonp(account_creator.validation_errors.full_messages, 410) && return unless account_creator.valid?
+        render_jsonp account_creator.validation_errors.full_messages, 410 && return unless account_creator.valid?
 
         account_creator.enqueue_creation(self)
 

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -18,14 +18,14 @@ module Carto
           Carto::Api::UserPresenter.new(user, current_viewer: current_viewer).to_poro_without_id
         end
 
-        render_jsonp(presentations, 200)
+        render_jsonp presentations, 200
       end
 
       def show
         presentation = Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer)
                                                 .to_poro_without_id
 
-        render_jsonp(presentation, 200)
+        render_jsonp presentation, 200
       end
 
       def create
@@ -108,10 +108,10 @@ module Carto
       end
 
       def destroy
-        render_jsonp("Can't delete org owner", 401) && return if @organization.owner_id == @user.id
+        render_jsonp "Can't delete org owner", 401 && return if @organization.owner_id == @user.id
 
         unless @user.can_delete
-          render_jsonp("Can't delete @user. #{'Has shared entities' if @user.has_shared_entities?}", 410)
+          render_jsonp "Can't delete @user. #{'Has shared entities' if @user.has_shared_entities?}", 410
         end
 
         @user.delete_in_central

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -15,14 +15,17 @@ module Carto
 
       def index
         presentations = @organization.users.each do |user|
-          Carto::Api::UserPresenter.new(user, current_viewer: current_viewer).to_poro
+          Carto::Api::UserPresenter.new(user, current_viewer: current_viewer).to_poro_without_id
         end
 
         render_jsonp(presentations, 200)
       end
 
       def show
-        render_jsonp(Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer).to_poro, 200)
+        presentation = Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer)
+                                                .to_poro_without_id
+
+        render_jsonp(presentation, 200)
       end
 
       def create
@@ -60,9 +63,7 @@ module Carto
 
         presentation = Carto::Api::UserPresenter.new(account_creator.user,
                                                      current_viewer: current_viewer)
-                                                .to_poro
-
-        presentation.delete(:id) # We don't return the id since this API uses usernames
+                                                .to_poro_without_id
 
         render_jsonp presentation, 200
       rescue => e
@@ -96,7 +97,10 @@ module Carto
         @user.update_in_central
         @user.save
 
-        render_jsonp Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer).to_poro, 200
+        presentation = Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer)
+                                                .to_poro_without_id
+
+        render_jsonp presentation, 200
       rescue CartoDB::CentralCommunicationFailure => e
         CartoDB.notify_exception(e)
 

--- a/app/controllers/carto/api/user_presenter.rb
+++ b/app/controllers/carto/api/user_presenter.rb
@@ -37,6 +37,14 @@ module Carto
         poro
       end
 
+      def to_poro_without_id
+        presentation = to_poro
+
+        presentation.delete(:id)
+
+        presentation
+      end
+
       def to_public_poro
         return {} if @user.nil?
 


### PR DESCRIPTION
Fixes #9455

It has been decided that since EUMAPI works with usernames, it's misleading to return ids.

Please CR @juanignaciosl 