### PR TITLE
Fix privacy dropdown styles

### DIFF
--- a/app/assets/stylesheets/editor-3/privacy-dropdown.css.scss
+++ b/app/assets/stylesheets/editor-3/privacy-dropdown.css.scss
@@ -34,3 +34,12 @@
 .Privacy-passwordField {
   padding: $baseSize $baseSize + 4;
 }
+
+.Editor-PrivacyDialog {
+  position: absolute;
+  top: $baseSize * 4;
+  right: 0;
+  left: 0;
+  width: 248px;
+  z-index: 11;
+}

--- a/lib/assets/javascripts/cartodb3/components/modals/publish/publish-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/publish/publish-view.js
@@ -96,6 +96,7 @@ module.exports = CoreView.extend({
     var publishButton;
     var shareWith;
     var upgradeView;
+    var publishedOn;
 
     dropdown = new PrivacyDropdown({
       privacyCollection: this._privacyCollection,
@@ -117,7 +118,11 @@ module.exports = CoreView.extend({
       this.$('.js-update').append(publishButton.render().el);
       this.addView(publishButton);
     } else {
-      this.$('.js-update').html(_t('editor.published', { when: moment(this._visDefinitionModel.get('updated_at')).fromNow() }));
+      publishedOn = _t('components.modals.publish.share.last-published', { date:
+                      moment(this._visDefinitionModel.get('updated_at')).format('Do MMMM YYYY, HH:mm')
+                    });
+
+      this.$('.js-update').html(publishedOn);
     }
 
     if (this._hasShareStats()) {


### PR DESCRIPTION
This PR fixes #9495.

![dropdown-privacy](https://cloud.githubusercontent.com/assets/1366843/17864418/4f2cfaae-689e-11e6-9834-74070d740635.gif)

For some reason, the dropdown styles for the password step were missing, this PR get them back. Also fix the locales for the header when no mapcaps are available, matching the format we have for the publish functionality.

cc @xavijam @piensaenpixel 