### PR TITLE
Move sql statements into transaction_with_timeout (Table#import_cleanup)

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -326,7 +326,7 @@ class Table
 
       existing_pk = existing_pk[:pk_name] unless existing_pk.nil?
 
-        user_database.run(%Q{
+        user_database.run(%{
           ALTER TABLE #{qualified_table_name} DROP CONSTRAINT "#{existing_pk}"
         }) unless existing_pk.nil?
       end
@@ -335,7 +335,7 @@ class Table
       self.schema(reload: true, cartodb_types: false).each do |column|
         if column[1] =~ /^character varying/
           owner.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
-            user_database.run(%Q{ALTER TABLE #{qualified_table_name} ALTER COLUMN "#{column[0]}" TYPE text})
+            user_database.run(%{ALTER TABLE #{qualified_table_name} ALTER COLUMN "#{column[0]}" TYPE text})
           end
         end
       end
@@ -345,22 +345,22 @@ class Table
         begin
           already_had_cartodb_id = false
           owner.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
-            user_database.run(%Q{ALTER TABLE #{qualified_table_name} ADD COLUMN cartodb_id SERIAL})
+            user_database.run(%{ALTER TABLE #{qualified_table_name} ADD COLUMN cartodb_id SERIAL})
           end
         rescue
           already_had_cartodb_id = true
         end
         unless already_had_cartodb_id
           owner.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
-            user_database.run(%Q{
+            user_database.run(%{
               UPDATE #{qualified_table_name}
               SET cartodb_id = CAST(#{aux_cartodb_id_column} AS INTEGER)
             })
 
-            cartodb_id_sequence_name = user_database[%Q{
+            cartodb_id_sequence_name = user_database[%{
               SELECT pg_get_serial_sequence('#{owner.database_schema}.#{name}', 'cartodb_id')
             }].first[:pg_get_serial_sequence]
-            max_cartodb_id = user_database[%Q{SELECT max(cartodb_id) FROM #{qualified_table_name}}].first[:max]
+            max_cartodb_id = user_database[%{SELECT max(cartodb_id) FROM #{qualified_table_name}}].first[:max]
             # only reset the sequence on real imports.
 
             if max_cartodb_id
@@ -369,7 +369,7 @@ class Table
           end
         end
         owner.transaction_with_timeout(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
-          user_database.run(%Q{ALTER TABLE #{qualified_table_name} DROP COLUMN #{aux_cartodb_id_column}})
+          user_database.run(%{ALTER TABLE #{qualified_table_name} DROP COLUMN #{aux_cartodb_id_column}})
         end
       end
   end


### PR DESCRIPTION
WIP probably, not proud of this diff, so very open to suggestions. Also a note: this code should be deleted as soon as we apply some pending tweaks to ogr: setting `cartodb_id` as ogr primary key.

====

In #9588 I detected timeouts for the statements inside `import_cleanup`. Then I noticed that these were not using our "timeout improvements" that we applied months ago to other methods which ran queries to the database and can be expensive if the dataset is big (I reproduced it with ~1M rows dataset).

We want to use `transaction_with_timeout`, which is the only way we have right now to go through pgbouncer and be able to set a statement timeout without it getting overriden. Previously, the whole method was running queries via `in_database as superuser` but this doesn't take care of timeouts.

The problem now is: when using `transaction_with_timeout`, we need to split the code into several transactions because `ALTER TABLE` statements (not all, but the ones here) are using an exclusive access lock over the table, and this lock is not closed until the transaction commits.

I have used  `transaction_with_timeout` splitting it as soon as an `ALTER` statement occurs -- you can see I aggregated a set of update/selects/alter because locks don't cause a trouble there.