### PR TITLE
Add new keys and adapt UsageMetrics to include mapzen services

### DIFF
--- a/app/helpers/data_services_metrics_helper.rb
+++ b/app/helpers/data_services_metrics_helper.rb
@@ -1,7 +1,8 @@
 # encoding: utf-8
 
 require_relative '../../services/dataservices-metrics/lib/geocoder_usage_metrics'
-require_relative '../../services/dataservices-metrics/lib/here_isolines_usage_metrics'
+require_relative '../../services/dataservices-metrics/lib/isolines_usage_metrics'
+require_relative '../../services/dataservices-metrics/lib/routing_usage_metrics'
 require_relative '../../services/dataservices-metrics/lib/observatory_snapshot_usage_metrics'
 require_relative '../../services/dataservices-metrics/lib/observatory_general_usage_metrics'
 
@@ -65,7 +66,7 @@ module DataServicesMetricsHelper
 
   def get_here_isolines_data(user, from, to)
     orgname = user.organization.nil? ? nil : user.organization.name
-    usage_metrics = CartoDB::HereIsolinesUsageMetrics.new(user.username, orgname)
+    usage_metrics = CartoDB::IsolinesUsageMetrics.new(user.username, orgname)
     here_isolines_key = :here_isolines
     countable_requests = 0
     from.upto(to).each do |date|

--- a/services/dataservices-metrics/lib/isolines_usage_metrics.rb
+++ b/services/dataservices-metrics/lib/isolines_usage_metrics.rb
@@ -6,7 +6,7 @@ require_relative 'service_usage_metrics'
 module CartoDB
   # The purpose of this class is to encapsulate storage of usage metrics.
   # This shall be used for billing, quota checking and metrics.
-  class HereIsolinesUsageMetrics < ServiceUsageMetrics
+  class IsolinesUsageMetrics < ServiceUsageMetrics
 
     VALID_METRICS = [
       :total_requests,
@@ -17,7 +17,8 @@ module CartoDB
     ]
 
     VALID_SERVICES = [
-      :here_isolines
+      :here_isolines,
+      :mapzen_isolines
     ]
 
     def initialize(username, orgname = nil, redis=$geocoder_metrics)
@@ -29,7 +30,7 @@ module CartoDB
     def check_valid_data(service, metric, amount = 0)
       raise ArgumentError.new('Invalid service') unless VALID_SERVICES.include?(service)
       raise ArgumentError.new('Invalid metric') unless VALID_METRICS.include?(metric)
-      raise ArgumentError.new('Invalid here isolines metric amount') if !amount.nil? and amount < 0
+      raise ArgumentError.new('Invalid isolines metric amount') if !amount.nil? and amount < 0
     end
   end
 end

--- a/services/dataservices-metrics/lib/routing_usage_metrics.rb
+++ b/services/dataservices-metrics/lib/routing_usage_metrics.rb
@@ -6,24 +6,20 @@ require_relative 'service_usage_metrics'
 module CartoDB
   # The purpose of this class is to encapsulate storage of usage metrics.
   # This shall be used for billing, quota checking and metrics.
-  class GeocoderUsageMetrics < ServiceUsageMetrics
+  class RoutingUsageMetrics < ServiceUsageMetrics
 
     VALID_METRICS = [
       :total_requests,
       :failed_responses,
       :success_responses,
-      :empty_responses,
-    ]
+      :empty_responses
+    ].freeze
 
     VALID_SERVICES = [
-      :geocoder_internal,
-      :geocoder_here,
-      :geocoder_google,
-      :geocoder_cache,
-      :geocoder_mapzen
-    ]
+      :routing_mapzen
+    ].freeze
 
-    def initialize(username, orgname = nil, redis=$geocoder_metrics)
+    def initialize(username, orgname = nil, redis = $geocoder_metrics)
       super(username, orgname, redis)
     end
 
@@ -32,7 +28,7 @@ module CartoDB
     def check_valid_data(service, metric, amount = 0)
       raise ArgumentError.new('Invalid service') unless VALID_SERVICES.include?(service)
       raise ArgumentError.new('Invalid metric') unless VALID_METRICS.include?(metric)
-      raise ArgumentError.new('Invalid geocoder metric amount') if !amount.nil? and amount < 0
+      raise ArgumentError.new('Invalid routing metric amount') if !amount.nil? and amount < 0
     end
   end
 end

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -191,17 +191,17 @@ shared_examples_for "user models" do
     end
 
     it 'calculates the remaining quota for a non-org user correctly' do
-      usage_metrics = CartoDB::HereIsolinesUsageMetrics.new(@user1.username, nil, @mock_redis)
-      CartoDB::HereIsolinesUsageMetrics.stubs(:new).returns(usage_metrics)
+      usage_metrics = CartoDB::IsolinesUsageMetrics.new(@user1.username, nil, @mock_redis)
+      CartoDB::IsolinesUsageMetrics.stubs(:new).returns(usage_metrics)
       usage_metrics.incr(:here_isolines, :isolines_generated, 100, DateTime.current)
 
       @user1.remaining_here_isolines_quota.should == 400
     end
 
     it 'takes into account here isoline requests performed by the org users' do
