### PR TITLE
basemaps: mapbox tab

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/add-basemap-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/add-basemap-model.js
@@ -46,6 +46,9 @@ module.exports = Backbone.Model.extend({
     if (this.activeTabModel().hasAlreadyAddedLayer(this._customBaselayersCollection)) {
       // update selected in basemaps collection
       this._basemapsCollection.updateSelected(attrs.className);
+      // update category if needed in basemaps collection,
+      // this is the case for mapbox basemaps which were stored without category in the editor
+      this._basemapsCollection.updateCategory(attrs.className, attrs.category);
 
       // update baselayer
       this._onBasemapSaved(attrs);

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/add-basemap-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/add-basemap-model.js
@@ -45,7 +45,7 @@ module.exports = Backbone.Model.extend({
 
     if (this.activeTabModel().hasAlreadyAddedLayer(this._customBaselayersCollection)) {
       // update selected in basemaps collection
-      this._basemapsCollection.updateSelected(attrs.className, attrs);
+      this._basemapsCollection.updateSelected(attrs.className);
 
       // update baselayer
       this._onBasemapSaved(attrs);

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/add-basemap-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/add-basemap-model.js
@@ -1,6 +1,7 @@
 var Backbone = require('backbone');
 var XYZModel = require('./xyz/xyz-model.js');
 var mosaicThumbnail = require('../../mosaic/mosaic-thumbnail.tpl');
+var MapboxModel = require('./mapbox/mapbox-model.js');
 
 /**
  * Add basemap model
@@ -44,7 +45,7 @@ module.exports = Backbone.Model.extend({
 
     if (this.activeTabModel().hasAlreadyAddedLayer(this._customBaselayersCollection)) {
       // update selected in basemaps collection
-      this._basemapsCollection.updateSelected(attrs.className);
+      this._basemapsCollection.updateSelected(attrs.className, attrs);
 
       // update baselayer
       this._onBasemapSaved(attrs);
@@ -102,7 +103,8 @@ module.exports = Backbone.Model.extend({
 
   _initTabs: function () {
     var tabs = new Backbone.Collection([
-      new XYZModel()
+      new XYZModel(),
+      new MapboxModel()
     ]);
     this.set({
       tabs: tabs,

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/add-basemap-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/add-basemap-view.js
@@ -6,7 +6,7 @@ var ViewFactory = require('../../view-factory');
 var renderLoading = require('../../loading/render-loading');
 var ErrorView = require('../../error/error-view');
 var _ = require('underscore');
-var TabsView = require('./tabs-view.js');
+var TabsView = require('./tabs-view');
 
 /**
  * Add basemap dialog

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/enter-url.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/enter-url.tpl
@@ -7,7 +7,7 @@
       <label class="Form-label"><%- _t('components.modals.add-basemap.mapbox.enter') %></label>
     </div>
     <div class="Form-rowData Form-rowData--longer">
-      <input type="text" class="Form-input Form-input--longer js-url" value="<%- url %>" placeholder="E.g. username.ab12cd3">
+      <input type="text" class="Form-input Form-input--longer js-url" value="<%- url %>" placeholder="<%- _t('components.modals.add-basemap.mapbox.username') %>">
     </div>
   </div>
   <div class="Form-row CDB-Text CDB-Size-medium">
@@ -15,7 +15,7 @@
       <label class="Form-label Form-label--multipleLines"><%- _t('components.modals.add-basemap.mapbox.enter-token') %></label>
     </div>
     <div class="Form-rowData Form-rowData--longer">
-      <input type="text" class="Form-input Form-input--longer js-access-token" value="<%- accessToken %>" placeholder="E.g. pk.bfg32ewdsadeyJ1Ijoi…">
+      <input type="text" class="Form-input Form-input--longer js-access-token" value="<%- accessToken %>" placeholder="<%- _t('components.modals.add-basemap.mapbox.access-token') %>">
       <div class="Form-inputError js-error <%- lastErrorMsg ? 'is-visible' : '' %>"><%- lastErrorMsg %></div>
     </div>
   </div>

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/enter-url.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/enter-url.tpl
@@ -1,0 +1,39 @@
+<div class="ImportPanel">
+  <div class="ImportPanel-header">
+    <h3 class="CDB-Text CDB-Size-large u-mainTextColor u-secondaryTextColor u-bSpace--m"><%- _t('components.modals.add-basemap.mapbox.insert') %></h3>
+  </div>
+  <div class="Form-row CDB-Text CDB-Size-medium">
+    <div class="Form-rowLabel">
+      <label class="Form-label"><%- _t('components.modals.add-basemap.mapbox.enter') %></label>
+    </div>
+    <div class="Form-rowData Form-rowData--longer">
+      <input type="text" class="Form-input Form-input--longer js-url" value="<%- url %>" placeholder="E.g. username.ab12cd3">
+    </div>
+  </div>
+  <div class="Form-row CDB-Text CDB-Size-medium">
+    <div class="Form-rowLabel">
+      <label class="Form-label Form-label--multipleLines"><%- _t('components.modals.add-basemap.mapbox.enter-token') %></label>
+    </div>
+    <div class="Form-rowData Form-rowData--longer">
+      <input type="text" class="Form-input Form-input--longer js-access-token" value="<%- accessToken %>" placeholder="E.g. pk.bfg32ewdsadeyJ1Ijoi…">
+      <div class="Form-inputError js-error <%- lastErrorMsg ? 'is-visible' : '' %>"><%- lastErrorMsg %></div>
+    </div>
+  </div>
+</div>
+
+<div class="Dialog-footer Dialog-footer--expanded CreateDialog-footer">
+  <div>
+    <div class="CreateDialog-footerShadow"></div>
+    <div class="CreateDialog-footerLine"></div>
+    <div class="CreateDialog-footerInner ">
+      <div class="CreateDialog-footerInfo"></div>
+      <div class="CreateDialog-footerActions">
+        <%/* ok class == let parent dialog view handle the click event */%>
+        <button class="CDB-Button CDB-Button--primary is-disabled js-ok ok">
+          <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-medium u-upperCase"><%- _t('components.modals.add-basemap.add-btn') %></span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.js
@@ -29,7 +29,7 @@ module.exports = Backbone.Model.extend({
 
   hasAlreadyAddedLayer: function (userLayers) {
     var urlTemplate = this.get('layer').get('urlTemplate');
-    return _.any(userLayers.custom(), function (customLayer) {
+    return _.any(userLayers.isCustomCategory(), function (customLayer) {
       return customLayer.get('urlTemplate') === urlTemplate;
     });
   },

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.js
@@ -1,0 +1,64 @@
+var Backbone = require('backbone');
+var _ = require('underscore');
+var MapboxView = require('./mapbox-view');
+var MapboxToTileLayerFactory = require('./mapbox-to-tile-layer-factory');
+
+/**
+ * View model for Mapbox tab content.
+ */
+
+module.exports = Backbone.Model.extend({
+
+  defaults: {
+    name: 'mapbox',
+    label: 'Mapbox',
+    currentView: 'enterURL', //, validatingInputs, valid
+    lastErrorMsg: '', // set if fails to save
+    layer: undefined // will be set when valid
+  },
+
+  createView: function () {
+    this.set({
+      currentView: 'enterURL',
+      layer: undefined
+    });
+    return new MapboxView({
+      model: this
+    });
+  },
+
+  hasAlreadyAddedLayer: function (userLayers) {
+    var urlTemplate = this.get('layer').get('urlTemplate');
+    return _.any(userLayers.custom(), function (customLayer) {
+      return customLayer.get('urlTemplate') === urlTemplate;
+    });
+  },
+
+  save: function (url, accessToken) {
+    this.set({
+      currentView: 'validatingInputs',
+      url: url,
+      accessToken: accessToken
+    });
+
+    var self = this;
+
+    var mf = new MapboxToTileLayerFactory({
+      url: url,
+      accessToken: accessToken
+    });
+    mf.createTileLayer({
+      success: function (tileLayer) {
+        self.set('layer', tileLayer);
+        self.trigger('saveBasemap');
+      },
+      error: function (errorMsg) {
+        self.set({
+          currentView: 'enterURL',
+          lastErrorMsg: errorMsg
+        });
+      }
+    });
+  }
+
+});

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.js
@@ -34,7 +34,7 @@ module.exports = Backbone.Model.extend({
     });
   },
 
-  save: function (url, accessToken) {
+  validateInputs: function (url, accessToken) {
     this.set({
       currentView: 'validatingInputs',
       url: url,

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.js
@@ -133,9 +133,9 @@ module.exports = Backbone.Model.extend({
   _errorToMsg: function (error) {
     if (typeof error === 'object' || !error) {
       if (error && error.status && error.status === 401) {
-        return 'Error retrieving your basemap. Please, check your access token.';
+        return _t('components.modals.add-basemap.mapbox.error');
       } else {
-        return 'This URL is not valid.';
+        return _t('components.modals.add-basemap.mapbox.invalid');
       }
     }
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.js
@@ -1,4 +1,4 @@
-/* global Image */
+/* global Image, location */
 
 var $ = require('jquery');
 var _ = require('underscore');

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.js
@@ -6,8 +6,7 @@ var Backbone = require('backbone');
 var CustomBaselayerModel = require('../../../../data/custom-baselayer-model');
 
 /**
- * Factory to create a cdb.admin.TileLayer from a given URL and access token tuple for Mapbox.
- * Extracted from mapbox_basemap_pane/mapbox_to_tile_layer_factory, to maintain current logic, since it's rather complex…
+ * Factory to create a CustomBaselayerModel from a given URL and access token tuple for Mapbox.
  */
 
 module.exports = Backbone.Model.extend({

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.js
@@ -1,0 +1,198 @@
+/* global Image */
+
+var $ = require('jquery');
+var _ = require('underscore');
+var Backbone = require('backbone');
+var CustomBaselayerModel = require('../../../../data/custom-baselayer-model');
+
+/**
+ * Factory to create a cdb.admin.TileLayer from a given URL and access token tuple for Mapbox.
+ * Extracted from mapbox_basemap_pane/mapbox_to_tile_layer_factory, to maintain current logic, since it's rather complex…
+ */
+
+module.exports = Backbone.Model.extend({
+
+  defaults: {
+    url: '',
+    accessToken: ''
+  },
+
+  _MAPBOX: {
+    version: 4,
+    https: 'https://dnv9my2eseobd.cloudfront.net',
+    base: 'https://a.tiles.mapbox.com/'
+  },
+
+  /**
+   * @param {Object} callbacks
+   *   success {Function} given a new TileLayer object
+   *   error {Function} given an error explanation
+   */
+  createTileLayer: function (callbacks) {
+    var val = this.get('url');
+    var url = this._lowerXYZ(val);
+    var access_token = this.get('accessToken');
+    var type = 'json';
+    var subdomains = ['a', 'b', 'c'];
+    var mapbox_id;
+
+    // Detects the URL's type
+    if (url.indexOf('{x}') < 0 && url.indexOf('tiles.mapbox.com') !== -1) {
+      mapbox_id = this._getMapBoxMapID(url);
+      if (mapbox_id) {
+        type = 'mapbox_id';
+        url = mapbox_id;
+      }
+    } else if (url.indexOf('{x}') !== -1) {
+      type = 'xyz';
+      url = url.replace(/\{s\}/g, function () {
+        return subdomains[Math.floor(Math.random() * 3)];
+      })
+        .replace(/\{x\}/g, '0')
+        .replace(/\{y\}/g, '0')
+        .replace(/\{z\}/g, '0');
+    } else if (url && url.indexOf('http') < 0 && url.match(/(.*?)\.(.*)/) != null && url.match(/(.*?)\.(.*)/).length === 3) {
+      type = 'mapbox_id';
+      mapbox_id = val;
+    } else { // If not, check https
+      url = this._fixHTTPS(url);
+    }
+
+    var self = this;
+    var image;
+    if (type === 'mapbox') {
+      callbacks.success(this._newTileLayer({ tiles: [url] }));
+    } else if (type === 'xyz') {
+      image = new Image();
+      image.onload = function () {
+        callbacks.success(self._newTileLayer({
+          tiles: [self._lowerXYZ(val)]
+        }));
+      };
+      image.onerror = function () {
+        callbacks.error(self._errorToMsg());
+      };
+      image.src = url;
+    } else if (type === 'mapbox_id') {
+      var params = '?access_token=' + access_token;
+      var base_url = this._MAPBOX.base + 'v' + this._MAPBOX.version + '/' + mapbox_id;
+      var tile_url = base_url + '/{z}/{x}/{y}.png' + params;
+      var json_url = base_url + '.json' + params;
+
+      // JQuery has a faulty implementation of the getJSON method and doesn't return
+      // a 404, so we use a timeout. TODO: replace with CORS
+      var errorTimeout = setTimeout(function () {
+        callbacks.error(self._errorToMsg());
+      }, 5000);
+
+      $.ajax({
+        url: json_url,
+        success: function (data) {
+          clearTimeout(errorTimeout);
+          callbacks.success(self._newTileLayer({
+            tiles: [tile_url],
+            attribution: data.attribution,
+            minzoom: data.minzoom,
+            maxzoom: data.maxzoom,
+            name: data.name
+          }));
+        },
+        error: function (e) {
+          clearTimeout(errorTimeout);
+          callbacks.error(self._errorToMsg(e));
+        }
+      });
+    } else {
+      callbacks.error(this._errorToMsg());
+    }
+  },
+
+  _newTileLayer: function (data) {
+    // Check if the respond is an array
+    // In that case, get only the first
+    if (_.isArray(data) && _.size(data) > 0) {
+      data = _.first(data);
+    }
+
+    var url = data.tiles[0];
+    var attribution = data.attribution || null;
+
+    var layer = new CustomBaselayerModel({
+      urlTemplate: url,
+      attribution: attribution,
+      maxZoom: data.maxzoom || 21,
+      minZoom: data.minzoom || 0,
+      name: data.name || '',
+      category: 'Mapbox',
+      type: 'Tiled'
+    });
+    layer.set('className', layer._generateClassName(url));
+
+    return layer;
+  },
+
+  _errorToMsg: function (error) {
+    if (typeof error === 'object' || !error) {
+      if (error && error.status && error.status === 401) {
+        return 'Error retrieving your basemap. Please, check your access token.';
+      } else {
+        return 'This URL is not valid.';
+      }
+    }
+
+    return error;
+  },
+
+  _lowerXYZ: function (url) {
+    return url.replace(/\{S\}/g, '{s}')
+      .replace(/\{X\}/g, '{x}')
+      .replace(/\{Y\}/g, '{y}')
+      .replace(/\{Z\}/g, '{z}');
+  },
+
+  // Extracts the Mapbox MapId from a Mapbox URL
+  _getMapBoxMapID: function (url) {
+    // http://d.tiles.mapbox.com/v3/{user}.{map}/3/4/3.png
+    // http://a.tiles.mapbox.com/v3/{user}.{map}/page.html
+    // http://a.tiles.mapbox.com/v4/{user}.{map}.*
+    var reg1 = /https?:\/\/[a-z]?\.?tiles\.mapbox.com\/v(\d)\/([^\/.]*)\.([^\/.]*)/;
+
+    // https://tiles.mapbox.com/{user}/edit/{map}?newmap&preset=Streets#3/0.00/-0.09
+    var reg2 = /https?:\/\/tiles\.mapbox\.com\/(.*?)\/edit\/(.*?)(\?|#)/;
+
+    var match = '';
+
+    // Check first expresion
+    match = url.match(reg1);
+
+    if (match && match[1] && match[2]) {
+      return match[2] + '.' + match[3];
+    }
+
+    // Check second expresion
+    match = url.match(reg2);
+
+    if (match && match[1] && match[2]) {
+      return match[1] + '.' + match[2];
+    }
+  },
+
+  /**
+   * return a https url if the current application is loaded from https
+   */
+  _fixHTTPS: function (url, loc) {
+    loc = loc || location;
+
+    // fix the url to https or http
+    if (url.indexOf('https') !== 0 && loc.protocol === 'https:') {
+      // search for mapping
+      var i = url.indexOf('mapbox.com');
+      if (i !== -1) {
+        return this._MAPBOX.https + url.substr(i + 'mapbox.com'.length);
+      }
+      return url.replace(/http/, 'https');
+    }
+    return url;
+  }
+
+});

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.js
@@ -66,20 +66,24 @@ module.exports = CoreView.extend({
 
   _onClickOK: function (e) {
     this.killEvent(e);
+
     if (this._hasValues()) {
       var url = this._urlVal();
       var accessToken = this._accessToken();
-      this.model.save(url, accessToken);
+
+      this.model.validateInputs(url, accessToken);
     }
   },
 
   _onKeyDown: function (e) {
     e.stopPropagation();
+
     this.$('.js-error').removeClass('is-visible');
   },
 
   _onKeyUp: function (e) {
     e.stopPropagation();
+
     this.$('.js-ok').toggleClass('is-disabled', !this._hasValues());
   }
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.js
@@ -1,0 +1,86 @@
+var CoreView = require('backbone/core-view');
+var ViewFactory = require('../../../view-factory');
+var renderLoading = require('../../../loading/render-loading');
+var enterUrl = require('./enter-url.tpl');
+
+/**
+ * Represents the Mapbox tab content.
+ */
+
+module.exports = CoreView.extend({
+
+  events: {
+    'click .js-ok': '_onClickOK',
+    'keydown': '_onKeyDown',
+    'keyup': '_onKeyUp'
+  },
+
+  initialize: function () {
+    this._initBinds();
+  },
+
+  render: function () {
+    this.clearSubViews();
+
+    var view;
+
+    switch (this.model.get('currentView')) {
+      case 'validatingInputs':
+        view = ViewFactory.createByHTML(
+          renderLoading({
+            title: _t('components.modals.add-basemap.validating')
+          })
+        );
+        break;
+      case 'enterURL':
+      default:
+        view = ViewFactory.createByHTML(
+          enterUrl({
+            url: this.model.get('url'),
+            accessToken: this.model.get('accessToken'),
+            lastErrorMsg: this.model.get('lastErrorMsg')
+          })
+        );
+    }
+    this.addView(view);
+    this.$el.append(view.render().el);
+
+    return this;
+  },
+
+  _initBinds: function () {
+    this.model.bind('change', this.render, this);
+  },
+
+  _hasValues: function () {
+    return this._urlVal() && this._accessToken();
+  },
+
+  _urlVal: function () {
+    return this.$('.js-url').val();
+  },
+
+  _accessToken: function () {
+    return this.$('.js-access-token').val();
+  },
+
+  _onClickOK: function (e) {
+    this.killEvent(e);
+    if (this._hasValues()) {
+      var url = this._urlVal();
+      var accessToken = this._accessToken();
+      this.model.save(url, accessToken);
+    }
+  },
+
+  _onKeyDown: function (e) {
+    e.stopPropagation();
+    this.$('.js-error').removeClass('is-visible');
+  },
+
+  _onKeyUp: function (e) {
+    e.stopPropagation();
+    this.$('.js-ok').toggleClass('is-disabled', !this._hasValues());
+  }
+
+});

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/xyz/xyz-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/xyz/xyz-model.js
@@ -22,7 +22,7 @@ module.exports = Backbone.Model.extend({
 
   hasAlreadyAddedLayer: function (userLayers) {
     var urlTemplate = this.get('layer').get('urlTemplate');
-    return _.any(userLayers.custom(), function (customLayer) {
+    return _.any(userLayers.isCustomCategory(), function (customLayer) {
       return customLayer.get('urlTemplate') === urlTemplate;
     });
   }

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/xyz/xyz.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/xyz/xyz.tpl
@@ -1,10 +1,10 @@
 <div class="ImportPanel">
   <div class="ImportPanel-header">
-    <h3 class="CDB-Text CDB-Size-large u-mainTextColor u-secondaryTextColor u-bSpace--m">Insert your XYZ URL</h3>
+    <h3 class="CDB-Text CDB-Size-large u-mainTextColor u-secondaryTextColor u-bSpace--m"><%- _t('components.modals.add-basemap.xyz.insert') %></h3>
   </div>
   <div class="Form-row CDB-Text CDB-Size-medium">
     <div class="Form-rowLabel">
-      <label class="Form-label">Enter a URL</label>
+      <label class="Form-label"><%- _t('components.modals.add-basemap.xyz.enter') %></label>
     </div>
     <div class="Form-rowData Form-rowData--longer">
       <input type="text" class="Form-input Form-input--longerMorePadding has-icon XYZPanel-input js-url" value="" placeholder="E.g. https://{s}.carto.com/foobar/{z}/{x}/{y}.png">

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/xyz/xyz.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/xyz/xyz.tpl
@@ -7,7 +7,7 @@
       <label class="Form-label"><%- _t('components.modals.add-basemap.xyz.enter') %></label>
     </div>
     <div class="Form-rowData Form-rowData--longer">
-      <input type="text" class="Form-input Form-input--longerMorePadding has-icon XYZPanel-input js-url" value="" placeholder="E.g. https://{s}.carto.com/foobar/{z}/{x}/{y}.png">
+      <input type="text" class="Form-input Form-input--longerMorePadding has-icon XYZPanel-input js-url" value="" placeholder="<%- _t('components.modals.add-basemap.xyz.eg') %> https://{s}.carto.com/foobar/{z}/{x}/{y}.png">
       <i class="Spinner XYZPanel-inputIcon XYZPanel-inputIcon--loader Spinner--formIcon Form-inputIcon js-validating" style="display: none;"></i>
       <div class="Checkbox XYZPanel-inputCheckbox js-tms" data-title="Inverts Y axis numbering for tiles">
         <button class="Checkbox-input"></button>

--- a/lib/assets/javascripts/cartodb3/data/custom-baselayers-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/custom-baselayers-collection.js
@@ -28,7 +28,7 @@ module.exports = Backbone.Collection.extend({
     this._currentUserId = opts.currentUserId;
   },
 
-  custom: function () {
+  isCustomCategory: function () {
     var custom = this.where(function (mdl) {
       return ['Mapbox', 'Custom', undefined].some(function (category) {
         return mdl.get('category') === category;

--- a/lib/assets/javascripts/cartodb3/data/custom-baselayers-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/custom-baselayers-collection.js
@@ -30,8 +30,8 @@ module.exports = Backbone.Collection.extend({
 
   custom: function () {
     var custom = this.where(function (mdl) {
-      return ['Mapbox', 'Custom', undefined].some(function (cat) {
-        return mdl.get('category') === cat;
+      return ['Mapbox', 'Custom', undefined].some(function (category) {
+        return mdl.get('category') === category;
       });
     });
     return custom;

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -257,7 +257,7 @@ module.exports = Backbone.Collection.extend({
         }
       }.bind(this),
       error: function () {
-        self.trigger('savingLayersError');
+        this.trigger('savingLayersError');
       }.bind(this)
     };
 

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -269,12 +269,12 @@ module.exports = Backbone.Collection.extend({
       this._createBaseLayer(newBaseLayerAttrs, baseLayerOptions);
     }
 
-    var labelsLayerOptions = baseLayerOptions;
-    labelsLayerOptions.success = function () {
-      self.trigger('savingLayersSuccess');
-    };
-
     if (newBaseLayerHasLabels) {
+      var labelsLayerOptions = baseLayerOptions;
+      labelsLayerOptions.success = function () {
+        self.trigger('savingLayersSuccess');
+      };
+
       if (this._hasLabelsLayer()) {
         this._updateLabelsLayer(newBaseLayerAttrs, labelsLayerOptions);
       } else {
@@ -299,8 +299,10 @@ module.exports = Backbone.Collection.extend({
       var itsTemplate = (other.urlTemplate != null) ? other.urlTemplate : other.options.urlTemplate;
       var myName = (me.name != null) ? me.name : me.options.name;
       var itsName = (other.name != null) ? other.name : other.options.name;
+      var myCategory = (me.category != null) ? me.category : me.options.category;
+      var itsCategory = (other.category != null) ? other.category : other.options.category;
 
-      return myTemplate === itsTemplate && myName === itsName;
+      return myTemplate === itsTemplate && myName === itsName && myCategory === itsCategory;
     }
 
     return false;

--- a/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -239,8 +239,6 @@ module.exports = Backbone.Collection.extend({
   },
 
   setBaseLayer: function (newBaseLayerAttrs) {
-    var self = this;
-
     this.trigger('savingLayers');
 
     newBaseLayerAttrs = _.clone(newBaseLayerAttrs);
@@ -255,12 +253,12 @@ module.exports = Backbone.Collection.extend({
     var baseLayerOptions = {
       success: function () {
         if (!newBaseLayerHasLabels) {
-          self.trigger('savingLayersSuccess');
+          this.trigger('savingLayersSuccess');
         }
-      },
+      }.bind(this),
       error: function () {
         self.trigger('savingLayersError');
-      }
+      }.bind(this)
     };
 
     if (this._hasBaseLayer()) {
@@ -272,8 +270,8 @@ module.exports = Backbone.Collection.extend({
     if (newBaseLayerHasLabels) {
       var labelsLayerOptions = baseLayerOptions;
       labelsLayerOptions.success = function () {
-        self.trigger('savingLayersSuccess');
-      };
+        this.trigger('savingLayersSuccess');
+      }.bind(this);
 
       if (this._hasLabelsLayer()) {
         this._updateLabelsLayer(newBaseLayerAttrs, labelsLayerOptions);

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-view.js
@@ -219,6 +219,11 @@ module.exports = CoreView.extend({
     this._categoriesCollection.bind('change:selected', this._onChangeSelectedCategory, this);
     this.add_related_model(this._categoriesCollection);
 
+    this._basemapsCollection.bind('change:category', function (mdl) {
+      var userLayersMdl = this._customBaselayersCollection.get(mdl.get('id'));
+      userLayersMdl.set('category', mdl.get('category'));
+      userLayersMdl.save();
+    }, this);
     this._basemapsCollection.bind('remove', function (mdl) {
       var userLayersMdl = this._customBaselayersCollection.get(mdl.get('id'));
       userLayersMdl.destroy();

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-view.js
@@ -251,8 +251,8 @@ module.exports = CoreView.extend({
     return this;
   },
 
-  _updateSelectedCategory: function (cat) {
-    var newCategory = this._categoriesCollection.findWhere({ val: cat });
+  _updateSelectedCategory: function (category) {
+    var newCategory = this._categoriesCollection.findWhere({ val: category });
     newCategory && newCategory.set({ selected: true });
   },
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-mosaic-add-item-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-mosaic-add-item-view.js
@@ -57,8 +57,8 @@ module.exports = CoreView.extend({
       var addBasemapModel = new AddBasemapModel({}, {
         layerDefinitionsCollection: self._layerDefinitionsCollection,
         basemapsCollection: self._basemapsCollection,
-        customBaselayersCollection: self._customBaselayersCollection
-        // currentTab: self._currentTab
+        customBaselayersCollection: self._customBaselayersCollection,
+        currentTab: self._currentTab
       });
 
       return new AddBasemapView({

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-select-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-select-view.js
@@ -31,9 +31,9 @@ module.exports = CoreView.extend({
     this.clearSubViews();
     this.$el.html(template());
 
-    var cat = this._selectedCategoryVal.toLowerCase();
+    var category = this._selectedCategoryVal.toLowerCase();
 
-    switch (cat) {
+    switch (category) {
       case 'color':
         this._renderForm();
         break;
@@ -41,7 +41,7 @@ module.exports = CoreView.extend({
         this._renderCustomMosaic();
         break;
       case 'mapbox':
-        this._renderCustomMosaic(cat);
+        this._renderCustomMosaic(category);
         break;
       default:
         this._renderMosaic();
@@ -81,7 +81,7 @@ module.exports = CoreView.extend({
     this.$('.js-select').append(view.render().el);
   },
 
-  _renderCustomMosaic: function (cat) {
+  _renderCustomMosaic: function (category) {
     var view = new BasemapMosaicFormView({
       collection: this._filteredBasemapsCollection,
       template: require('./basemap-mosaic.tpl'),
@@ -90,7 +90,7 @@ module.exports = CoreView.extend({
       customBaselayersCollection: this._customBaselayersCollection,
       modals: this._modals,
       disabled: this._disabled,
-      currentTab: cat
+      currentTab: category
     });
     this.addView(view);
     this.$('.js-select').append(view.render().el);

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-select-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-select-view.js
@@ -40,6 +40,9 @@ module.exports = CoreView.extend({
       case 'custom':
         this._renderCustomMosaic();
         break;
+      case 'mapbox':
+        this._renderCustomMosaic(cat);
+        break;
       default:
         this._renderMosaic();
     }
@@ -86,8 +89,8 @@ module.exports = CoreView.extend({
       basemapsCollection: this._basemapsCollection,
       customBaselayersCollection: this._customBaselayersCollection,
       modals: this._modals,
-      disabled: this._disabled
-      // currentTab: cat
+      disabled: this._disabled,
+      currentTab: cat
     });
     this.addView(view);
     this.$('.js-select').append(view.render().el);

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
@@ -28,8 +28,8 @@ module.exports = Backbone.Collection.extend({
     }
   },
 
-  findByCategory: function (cat) {
-    return this.where({ category: cat });
+  findByCategory: function (category) {
+    return this.where({ category: category });
   },
 
   getDefaultCategory: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
@@ -59,6 +59,11 @@ module.exports = Backbone.Collection.extend({
     newSelected.set({ selected: true });
   },
 
+  updateCategory: function (value, category) {
+    var newCategory = this.getByValue(value);
+    newCategory.set({ category: category });
+  },
+
   getByValue: function (value) {
     return _.first(this.where({ val: value }));
   },

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
@@ -54,9 +54,9 @@ module.exports = Backbone.Collection.extend({
     return _.first(this.where({ selected: true }));
   },
 
-  updateSelected: function (value, attrs) {
+  updateSelected: function (value) {
     var newSelected = this.getByValue(value);
-    newSelected.set(_.extend({ selected: true }, attrs));
+    newSelected.set({ selected: true });
   },
 
   getByValue: function (value) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
@@ -56,7 +56,7 @@ module.exports = Backbone.Collection.extend({
 
   updateSelected: function (value, attrs) {
     var newSelected = this.getByValue(value);
-    newSelected.set(_.extend(attrs, { selected: true }));
+    newSelected.set(_.extend({ selected: true }, attrs));
   },
 
   getByValue: function (value) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/basemap-content-views/basemaps-collection.js
@@ -43,6 +43,7 @@ module.exports = Backbone.Collection.extend({
     var categories = this.chain()
       .map(function (model) { return model.get('category'); })
       .concat('Custom')
+      .concat('Mapbox')
       .uniq()
       .value();
 
@@ -53,9 +54,9 @@ module.exports = Backbone.Collection.extend({
     return _.first(this.where({ selected: true }));
   },
 
-  updateSelected: function (value) {
+  updateSelected: function (value, attrs) {
     var newSelected = this.getByValue(value);
-    newSelected.set({ selected: true });
+    newSelected.set(_.extend(attrs, { selected: true }));
   },
 
   getByValue: function (value) {

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -456,7 +456,7 @@
           "enter": "Enter your map ID/URL",
           "enter-token": "Enter your access token",
           "username": "E.g. username.ab12cd3",
-          "username": "E.g. pk.bfg32ewdsadeyJ1Ijoi…"
+          "access-token": "E.g. pk.bfg32ewdsadeyJ1Ijoi…"
         }
       },
       "export-data": {

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -454,7 +454,9 @@
         "mapbox": {
           "insert": "Insert your Mapbox URL",
           "enter": "Enter your map ID/URL",
-          "enter-token": "Enter your access token"
+          "enter-token": "Enter your access token",
+          "username": "E.g. username.ab12cd3",
+          "username": "E.g. pk.bfg32ewdsadeyJ1Ijoi…"
         }
       },
       "export-data": {

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -446,8 +446,15 @@
         "saving": "Saving layer…",
         "fetching": "Fetching layers…",
         "get-layers": "Get layers",
-        "xyz":{
+        "xyz": {
+          "insert": "Insert your XYZ URL",
+          "enter": "Enter a URL",
           "not-valid": "It does not look like a valid XYZ URL"
+        },
+        "mapbox": {
+          "insert": "Insert your Mapbox URL",
+          "enter": "Enter your map ID/URL",
+          "enter-token": "Enter your access token"
         }
       },
       "export-data": {

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -449,14 +449,17 @@
         "xyz": {
           "insert": "Insert your XYZ URL",
           "enter": "Enter a URL",
-          "not-valid": "It does not look like a valid XYZ URL"
+          "not-valid": "It does not look like a valid XYZ URL",
+          "eg": "E.g."
         },
         "mapbox": {
           "insert": "Insert your Mapbox URL",
           "enter": "Enter your map ID/URL",
           "enter-token": "Enter your access token",
           "username": "E.g. username.ab12cd3",
-          "access-token": "E.g. pk.bfg32ewdsadeyJ1Ijoi…"
+          "access-token": "E.g. pk.bfg32ewdsadeyJ1Ijoi…",
+          "error": "Error retrieving your basemap. Please, check your access token.",
+          "invalid": "This URL is not valid."
         }
       },
       "export-data": {

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/add-basemap-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/add-basemap-model.spec.js
@@ -134,7 +134,18 @@ describe('components/modals/add-basemap/add-basemap-model', function () {
       });
 
       it('should update selected in basemapsCollection', function () {
-        expect(this.model._basemapsCollection.updateSelected).toHaveBeenCalledWith('httpsbexamplecomzxypng');
+        expect(this.model._basemapsCollection.updateSelected).toHaveBeenCalledWith('httpsbexamplecomzxypng', {
+          id: 'basemap-id-2',
+          className: 'httpsbexamplecomzxypng',
+          urlTemplate: 'https://b.example.com/{z}/{x}/{y}.png',
+          attribution: null,
+          maxZoom: 21,
+          minZoom: 0,
+          name: '',
+          tms: false,
+          category: 'Custom',
+          type: 'Tiled'
+        });
       });
     });
 

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/add-basemap-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/add-basemap-model.spec.js
@@ -134,18 +134,7 @@ describe('components/modals/add-basemap/add-basemap-model', function () {
       });
 
       it('should update selected in basemapsCollection', function () {
-        expect(this.model._basemapsCollection.updateSelected).toHaveBeenCalledWith('httpsbexamplecomzxypng', {
-          id: 'basemap-id-2',
-          className: 'httpsbexamplecomzxypng',
-          urlTemplate: 'https://b.example.com/{z}/{x}/{y}.png',
-          attribution: null,
-          maxZoom: 21,
-          minZoom: 0,
-          name: '',
-          tms: false,
-          category: 'Custom',
-          type: 'Tiled'
-        });
+        expect(this.model._basemapsCollection.updateSelected).toHaveBeenCalledWith('httpsbexamplecomzxypng');
       });
     });
 

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/add-basemap-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/add-basemap-view.spec.js
@@ -70,32 +70,32 @@ describe('components/modals/add-basemap/add-basemap-view', function () {
   });
 
   it('should start on XYZ view', function () {
-    expect(this.innerHTML()).toContain('Insert your XYZ URL');
+    expect(this.innerHTML()).toContain('components.modals.add-basemap.xyz.insert');
   });
 
   it('should highlight the selected tab', function () {
     expect(this.innerHTML()).toMatch('name="xyz".*is-selected');
-    expect(this.innerHTML()).not.toMatch('name="wms".*is-selected');
+    expect(this.innerHTML()).not.toMatch('name="mapbox".*is-selected');
   });
 
   it('should not have any leaks', function () {
     expect(this.view).toHaveNoLeaks();
   });
 
-  // describe('when clicking on a tab', function () {
-  //   beforeEach(function () {
-  //     this.view.$('button[data-name="wms"]').click();
-  //   });
+  describe('when clicking on a tab', function () {
+    beforeEach(function () {
+      this.view.$('button[data-name="mapbox"]').click();
+    });
 
-  //   it('should change tab', function () {
-  //     expect(this.innerHTML()).toContain('Insert your WMS/WMTS URL');
-  //   });
+    it('should change tab', function () {
+      expect(this.innerHTML()).toContain('components.modals.add-basemap.mapbox.insert');
+    });
 
-  //   it('should highlight new tab', function () {
-  //     expect(this.innerHTML()).toMatch('name="wms".*is-selected');
-  //     expect(this.innerHTML()).not.toMatch('name="xyz".*is-selected');
-  //   });
-  // });
+    it('should highlight new tab', function () {
+      expect(this.innerHTML()).toMatch('name="mapbox".*is-selected');
+      expect(this.innerHTML()).not.toMatch('name="xyz".*is-selected');
+    });
+  });
 
   describe('when click OK', function () {
     beforeEach(function () {

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.spec.js
@@ -1,9 +1,9 @@
 var ConfigModel = require('../../../../../../../javascripts/cartodb3/data/config-model');
-var XYZViewModel = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/xyz/xyz-model');
+var MapboxModel = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-model.js');
 var CustomBaselayersCollection = require('../../../../../../../javascripts/cartodb3/data/custom-baselayers-collection');
 var CustomBaselayerModel = require('../../../../../../../javascripts/cartodb3/data/custom-baselayer-model');
 
-describe('components/modals/add-basemap/xyz/xyz-model', function () {
+describe('editor/components/modals/add-basemap/mapbox/mapbox-model', function () {
   beforeEach(function () {
     var configModel = new ConfigModel({
       base_url: '/u/pepe'
@@ -12,16 +12,16 @@ describe('components/modals/add-basemap/xyz/xyz-model', function () {
     this.customBaselayersCollection = new CustomBaselayersCollection([{
       id: 'basemap-id-1',
       options: {
-        urlTemplate: 'https://a.example.com/{z}/{x}/{y}.png',
-        category: 'Custom',
-        className: 'httpsaexamplecomzxypng'
+        urlTemplate: 'https://a.tiles.mapbox.com/v4/map.id/{z}/{x}/{y}.png?access_token=',
+        category: 'Mapbox',
+        className: 'httpsatilesmapboxcomv4mapidzxypngaccess_token'
       }
     }], {
       configModel: configModel,
       currentUserId: 'current-user-id'
     });
 
-    this.model = new XYZViewModel();
+    this.model = new MapboxModel();
   });
 
   describe('.hasAlreadyAddedLayer', function () {

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.spec.js
@@ -1,0 +1,196 @@
+var $ = require('jquery');
+var MapboxToTileLayerFactory = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory');
+
+describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory', function () {
+  beforeEach(function() {
+    this.factory = new MapboxToTileLayerFactory({
+      url: 'https://a.tiles.mapbox.com/v4/username.123abc45d/',
+      accessToken: 'x.y123zwv456'
+    });
+  });
+
+  describe('._fixHTTPS', function() {
+    it('should fix mapbox https url', function() {
+      var url = MapboxToTileLayerFactory.prototype._fixHTTPS('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json', {
+        protocol: 'https:'
+      });
+      expect(url).toEqual('https://dnv9my2eseobd.cloudfront.net/v4/examples.map-4l7djmvo.json');
+
+      url = MapboxToTileLayerFactory.prototype._fixHTTPS('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json', {
+        protocol: 'http:'
+      });
+      expect(url).toEqual('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json')
+    });
+  });
+
+  describe('.createTileLayer', function() {
+    beforeEach(function() {
+      this.successSpy = jasmine.createSpy('success');
+      this.errorSpy = jasmine.createSpy('error');
+      this.callbacks = {
+        success: this.successSpy,
+        error: this.errorSpy
+      };
+
+      // for sure jasmine has a function for this
+      spyOn($, 'ajax');
+    });
+
+    describe('when provided an edit URL', function() {
+      beforeEach(function() {
+        this.username = 'cartodb';
+        this.mapID = 'map-eeoepub0';
+        this.mapboxID = this.username + '.' + this.mapID;
+        this.accessToken = 'ACCESS_TOKEN';
+
+        this.factory.set({
+          url: 'https://tiles.mapbox.com/' + this.username + '/edit/' + this.mapID + '#3/0.09/0.00',
+          accessToken: this.accessToken
+        });
+        this.factory.createTileLayer(this.callbacks);
+      });
+
+      describe('when valid URL and access token', function() {
+        beforeEach(function() {
+          $.ajax.calls.argsFor(0)[0].success({
+            attribution: 'attribution str',
+            minzoom: 2,
+            maxzoom: 4
+          });
+        });
+
+        it('should call the success callback', function() {
+          expect(this.successSpy).toHaveBeenCalled();
+        });
+
+        it('should have an expected urlTemplate value on the returned layer', function() {
+          expect(this.successSpy).toHaveBeenCalledWith(jasmine.any(Object));
+          var url = 'https://a.tiles.mapbox.com/v4/' + this.mapboxID + '/{z}/{x}/{y}.png?access_token=' + this.accessToken;
+          expect(this.successSpy.calls.argsFor(0)[0].get('urlTemplate')).toEqual(url);
+        });
+
+        it('should also set expected metadata', function() {
+          var tileLayer = this.successSpy.calls.argsFor(0)[0];
+          expect(tileLayer.get('attribution')).toEqual('attribution str');
+          expect(tileLayer.get('minZoom')).toEqual(2);
+          expect(tileLayer.get('maxZoom')).toEqual(4);
+        });
+      });
+
+      describe('when fails to validate URL or access token', function() {
+        beforeEach(function() {
+          $.ajax.calls.argsFor(0)[0].error();
+        });
+
+        it('should call error callback with error message', function() {
+          expect(this.errorSpy).toHaveBeenCalled();
+          expect(this.errorSpy).toHaveBeenCalledWith(jasmine.any(String));
+        });
+      });
+    });
+
+    describe('when provided an embed URL', function() {
+      beforeEach(function() {
+        this.mapboxID = 'cartodb.map-eeoepub0';
+        this.accessToken = 'ACCESS_TOKEN';
+
+        this.factory.set({
+          url: 'http://a.tiles.mapbox.com/v4/' + this.mapboxID + '/page.html',
+          accessToken: this.accessToken
+        });
+        this.factory.createTileLayer(this.callbacks);
+      });
+
+      describe('when valid URL and access token', function() {
+        beforeEach(function() {
+          $.ajax.calls.argsFor(0)[0].success({
+            attribution: 'attribution str',
+            minzoom: 2,
+            maxzoom: 4
+          });
+        });
+
+        it('should call the success callback', function() {
+          expect(this.successSpy).toHaveBeenCalled();
+        });
+
+        it('should have an expected urlTemplate value on the returned layer', function() {
+          expect(this.successSpy).toHaveBeenCalledWith(jasmine.any(Object));
+          var url = 'https://a.tiles.mapbox.com/v4/' + this.mapboxID + '/{z}/{x}/{y}.png?access_token=' + this.accessToken;
+          expect(this.successSpy.calls.argsFor(0)[0].get('urlTemplate')).toEqual(url);
+        });
+
+        it('should also set expected metadata', function() {
+          var tileLayer = this.successSpy.calls.argsFor(0)[0];
+          expect(tileLayer.get('attribution')).toEqual('attribution str');
+          expect(tileLayer.get('minZoom')).toEqual(2);
+          expect(tileLayer.get('maxZoom')).toEqual(4);
+        });
+      });
+
+      describe('when fails to validate URL or access token', function() {
+        beforeEach(function() {
+          $.ajax.calls.argsFor(0)[0].error();
+        });
+
+        it('should call error callback with error message', function() {
+          expect(this.errorSpy).toHaveBeenCalled();
+          expect(this.errorSpy).toHaveBeenCalledWith(jasmine.any(String));
+        });
+      });
+    });
+
+    describe('when provided a XYZ URL', function() {
+      beforeEach(function() {
+        this.mapboxID = 'cartodb.map-eeoepub0';
+        this.accessToken = 'ACCESS_TOKEN';
+
+        var self = this;
+        this.img = {};
+        spyOn(window, 'Image').and.callFake( function() {
+          return self.img;
+        });
+
+        this.factory.set({
+          url: 'https://a.tiles.mapbox.com/v4/' + this.mapboxID + '/{z}/{y}/{x}.png',
+          accessToken: this.accessToken
+        });
+        this.factory.createTileLayer(this.callbacks);
+      });
+
+      describe('when valid URL, access token and tiles', function() {
+        beforeEach(function() {
+          this.img.onload();
+        });
+
+        it('should call the success callback', function() {
+          expect(this.successSpy).toHaveBeenCalled();
+        });
+
+        it('should have an expected urlTemplate value on the returned layer', function() {
+          expect(this.successSpy).toHaveBeenCalledWith(jasmine.any(Object));
+          var url = 'https://a.tiles.mapbox.com/v4/' + this.mapboxID + '/{z}/{y}/{x}.png';
+          expect(this.successSpy.calls.argsFor(0)[0].get('urlTemplate')).toEqual(url);
+        });
+
+        it('should also set expected metadata', function() {
+          var tileLayer = this.successSpy.calls.argsFor(0)[0];
+          expect(tileLayer.get('attribution')).toBeNull();
+          expect(tileLayer.get('minZoom')).toEqual(0);
+          expect(tileLayer.get('maxZoom')).toEqual(21);
+        });
+      });
+
+      describe('when fails to validate URL or access token', function() {
+        beforeEach(function() {
+          this.img.onerror();
+        });
+
+        it('should call error callback with error message', function() {
+          expect(this.errorSpy).toHaveBeenCalled();
+          expect(this.errorSpy).toHaveBeenCalledWith(jasmine.any(String));
+        });
+      });
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory.spec.js
@@ -2,15 +2,15 @@ var $ = require('jquery');
 var MapboxToTileLayerFactory = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory');
 
 describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory', function () {
-  beforeEach(function() {
+  beforeEach(function () {
     this.factory = new MapboxToTileLayerFactory({
       url: 'https://a.tiles.mapbox.com/v4/username.123abc45d/',
       accessToken: 'x.y123zwv456'
     });
   });
 
-  describe('._fixHTTPS', function() {
-    it('should fix mapbox https url', function() {
+  describe('._fixHTTPS', function () {
+    it('should fix mapbox https url', function () {
       var url = MapboxToTileLayerFactory.prototype._fixHTTPS('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json', {
         protocol: 'https:'
       });
@@ -19,12 +19,12 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
       url = MapboxToTileLayerFactory.prototype._fixHTTPS('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json', {
         protocol: 'http:'
       });
-      expect(url).toEqual('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json')
+      expect(url).toEqual('http://a.tiles.mapbox.com/v4/examples.map-4l7djmvo.json');
     });
   });
 
-  describe('.createTileLayer', function() {
-    beforeEach(function() {
+  describe('.createTileLayer', function () {
+    beforeEach(function () {
       this.successSpy = jasmine.createSpy('success');
       this.errorSpy = jasmine.createSpy('error');
       this.callbacks = {
@@ -36,8 +36,8 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
       spyOn($, 'ajax');
     });
 
-    describe('when provided an edit URL', function() {
-      beforeEach(function() {
+    describe('when provided an edit URL', function () {
+      beforeEach(function () {
         this.username = 'cartodb';
         this.mapID = 'map-eeoepub0';
         this.mapboxID = this.username + '.' + this.mapID;
@@ -50,8 +50,8 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
         this.factory.createTileLayer(this.callbacks);
       });
 
-      describe('when valid URL and access token', function() {
-        beforeEach(function() {
+      describe('when valid URL and access token', function () {
+        beforeEach(function () {
           $.ajax.calls.argsFor(0)[0].success({
             attribution: 'attribution str',
             minzoom: 2,
@@ -59,17 +59,17 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
           });
         });
 
-        it('should call the success callback', function() {
+        it('should call the success callback', function () {
           expect(this.successSpy).toHaveBeenCalled();
         });
 
-        it('should have an expected urlTemplate value on the returned layer', function() {
+        it('should have an expected urlTemplate value on the returned layer', function () {
           expect(this.successSpy).toHaveBeenCalledWith(jasmine.any(Object));
           var url = 'https://a.tiles.mapbox.com/v4/' + this.mapboxID + '/{z}/{x}/{y}.png?access_token=' + this.accessToken;
           expect(this.successSpy.calls.argsFor(0)[0].get('urlTemplate')).toEqual(url);
         });
 
-        it('should also set expected metadata', function() {
+        it('should also set expected metadata', function () {
           var tileLayer = this.successSpy.calls.argsFor(0)[0];
           expect(tileLayer.get('attribution')).toEqual('attribution str');
           expect(tileLayer.get('minZoom')).toEqual(2);
@@ -77,20 +77,20 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
         });
       });
 
-      describe('when fails to validate URL or access token', function() {
-        beforeEach(function() {
+      describe('when fails to validate URL or access token', function () {
+        beforeEach(function () {
           $.ajax.calls.argsFor(0)[0].error();
         });
 
-        it('should call error callback with error message', function() {
+        it('should call error callback with error message', function () {
           expect(this.errorSpy).toHaveBeenCalled();
           expect(this.errorSpy).toHaveBeenCalledWith(jasmine.any(String));
         });
       });
     });
 
-    describe('when provided an embed URL', function() {
-      beforeEach(function() {
+    describe('when provided an embed URL', function () {
+      beforeEach(function () {
         this.mapboxID = 'cartodb.map-eeoepub0';
         this.accessToken = 'ACCESS_TOKEN';
 
@@ -101,8 +101,8 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
         this.factory.createTileLayer(this.callbacks);
       });
 
-      describe('when valid URL and access token', function() {
-        beforeEach(function() {
+      describe('when valid URL and access token', function () {
+        beforeEach(function () {
           $.ajax.calls.argsFor(0)[0].success({
             attribution: 'attribution str',
             minzoom: 2,
@@ -110,17 +110,17 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
           });
         });
 
-        it('should call the success callback', function() {
+        it('should call the success callback', function () {
           expect(this.successSpy).toHaveBeenCalled();
         });
 
-        it('should have an expected urlTemplate value on the returned layer', function() {
+        it('should have an expected urlTemplate value on the returned layer', function () {
           expect(this.successSpy).toHaveBeenCalledWith(jasmine.any(Object));
           var url = 'https://a.tiles.mapbox.com/v4/' + this.mapboxID + '/{z}/{x}/{y}.png?access_token=' + this.accessToken;
           expect(this.successSpy.calls.argsFor(0)[0].get('urlTemplate')).toEqual(url);
         });
 
-        it('should also set expected metadata', function() {
+        it('should also set expected metadata', function () {
           var tileLayer = this.successSpy.calls.argsFor(0)[0];
           expect(tileLayer.get('attribution')).toEqual('attribution str');
           expect(tileLayer.get('minZoom')).toEqual(2);
@@ -128,26 +128,26 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
         });
       });
 
-      describe('when fails to validate URL or access token', function() {
-        beforeEach(function() {
+      describe('when fails to validate URL or access token', function () {
+        beforeEach(function () {
           $.ajax.calls.argsFor(0)[0].error();
         });
 
-        it('should call error callback with error message', function() {
+        it('should call error callback with error message', function () {
           expect(this.errorSpy).toHaveBeenCalled();
           expect(this.errorSpy).toHaveBeenCalledWith(jasmine.any(String));
         });
       });
     });
 
-    describe('when provided a XYZ URL', function() {
-      beforeEach(function() {
+    describe('when provided a XYZ URL', function () {
+      beforeEach(function () {
         this.mapboxID = 'cartodb.map-eeoepub0';
         this.accessToken = 'ACCESS_TOKEN';
 
         var self = this;
         this.img = {};
-        spyOn(window, 'Image').and.callFake( function() {
+        spyOn(window, 'Image').and.callFake(function () {
           return self.img;
         });
 
@@ -158,22 +158,22 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
         this.factory.createTileLayer(this.callbacks);
       });
 
-      describe('when valid URL, access token and tiles', function() {
-        beforeEach(function() {
+      describe('when valid URL, access token and tiles', function () {
+        beforeEach(function () {
           this.img.onload();
         });
 
-        it('should call the success callback', function() {
+        it('should call the success callback', function () {
           expect(this.successSpy).toHaveBeenCalled();
         });
 
-        it('should have an expected urlTemplate value on the returned layer', function() {
+        it('should have an expected urlTemplate value on the returned layer', function () {
           expect(this.successSpy).toHaveBeenCalledWith(jasmine.any(Object));
           var url = 'https://a.tiles.mapbox.com/v4/' + this.mapboxID + '/{z}/{y}/{x}.png';
           expect(this.successSpy.calls.argsFor(0)[0].get('urlTemplate')).toEqual(url);
         });
 
-        it('should also set expected metadata', function() {
+        it('should also set expected metadata', function () {
           var tileLayer = this.successSpy.calls.argsFor(0)[0];
           expect(tileLayer.get('attribution')).toBeNull();
           expect(tileLayer.get('minZoom')).toEqual(0);
@@ -181,12 +181,12 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-facto
         });
       });
 
-      describe('when fails to validate URL or access token', function() {
-        beforeEach(function() {
+      describe('when fails to validate URL or access token', function () {
+        beforeEach(function () {
           this.img.onerror();
         });
 
-        it('should call error callback with error message', function() {
+        it('should call error callback with error message', function () {
           expect(this.errorSpy).toHaveBeenCalled();
           expect(this.errorSpy).toHaveBeenCalledWith(jasmine.any(String));
         });

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.spec.js
@@ -11,12 +11,12 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-view', function () 
     this.view.render();
   });
 
-  it('should render the inputs', function() {
+  it('should render the inputs', function () {
     expect(this.view.$('input').length).toEqual(2);
   });
 
-  describe('when click save', function() {
-    beforeEach(function() {
+  describe('when click save', function () {
+    beforeEach(function () {
       spyOn(MapboxToTileLayerFactory.prototype, 'createTileLayer');
       spyOn(this.model, 'save').and.callThrough();
       this.view.$('.js-url').val('mapbox/URL');
@@ -24,39 +24,39 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-view', function () 
       this.view.$('.js-ok').click();
     });
 
-    it('should call save on model with current values', function() {
+    it('should call save on model with current values', function () {
       expect(this.model.save).toHaveBeenCalled();
       expect(this.model.save).toHaveBeenCalledWith('mapbox/URL', 'abc123');
     });
 
-    it('should show the loading message', function() {
+    it('should show the loading message', function () {
       expect(this.innerHTML()).toContain('components.modals.add-basemap.validating');
       expect(this.view.$('input').length).toEqual(0);
     });
 
-    describe('when layer is created', function() {
-      beforeEach(function() {
+    describe('when layer is created', function () {
+      beforeEach(function () {
         this.saveBasemapSpy = jasmine.createSpy('saveBasemap');
         this.model.bind('saveBasemap', this.saveBasemapSpy);
         this.tileLayer = jasmine.createSpy('CustomBaselayerModel');
         MapboxToTileLayerFactory.prototype.createTileLayer.calls.argsFor(0)[0].success(this.tileLayer);
       });
 
-      it('should set the layer on the model', function() {
+      it('should set the layer on the model', function () {
         expect(this.model.get('layer')).toBe(this.tileLayer);
       });
 
-      it('should trigger saveBasemap event', function() {
+      it('should trigger saveBasemap event', function () {
         expect(this.saveBasemapSpy).toHaveBeenCalled();
       });
     });
 
-    describe('when layer fails to be created', function() {
-      beforeEach(function() {
+    describe('when layer fails to be created', function () {
+      beforeEach(function () {
         MapboxToTileLayerFactory.prototype.createTileLayer.calls.argsFor(0)[0].error('something failed');
       });
 
-      it('should show the start view again', function() {
+      it('should show the start view again', function () {
         expect(this.view.$('input').length).toEqual(2);
       });
     });

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.spec.js
@@ -18,15 +18,15 @@ describe('editor/components/modals/add-basemap/mapbox/mapbox-view', function () 
   describe('when click save', function () {
     beforeEach(function () {
       spyOn(MapboxToTileLayerFactory.prototype, 'createTileLayer');
-      spyOn(this.model, 'save').and.callThrough();
+      spyOn(this.model, 'validateInputs').and.callThrough();
       this.view.$('.js-url').val('mapbox/URL');
       this.view.$('.js-access-token').val('abc123');
       this.view.$('.js-ok').click();
     });
 
-    it('should call save on model with current values', function () {
-      expect(this.model.save).toHaveBeenCalled();
-      expect(this.model.save).toHaveBeenCalledWith('mapbox/URL', 'abc123');
+    it('should call validateInputs on model with current values', function () {
+      expect(this.model.validateInputs).toHaveBeenCalled();
+      expect(this.model.validateInputs).toHaveBeenCalledWith('mapbox/URL', 'abc123');
     });
 
     it('should show the loading message', function () {

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/mapbox/mapbox-view.spec.js
@@ -1,0 +1,72 @@
+var MapboxView = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-view');
+var MapboxModel = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-model');
+var MapboxToTileLayerFactory = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/mapbox/mapbox-to-tile-layer-factory');
+
+describe('editor/components/modals/add-basemap/mapbox/mapbox-view', function () {
+  beforeEach(function () {
+    this.model = new MapboxModel();
+    this.view = new MapboxView({
+      model: this.model
+    });
+    this.view.render();
+  });
+
+  it('should render the inputs', function() {
+    expect(this.view.$('input').length).toEqual(2);
+  });
+
+  describe('when click save', function() {
+    beforeEach(function() {
+      spyOn(MapboxToTileLayerFactory.prototype, 'createTileLayer');
+      spyOn(this.model, 'save').and.callThrough();
+      this.view.$('.js-url').val('mapbox/URL');
+      this.view.$('.js-access-token').val('abc123');
+      this.view.$('.js-ok').click();
+    });
+
+    it('should call save on model with current values', function() {
+      expect(this.model.save).toHaveBeenCalled();
+      expect(this.model.save).toHaveBeenCalledWith('mapbox/URL', 'abc123');
+    });
+
+    it('should show the loading message', function() {
+      expect(this.innerHTML()).toContain('components.modals.add-basemap.validating');
+      expect(this.view.$('input').length).toEqual(0);
+    });
+
+    describe('when layer is created', function() {
+      beforeEach(function() {
+        this.saveBasemapSpy = jasmine.createSpy('saveBasemap');
+        this.model.bind('saveBasemap', this.saveBasemapSpy);
+        this.tileLayer = jasmine.createSpy('CustomBaselayerModel');
+        MapboxToTileLayerFactory.prototype.createTileLayer.calls.argsFor(0)[0].success(this.tileLayer);
+      });
+
+      it('should set the layer on the model', function() {
+        expect(this.model.get('layer')).toBe(this.tileLayer);
+      });
+
+      it('should trigger saveBasemap event', function() {
+        expect(this.saveBasemapSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('when layer fails to be created', function() {
+      beforeEach(function() {
+        MapboxToTileLayerFactory.prototype.createTileLayer.calls.argsFor(0)[0].error('something failed');
+      });
+
+      it('should show the start view again', function() {
+        expect(this.view.$('input').length).toEqual(2);
+      });
+    });
+  });
+
+  it('should have no leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  afterEach(function () {
+    this.view.clean();
+  });
+});

--- a/lib/assets/test/spec/cartodb3/components/modals/add-basemap/xyz/xyz-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-basemap/xyz/xyz-view.spec.js
@@ -1,6 +1,6 @@
 var _ = require('underscore');
 var XYZView = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/xyz/xyz-view');
-var XYZViewModel = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/xyz/xyz-model');
+var XYZModel = require('../../../../../../../javascripts/cartodb3/components/modals/add-basemap/xyz/xyz-model');
 var CustomBaselayerModel = require('../../../../../../../javascripts/cartodb3/data/custom-baselayer-model');
 
 describe('components/modals/add-basemap/xyz/xyz-view', function () {
@@ -11,7 +11,7 @@ describe('components/modals/add-basemap/xyz/xyz-view', function () {
       };
     });
 
-    this.model = new XYZViewModel();
+    this.model = new XYZModel();
     this.view = new XYZView({
       model: this.model
     });

--- a/lib/assets/test/spec/cartodb3/data/user-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/user-model.spec.js
@@ -16,7 +16,7 @@ describe('data/user-model', function () {
         options: {
           visible: true,
           type: 'Tiled',
-          urlTemplate: 'https://a.tiles.mapbox.com/v4/aj.um7z9lus/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpbG10dnA3NzY3OTZ0dmtwejN2ZnUycjYifQ.1W5oTOnWXQ9R1w8u3Oo1yA',
+          urlTemplate: 'https://a.tiles.mapbox.com/v4/username.12ab45c/{z}/{x}/{y}.png?access_token=aBcDC12323abc',
           attribution: '<a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox &copy; OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>',
           maxZoom: 21,
           minZoom: 0,

--- a/lib/assets/test/spec/cartodb3/editor/layers/basemap-content-views/basemap-select-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/basemap-content-views/basemap-select-view.spec.js
@@ -121,23 +121,23 @@ describe('editor/layers/basemap-content-views/basemap-select-view', function () 
       subdomains: '',
       labels: null,
       type: 'Tiled'
-    // }, {
-    //   id: 'basemap-id-2',
-    //   urlTemplate: 'https://a.tiles.mapbox.com/v4/aj.um7z9lus/{z}/{x}/{y}.png?access_token=',
-    //   minZoom: 0,
-    //   maxZoom: 21,
-    //   name: 'MapBox Streets Outdoors Global Preview',
-    //   className: 'httpsatilesmapboxcomv4ajum7z9luszxypngaccess_token',
-    //   attribution: '<a href=\'https://www.mapbox.com/about/maps/\' target=\'_blank\'>&copy; Mapbox &copy; OpenStreetMap</a> <a class=\'mapbox-improve-map\' href=\'https://www.mapbox.com/map-feedback/\' target=\'_blank\'>Improve this map</a>',
-    //   category: 'Mapbox',
-    //   selected: false,
-    //   val: 'httpsatilesmapboxcomv4ajum7z9luszxypngaccess_token',
-    //   label: 'MapBox Streets Outdoors Global Preview',
-    //   default: false,
-    //   subdomains: '',
-    //   labels: null,
-    //   type: 'Tiled',
-    //   highlighted: false
+    }, {
+      id: 'basemap-id-2',
+      urlTemplate: 'https://a.tiles.mapbox.com/v4/aj.um7z9lus/{z}/{x}/{y}.png?access_token=',
+      minZoom: 0,
+      maxZoom: 21,
+      name: 'MapBox Streets Outdoors Global Preview',
+      className: 'httpsatilesmapboxcomv4ajum7z9luszxypngaccess_token',
+      attribution: '<a href=\'https://www.mapbox.com/about/maps/\' target=\'_blank\'>&copy; Mapbox &copy; OpenStreetMap</a> <a class=\'mapbox-improve-map\' href=\'https://www.mapbox.com/map-feedback/\' target=\'_blank\'>Improve this map</a>',
+      category: 'Mapbox',
+      selected: false,
+      val: 'httpsatilesmapboxcomv4ajum7z9luszxypngaccess_token',
+      label: 'MapBox Streets Outdoors Global Preview',
+      default: false,
+      subdomains: '',
+      labels: null,
+      type: 'Tiled',
+      highlighted: false
     }]);
 
     this.customBaselayersCollection = new CustomBaselayersCollection([{
@@ -215,6 +215,20 @@ describe('editor/layers/basemap-content-views/basemap-select-view', function () 
 
       expect(this.view._filteredBasemapsCollection.length).toBe(1);
       expect(this.view.$('.Mosaic-item').length).toBe(2); // Custom basemap and "Add basemap" button
+    });
+
+    it('should render mosaic if category is Mapbox', function () {
+      this.view = new BasemapSelectView({
+        layerDefinitionsCollection: this.layerDefinitionsCollection,
+        basemapsCollection: this.basemapsCollection,
+        selectedCategoryVal: 'Mapbox',
+        customBaselayersCollection: this.customBaselayersCollection,
+        modals: {}
+      });
+      this.view.render();
+
+      expect(this.view._filteredBasemapsCollection.length).toBe(1);
+      expect(this.view.$('.Mosaic-item').length).toBe(2); // Mapbox basemap and "Add basemap" button
     });
 
     it('should render form if category is Color', function () {

--- a/lib/assets/test/spec/cartodb3/editor/layers/basemap-content-views/basemap-select-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/basemap-content-views/basemap-select-view.spec.js
@@ -123,15 +123,15 @@ describe('editor/layers/basemap-content-views/basemap-select-view', function () 
       type: 'Tiled'
     }, {
       id: 'basemap-id-2',
-      urlTemplate: 'https://a.tiles.mapbox.com/v4/aj.um7z9lus/{z}/{x}/{y}.png?access_token=',
+      urlTemplate: 'https://a.tiles.mapbox.com/v4/username.12ab45c/{z}/{x}/{y}.png?access_token=aBcDC12323abc',
       minZoom: 0,
       maxZoom: 21,
       name: 'MapBox Streets Outdoors Global Preview',
-      className: 'httpsatilesmapboxcomv4ajum7z9luszxypngaccess_token',
+      className: 'httpsatilesmapboxcomv4username12ab45czxypngaccess_tokenaBcDC12323abc',
       attribution: '<a href=\'https://www.mapbox.com/about/maps/\' target=\'_blank\'>&copy; Mapbox &copy; OpenStreetMap</a> <a class=\'mapbox-improve-map\' href=\'https://www.mapbox.com/map-feedback/\' target=\'_blank\'>Improve this map</a>',
       category: 'Mapbox',
       selected: false,
-      val: 'httpsatilesmapboxcomv4ajum7z9luszxypngaccess_token',
+      val: 'httpsatilesmapboxcomv4username12ab45czxypngaccess_tokenaBcDC12323abc',
       label: 'MapBox Streets Outdoors Global Preview',
       default: false,
       subdomains: '',

--- a/lib/assets/test/spec/cartodb3/editor/layers/basemap-content-views/basemaps-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/basemap-content-views/basemaps-collection.spec.js
@@ -98,9 +98,6 @@ describe('editor/layers/basemap-content-views/basemaps-collection', function () 
       tooltip: null,
       id: 'basemap-id-1',
       order: 26
-    }, {
-      parse: true,
-      silent: true
     });
 
     this.collection.add({
@@ -121,9 +118,6 @@ describe('editor/layers/basemap-content-views/basemaps-collection', function () 
       },
       order: 29,
       tooltip: null
-    }, {
-      parse: true,
-      silent: true
     });
   });
 
@@ -164,7 +158,7 @@ describe('editor/layers/basemap-content-views/basemaps-collection', function () 
 
   describe('.getCategories', function () {
     it('should return an array of categories', function () {
-      expect(this.collection.getCategories().length).toBe(5); // CARTO, Here, Stamen, Color, Custom
+      expect(this.collection.getCategories().length).toBe(6); // CARTO, Here, Stamen, Color, Custom, Mapbox
     });
   });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/basemap-content-views/basemaps-collection.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/basemap-content-views/basemaps-collection.spec.js
@@ -83,41 +83,27 @@ describe('editor/layers/basemap-content-views/basemaps-collection', function () 
     }]);
 
     this.collection.add({
-      options: {
-        visible: true,
-        type: 'Tiled',
-        urlTemplate: 'https://a.tiles.mapbox.com/v4/aj.um7z9lus/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpbG10dnA3NzY3OTZ0dmtwejN2ZnUycjYifQ.1W5oTOnWXQ9R1w8u3Oo1yA',
-        attribution: '<a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox &copy; OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>',
-        maxZoom: 21,
-        minZoom: 0,
-        name: 'MapBox Streets Outdoors Global Preview',
-        order: 26
-      },
-      kind: 'tiled',
-      infowindow: null,
-      tooltip: null,
       id: 'basemap-id-1',
-      order: 26
+      urlTemplate: 'https://a.tiles.mapbox.com/v4/username.12ab45c/{z}/{x}/{y}.png?access_token=aBcDC12323abc',
+      maxZoom: 21,
+      minZoom: 0,
+      name: 'MapBox Streets Outdoors Global Preview',
+      className: 'httpsatilesmapboxcomv4username12ab45czxypngaccess_tokenaBcDC12323abc',
+      attribution: '<a href="https://www.mapbox.com/about/maps/" target="_blank">&copy; Mapbox &copy; OpenStreetMap</a> <a class="mapbox-improve-map" href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a>',
+      order: 26,
+      val: 'httpsatilesmapboxcomv4username12ab45czxypngaccess_tokenaBcDC12323abc'
     });
 
     this.collection.add({
       id: 'basemap-id-2',
-      infowindow: null,
-      kind: 'tiled',
-      options: {
-        attribution: null,
-        className: 'httpsstamentilessasslfastlynetwatercolorzxyjpg',
-        maxZoom: 21,
-        minZoom: 0,
-        name: 'Custom basemap 29',
-        order: 29,
-        tms: false,
-        type: 'Tiled',
-        urlTemplate: 'https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg',
-        visible: true
-      },
+      urlTemplate: 'https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg',
+      maxZoom: 21,
+      minZoom: 0,
+      name: 'Custom basemap 29',
+      className: 'httpsstamentilessasslfastlynetwatercolorzxyjpg',
+      attribution: null,
       order: 29,
-      tooltip: null
+      val: 'httpsstamentilessasslfastlynetwatercolorzxyjpg'
     });
   });
 
@@ -174,6 +160,17 @@ describe('editor/layers/basemap-content-views/basemaps-collection', function () 
       expect(l1.get('className')).toBe('dark_matter_rainbow');
       expect(l0.get('selected')).toBeFalsy();
       expect(l1).toBeTruthy();
+    });
+  });
+
+  describe('.updateCategory', function () {
+    it('should update category passing the classname and a category', function () {
+      var l5 = this.collection.at(5);
+
+      expect(l5.get('category')).toBe('Custom');
+      console.log((l5.attributes));
+      this.collection.updateCategory('httpsatilesmapboxcomv4username12ab45czxypngaccess_tokenaBcDC12323abc', 'Mapbox');
+      expect(l5.get('category')).toBe('Mapbox');
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.41",
+  "version": "4.1.42",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.38",
+  "version": "4.1.39",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
added mapbox basemaps support to add basemaps modal, it will work as previously, the only change is a category attribute will be added to the custombaselayer in order to be consistent with baselayer category, thus category carrousel update

inherited tests from previous mapbox basemaps tab

find an animation below, and the feature working in ded02

![mapboxbasemaps](https://cloud.githubusercontent.com/assets/36676/18281622/d4234a72-745d-11e6-8714-340ddc10e758.gif)

