### PR TITLE
Fetch the row if the geometry is not loaded.

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/table/body/table-body-view.js
+++ b/lib/assets/javascripts/cartodb3/components/table/body/table-body-view.js
@@ -341,13 +341,7 @@ module.exports = CoreView.extend({
     }
   },
 
-  _editCell: function (rowModel, attribute) {
-    // If geom is not fetched, then bring the complete row information and wait
-    if (!rowModel.isGeomLoaded()) {
-      this._fetchRow(rowModel, attribute);
-      return;
-    }
-
+  _doCellEdition: function (rowModel, attribute) {
     var $tableRow = this.$('[data-model="' + rowModel.cid + '"]');
     var $tableCell = $tableRow.find('[data-attribute="' + attribute + '"]');
     var $options = $tableCell.find('.js-options');
@@ -402,6 +396,11 @@ module.exports = CoreView.extend({
       },
       position
     );
+  },
+
+  _editCell: function (rowModel, attribute) {
+    var callback = this._doCellEdition.bind(this, rowModel, attribute);
+    rowModel.fetchRowIfGeomIsNotLoaded(callback);
   },
 
   _removeRow: function (rowModel) {

--- a/lib/assets/javascripts/cartodb3/components/table/body/table-body-view.js
+++ b/lib/assets/javascripts/cartodb3/components/table/body/table-body-view.js
@@ -342,6 +342,12 @@ module.exports = CoreView.extend({
   },
 
   _editCell: function (rowModel, attribute) {
+    // If geom is not fetched, then bring the complete row information and wait
+    if (!rowModel.isGeomLoaded()) {
+      this._fetchRow(rowModel, attribute);
+      return;
+    }
+
     var $tableRow = this.$('[data-model="' + rowModel.cid + '"]');
     var $tableCell = $tableRow.find('[data-attribute="' + attribute + '"]');
     var $options = $tableCell.find('.js-options');
@@ -434,6 +440,15 @@ module.exports = CoreView.extend({
     this.$('.js-tbody').animate({
       scrollTop: tbodyHeight
     }, 'slow');
+  },
+
+  _fetchRow: function (rowModel, attribute) {
+    // This method is call from the editCell call, so in order to complete the flow
+    // we call it back again when the row is fetched
+    var cb = this._editCell.bind(this, rowModel, attribute);
+    rowModel.fetch({
+      success: cb
+    });
   },
 
   clean: function () {

--- a/lib/assets/javascripts/cartodb3/components/table/body/table-body-view.js
+++ b/lib/assets/javascripts/cartodb3/components/table/body/table-body-view.js
@@ -441,15 +441,6 @@ module.exports = CoreView.extend({
     }, 'slow');
   },
 
-  _fetchRow: function (rowModel, attribute) {
-    // This method is call from the editCell call, so in order to complete the flow
-    // we call it back again when the row is fetched
-    var cb = this._editCell.bind(this, rowModel, attribute);
-    rowModel.fetch({
-      success: cb
-    });
-  },
-
   clean: function () {
     this._destroyScrollBinding();
     CoreView.prototype.clean.apply(this);

--- a/lib/assets/javascripts/cartodb3/data/query-row-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-row-model.js
@@ -1,15 +1,6 @@
 var Backbone = require('backbone');
 var _ = require('underscore');
 
-var WKT_TYPES = [
-  'POINT',
-  'LINESTRING',
-  'POLYGON',
-  'MULTIPOINT',
-  'MULTILINESTRING',
-  'MULTIPOLYGON'
-];
-
 module.exports = Backbone.Model.extend({
 
   // In case that there is already an id attribute
@@ -49,8 +40,12 @@ module.exports = Backbone.Model.extend({
   },
 
   isGeomLoaded: function () {
-    var geojson = this.get('the_geom');
-    return !_.contains(WKT_TYPES, geojson);
+    try {
+      JSON.parse(this.get('the_geom'));
+      return true;
+    } finally {
+      return false;
+    }
   },
 
   fetchRowIfGeomIsNotLoaded: function (callback) {

--- a/lib/assets/javascripts/cartodb3/data/query-row-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-row-model.js
@@ -1,6 +1,15 @@
 var Backbone = require('backbone');
 var _ = require('underscore');
 
+var WKT_TYPES = [
+  'POINT',
+  'LINESTRING',
+  'POLYGON',
+  'MULTIPOINT',
+  'MULTILINESTRING',
+  'MULTIPOLYGON'
+];
+
 module.exports = Backbone.Model.extend({
 
   // In case that there is already an id attribute
@@ -37,6 +46,11 @@ module.exports = Backbone.Model.extend({
 
   isNew: function () {
     return !this.has('cartodb_id');
+  },
+
+  isGeomLoaded: function () {
+    var geojson = this.get('the_geom');
+    return !_.contains(WKT_TYPES, geojson);
   },
 
   _onError: function () {

--- a/lib/assets/javascripts/cartodb3/data/query-row-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-row-model.js
@@ -43,7 +43,7 @@ module.exports = Backbone.Model.extend({
     try {
       JSON.parse(this.get('the_geom'));
       return true;
-    } finally {
+    } catch (e) {
       return false;
     }
   },

--- a/lib/assets/javascripts/cartodb3/data/query-row-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-row-model.js
@@ -53,6 +53,17 @@ module.exports = Backbone.Model.extend({
     return !_.contains(WKT_TYPES, geojson);
   },
 
+  fetchRowIfGeomIsNotLoaded: function (callback) {
+    if (this.isGeomLoaded()) {
+      callback();
+      return;
+    }
+
+    this.fetch({
+      success: callback
+    });
+  },
+
   _onError: function () {
     this.set(this.previousAttributes());
   },


### PR DESCRIPTION
This PR fixes #9592.

It fetches the row information when the geom is not loaded, that happens for polygons and lines, but not points. It uses the same approach as we had in the editor.

cc @gfiorav @xavijam 