### PR TITLE
Check alternative_names is not undefined before accessing properties.

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
@@ -153,7 +153,7 @@ module.exports = CoreView.extend({
     _.each(this.model.get('fields'), function (field, i) {
       var f = _.clone(field);
       f.position = i;
-      if (alternative_names[f.name]) {
+      if (alternative_names && alternative_names[f.name]) {
         f.alternative_name = alternative_names[f.name];
       }
       fields.push(f);


### PR DESCRIPTION
This PR fixes this annoying bug:

![bug-empty-panel](https://cloud.githubusercontent.com/assets/1366843/18241076/8d70866c-734f-11e6-8c1c-fad014cda1f5.gif)

Not sure if it hides any deeper issue, but it fixes the empty panel.
CR @matallo 🙏 