-      usage_metrics_1 = CartoDB::HereIsolinesUsageMetrics.new(@org_user_1.username, @organization.name, @mock_redis)
-      usage_metrics_2 = CartoDB::HereIsolinesUsageMetrics.new(@org_user_2.username, @organization.name, @mock_redis)
-      CartoDB::HereIsolinesUsageMetrics.stubs(:new).
+      usage_metrics_1 = CartoDB::IsolinesUsageMetrics.new(@org_user_1.username, @organization.name, @mock_redis)
+      usage_metrics_2 = CartoDB::IsolinesUsageMetrics.new(@org_user_2.username, @organization.name, @mock_redis)
+      CartoDB::IsolinesUsageMetrics.stubs(:new).
         with(@organization.owner.username, @organization.name).
         returns(usage_metrics_1)
       usage_metrics_1.incr(:here_isolines, :isolines_generated, 100, DateTime.current)
@@ -231,8 +231,8 @@ shared_examples_for "user models" do
     end
 
     it 'calculates the used here isolines quota in the current billing cycle' do
-      usage_metrics = CartoDB::HereIsolinesUsageMetrics.new(@user1.username, nil, @mock_redis)
-      CartoDB::HereIsolinesUsageMetrics.stubs(:new).returns(usage_metrics)
+      usage_metrics = CartoDB::IsolinesUsageMetrics.new(@user1.username, nil, @mock_redis)
+      CartoDB::IsolinesUsageMetrics.stubs(:new).returns(usage_metrics)
       usage_metrics.incr(:here_isolines, :isolines_generated, 10, DateTime.current)
       usage_metrics.incr(:here_isolines, :isolines_generated, 100, (DateTime.current - 2))
 
@@ -240,9 +240,9 @@ shared_examples_for "user models" do
     end
 
     it 'calculates the used here isolines quota for an organization' do
-      usage_metrics_1 = CartoDB::HereIsolinesUsageMetrics.new(@org_user_1.username, @organization.name, @mock_redis)
-      usage_metrics_2 = CartoDB::HereIsolinesUsageMetrics.new(@org_user_2.username, @organization.name, @mock_redis)
-      CartoDB::HereIsolinesUsageMetrics.stubs(:new).
+      usage_metrics_1 = CartoDB::IsolinesUsageMetrics.new(@org_user_1.username, @organization.name, @mock_redis)
+      usage_metrics_2 = CartoDB::IsolinesUsageMetrics.new(@org_user_2.username, @organization.name, @mock_redis)
+      CartoDB::IsolinesUsageMetrics.stubs(:new).
         with(@organization.owner.username, @organization.name).
         returns(usage_metrics_1)
       usage_metrics_1.incr(:here_isolines, :isolines_generated, 100, DateTime.current)
@@ -252,8 +252,8 @@ shared_examples_for "user models" do
     end
 
     it 'calculates the used here isolines quota in the current billing cycle including empty requests' do
-      usage_metrics = CartoDB::HereIsolinesUsageMetrics.new(@user1.username, nil, @mock_redis)
-      CartoDB::HereIsolinesUsageMetrics.stubs(:new).returns(usage_metrics)
+      usage_metrics = CartoDB::IsolinesUsageMetrics.new(@user1.username, nil, @mock_redis)
+      CartoDB::IsolinesUsageMetrics.stubs(:new).returns(usage_metrics)
       usage_metrics.incr(:here_isolines, :isolines_generated, 10, DateTime.current)
       usage_metrics.incr(:here_isolines, :isolines_generated, 100, (DateTime.current - 2))
       usage_metrics.incr(:here_isolines, :empty_responses, 10, (DateTime.current - 2))

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 require 'ostruct'
 require_relative '../spec_helper'
 require_relative 'user_shared_examples'
-require_relative '../../services/dataservices-metrics/lib/here_isolines_usage_metrics'
+require_relative '../../services/dataservices-metrics/lib/isolines_usage_metrics'
 require_relative '../../services/dataservices-metrics/lib/observatory_snapshot_usage_metrics'
 require_relative '../../services/dataservices-metrics/lib/observatory_general_usage_metrics'
 require 'factories/organizations_contexts'
@@ -724,8 +724,8 @@ describe User do
     before do
       delete_user_data @user
       @mock_redis = MockRedis.new
-      @usage_metrics = CartoDB::HereIsolinesUsageMetrics.new(@user.username, nil, @mock_redis)
-      CartoDB::HereIsolinesUsageMetrics.stubs(:new).returns(@usage_metrics)
+      @usage_metrics = CartoDB::IsolinesUsageMetrics.new(@user.username, nil, @mock_redis)
+      CartoDB::IsolinesUsageMetrics.stubs(:new).returns(@usage_metrics)
       @user.stubs(:last_billing_cycle).returns(Date.today)
       @user.period_end_date = (DateTime.current + 1) << 1
       @user.save.reload


### PR DESCRIPTION
Closes #9515 

* `HereIsolinesUsageMetrics` has been renamed to a more generic `IsolinesUsageMetrics`, and the code that uses it has been updated for the change. See occurrences [here - HereIsolinesUsageMetrics](https://github.com/CartoDB/cartodb/search?utf8=%E2%9C%93&q=HereIsolinesUsageMetrics&type=Code) and [here - here_isolines_usage_metrics](https://github.com/CartoDB/cartodb/search?utf8=%E2%9C%93&q=here_isolines_usage_metrics&type=Code).
  * Add `mapzen_isolines` key as valid for isolines
* Add `geocoder_mapzen` key as valid for geocoder
* Add `RoutingUsageMetrics` class
  * Add `routing_mapzen` key as valid for routing
