### PR TITLE
9533 query rewriter

### DIFF
--- a/app/models/carto/analysis_node.rb
+++ b/app/models/carto/analysis_node.rb
@@ -59,7 +59,7 @@ class Carto::AnalysisNode
   end
 
   def fix_analysis_node_queries(old_username, new_user, renamed_tables)
-    if options && options.has_key?(:table_name)
+    if options && options.key?(:table_name)
       old_table_name = options[:table_name]
       options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
     end

--- a/app/models/carto/analysis_node.rb
+++ b/app/models/carto/analysis_node.rb
@@ -1,6 +1,9 @@
 # encoding: UTF-8
+require_dependency 'carto/query_rewriter'
 
 class Carto::AnalysisNode
+  include Carto::QueryRewriter
+
   def initialize(definition)
     @definition = definition
   end
@@ -53,6 +56,20 @@ class Carto::AnalysisNode
   def source_descendants
     return [self] if source?
     children.map(&:source_descendants).flatten
+  end
+
+  def fix_analysis_node_queries(old_username, new_user, renamed_tables)
+    if options && options.has_key?(:table_name)
+      old_table_name = options[:table_name]
+      options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
+    end
+
+    if params && old_username
+      query = params[:query]
+      params[:query] = rewrite_query(query, old_username, new_user, renamed_tables) if query.present?
+    end
+
+    children.each { |child| child.fix_analysis_node_queries(old_username, new_user, renamed_tables) }
   end
 
   private

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -216,12 +216,12 @@ module Carto
     def fix_layer_user_information(old_username, new_user, renamed_tables)
       new_username = new_user.username
 
-      if options.has_key?(:user_name)
+      if options.key?(:user_name)
         old_username ||= options[:user_name]
         options[:user_name] = new_username
       end
 
-      if options.has_key?(:table_name)
+      if options.key?(:table_name)
         old_table_name = options[:table_name]
         options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
       end

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 require_relative './carto_json_serializer'
 require_dependency 'carto/table_utils'
+require_dependency 'carto/query_rewriter'
 
 module Carto
   module LayerTableDependencies
@@ -50,6 +51,7 @@ module Carto
   class Layer < ActiveRecord::Base
     include Carto::TableUtils
     include LayerTableDependencies
+    include Carto::QueryRewriter
 
     serialize :options, CartoJsonSerializer
     serialize :infowindow, CartoJsonSerializer
@@ -209,6 +211,24 @@ module Carto
 
     def register_table_dependencies
       self.user_tables = affected_tables if data_layer?
+    end
+
+    def fix_layer_user_information(old_username, new_user, renamed_tables)
+      new_username = new_user.username
+
+      if options.has_key?(:user_name)
+        old_username ||= options[:user_name]
+        options[:user_name] = new_username
+      end
+
+      if options.has_key?(:table_name)
+        old_table_name = options[:table_name]
+        options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
+      end
+
+      # query_history is not modified as a safety measure for cases where this naive replacement doesn't work
+      query = options[:query]
+      options[:query] = rewrite_query(query, old_username, new_user, renamed_tables) if query.present?
     end
 
     private

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -4,12 +4,13 @@ require_relative 'layer/presenter'
 require_relative 'table/user_table'
 require_relative '../../lib/cartodb/stats/editor_apis'
 require_dependency 'carto/table_utils'
+require_dependency 'carto/query_rewriter'
 require_relative 'carto/layer'
 
 class Layer < Sequel::Model
   include Carto::TableUtils
-
   include Carto::LayerTableDependencies
+  include Carto::QueryRewriter
 
   plugin :serialization, :json, :options, :infowindow, :tooltip
 
@@ -185,6 +186,10 @@ class Layer < Sequel::Model
 
   def user
     map.user if map
+  end
+
+  def qualify_for_organization(owner_username)
+    options['query'] = qualify_query(query, options['table_name'], owner_username)
   end
 
   private

