### PR TITLE
9509 mapcard preview authtokens

### DIFF
--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -116,7 +116,7 @@ module Carto
       private
 
       def auth_tokens
-        if @visualization.password_protected?
+        if @visualization.password_protected? && @visualization.user.id == @current_viewer.id
           @visualization.get_auth_tokens
         elsif @visualization.is_privacy_private?
           @current_viewer.get_auth_tokens

--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -64,7 +64,8 @@ module Carto
           children: @visualization.children.map { |v| children_poro(v) },
           liked: @current_viewer ? @visualization.is_liked_by_user_id?(@current_viewer.id) : false,
           url: url,
-          uses_builder_features: @visualization.uses_builder_features?
+          uses_builder_features: @visualization.uses_builder_features?,
+          auth_tokens: auth_tokens
         }
         poro.merge!( { related_tables: related_tables } ) if @options.fetch(:related, true)
         poro
@@ -113,6 +114,17 @@ module Carto
       end
 
       private
+
+      def auth_tokens
+        if @visualization.password_protected?
+          @visualization.get_auth_tokens
+        elsif @visualization.is_privacy_private?
+          @current_viewer.get_auth_tokens
+        else
+          []
+        end
+      end
+
 
       def related_tables
         related = @visualization.table ?

--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -125,7 +125,6 @@ module Carto
         end
       end
 
-
       def related_tables
         related = @visualization.table ?
           @visualization.related_tables.select { |table| table.id != @visualization.table.id } :

--- a/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
@@ -22,8 +22,8 @@ module.exports = cdb.core.View.extend({
 
   _TEMPLATES: {
     // Using <%= %> instead of <%- %> because if not / characters (for example) will be escaped
-    regular: '<%- protocol %>://<%= mapsApiResource %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png<%- authTokens %>',
-    cdn: '<%- protocol %>://<%- cdn %>/<%- username %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png<%- authTokens %>'
+    regular: '<%- protocol %>://<%= mapsApiResource %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png<%= authTokens %>',
+    cdn: '<%- protocol %>://<%- cdn %>/<%- username %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png<%= authTokens %>'
   },
 
   initialize: function() {

--- a/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
+++ b/lib/assets/javascripts/cartodb/common/views/mapcard_preview.js
@@ -16,13 +16,14 @@ module.exports = cdb.core.View.extend({
     username: '',
     visId: '',
     mapsApiResource: '',
-    className: ''
+    className: '',
+    authTokens: []
   },
 
   _TEMPLATES: {
     // Using <%= %> instead of <%- %> because if not / characters (for example) will be escaped
-    regular: '<%- protocol %>://<%= mapsApiResource %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png',
-    cdn: '<%- protocol %>://<%- cdn %>/<%- username %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png'
+    regular: '<%- protocol %>://<%= mapsApiResource %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png<%- authTokens %>',
+    cdn: '<%- protocol %>://<%- cdn %>/<%- username %>/api/v1/map/static/named/<%- tpl %>/<%- width %>/<%- height %>.png<%- authTokens %>'
   },
 
   initialize: function() {
@@ -55,7 +56,8 @@ module.exports = cdb.core.View.extend({
       mapsApiResource: this.options.mapsApiResource,
       tpl: this._generateImageTemplate(),
       width: this.options.width,
-      height: this.options.height
+      height: this.options.height,
+      authTokens: this._generateAuthTokensParams()
     };
 
     if (cdnConfig) {
@@ -65,6 +67,15 @@ module.exports = cdb.core.View.extend({
     var url = template(options);
 
     this._loadImage({}, url);
+  },
+
+  _generateAuthTokensParams: function () {
+    var authTokens = this.options.authTokens;
+    if (authTokens && authTokens.length > 0) {
+      return '?' + _.map(authTokens, function (t) { return 'auth_token=' + t; }).join('&');
+    } else {
+      return '';
+    }
   },
 
   _isHTTPS: function() {

--- a/lib/assets/javascripts/cartodb/dashboard/maps/maps_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/maps/maps_item.js
@@ -129,7 +129,8 @@ module.exports = cdb.core.View.extend({
       privacy: this.model.get("privacy"),
       mapsApiResource: cdb.config.getMapsResourceName(ownerUsername),
       username: ownerUsername,
-      visId: this.model.get('id')
+      visId: this.model.get('id'),
+      authTokens: this.model.get('auth_tokens')
     });
 
     if (this.imageURL) {

--- a/lib/assets/test/spec/cartodb/common/views/mapcard_preview.spec.js
+++ b/lib/assets/test/spec/cartodb/common/views/mapcard_preview.spec.js
@@ -38,6 +38,13 @@ describe('common/views/mapcard_preview', function() {
     expect(view.options.height).toEqual(99);
   });
 
+  it('should pass auth tokens if specified', function() {
+    this.view.options.authTokens = ['secure', 'token'];
+    spyOn(this.view, '_loadImage').and.callThrough();
+    this.view.load();
+    expect(this.view._loadImage).toHaveBeenCalledWith(jasmine.any(Object), 'http://javier.hello.com/api/v1/map/static/named/tpl_oooo_llll_aaaa_mmmm/300/170.png?auth_token=secure&auth_token=token');
+  });
+
   describe('with vis_id', function() {
 
     beforeEach(function() {

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -285,6 +285,7 @@ describe Carto::Api::VisualizationsController do
 
       # This is only in the Carto::Visualization presenter (not in old member presenter)
       expected_visualization['uses_builder_features'] = false
+      expected_visualization['auth_tokens'] = nil # normalize_hash converts [] to nil
 
       response = response_body(type: CartoDB::Visualization::Member::TYPE_CANONICAL)
       # INFO: old API won't support server side generated urls for visualizations. See #5250 and #5279


### PR DESCRIPTION
Closes #9509 

Pases auth_token to the dashboard visualization list in order to be able to show preview for shared/protected visualizations.