### PR TITLE
SQL query error message

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/notifier/notifier-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/notifier/notifier-item-view.js
@@ -23,7 +23,7 @@ module.exports = CoreView.extend({
 
     this._delay = this._notifierModel.get('delay') || this._notifierModel.get('defaultDelay');
 
-    if (this._notifierModel.get('delay')) {
+    if (this._notifierModel.get('delay') && this._notifierModel.get('closable') !== false) {
       this._timeout = setTimeout(this._autoClose.bind(this), this._delay);
     }
 
@@ -119,7 +119,7 @@ module.exports = CoreView.extend({
   },
 
   _onChangeStatus: function (model, status) {
-    if (status === 'success' || status === 'error') {
+    if ((status === 'success' || status === 'error') && this._notifierModel.get('closable') !== false) {
       this._timeout = setTimeout(this._autoClose.bind(this), this._delay);
     }
   }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -18,7 +18,8 @@ var legendTemplate = require('./layer-content-views/legend/empty.tpl');
 
 module.exports = CoreView.extend({
   events: {
-    'click .js-back': '_onClickBack'
+    'click .js-back': '_onClickBack',
+    'click .js-fix-sql': '_onClickFixSQL'
   },
 
   options: {
@@ -317,6 +318,11 @@ module.exports = CoreView.extend({
   _onClickBack: function () {
     this._editorModel.set({ edition: false });
     this.stackLayoutModel.prevStep('layers');
+  },
+
+  _onClickFixSQL: function () {
+    this._editorModel.set({edition: false}, {silent: true});
+    this._layerTabPaneView.getTabPane('data').set({selected: true});
   },
 
   _changeStyle: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-sql-error.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-sql-error.tpl
@@ -1,3 +1,3 @@
 <h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor">
-  <%- _t('editor.layers.analysis.error-sql') %>
+  <%= body %>
 </h2>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-sql-error.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-sql-error.tpl
@@ -1,0 +1,3 @@
+<h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor">
+  <%- _t('editor.layers.analysis.error-sql') %>
+</h2>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-error.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-error.tpl
@@ -1,3 +1,3 @@
 <h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor">
-  <%- _t('editor.data.error-sql') %>
+  <%= body %>
 </h2>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-error.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-error.tpl
@@ -1,0 +1,3 @@
+<h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor">
+  <%- _t('editor.data.error-sql') %>
+</h2>

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -136,7 +136,9 @@ module.exports = CoreView.extend({
 
   _handleStats: function () {
     if (this._columnsReady()) {
-      this.modelView.set({state: STATES.ready});
+      // we force render because the state could be ready already
+      this.modelView.set({state: STATES.ready}, {silent: true});
+      this.render();
     } else {
       // if there are not stats, we hide loading and show placeholder
       renderLoading = false;

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -4,9 +4,9 @@ var CoreView = require('backbone/core-view');
 var StatView = require('./stat-view');
 var dataNotReadyTemplate = require('./data-content-not-ready.tpl');
 var dataErrorTemplate = require('./data-content-error.tpl');
+var actionErrorTemplate = require('../../sql-error-action.tpl');
 var QuerySanity = require('../../query-sanity-check');
 
-var ACTION_ERROR_TEMPLATE = _.template("<button class='CDB-Text u-actionTextColor js-fix-sql'><%- label %></button>");
 var renderLoading = true;
 
 var STATES = {
@@ -73,7 +73,7 @@ module.exports = CoreView.extend({
     this.$el.append(
       dataErrorTemplate({
         body: _t('editor.error-query.body', {
-          action: ACTION_ERROR_TEMPLATE({
+          action: actionErrorTemplate({
             label: _t('editor.error-query.label')
           })
         })

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -1,8 +1,17 @@
 var _ = require('underscore');
+var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 var StatView = require('./stat-view');
 var dataNotReadyTemplate = require('./data-content-not-ready.tpl');
+var dataErrorTemplate = require('./data-content-error.tpl');
 var renderLoading = true;
+
+var STATES = {
+  ready: 'ready',
+  loading: 'loading',
+  fetched: 'fetched',
+  error: 'error'
+};
 
 module.exports = CoreView.extend({
   className: 'Editor-dataContent',
@@ -11,6 +20,7 @@ module.exports = CoreView.extend({
     if (!opts.widgetDefinitionsCollection) throw new Error('widgetDefinitionsCollection is required');
     if (!opts.columnsModel) throw new Error('columnsModel is required');
     if (!opts.stackLayoutModel) throw new Error('StackLayoutModel is required');
+    if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
     if (!opts.infoboxModel) throw new Error('infoboxModel is required');
     if (!opts.userActions) throw new Error('userActions is required');
 
@@ -21,18 +31,32 @@ module.exports = CoreView.extend({
     this._columnsModel = opts.columnsModel;
     this._columnsCollection = this._columnsModel.getCollection();
     this._userActions = opts.userActions;
+    this._querySchemaModel = opts.querySchemaModel;
+
+    this.modelView = new Backbone.Model({
+      state: STATES.loading
+    });
 
     this._initBinds();
+    this._showErrors();
   },
 
   render: function () {
     this.clearSubViews();
     this.$el.empty();
-    if (this._columnsReady()) {
-      this._renderStats();
-    } else {
+
+    if (this._hasError()) {
+      this._showError();
+    } else if (this._isLoading()) {
       this._showLoading();
+    } else if (this._isReady()) {
+      if (this._columnsReady()) {
+        this._renderStats();
+      } else {
+        this._showLoading();
+      }
     }
+
     return this;
   },
 
@@ -45,6 +69,25 @@ module.exports = CoreView.extend({
     );
   },
 
+  _showError: function () {
+    this.$el.empty();
+    this.$el.append(
+      dataErrorTemplate()
+    );
+  },
+
+  _hasError: function () {
+    return this.modelView.get('state') === STATES.error;
+  },
+
+  _isLoading: function () {
+    return this.modelView.get('state') === STATES.loading;
+  },
+
+  _isReady: function () {
+    return this.modelView.get('state') === STATES.ready;
+  },
+
   _columnsReady: function () {
     return this._columnsModel.get('render') === true;
   },
@@ -55,6 +98,29 @@ module.exports = CoreView.extend({
 
     this._columnsCollection.on('change:selected', this._handleWidget, this);
     this.add_related_model(this._columnsCollection);
+
+    this._querySchemaModel.on('change:status', this._onQuerySchemaStatusChange, this);
+    this._querySchemaModel.on('change:query_errors', this._showErrors, this);
+    this.add_related_model(this._querySchemaModel);
+
+    this.modelView.on('change:state', this.render, this);
+    this.add_related_model(this.modelView);
+  },
+
+  _onQuerySchemaStatusChange: function () {
+    this._hasFetchedQuerySchema() && this.modelView.set({state: STATES.ready});
+  },
+
+  _hasFetchedQuerySchema: function () {
+    return this._querySchemaModel.get('status') === STATES.fetched;
+  },
+
+  _showErrors: function (model) {
+    var errors = this._querySchemaModel.get('query_errors');
+
+    if (errors && errors.length > 0) {
+      this.modelView.set({state: STATES.error});
+    }
   },
 
   _handleWidget: function (model) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -4,6 +4,8 @@ var CoreView = require('backbone/core-view');
 var StatView = require('./stat-view');
 var dataNotReadyTemplate = require('./data-content-not-ready.tpl');
 var dataErrorTemplate = require('./data-content-error.tpl');
+var QuerySanity = require('../../query-sanity-check');
+
 var renderLoading = true;
 
 var STATES = {
@@ -31,14 +33,14 @@ module.exports = CoreView.extend({
     this._columnsModel = opts.columnsModel;
     this._columnsCollection = this._columnsModel.getCollection();
     this._userActions = opts.userActions;
-    this._querySchemaModel = opts.querySchemaModel;
+    this.querySchemaModel = opts.querySchemaModel;
 
     this.modelView = new Backbone.Model({
-      state: STATES.loading
+      state: this._getInitialState()
     });
 
     this._initBinds();
-    this._showErrors();
+    QuerySanity.track(this, this.render.bind(this));
   },
 
   render: function () {
@@ -50,11 +52,7 @@ module.exports = CoreView.extend({
     } else if (this._isLoading()) {
       this._showLoading();
     } else if (this._isReady()) {
-      if (this._columnsReady()) {
-        this._renderStats();
-      } else {
-        this._showLoading();
-      }
+      this._renderStats();
     }
 
     return this;
@@ -76,6 +74,10 @@ module.exports = CoreView.extend({
     );
   },
 
+  _getInitialState: function () {
+    return this._columnsReady() ? STATES.ready : STATES.loading;
+  },
+
   _hasError: function () {
     return this.modelView.get('state') === STATES.error;
   },
@@ -93,34 +95,11 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
-    this._columnsModel.on('change:render', this._renderStats, this);
+    this._columnsModel.on('change:render', this._handleStats, this);
     this.add_related_model(this._columnsModel);
 
     this._columnsCollection.on('change:selected', this._handleWidget, this);
     this.add_related_model(this._columnsCollection);
-
-    this._querySchemaModel.on('change:status', this._onQuerySchemaStatusChange, this);
-    this._querySchemaModel.on('change:query_errors', this._showErrors, this);
-    this.add_related_model(this._querySchemaModel);
-
-    this.modelView.on('change:state', this.render, this);
-    this.add_related_model(this.modelView);
-  },
-
-  _onQuerySchemaStatusChange: function () {
-    this._hasFetchedQuerySchema() && this.modelView.set({state: STATES.ready});
-  },
-
-  _hasFetchedQuerySchema: function () {
-    return this._querySchemaModel.get('status') === STATES.fetched;
-  },
-
-  _showErrors: function (model) {
-    var errors = this._querySchemaModel.get('query_errors');
-
-    if (errors && errors.length > 0) {
-      this.modelView.set({state: STATES.error});
-    }
   },
 
   _handleWidget: function (model) {
@@ -153,6 +132,16 @@ module.exports = CoreView.extend({
       selected: false,
       widget: null
     });
+  },
+
+  _handleStats: function () {
+    if (this._columnsReady()) {
+      this.modelView.set({state: STATES.ready});
+    } else {
+      // if there are not stats, we hide loading and show placeholder
+      renderLoading = false;
+      this.modelView.set({state: STATES.loading});
+    }
   },
 
   _renderStats: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -6,6 +6,7 @@ var dataNotReadyTemplate = require('./data-content-not-ready.tpl');
 var dataErrorTemplate = require('./data-content-error.tpl');
 var QuerySanity = require('../../query-sanity-check');
 
+var ACTION_ERROR_TEMPLATE = _.template("<button class='CDB-Text u-actionTextColor js-fix-sql'><%- label %></button>");
 var renderLoading = true;
 
 var STATES = {
@@ -70,7 +71,13 @@ module.exports = CoreView.extend({
   _showError: function () {
     this.$el.empty();
     this.$el.append(
-      dataErrorTemplate()
+      dataErrorTemplate({
+        body: _t('editor.error-query.body', {
+          action: ACTION_ERROR_TEMPLATE({
+            label: _t('editor.error-query.label')
+          })
+        })
+      })
     );
   },
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -76,11 +76,6 @@ module.exports = CoreView.extend({
 
     this._configPanes();
     this._initBinds();
-    this._initData();
-
-    // If there are errors in the SQL, open the sql editor by default
-    // we defer it to not interfere with the high order tabpane item selection
-    setTimeout(this._redirectIfErrors.bind(this), 0);
   },
 
   render: function () {
@@ -97,14 +92,6 @@ module.exports = CoreView.extend({
       this._editorModel.set({
         edition: true
       });
-    }
-  },
-
-  _initData: function () {
-    if (!this._hasFetchedQuerySchema()) {
-      this._querySchemaModel.fetch();
-    } else {
-      this._onQuerySchemaStatusChange();
     }
   },
 
@@ -408,6 +395,10 @@ module.exports = CoreView.extend({
 
     this.$el.append(panelWithOptionsView.render().el);
     this.addView(panelWithOptionsView);
+
+    // If there are errors in the SQL, open the sql editor by default
+    // we defer it to not interfere with the high order tabpane item selection
+    setTimeout(this._redirectIfErrors.bind(this), 0);
   },
 
   clean: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -76,6 +76,7 @@ module.exports = CoreView.extend({
 
     this._configPanes();
     this._initBinds();
+    this._initData();
   },
 
   render: function () {
@@ -83,6 +84,12 @@ module.exports = CoreView.extend({
     this.$el.empty();
     this._initViews();
     return this;
+  },
+
+  _initData: function () {
+    if (this._hasFetchedQuerySchema()) {
+      this._onQuerySchemaStatusChange();
+    }
   },
 
   _redirectIfErrors: function () {
@@ -108,7 +115,7 @@ module.exports = CoreView.extend({
   },
 
   _hasFetchedQuerySchema: function () {
-    return this._querySchemaModel.get('status') === 'fetched';
+    return this._querySchemaModel.isFetched();
   },
 
   _initBinds: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -77,6 +77,10 @@ module.exports = CoreView.extend({
     this._configPanes();
     this._initBinds();
     this._initData();
+
+    // If there are errors in the SQL, open the sql editor by default
+    // we defer it to not interfere with the high order tabpane item selection
+    setTimeout(this._redirectIfErrors.bind(this), 0);
   },
 
   render: function () {
@@ -84,6 +88,16 @@ module.exports = CoreView.extend({
     this.$el.empty();
     this._initViews();
     return this;
+  },
+
+  _redirectIfErrors: function () {
+    var errors = this._querySchemaModel.get('query_errors');
+    if (errors && errors.length > 0) {
+      this._showErrors();
+      this._editorModel.set({
+        edition: true
+      });
+    }
   },
 
   _initData: function () {
@@ -294,6 +308,7 @@ module.exports = CoreView.extend({
               stackLayoutModel: self._stackLayoutModel,
               widgetDefinitionsCollection: self._widgetDefinitionsCollection,
               columnsModel: self._columnsModel,
+              querySchemaModel: self._querySchemaModel,
               userActions: self._userActions,
               infoboxModel: self._infoboxModel
             });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -199,9 +199,11 @@ module.exports = CoreView.extend({
 
   _showErrors: function (model) {
     var errors = this._querySchemaModel.get('query_errors');
+    var hasErrors = errors && errors.length > 0;
     this._codemirrorModel.set('errors', this._parseErrors(errors));
+    this._editorModel.set('disabled', hasErrors);
 
-    if (errors && errors.length > 0) {
+    if (hasErrors) {
       SQLNotifications.showErrorNotification(this._parseErrors(errors));
     }
   },

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -405,6 +405,7 @@ module.exports = CoreView.extend({
     this.$el.append(panelWithOptionsView.render().el);
     this.addView(panelWithOptionsView);
 
+    // TOFIX
     // If there are errors in the SQL, open the sql editor by default
     // we defer it to not interfere with the high order tabpane item selection
     setTimeout(this._redirectIfErrors.bind(this), 0);

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/layer-content-analyses-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/layer-content-analyses-view.js
@@ -1,4 +1,5 @@
 var Backbone = require('backbone');
+var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var ScrollView = require('../../../components/scroll/scroll-view');
 var ViewFactory = require('../../../components/view-factory');
@@ -8,6 +9,8 @@ var AnalysisFormView = require('./analyses/analysis-form-view');
 var AnalysesWorkflowView = require('./analyses/analyses-workflow-view');
 var AnalysisControlsView = require('./analyses/analysis-controls-view');
 var QuerySanity = require('../query-sanity-check');
+
+var ACTION_ERROR_TEMPLATE = _.template("<button class='CDB-Text u-actionTextColor js-fix-sql'><%- label %></button>");
 
 var STATES = {
   ready: 'ready',
@@ -64,7 +67,13 @@ module.exports = CoreView.extend({
 
     if (this._hasError()) {
       this.$el.html(
-        analysisSQLErrorTemplate()
+        analysisSQLErrorTemplate({
+          body: _t('editor.error-query.body', {
+            action: ACTION_ERROR_TEMPLATE({
+              label: _t('editor.error-query.label')
+            })
+          })
+        })
       );
     } else {
       if (this._analysisFormsCollection.isEmpty()) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/layer-content-analyses-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/layer-content-analyses-view.js
@@ -1,5 +1,4 @@
 var Backbone = require('backbone');
-var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var ScrollView = require('../../../components/scroll/scroll-view');
 var ViewFactory = require('../../../components/view-factory');
@@ -9,8 +8,7 @@ var AnalysisFormView = require('./analyses/analysis-form-view');
 var AnalysesWorkflowView = require('./analyses/analyses-workflow-view');
 var AnalysisControlsView = require('./analyses/analysis-controls-view');
 var QuerySanity = require('../query-sanity-check');
-
-var ACTION_ERROR_TEMPLATE = _.template("<button class='CDB-Text u-actionTextColor js-fix-sql'><%- label %></button>");
+var actionErrorTemplate = require('../sql-error-action.tpl');
 
 var STATES = {
   ready: 'ready',
@@ -69,7 +67,7 @@ module.exports = CoreView.extend({
       this.$el.html(
         analysisSQLErrorTemplate({
           body: _t('editor.error-query.body', {
-            action: ACTION_ERROR_TEMPLATE({
+            action: actionErrorTemplate({
               label: _t('editor.error-query.label')
             })
           })

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/layer-content-analyses-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/layer-content-analyses-view.js
@@ -3,9 +3,18 @@ var CoreView = require('backbone/core-view');
 var ScrollView = require('../../../components/scroll/scroll-view');
 var ViewFactory = require('../../../components/view-factory');
 var analysisPlaceholderTemplate = require('./analyses/analyses-placeholder.tpl');
+var analysisSQLErrorTemplate = require('./analyses/analyses-sql-error.tpl');
 var AnalysisFormView = require('./analyses/analysis-form-view');
 var AnalysesWorkflowView = require('./analyses/analyses-workflow-view');
 var AnalysisControlsView = require('./analyses/analysis-controls-view');
+var QuerySanity = require('../query-sanity-check');
+
+var STATES = {
+  ready: 'ready',
+  loading: 'loading',
+  fetched: 'fetched',
+  error: 'error'
+};
 
 /**
  * LayerContentAnalysesView:
@@ -39,7 +48,55 @@ module.exports = CoreView.extend({
     this._configModel = opts.configModel;
 
     this._viewModel = new Backbone.Model({selectedNodeId: this.options.selectedNodeId});
+    this.querySchemaModel = this._layerDefinitionModel.getAnalysisDefinitionNodeModel().querySchemaModel;
 
+    this.modelView = new Backbone.Model({
+      state: this._getInitialState()
+    });
+
+    this._initBinds();
+
+    QuerySanity.track(this, this.render.bind(this));
+  },
+
+  render: function () {
+    this.clearSubViews();
+
+    if (this._hasError()) {
+      this.$el.html(
+        analysisSQLErrorTemplate()
+      );
+    } else {
+      if (this._analysisFormsCollection.isEmpty()) {
+        this.$el.html(analysisPlaceholderTemplate({
+          layerId: this._layerDefinitionModel.id
+        }));
+      } else {
+        this.$el.empty();
+        var formModel = this._formModel();
+        this._renderScrollableListView(formModel);
+        this._renderControlsView(formModel);
+      }
+    }
+
+    return this;
+  },
+
+  clean: function () {
+    CoreView.prototype.clean.apply(this, arguments);
+    this._selectedNodeId(null, {silent: true});
+    this.viewModel = null;
+  },
+
+  _getInitialState: function () {
+    return STATES.loading;
+  },
+
+  _hasError: function () {
+    return this.modelView.get('state') === STATES.error;
+  },
+
+  _initBinds: function () {
     // Init listeners
     this._viewModel.on('change:selectedNodeId', this.render, this);
     this.add_related_model(this._viewModel);
@@ -50,29 +107,6 @@ module.exports = CoreView.extend({
     this._analysisFormsCollection.on('add', this._onFormModelAdded, this);
     this._analysisFormsCollection.on('remove', this._onFormModelRemoved, this);
     this.add_related_model(this._analysisFormsCollection);
-  },
-
-  render: function () {
-    this.clearSubViews();
-
-    if (this._analysisFormsCollection.isEmpty()) {
-      this.$el.html(analysisPlaceholderTemplate({
-        layerId: this._layerDefinitionModel.id
-      }));
-    } else {
-      this.$el.empty();
-      var formModel = this._formModel();
-      this._renderScrollableListView(formModel);
-      this._renderControlsView(formModel);
-    }
-
-    return this;
-  },
-
-  clean: function () {
-    CoreView.prototype.clean.apply(this, arguments);
-    this._selectedNodeId(null, {silent: true});
-    this.viewModel = null;
   },
 
   _renderScrollableListView: function (formModel) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/query-sanity-check.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/query-sanity-check.js
@@ -27,7 +27,15 @@ module.exports = {
   },
 
   _checkErrors: function () {
-    this._hasErrors() && this.modelView.set({state: STATES.error});
+    if (this._hasErrors()) {
+      this.modelView.set({state: STATES.error});
+    } else {
+      if (this.querySchemaModel.isFetched()) {
+        this.modelView.set({state: STATES.ready});
+      } else {
+        this.modelView.set({state: STATES.loading});
+      }
+    }
   },
 
   _hasErrors: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/query-sanity-check.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/query-sanity-check.js
@@ -1,0 +1,37 @@
+var STATES = {
+  ready: 'ready',
+  loading: 'loading',
+  fetched: 'fetched',
+  error: 'error'
+};
+
+module.exports = {
+  track: function (view, callback) {
+    if (view.modelView === undefined) throw new Error('modelView is required');
+    if (view.querySchemaModel === undefined) throw new Error('querySchemaModel is required');
+
+    this.modelView = view.modelView;
+    this.querySchemaModel = view.querySchemaModel;
+
+    this.querySchemaModel.on('change:query_errors', this._checkErrors, this);
+    view.add_related_model(view.querySchemaModel);
+
+    this.modelView.on('change:state', callback);
+    view.add_related_model(this.modelView);
+
+    if (this.querySchemaModel.canFetch() && !this._hasErrors()) {
+      this.querySchemaModel.fetch();
+    }
+
+    this._checkErrors();
+  },
+
+  _checkErrors: function () {
+    this._hasErrors() && this.modelView.set({state: STATES.error});
+  },
+
+  _hasErrors: function () {
+    var errors = this.querySchemaModel.get('query_errors');
+    return (errors && errors.length > 0);
+  }
+};

--- a/lib/assets/javascripts/cartodb3/editor/layers/sql-error-action.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/sql-error-action.tpl
@@ -1,0 +1,1 @@
+<button class='CDB-Text u-actionTextColor js-fix-sql'><%- label %></button>

--- a/lib/assets/javascripts/cartodb3/editor/style/style-content-sql-error.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-content-sql-error.tpl
@@ -1,3 +1,3 @@
 <h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor">
-  <%- _t('editor.style.error-sql') %>
+  <%= body %>
 </h2>

--- a/lib/assets/javascripts/cartodb3/editor/style/style-content-sql-error.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-content-sql-error.tpl
@@ -1,0 +1,3 @@
+<h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor">
+  <%- _t('editor.style.error-sql') %>
+</h2>

--- a/lib/assets/javascripts/cartodb3/editor/style/style-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-content-view.js
@@ -10,6 +10,7 @@ var styleSQLErrorTemplate = require('./style-content-sql-error.tpl');
 var OverlayView = require('../components/overlay/overlay-view');
 var Notifier = require('../../components/notifier/notifier');
 var QuerySanity = require('../layers/query-sanity-check');
+var ACTION_ERROR_TEMPLATE = _.template("<button class='CDB-Text u-actionTextColor js-fix-sql'><%- label %></button>");
 
 var STATES = {
   ready: 'ready',
@@ -110,7 +111,13 @@ module.exports = CoreView.extend({
 
   _renderError: function () {
     this.$el.append(
-      styleSQLErrorTemplate()
+      styleSQLErrorTemplate({
+        body: _t('editor.error-query.body', {
+          action: ACTION_ERROR_TEMPLATE({
+            label: _t('editor.error-query.label')
+          })
+        })
+      })
     );
   },
 

--- a/lib/assets/javascripts/cartodb3/editor/style/style-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-content-view.js
@@ -10,7 +10,7 @@ var styleSQLErrorTemplate = require('./style-content-sql-error.tpl');
 var OverlayView = require('../components/overlay/overlay-view');
 var Notifier = require('../../components/notifier/notifier');
 var QuerySanity = require('../layers/query-sanity-check');
-var ACTION_ERROR_TEMPLATE = _.template("<button class='CDB-Text u-actionTextColor js-fix-sql'><%- label %></button>");
+var actionErrorTemplate = require('../layers/sql-error-action.tpl');
 
 var STATES = {
   ready: 'ready',
@@ -113,7 +113,7 @@ module.exports = CoreView.extend({
     this.$el.append(
       styleSQLErrorTemplate({
         body: _t('editor.error-query.body', {
-          action: ACTION_ERROR_TEMPLATE({
+          action: actionErrorTemplate({
             label: _t('editor.error-query.label')
           })
         })

--- a/lib/assets/javascripts/cartodb3/editor/style/style-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-content-view.js
@@ -1,3 +1,4 @@
+var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 var _ = require('underscore');
 var StyleFormView = require('./style-form/style-form-view');
@@ -5,8 +6,17 @@ var StylesFactory = require('./styles-factory');
 var CarouselFormView = require('../../components/carousel-form-view');
 var CarouselCollection = require('../../components/custom-carousel/custom-carousel-collection');
 var styleFormNotReadyTemplate = require('./style-form-not-ready.tpl');
+var styleSQLErrorTemplate = require('./style-content-sql-error.tpl');
 var OverlayView = require('../components/overlay/overlay-view');
 var Notifier = require('../../components/notifier/notifier');
+var QuerySanity = require('../layers/query-sanity-check');
+
+var STATES = {
+  ready: 'ready',
+  loading: 'loading',
+  fetched: 'fetched',
+  error: 'error'
+};
 
 module.exports = CoreView.extend({
 
@@ -30,8 +40,12 @@ module.exports = CoreView.extend({
     this._styleModel = opts.styleModel;
     this._overlayModel = opts.overlayModel;
     this._modals = opts.modals;
-    this._querySchemaModel = opts.querySchemaModel;
+    this.querySchemaModel = opts.querySchemaModel;
     this._freezeTorgeAggregation = opts.freezeTorgeAggregation;
+
+    this.modelView = new Backbone.Model({
+      state: STATES.loading
+    });
 
     this._carouselCollection = new CarouselCollection(
       _.map(StylesFactory.getStyleTypes(this._styleModel.get('type'), this._getCurrentSimpleGeometryType()), function (type) {
@@ -48,17 +62,17 @@ module.exports = CoreView.extend({
 
     this._initBinds();
 
-    if (this._querySchemaModel.get('status') === 'unfetched') {
-      this._querySchemaModel.fetch();
-    }
+    QuerySanity.track(this, this.render.bind(this));
   },
 
   render: function () {
     this.clearSubViews();
     this.$el.empty();
-    if (this._querySchemaModel.get('status') !== 'fetched') {
+    if (this._hasError()) {
+      this._renderError();
+    } else if (this._isLoading()) {
       this._renderStateless();
-    } else {
+    } else if (this._isReady()) {
       if (this._getCurrentSimpleGeometryType() === 'point') {
         this._renderCarousel();
       }
@@ -68,15 +82,23 @@ module.exports = CoreView.extend({
     return this;
   },
 
-  _initBinds: function () {
-    this._querySchemaModel.bind('change:status', function (status) {
-      // Only render again if a new fetched status has changed
-      if (this._querySchemaModel.get('status') === 'fetched') {
-        this.render();
-      }
-    }, this);
-    this.add_related_model(this._querySchemaModel);
+  _hasError: function () {
+    return this.modelView.get('state') === STATES.error;
+  },
 
+  _isLoading: function () {
+    return this.modelView.get('state') === STATES.loading;
+  },
+
+  _isReady: function () {
+    return this.modelView.get('state') === STATES.ready;
+  },
+
+  _getInitialState: function () {
+    return STATES.loading;
+  },
+
+  _initBinds: function () {
     this._carouselCollection.on('change:selected', this._onSelectAggregation, this);
     this.add_related_model(this._carouselCollection);
 
@@ -84,6 +106,12 @@ module.exports = CoreView.extend({
     this._styleModel.bind('undo redo', this.render, this);
     this._styleModel.bind('change', this._onStyleChange, this);
     this.add_related_model(this._styleModel);
+  },
+
+  _renderError: function () {
+    this.$el.append(
+      styleSQLErrorTemplate()
+    );
   },
 
   _renderStateless: function () {
@@ -169,7 +197,7 @@ module.exports = CoreView.extend({
       layerDefinitionModel: this._layerDefinitionModel,
       styleModel: this._styleModel,
       configModel: this._configModel,
-      querySchemaModel: this._querySchemaModel
+      querySchemaModel: this.querySchemaModel
     });
     this.$el.append(this._styleForm.render().el);
     this.addView(this._styleForm);
@@ -182,6 +210,6 @@ module.exports = CoreView.extend({
   },
 
   _getCurrentSimpleGeometryType: function () {
-    return this._querySchemaModel.get('simple_geom') || 'point';
+    return this.querySchemaModel.get('simple_geom') || 'point';
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/style/style-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-view.js
@@ -84,6 +84,9 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
+    this._querySchemaModel.on('change:query_errors', this._updateEditor, this);
+    this.add_related_model(this._querySchemaModel);
+
     this._styleModel.bind('change', function () {
       this._codemirrorModel.set('content', this._layerDefinitionModel.get('cartocss'));
     }, this);
@@ -93,6 +96,12 @@ module.exports = CoreView.extend({
       this._codemirrorModel.set('content', this._cartocssModel.get('content'));
     }, this);
     this.add_related_model(this._cartocssModel);
+  },
+
+  _updateEditor: function (model) {
+    var errors = this._querySchemaModel.get('query_errors');
+    var hasErrors = errors && errors.length > 0;
+    this._editorModel.set('disabled', hasErrors);
   },
 
   _saveCartoCSS: function () {
@@ -340,7 +349,8 @@ module.exports = CoreView.extend({
       createControlView: function () {
         return new Toggler({
           editorModel: self._editorModel,
-          labels: [_t('editor.style.style-toggle.values'), _t('editor.style.style-toggle.cartocss')]
+          labels: [_t('editor.style.style-toggle.values'), _t('editor.style.style-toggle.cartocss')],
+          isDisableable: true
         });
       },
       createActionView: function () {

--- a/lib/assets/javascripts/cartodb3/sql-notifications.js
+++ b/lib/assets/javascripts/cartodb3/sql-notifications.js
@@ -2,13 +2,13 @@ var _ = require('underscore');
 var Notifier = require('./components/notifier/notifier');
 
 var NOTIFICATION_ERROR_TEMPLATE = _.template("<span class='CDB-Text u-errorTextColor'><%- title %></span>");
-var NOTIFICATION_PREFIX = 'sql-notification-';
+var NOTIFICATION_PREFIX = 'sql-notifications';
 
 var SQLNotifications = {
   track: function (view) {
     // In order to not bloat the notification center we will create
     // only one notification, and update it along the way
-    this._notificationId = NOTIFICATION_PREFIX + view.cid;
+    this._notificationId = NOTIFICATION_PREFIX;
   },
 
   removeNotification: function () {
@@ -28,8 +28,7 @@ var SQLNotifications = {
         }),
         error: this._transformErrors(errors)
       }),
-      closable: true,
-      delay: Notifier.DEFAULT_DELAY
+      closable: false
     };
 
     this._addOrUpdateNotification(this._notificationId, notificationAttrs);

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1686,7 +1686,8 @@
         "animated-resolution": "resolution",
         "animated-steps": "steps",
         "animated-duration": "duration"
-      }
+      },
+      "error-sql": "Errors found in your SQL query. Fix them before continuing."
     },
     "widgets": {
       "options": {

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1273,6 +1273,9 @@
         "click": "Click",
         "hover": "Hover"
       },
+      "analysis": {
+        "error-sql": "Errors found in your SQL query. Fix them before continuing."
+      },
       "analysis-form": {
         "quota": {
           "cancel": "cancel",

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1505,7 +1505,8 @@
           "title": "NO DATA AVAILABLE",
           "body": "There is no data available to be displayed."
         }
-      }
+      },
+      "error-sql": "Errors found in your SQL query. Fix them before continuing."
     },
     "infowindow": {
       "apply": "APPLY",

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1102,6 +1102,11 @@
     "button_add": "Add",
     "button_share": "SHARE",
     "unpublished-changes": "Unpublished changes",
+    "error-query": {
+      "body": "Errors found in your SQL query. %{action} before continuing.",
+      "label": "Fix them"
+    },
+
     "settings": {
       "menu-tab-pane-labels": {
         "preview": "Preview",
@@ -1272,9 +1277,6 @@
       "infowindow-menu-tab-pane-labels": {
         "click": "Click",
         "hover": "Hover"
-      },
-      "analysis": {
-        "error-sql": "Errors found in your SQL query. Fix them before continuing."
       },
       "analysis-form": {
         "quota": {
@@ -1508,8 +1510,7 @@
           "title": "NO DATA AVAILABLE",
           "body": "There is no data available to be displayed."
         }
-      },
-      "error-sql": "Errors found in your SQL query. Fix them before continuing."
+      }
     },
     "infowindow": {
       "apply": "APPLY",
@@ -1689,8 +1690,7 @@
         "animated-resolution": "resolution",
         "animated-steps": "steps",
         "animated-duration": "duration"
-      },
-      "error-sql": "Errors found in your SQL query. Fix them before continuing."
+      }
     },
     "widgets": {
       "options": {

--- a/lib/assets/test/spec/cartodb3/components/notifier/notifier-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/notifier/notifier-view.spec.js
@@ -128,8 +128,11 @@ describe('components/notifier/notifier-view', function () {
 
   it('should autoclose on success', function () {
     var model = Notifier.getNotification('foo');
-    model.updateStatus('success');
+    model.updateStatus('error');
+    jasmine.clock().tick(Notifier.DEFAULT_DELAY + 1);
     expect(view.$('.Notifier-inner').length).toBe(1);
+    model.updateClosable(true);
+    model.updateStatus('success');
     jasmine.clock().tick(Notifier.DEFAULT_DELAY + 1);
     expect(view.$('.Notifier-inner').length).toBe(0);
   });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
@@ -4,6 +4,7 @@ var ConfigModel = require('../../../../../../../javascripts/cartodb3/data/config
 var DataContentView = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view');
 var DataColumnsModel = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/data/data-columns-model');
 var TableStats = require('../../../../../../../javascripts/cartodb3/components/modals/add-widgets/tablestats');
+var QuerySchemaModel = require('../../../../../../../javascripts/cartodb3/data/query-schema-model');
 
 describe('editor/layers/layers-content-view/data/data-content-view', function () {
   var view;
@@ -81,10 +82,18 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
       }
     };
 
+    var querySchemaModel = new QuerySchemaModel({
+      query: 'SELECT * FROM table',
+      status: 'fetched'
+    }, {
+      configModel: {}
+    });
+
     view = new DataContentView({
       widgetDefinitionsCollection: widgetDefinitionsCollection,
       stackLayoutModel: stackLayoutModel,
       userActions: userActions,
+      querySchemaModel: querySchemaModel,
       columnsNumberModel: columnModel,
       columnsModel: columnsModel,
       infoboxModel: new Backbone.Model()

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
@@ -106,7 +106,8 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
     view.render();
   });
 
-  it('should render "placeholder" if columns not ready', function () {
+  it('should render "placeholder" if loading', function () {
+    view.modelView.set({state: 'loading'});
     expect(view.$('.FormPlaceholder-paragraph').length).toBe(4);
     expect(_.keys(view._subviews).length).toBe(0);
   });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
@@ -46,7 +46,6 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
 
     this.editorModel = new Backbone.Model();
     this.editorModel.isEditing = function () { return false; };
-    this.vis = jasmine.createSpyObj('vis', ['instantiateMap']);
     this.userActions = jasmine.createSpyObj('userActions', ['saveAnalysisSourceQuery']);
 
     this.visDefinitionModel = new VisDefinitionModel({
@@ -69,9 +68,7 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
       layerDefinitionModel: this.layerDefinitionModel,
       stackLayoutModel: this.stackLayoutModel,
       widgetDefinitionsCollection: new Backbone.Collection(),
-      querySchemaModel: this.querySchemaModel,
       editorModel: this.editorModel,
-      vis: this.vis,
       userActions: this.userActions,
       configModel: this.configModel
     });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
@@ -5,6 +5,7 @@ var QuerySchemaModel = require('../../../../../../../javascripts/cartodb3/data/q
 var SQLModel = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/data/data-sql-model');
 var VisDefinitionModel = require('../../../../../../../javascripts/cartodb3/data/vis-definition-model');
 var Notifier = require('../../../../../../../javascripts/cartodb3/components/notifier/notifier.js');
+var SQLNotifications = require('../../../../../../../javascripts/cartodb3/sql-notifications.js');
 var cdb = require('cartodb.js');
 
 describe('editor/layers/layers-content-view/data/data-view', function () {
@@ -62,7 +63,9 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
       visDefinitionModel: this.visDefinitionModel
     });
 
-    spyOn(Notifier, 'addNotification').and.callThrough();
+    spyOn(SQLNotifications, 'showErrorNotification');
+    spyOn(SQLNotifications, 'removeNotification');
+    spyOn(SQLNotifications, '_addOrUpdateNotification');
 
     this.view = new DataView({
       layerDefinitionModel: this.layerDefinitionModel,
@@ -154,16 +157,22 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
   });
 
   it('should not throw notification if same query that is applied', function () {
+    SQLNotifications._addOrUpdateNotification.calls.reset();
     spyOn(this.node.querySchemaModel, 'fetch');
     this.view._sqlModel.set('content', 'SELECT * FROM table');
     this.view._codemirrorModel.set('content', 'SELECT * + FROM table');
     this.view._parseSQL();
     expect(this.node.querySchemaModel.fetch).toHaveBeenCalled();
+
+    this.node.querySchemaModel.set('query', 'SELECT * FROM table');
     this.node.querySchemaModel.set('query_errors', ['Syntax error']);
     this.view._codemirrorModel.set('content', 'SELECT * FROM table');
     this.node.querySchemaModel.set('query_errors', []);
-    this.view._saveSQL();
-    expect(Notifier.addNotification).toHaveBeenCalledTimes(1);
+    this.view._parseSQL();
+
+    expect(SQLNotifications.showErrorNotification).toHaveBeenCalledTimes(1);
+    expect(SQLNotifications.removeNotification).toHaveBeenCalledTimes(1);
+    expect(SQLNotifications._addOrUpdateNotification).toHaveBeenCalledTimes(1);
   });
 
   it('should not have leaks', function () {

--- a/lib/assets/test/spec/cartodb3/editor/style/style-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-content-view.spec.js
@@ -52,18 +52,6 @@ describe('editor/style/style-content-view', function () {
   });
 
   describe('._initBinds', function () {
-    it('should render when query schema is fetched', function () {
-      StyleContentView.prototype.render.calls.reset();
-      this.querySchemaModel.set('status', 'fetched');
-      expect(StyleContentView.prototype.render).toHaveBeenCalled();
-    });
-
-    it('should not render when query schema is loading/fetching', function () {
-      StyleContentView.prototype.render.calls.reset();
-      this.querySchemaModel.set('status', 'fetching');
-      expect(StyleContentView.prototype.render).not.toHaveBeenCalled();
-    });
-
     it('should render when styleModel is undone or redone', function () {
       StyleContentView.prototype.render.calls.reset();
       var fill = _.clone(this.model.get('fill'));
@@ -93,12 +81,14 @@ describe('editor/style/style-content-view', function () {
   });
 
   describe('.render', function () {
-    it('should render "placeholder" if query schema model is not fetched', function () {
+    it('should render "placeholder" if state is loading', function () {
+      this.view.modelView.set({state: 'loading'});
       expect(this.view.$('.FormPlaceholder-paragraph').length).toBe(4);
       expect(_.size(this.view._subviews)).toBe(0);
     });
 
-    it('should render properly when query schema is fetched', function () {
+    it('should render properly when state is ready and query schema is fetched', function () {
+      this.view.modelView.set({state: 'ready'});
       this.querySchemaModel.set('status', 'fetched');
       this.view.render();
       expect(this.view.$('.Carousel').length).toBe(1);
@@ -108,6 +98,7 @@ describe('editor/style/style-content-view', function () {
 
     it('should not render carousel view when geometry is not point', function () {
       spyOn(this.view, '_getCurrentSimpleGeometryType').and.returnValue('polygon');
+      this.view.modelView.set({state: 'ready'});
       this.querySchemaModel.set('status', 'fetched');
       this.view.render();
       expect(this.view.$('.Carousel').length).toBe(0);


### PR DESCRIPTION
This PR fixes #9497 and #9475.

I added a direct link to the message, so the user can easily access to the sql editor to fix the query. Please @urbanphes @saleiva confirm this is ok.

Also, in order to reduce the noise about notifications, we make the error notification fixed (not closable), so when the user changes the active tab, the notification remains with the error to add some context.

![sql-error](https://cloud.githubusercontent.com/assets/1366843/17974521/ba273c44-6ae6-11e6-8545-b3bf58cd3abb.gif)

cc @xavijam 
