### PR TITLE
popups: fix field inputs in firefox

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
@@ -130,7 +130,7 @@ module.exports = CoreView.extend({
       opacity: 0.8,
       update: this._onSortableFinish.bind(this),
       forcePlaceholderSize: false
-    }).disableSelection();
+    });
   },
 
   _destroySortable: function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.04",
+  "version": "4.2.06",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
close https://github.com/CartoDB/cartodb/issues/9780

![tilejsonbasemaps](https://cloud.githubusercontent.com/assets/36676/18674756/98726758-7f50-11e6-9a78-14b4d1812884.gif)


we don't really need the `.disableSelection`

CR @nobuti 