### PR TITLE
Reset styles when new layer is created from a analysis drop action

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -60,6 +60,48 @@ module.exports = function (params) {
       });
   };
 
+  var resetStylesWhenGeometryChanges = function (nodeDefModel, layerDefModel, forceStyleUpdate) {
+    var CHANGE_READY = 'change:ready';
+    var onQuerySchemaReady;
+    onQuerySchemaReady = function () {
+      var querySchemaModel = nodeDefModel.querySchemaModel;
+      if (querySchemaModel.get('ready')) {
+        querySchemaModel.off(CHANGE_READY, onQuerySchemaReady);
+      } else {
+        return; // wait until ready
+      }
+
+      var CHANGE_STATUS = 'change:status';
+      var saveDefaultStylesIfStillRelevant;
+      saveDefaultStylesIfStillRelevant = function () {
+        if (querySchemaModel.get('status') !== 'fetched') return; // wait until fetched
+
+        querySchemaModel.off(CHANGE_STATUS, saveDefaultStylesIfStillRelevant); // only do this once
+
+        if ( // Only apply changes if:
+          layerDefinitionsCollection.contains(layerDefModel) && // layer still exist
+          layerDefModel.get('source') === nodeDefModel.id && // node is still the head of layer
+          layerDefModel.styleModel.get('type') === 'none' || forceStyleUpdate // layer have no styles applied
+        ) {
+          var simpleGeometryType = querySchemaModel.get('simple_geom');
+
+          if (simpleGeometryType) {
+            layerDefModel.styleModel.setDefaultPropertiesByType('simple', simpleGeometryType);
+          } else {
+            layerDefModel.styleModel.setDefaultPropertiesByType('none'); // fallback if there is no known geometry
+          }
+
+          layerDefModel.save();
+        }
+      };
+      saveDefaultStylesIfStillRelevant();
+      querySchemaModel.on(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
+      querySchemaModel.fetch();
+    };
+    nodeDefModel.querySchemaModel.on(CHANGE_READY, onQuerySchemaReady);
+    onQuerySchemaReady();
+  };
+
   return {
     saveAnalysis: function (analysisFormModel) {
       if (!analysisFormModel.isValid()) return;
@@ -91,45 +133,7 @@ module.exports = function (params) {
       });
       analysisDefinitionsCollection.saveAnalysisForLayer(layerDefModel);
 
-      var CHANGE_READY = 'change:ready';
-      var onQuerySchemaReady;
-      onQuerySchemaReady = function () {
-        var querySchemaModel = nodeDefModel.querySchemaModel;
-        if (querySchemaModel.get('ready')) {
-          querySchemaModel.off(CHANGE_READY, onQuerySchemaReady);
-        } else {
-          return; // wait until ready
-        }
-
-        var CHANGE_STATUS = 'change:status';
-        var saveDefaultStylesIfStillRelevant;
-        saveDefaultStylesIfStillRelevant = function () {
-          if (querySchemaModel.get('status') !== 'fetched') return; // wait until fetched
-
-          querySchemaModel.off(CHANGE_STATUS, saveDefaultStylesIfStillRelevant); // only do this once
-
-          if ( // Only apply changes if:
-            layerDefinitionsCollection.contains(layerDefModel) && // layer still exist
-            layerDefModel.get('source') === nodeDefModel.id && // node is still the head of layer
-            layerDefModel.styleModel.get('type') === 'none' // layer have no styles applied
-          ) {
-            var simpleGeometryType = querySchemaModel.get('simple_geom');
-
-            if (simpleGeometryType) {
-              layerDefModel.styleModel.setDefaultPropertiesByType('simple', simpleGeometryType);
-            } else {
-              layerDefModel.styleModel.setDefaultPropertiesByType('none'); // fallback if there is no known geometry
-            }
-
-            layerDefModel.save();
-          }
-        };
-        saveDefaultStylesIfStillRelevant();
-        querySchemaModel.on(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
-        querySchemaModel.fetch();
-      };
-      nodeDefModel.querySchemaModel.on(CHANGE_READY, onQuerySchemaReady);
-      onQuerySchemaReady();
+      resetStylesWhenGeometryChanges(nodeDefModel, layerDefModel);
 
       return nodeDefModel;
     },
@@ -196,6 +200,8 @@ module.exports = function (params) {
 
       layerDefModel.save({source: primarySourceNode.id});
       analysisDefinitionsCollection.saveAnalysisForLayer(layerDefModel);
+
+      resetStylesWhenGeometryChanges(primarySourceNode, layerDefModel);
 
       deleteOrphanedAnalyses();
     },
@@ -282,6 +288,11 @@ module.exports = function (params) {
       var tableNameAlias;
       var newLetter = layerDefinitionsCollection.nextLetter();
 
+      var onNewLayerSaved = function (layer) {
+        resetStylesWhenGeometryChanges(layer.getAnalysisDefinitionNodeModel(), layer, true);
+        layerDefinitionsCollection.save(); // to persist layers order
+      };
+
       var prevLayer = layerDefinitionsCollection.findWhere({source: nodeId});
       if (prevLayer) {
         if (nodeDefModel.hasPrimarySource()) {
@@ -337,10 +348,11 @@ module.exports = function (params) {
           // Re-add source layer again, but after the new layer was created and before layer is getting saved
           layerDefinitionsCollection.add(prevLayer, {at: newPosition});
 
+          // Reset styles from previous layer
+          resetStylesWhenGeometryChanges(prevLayer.getAnalysisDefinitionNodeModel(), prevLayer, true);
+
           newLayerDefModel.save(null, {
-            success: function () {
-              layerDefinitionsCollection.save(); // to persist layers order
-            }
+            success: onNewLayerSaved
           });
           nodeDefModel.destroy(); // replaced by new node
         } else {
@@ -364,9 +376,7 @@ module.exports = function (params) {
           });
           newLayerDefModel = layerDefinitionsCollection.create(attrs, {
             at: newPosition,
-            success: function () {
-              layerDefinitionsCollection.save(); // to persist layers order
-            }
+            success: onNewLayerSaved
           });
         }
       } else {
@@ -412,9 +422,7 @@ module.exports = function (params) {
         });
         newLayerDefModel = layerDefinitionsCollection.create(attrs, {
           at: newPosition,
-          success: function () {
-            layerDefinitionsCollection.save(); // for orders to be up-to-date
-          }
+          success: onNewLayerSaved
         });
         analysisDefinitionsCollection.saveAnalysisForLayer(newLayerDefModel);
         nodeDefModel.destroy(); // replaced by new node

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -352,7 +352,9 @@ module.exports = function (params) {
           resetStylesWhenGeometryChanges(prevLayer.getAnalysisDefinitionNodeModel(), prevLayer, true);
 
           newLayerDefModel.save(null, {
-            success: onNewLayerSaved
+            success: function () {
+              onNewLayerSaved(newLayerDefModel);
+            }
           });
           nodeDefModel.destroy(); // replaced by new node
         } else {
@@ -376,7 +378,9 @@ module.exports = function (params) {
           });
           newLayerDefModel = layerDefinitionsCollection.create(attrs, {
             at: newPosition,
-            success: onNewLayerSaved
+            success: function () {
+              onNewLayerSaved(newLayerDefModel);
+            }
           });
         }
       } else {
@@ -422,7 +426,9 @@ module.exports = function (params) {
         });
         newLayerDefModel = layerDefinitionsCollection.create(attrs, {
           at: newPosition,
-          success: onNewLayerSaved
+          success: function () {
+            onNewLayerSaved(newLayerDefModel);
+          }
         });
         analysisDefinitionsCollection.saveAnalysisForLayer(newLayerDefModel);
         nodeDefModel.destroy(); // replaced by new node

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -81,7 +81,7 @@ module.exports = function (params) {
         if ( // Only apply changes if:
           layerDefinitionsCollection.contains(layerDefModel) && // layer still exist
           layerDefModel.get('source') === nodeDefModel.id && // node is still the head of layer
-          layerDefModel.styleModel.get('type') === 'none' || forceStyleUpdate // layer have no styles applied
+          layerDefModel.styleModel.get('type') === 'none' || forceStyleUpdate // layer have no styles applied
         ) {
           var simpleGeometryType = querySchemaModel.get('simple_geom');
 

--- a/lib/assets/test/spec/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/user-actions.spec.js
@@ -11,6 +11,7 @@ var WidgetDefinitionsCollection = require('../../../../javascripts/cartodb3/data
 var AnalysisFormModel = require('../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model');
 var WidgetOptionModel = require('../../../../javascripts/cartodb3/components/modals/add-widgets/widget-option-model');
 var UserActions = require('../../../../javascripts/cartodb3/data/user-actions');
+var StyleModel = require('../../../../javascripts/cartodb3/editor/style/style-definition-model');
 var AreaOfInfluenceFormModel = require('../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/area-of-influence-form-model');
 var CategoryWidgetOptionModel = require('../../../../javascripts/cartodb3/components/modals/add-widgets/category/category-option-model');
 var FilterByNodeColumnFormModel = require('../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-by-node-column');
@@ -1096,6 +1097,7 @@ describe('cartodb3/data/user-actions', function () {
         ]);
 
         spyOn(this.layerDefinitionsCollection, 'create').and.callThrough();
+        spyOn(StyleModel.prototype, 'setDefaultPropertiesByType');
         this.userActions.createLayerForAnalysisNode('a0', {at: 1});
         this.newLayerDefModel = this.layerDefinitionsCollection.findWhere({letter: 'b'});
       });
@@ -1108,6 +1110,12 @@ describe('cartodb3/data/user-actions', function () {
         expect(this.newLayerDefModel.get('table_name')).toEqual('alice', 'should have same table name');
         expect(this.newLayerDefModel.get('table_name_alias')).toEqual('alice_alias', 'should have same table name alias');
         expect(this.newLayerDefModel.get('order')).toEqual(1, 'should be the same as given at position');
+      });
+
+      it('should reset styles when layer is saved and query-schema-model has been fetched', function () {
+        var querySchemaModel = this.newLayerDefModel.getAnalysisDefinitionNodeModel().querySchemaModel;
+        querySchemaModel.set({ status: 'fetched', ready: true });
+        expect(StyleModel.prototype.setDefaultPropertiesByType).toHaveBeenCalled();
       });
 
       it('should not change any analysis', function () {
@@ -1227,6 +1235,7 @@ describe('cartodb3/data/user-actions', function () {
 
       describe('when created a layer successfully', function () {
         beforeEach(function () {
+          spyOn(StyleModel.prototype, 'setDefaultPropertiesByType');
           spyOn(this.layerDefinitionsCollection, 'save').and.callThrough();
           this.layerDefinitionsCollection.create.calls.argsFor(0)[1].success();
         });
@@ -1237,6 +1246,13 @@ describe('cartodb3/data/user-actions', function () {
 
         it('should save layers', function () {
           expect(this.layerDefinitionsCollection.save).toHaveBeenCalled();
+        });
+
+        it('should reset the styles', function () {
+          var newLayerDefModel = this.layerDefinitionsCollection.at(1);
+          var querySchemaModel = newLayerDefModel.getAnalysisDefinitionNodeModel().querySchemaModel;
+          querySchemaModel.set({ status: 'fetched', ready: true });
+          expect(StyleModel.prototype.setDefaultPropertiesByType).toHaveBeenCalled();
         });
       });
 
@@ -1280,6 +1296,7 @@ describe('cartodb3/data/user-actions', function () {
       });
 
       beforeEach(function () {
+        spyOn(StyleModel.prototype, 'setDefaultPropertiesByType');
         this.userActions.createLayerForAnalysisNode('a2', {at: 2});
       });
 
@@ -1308,6 +1325,13 @@ describe('cartodb3/data/user-actions', function () {
         expect(this.analysisDefinitionsCollection.pluck('node_id')).toEqual(['a1', 'b1']);
       });
 
+      it('should reset styles from the previous layer', function () {
+        var prevLayerDefModel = this.layerDefinitionsCollection.at(1);
+        var querySchemaModel = prevLayerDefModel.getAnalysisDefinitionNodeModel().querySchemaModel;
+        querySchemaModel.set({ status: 'fetched', ready: true });
+        expect(StyleModel.prototype.setDefaultPropertiesByType).toHaveBeenCalled();
+      });
+
       describe('when created a layer successfully', function () {
         beforeEach(function () {
           spyOn(this.layerDefinitionsCollection, 'save').and.callThrough();
@@ -1320,6 +1344,14 @@ describe('cartodb3/data/user-actions', function () {
 
         it('should save layers', function () {
           expect(this.layerDefinitionsCollection.save).toHaveBeenCalled();
+        });
+
+        it('should reset the styles', function () {
+          var newLayerDefModel = this.layerDefinitionsCollection.at(0);
+          var querySchemaModel = newLayerDefModel.getAnalysisDefinitionNodeModel().querySchemaModel;
+          StyleModel.prototype.setDefaultPropertiesByType.calls.reset();
+          querySchemaModel.set({ status: 'fetched', ready: true });
+          expect(StyleModel.prototype.setDefaultPropertiesByType).toHaveBeenCalled();
         });
       });
 


### PR DESCRIPTION
Previously, we were resetting styles to the simple one only when a new analysis was added. But we forgot several cases.

- When an analysis is deleted (fixed in case **A**, marked in the files).
- When a layer is created when an analysis is dragged out (fixed in case **B**, **C** and **D**, marked in the files).
  - B: Node is head of a layer
  - C: Node is the source of a prevLayer.
  - D: Node is NOT a head of a node.
Just moved the same logic done when analysis is added, and used where required.

CR: @nobuti 

cc @saleiva, who spotted first.