--- a/app/models/map/copier.rb
+++ b/app/models/map/copier.rb
@@ -33,8 +33,8 @@ module CartoDB
         end
       end
 
-      def copy_data_layers(origin_map, destination_map)
-        data_layer_copies_from(origin_map).map do |layer|
+      def copy_data_layers(origin_map, destination_map, user)
+        data_layer_copies_from(origin_map, user).map do |layer|
           link(destination_map, layer)
         end
       end
@@ -43,10 +43,12 @@ module CartoDB
 
       attr_reader :map
 
-      def data_layer_copies_from(map)
-        map.carto_and_torque_layers.map { |layer|
-          layer.copy
-        }
+      def data_layer_copies_from(map, user)
+        map.carto_and_torque_layers.map do |layer|
+          new_layer = layer.copy
+          new_layer.qualify_for_organization(map.user.username)
+          new_layer
+        end
       end
 
       def layer_copies_from(map)

--- a/app/models/map/copier.rb
+++ b/app/models/map/copier.rb
@@ -33,8 +33,8 @@ module CartoDB
         end
       end
 
-      def copy_data_layers(origin_map, destination_map)
-        data_layer_copies_from(origin_map).map do |layer|
+      def copy_data_layers(origin_map, destination_map, user)
+        data_layer_copies_from(origin_map, user).map do |layer|
           link(destination_map, layer)
         end
       end
@@ -43,10 +43,10 @@ module CartoDB
 
       attr_reader :map
 
-      def data_layer_copies_from(map)
+      def data_layer_copies_from(map, user)
         map.carto_and_torque_layers.map do |layer|
           new_layer = layer.copy
-          new_layer.qualify_for_organization(map.user.username)
+          new_layer.qualify_for_organization(map.user.username) if user.id != map.user.id
           new_layer
         end
       end

--- a/app/models/map/copier.rb
+++ b/app/models/map/copier.rb
@@ -33,8 +33,8 @@ module CartoDB
         end
       end
 
-      def copy_data_layers(origin_map, destination_map, user)
-        data_layer_copies_from(origin_map, user).map do |layer|
+      def copy_data_layers(origin_map, destination_map)
+        data_layer_copies_from(origin_map).map do |layer|
           link(destination_map, layer)
         end
       end
@@ -43,7 +43,7 @@ module CartoDB
 
       attr_reader :map
 
-      def data_layer_copies_from(map, user)
+      def data_layer_copies_from(map)
         map.carto_and_torque_layers.map do |layer|
           new_layer = layer.copy
           new_layer.qualify_for_organization(map.user.username)

--- a/app/models/visualization/table_blender.rb
+++ b/app/models/visualization/table_blender.rb
@@ -18,7 +18,7 @@ module CartoDB
         destination_map = copier.new_map_from(maps.first).save
 
         copier.copy_base_layer(maps.first, destination_map)
-        maps.each { |map| copier.copy_data_layers(map, destination_map, @user) }
+        maps.each { |map| copier.copy_data_layers(map, destination_map) }
 
         destination_map.user = user
         destination_map.save

--- a/app/models/visualization/table_blender.rb
+++ b/app/models/visualization/table_blender.rb
@@ -18,7 +18,7 @@ module CartoDB
         destination_map = copier.new_map_from(maps.first).save
 
         copier.copy_base_layer(maps.first, destination_map)
-        maps.each { |map| copier.copy_data_layers(map, destination_map) }
+        maps.each { |map| copier.copy_data_layers(map, destination_map, user) }
 
         destination_map.user = user
         destination_map.save

--- a/app/models/visualization/table_blender.rb
+++ b/app/models/visualization/table_blender.rb
@@ -18,7 +18,7 @@ module CartoDB
         destination_map = copier.new_map_from(maps.first).save
 
         copier.copy_base_layer(maps.first, destination_map)
