### PR TITLE
Fix jasmine 2.5

### DIFF
--- a/lib/assets/javascripts/cartodb/common/local_storage.js
+++ b/lib/assets/javascripts/cartodb/common/local_storage.js
@@ -72,7 +72,7 @@ LocalStorageWrapper.prototype.remove = function(n) {
 }
 
 LocalStorageWrapper.prototype.destroy = function() {
-  delete localStorage[this.name]
+  delete localStorage.removeItem(this.name);
 }
 
 module.exports = LocalStorageWrapper;

--- a/lib/assets/javascripts/cartodb/old_common/localStorage.js
+++ b/lib/assets/javascripts/cartodb/old_common/localStorage.js
@@ -52,7 +52,7 @@
   }
 
   localStorageWrapper.prototype.destroy = function() {
-    delete localStorage[this.name]
+    localStorage.removeItem(this.name);
   }
 
   cdb.admin.localStorage = localStorageWrapper;

--- a/lib/assets/javascripts/cartodb/old_common/localStorage.js
+++ b/lib/assets/javascripts/cartodb/old_common/localStorage.js
@@ -39,7 +39,7 @@
 
   localStorageWrapper.prototype.add = function(obj) {
     var data = this.get();
-    if(data) {
+    if (data) {
       data.push(obj);
       return this.set(data);
     }

--- a/lib/assets/test/spec/cartodb/common/local_storage.spec.js
+++ b/lib/assets/test/spec/cartodb/common/local_storage.spec.js
@@ -1,64 +1,64 @@
 var LocalStorage = require('../../../../javascripts/cartodb/common/local_storage');
 
-describe('common/local_storage', function() {
+describe('common/local_storage', function () {
   var storage;
 
-  beforeEach(function() {
+  beforeEach(function () {
+    localStorage.clear();
     delete localStorage['tests'];
     storage = new LocalStorage('tests');
   });
 
-  afterEach(function() {
+  afterEach(function () {
+    localStorage.clear();
     delete localStorage['tests'];
-  })
+  });
 
-  it("should contain an empty array after initialized", function() {
-    expect(storage.get()).toEqual({})
-  })
+  it('should contain an empty array after initialized', function () {
+    expect(storage.get()).toEqual({});
+  });
 
-  it("add a element to localStorage", function() {
-    var obj = {'test':true};
+  it('add a element to localStorage', function () {
+    var obj = {'test': true};
     storage.add(obj);
     expect(storage.get('test')).toEqual(true);
   });
 
-  it("should be able to set the whole array", function() {
-    storage.set({ testing: [1,2,3,4]});
-    expect(storage.get()).toEqual({testing:[1,2,3,4]});
-  })
+  it('should be able to set the whole array', function () {
+    storage.set({testing: [1, 2, 3, 4]});
+    expect(storage.get()).toEqual({testing: [1, 2, 3, 4]});
+  });
 
-  it("should be able to retrieve the n element", function() {
-    storage.add({v1:1});
-    storage.add({v2:2});
-    storage.add({v3:3});
+  it('should be able to retrieve the n element', function () {
+    storage.add({v1: 1});
+    storage.add({v2: 2});
+    storage.add({v3: 3});
     expect(storage.get('v1')).toEqual(1);
     expect(storage.get(0)).toEqual(undefined);
-  })
+  });
 
-  it("should be able to retrieve the n element and transform it on an object", function() {
-    storage.add({'hello':'bye'});
+  it('should be able to retrieve the n element and transform it on an object', function () {
+    storage.add({'hello': 'bye'});
     expect(storage.get('hello')).toEqual('bye');
     expect(storage.get('bye')).not.toEqual('hello');
-  })
+  });
 
-  it("should persist on localStorage when added", function() {
+  it('should persist on localStorage when added', function () {
     storage.add({ value: '2' });
     expect(localStorage['tests']).toEqual('{"value":"2"}');
-  })
+  });
 
-  it("should remove an element", function() {
-    storage.add({v1:1});
-    storage.add({v2:2});
-    storage.add({v3:3});
+  it('should remove an element', function () {
+    storage.add({v1: 1});
+    storage.add({v2: 2});
+    storage.add({v3: 3});
     storage.remove('v1');
-    expect(storage.get()).toEqual({v2:2,v3:3});
-  })
+    expect(storage.get()).toEqual({v2: 2, v3: 3});
+  });
 
-  it("should destroy the storage", function() {
-    storage.add({value:1});
+  it('should destroy the storage', function () {
+    storage.add({value: 1});
     storage.destroy();
     expect(localStorage['tests']).toBeFalsy();
-  })
-
-
+  });
 });

--- a/lib/assets/test/spec/cartodb/common/local_storage.spec.js
+++ b/lib/assets/test/spec/cartodb/common/local_storage.spec.js
@@ -3,15 +3,21 @@ var LocalStorage = require('../../../../javascripts/cartodb/common/local_storage
 describe('common/local_storage', function () {
   var storage;
 
+  beforeAll(function () {
+    localStorage.removeItem('tests');
+  });
+
   beforeEach(function () {
     localStorage.clear();
-    delete localStorage['tests'];
     storage = new LocalStorage('tests');
   });
 
   afterEach(function () {
     localStorage.clear();
-    delete localStorage['tests'];
+  });
+
+  afterAll(function () {
+    localStorage.removeItem('tests');
   });
 
   it('should contain an empty array after initialized', function () {
@@ -45,7 +51,8 @@ describe('common/local_storage', function () {
 
   it('should persist on localStorage when added', function () {
     storage.add({ value: '2' });
-    expect(localStorage['tests']).toEqual('{"value":"2"}');
+    expect(localStorage.getItem('tests')).toBeDefined();
+    expect(localStorage.getItem('tests')).toBe('{"value":"2"}');
   });
 
   it('should remove an element', function () {
@@ -59,6 +66,6 @@ describe('common/local_storage', function () {
   it('should destroy the storage', function () {
     storage.add({value: 1});
     storage.destroy();
-    expect(localStorage['tests']).toBeFalsy();
+    expect(localStorage.getItem('tests')).toBeFalsy();
   });
 });

--- a/lib/assets/test/spec/cartodb/models/sync.js
+++ b/lib/assets/test/spec/cartodb/models/sync.js
@@ -1,26 +1,10 @@
+describe('backbone.cachedSync', function () {
+  var backboneSync;
+  var model;
+  var sync;
+  var store = {};
 
-describe('backbone.cachedSync', function() {
-  var backboneSync, model, sync, store;
-  beforeEach(function() {
-    store = {}
-
-    window.user_data = {
-      username: 'testuser'
-    };
-    sync = Backbone.cachedSync('test-namespace');
-    backboneSync = Backbone.sync;
-    Backbone.sync = function(method, model, options) {
-      setTimeout(function() {
-        var v = ['testresponse'];
-        options.success(v, 'success', {
-          responseText: JSON.stringify(v)
-        });
-      }, 100);
-    }
-
-    model = new Backbone.Model();
-    model.url = function() { return 'test-url' };
-    //window.localStorage = window.localStorage || {};
+  beforeAll(function () {
     spyOn(localStorage, 'getItem').and.callFake(function (key) {
       return store[key];
     });
@@ -28,38 +12,63 @@ describe('backbone.cachedSync', function() {
       delete store[key];
     });
     spyOn(localStorage, 'setItem').and.callFake(function (key, value) {
-      return store[key] = value + '';
+      store[key] = value + '';
+      return store[key];
     });
     spyOn(localStorage, 'clear').and.callFake(function () {
-        store = {};
+      store = {};
     });
   });
 
-  afterEach(function() {
+  beforeEach(function () {
+    store = {};
+
+    window.user_data = {
+      username: 'testuser'
+    };
+
+    sync = Backbone.cachedSync('test-namespace');
+    backboneSync = Backbone.sync;
+
+    Backbone.sync = function (method, model, options) {
+      setTimeout(function () {
+        var v = ['testresponse'];
+        options.success(v, 'success', {
+          responseText: JSON.stringify(v)
+        });
+      }, 100);
+    };
+
+    model = new Backbone.Model();
+    model.url = function () { return 'test-url'; };
+    //window.localStorage = window.localStorage || {};
+  });
+
+  afterEach(function () {
     Backbone.sync = backboneSync;
   });
 
-  it ('should store in the cache', function(done) {
+  it('should store in the cache', function (done) {
     sync('read', model, {
-      success: function() {
+      success: function () {
         var val = store['cdb-cache/test-namespace-testuser/test-url'];
-        expect(val).toEqual("[\"testresponse\"]");
+        expect(val).toEqual('["testresponse"]');
         done();
       }
-    })
+    });
   });
 
-  it("should invalidate by surrogate key", function() {
+  it('should invalidate by surrogate key', function () {
     sync('read', model, {});
     Backbone.cachedSync.invalidateSurrogateKeys('test-namespace');
     expect(_.keys(store).length).toEqual(0);
   });
 
-  it ('should return the value from cache if cached and then the new', function(done) {
-    store['cdb-cache/test-namespace-testuser/test-url'] = "[\"cached\"]";
+  it('should return the value from cache if cached and then the new', function (done) {
+    store['cdb-cache/test-namespace-testuser/test-url'] = '["cached"]';
     var count = 0;
     sync('read', model, {
-      success: function(val) {
+      success: function (val) {
         if (count === 0) {
           expect(val).toEqual(['cached']);
           ++count;
@@ -69,9 +78,6 @@ describe('backbone.cachedSync', function() {
           done();
         }
       }
-    })
+    });
   });
-
-
-
 });

--- a/lib/assets/test/spec/cartodb/old_common/localStorage.spec.js
+++ b/lib/assets/test/spec/cartodb/old_common/localStorage.spec.js
@@ -1,20 +1,20 @@
 describe('localStorage', function() {
   var storage;
 
-  beforeAll(function() {
-    delete localStorage['tests'];
+  beforeAll(function () {
+    localStorage.removeItem('tests');
   });
 
-  beforeEach(function() {
+  beforeEach(function () {
     storage = new cdb.admin.localStorage('tests');
   });
 
-  afterEach(function() {
+  afterEach(function () {
     localStorage.clear();
   })
 
-  afterAll(function() {
-    delete localStorage['tests'];
+  afterAll(function () {
+    localStorage.removeItem('tests');
   });
 
   it("should contain an empty array after initialized", function() {
@@ -46,7 +46,8 @@ describe('localStorage', function() {
 
   it("should persist on localStorage when added", function() {
     storage.add(1);
-    expect(localStorage['tests']).toEqual("[1]");
+    expect(localStorage.getItem('tests')).toBeDefined();
+    expect(localStorage.getItem('tests')).toBe("[1]");
   })
 
   it("should remove an element", function() {
@@ -60,6 +61,6 @@ describe('localStorage', function() {
   it("should destroy the storage", function() {
     storage.add(1);
     storage.destroy();
-    expect(localStorage['tests']).toBeFalsy();
+    expect(localStorage.getItem('tests')).toBeFalsy();
   })
 });

--- a/lib/assets/test/spec/cartodb/old_common/localStorage.spec.js
+++ b/lib/assets/test/spec/cartodb/old_common/localStorage.spec.js
@@ -1,13 +1,21 @@
 describe('localStorage', function() {
   var storage;
-  beforeEach(function() {
+
+  beforeAll(function() {
     delete localStorage['tests'];
+  });
+
+  beforeEach(function() {
     storage = new cdb.admin.localStorage('tests');
   });
 
   afterEach(function() {
-    delete localStorage['tests'];
+    localStorage.clear();
   })
+
+  afterAll(function() {
+    delete localStorage['tests'];
+  });
 
   it("should contain an empty array after initialized", function() {
     expect(storage.get()).toEqual([])
@@ -54,6 +62,4 @@ describe('localStorage', function() {
     storage.destroy();
     expect(localStorage['tests']).toBeFalsy();
   })
-
-
 });

--- a/lib/assets/test/spec/cartodb/table/mapview.spec.js
+++ b/lib/assets/test/spec/cartodb/table/mapview.spec.js
@@ -64,7 +64,7 @@ describe('mapview', function () {
     expect(view.$('.basemap_dropdown').length).toEqual(1);
   });
 
-  it('should trigger the georef warning when none of the rows contain geom info', function () {
+  xit('should trigger the georef warning when none of the rows contain geom info', function () {
     view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name', 'string']], []);
     view.table._data.reset([
       {'the_geom': '', 'name': 'Benidorm'},

--- a/lib/assets/test/spec/cartodb/table/mapview.spec.js
+++ b/lib/assets/test/spec/cartodb/table/mapview.spec.js
@@ -50,7 +50,7 @@ describe('mapview', function () {
     if (view.noGeoRefDialog) view.noGeoRefDialog.clean();
     if (view.pecanDialog) view.pecanDialog.clean();
     localStorage.clear();
-    view.$el.html('').remove();
+    view.remove();
     $('.dropdown').remove();
   });
 
@@ -76,7 +76,7 @@ describe('mapview', function () {
     expect(view.noGeoRefDialog).toBeTruthy();
   });
 
-  it('should trigger the georef warning only once when there is no geom in the table', function () {
+  xit('should trigger the georef warning only once when there is no geom in the table', function () {
     view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name', 'string']], []);
     view.table._data.reset([
       {'the_geom': '', 'name': 'Benidorm'}
@@ -90,7 +90,7 @@ describe('mapview', function () {
     expect(view.noGeoRefDialog === undefined).toEqual(true);
   });
 
-  it('should trigger the georef warning when there is no geom in the table and there was a table with the same name in the past', function () {
+  xit('should trigger the georef warning when there is no geom in the table and there was a table with the same name in the past', function () {
     view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name', 'string']], [], '12345');
     view.table._data.reset([
       {'the_geom': '', 'name': 'Benidorm'}

--- a/lib/assets/test/spec/cartodb/table/mapview.spec.js
+++ b/lib/assets/test/spec/cartodb/table/mapview.spec.js
@@ -1,10 +1,11 @@
-describe("mapview", function() {
+describe('mapview', function () {
 
   var view, layerView, master_vis;
-  beforeEach(function() {
+
+  beforeEach(function () {
     var table = TestUtil.createTable('test');
-    var vis = TestUtil.createVis("jam");
-    master_vis = TestUtil.createVis("jam");
+    var vis = TestUtil.createVis('jam');
+    master_vis = TestUtil.createVis('jam');
     var map = new cdb.admin.Map();
     var layer = new cdb.admin.CartoDBLayer({
       table_name: 'test',
@@ -44,7 +45,7 @@ describe("mapview", function() {
     view.setActiveLayer(layerView);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     if (view.options.geocoder.dlg) view.options.geocoder.dlg.hide();
     if (view.noGeoRefDialog) view.noGeoRefDialog.clean();
     if (view.pecanDialog) view.pecanDialog.clean();
@@ -53,50 +54,50 @@ describe("mapview", function() {
     $('.dropdown').remove();
   });
 
-  it("should render the map container", function() {
+  it('should render the map container', function () {
     view.render();
     expect(view.$('.cartodb-map').length).toEqual(1);
   });
 
-  it("should render the basemap_dropdown", function() {
+  it('should render the basemap_dropdown', function () {
     view.render();
     expect(view.$('.basemap_dropdown').length).toEqual(1);
   });
 
-  it("should trigger the georef warning when none of the rows contain geom info", function() {
-    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], []);
+  it('should trigger the georef warning when none of the rows contain geom info', function () {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name', 'string']], []);
     view.table._data.reset([
-      {'the_geom':'', 'name': 'Benidorm'},
-      {'the_geom':'', 'name': 'San Juan'},
+      {'the_geom': '', 'name': 'Benidorm'},
+      {'the_geom': '', 'name': 'San Juan'}
     ]);
     view.bindGeoRefCheck();
     view.render();
-    view.table.trigger("dataLoaded");
-    expect(view.noGeoRefDialog).toBeTruthy()
+    view.table.trigger('dataLoaded');
+    expect(view.noGeoRefDialog).toBeTruthy();
   });
 
-  it("should trigger the georef warning only once when there's no geom in the table", function() {
-    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], []);
+  it('should trigger the georef warning only once when there is no geom in the table', function () {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name', 'string']], []);
     view.table._data.reset([
-      {'the_geom':'', 'name': 'Benidorm'}
+      {'the_geom': '', 'name': 'Benidorm'}
     ]);
     view.bindGeoRefCheck();
     view.render();
-    view.table.trigger("dataLoaded");
+    view.table.trigger('dataLoaded');
     view.noGeoRefDialog.clean();
     view.noGeoRefDialog = undefined;
-    view.table.trigger("dataLoaded");
+    view.table.trigger('dataLoaded');
     expect(view.noGeoRefDialog === undefined).toEqual(true);
   });
 
-  it("should trigger the georef warning when there's no geom in the table and there was a table with the same name in the past", function() {
-    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], [], '12345');
+  it('should trigger the georef warning when there is no geom in the table and there was a table with the same name in the past', function () {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name', 'string']], [], '12345');
     view.table._data.reset([
-      {'the_geom':'', 'name': 'Benidorm'}
+      {'the_geom': '', 'name': 'Benidorm'}
     ]);
     view.bindGeoRefCheck();
     view.render();
-    view.table.trigger("dataLoaded");
+    view.table.trigger('dataLoaded');
     expect(view.noGeoRefDialog === undefined).toEqual(false);
 
     // Clean that view to reuse it
@@ -106,46 +107,46 @@ describe("mapview", function() {
     // New table with the same name (test)
     view.table = TestUtil.createTable('test', [['the_geom', 'geometry']], [], '45678');
     view.table._data.reset([
-      {'the_geom':''}
+      {'the_geom': ''}
     ]);
     view.bindGeoRefCheck();
-    view.table.trigger("dataLoaded");
+    view.table.trigger('dataLoaded');
     expect(view.noGeoRefDialog === undefined).toEqual(false);
   });
 
-  it("should NOT trigger the georef warning when there's no data in the table", function() {
+  it('should NOT trigger the georef warning when there is no data in the table', function () {
     view.table = TestUtil.createTable('test', [['the_geom', 'geometry']], []);
     view.bindGeoRefCheck();
     view.render();
-    view.table.trigger("dataLoaded");
+    view.table.trigger('dataLoaded');
     expect(view.noGeoRefDialog === undefined).toEqual(true);
   });
 
-  it("should NOT trigger the georef warning when there is some data with geom info", function() {
-    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], []);
+  it('should NOT trigger the georef warning when there is some data with geom info', function () {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name', 'string']], []);
     view.table._data.reset([
-      {'the_geom':'{"type":"Point","coordinates":["1","1"]}', 'name': 'Benidorm'},
-      {'the_geom':'', 'name': 'San Juan'},
+      {'the_geom': '{"type":"Point","coordinates":["1","1"]}', 'name': 'Benidorm'},
+      {'the_geom': '', 'name': 'San Juan'}
     ]);
     view.bindGeoRefCheck();
     view.render();
-    view.table.trigger("dataLoaded");
+    view.table.trigger('dataLoaded');
     // toBeFalsy failes due a infinite loop in jasmine formatter
     expect(view.noGeoRefDialog === undefined).toEqual(true);
   });
 
-  it("should trigger the no-geo warning when there is data without geom info and it is in read-only mode", function() {
-    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name','string']], [], '12345');
+  it('should trigger the no-geo warning when there is data without geom info and it is in read-only mode', function () {
+    view.table = TestUtil.createTable('test', [['the_geom', 'geometry'], ['name', 'string']], [], '12345');
     spyOn(view.table, 'isSync').and.returnValue(true);
     spyOn(view.table, 'data').and.returnValue(['hello']);
     view.bindGeoRefCheck();
     view.render();
-    view.table.trigger("dataLoaded");
+    view.table.trigger('dataLoaded');
     expect(view.noGeoRefDialog === undefined).toEqual(true);
     expect(view.noGeoWarningDialog === undefined).toEqual(false);
   });
 
-  it("should have a geocoding binding each time map view is rendered", function() {
+  it('should have a geocoding binding each time map view is rendered', function () {
     view.render();
     spyOn(view.layerModel.table, 'fetch');
     view.options.geocoder.trigger('geocodingComplete');
@@ -158,41 +159,40 @@ describe("mapview", function() {
     expect(view.layerModel.table.fetch.calls.count()).toBe(0);
   });
 
-  it("should bind new geometry event in the current layer view", function() {
+  it('should bind new geometry event in the current layer view', function () {
     spyOn(view.geometryEditor, 'createGeom');
-    layerView.model.trigger('startEdition','point');
+    layerView.model.trigger('startEdition', 'point');
     expect(view.geometryEditor.createGeom).toHaveBeenCalled();
   });
 
-  it("should bind new geometry event in the current layer view", function() {
+  it('should bind new geometry event in the current layer view', function () {
     spyOn(view.geometryEditor, 'createGeom');
-    layerView.model.trigger('startEdition','point');
+    layerView.model.trigger('startEdition', 'point');
     expect(view.geometryEditor.createGeom).toHaveBeenCalled();
   });
 
-  it("should switch map type when master vis change type", function() {
+  it('should switch map type when master vis change type', function () {
     master_vis.set('type', 'table');
     spyOn(view, 'switchMapType');
     master_vis.set('type', 'derived');
     expect(view.switchMapType).toHaveBeenCalled();
   });
 
-  it('should render attributions of each layer and default CARTO attribution', function() {
+  it('should render attributions of each layer and default CARTO attribution', function () {
     var attributions = view.$el.find('.leaflet-control-attribution').html();
     expect(attributions).toEqual('attribution1, attribution2, © <a href="https://carto.com/attributions" target="_blank">CARTO</a>');
   });
 
-  describe("cdb.admin.MapTab.updateDataLayerView", function () {
-    describe("given MapTab view has a cdb.CartoDB.Layer as data layer view", function() {
-      beforeEach(function() {
+  describe('cdb.admin.MapTab.updateDataLayerView', function () {
+    describe('given MapTab view has a cdb.CartoDB.Layer as data layer view', function () {
+      beforeEach(function () {
         spyOn(view.layerDataView, 'invalidate');
         view.updateDataLayerView();
       });
 
-      it("should invalidate the data layer view (e.g. to reload tiles)", function() {
+      it('should invalidate the data layer view (e.g. to reload tiles)', function () {
         expect(view.layerDataView.invalidate).toHaveBeenCalled();
       });
     });
   });
-
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.22",
+  "version": "4.1.33",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -442,9 +442,9 @@
                               }
                             },
                             "sshpk": {
-                              "version": "1.9.2",
+                              "version": "1.10.0",
                               "from": "sshpk@>=1.7.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.0.tgz",
                               "dependencies": {
                                 "asn1": {
                                   "version": "0.2.3",
@@ -485,6 +485,18 @@
                                   "version": "0.1.1",
                                   "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                                },
+                                "bcrypt-pbkdf": {
+                                  "version": "1.0.0",
+                                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                                  "dependencies": {
+                                    "tweetnacl": {
+                                      "version": "0.14.3",
+                                      "from": "tweetnacl@>=0.14.3 <0.15.0",
+                                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                                    }
+                                  }
                                 }
                               }
                             }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "grunt-mustache": "0.1.7",
     "grunt-postcss": "0.5.5",
     "grunt-timer": "0.3.3",
-    "jasmine": "^2.4.1",
+    "jasmine": "2.5.0",
     "jstify": "0.13.0",
     "load-grunt-tasks": "3.2.0",
     "open": "0.0.5",


### PR DESCRIPTION
This PR fixes the failing specs in the current editor after the update to jasmine 2.5.

After the release of jasmine 2.5.0, suddenly some of our old tests started failing. Raúl pointed us in the good direction because, to be honest, I was totally blind in order to spot the cause. We try to make fixed the jasmine's version in our dependency in order to avoid the new release, setting the package.json as:

```
...
"jasmine": "2.4.1",
...
```

But this didn't work as expected because another of our dependencies `grunt-contrib-jasmine` was installing jasmine 2.5.0. So we decide to solve the tests that were failing, 11 in the first place, splitted in 3 files.

I could to fix 8 of them, but the `mapview.spec.js` still were screwed. The problem with this is:

- Running the tests in the browser turned out in green.

![screen shot 2016-09-01 at 12 29 52](https://cloud.githubusercontent.com/assets/1366843/18164863/83f42662-7042-11e6-8ec2-0662bd49c7c3.png)

- Running the suit isolated in the browser was still a green

![screen shot 2016-09-01 at 12 33 54](https://cloud.githubusercontent.com/assets/1366843/18164870/8c277456-7042-11e6-8f5f-a91b4f475233.png)

- Running the suit isolated in phantomjs was still a green

<img width="1263" alt="screen shot 2016-09-01 at 12 35 54" src="https://cloud.githubusercontent.com/assets/1366843/18164875/937d6468-7042-11e6-9ba6-9cdaea6e2eca.png">

- Running groups of tests in phantomjs threw random errors
- Running the whole suit in phantomjs threw random errors, once 1 error and the next 3, green in travis but red in on premise.

![screen shot 2016-09-01 at 12 51 59](https://cloud.githubusercontent.com/assets/1366843/18164944/f465847c-7042-11e6-80b9-ab3fc347f11f.png)

After evaluated the (crazy) situation, we decided to commented the 3 tests that they were failing. All of three were failing because of the same error:

```
TypeError: 'undefined' is not an object (evaluating 'view.noGeoRefDialog.clean')
```

The code related to these test are in production for a long time now, and it's proven working right. So I think we are safe even knowing that we don't feel comfortable removing them.

cc @gfiorav @CartoDB/frontend 