### PR TITLE
C1452 remove dev mobile app type

### DIFF
--- a/app/controllers/carto/admin/mobile_apps_controller.rb
+++ b/app/controllers/carto/admin/mobile_apps_controller.rb
@@ -74,7 +74,6 @@ class Carto::Admin::MobileAppsController < Admin::AdminController
     @mobile_app.name = updated_attributes[:name]
     @mobile_app.icon_url = updated_attributes[:icon_url]
     @mobile_app.description = updated_attributes[:description]
-    @mobile_app.app_type = updated_attributes[:app_type]
 
     unless @mobile_app.valid?
       flash.now[:error] = @mobile_app.errors.full_messages.join(', ')

--- a/app/controllers/carto/admin/mobile_apps_controller.rb
+++ b/app/controllers/carto/admin/mobile_apps_controller.rb
@@ -33,7 +33,6 @@ class Carto::Admin::MobileAppsController < Admin::AdminController
   end
 
   def show
-    @max_dev_users = Carto::MobileApp::MAX_DEV_USERS
   end
 
   def new
@@ -78,7 +77,6 @@ class Carto::Admin::MobileAppsController < Admin::AdminController
     @mobile_app.app_type = updated_attributes[:app_type]
 
     unless @mobile_app.valid?
-      @max_dev_users = Carto::MobileApp::MAX_DEV_USERS
       flash.now[:error] = @mobile_app.errors.full_messages.join(', ')
       render :show
       return

--- a/app/controllers/carto/api/mobile_app_presenter.rb
+++ b/app/controllers/carto/api/mobile_app_presenter.rb
@@ -67,11 +67,6 @@ module Carto
               available: app_type_available?('open', @current_user.open_apps_enabled?),
               selected: app_type_selected?('open')
             },
