### PR TITLE
Allows changing the color picker color using the input fields

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
@@ -6,6 +6,11 @@ var template = require('./template.tpl');
 var Utils = require('../../../../../helpers/utils');
 
 module.exports = CoreView.extend({
+  events: {
+    'keyup .js-hex': '_onChangeHex',
+    'keyup .js-inputColor': '_onChangeColorValue',
+    'keyup .js-a': '_onChangeOpacity'
+  },
 
   initialize: function (opts) {
     var opacity = opts.opacity !== undefined && opts.opacity !== null ? opts.opacity : 1;
@@ -91,15 +96,58 @@ module.exports = CoreView.extend({
   },
 
   _onChangeColor: function () {
-    this.trigger('change', { opacity: this.model.get('opacity'), hex: this.model.get('hex') }, this);
-    this.$('.js-hex').val(this.model.get('hex').substr(1));
+    this.trigger('change', {
+      opacity: this.model.get('opacity'),
+      hex: this.model.get('hex')
+    }, this);
+
+    this.$('.js-hex').val(this.model.get('hex'));
     this.$('.js-r').val(this.model.get('r'));
     this.$('.js-g').val(this.model.get('g'));
     this.$('.js-b').val(this.model.get('b'));
     this.$('.js-a').val(this.model.get('opacity'));
   },
 
-  setColor: function (color) {
-    this.$('.js-colorPicker').colorpicker('setValue', color);
+  _onChangeOpacity: function () {
+    var opacity = +this.$('.js-a').val();
+    if (_.isNumber(opacity) && opacity >= 0 && opacity <= 1) {
+      this.setColor(this.model.get('hex'), opacity);
+    }
+  },
+
+  _onChangeColorValue: function (e) {
+    this.$(e.target).removeClass('has-error');
+
+    var r = +this.$('.js-r').val();
+    var g = +this.$('.js-g').val();
+    var b = +this.$('.js-b').val();
+
+    var hex = Utils.rgbToHex(r, g, b);
+
+    if (Utils.isValidHex(hex)) {
+      this.setColor(hex);
+    } else {
+      this.$(e.target).addClass('has-error');
+    }
+  },
+
+  _onChangeHex: function (e) {
+    this.$(e.target).removeClass('has-error');
+
+    var hex = this.$('.js-hex').val();
+
+    if (Utils.isValidHex(hex)) {
+      this.setColor(hex);
+    } else {
+      this.$(e.target).addClass('has-error');
+    }
+  },
+
+  setColor: function (hex, opacity) {
+    if (opacity === undefined) {
+      opacity = this.model.get('opacity') || 1;
+    }
+
+    this.$('.js-colorPicker').colorpicker('setValue', Utils.hexToRGBA(hex, opacity));
   }
 });

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/template.tpl
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/color-picker/template.tpl
@@ -6,15 +6,15 @@
       <span class="ColorPicker-inputLabel u-upperCase">HEX</span>
     </div>
     <div class="ColorPicker-inputWrapper">
-      <input type="text" class="CDB-InputText ColorPicker-input js-r" value="<%- r %>"/>
+      <input type="text" class="CDB-InputText ColorPicker-input js-inputColor js-r" value="<%- r %>"/>
       <span class="ColorPicker-inputLabel u-upperCase">R</span>
     </div>
     <div class="ColorPicker-inputWrapper">
-      <input type="text" class="CDB-InputText ColorPicker-input js-g" value="<%- g %>" />
+      <input type="text" class="CDB-InputText ColorPicker-input js-inputColor js-g" value="<%- g %>" />
       <span class="ColorPicker-inputLabel u-upperCase">G</span>
     </div>
     <div class="ColorPicker-inputWrapper">
-      <input type="text" class="CDB-InputText ColorPicker-input js-b" value="<%- b %>" />
+      <input type="text" class="CDB-InputText ColorPicker-input js-inputColor js-b" value="<%- b %>" />
       <span class="ColorPicker-inputLabel u-upperCase">B</span>
     </div>
     <div class="ColorPicker-inputWrapper">

--- a/lib/assets/javascripts/cartodb3/helpers/utils.js
+++ b/lib/assets/javascripts/cartodb3/helpers/utils.js
@@ -115,6 +115,30 @@ module.exports = {
   },
 
   /*
+   * rgbToHex
+   *
+   */
+  rgbToHex: function (r, g, b) {
+    function componentToHex (c) {
+      var hex = c.toString(16);
+      return hex.length === 1 ? '0' + hex : hex;
+    }
+
+    return '#' + componentToHex(r) + componentToHex(g) + componentToHex(b);
+  },
+
+  /*
+   *  Returns true if the hex color passed as an input is valid
+   *  input -> hex (#FF00FF)
+   *  output -> true
+   *
+   * @return a boolean
+   */
+  isValidHex: function (hex) {
+    return !!hex.match(/(^#?[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i);
+  },
+
+  /*
    *  Transforms an hex color into its RGB representation
    *  input ->  hex (#FF00FF)
    *  output ->  { r: 255, g: 0, b: 255 }

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/color-picker/color-picker.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/color-picker/color-picker.spec.js
@@ -1,3 +1,4 @@
+var $ = require('jquery');
 var ColorPicker = require('../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker');
 
 describe('components/form-components/editors/fill/color-picker/color-picker', function () {
@@ -39,6 +40,47 @@ describe('components/form-components/editors/fill/color-picker/color-picker', fu
       expect(this.view.$('.js-a').val()).toBe('0.5');
       expect(this.view.$('.js-a').hasClass('is-disabled')).toBe(true);
       expect(this.view.$('.js-colorPicker .js-alpha').hasClass('is-hidden')).toBe(true);
+    });
+
+    it('should change the hex color directly', function () {
+      this.view.$('.js-hex').val('#CCC');
+      var e = $.Event('keyup');
+      e.which = 37;
+      this.view.$('.js-hex').trigger(e);
+
+      expect(this.view.model.get('hex')).toBe('#cccccc');
+    });
+
+    it('should change each color individually', function () {
+      this.view.$('.js-r').val('10');
+      this.view.$('.js-g').val('20');
+      this.view.$('.js-b').val('30');
+      var e = $.Event('keyup');
+      e.which = 37;
+      this.view.$('.js-r').trigger(e);
+
+      expect(this.view.model.get('hex')).toBe('#0a141e');
+    });
+
+    it('should change each the alpha', function () {
+      this.view.$('.js-a').val('0.7');
+      var e = $.Event('keyup');
+      e.which = 37;
+      this.view.$('.js-a').trigger(e);
+
+      expect(this.view.model.get('opacity')).toBe(0.7);
+    });
+
+    it('should show the errors', function () {
+      this.view.$('.js-r').val('10');
+      this.view.$('.js-g').val('20');
+      this.view.$('.js-b').val('what?');
+      var e = $.Event('keyup');
+      e.which = 37;
+      this.view.$('.js-b').trigger(e);
+
+      expect(this.view.model.get('hex')).toBe('#A6CEE3');
+      expect(this.view.$('.js-b').hasClass('has-error')).toBeTruthy();
     });
 
     afterEach(function () {

--- a/lib/assets/test/spec/cartodb3/helpers/utils.spec.js
+++ b/lib/assets/test/spec/cartodb3/helpers/utils.spec.js
@@ -86,11 +86,41 @@ describe('helpers/utils', function () {
     });
   });
 
+  describe('.rgbToHex', function () {
+    it('should get a rgb string', function () {
+      expect(Utils.rgbToHex(0, 0, 0)).toEqual('#000000');
+      expect(Utils.rgbToHex(255, 255, 255)).toEqual('#ffffff');
+      expect(Utils.rgbToHex(255, 0, 204)).toEqual('#ff00cc');
+    });
+  });
+
   describe('.hexToRGBA', function () {
     it('should get a RGBA string', function () {
       expect(Utils.hexToRGBA('#FFF', 0.5)).toEqual('rgba(255, 255, 255, 0.5)');
       expect(Utils.hexToRGBA('#FFFFFF', 0.5)).toEqual('rgba(255, 255, 255, 0.5)');
       expect(Utils.hexToRGBA('#E5FFCC', 1)).toEqual('rgba(229, 255, 204, 1)');
+    });
+  });
+
+  describe('.isValidHex', function () {
+    it('should return true if the CSS is valid', function () {
+      expect(Utils.isValidHex('#FFF')).toBeTruthy();
+      expect(Utils.isValidHex('#FFFFFF')).toBeTruthy();
+      expect(Utils.isValidHex('#E5FFCC')).toBeTruthy();
+      expect(Utils.isValidHex('#fff')).toBeTruthy();
+      expect(Utils.isValidHex('#111111')).toBeTruthy();
+      expect(Utils.isValidHex('#000')).toBeTruthy();
+      expect(Utils.isValidHex('#fabaDA')).toBeTruthy();
+    });
+
+    it('should return false if the CSS is not valid', function () {
+      expect(Utils.isValidHex('FFF')).toBeFalsy();
+      expect(Utils.isValidHex('#FFFFF')).toBeFalsy();
+      expect(Utils.isValidHex('#C')).toBeFalsy();
+      expect(Utils.isValidHex('red')).toBeFalsy();
+      expect(Utils.isValidHex(' ')).toBeFalsy();
+      expect(Utils.isValidHex('')).toBeFalsy();
+      expect(Utils.isValidHex('#')).toBeFalsy();
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.33",
+  "version": "4.1.34",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR allows using the keyboard to change the selected color in the builder color picker. In case the user introduces an invalid input, the fields show an error state:

![hex](https://cloud.githubusercontent.com/assets/4933/18172609/6659dac4-7066-11e6-92e1-f533c7976998.gif)


CR: @nobuti 

Closes #8363
Closes #8781
Closes #8536