-        maps.each { |map| copier.copy_data_layers(map, destination_map) }
+        maps.each { |map| copier.copy_data_layers(map, destination_map, @user) }
 
         destination_map.user = user
         destination_map.save

--- a/app/services/carto/visualizations_export_persistence_service.rb
+++ b/app/services/carto/visualizations_export_persistence_service.rb
@@ -17,7 +17,7 @@ module Carto
 
         ensure_unique_name(user, visualization)
 
-        visualization.layers.each { |layer| fix_layer_user_information(layer, old_username, user, renamed_tables) }
+        visualization.layers.each { |layer| layer.fix_layer_user_information(old_username, user, renamed_tables) }
         visualization.analyses.each do |analysis|
           analysis.analysis_node.fix_analysis_node_queries(old_username, user, renamed_tables)
         end
@@ -105,25 +105,6 @@ module Carto
         end
       end
       visualization.map.layers = layers
-    end
-
-    def fix_layer_user_information(layer, old_username, new_user, renamed_tables)
-      new_username = new_user.username
-
-      options = layer.options
-      if options.has_key?(:user_name)
-        old_username ||= options[:user_name]
-        options[:user_name] = new_username
-      end
-
-      if options.has_key?(:table_name)
-        old_table_name = options[:table_name]
-        options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
-      end
-
-      # query_history is not modified as a safety measure for cases where this naive replacement doesn't work
-      query = options[:query]
-      options[:query] = rewrite_query(query, old_username, new_user, renamed_tables) if query.present?
     end
   end
 end

--- a/app/services/carto/visualizations_export_persistence_service.rb
+++ b/app/services/carto/visualizations_export_persistence_service.rb
@@ -19,7 +19,7 @@ module Carto
 
         visualization.layers.each { |layer| fix_layer_user_information(layer, old_username, user, renamed_tables) }
         visualization.analyses.each do |analysis|
-          fix_analysis_node_queries(analysis.analysis_node, old_username, user, renamed_tables)
+          analysis.analysis_node.fix_analysis_node_queries(old_username, user, renamed_tables)
         end
 
         permission = Carto::Permission.new(owner: user, owner_username: user.username)

--- a/app/services/carto/visualizations_export_persistence_service.rb
+++ b/app/services/carto/visualizations_export_persistence_service.rb
@@ -1,10 +1,12 @@
 require 'uuidtools'
 require_dependency 'carto/uuidhelper'
+require_dependency 'carto/query_rewriter'
 
 module Carto
   # Export/import is versioned, but importing should generate a model tree that can be persisted by this class
   class VisualizationsExportPersistenceService
     include Carto::UUIDHelper
+    include Carto::QueryRewriter
 
     def save_import(user, visualization, renamed_tables: {})
       old_username = visualization.user.username if visualization.user
@@ -122,60 +124,6 @@ module Carto
       # query_history is not modified as a safety measure for cases where this naive replacement doesn't work
       query = options[:query]
       options[:query] = rewrite_query(query, old_username, new_user, renamed_tables) if query.present?
