### PR TITLE
Background-size cover for avatars.

### DIFF
--- a/app/assets/stylesheets/editor-3/share.css.scss
+++ b/app/assets/stylesheets/editor-3/share.css.scss
@@ -41,8 +41,8 @@
   width: 16px;
   height: 16px;
   border-radius: $halfBaseSize / 2;
-  background-size: cover;
   background-position: center center;
+  background-size: cover;
 }
 
 .Share-wrapper {

--- a/app/assets/stylesheets/editor-3/share.css.scss
+++ b/app/assets/stylesheets/editor-3/share.css.scss
@@ -38,8 +38,11 @@
 
 .Share-user {
   display: block;
+  width: 16px;
   height: 16px;
   border-radius: $halfBaseSize / 2;
+  background-size: cover;
+  background-position: center center;
 }
 
 .Share-wrapper {
@@ -51,7 +54,13 @@
 }
 
 .Share-user--big {
+  width: 24px;
   height: 24px;
+}
+
+.Share-user--huge {
+  width: 38px;
+  height: 38px;
 }
 
 .Share-permission {
@@ -86,10 +95,6 @@
   border: 1px solid $cMainLine;
   border-radius: 3px;
   font-size: 22px;
-
-  img {
-    max-width: 100%;
-  }
 }
 
 .Share-togglers {

--- a/lib/assets/javascripts/cartodb3/components/modals/publish/share-with.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/publish/share-with.tpl
@@ -1,5 +1,5 @@
 <% if (people > 0) { %>
-<img class="Share-user <%- avatarClass %> u-rSpace u-iBlock" src="<%- avatar %>">
+<div class="Share-user <%- avatarClass %> u-rSpace u-iBlock" style="background-image: url(<%- avatar %>)"></div>
 <span class="u-secondaryTextColor CDB-Text CDB-Size-small <%- separationClass %>">+ <%- people %></span>
 <% } else { %>
   <% if (hasAction) { %>

--- a/lib/assets/javascripts/cartodb3/components/modals/publish/share/share-permission.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/publish/share/share-permission.tpl
@@ -1,7 +1,7 @@
 <div class="Share-permissionInfo">
   <div class="Share-permissionIcon">
     <% if (avatar) { %>
-        <img src="<%- avatar %>" class="UserAvatar-img UserAvatar-img--medium" />
+      <div class="Share-user Share-user--huge" style="background-image: url(<%- avatar %>)"></div>
     <% } else { %>
         <i class="CDB-IconFont CDB-IconFont-people"></i>
     <% } %>

--- a/lib/assets/javascripts/cartodb3/components/modals/publish/share/user.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/publish/share/user.tpl
@@ -1,1 +1,1 @@
-<img class="Share-user u-rSpace js-avatar" src="<%- avatar %>" data-title="<%- username %>">
+<div class="Share-user u-rSpace js-avatar" style="background-image: url(<%- avatar %>)" data-title="<%- username %>"></div>


### PR DESCRIPTION
This PR fixes #9340.

The best solution would be to use `object-fill` property but IE doesn't implement it, so instead of making a polyfill, the plug and play solution is to use images as background, letting the hard work of managing proportions to css.

cc @piensaenpixel 