### PR TITLE
Force full refresh on all dependencies when using update-internal-deps

### DIFF
--- a/lib/assets/test/jasmine/cartodb3/data/analysis-definition-node-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/analysis-definition-node-model.spec.js
@@ -33,8 +33,7 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
           kind: 'walk',
           time: 300,
           dissolved: true,
-          isolines: 3,
-          provider: 'heremaps'
+          isolines: 3
         },
         options: {
           optional: 'goes separately'
@@ -88,8 +87,7 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
       time: 300,
       dissolved: true,
       isolines: 3,
-      optional: 'goes separately',
-      provider: 'heremaps'
+      optional: 'goes separately'
     });
     expect(this.b1.attributes).toEqual({
       id: 'b1',
@@ -203,8 +201,7 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
             kind: 'walk',
             time: 300,
             dissolved: true,
-            isolines: 3,
-            provider: 'heremaps'
+            isolines: 3
           }
         }));
 
@@ -253,8 +250,7 @@ describe('cartodb3/data/analysis-definition-node-model', function () {
             kind: 'walk',
             time: 300,
             dissolved: true,
-            isolines: 3,
-            provider: 'heremaps'
+            isolines: 3
           }
         });
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,117 +1,117 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.5",
+  "version": "4.1.7",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
-      "from": "https://registry.npmjs.org/backbone/-/backbone-1.2.3.tgz",
+      "from": "backbone@1.2.3",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.3.tgz"
     },
     "backbone-forms": {
       "version": "0.14.0",
-      "from": "https://registry.npmjs.org/backbone-forms/-/backbone-forms-0.14.0.tgz",
+      "from": "backbone-forms@0.14.0",
       "resolved": "https://registry.npmjs.org/backbone-forms/-/backbone-forms-0.14.0.tgz"
     },
     "backbone-model-file-upload": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/backbone-model-file-upload/-/backbone-model-file-upload-1.0.0.tgz",