-    end
-
-    def fix_analysis_node_queries(node, old_username, new_user, renamed_tables)
-      options = node.options
-
-      if options && options.has_key?(:table_name)
-        old_table_name = options[:table_name]
-        options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
-      end
-
-      params = node.params
-      if params && old_username
-        query = params[:query]
-        params[:query] = rewrite_query(query, old_username, new_user, renamed_tables) if query.present?
-      end
-
-      node.children.each { |child| fix_analysis_node_queries(child, old_username, new_user, renamed_tables) }
-    end
-
-    def rewrite_query(query, old_username, new_user, renamed_tables)
-      new_query = rewrite_query_for_new_user(query, old_username, new_user)
-      new_query = rewrite_query_for_renamed_tables(new_query, renamed_tables) if renamed_tables.present?
-      if test_query(new_user, new_query)
-        new_query
-      else
-        CartoDB::Logger.debug(message: 'Did not rewrite query on import', old_query: query, new_query: new_query,
-                              old_username: @old_username, user: new_user, renamed_tables: renamed_tables)
-        query
-      end
-    end
-
-    def test_query(user, query)
-      user.in_database.execute("EXPLAIN (#{query})")
-      true
-    rescue
-      false
-    end
-
-    def rewrite_query_for_new_user(query, old_username, new_user)
-      if new_user.username == new_user.database_schema
-        new_schema = new_user.sql_safe_database_schema
-        query.gsub(" #{old_username}.", " #{new_schema}.").gsub(" \"#{old_username}\".", " #{new_schema}.")
-      else
-        query.gsub(" #{old_username}.", " ").gsub(" \"#{old_username}\".", " ")
-      end
-    end
-
-    PSQL_WORD_CHARS = '[$_[[:alnum:]]]'.freeze
-    def rewrite_query_for_renamed_tables(query, renamed_tables)
-      renamed_tables.reduce(query) do |sql, (old_name, new_name)|
-        # Replaces the table name only if it matches the whole word
-        # i.e: previous and next characters are not PSQL_WORD_CHARS (alphanumerics, _ or $)
-        sql.gsub(/(?<!#{PSQL_WORD_CHARS})#{Regexp.escape(old_name)}(?!#{PSQL_WORD_CHARS})/, new_name)
-      end
     end
   end
 end

--- a/lib/carto/query_rewriter.rb
+++ b/lib/carto/query_rewriter.rb
@@ -13,6 +13,10 @@ module Carto
       end
     end
 
+    def qualify_query(query, table_name, username)
+      query.gsub(/(?<!\.)("?#{table_name}"?)/, username + '.\\1')
+    end
+
     private
 
     def test_query(user, query)

--- a/lib/carto/query_rewriter.rb
+++ b/lib/carto/query_rewriter.rb
@@ -13,23 +13,6 @@ module Carto
       end
     end
 
-    def fix_analysis_node_queries(node, old_username, new_user, renamed_tables)
-      options = node.options
-
-      if options && options.has_key?(:table_name)
-        old_table_name = options[:table_name]
-        options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
-      end
-
-      params = node.params
-      if params && old_username
-        query = params[:query]
-        params[:query] = rewrite_query(query, old_username, new_user, renamed_tables) if query.present?
-      end
-
-      node.children.each { |child| fix_analysis_node_queries(child, old_username, new_user, renamed_tables) }
-    end
-
     private
 
     def test_query(user, query)

--- a/lib/carto/query_rewriter.rb
+++ b/lib/carto/query_rewriter.rb
@@ -1,0 +1,60 @@
+module Carto
+  module QueryRewriter
+    def rewrite_query(query, old_username, new_user, renamed_tables)
+      new_query = query
+      new_query = rewrite_query_for_new_user(query, old_username, new_user) if old_username != new_user.username
+      new_query = rewrite_query_for_renamed_tables(new_query, renamed_tables) if renamed_tables.present?
+      if test_query(new_user, new_query)
+        new_query
+      else
+        CartoDB::Logger.debug(message: 'Did not rewrite query', old_query: query, new_query: new_query,
+                              old_username: old_username, user: new_user, renamed_tables: renamed_tables)
+        query
+      end
+    end
+
+    def fix_analysis_node_queries(node, old_username, new_user, renamed_tables)
+      options = node.options
+
+      if options && options.has_key?(:table_name)
+        old_table_name = options[:table_name]
+        options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
+      end
+
+      params = node.params
+      if params && old_username
+        query = params[:query]
+        params[:query] = rewrite_query(query, old_username, new_user, renamed_tables) if query.present?
+      end
+
+      node.children.each { |child| fix_analysis_node_queries(child, old_username, new_user, renamed_tables) }
+    end
+
+    private
+
+    def test_query(user, query)
+      user.in_database.execute("EXPLAIN (#{query})")
+      true
+    rescue
+      false
+    end
+
+    def rewrite_query_for_new_user(query, old_username, new_user)
+      if new_user.username == new_user.database_schema
+        new_schema = new_user.sql_safe_database_schema
+        query.gsub(" #{old_username}.", " #{new_schema}.").gsub(" \"#{old_username}\".", " #{new_schema}.")
+      else
+        query.gsub(" #{old_username}.", " ").gsub(" \"#{old_username}\".", " ")
+      end
+    end
+
+    PSQL_WORD_CHARS = '[$_[[:alnum:]]]'.freeze
+    def rewrite_query_for_renamed_tables(query, renamed_tables)
+      renamed_tables.reduce(query) do |sql, (old_name, new_name)|
+        # Replaces the table name only if it matches the whole word
+        # i.e: previous and next characters are not PSQL_WORD_CHARS (alphanumerics, _ or $)
+        sql.gsub(/(?<!#{PSQL_WORD_CHARS})#{Regexp.escape(old_name)}(?!#{PSQL_WORD_CHARS})/, new_name)
+      end
+    end
+  end
+end

--- a/spec/requests/api/json/visualizations_controller_spec.rb
+++ b/spec/requests/api/json/visualizations_controller_spec.rb
@@ -185,7 +185,7 @@ describe Api::Json::VisualizationsController do
           type: 'derived',
           tables: ["#{@org_user_1.username}.#{table1.name}"]
         }
-        post_json(api_v1_visualizations_create_url(user_domain: @org_user_2.username, api_key: @org_user_2.api_key),
+        post_json(api_v1_visualizations_create_url(user_domain: @org_user_1.username, api_key: @org_user_1.api_key),
                   payload) do |response|
           response.status.should eq 200
           vid = response.body[:id]

--- a/spec/requests/api/json/visualizations_controller_spec.rb
+++ b/spec/requests/api/json/visualizations_controller_spec.rb
@@ -154,6 +154,25 @@ describe Api::Json::VisualizationsController do
           v.map.user.should eq @org_user_2
         end
       end
+
+      it 'rewrites queries for other user datasets' do
+        table1 = create_table(user_id: @org_user_1.id)
+        layer = table1.map.data_layers.first
+        layer.options['query'] = "SELECT * FROM #{table1.name} LIMIT 1"
+        layer.save
+        share_table_with_user(table1, @org_user_2)
+        payload = {
+          type: 'derived',
+          tables: ["#{@org_user_1.username}.#{table1.name}"]
+        }
+        post_json(api_v1_visualizations_create_url(user_domain: @org_user_2.username, api_key: @org_user_2.api_key),
+                  payload) do |response|
+          response.status.should eq 200
+          vid = response.body[:id]
+          v = CartoDB::Visualization::Member.new(id: vid).fetch
+          v.map.data_layers.first.options['query'].should eq "SELECT * FROM #{@org_user_1.username}.#{table1.name} LIMIT 1"
+        end
+      end
     end
   end
 

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -540,6 +540,7 @@ describe Carto::VisualizationsExportService2 do
             service = Carto::VisualizationsExportService2.new
             built_viz = service.build_visualization_from_json_export(export_2_0_1.to_json)
             Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(true)
+            Carto::AnalysisNode.any_instance.stubs(:test_query).returns(true)
             imported_viz = Carto::VisualizationsExportPersistenceService.new.save_import(@user, built_viz)
             imported_viz.layers[1].options[:user_name].should eq @user.username
           end
@@ -663,6 +664,7 @@ describe Carto::VisualizationsExportService2 do
         delete_user_data @org_user_with_dash_1
         delete_user_data @org_user_with_dash_2
         Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(true)
+        Carto::AnalysisNode.any_instance.stubs(:test_query).returns(true)
       end
 
       let(:table_name) { 'a_shared_table' }
@@ -766,6 +768,7 @@ describe Carto::VisualizationsExportService2 do
 
       it 'does not replace owner name with new user name on import when new query fails' do
         Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(false)
+        Carto::AnalysisNode.any_instance.stubs(:test_query).returns(false)
         source_user = @carto_org_user_1
         target_user = @carto_org_user_2
         setup_visualization_with_layer_query(source_user, target_user)
@@ -784,6 +787,7 @@ describe Carto::VisualizationsExportService2 do
 
       before(:each) do
         Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(true)
+        Carto::AnalysisNode.any_instance.stubs(:test_query).returns(true)
       end
 
       def default_query(table_name = @table.name)
@@ -873,6 +877,7 @@ describe Carto::VisualizationsExportService2 do
 
       it 'does not replace table name when query fails' do
         Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(false)
+        Carto::AnalysisNode.any_instance.stubs(:test_query).returns(false)
         setup_visualization_with_layer_query('tabula', 'SELECT * FROM tabula WHERE tabulacol=2')
         renamed_tables = { 'tabula' => 'rasa' }
         import_and_check_query(renamed_tables, 'rasa', 'SELECT * FROM tabula WHERE tabulacol=2')

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -541,6 +541,7 @@ describe Carto::VisualizationsExportService2 do
             built_viz = service.build_visualization_from_json_export(export_2_0_1.to_json)
             Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(true)
             Carto::AnalysisNode.any_instance.stubs(:test_query).returns(true)
+            Carto::Layer.any_instance.stubs(:test_query).returns(true)
             imported_viz = Carto::VisualizationsExportPersistenceService.new.save_import(@user, built_viz)
             imported_viz.layers[1].options[:user_name].should eq @user.username
           end
@@ -665,6 +666,7 @@ describe Carto::VisualizationsExportService2 do
         delete_user_data @org_user_with_dash_2
         Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(true)
         Carto::AnalysisNode.any_instance.stubs(:test_query).returns(true)
+        Carto::Layer.any_instance.stubs(:test_query).returns(true)
       end
 
       let(:table_name) { 'a_shared_table' }
@@ -769,6 +771,7 @@ describe Carto::VisualizationsExportService2 do
       it 'does not replace owner name with new user name on import when new query fails' do
         Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(false)
         Carto::AnalysisNode.any_instance.stubs(:test_query).returns(false)
+        Carto::Layer.any_instance.stubs(:test_query).returns(false)
         source_user = @carto_org_user_1
         target_user = @carto_org_user_2
         setup_visualization_with_layer_query(source_user, target_user)
@@ -788,6 +791,7 @@ describe Carto::VisualizationsExportService2 do
       before(:each) do
         Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(true)
         Carto::AnalysisNode.any_instance.stubs(:test_query).returns(true)
+        Carto::Layer.any_instance.stubs(:test_query).returns(true)
       end
 
       def default_query(table_name = @table.name)
@@ -878,6 +882,7 @@ describe Carto::VisualizationsExportService2 do
       it 'does not replace table name when query fails' do
         Carto::VisualizationsExportPersistenceService.any_instance.stubs(:test_query).returns(false)
         Carto::AnalysisNode.any_instance.stubs(:test_query).returns(false)
+        Carto::Layer.any_instance.stubs(:test_query).returns(false)
         setup_visualization_with_layer_query('tabula', 'SELECT * FROM tabula WHERE tabulacol=2')
         renamed_tables = { 'tabula' => 'rasa' }
         import_and_check_query(renamed_tables, 'rasa', 'SELECT * FROM tabula WHERE tabulacol=2')


### PR DESCRIPTION
Qualifies table names in queries when creating a map from a shared dataset.

Also does a refactor trying to unify some of the query rewriting code. It is actually not needed with the latest version of this patch (I first thought that I could reuse the same query rewriting than in the importer for this, but qualifying != schema rewriting). I still kept it as I think it is a nice addition.

Fixes #9533