### PR TITLE
Update the form model when the widget definition model changes.

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-fields-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-fields-view.js
@@ -20,9 +20,10 @@ module.exports = CoreView.extend({
     this._widgetDefinitionModel = opts.widgetDefinitionModel;
     this._querySchemaModel = opts.querySchemaModel;
 
+    this._widgetDefinitionModel = opts.widgetDefinitionModel;
     this._widgetFormModel = WidgetFormFactory.createWidgetFormModel(opts.widgetDefinitionModel, this._querySchemaModel);
     this._widgetFormModel.updateSchema();
-    this._widgetFormModel.bind('change', _.debounce(this._onFormChange.bind(this), 500));
+    this._initBinds();
   },
 
   render: function () {
@@ -30,6 +31,16 @@ module.exports = CoreView.extend({
     this.$el.empty();
     this._initViews();
     return this;
+  },
+
+  _initBinds: function () {
+    this._widgetFormModel.bind('change', _.debounce(this._onFormChange.bind(this), 500));
+    this.add_related_model(this._widgetFormModel);
+
+    this._widgetDefinitionModel.on('change:title', function (model, title) {
+      this._widgetFormModel.set({title: title}, {silent: true}); // silent to avoid sending the form
+    }, this);
+    this.add_related_model(this._widgetDefinitionModel);
   },
 
   _initViews: function () {

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/widgets-form-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/widgets-form-view.spec.js
@@ -62,6 +62,11 @@ describe('editor/widgets/widgets-form/widgets-form-view', function () {
     expect(_.size(this.view._subviews)).toBe(2); // carousel and form fields
   });
 
+  it('should update form model when widgetDefinitionModel rename', function () {
+    this.widgetDefinitionModel.set({title: 'wadus'});
+    expect(this.view._formView._widgetFormModel.get('title')).toBe('wadus');
+  });
+
   it('should have enabler editor component for suffix and prefix, disable by default', function () {
     expect(this.view.$('input[name=prefix]').length).toBe(1);
     expect(this.view.$('input[name=suffix]').length).toBe(1);


### PR DESCRIPTION
This PR fixes #9628.

![widget-rename](https://cloud.githubusercontent.com/assets/1366843/18194918/358d029e-70e9-11e6-90bb-306ff9d60aa2.gif)

CR @javierarce 🙏 