+      "from": "backbone-model-file-upload@1.0.0",
       "resolved": "https://registry.npmjs.org/backbone-model-file-upload/-/backbone-model-file-upload-1.0.0.tgz",
       "dependencies": {
         "bower": {
           "version": "1.7.9",
-          "from": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz",
+          "from": "bower@>=1.3.12 <2.0.0",
           "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.9.tgz"
         },
         "formidable": {
           "version": "1.0.17",
-          "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
+          "from": "formidable@>=1.0.15 <1.1.0",
           "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
         },
         "grunt-contrib-jasmine": {
           "version": "0.6.5",
-          "from": "https://registry.npmjs.org/grunt-contrib-jasmine/-/grunt-contrib-jasmine-0.6.5.tgz",
+          "from": "grunt-contrib-jasmine@>=0.6.5 <0.7.0",
           "resolved": "https://registry.npmjs.org/grunt-contrib-jasmine/-/grunt-contrib-jasmine-0.6.5.tgz",
           "dependencies": {
             "grunt-lib-phantomjs": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.4.0.tgz",
+              "from": "grunt-lib-phantomjs@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.4.0.tgz",
               "dependencies": {
                 "eventemitter2": {
                   "version": "0.4.14",
-                  "from": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+                  "from": "eventemitter2@>=0.4.9 <0.5.0",
                   "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
                 },
                 "semver": {
                   "version": "1.0.14",
-                  "from": "https://registry.npmjs.org/semver/-/semver-1.0.14.tgz",
+                  "from": "semver@>=1.0.14 <1.1.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-1.0.14.tgz"
                 },
                 "temporary": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
+                  "from": "temporary@>=0.0.4 <0.1.0",
                   "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
                   "dependencies": {
                     "package": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
+                      "from": "package@>=1.0.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz"
                     }
                   }
                 },
                 "phantomjs": {
                   "version": "1.9.20",
-                  "from": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.20.tgz",
+                  "from": "phantomjs@>=1.9.0-1 <1.10.0",
                   "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.20.tgz",
                   "dependencies": {
                     "extract-zip": {
                       "version": "1.5.0",
-                      "from": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
+                      "from": "extract-zip@>=1.5.0 <1.6.0",
                       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
                       "dependencies": {
                         "concat-stream": {
                           "version": "1.5.0",
-                          "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                          "from": "concat-stream@1.5.0",
                           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                           "dependencies": {
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "from": "inherits@>=2.0.1 <2.1.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "typedarray": {
                               "version": "0.0.6",
-                              "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                              "from": "typedarray@>=0.0.5 <0.1.0",
                               "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                             },
                             "readable-stream": {
                               "version": "2.0.6",
-                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                              "from": "readable-stream@>=2.0.0 <2.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "isarray": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                  "from": "isarray@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.7",
-                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
@@ -120,34 +120,34 @@
                         },
                         "debug": {
                           "version": "0.7.4",
-                          "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                          "from": "debug@0.7.4",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                         },
                         "mkdirp": {
                           "version": "0.5.0",
-                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "from": "mkdirp@0.5.0",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.8",
-                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "from": "minimist@0.0.8",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                             }
                           }
                         },
                         "yauzl": {
                           "version": "2.4.1",
-                          "from": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+                          "from": "yauzl@2.4.1",
                           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
                           "dependencies": {
                             "fd-slicer": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+                              "from": "fd-slicer@>=1.0.1 <1.1.0",
                               "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
                               "dependencies": {
                                 "pend": {
                                   "version": "1.2.0",
-                                  "from": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+                                  "from": "pend@>=1.2.0 <1.3.0",
                                   "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
                                 }
                               }
@@ -158,79 +158,79 @@
                     },
                     "fs-extra": {
                       "version": "0.26.7",
-                      "from": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+                      "from": "fs-extra@>=0.26.4 <0.27.0",
                       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
                       "dependencies": {
                         "graceful-fs": {
-                          "version": "4.1.4",
-                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+                          "version": "4.1.6",
+                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
                         },
                         "jsonfile": {
                           "version": "2.3.1",
-                          "from": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz",
+                          "from": "jsonfile@>=2.1.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.3.1.tgz"
                         },
                         "klaw": {
                           "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz",
+                          "from": "klaw@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.0.tgz"
                         },
                         "path-is-absolute": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                         },
                         "rimraf": {
-                          "version": "2.5.3",
-                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
+                          "version": "2.5.4",
+                          "from": "rimraf@>=2.2.8 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                           "dependencies": {
                             "glob": {
                               "version": "7.0.5",
-                              "from": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+                              "from": "glob@>=7.0.5 <8.0.0",
                               "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
                               "dependencies": {
                                 "fs.realpath": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                                  "from": "fs.realpath@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                                 },
                                 "inflight": {
                                   "version": "1.0.5",
-                                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "minimatch": {
-                                  "version": "3.0.2",
-                                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                                  "version": "3.0.3",
+                                  "from": "minimatch@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                                   "dependencies": {
                                     "brace-expansion": {
                                       "version": "1.1.6",
-                                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "0.4.2",
-                                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                                          "from": "balanced-match@>=0.4.1 <0.5.0",
                                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                         },
                                         "concat-map": {
                                           "version": "0.0.1",
-                                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                          "from": "concat-map@0.0.1",
                                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                         }
                                       }
@@ -239,12 +239,12 @@
                                 },
                                 "once": {
                                   "version": "1.3.3",
-                                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "from": "once@>=1.3.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
@@ -257,22 +257,22 @@
                     },
                     "hasha": {
                       "version": "2.2.0",
-                      "from": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+                      "from": "hasha@>=2.2.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
                       "dependencies": {
                         "is-stream": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                          "from": "is-stream@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
@@ -281,57 +281,57 @@
                     },
                     "kew": {
                       "version": "0.7.0",
-                      "from": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+                      "from": "kew@>=0.7.0 <0.8.0",
                       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
                     },
                     "progress": {
                       "version": "1.1.8",
-                      "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+                      "from": "progress@>=1.1.8 <1.2.0",
                       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
                     },
                     "request": {
                       "version": "2.67.0",
-                      "from": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+                      "from": "request@>=2.67.0 <2.68.0",
                       "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
                       "dependencies": {
                         "bl": {
                           "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+                          "from": "bl@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "2.0.6",
-                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                              "from": "readable-stream@>=2.0.5 <2.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                  "from": "isarray@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.7",
-                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
@@ -340,143 +340,143 @@
                         },
                         "caseless": {
                           "version": "0.11.0",
-                          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                          "from": "caseless@>=0.11.0 <0.12.0",
                           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
                         },
                         "extend": {
                           "version": "3.0.0",
-                          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                          "from": "extend@>=3.0.0 <3.1.0",
                           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
                         },
                         "forever-agent": {
                           "version": "0.6.1",
-                          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                          "from": "forever-agent@>=0.6.1 <0.7.0",
                           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                         },
                         "form-data": {
                           "version": "1.0.0-rc4",
-                          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+                          "from": "form-data@>=1.0.0-rc3 <1.1.0",
                           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
                           "dependencies": {
                             "async": {
                               "version": "1.5.2",
-                              "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                              "from": "async@>=1.5.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                             }
                           }
                         },
                         "json-stringify-safe": {
                           "version": "5.0.1",
-                          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
                           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                         },
                         "mime-types": {
                           "version": "2.1.11",
-                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                          "from": "mime-types@>=2.1.7 <2.2.0",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.23.0",
-                              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
+                              "from": "mime-db@>=1.23.0 <1.24.0",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                             }
                           }
                         },
                         "node-uuid": {
                           "version": "1.4.7",
-                          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                          "from": "node-uuid@>=1.4.7 <1.5.0",
                           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                         },
                         "qs": {
                           "version": "5.2.1",
-                          "from": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
+                          "from": "qs@>=5.2.0 <5.3.0",
                           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz"
                         },
                         "tunnel-agent": {
                           "version": "0.4.3",
-                          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+                          "from": "tunnel-agent@>=0.4.1 <0.5.0",
                           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
                         },
                         "tough-cookie": {
                           "version": "2.2.2",
-                          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
+                          "from": "tough-cookie@>=2.2.0 <2.3.0",
                           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                         },
                         "http-signature": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                          "from": "http-signature@>=1.1.0 <1.2.0",
                           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                           "dependencies": {
                             "assert-plus": {
                               "version": "0.2.0",
-                              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                              "from": "assert-plus@>=0.2.0 <0.3.0",
                               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                             },
                             "jsprim": {
                               "version": "1.3.0",
-                              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                              "from": "jsprim@>=1.2.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
                               "dependencies": {
                                 "extsprintf": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                                  "from": "extsprintf@1.0.2",
                                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                                 },
                                 "json-schema": {
                                   "version": "0.2.2",
-                                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
+                                  "from": "json-schema@0.2.2",
                                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                                 },
                                 "verror": {
                                   "version": "1.3.6",
-                                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                                  "from": "verror@1.3.6",
                                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                                 }
                               }
                             },
                             "sshpk": {
-                              "version": "1.8.3",
-                              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+                              "version": "1.9.2",
+                              "from": "sshpk@>=1.7.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
                               "dependencies": {
                                 "asn1": {
                                   "version": "0.2.3",
-                                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                                  "from": "asn1@>=0.2.3 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                                 },
                                 "assert-plus": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                  "from": "assert-plus@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                                 },
                                 "dashdash": {
                                   "version": "1.14.0",
-                                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                                  "from": "dashdash@>=1.12.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
                                 },
                                 "getpass": {
                                   "version": "0.1.6",
-                                  "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                                  "from": "getpass@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                                 },
                                 "jsbn": {
                                   "version": "0.1.0",
-                                  "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                                  "from": "jsbn@>=0.1.0 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                                 },
                                 "tweetnacl": {
                                   "version": "0.13.3",
-                                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                                  "from": "tweetnacl@>=0.13.0 <0.14.0",
                                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
                                 },
                                 "jodid25519": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                                  "from": "jodid25519@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                                 },
                                 "ecc-jsbn": {
                                   "version": "0.1.1",
-                                  "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                                 }
                               }
@@ -485,173 +485,173 @@
                         },
                         "oauth-sign": {
                           "version": "0.8.2",
-                          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                          "from": "oauth-sign@>=0.8.0 <0.9.0",
                           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
                         },
                         "hawk": {
                           "version": "3.1.3",
-                          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                          "from": "hawk@>=3.1.0 <3.2.0",
                           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                           "dependencies": {
                             "hoek": {
                               "version": "2.16.3",
-                              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                              "from": "hoek@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                             },
                             "boom": {
                               "version": "2.10.1",
-                              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                              "from": "boom@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                             },
                             "cryptiles": {
                               "version": "2.0.5",
-                              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                              "from": "cryptiles@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                             },
                             "sntp": {
                               "version": "1.0.9",
-                              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                              "from": "sntp@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                             }
                           }
                         },
                         "aws-sign2": {
                           "version": "0.6.0",
-                          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                          "from": "aws-sign2@>=0.6.0 <0.7.0",
                           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                         },
                         "stringstream": {
                           "version": "0.0.5",
-                          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                          "from": "stringstream@>=0.0.4 <0.1.0",
                           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                         },
                         "combined-stream": {
                           "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                          "from": "combined-stream@>=1.0.5 <1.1.0",
                           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                           "dependencies": {
                             "delayed-stream": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                              "from": "delayed-stream@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                             }
                           }
                         },
                         "isstream": {
                           "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                          "from": "isstream@>=0.1.2 <0.2.0",
                           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
                         },
                         "is-typedarray": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                          "from": "is-typedarray@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
                         },
                         "har-validator": {
                           "version": "2.0.6",
-                          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+                          "from": "har-validator@>=2.0.2 <2.1.0",
                           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.3",
-                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "from": "chalk@>=1.1.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.2.1",
-                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.5",
-                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.1",
-                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
                             },
                             "commander": {
                               "version": "2.9.0",
-                              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                              "from": "commander@>=2.9.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                               "dependencies": {
                                 "graceful-readlink": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                                  "from": "graceful-readlink@>=1.0.0",
                                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                                 }
                               }
                             },
                             "is-my-json-valid": {
                               "version": "2.13.1",
-                              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
                               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                               "dependencies": {
                                 "generate-function": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                                  "from": "generate-function@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                                 },
                                 "generate-object-property": {
                                   "version": "1.2.0",
-                                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                                  "from": "generate-object-property@>=1.1.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                                   "dependencies": {
                                     "is-property": {
                                       "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                                      "from": "is-property@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                                     }
                                   }
                                 },
                                 "jsonpointer": {
                                   "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
+                                  "from": "jsonpointer@2.0.0",
                                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                                 },
                                 "xtend": {
                                   "version": "4.0.1",
-                                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                                  "from": "xtend@>=4.0.0 <5.0.0",
                                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                                 }
                               }
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                                 }
                               }
@@ -662,24 +662,24 @@
                     },
                     "request-progress": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+                      "from": "request-progress@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
                       "dependencies": {
                         "throttleit": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+                          "from": "throttleit@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
                         }
                       }
                     },
                     "which": {
                       "version": "1.2.10",
-                      "from": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
+                      "from": "which@>=1.2.2 <1.3.0",
                       "resolved": "https://registry.npmjs.org/which/-/which-1.2.10.tgz",
                       "dependencies": {
                         "isexe": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                          "from": "isexe@>=1.1.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
                         }
                       }
@@ -690,211 +690,211 @@
             },
             "rimraf": {
               "version": "2.1.4",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
+              "from": "rimraf@>=2.1.4 <2.2.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                  "from": "graceful-fs@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                 }
               }
             },
             "chalk": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "from": "chalk@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
               "dependencies": {
                 "has-color": {
                   "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+                  "from": "has-color@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
                 },
                 "ansi-styles": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+                  "from": "ansi-styles@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
                 },
                 "strip-ansi": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+                  "from": "strip-ansi@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
                 }
               }
             },
             "es5-shim": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/es5-shim/-/es5-shim-2.3.0.tgz",
+              "from": "es5-shim@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-2.3.0.tgz"
             }
           }
         },
         "grunt-run": {
           "version": "0.3.0",
-          "from": "https://registry.npmjs.org/grunt-run/-/grunt-run-0.3.0.tgz",
+          "from": "grunt-run@>=0.3.0 <0.4.0",
           "resolved": "https://registry.npmjs.org/grunt-run/-/grunt-run-0.3.0.tgz"
         },
         "grunt-run-node": {
           "version": "0.1.3",
-          "from": "https://registry.npmjs.org/grunt-run-node/-/grunt-run-node-0.1.3.tgz",
+          "from": "grunt-run-node@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/grunt-run-node/-/grunt-run-node-0.1.3.tgz"
         },
         "grunt-template-jasmine-requirejs": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/grunt-template-jasmine-requirejs/-/grunt-template-jasmine-requirejs-0.2.3.tgz",
+          "from": "grunt-template-jasmine-requirejs@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-template-jasmine-requirejs/-/grunt-template-jasmine-requirejs-0.2.3.tgz"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "from": "lodash@>=2.4.1 <2.5.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "backbone-undo": {
       "version": "0.2.5",
-      "from": "git://github.com/cartodb/Backbone.Undo.js.git#c10e9977d22ecea1fabe894be650c78ac548911f",
+      "from": "cartodb/Backbone.Undo.js#c10e997",
       "resolved": "git://github.com/cartodb/Backbone.Undo.js.git#c10e9977d22ecea1fabe894be650c78ac548911f"
     },
     "bootstrap-colorpicker": {
       "version": "2.3.3",
-      "from": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-2.3.3.tgz",
+      "from": "bootstrap-colorpicker@2.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-2.3.3.tgz"
     },
     "browserify-shim": {
       "version": "3.8.12",
-      "from": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.12.tgz",
+      "from": "browserify-shim@3.8.12",
       "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.12.tgz",
       "dependencies": {
         "exposify": {
           "version": "0.4.3",
-          "from": "https://registry.npmjs.org/exposify/-/exposify-0.4.3.tgz",
+          "from": "exposify@>=0.4.3 <0.5.0",
           "resolved": "https://registry.npmjs.org/exposify/-/exposify-0.4.3.tgz",
           "dependencies": {
             "globo": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/globo/-/globo-1.0.2.tgz",
+              "from": "globo@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/globo/-/globo-1.0.2.tgz",
               "dependencies": {
                 "accessory": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/accessory/-/accessory-1.0.1.tgz",
+                  "from": "accessory@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/accessory/-/accessory-1.0.1.tgz",
                   "dependencies": {
                     "dot-parts": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/dot-parts/-/dot-parts-1.0.1.tgz",
+                      "from": "dot-parts@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/dot-parts/-/dot-parts-1.0.1.tgz"
                     }
                   }
                 },
                 "is-defined": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-defined/-/is-defined-1.0.0.tgz",
+                  "from": "is-defined@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/is-defined/-/is-defined-1.0.0.tgz"
                 },
                 "ternary": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ternary/-/ternary-1.0.0.tgz",
+                  "from": "ternary@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/ternary/-/ternary-1.0.0.tgz"
                 }
               }
             },
             "has-require": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/has-require/-/has-require-1.1.0.tgz",
