### PR TITLE
Fixes some minor issues with the connect with lines analysis

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines-form-model.js
@@ -53,14 +53,15 @@ module.exports = BaseAnalysisFormModel.extend({
 
     this.listenTo(this._columnOptions, 'columnsFetched', this._setSchema);
     this.listenTo(this._targetColumnOptions, 'columnsFetched', this._setSchema);
+    this.listenTo(this._analysisSourceOptionsModel, 'change:fetching', this._setSchema);
 
     this.on('change:target', this._onChangeTarget, this);
-
     this.on('change:type', this._onTypeChanged, this);
     this.on('change:order', this._setSchema, this);
     this.on('change:group', this._setSchema, this);
 
     this._setSchema();
+    this._fetchColumns();
   },
 
   _onTypeChanged: function () {
@@ -129,7 +130,10 @@ module.exports = BaseAnalysisFormModel.extend({
       target: {
         type: 'NodeDataset',
         title: _t('editor.layers.analysis-form.target-column'),
-        options: this._getSourceOptionsForSource('target', '*'),
+        options: this._getSourceOptionsForSource('target', 'point'),
+        editorAttrs: {
+          disabled: this._isSourceDisabled('target')
+        },
         validators: ['required']
       },
       target_column: {
@@ -140,7 +144,7 @@ module.exports = BaseAnalysisFormModel.extend({
       target_source_column: {
         type: 'Select',
         title: _t('editor.layers.analysis-form.target-column'),
-        options: this._getTargetColumnOptions('target_source_column'),
+        options: this._getTargetSourceColumnOptions('target_source_column'),
         editorAttrs: {
           disabled: this._isTargetColumnDisabled()
         }
@@ -255,7 +259,7 @@ module.exports = BaseAnalysisFormModel.extend({
     return opts;
   },
 
-  _getTargetColumnOptions: function (attr) {
+  _getTargetSourceColumnOptions: function (attr) {
     var opts = this._targetColumnOptions.all();
 
     if (this._targetColumnOptions.get('columnsFetched') && this.get(attr)) {
@@ -291,9 +295,7 @@ module.exports = BaseAnalysisFormModel.extend({
   _getSourceOptionsForSource: function (sourceAttrName, requiredSimpleGeometryType) {
     var currentSource = this.get(sourceAttrName);
 
-    if (this._isPrimarySource(sourceAttrName)) {
-      return [currentSource];
-    } else if (this._isFetchingOptions()) {
+    if (this._isFetchingOptions()) {
       return [{
         val: currentSource,
         label: _t('editor.layers.analysis-form.loading'),
@@ -301,13 +303,12 @@ module.exports = BaseAnalysisFormModel.extend({
       }];
     } else {
       // fetched
-      var sourceId = this._layerDefinitionModel.get('source');
+      var source = this._getSourceOption()[0];
       return this._analysisSourceOptionsModel
-        .getSelectOptions(requiredSimpleGeometryType)
-        .filter(function (d) {
-          // Can't select own layer as source, so exclude it
-          return d.val !== sourceId;
-        });
+      .getSelectOptions(requiredSimpleGeometryType)
+      .filter(function (d) {
+        return d.val !== source.val && d.val !== source.layerName;
+      });
     }
   },
 
@@ -325,5 +326,9 @@ module.exports = BaseAnalysisFormModel.extend({
 
   _isTargetColumnDisabled: function () {
     return !this._targetColumnOptions.get('columnsFetched');
+  },
+
+  _isSourceDisabled: function (sourceAttrName) {
+    return this._isPrimarySource(sourceAttrName) || this._isFetchingOptions();
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-sequential.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-sequential.js
@@ -7,7 +7,6 @@ module.exports = {
   parametersDataSchema: 'order,order_column,order_type',
 
   parse: function (nodeAttrs) {
-
     return {
       type: 'line-sequential',
       order: !!nodeAttrs.order_column,

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-sequential.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-sequential.js
@@ -16,6 +16,9 @@ module.exports = {
   },
 
   formatAttrs: function (formAttrs, columnOptions) {
+    if (!formAttrs.order) {
+      formAttrs = _.omit(formAttrs, ['order_column', 'order_type']);
+    }
     formAttrs = _.omit(formAttrs, 'order');
     return formAttrs;
   }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-sequential.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-sequential.js
@@ -7,9 +7,10 @@ module.exports = {
   parametersDataSchema: 'order,order_column,order_type',
 
   parse: function (nodeAttrs) {
+
     return {
       type: 'line-sequential',
-      order: !nodeAttrs.order_column,
+      order: !!nodeAttrs.order_column,
       order_column: nodeAttrs.order_column,
       order_type: nodeAttrs.order_type
     };

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-source-to-target.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-source-to-target.js
@@ -19,6 +19,11 @@ module.exports = {
 
   formatAttrs: function (formAttrs, columnOptions) {
     formAttrs.target_column = formAttrs.target_source_column;
+
+    if (!formAttrs.group) {
+      formAttrs = _.omit(formAttrs, ['source_column', 'target_column']);
+    }
+
     formAttrs = _.omit(formAttrs, ['target_source_column', 'group']);
     return formAttrs;
   }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-source-to-target.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/connect-with-lines/line-source-to-target.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   formatAttrs: function (formAttrs, columnOptions) {
-    formAttrs.target_source = formAttrs.target_source_column;
+    formAttrs.target_column = formAttrs.target_source_column;
     formAttrs = _.omit(formAttrs, ['target_source_column', 'group']);
     return formAttrs;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.25",
+  "version": "4.1.26",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.26",
+  "version": "4.1.27",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR: 

* Closes #9593 with [this](https://github.com/CartoDB/cartodb/pull/9601/files#diff-17c52b0a9555ef45691c0934f41b8952R56) (Target column in the connect with lines analysis doesn't stop loading fields)
* Closes #9590 with [this](https://github.com/CartoDB/cartodb/pull/9601/files#diff-161bf874b8d9259fe8fbf3265215fa00R12) (Connect with lines "sequential" analysis shows the order input checked by default )
* Closes #9600 with [this](https://github.com/CartoDB/cartodb/pull/9601/files#diff-e0644e71f9b7e5e12cd7aa85dee54038R21) (Doesn't return the target_column_value) 
* Closes #9602 with [this](https://github.com/CartoDB/cartodb/pull/9601/files#diff-e0644e71f9b7e5e12cd7aa85dee54038R21) and [this](https://github.com/CartoDB/cartodb/pull/9601/files#diff-161bf874b8d9259fe8fbf3265215fa00R19) (avoid sending disabled params for the `line-source-to-target` and `line-sequential` analysis)

It also fixes an issue where the `target` combo was showing polygons and not just points (with [this](https://github.com/CartoDB/cartodb/pull/9601/files#diff-17c52b0a9555ef45691c0934f41b8952R133))