### PR TITLE
Switch vacuum full by vacuum analyze from table.optimize

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -468,7 +468,7 @@ class Table
   def optimize
     owner.db_service.in_database_direct_connection({statement_timeout: STATEMENT_TIMEOUT}) do |user_direct_conn|
       user_direct_conn.run(%Q{
-        VACUUM FULL #{qualified_table_name}
+        VACUUM ANALYZE #{qualified_table_name}
         })
     end
   rescue => e

--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -189,7 +189,7 @@ describe Map do
       table.optimize
 
       table.map.recalculate_bounds!
-      table.map.view_bounds_ne.should == "[40.428198, -3.699732]"
+      table.map.view_bounds_ne.should == "[40.4283, -3.69968]"
       table.map.view_bounds_sw.should == "[40.415113, -3.70957]"
     end
 

--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -190,7 +190,7 @@ describe Map do
 
       table.map.recalculate_bounds!
       table.map.view_bounds_ne.should == "[40.4283, -3.69968]"
-      table.map.view_bounds_sw.should == "[40.415113, -3.70957]"
+      table.map.view_bounds_sw.should == "[40.415, -3.70962]"
     end
 
     it "recenters map using bounds" do


### PR DESCRIPTION
Closes #9586

This change was intended to be done [here](https://github.com/CartoDB/cartodb/pull/7263) months ago. It's funny but we missed it.

Copying below the description of the old PR:

====

In the past, the import process was highly manipulating the target tables: creating, renaming and dropping columns (for example, in the QueryBatcher). In that scenario, having a vacuum full running for each import might make sense to clean the table.

This `table.optimize` function is called from `app/models/data_import.rb` in `migrate_existing` and `app/models/table_registrar.rb` in `register`. 

Performing a vacuum full on a table which has been newly created and has not suffered those manipulations has a cost in the import time, so we are substituting it by a simpler "VACUUM ANALYZE" which will update the stats (might be important for calculating bounds when the geometries have changed, e.g. in geo-guessing).