### PR TITLE
Disable the option of adding widgets if no geometry data

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-widgets/create-tuples-items.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-widgets/create-tuples-items.js
@@ -26,6 +26,7 @@ module.exports = function (analysisDefinitionNodesCollection, layerDefinitionsCo
 
       var querySchemaModel = nodeDefModel.querySchemaModel;
       if (!querySchemaModel) return tuplesItems;
+      if (!querySchemaModel.hasGeometryData()) return tuplesItems;
 
       querySchemaModel.columnsCollection.each(function (m) {
         var columnName = m.get('name');

--- a/lib/assets/javascripts/cartodb3/data/query-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/data/query-schema-model.js
@@ -12,6 +12,13 @@ var PARAMS = {
   page: 0
 };
 
+var STATUS = {
+  unavailable: 'unavailable',
+  unfetched: 'unfetched',
+  fetching: 'fetching',
+  fetched: 'fetched'
+};
+
 /**
  * Model to represent a schema of a SQL query.
  */
@@ -19,7 +26,7 @@ module.exports = Backbone.Model.extend({
 
   defaults: {
     query: '',
-    status: 'unavailable', // , unfetched, fetching, fetched
+    status: STATUS.unavailable, // , unfetched, fetching, fetched
     ready: false, // until true there's no data available on the table(s) used in the query,
     simple_geom: undefined // may be known before ready (e.g. persisted from a previos app life-cycle)
   },
@@ -44,7 +51,7 @@ module.exports = Backbone.Model.extend({
   },
 
   isFetched: function () {
-    return this.get('status') === 'fetched';
+    return this.get('status') === STATUS.fetched;
   },
 
   canFetch: function () {
@@ -54,7 +61,7 @@ module.exports = Backbone.Model.extend({
   fetch: function (opts) {
     if (!this.canFetch()) return;
 
-    this.set('status', 'fetching');
+    this.set('status', STATUS.fetching);
 
     opts = opts || {};
     var errorCallback = opts && opts.error;
@@ -75,7 +82,7 @@ module.exports = Backbone.Model.extend({
       errorCallback && errorCallback(error);
       this.set({
         query_errors: error,
-        status: 'unavailable'
+        status: STATUS.unavailable
       });
     }.bind(this);
 
@@ -97,9 +104,13 @@ module.exports = Backbone.Model.extend({
     var geometry = rawGeom && createGeometry(rawGeom);
 
     return {
-      status: 'fetched',
+      status: STATUS.fetched,
       simple_geom: geometry && geometry.getSimpleType()
     };
+  },
+
+  hasGeometryData: function () {
+    return this.get('status') === STATUS.fetched && this.get('simple_geom') != null;
   },
 
   /**

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -17,8 +17,6 @@ var STATES = {
 };
 
 module.exports = CoreView.extend({
-  className: 'Editor-dataContent',
-
   initialize: function (opts) {
     if (!opts.widgetDefinitionsCollection) throw new Error('widgetDefinitionsCollection is required');
     if (!opts.columnsModel) throw new Error('columnsModel is required');
@@ -73,7 +71,6 @@ module.exports = CoreView.extend({
   },
 
   _showError: function () {
-    this.$el.empty();
     this.$el.append(
       dataErrorTemplate({
         body: _t('editor.error-query.body', {
@@ -86,7 +83,6 @@ module.exports = CoreView.extend({
   },
 
   _showNoGeometryData: function () {
-    this.$el.empty();
     this.$el.append(
       dataErrorTemplate({
         body: _t('editor.no-geometry-data')

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -48,12 +48,16 @@ module.exports = CoreView.extend({
     this.clearSubViews();
     this.$el.empty();
 
-    if (this._hasError()) {
-      this._showError();
-    } else if (this._isLoading()) {
-      this._showLoading();
-    } else if (this._isReady()) {
-      this._renderStats();
+    if (!this.querySchemaModel.hasGeometryData()) {
+      this._showNoGeometryData();
+    } else {
+      if (this._hasError()) {
+        this._showError();
+      } else if (this._isLoading()) {
+        this._showLoading();
+      } else if (this._isReady()) {
+        this._renderStats();
+      }
     }
 
     return this;
@@ -81,6 +85,15 @@ module.exports = CoreView.extend({
     );
   },
 
+  _showNoGeometryData: function () {
+    this.$el.empty();
+    this.$el.append(
+      dataErrorTemplate({
+        body: _t('editor.no-geometry-data')
+      })
+    );
+  },
+
   _getInitialState: function () {
     return this._columnsReady() ? STATES.ready : STATES.loading;
   },
@@ -102,6 +115,9 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
+    this.querySchemaModel.on('change:simple_geom', this.render, this);
+    this.add_related_model(this.querySchemaModel);
+
     this._columnsModel.on('change:render', this._handleStats, this);
     this.add_related_model(this._columnsModel);
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-content-view.js
@@ -85,7 +85,7 @@ module.exports = CoreView.extend({
   _showNoGeometryData: function () {
     this.$el.append(
       dataErrorTemplate({
-        body: _t('editor.no-geometry-data')
+        body: _t('editor.data.no-geometry-data')
       })
     );
   },

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widget-content-error.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widget-content-error.tpl
@@ -1,0 +1,3 @@
+<h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor">
+  <%= body %>
+</h2>

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
@@ -3,6 +3,7 @@ var template = require('./widgets-view.tpl');
 var widgetPlaceholderTemplate = require('./widgets-placeholder.tpl');
 var CoreView = require('backbone/core-view');
 var $ = require('jquery');
+var widgetsErrorTemplate = require('./widget-content-error.tpl');
 
 require('jquery-ui');
 
@@ -32,14 +33,36 @@ module.exports = CoreView.extend({
   render: function () {
     this._destroySortable();
     this.clearSubViews();
-    if (this._widgetDefinitionsCollection.size() > 0) {
-      this.$el.html(template);
-      this._widgetDefinitionsCollection.each(this._addWidgetItem, this);
-      this._initSortable();
+
+    if (!this._anyGeometryData()) {
+      this._showNoGeometryData();
     } else {
-      this.$el.append(widgetPlaceholderTemplate());
+      if (this._widgetDefinitionsCollection.size() > 0) {
+        this.$el.html(template);
+        this._widgetDefinitionsCollection.each(this._addWidgetItem, this);
+        this._initSortable();
+      } else {
+        this.$el.append(widgetPlaceholderTemplate());
+      }
     }
     return this;
+  },
+
+  _showNoGeometryData: function () {
+    this.$el.append(
+      widgetsErrorTemplate({
+        body: _t('editor.no-geometry-data')
+      })
+    );
+  },
+
+  _anyGeometryData: function () {
+    return this._layerDefinitionsCollection.filter(function (layerDefModel) {
+      return layerDefModel.isDataLayer();
+    }).some(function (layerDefModel) {
+      var querySchemaModel = layerDefModel.getAnalysisDefinitionNodeModel().querySchemaModel;
+      return querySchemaModel && querySchemaModel.hasGeometryData();
+    });
   },
 
   _initSortable: function () {

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
@@ -57,6 +57,7 @@ module.exports = CoreView.extend({
   },
 
   _anyGeometryData: function () {
+    // we work with _layerDefinitionsCollection instead of analysis collection
     return this._layerDefinitionsCollection.filter(function (layerDefModel) {
       return layerDefModel.isDataLayer();
     }).some(function (layerDefModel) {

--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-view.js
@@ -51,7 +51,7 @@ module.exports = CoreView.extend({
   _showNoGeometryData: function () {
     this.$el.append(
       widgetsErrorTemplate({
-        body: _t('editor.no-geometry-data')
+        body: _t('editor.widgets.no-geometry-data')
       })
     );
   },

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1123,7 +1123,6 @@
       "body": "Errors found in your SQL query. %{action} before continuing.",
       "label": "Fix them"
     },
-    "no-geometry-data": "Unfortunately, widgets require geometry data in your dataset.",
     "settings": {
       "menu-tab-pane-labels": {
         "preview": "Preview",
@@ -1524,6 +1523,7 @@
       }
     },
     "data": {
+      "no-geometry-data": "Your dataset doesn't contain any geometry data.",
       "stats": {
         "add-widget": "Add as a widget",
         "edit": "EDIT",
@@ -1741,6 +1741,7 @@
       }
     },
     "widgets": {
+      "no-geometry-data": "Your dataset lacks of geometry data and it's not possible to add a widget.",
       "options": {
         "remove": "Delete...",
         "rename": "Rename",

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1123,7 +1123,7 @@
       "body": "Errors found in your SQL query. %{action} before continuing.",
       "label": "Fix them"
     },
-
+    "no-geometry-data": "Unfortunately, widgets require geometry data in your dataset.",
     "settings": {
       "menu-tab-pane-labels": {
         "preview": "Preview",

--- a/lib/assets/test/spec/cartodb3/components/modals/add-widgets/create-tuples-items.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-widgets/create-tuples-items.spec.js
@@ -9,33 +9,33 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
     var configModel = new ConfigModel({
       base_url: '/u/pepe'
     });
-    var analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
+    this.analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
       configModel: configModel
     });
 
-    analysisDefinitionNodesCollection.add({
+    this.analysisDefinitionNodesCollection.add({
       id: 'a0',
       type: 'source',
       query: 'SELECT * FROM table_name'
     });
-    analysisDefinitionNodesCollection.add({
+    this.analysisDefinitionNodesCollection.add({
       id: 'b0',
       type: 'source',
       query: 'SELECT * FROM table_name_two'
     });
-    analysisDefinitionNodesCollection.add({
+    this.analysisDefinitionNodesCollection.add({
       id: 'a1',
       type: 'buffer',
       radio: 300,
       source: 'a0'
     });
-    analysisDefinitionNodesCollection.add({
+    this.analysisDefinitionNodesCollection.add({
       id: 'b1',
       type: 'buffer',
       radio: 300,
       source: 'a1'
     });
-    analysisDefinitionNodesCollection.add({
+    this.analysisDefinitionNodesCollection.add({
       id: 'secondary_source', // created when selecting secondary nodes, so technically orphaned if not used later.
       type: 'source',
       query: 'SELECT * FROM secondary_source'
@@ -60,11 +60,11 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
       }
     ], {
       configModel: configModel,
-      analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
+      analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
       mapId: 'm-123'
     });
 
-    var a1 = analysisDefinitionNodesCollection.get('a1');
+    var a1 = this.analysisDefinitionNodesCollection.get('a1');
     a1.querySchemaModel.columnsCollection.reset([
       {
         name: 'cartodb_id',
@@ -89,7 +89,7 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
         type: 'date'
       }
     ]);
-    var b1 = analysisDefinitionNodesCollection.get('b1');
+    var b1 = this.analysisDefinitionNodesCollection.get('b1');
     b1.querySchemaModel.columnsCollection.reset([
       {
         name: 'cartodb_id',
@@ -99,7 +99,7 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
         type: 'number'
       }
     ]);
-    var secondary = analysisDefinitionNodesCollection.get('secondary_source');
+    var secondary = this.analysisDefinitionNodesCollection.get('secondary_source');
     secondary.querySchemaModel.columnsCollection.reset([
       {
         name: 'only_for_secondary',
@@ -107,7 +107,15 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
       }
     ]);
 
-    this.tuplesItems = createTuplesItems(analysisDefinitionNodesCollection, this.layerDefinitionsCollection);
+    a1.querySchemaModel.hasGeometryData = function () {
+      return true;
+    };
+
+    b1.querySchemaModel.hasGeometryData = function () {
+      return true;
+    };
+
+    this.tuplesItems = createTuplesItems(this.analysisDefinitionNodesCollection, this.layerDefinitionsCollection);
   });
 
   it('should return an object', function () {
@@ -125,6 +133,18 @@ describe('components/modals/add-widgets/create-tuples-items', function () {
     expect(keys).not.toContain('the_geom_webmercator');
     expect(keys).not.toContain('created_at');
     expect(keys).not.toContain('updated_at');
+  });
+
+  it('should not contain a tuple when no geometry data', function () {
+    var b1 = this.analysisDefinitionNodesCollection.get('b1');
+    b1.querySchemaModel.hasGeometryData = function () {
+      return false;
+    };
+    this.tuplesItems = createTuplesItems(this.analysisDefinitionNodesCollection, this.layerDefinitionsCollection);
+
+    var tuples = this.tuplesItems['pop_count-number'];
+    expect(tuples.length).toBe(1);
+    expect(tuples[0].layerDefinitionModel.id).toEqual('l1');
   });
 
   it('should contain a tuple of column+layer definition in each item', function () {

--- a/lib/assets/test/spec/cartodb3/editor/editor-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/editor-view.spec.js
@@ -20,6 +20,13 @@ describe('editor/editor-view', function () {
       configModel: {}
     });
 
+    this.analysisDefinitionNodeModel = new Backbone.Model();
+    this.analysisDefinitionNodeModel.querySchemaModel = new Backbone.Model();
+    this.analysisDefinitionNodeModel.querySchemaModel.hasGeometryData = function () {
+      return true;
+    };
+    spyOn(this.layerDefinitionModel, 'getAnalysisDefinitionNodeModel').and.returnValue(this.analysisDefinitionNodeModel);
+
     var privacyCollection = new PrivacyCollection([{
       privacy: 'PUBLIC',
       title: 'Public',

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
@@ -8,6 +8,8 @@ var QuerySchemaModel = require('../../../../../../../javascripts/cartodb3/data/q
 
 describe('editor/layers/layers-content-view/data/data-content-view', function () {
   var view;
+  var layerDefinitionModel;
+  var querySchemaModel;
 
   beforeEach(function () {
     var configModel = new ConfigModel({
@@ -20,9 +22,23 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
       configModel: configModel
     });
 
-    var layerDefinitionModel = new Backbone.Model();
+    querySchemaModel = new QuerySchemaModel({
+      query: 'SELECT * FROM table',
+      status: 'fetched'
+    }, {
+      configModel: {}
+    });
+
+    querySchemaModel.hasGeometryData = function () {
+      return true;
+    };
+
+    var analysisDefinitionNodeModel = new Backbone.Model();
+    analysisDefinitionNodeModel.querySchemaModel = querySchemaModel;
+
+    layerDefinitionModel = new Backbone.Model();
     layerDefinitionModel.getAnalysisDefinitionNodeModel = function () {
-      return new Backbone.Model();
+      return analysisDefinitionNodeModel;
     };
 
     var widgetDefinitionsCollection = new Backbone.Collection([
@@ -82,13 +98,6 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
       }
     };
 
-    var querySchemaModel = new QuerySchemaModel({
-      query: 'SELECT * FROM table',
-      status: 'fetched'
-    }, {
-      configModel: {}
-    });
-
     view = new DataContentView({
       widgetDefinitionsCollection: widgetDefinitionsCollection,
       stackLayoutModel: stackLayoutModel,
@@ -109,6 +118,14 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
   it('should render "placeholder" if loading', function () {
     view.modelView.set({state: 'loading'});
     expect(view.$('.FormPlaceholder-paragraph').length).toBe(4);
+    expect(_.keys(view._subviews).length).toBe(0);
+  });
+
+  it('should render no geometry view if no data', function () {
+    spyOn(view.querySchemaModel, 'hasGeometryData').and.returnValue(false);
+    view.render();
+
+    expect(view.$el.text()).toContain('editor.no-geometry-data');
     expect(_.keys(view._subviews).length).toBe(0);
   });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/data/data-content-view.spec.js
@@ -125,7 +125,7 @@ describe('editor/layers/layers-content-view/data/data-content-view', function ()
     spyOn(view.querySchemaModel, 'hasGeometryData').and.returnValue(false);
     view.render();
 
-    expect(view.$el.text()).toContain('editor.no-geometry-data');
+    expect(view.$el.text()).toContain('editor.data.no-geometry-data');
     expect(_.keys(view._subviews).length).toBe(0);
   });
 

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
@@ -21,6 +21,13 @@ describe('editor/widgets/widgets-view', function () {
       configModel: this.configModel
     });
 
+    this.analysisDefinitionNodeModel = new Backbone.Model();
+    this.analysisDefinitionNodeModel.querySchemaModel = new Backbone.Model();
+    this.analysisDefinitionNodeModel.querySchemaModel.hasGeometryData = function () {
+      return true;
+    };
+    spyOn(this.model, 'getAnalysisDefinitionNodeModel').and.returnValue(this.analysisDefinitionNodeModel);
+
     this.widgetDefinitionsCollection = new Backbone.Collection();
     this.layerDefinitionsCollection = new Backbone.Collection([
       this.model

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
@@ -53,6 +53,17 @@ describe('editor/widgets/widgets-view', function () {
     this.view.render();
   });
 
+  describe('when no geometry data', function () {
+    it('should render no geometry view if no data', function () {
+      this.analysisDefinitionNodeModel.querySchemaModel.hasGeometryData = function () {
+        return false;
+      };
+      this.view.render();
+
+      expect(this.view.$el.text()).toContain('editor.widgets.no-geometry-data');
+    });
+  });
+
   describe('sortable', function () {
     beforeEach(function () {
       this.widgetDefModel1 = new WidgetDefinitionModel({


### PR DESCRIPTION
This PR fixes #9560.

![widget-geometry](https://cloud.githubusercontent.com/assets/1366843/18086652/41ba3f80-6eb1-11e6-9ce6-142e2ba30c32.gif)

If the layer (aka the dataset) doesn't include geometry data:
- the data panel view of that layer doesn't show any column to add the widgets, showing the message you see above.
- the widgets view still invites the user to add widgets, but only for those layers with geometry data in its dataset.
- when there is no geometry data at all, this view shows the message too.

@javierarce could you take a look? Also, not convinced about the message, maybe (I'm sure actually) you can improve it :)
