### PR TITLE
replace instagram description in twitter connector fallback

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/fallbacks/import-twitter-fallback.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-layer/content/imports/fallbacks/import-twitter-fallback.tpl
@@ -4,7 +4,7 @@
   </div>
   <h3 class="CDB-Text CDB-Size-large u-mainTextColor u-secondaryTextColor u-bSpace--m"><%- _t('components.modals.add-layer.imports.twitter.fallback-title', { brand: 'Twitter' }) %></h3>
   <p class="CDB-Text CDB-Size-medium u-altTextColor u-bSpace--xl">
-    <%- _t('components.modals.add-layer.imports.instagram.fallback-desc', { brand: 'Twitter' }) %>
+    <%- _t('components.modals.add-layer.imports.twitter.fallback-desc', { brand: 'Twitter' }) %>
   </p>
   <a href="mailto:sales@carto.com?subject=<%- _t('components.modals.add-layer.imports.demo-email-title', { name: 'Twitter' }) %>&body=<%- _t('components.modals.add-layer.imports.demo-email-desc', { name: 'Twitter' }) %>" class="CDB-Button CDB-Button--primary CDB-Button--medium">
     <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-medium u-upperCase">ask for a demo</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.08",
+  "version": "4.2.09",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- the string seems to be wrong (see attached)

![screen shot 2016-09-21 at 14 20 19](https://cloud.githubusercontent.com/assets/36676/18710665/b2167d6e-8006-11e6-9883-ea537573ab62.png)

fixed with the proper localized string for twitter

CR @xavijam 