### PR TITLE
Rescue untreated exceptions to set error 99999

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -720,8 +720,14 @@ class DataImport < Sequel::Model
       importer.run(tracker)
       log.append 'After importer run'
     end
+
     store_results(importer, runner, datasource_provider, manual_fields)
     importer.nil? ? false : importer.success?
+  rescue => e
+    # Note: If this exception is not treated, results will not be defined
+    # and the import will finish with a null error_code
+    set_error(manual_fields.fetch(:error_code, 99999))
+    raise e
   end
 
   # Note: Assumes that if importer is nil an error happened


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb/issues/9812

=====

If an exception is raised here, `store_results` never occurs and the DataImport finishes with results = `[]`.

This is affecting the MailNotifier: https://github.com/CartoDB/cartodb/issues/9805

Calling `set_error` will setup the default 99999 (missing until now) and build a results array out of this. Unfortunately, this won't provide the table name though or any other metadata, but will return a non-empty results with a non-null error code:

````
[<CartoDB::Importer2::Result @name=, @schema=, @extension=, @tables=, @success=false, @error_code=99999, @support_tables=, @original_name=>]
````

This should fix also another problem we noticed which is that some imports end up with null error_code because it's never treated. Wondering if it'd be worthy to send the whole `importer.results` (whenever importer is defined) and manipulate those by setting the error code if null, and the success to false (it's generally true in Data Import because Importer raised the exception without treating the results, or because an error happened above the Importer layer). 