### PR TITLE
Centroid Analysis UI should have aggregation in a separated step

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/centroid-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/centroid-form-model.js
@@ -4,7 +4,7 @@ var template = require('./centroid-form.tpl');
 var ColumnOptions = require('../column-options');
 
 var FORMAT_FIELD_NAMES = 'category_column,aggregation,aggregation_column,weight_column';
-var FIELDS = 'category,aggregate,weight';
+var PARAMETERS_DATA_FIELDS = 'source,category,weight';
 
 /**
  * Form model for a centroid and weighted-centroid analysis
@@ -76,7 +76,7 @@ module.exports = BaseAnalysisFormModel.extend({
 
   getTemplateData: function () {
     return {
-      parametersDataFields: FIELDS
+      parametersDataFields: PARAMETERS_DATA_FIELDS
     };
   },
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/centroid-form.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/centroid-form.tpl
@@ -1,7 +1,7 @@
 <form>
   <div class="Editor-HeaderInfo">
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">2</div>
-    <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source">
+    <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="<%= parametersDataFields %>">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
         <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('analyses.centroid.title') %></h2>
       </div>
@@ -10,11 +10,11 @@
   </div>
   <div class="Editor-HeaderInfo">
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">3</div>
-    <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="<%= parametersDataFields %>">
+    <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="aggregate">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
-        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('editor.layers.analysis-form.parameters') %></h2>
+        <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('editor.layers.analysis-form.value-aggregation') %></h2>
       </div>
-      <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--xl"><%- _t('editor.layers.analysis-form.tune-centroid') %></p>
+      <p class="CDB-Text u-upperCase CDB-FontSize-small u-altTextColor u-bSpace--xl"><%- _t('editor.layers.analysis-form.value-aggregation-centroids') %></p>
     </div>
   </div>
 </form>

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1469,6 +1469,7 @@
         "value": "Value",
         "value-aggregation": "Value aggregation",
         "value-aggregation-desc": "Aggregate the desired value in your polygon(s)",
+        "value-aggregation-centroids": "Aggregate the desired value in your centroid(s)",
         "walk": "Walk",
         "weight": "Weight",
         "weight-column": "Weight column",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.25",
+  "version": "4.1.26",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.28",
+  "version": "4.1.29",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #9589

This PR moves the aggregation option to it's own section, as in the original design: 

![screen shot 2016-08-29 at 17 06 03](https://cloud.githubusercontent.com/assets/4933/18056297/9b5e9ad2-6e0b-11e6-8a0d-6110b8d1f5d5.png)

CR: @nobuti 
CC: @saleiva 
