### PR TITLE
Move copy privileges after cartodbfy, as it may rewrite the table

### DIFF
--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -27,12 +27,12 @@ module CartoDB
             data_for_exception << "1st result:#{runner.results.first.inspect}"
             raise data_for_exception
           end
-          copy_privileges(user.database_schema, table_name, result.schema, result.table_name)
           index_statements = generate_index_statements(user.database_schema, table_name)
           move_to_schema(result)
           geo_type = fix_the_geom_type!(user.database_schema, result.table_name)
           import_cleanup(user.database_schema, result.table_name)
           cartodbfy(result.table_name)
+          copy_privileges(user.database_schema, table_name, user.database_schema, result.table_name)
           overwrite(table_name, result)
           setup_table(table_name, geo_type)
           run_index_statements(index_statements)


### PR DESCRIPTION
Fixes #9527 

Moved copy privileges after cartodbfy, as under some circunstances, that recreates the table (and loses all the privileges).

Please CR @iriberri 