-            "dev": {
-              text: "Limited to 5 users, unlimited feature-wise. <a href='#'>Learn more</a>.",
-              available: app_type_available?('dev', true),
-              selected: app_type_selected?('dev')
-            },
             "private": {
               text: "Only for enterprise. <a href='#'>Learn more</a>.",
               available: app_type_available?('private', @current_user.private_apps_enabled?),

--- a/app/helpers/mobile_apps_helper.rb
+++ b/app/helpers/mobile_apps_helper.rb
@@ -15,8 +15,6 @@ module MobileAppsHelper
 
   def progress_bar_width
     case @mobile_app.app_type
-    when 'dev'
-      (@mobile_app.monthly_users * 100) / @max_dev_users
     when 'open'
       (@mobile_app.monthly_users * 100) / progress_bar_max_users
     when 'private'
@@ -30,8 +28,6 @@ module MobileAppsHelper
 
   def progress_bar_max_users
     case @mobile_app.app_type
-    when 'dev'
-      @max_dev_users
     when 'open'
       current_user.mobile_max_open_users
     when 'private'

--- a/app/models/carto/mobile_app.rb
+++ b/app/models/carto/mobile_app.rb
@@ -4,8 +4,7 @@ class Carto::MobileApp
   extend ActiveModel::Naming
 
   APP_PLATFORMS = %w(android ios xamarin-android xamarin-ios windows-phone).freeze
-  APP_TYPES = %w(dev open private).freeze
-  MAX_DEV_USERS = 5
+  APP_TYPES = %w(open private).freeze
 
   validates :name,          presence: true
   validates :icon_url,      presence: true

--- a/app/views/carto/admin/mobile_apps/_form.html.erb
+++ b/app/views/carto/admin/mobile_apps/_form.html.erb
@@ -89,36 +89,17 @@
     </div>
     <%- app_types = @mobile_app.data(current_user, fetch_app_types: true)[:app_types] %>
     <%- if @mobile_app.persisted? %>
-      <%- if @mobile_app.app_type === 'dev' %>
-        <%- app_types.each do |type, values| %>
-          <%- is_disabled = values[:available] === true ? '' : 'disabled' %>
-          <%- is_checked = values[:selected] === true ? 'checked' : '' %>
-
-          <div class="FormAccount-rowData in-block u-vspace-s">
-            <div class="RadioButton">
-              <input class="CDB-Radio js-changeMobileAppType" type="radio" name="mobile_app[app_type]" value="<%= type %>" <%= is_checked %> <%= is_disabled %> required>
-              <span class="CDB-Radio-face"></span>
-              <label class="u-iBlock u-lSpace CDB-Text CDB-Size-medium is-semibold u-lSpace--xl <%= is_disabled == 'disabled' ? 'u-altTextColor' : 'u-secondaryTextColor' %>"><%= type.capitalize %></label>
-            </div>
-            <div class="FormAccount-rowInfo u-lspace-28">
-              <p class="FormAccount-rowInfoText"><%= values[:text].html_safe %></p>
-            </div>
-          </div>
-        <% end %>
-      <% else %>
-        <%- app_type = app_types[@mobile_app.app_type.to_sym] %>
-        <div class="FormAccount-rowData in-block u-vspace-s">
-          <div class="RadioButton">
-            <input class="CDB-Radio" type="radio" checked required disabled>
-            <span class="CDB-Radio-face"></span>
-            <label class="Ru-iBlock u-lSpace CDB-Text CDB-Size-medium is-semibold u-secondaryTextColor u-lSpace--xl"><%= @mobile_app.app_type.capitalize %></label>
-          </div>
-          <div class="FormAccount-rowInfo u-lspace-28">
-            <p class="FormAccount-rowInfoText"><%= app_type[:text].html_safe %></p>
-          </div>
+      <%- app_type = app_types[@mobile_app.app_type.to_sym] %>
+      <div class="FormAccount-rowData in-block u-vspace-s">
+        <div class="RadioButton">
+          <input class="CDB-Radio" type="radio" checked required disabled>
+          <span class="CDB-Radio-face"></span>
+          <label class="Ru-iBlock u-lSpace CDB-Text CDB-Size-medium is-semibold u-secondaryTextColor u-lSpace--xl"><%= @mobile_app.app_type.capitalize %></label>
         </div>
-      <% end %>
-
+        <div class="FormAccount-rowInfo u-lspace-28">
+          <p class="FormAccount-rowInfoText"><%= app_type[:text].html_safe %></p>
+        </div>
+      </div>
     <% else %>
 
       <%- app_types.each do |type, values| %>
@@ -173,7 +154,7 @@
         <div class="ProgressBar">
           <span class="ProgressBar-bar <%= progress_bar_range(progress_bar_width) %>" style="width: <%= progress_bar_width %>%"></span>
         </div>
-        <div class="ProgressBar-legend"><%= number_with_delimiter(@mobile_app.monthly_users, delimiter: ",") %><%- if @mobile_app.app_type == "dev" %>/<%= progress_bar_max_users %><% end %> monthly users</div>
+        <div class="ProgressBar-legend"><%= number_with_delimiter(@mobile_app.monthly_users, delimiter: ",") %> monthly users</div>
       </div>
     </div>
 

--- a/app/views/carto/admin/mobile_apps/_form.html.erb
+++ b/app/views/carto/admin/mobile_apps/_form.html.erb
@@ -92,7 +92,7 @@
       <%- app_type = app_types[@mobile_app.app_type.to_sym] %>
       <div class="FormAccount-rowData in-block u-vspace-s">
         <div class="RadioButton">
-          <input class="CDB-Radio" type="radio" checked required disabled>
+          <input class="CDB-Radio" type="radio" checked required>
           <span class="CDB-Radio-face"></span>
           <label class="Ru-iBlock u-lSpace CDB-Text CDB-Size-medium is-semibold u-secondaryTextColor u-lSpace--xl"><%= @mobile_app.app_type.capitalize %></label>
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.1.43",
+  "version": "4.1.44",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/spec/requests/carto/admin/mobile_apps_controller_spec.rb
+++ b/spec/requests/carto/admin/mobile_apps_controller_spec.rb
@@ -119,7 +119,7 @@ describe Carto::Admin::MobileAppsController do
 
     it 'validates app before sending to Central' do
       Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(true)
-      Cartodb::Central.any_instance.stubs(:get_mobile_app).returns(id: TEST_UUID, monthly_users: 0, app_type: 'dev', platform: 'android').once
+      Cartodb::Central.any_instance.stubs(:get_mobile_app).returns(id: TEST_UUID, monthly_users: 0, app_type: 'open', platform: 'android').once
       Cartodb::Central.any_instance.stubs(:update_mobile_app).returns(mobile_app: {}).never
       login(@user)
       put mobile_app_path(id: TEST_UUID), mobile_app: update_app.merge(name: '')

--- a/spec/requests/carto/admin/mobile_apps_controller_spec.rb
+++ b/spec/requests/carto/admin/mobile_apps_controller_spec.rb
@@ -13,7 +13,7 @@ describe Carto::Admin::MobileAppsController do
     icon_url:     'http://icon.png',
     platform:     'android',
     app_id:       'com.app.id',
-    app_type:     'dev'
+    app_type:     'open'
   }.freeze
 
   before(:all) do
@@ -51,7 +51,7 @@ describe Carto::Admin::MobileAppsController do
   describe '#show' do
     it 'loads app from Central' do
       Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(true)
-      Cartodb::Central.any_instance.stubs(:get_mobile_app).returns(id: TEST_UUID, monthly_users: 0, app_type: 'dev', platform: 'android').once
+      Cartodb::Central.any_instance.stubs(:get_mobile_app).returns(id: TEST_UUID, monthly_users: 0, app_type: 'open', platform: 'android').once
       login(@user)
       get mobile_app_path(id: TEST_UUID)
       response.status.should eq 200


### PR DESCRIPTION
Removing dev app_type, we will give open apps and most features to all users, so it doesn't make much sense to have this.