### PR TITLE
Fixed problem with table rows request failing

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/table/body/table-body-view.js
+++ b/lib/assets/javascripts/cartodb3/components/table/body/table-body-view.js
@@ -17,6 +17,7 @@ var ErrorView = require('../../error/error-view');
 var tableNoRowsTemplate = require('./table-no-rows.tpl');
 var EditorsServiceModel = require('../editors/editors-service-model');
 var EditorsModel = require('../editors/types/editor-model');
+var errorParser = require('../../../helpers/error-parser');
 
 var EDITORS_MAP = {
   'string': require('../editors/types/editor-string-view'),
@@ -98,8 +99,8 @@ module.exports = CoreView.extend({
       }
     }, this);
     this._rowsCollection.bind('remove', this._onRemoveRow, this);
-    this._rowsCollection.bind('error', function (error) {
-      this._renderError(error && error[0]);
+    this._rowsCollection.bind('error', function (mdl, response) {
+      this._renderError(errorParser(response));
     }, this);
     this.add_related_model(this._queryGeometryModel);
     this.add_related_model(this._querySchemaModel);

--- a/lib/assets/javascripts/cartodb3/data/query-rows-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/query-rows-collection.js
@@ -100,10 +100,8 @@ module.exports = Backbone.Collection.extend({
     opts.method = this._httpMethod();
     var errorCallback = opts.error;
     opts.error = function (mdl, response) {
-      var error = response.responseText ? JSON.parse(response.responseText).error : [];
       errorCallback && errorCallback(mdl, response);
-      this.trigger('error', error, this);
-    }.bind(this);
+    };
 
     // Needed to reset the whole collection when a fetch is done
     opts.reset = true;

--- a/lib/assets/javascripts/cartodb3/helpers/error-parser.js
+++ b/lib/assets/javascripts/cartodb3/helpers/error-parser.js
@@ -1,6 +1,9 @@
+var _ = require('underscore');
+var DEFAULT_ERROR_MSG = '';
+
 /**
  *  Return error message when backend request fails
- *  It tries to get responseText > errors array, if not gets `statusText`.
+ *  It tries to get responseText > errors and error arrays, if not gets `statusText`.
  */
 
 module.exports = function (e) {
@@ -8,14 +11,19 @@ module.exports = function (e) {
 
   try {
     var responseText = e.responseText && JSON.parse(e.responseText);
-    var errorMessage = e.statusText;
+    var errorMessage = e.statusText || DEFAULT_ERROR_MSG;
 
     if (responseText) {
-      errorMessage = responseText.errors && responseText.errors.join(',');
+      var errors = _.compact(
+        _.map(['errors', 'error'], function (type) {
+          return responseText[type] && responseText[type].join(', ');
+        })
+      );
+      errorMessage = errors.join(', ');
     }
 
     return errorMessage;
   } catch (err) {
-    return '';
+    return DEFAULT_ERROR_MSG;
   }
 };

--- a/lib/assets/test/spec/cartodb3/helpers/error-parser.spec.js
+++ b/lib/assets/test/spec/cartodb3/helpers/error-parser.spec.js
@@ -1,0 +1,47 @@
+var errorParser = require('../../../../javascripts/cartodb3/helpers/error-parser');
+
+describe('helpers/error-parser', function () {
+  it('should not provide error info if there isn\'t anything', function () {
+    expect(errorParser({})).toBe('');
+  });
+
+  it('should provide status text if there is no response text', function () {
+    var error = {
+      statusText: ':scream:'
+    };
+    expect(errorParser(error)).toBe(':scream:');
+  });
+
+  it('should not provide anything if response is not correctly defined', function () {
+    var error = {
+      whatever: true,
+      error: 'haasss',
+      responseText: '{error: ["boom"]}' // Bad JSON
+    };
+    expect(errorParser(error)).toBe('');
+  });
+
+  it('should return error if it is defined within responseText', function () {
+    var error = {
+      statusText: 'hello',
+      responseText: '{"error": ["boom"]}'
+    };
+    expect(errorParser(error)).toBe('boom');
+  });
+
+  it('should return several errors if there are more than one', function () {
+    var error = {
+      statusText: 'hello',
+      responseText: '{"error": ["boom", "danger"]}'
+    };
+    expect(errorParser(error)).toBe('boom, danger');
+  });
+
+  it('should display all errors together although they are different', function () {
+    var error = {
+      statusText: 'hello',
+      responseText: '{"error": ["boom", "danger"], "errors": ["hellooo"]}'
+    };
+    expect(errorParser(error)).toBe('hellooo, boom, danger');
+  });
+});


### PR DESCRIPTION
Basically, Backbone already triggers an `error` event when the request fails, so we were triggering twice 😱 , unnecessary. So making use of it and the errorParser. Added some tests to that helper and adding the possibility to be used everywhere in the application.

CR: @nobuti 
cc @CartoDB/frontend 