### PR TITLE
Propagate table name changes to source analyses

### DIFF
--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -91,17 +91,18 @@ class Carto::Analysis < ActiveRecord::Base
   RENAMABLE_ATTRIBUTES = ['query', 'table_name'].freeze
 
   def rename_table_in_definition(definition, target, substitution)
-    if definition.is_a?(Hash)
-      definition.each do |key, value|
-        if value.is_a?(String) && RENAMABLE_ATTRIBUTES.include?(key.to_s)
-          value.gsub!(/\b#{target}\b/, substitution)
-        else
-          rename_table_in_definition(value, target, substitution)
-        end
-      end
-    elsif definition.is_a?(Array)
-      definition.each do |value|
+    return unless definition.is_a?(Hash)
+
+    definition.each do |key, value|
+      case value
+      when String
+        value.gsub!(/\b#{target}\b/, substitution) if RENAMABLE_ATTRIBUTES.include?(key.to_s)
+      when Hash
         rename_table_in_definition(value, target, substitution)
+      when Array
+        value.each do |element|
+          rename_table_in_definition({ "#{key}": element }, target, substitution)
+        end
       end
     end
   end

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -101,6 +101,8 @@ class Carto::Analysis < ActiveRecord::Base
         rename_table_in_definition(value, target, substitution)
       when Array
         value.each do |element|
+          # Split up the problem, always deal with Hashes.
+          # See https://github.com/CartoDB/cartodb/pull/9651/files
           rename_table_in_definition({ "#{key}": element }, target, substitution)
         end
       end

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -93,7 +93,7 @@ class Carto::Analysis < ActiveRecord::Base
   def rename_table_in_definition(definition, target, substitution)
     if definition.is_a?(Hash)
       definition.each do |key, value|
-        if value.is_a?(String) && RENAMABLE_ATTRIBUTES.include?(key.to_s) && value.include?(target)
+        if value.is_a?(String) && RENAMABLE_ATTRIBUTES.include?(key.to_s)
           value.gsub!(/\b#{target}\b/, substitution)
         else
           rename_table_in_definition(value, target, substitution)

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -88,7 +88,7 @@ class Carto::Analysis < ActiveRecord::Base
 
   private
 
-  RENAMABLE_TAGS = ['query', 'table_name'].freeze
+  RENAMABLE_ATTRIBUTES = ['query', 'table_name'].freeze
 
   def rename_in_definition!(hash, target, substitution)
     hash.each do |key, value|
@@ -96,7 +96,7 @@ class Carto::Analysis < ActiveRecord::Base
         rename_in_definition!(value, target, substitution)
       elsif value.is_a?(Array)
         rename_in_array!(value, target, substitution)
-      elsif RENAMABLE_TAGS.include?(key.to_s) && value.include?(target)
+      elsif RENAMABLE_ATTRIBUTES.include?(key.to_s) && value.include?(target)
         value.gsub!(target, substitution)
       end
     end
@@ -110,7 +110,7 @@ class Carto::Analysis < ActiveRecord::Base
         rename_in_definition!(value, target, substitution)
       elsif value.is_a?(Array)
         rename_in_array!(value, target, substitution)
-      elsif RENAMABLE_TAGS.include?(key.to_s) && value.include?(target)
+      elsif RENAMABLE_ATTRIBUTES.include?(key.to_s) && value.include?(target)
         value.gsub!(target, substitution)
       end
     end

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -187,10 +187,6 @@ class Layer < Sequel::Model
     map.user if map
   end
 
-  def carto_layer
-    Carto::Layer.find(id) if persisted?
-  end
-
   private
 
   def rename_in(target, anchor, substitution)

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -187,6 +187,10 @@ class Layer < Sequel::Model
     map.user if map
   end
 
+  def carto_layer
+    Carto::Layer.find(id) if persisted?
+  end
+
   private
 
   def rename_in(target, anchor, substitution)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1362,7 +1362,7 @@ class Table
 
     affected_visualizations.each do |visualization|
       visualization.analyses.each do |analysis|
-        new_analysis_definition = analysis.update_table_name!(@name_changed_from, name)
+        analysis.update_table_name!(@name_changed_from, name)
       end
     end
   end

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1353,7 +1353,11 @@ class Table
   private
 
   def related_visualizations
-    @user_table.layers.map(&:carto_layer).map(&:visualization).flatten.uniq.compact
+    carto_layers = @user_table.layers.map do |layer|
+      Carto::Layer.find(layer.id) if layer.persisted?
+    end
+
+    carto_layers.flatten.compact.uniq.map(&:visualization).flatten.compact.uniq
   end
 
   def propagate_name_change_to_analyses

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1357,7 +1357,7 @@ class Table
       Carto::Layer.find(layer.id) if layer.persisted?
     end
 
-    carto_layers.flatten.compact.uniq.map(&:visualization).flatten.compact.uniq
+    carto_layers.flatten.compact.uniq.map(&:visualization).uniq
   end
 
   def propagate_name_change_to_analyses

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1352,15 +1352,12 @@ class Table
 
   private
 
-  def propagate_name_change_to_analyses
-    affected_visualizations = @user_table.layers
-                                         .map(&:carto_layer)
-                                         .map(&:visualization)
-                                         .flatten
-                                         .uniq
-                                         .compact
+  def related_visualizations
+    @user_table.layers.map(&:carto_layer).map(&:visualization).flatten.uniq.compact
+  end
 
-    affected_visualizations.each do |visualization|
+  def propagate_name_change_to_analyses
+    related_visualizations.each do |visualization|
       visualization.analyses.each do |analysis|
         analysis.update_table_name!(@name_changed_from, name)
       end

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1353,7 +1353,7 @@ class Table
   private
 
   def related_visualizations
-    carto_layers = @user_table.layers.map do |layer|
+    carto_layers = layers.map do |layer|
       Carto::Layer.find(layer.id) if layer.persisted?
     end
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1357,7 +1357,7 @@ class Table
       Carto::Layer.find(layer.id) if layer.persisted?
     end
 
-    carto_layers.flatten.compact.uniq.map(&:visualization).uniq
+    carto_layers.flatten.compact.uniq.map(&:visualization).compact.uniq
   end
 
   def propagate_name_change_to_analyses

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1223,8 +1223,6 @@ class Table
         end
       end
 
-
-
       begin
         propagate_name_change_to_analyses
         propagate_namechange_to_table_vis

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1359,7 +1359,7 @@ class Table
   def propagate_name_change_to_analyses
     related_visualizations.each do |visualization|
       visualization.analyses.each do |analysis|
-        analysis.update_table_name!(@name_changed_from, name)
+        analysis.update_table_name(@name_changed_from, name)
       end
     end
   end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -145,6 +145,26 @@ describe Table do
       table.table_visualization.name  .should == table.name
     end
 
+    it 'propagates name changes to analyses' do
+      table = create_table(name: 'bogus_name', user_id: @user.id)
+
+      analysis = Carto::Analysis.source_analysis_for_layer(table.layers.first.carto_layer, 0)
+      analysis.save
+
+      table.name.should eq 'bogus_name'
+
+      table.name = 'new_name'
+      table.save
+
+      analysis.reload
+
+      analysis.analysis_definition[:options][:table_name].should eq 'new_name'
+      analysis.analysis_definition[:params][:query].should include('new_name')
+
+      analysis.destroy
+      table.destroy
+    end
+
     it 'receives a name change if table visualization name changed' do
       Table.any_instance.stubs(:update_cdb_tablemetadata)
 

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -147,8 +147,9 @@ describe Table do
 
     it 'propagates name changes to analyses' do
       table = create_table(name: 'bogus_name', user_id: @user.id)
+      carto_layer = Carto::Layer.find(table.layers.first.id)
 
-      analysis = Carto::Analysis.source_analysis_for_layer(table.layers.first.carto_layer, 0)
+      analysis = Carto::Analysis.source_analysis_for_layer(carto_layer, 0)
       analysis.save
 
       table.name.should eq 'bogus_name'


### PR DESCRIPTION
Fixes #9633

In the same manner that we rewrite queries on layers on table name change, we should do the same with analyses. This code follows the same philosophy and tries to minimise the hassle for the lack of layer <-> source analysis relation and maximise the "generic" aspect of analyses.