### PR TITLE
Fix dataset sync view to correctly check state

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/synchronization-model.js
+++ b/lib/assets/javascripts/cartodb3/data/synchronization-model.js
@@ -127,16 +127,15 @@ module.exports = Backbone.Model.extend({
   },
 
   isSyncing: function () {
-    return this.get('state') === 'syncing';
+    return this.get('state') === 'syncing' || this.get('state') === 'queued';
   },
 
   canSyncNow: function () {
     var ranAt = new Date(this.get('ran_at'));
     var now = new Date();
-    var state = this.get('state');
     var gap = SYNC_GAP; // Importer needs some time to perform the next sync, set 15 min as default.
 
-    if (state === 'syncing') {
+    if (this.isSyncing()) {
       return false;
     }
 

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-content/dataset-content-sync-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-content/dataset-content-sync-view.js
@@ -113,16 +113,18 @@ module.exports = CoreView.extend({
   },
 
   _finishSync: function () {
-    this._unbindChangeSyncEvent();
-    this._syncModel.destroyCheck();
+    if (!this._syncModel.isSyncing()) {
+      this._unbindChangeSyncEvent();
+      this._syncModel.destroyCheck();
 
-    // Reload table
-    this._querySchemaModel.set({
-      status: 'unfetched',
-      query: 'SELECT * FROM ' + this._tableModel.getUnquotedName()
-    });
+      // Reload table
+      this._querySchemaModel.set({
+        status: 'unfetched',
+        query: 'SELECT * FROM ' + this._tableModel.getUnquotedName()
+      });
 
-    this.render();
+      this.render();
+    }
   },
 
   _showSyncNowModal: function (e) {
@@ -142,7 +144,9 @@ module.exports = CoreView.extend({
           });
 
           self._syncModel.bind('change:state', function () {
-            modalModel.destroy();
+            if (!self._syncModel.isSyncing()) {
+              modalModel.destroy();
+            }
           }, self);
 
           self._syncModel.syncNow(self._startSync);


### PR DESCRIPTION
 - Considers the queued state as part of the syncing process so the modal doesn't immediately disappear.
 - Correctly hides the syncing modal only when the status changes to success/failure, but not when changing from queued to syncing