### PR TITLE
Removed cartofante icon from dashboard notifications

### DIFF
--- a/lib/assets/javascripts/cartodb/common/views/dashboard_header/notifications/view.js
+++ b/lib/assets/javascripts/cartodb/common/views/dashboard_header/notifications/view.js
@@ -102,7 +102,7 @@ module.exports = cdb.core.View.extend({
     // try_trial -> trial_end_at is null && user is not paid user
     if (!d.isInsideOrg && d.accountType === 'free' && this.user.get("table_count") > 0) {
       arr.push({
-        iconFont: 'CDB-IconFont-cartoFante',
+        iconFont: 'CDB-IconFont-gift',
         severity: 'NotificationsList-itemIcon--positive',
         type:   'try_trial',
         msg:    cdb.templates.getTemplate('common/views/dashboard_header/notifications/templates/try_trial')(d),


### PR DESCRIPTION
Fixes #8663

<img width="443" alt="screen shot 2016-08-25 at 16 50 41" src="https://cloud.githubusercontent.com/assets/2141690/17973913/65912fde-6ae4-11e6-9d5d-df0acfaa3b97.png">

CR @xavijam 