+              "from": "has-require@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/has-require/-/has-require-1.1.0.tgz"
             },
             "map-obj": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+              "from": "map-obj@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
             },
             "replace-requires": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/replace-requires/-/replace-requires-1.0.3.tgz",
+              "from": "replace-requires@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/replace-requires/-/replace-requires-1.0.3.tgz",
               "dependencies": {
                 "detective": {
                   "version": "4.1.1",
-                  "from": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
+                  "from": "detective@>=4.1.0 <4.2.0",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "1.2.2",
-                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                      "from": "acorn@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     },
                     "defined": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+                      "from": "defined@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                     },
                     "escodegen": {
-                      "version": "1.8.0",
-                      "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
+                      "version": "1.8.1",
+                      "from": "escodegen@>=1.4.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
                       "dependencies": {
                         "estraverse": {
                           "version": "1.9.3",
-                          "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                          "from": "estraverse@>=1.9.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                          "from": "esutils@>=2.0.2 <3.0.0",
                           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "esprima": {
                           "version": "2.7.2",
-                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
+                          "from": "esprima@>=2.7.1 <3.0.0",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
                         },
                         "optionator": {
                           "version": "0.8.1",
-                          "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
+                          "from": "optionator@>=0.8.1 <0.9.0",
                           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
                           "dependencies": {
                             "prelude-ls": {
                               "version": "1.1.2",
-                              "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                              "from": "prelude-ls@>=1.1.2 <1.2.0",
                               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
                             },
                             "deep-is": {
                               "version": "0.1.3",
-                              "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                              "from": "deep-is@>=0.1.3 <0.2.0",
                               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                             },
                             "wordwrap": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                              "from": "wordwrap@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
                             },
                             "type-check": {
                               "version": "0.3.2",
-                              "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                              "from": "type-check@>=0.3.2 <0.4.0",
                               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                             },
                             "levn": {
                               "version": "0.3.0",
-                              "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                              "from": "levn@>=0.3.0 <0.4.0",
                               "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
                             },
                             "fast-levenshtein": {
                               "version": "1.1.4",
-                              "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
+                              "from": "fast-levenshtein@>=1.1.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz"
                             }
                           }
                         },
                         "source-map": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                          "from": "source-map@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                           "dependencies": {
                             "amdefine": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                              "from": "amdefine@>=0.0.4",
                               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
@@ -905,68 +905,68 @@
                 },
                 "has-require": {
                   "version": "1.2.2",
-                  "from": "https://registry.npmjs.org/has-require/-/has-require-1.2.2.tgz",
+                  "from": "has-require@>=1.2.1 <1.3.0",
                   "resolved": "https://registry.npmjs.org/has-require/-/has-require-1.2.2.tgz",
                   "dependencies": {
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "from": "escape-string-regexp@>=1.0.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     }
                   }
                 },
                 "patch-text": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/patch-text/-/patch-text-1.0.2.tgz",
+                  "from": "patch-text@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/patch-text/-/patch-text-1.0.2.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "from": "xtend@>=4.0.0 <4.1.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.4.2",
-              "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+              "from": "through2@>=0.4.0 <0.5.0",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.34",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "2.1.2",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+                  "from": "xtend@>=2.1.1 <2.2.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
                   "dependencies": {
                     "object-keys": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+                      "from": "object-keys@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                     }
                   }
@@ -975,32 +975,32 @@
             },
             "transformify": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/transformify/-/transformify-0.1.2.tgz",
+              "from": "transformify@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/transformify/-/transformify-0.1.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -1011,54 +1011,54 @@
         },
         "mothership": {
           "version": "0.2.0",
-          "from": "https://registry.npmjs.org/mothership/-/mothership-0.2.0.tgz",
+          "from": "mothership@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/mothership/-/mothership-0.2.0.tgz",
           "dependencies": {
             "find-parent-dir": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+              "from": "find-parent-dir@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz"
             }
           }
         },
         "rename-function-calls": {
           "version": "0.1.1",
-          "from": "https://registry.npmjs.org/rename-function-calls/-/rename-function-calls-0.1.1.tgz",
+          "from": "rename-function-calls@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/rename-function-calls/-/rename-function-calls-0.1.1.tgz",
           "dependencies": {
             "detective": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
+              "from": "detective@>=3.1.0 <3.2.0",
               "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz",
               "dependencies": {
                 "escodegen": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+                  "from": "escodegen@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
                   "dependencies": {
                     "esprima": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                      "from": "esprima@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                     },
                     "estraverse": {
                       "version": "1.5.1",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+                      "from": "estraverse@>=1.5.0 <1.6.0",
                       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
                     },
                     "esutils": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+                      "from": "esutils@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
                     },
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "from": "source-map@>=0.1.30 <0.2.0",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                          "from": "amdefine@>=0.0.4",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
@@ -1067,7 +1067,7 @@
                 },
                 "esprima-fb": {
                   "version": "3001.1.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+                  "from": "esprima-fb@3001.1.0-dev-harmony-fb",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
                 }
               }
@@ -1076,44 +1076,43 @@
         },
         "resolve": {
           "version": "0.6.3",
-          "from": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+          "from": "resolve@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz"
         },
         "through": {
           "version": "2.3.8",
-          "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "from": "through@>=2.3.4 <2.4.0",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
         }
       }
     },
     "camshaft-reference": {
-      "version": "0.24.0",
-      "from": "https://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.24.0.tgz",
-      "resolved": "https://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.24.0.tgz"
+      "version": "0.25.0",
+      "from": "camshaft-reference@<2.0.0"
     },
     "carto": {
       "version": "0.15.1-cdb1",
-      "from": "git://github.com/cartodb/carto.git#f17aea8657ea27f2a660db15dd13b57127e823f9",
+      "from": "cartodb/carto#master",
       "resolved": "git://github.com/cartodb/carto.git#f17aea8657ea27f2a660db15dd13b57127e823f9",
       "dependencies": {
         "mapnik-reference": {
           "version": "6.0.5",
-          "from": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz",
+          "from": "mapnik-reference@>=6.0.2 <6.1.0",
           "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "from": "optimist@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "from": "minimist@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
@@ -1122,12 +1121,12 @@
     },
     "cartocolor": {
       "version": "3.0.0",
-      "from": "https://registry.npmjs.org/cartocolor/-/cartocolor-3.0.0.tgz",
+      "from": "cartocolor@3.0.0",
       "resolved": "https://registry.npmjs.org/cartocolor/-/cartocolor-3.0.0.tgz",
       "dependencies": {
         "colorbrewer": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz",
+          "from": "colorbrewer@1.0.0",
           "resolved": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz"
         }
       }
@@ -1140,7 +1139,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#87d4c09358aaef0cd31ce5f6872b419294526f1f",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#a31fe4438bc3816bab9747abd0b7d2cd9801f3e3",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1289,13 +1288,13 @@
     },
     "cartodb-pecan": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/cartodb-pecan/-/cartodb-pecan-0.2.0.tgz",
+      "from": "cartodb-pecan@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/cartodb-pecan/-/cartodb-pecan-0.2.0.tgz"
     },
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#87d4c09358aaef0cd31ce5f6872b419294526f1f",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#a31fe4438bc3816bab9747abd0b7d2cd9801f3e3",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1437,27 +1436,27 @@
     },
     "clipboard": {
       "version": "1.5.12",
-      "from": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.12.tgz",
+      "from": "clipboard@1.5.12",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.12.tgz",
       "dependencies": {
         "good-listener": {
           "version": "1.1.7",
-          "from": "https://registry.npmjs.org/good-listener/-/good-listener-1.1.7.tgz",
+          "from": "good-listener@>=1.1.6 <2.0.0",
           "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.1.7.tgz",
           "dependencies": {
             "delegate": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/delegate/-/delegate-3.0.1.tgz",
+              "from": "delegate@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.0.1.tgz",
               "dependencies": {
                 "closest": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/closest/-/closest-0.0.1.tgz",
+                  "from": "closest@0.0.1",
                   "resolved": "https://registry.npmjs.org/closest/-/closest-0.0.1.tgz",
                   "dependencies": {
                     "matches-selector": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/matches-selector/-/matches-selector-0.0.1.tgz",
+                      "from": "matches-selector@0.0.1",
                       "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-0.0.1.tgz"
                     }
                   }
@@ -1468,54 +1467,54 @@
         },
         "select": {
           "version": "1.0.6",
-          "from": "https://registry.npmjs.org/select/-/select-1.0.6.tgz",
+          "from": "select@>=1.0.6 <2.0.0",
           "resolved": "https://registry.npmjs.org/select/-/select-1.0.6.tgz"
         },
         "tiny-emitter": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.1.0.tgz",
+          "from": "tiny-emitter@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.1.0.tgz"
         }
       }
     },
     "codemirror": {
       "version": "5.14.2",
-      "from": "https://registry.npmjs.org/codemirror/-/codemirror-5.14.2.tgz",
+      "from": "codemirror@5.14.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.14.2.tgz"
     },
     "jquery": {
       "version": "2.1.4",
-      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
+      "from": "jquery@2.1.4",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
     },
     "moment": {
       "version": "2.10.6",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
+      "from": "moment@2.10.6",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
     },
     "node-polyglot": {
       "version": "1.0.0",
-      "from": "https://registry.npmjs.org/node-polyglot/-/node-polyglot-1.0.0.tgz",
+      "from": "node-polyglot@1.0.0",
       "resolved": "https://registry.npmjs.org/node-polyglot/-/node-polyglot-1.0.0.tgz"
     },
     "perfect-scrollbar": {
       "version": "0.6.7",
-      "from": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-0.6.7.tgz",
+      "from": "perfect-scrollbar@0.6.7",
       "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-0.6.7.tgz"
     },
     "queue-async": {
       "version": "1.2.1",
-      "from": "https://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz",
+      "from": "queue-async@1.2.1",
       "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz"
     },
     "torque.js": {
       "version": "2.15.1",
-      "from": "https://registry.npmjs.org/torque.js/-/torque.js-2.15.1.tgz",
+      "from": "torque.js@>=2.15.1 <2.16.0",
       "resolved": "https://registry.npmjs.org/torque.js/-/torque.js-2.15.1.tgz"
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "from": "underscore@1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "test": "jasmine",
     "test-debug": "node-debug --no-preload ./node_modules/.bin/jasmine --",
     "test-watch": "watch 'npm test' $npm_package_config_npmJsDir",
-    "preupdate-internal-deps": "rm -rf node_modules/camshaft-reference node_modules/cartoassets node_modules/cartodb-deep-insights.js node_modules/cartodb.js",
-    "update-internal-deps": "npm update camshaft-reference cartoassets cartodb-deep-insights.js cartodb.js && npm shrinkwrap"
+    "preupdate-internal-deps": "echo 'DEPRECATED TASK, use `npm run-script update-internal-deps` instead'",
+    "update-internal-deps": "rm -rf node_modules && npm install --no-shrinkwrap && npm shrinkwrap"
   }
 }


### PR DESCRIPTION
It also deprecates `preupdate-internal-deps`.

cc @xavijam @nobuti 