### PR TITLE
Persist source node geometry when a query is applied

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
@@ -21,8 +21,6 @@ module.exports = Backbone.Model.extend({
       simple_geom: simpleGeom,
       status: simpleGeom ? 'fetched' : 'unfetched'
     }, modelOpts);
-
-    this.listenTo(this.queryGeometryModel, 'change:simple_geom', this._onGeometryTypeChanged);
   },
 
   /**
@@ -232,10 +230,6 @@ module.exports = Backbone.Model.extend({
    */
   _sourceNames: function () {
     return camshaftReference.getSourceNamesForAnalysisType(this.get('type'));
-  },
-
-  _onGeometryTypeChanged: function (m, value) {
-    this.set('simple_geom', value);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-source-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-source-model.js
@@ -25,12 +25,18 @@ module.exports = AnalysisDefinitionNodeModel.extend({
     }, {
       configModel: opts.configModel
     });
+
+    this.listenTo(this.queryGeometryModel, 'change:simple_geom', this._onGeometryTypeChanged);
   },
 
   fetchTable: function () {
     if (!this.tableModel.get('id')) {
       this.tableModel.fetch();
     }
+  },
+
+  _onGeometryTypeChanged: function (m, value) {
+    this.set('simple_geom', value);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -188,10 +188,9 @@ module.exports = CoreView.extend({
       });
 
       this._queryGeometryModel.set({
-        status: 'unfetched',
-        query: currentQuery,
-        simple_geom: ''
-      }, { silent: true });
+        simple_geom: '',
+        query: currentQuery
+      });
 
       SQLNotifications.showNotification({
         status: 'loading',
@@ -199,11 +198,9 @@ module.exports = CoreView.extend({
         closable: false
       });
 
-      this._querySchemaModel.fetch({
-        success: this._saveSQL.bind(this)
-      });
-
-      this._queryGeometryModel.fetch();
+      var saveSQL = _.after(2, this._saveSQL.bind(this));
+      this._querySchemaModel.fetch({ success: saveSQL });
+      this._queryGeometryModel.fetch({ complete: saveSQL });
     }
   },
 


### PR DESCRIPTION
Basically, after updating everything with the PR about `query-geometry-model`, I missed the case when a query was applied and it could change the geometry type (for example, not requesting the `the_geom_webmercator` column).

So the idea is, wait until query-schema-model and query-geometry-model fetch has completed (successfully or badly in this last case), and then run `_saveSQL`, where analysis is saved ([here](https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js#L233)). That means geometry_type will be included in the node definition and it will be stored in the analysis definition.

About nodes those are not source type, we check geometry when the Builder app has started, due to checks from CartoDB.js, so I'd not store those for the moment, it doesn't make sense.

Sounds cool @nobuti?

