### PR TITLE
Drop log_id foreign key from user migrations

### DIFF
--- a/db/migrate/20160920104742_drop_log_id_fk_from_migration_exports.rb
+++ b/db/migrate/20160920104742_drop_log_id_fk_from_migration_exports.rb
@@ -2,19 +2,18 @@ Sequel.migration do
   up do
     alter_table :user_migration_exports do
       drop_constraint :user_migration_exports_log_id_fkey
-    end 
+    end
     alter_table :user_migration_imports do
       drop_constraint :user_migration_imports_log_id_fkey
-    end 
-  end 
+    end
+  end
 
   down do
     alter_table :user_migration_exports do
       add_foreign_key [:log_id], :logs, null: false
-    end 
+    end
     alter_table :user_migration_imports do
       add_foreign_key [:log_id], :logs, null: false
-    end 
-  end 
+    end
+  end
 end
-

--- a/db/migrate/20160920104742_drop_log_id_fk_from_migration_exports.rb
+++ b/db/migrate/20160920104742_drop_log_id_fk_from_migration_exports.rb
@@ -1,0 +1,20 @@
+Sequel.migration do
+  up do
+    alter_table :user_migration_exports do
+      drop_constraint :user_migration_exports_log_id_fkey
+    end 
+    alter_table :user_migration_imports do
+      drop_constraint :user_migration_imports_log_id_fkey
+    end 
+  end 
+
+  down do
+    alter_table :user_migration_exports do
+      add_foreign_key [:log_id], :logs, null: false
+    end 
+    alter_table :user_migration_imports do
+      add_foreign_key [:log_id], :logs, null: false
+    end 
+  end 
+end
+


### PR DESCRIPTION
The log_id column is still mandatory because all the logic involves
writing a log. However, having a history of the logs of users migrations
is not really needed so, this way, it's possible to implement a retention policy
of the logs while keeping all the users migrations metadata

@juanignaciosl can you review?

/cc @javitonino 