### PR TITLE
Connector configuration

### DIFF
--- a/app/models/carto/connector_configuration.rb
+++ b/app/models/carto/connector_configuration.rb
@@ -43,11 +43,21 @@ class Carto::ConnectorConfiguration < ActiveRecord::Base
     config
   end
 
+  def self.for_organization(organization, provider)
+    if provider
+      config = where(organization_id: organization.id, connector_provider_id: provider.id).first
+      if config.blank?
+        config = default(provider)
+      end
+      config
+    end
+  end
+
   def self.for_user(user, provider)
     if provider
       config = where(user_id: user.id, connector_provider_id: provider.id).first
       if config.blank? && user.organization_id.present?
-        config = where(organization_id: user.organization_id, connector_provider_id: provider.id).first
+        config = for_organization(user.organization, provider)
       end
       if config.blank?
         config = default(provider)

--- a/app/models/carto/connector_configuration.rb
+++ b/app/models/carto/connector_configuration.rb
@@ -1,0 +1,58 @@
+# encoding: UTF-8
+
+require 'carto/connector'
+
+class Carto::ConnectorConfiguration < ActiveRecord::Base
+  belongs_to :connector_provider, class_name: Carto::ConnectorProvider
+  belongs_to :user, class_name: Carto::User
+  belongs_to :organization, class_name: Carto::Organization
+
+  # A ConnectorConfiguration can belong to either user or an organization, but not both;
+  # it may also be a default configuration (no user or organization).
+  # Only one configuration may exist for any valid combination of user, organization and provider.
+  # So we have 3 kinds of configuration records:
+  # * default configuration for provider: user.nil? && organization.nil? FIXME: remove this? (only app_config defaults)
+  # * organization configuration: user.nil? && organization.present?
+  # * user configuration: organization.nil? && user.present?
+  validates :connector_provider_id, presence: true
+  validates :user_id, uniqueness: { scope: [:connector_provider_id, :organization_id] }, if: 'organization_id.nil?'
+  validates :organization_id, uniqueness: { scope: [:connector_provider_id, :user_id] }, if: 'user_id.nil?'
+  validate :not_user_and_organization_simultaneously
+
+  def not_user_and_organization_simultaneously
+    if user_id.present? && organization_id.present?
+      errors.add(:user_id, "can't assign to an organization simultaneously with a user")
+    end
+  end
+
+  # columns:
+  # enabled boolean
+  # max_rows integer
+
+  def self.default(provider)
+    # Look for default provider configration
+    config = where(user_id: nil, organization_id: nil, connector_provider_id: provider.id).first
+    if !config
+      # Create in memory record using app_config defaults
+      config = new(
+        connector_provider: provider,
+        enabled:  Cartodb.get_config(:connectors, provider.name, 'enabled') || false,
+        max_rows: Cartodb.get_config(:connectors, provider.name, 'max_rows')
+      )
+    end
+    config
+  end
+
+  def self.for_user(user, provider)
+    if provider
+      config = where(user_id: user.id, connector_provider_id: provider.id).first
+      if config.blank? && user.organization_id.present?
+        config = where(organization_id: user.organization_id, connector_provider_id: provider.id).first
+      end
+      if config.blank?
+        config = default(provider)
+      end
+      config
+    end
+  end
+end

--- a/app/models/carto/connector_provider.rb
+++ b/app/models/carto/connector_provider.rb
@@ -7,18 +7,4 @@ class Carto::ConnectorProvider < ActiveRecord::Base
   validates :name, uniqueness: true
 
   has_many :connector_configurations
-
-  private
-
 end
-
-#
-# User methods (Carto::User too?)
-#
-# def connector_configuration(provider)
-#   config = ConnectorConfiguration.where(user_id: id, provider: provider)
-#   if config.blank? && organization.present?
-#     config = ConnectorConfiguration.where(organization_id: id, provider: provider)
-#   end
-#   config
-# end

--- a/app/models/carto/connector_provider.rb
+++ b/app/models/carto/connector_provider.rb
@@ -1,0 +1,24 @@
+# encoding: UTF-8
+
+require 'carto/connector'
+
+class Carto::ConnectorProvider < ActiveRecord::Base
+  validates :name, presence: true
+  validates :name, uniqueness: true
+
+  has_many :connector_configurations
+
+  private
+
+end
+
+#
+# User methods (Carto::User too?)
+#
+# def connector_configuration(provider)
+#   config = ConnectorConfiguration.where(user_id: id, provider: provider)
+#   if config.blank? && organization.present?
+#     config = ConnectorConfiguration.where(organization_id: id, provider: provider)
+#   end
+#   config
+# end

--- a/app/models/carto/helpers/has_connector_configuration.rb
+++ b/app/models/carto/helpers/has_connector_configuration.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 module Carto
   module HasConnectorConfiguration
     def connector_configuration(provider_name)

--- a/app/models/carto/helpers/has_connector_configuration.rb
+++ b/app/models/carto/helpers/has_connector_configuration.rb
@@ -1,0 +1,8 @@
+module Carto
+  module HasConnectorConfiguration
+    def connector_configuration(provider_name)
+      provider = ConnectorProvider.find_by_name(provider_name)
+      ConnectorConfiguration.for_user(self, provider)
+    end
+  end
+end

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -6,12 +6,14 @@ require_relative 'user_db_service'
 require_relative 'synchronization_oauth'
 require_relative '../../helpers/data_services_metrics_helper'
 require_dependency 'carto/helpers/auth_token_generator'
+require_dependency 'carto/helpers/has_connector_configuration'
 
 # TODO: This probably has to be moved as the service of the proper User Model
 class Carto::User < ActiveRecord::Base
   extend Forwardable
   include DataServicesMetricsHelper
   include Carto::AuthTokenGenerator
+  include Carto::HasConnectorConfiguration
 
   MIN_PASSWORD_LENGTH = 6
   MAX_PASSWORD_LENGTH = 64

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ require_dependency 'carto/user_db_size_cache'
 require_dependency 'cartodb/redis_vizjson_cache'
 require_dependency 'carto/bolt'
 require_dependency 'carto/helpers/auth_token_generator'
+require_dependency 'carto/helpers/has_connector_configuration'
 
 class User < Sequel::Model
   include CartoDB::MiniSequel
@@ -27,6 +28,7 @@ class User < Sequel::Model
   include CartoDB::ConfigUtils
   include DataServicesMetricsHelper
   include Carto::AuthTokenGenerator
+  include Carto::HasConnectorConfiguration
 
   self.strict_param_setting = false
 

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -499,19 +499,19 @@ defaults: &defaults
     tolerance_px: 1.0
   connectors:
     odbc:
-      available: false
+      enabled: false
       max_rows: nil
     mysql:
-      available: true
+      enabled: true
       max_rows: 500000
     postgresql:
-      available: true
+      enabled: true
       max_rows: 500000
     hive:
-      available: false
+      enabled: false
       max_rows: 500000
     sqlserver:
-      available: false
+      enabled: false
       max_rows: 500000
 
 development:

--- a/db/migrate/20160916131013_create_connector_providers_configurations.rb
+++ b/db/migrate/20160916131013_create_connector_providers_configurations.rb
@@ -1,0 +1,37 @@
+Sequel.migration do
+  up do
+    create_table :connector_providers do
+      Uuid     :id, primary_key: true, default: 'uuid_generate_v4()'.lit
+      DateTime :created_at, default: Sequel::CURRENT_TIMESTAMP
+      DateTime :updated_at, default: Sequel::CURRENT_TIMESTAMP
+      String   :name, null: false
+    end
+
+    alter_table :connector_providers do
+      add_index :name
+    end
+
+    create_table :connector_configurations do
+      Uuid     :id, primary_key: true, default: 'uuid_generate_v4()'.lit
+      DateTime :created_at, default: Sequel::CURRENT_TIMESTAMP
+      DateTime :updated_at, default: Sequel::CURRENT_TIMESTAMP
+      Boolean  :enabled, null: false
+      Integer  :max_rows, null: true
+
+      foreign_key :user_id, :users, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :organization_id, :organizations, type: :uuid, null: true, on_delete: :cascade
+      foreign_key :connector_provider_id, :connector_providers, type: :uuid, null: false, on_delete: :cascade
+    end
+
+    alter_table :connector_configurations do
+      add_index :user_id
+      add_index :organization_id
+      add_index :connector_provider_id
+    end
+  end
+
+  down do
+    drop_table :connector_configurations
+    drop_table :connector_providers
+  end
+end

--- a/lib/carto/connector.rb
+++ b/lib/carto/connector.rb
@@ -184,16 +184,21 @@ module Carto
       @logger.append message, truncate if @logger
     end
 
-    MAX_PG_IDENTIFIER_LEN = 60
+    # maximum unique identifier length in PostgreSQL
+    MAX_PG_IDENTIFIER_LEN = 63
+    # minimum length left available for the table part in foreign table names
     MIN_TAB_ID_LEN        = 10
 
+    # Named used for the foreign server (unique poer Connector instance)
     def server_name
       max_len = MAX_PG_IDENTIFIER_LEN - @unique_suffix.size - MIN_TAB_ID_LEN - 1
       connector_name = Carto::DB::Sanitize.sanitize_identifier @provider_name
-      connector_name[0...max_len]
-      "#{connector_name.downcase}_#{@unique_suffix}"
+      "#{connector_name[0...max_len].downcase}_#{@unique_suffix}"
     end
 
+    # Prefix to be used by foreign table names (so they're unique per Connector instance)
+    # This leaves at least MIN_TAB_ID_LEN available identifier characters given PostgreSQL's
+    # limit of MAX_PG_IDENTIFIER_LEN
     def foreign_prefix
       "#{server_name}_"
     end

--- a/lib/carto/connector.rb
+++ b/lib/carto/connector.rb
@@ -4,6 +4,7 @@ require_relative 'connector/fdw_support'
 require_relative 'connector/errors'
 require_relative 'connector/providers'
 require_relative 'connector/parameters'
+require_relative 'connector/context'
 
 module Carto
   # This class provides remote database connection services based on FDW
@@ -11,55 +12,29 @@ module Carto
 
     attr_reader :provider_name
 
-    def initialize(parameters, options = {})
-      @logger     = options[:logger]
-      @user       = options[:user]
+    def initialize(parameters, context)
+      @connector_context = Context.cast(context)
 
-      @unique_suffix = UUIDTools::UUID.timestamp_create.to_s.delete('-') # .to_i.to_s(16) # or hash from user, etc.
       @params = Parameters.new(parameters)
 
       @provider_name = @params[:provider]
       @provider_name ||= DEFAULT_PROVIDER
 
       raise InvalidParametersError.new(message: "Provider not defined") if @provider_name.blank?
-      @provider = Connector.provider_class(@provider_name).try :new, @params
+      @provider = Connector.provider_class(@provider_name).try :new, @connector_context, @params
       raise InvalidParametersError.new(message: "Invalid provider", provider: @provider_name) if @provider.blank?
     end
 
     def copy_table(schema_name:, table_name:)
-      log "Connector Copy table  #{schema_name}.#{table_name}"
-      validate!
-      # TODO: logging with CartoDB::Logger
-      with_server do
-        begin
-          qualified_table_name = %{"#{schema_name}"."#{table_name}"}
-          foreign_table_name = @provider.foreign_table_name(foreign_prefix)
-          log "Creating Foreign Table"
-          execute_as_superuser create_foreign_table_command
-          log "Copying Foreign Table"
-          max_rows = limits[:max_rows]
-          execute copy_foreign_table_command(
-            qualified_table_name, qualified_foreign_table_name(foreign_table_name), max_rows
-          )
-          check_copied_table_size(qualified_table_name, max_rows)
-        ensure
-          execute_as_superuser drop_foreign_table_command(foreign_table_name) if foreign_table_name
-        end
-      end
+      @provider.copy_table(schema_name: schema_name, table_name: table_name, limits: limits)
     end
 
     def list_tables(limit = nil)
-      validate! only: [:connection]
-      with_server do
-        # TODO: let the providers decide what needs to be executed as superuser
-        # (we use superuser here because the provider may need to create auxiliar foreing tables)
-        execute_as_superuser list_tables_command(limit)
-      end
+      @provider.list_tables(limits: limits.merge(max_listed_tables: limit))
     end
 
     def remote_data_updated?
-      # TODO: can we detect if query results have changed?
-      true
+      @provider.remote_data_updated?
     end
 
     def remote_table_name
@@ -75,15 +50,15 @@ module Carto
 
     # Check availability for a user and provider
     def check_availability!
-      Connector.check_availability!(@user)
+      Connector.check_availability!(@connector_context.user)
       if !enabled?
-        raise ConnectorsDisabledError.new(user: @user, provider: @provider_name)
+        raise ConnectorsDisabledError.new(user: @connector_context.user, provider: @provider_name)
       end
     end
 
     # Limits for the user/provider
     def limits
-      Connector.limits provider_name: @provider_name, user: @user
+      Connector.limits provider_name: @provider_name, user: @connector_context.user
     end
 
     # Availability for the user/provider
@@ -153,26 +128,6 @@ module Carto
 
     private
 
-    # Execute code that requires a FDW server/user mapping
-    # The server name is given by the method `#server_name`
-    def with_server
-      # Currently we create temporary server and user mapings when we need them,
-      # and drop them after use.
-      log "Creating Server"
-      execute_as_superuser create_server_command
-      log "Creating Usermap"
-      execute_as_superuser create_usermap_command
-      yield
-    rescue => error
-      log "Connector Error #{error}"
-      raise error
-    ensure
-      log "Connector cleanup"
-      execute_as_superuser drop_usermap_command
-      execute_as_superuser drop_server_command
-      log "Connector cleaned-up"
-    end
-
     # Validate parameters.
     # An array of parameter names to validate can be passed via :only.
     # By default all parameters are validated
@@ -181,119 +136,7 @@ module Carto
     end
 
     def log(message, truncate = true)
-      @logger.append message, truncate if @logger
-    end
-
-    # maximum unique identifier length in PostgreSQL
-    MAX_PG_IDENTIFIER_LEN = 63
-    # minimum length left available for the table part in foreign table names
-    MIN_TAB_ID_LEN        = 10
-
-    # Named used for the foreign server (unique poer Connector instance)
-    def server_name
-      max_len = MAX_PG_IDENTIFIER_LEN - @unique_suffix.size - MIN_TAB_ID_LEN - 1
-      connector_name = Carto::DB::Sanitize.sanitize_identifier @provider_name
-      "#{connector_name[0...max_len].downcase}_#{@unique_suffix}"
-    end
-
-    # Prefix to be used by foreign table names (so they're unique per Connector instance)
-    # This leaves at least MIN_TAB_ID_LEN available identifier characters given PostgreSQL's
-    # limit of MAX_PG_IDENTIFIER_LEN
-    def foreign_prefix
-      "#{server_name}_"
-    end
-
-    def foreign_table_schema
-      # since connectors' foreign table names are unique (because
-      # server names are unique and not reused)
-      # we could in principle use any schema (@schema, 'public', 'cdb_importer')
-      CartoDB::Connector::Importer::ORIGIN_SCHEMA
-    end
-
-    def qualified_foreign_table_name(foreign_table_name)
-      %{"#{foreign_table_schema}"."#{foreign_table_name}"}
-    end
-
-    def create_server_command
-      @provider.create_server_command server_name
-    end
-
-    def create_usermap_command
-      [
-        @provider.create_usermap_command(server_name, @user.database_username),
-        @provider.create_usermap_command(server_name, 'postgres')
-      ].join("\n")
-    end
-
-    def create_foreign_table_command
-      @provider.create_foreign_table_command server_name, foreign_table_schema,
-                                             foreign_prefix,
-                                             @user.database_username
-    end
-
-    def drop_server_command
-      @provider.drop_server_command server_name
-    end
-
-    def drop_usermap_command
-      [
-        @provider.drop_usermap_command(server_name, 'postgres'),
-        @provider.drop_usermap_command(server_name, @user.database_username)
-      ].join("\n")
-    end
-
-    def drop_foreign_table_command(foreign_table_name)
-      @provider.drop_foreign_table_command foreign_table_schema, foreign_table_name
-    end
-
-    def copy_foreign_table_command(local_table_name, foreign_table_name, max_rows)
-      limit = (max_rows && max_rows > 0) ? " LIMIT #{max_rows}" : ''
-      %{
-        CREATE TABLE #{local_table_name}
-          AS SELECT * FROM #{foreign_table_name}
-            #{limit};
-      }
-    end
-
-    def list_tables_command(limit)
-      @provider.list_tables_command(server_name, foreign_table_schema, foreign_prefix, limit)
-    end
-
-    def execute_as_superuser(command)
-      execute_in_user_database command, as: :superuser
-    end
-
-    def execute(command)
-      execute_in_user_database command
-    end
-
-    # Execute SQL command returning array of results.
-    # Commands with no results (e.g. UPDATE, etc.) will return an empty array (`[]`).
-    # Result rows are returned as hashes with indifferent access.
-    def execute_in_user_database(command, *args)
-      # This admits Carto::User or User users
-      db = @user.in_database(*args)
-      data = case db
-             when Sequel::Database
-               db.fetch(command).all
-             else
-               db.execute command
-             end
-      data.map(&:with_indifferent_access)
-    end
-
-    def check_copied_table_size(table_name, max_rows)
-      warnings = {}
-      if max_rows && max_rows > 0
-        num_rows = execute(%{
-          SELECT count(*) as num_rows FROM #{table_name};
-        }).first['num_rows']
-        if num_rows == max_rows
-          # The maximum number of rows per connection was reached
-          warnings[:max_rows_per_connection] = max_rows
-        end
-      end
-      warnings
+      @connector_context.log message, truncate
     end
   end
 end

--- a/lib/carto/connector.rb
+++ b/lib/carto/connector.rb
@@ -48,12 +48,12 @@ module Carto
       end
     end
 
-    def list_tables
+    def list_tables(limit = nil)
       validate! only: [:connection]
       with_server do
-        execute %{
-          SELECT * FROM ODBCTablesList('#{server_name}');
-        }
+        # TODO: let the providers decide what needs to be executed as superuser
+        # (we use superuser here because the provider may need to create auxiliar foreing tables)
+        execute_as_superuser list_tables_command(limit)
       end
     end
 
@@ -253,6 +253,10 @@ module Carto
           AS SELECT * FROM #{foreign_table_name}
             #{limit};
       }
+    end
+
+    def list_tables_command(limit)
+      @provider.list_tables_command(server_name, foreign_table_schema, foreign_prefix, limit)
     end
 
     def execute_as_superuser(command)

--- a/lib/carto/connector/context.rb
+++ b/lib/carto/connector/context.rb
@@ -1,0 +1,54 @@
+# Connector context
+# provides logging services and execution of SQL in the user database
+
+module Carto
+  # This class provides remote database connection services based on FDW
+  class Connector
+
+    class Context
+
+      attr_reader :user
+
+      def initialize(logger:, user:)
+        @logger     = logger
+        @user       = user
+      end
+
+      def self.cast(arg)
+        case arg
+        when Context
+          arg
+        else
+          new arg
+        end
+      end
+
+      def log(message, truncate = true)
+        @logger.append message, truncate if @logger
+      end
+
+      def execute_as_superuser(command)
+        execute_in_user_database command, as: :superuser
+      end
+
+      def execute(command)
+        execute_in_user_database command
+      end
+
+      # Execute SQL command returning array of results.
+      # Commands with no results (e.g. UPDATE, etc.) will return an empty array (`[]`).
+      # Result rows are returned as hashes with indifferent access.
+      def execute_in_user_database(command, *args)
+        # This admits Carto::User or User users
+        db = @user.in_database(*args)
+        data = case db
+               when Sequel::Database
+                 db.fetch(command).all
+               else
+                 db.execute command
+               end
+        data.map(&:with_indifferent_access)
+      end
+    end
+  end
+end

--- a/lib/carto/connector/fdw_support.rb
+++ b/lib/carto/connector/fdw_support.rb
@@ -54,8 +54,17 @@ module Carto
          }
       end
 
-      def fdw_drop_server(server_name)
-        "DROP SERVER IF EXISTS #{server_name};"
+      def fdw_create_foreign_table_if_not_exists(server_name, schema_name, table_name, columns, options)
+        %{
+          CREATE FOREIGN TABLE IF NOT EXISTS #{qualified_table_name(schema_name, table_name)} (#{columns * ','})
+            SERVER #{server_name}
+            #{options_clause(options)};
+         }
+      end
+
+      def fdw_drop_server(server_name, cascade: false)
+        cascade_clause = cascade ? ' CASCADE' : ''
+        "DROP SERVER IF EXISTS #{server_name}#{cascade_clause};"
       end
 
       def fdw_drop_usermap(server_name, user_name)
@@ -76,6 +85,10 @@ module Carto
       # This performs the same truncation PG does on too long table names
       def fdw_adjusted_table_name(name)
         name[0...PG_MAX_TABLE_NAME_LENGTH]
+      end
+
+      def fdw_qualified_table_name(schema_name, table_name)
+        qualified_table_name(schema_name, table_name)
       end
 
       private

--- a/lib/carto/connector/fdw_support.rb
+++ b/lib/carto/connector/fdw_support.rb
@@ -5,7 +5,7 @@
 module Carto
   class Connector
     module FdwSupport
-      def fdw_create_server(fdw, server_name, options)
+      def fdw_create_server_sql(fdw, server_name, options)
         %{
           CREATE SERVER #{server_name}
             FOREIGN DATA WRAPPER #{fdw}
@@ -13,7 +13,7 @@ module Carto
         }
       end
 
-      def fdw_create_usermap(server_name, user_name, options)
+      def fdw_create_usermap_sql(server_name, user_name, options)
         %{
           CREATE USER MAPPING FOR "#{user_name}"
             SERVER #{server_name}
@@ -21,7 +21,7 @@ module Carto
         }
       end
 
-      def fdw_import_foreign_schema(server_name, remote_schema_name, schema_name, options)
+      def fdw_import_foreign_schema_sql(server_name, remote_schema_name, schema_name, options)
         %{
           IMPORT FOREIGN SCHEMA "#{remote_schema_name}"
             FROM SERVER #{server_name}
@@ -30,23 +30,23 @@ module Carto
          }
       end
 
-      def fdw_import_foreign_schema_limited(server_name, remote_schema_name, schema_name, limited_to, options)
+      def fdw_import_foreign_schema_limited_sql(server_name, remote_schema_name, schema_name, limited_to, options)
         %{
           IMPORT FOREIGN SCHEMA "#{remote_schema_name}"
-            LIMIT TO #{limited_to}
+            LIMIT TO (#{Array(limited_to).join(',')})
             FROM SERVER #{server_name}
             INTO "#{schema_name}"
             #{options_clause(options)};
          }
       end
 
-      def fdw_grant_select(schema_name, table_name, user_name)
+      def fdw_grant_select_sql(schema_name, table_name, user_name)
         %{
           GRANT SELECT ON #{qualified_table_name(schema_name, table_name)} TO "#{user_name}";
          }
       end
 
-      def fdw_create_foreign_table(server_name, schema_name, table_name, columns, options)
+      def fdw_create_foreign_table_sql(server_name, schema_name, table_name, columns, options)
         %{
           CREATE FOREIGN TABLE #{qualified_table_name(schema_name, table_name)} (#{columns * ','})
             SERVER #{server_name}
@@ -54,7 +54,7 @@ module Carto
          }
       end
 
-      def fdw_create_foreign_table_if_not_exists(server_name, schema_name, table_name, columns, options)
+      def fdw_create_foreign_table_if_not_exists_sql(server_name, schema_name, table_name, columns, options)
         %{
           CREATE FOREIGN TABLE IF NOT EXISTS #{qualified_table_name(schema_name, table_name)} (#{columns * ','})
             SERVER #{server_name}
@@ -62,20 +62,20 @@ module Carto
          }
       end
 
-      def fdw_drop_server(server_name, cascade: false)
+      def fdw_drop_server_sql(server_name, cascade: false)
         cascade_clause = cascade ? ' CASCADE' : ''
         "DROP SERVER IF EXISTS #{server_name}#{cascade_clause};"
       end
 
-      def fdw_drop_usermap(server_name, user_name)
+      def fdw_drop_usermap_sql(server_name, user_name)
         %{DROP USER MAPPING IF EXISTS FOR "#{user_name}" SERVER #{server_name};}
       end
 
-      def fdw_drop_foreign_table(schema_name, table_name)
+      def fdw_drop_foreign_table_sql(schema_name, table_name)
         %{DROP FOREIGN TABLE IF EXISTS #{qualified_table_name(schema_name, table_name)};}
       end
 
-      def fdw_rename_foreign_table(schema, foreign_table_name, new_name)
+      def fdw_rename_foreign_table_sql(schema, foreign_table_name, new_name)
         %{
           ALTER FOREIGN TABLE #{qualified_table_name(schema, foreign_table_name)}
           RENAME TO #{qualified_table_name(nil, new_name)};

--- a/lib/carto/connector/providers/base.rb
+++ b/lib/carto/connector/providers/base.rb
@@ -48,9 +48,15 @@ module Carto
         must_be_defined_in_derived_class
       end
 
+      # SQL code to list the remote tables
+      # should return a set of rows with two columns: `schema` and `name`
+      def list_tables_command(_server_name)
+        must_be_defined_in_derived_class
+      end
+
       # SQL code to drop the FDW server
       def drop_server_command(server_name)
-        fdw_drop_server server_name
+        fdw_drop_server server_name, cascade: true
       end
 
       # SQL code to drop the user mapping

--- a/lib/carto/connector/providers/base.rb
+++ b/lib/carto/connector/providers/base.rb
@@ -1,6 +1,18 @@
 # encoding: utf-8
 
 # Base class for Connector Providers
+#
+# This is an abstract class; concrete classes derived from this one
+# must implement these methods:
+#
+# * `copy_table(schema_name:, table_name:, limits:)`
+# * `list_tables(limits:)`
+# * `remote_data_updated?`
+# * `table_name`
+# * `required_parameters`
+# * `optional_parameters`
+# * `features_information`
+#
 module Carto
   class Connector
     class Provider
@@ -22,12 +34,12 @@ module Carto
         raise InvalidParametersError.new(message: errors * "\n") if errors.present?
       end
 
-      def copy_table(schema_name:, table_name:)
-        must_be_defined_in_derived_class schema_name: schema_name, table_name: table_name
+      def copy_table(schema_name:, table_name:, limits:)
+        must_be_defined_in_derived_class schema_name: schema_name, table_name: table_name, limits: limits
       end
 
-      def list_tables(limit)
-        must_be_defined_in_derived_class limit
+      def list_tables(limits:)
+        must_be_defined_in_derived_class limits: limits
       end
 
       def remote_data_updated?

--- a/lib/carto/connector/providers/fdw.rb
+++ b/lib/carto/connector/providers/fdw.rb
@@ -1,0 +1,195 @@
+# encoding: utf-8
+
+require_relative './base'
+
+# Base class for Connector Providers
+# that use FDW to import data through a foreign table
+module Carto
+  class Connector
+    class FdwProvider < Provider
+      def copy_table(schema_name:, table_name:, limits: {})
+        log "Connector Copy table  #{schema_name}.#{table_name}"
+        validate!
+        # TODO: logging with CartoDB::Logger
+        with_server do
+          begin
+            qualified_table_name = fdw_qualified_table_name(schema_name, table_name)
+            foreign_table_name = foreign_table_name(foreign_prefix)
+            log "Creating Foreign Table"
+            execute_as_superuser _create_foreign_table_command
+            log "Copying Foreign Table"
+            max_rows = limits[:max_rows]
+            execute _copy_foreign_table_command(
+              qualified_table_name, qualified_foreign_table_name(foreign_table_name), max_rows
+            )
+            check_copied_table_size(qualified_table_name, max_rows)
+          ensure
+            execute_as_superuser _drop_foreign_table_command(foreign_table_name) if foreign_table_name
+          end
+        end
+      end
+
+      def list_tables(limits: {})
+        limit = limits[:max_listed_tables]
+        validate! only: [:connection]
+        with_server do
+          # TODO: let the providers decide what needs to be executed as superuser
+          # (we use superuser here because the provider may need to create auxiliar foreing tables)
+          execute_as_superuser _list_tables_command(limit)
+        end
+      end
+
+      def remote_data_updated?
+        # TODO: can we detect if query results have changed?
+        true
+      end
+
+      private
+
+      include FdwSupport
+
+      # Execute code that requires a FDW server/user mapping
+      # The server name is given by the method `#server_name`
+      def with_server
+        # Currently we create temporary server and user mapings when we need them,
+        # and drop them after use.
+        log "Creating Server"
+        execute_as_superuser _create_server_command
+        log "Creating Usermap"
+        execute_as_superuser _create_usermap_command
+        yield
+      rescue => error
+        log "Connector Error #{error}"
+        raise error
+      ensure
+        log "Connector cleanup"
+        execute_as_superuser _drop_usermap_command
+        execute_as_superuser _drop_server_command
+        log "Connector cleaned-up"
+      end
+
+      # maximum unique identifier length in PostgreSQL
+      MAX_PG_IDENTIFIER_LEN = 63
+      # minimum length left available for the table part in foreign table names
+      MIN_TAB_ID_LEN        = 10
+
+      # Named used for the foreign server (unique poer Connector instance)
+      def server_name
+        max_len = MAX_PG_IDENTIFIER_LEN - unique_suffix.size - MIN_TAB_ID_LEN - 1
+        connector_name = Carto::DB::Sanitize.sanitize_identifier self.class.to_s.split('::').last
+        "#{connector_name[0...max_len].downcase}_#{unique_suffix}"
+      end
+
+      # Prefix to be used by foreign table names (so they're unique per Connector instance)
+      # This leaves at least MIN_TAB_ID_LEN available identifier characters given PostgreSQL's
+      # limit of MAX_PG_IDENTIFIER_LEN
+      def foreign_prefix
+        "#{server_name}_"
+      end
+
+      def foreign_table_schema
+        # since connectors' foreign table names are unique (because
+        # server names are unique and not reused)
+        # we could in principle use any schema (@schema, 'public', 'cdb_importer')
+        CartoDB::Connector::Importer::ORIGIN_SCHEMA
+      end
+
+      def qualified_foreign_table_name(foreign_table_name)
+        %{"#{foreign_table_schema}"."#{foreign_table_name}"}
+      end
+
+      def _create_server_command
+        create_server_command server_name
+      end
+
+      def _create_usermap_command
+        [
+          create_usermap_command(server_name, @connector_context.user.database_username),
+          create_usermap_command(server_name, 'postgres')
+        ].join("\n")
+      end
+
+      def _create_foreign_table_command
+        create_foreign_table_command server_name, foreign_table_schema,
+                                               foreign_prefix,
+                                               @connector_context.user.database_username
+      end
+
+      def _drop_server_command
+        drop_server_command server_name
+      end
+
+      def _drop_usermap_command
+        [
+          drop_usermap_command(server_name, 'postgres'),
+          drop_usermap_command(server_name, @connector_context.user.database_username)
+        ].join("\n")
+      end
+
+      def _drop_foreign_table_command(foreign_table_name)
+        drop_foreign_table_command foreign_table_schema, foreign_table_name
+      end
+
+      def _copy_foreign_table_command(local_table_name, foreign_table_name, max_rows)
+        limit = (max_rows && max_rows > 0) ? " LIMIT #{max_rows}" : ''
+        %{
+          CREATE TABLE #{local_table_name}
+            AS SELECT * FROM #{foreign_table_name}
+              #{limit};
+        }
+      end
+
+      def _list_tables_command(limit)
+        list_tables_command(server_name, foreign_table_schema, foreign_prefix, limit)
+      end
+
+      # SQL code to create the FDW server
+      def create_server_command(_server_name)
+        must_be_defined_in_derived_class
+      end
+
+      # SQL code to create the usermap for the user and postgres roles
+      def create_usermap_command(_server_name, _username)
+        must_be_defined_in_derived_class
+      end
+
+      # SQL code to create the foreign table used for importing
+      def create_foreign_table_command(_server_name, _schema_name, _foreign_prefix, _username)
+        must_be_defined_in_derived_class
+      end
+
+      # SQL code to drop the FDW server
+      def drop_server_command(server_name)
+        fdw_drop_server server_name, cascade: true
+      end
+
+      # SQL code to drop the user mapping
+      def drop_usermap_command(server_name, user)
+        fdw_drop_usermap server_name, user
+      end
+
+      # SQL code to drop the foreign table
+      def drop_foreign_table_command(schema_name, table_name)
+        fdw_drop_foreign_table schema_name, table_name
+      end
+
+      def check_copied_table_size(table_name, max_rows)
+        warnings = {}
+        if max_rows && max_rows > 0
+          num_rows = execute(%{
+            SELECT count(*) as num_rows FROM #{table_name};
+          }).first['num_rows']
+          if num_rows == max_rows
+            # The maximum number of rows per connection was reached
+            warnings[:max_rows_per_connection] = max_rows
+          end
+        end
+        warnings
+      end
+
+      def unique_suffix
+        @unique_suffix ||= UUIDTools::UUID.timestamp_create.to_s.delete('-') # .to_i.to_s(16) # or hash from user, etc.
+      end
+    end
+  end
+end

--- a/lib/carto/connector/providers/generic_odbc.rb
+++ b/lib/carto/connector/providers/generic_odbc.rb
@@ -12,7 +12,7 @@ module Carto
     #
     class GenericOdbcProvider < OdbcProvider
 
-      def initialize(params)
+      def initialize(context, params)
         super
         if @connection
           @dsn        = @connection[:dsn]

--- a/lib/carto/connector/providers/odbc.rb
+++ b/lib/carto/connector/providers/odbc.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require_relative './base'
+require_relative './fdw'
 
 module Carto
   class Connector
@@ -25,9 +25,9 @@ module Carto
     #   * encoding (optional): character encoding used by the external database; default is UTF-8.
     #     The encoding names accepted are those accepted by PostgreSQL.
     #
-    class OdbcProvider < Provider
+    class OdbcProvider < FdwProvider
 
-      def initialize(params)
+      def initialize(context, params)
         super
         @columns = @params[:columns]
         @columns = @columns.split(',').map(&:strip) if @columns

--- a/lib/carto/connector/providers/odbc.rb
+++ b/lib/carto/connector/providers/odbc.rb
@@ -112,6 +112,12 @@ module Carto
         cmds.join "\n"
       end
 
+      def list_tables_command(server_name, _foreign_table_schema, _foreign_prefix, limit)
+        %{
+          SELECT * FROM ODBCTablesList('#{server_name}',#{limit.to_i});
+        }
+      end
+
       def features_information
         {
           "sql_queries":    true,

--- a/lib/carto/connector/providers/pg_fdw.rb
+++ b/lib/carto/connector/providers/pg_fdw.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require_relative './base'
+require_relative './fdw'
 
 module Carto
   class Connector
@@ -29,9 +29,9 @@ module Carto
     #
     # TODO: add support for sql_query parameter
     #
-    class PgFdwProvider < Provider
+    class PgFdwProvider < FdwProvider
 
-      def initialize(params)
+      def initialize(context, params)
         super
       end
 

--- a/lib/carto/connector/providers/pg_fdw.rb
+++ b/lib/carto/connector/providers/pg_fdw.rb
@@ -27,6 +27,9 @@ module Carto
     # This is not intended for production at the moment, this class is here to validate and test the
     # Connector hierarchy design.
     #
+    # Note that the password parameter is required: postgres_fdw won't allow non-superusers to connect
+    # to foreign servers that don't require a password (and table copy is performed using a non-superuser).
+    #
     # TODO: add support for sql_query parameter
     #
     class PgFdwProvider < FdwProvider
@@ -35,8 +38,8 @@ module Carto
         super
       end
 
-      REQUIRED_PARAMETERS = %w(table server database username).freeze
-      OPTIONAL_PARAMETERS = %w(schema port password).freeze
+      REQUIRED_PARAMETERS = %w(table server database username password).freeze
+      OPTIONAL_PARAMETERS = %w(schema port).freeze
 
       def optional_parameters
         OPTIONAL_PARAMETERS
@@ -60,43 +63,47 @@ module Carto
         schema
       end
 
-      def create_server_command(server_name)
-        fdw_create_server 'postgres_fdw', server_name, server_options
+      def fdw_create_server(server_name)
+        execute_as_superuser fdw_create_server_sql('postgres_fdw', server_name, server_options)
       end
 
-      def create_usermap_command(server_name, username)
-        fdw_create_usermap server_name, username, user_options
+      def fdw_create_usermap(server_name, username)
+        execute_as_superuser fdw_create_usermap_sql(server_name, username, user_options)
       end
 
-      def create_foreign_table_command(server_name, schema, foreign_prefix, username)
+      def fdw_create_foreign_table(server_name, schema, foreign_prefix, username)
         remote_table = table_name
         foreign_table = foreign_table_name(foreign_prefix)
         options = table_options
         cmds = []
-        cmds << fdw_import_foreign_schema_limited(server_name, remote_schema_name, schema, remote_table, options)
+        cmds << fdw_import_foreign_schema_limited_sql(server_name, remote_schema_name, schema, remote_table, options)
         if remote_table != foreign_table
-          cmds << fdw_rename_foreign_table(schema, remote_table, foreign_table)
+          cmds << fdw_rename_foreign_table_sql(schema, remote_table, foreign_table)
         end
-        cmds << fdw_grant_select(schema, foreign_table_name(foreign_prefix), username)
-        cmds.join "\n"
+        cmds << fdw_grant_select_sql(schema, foreign_table_name(foreign_prefix), username)
+        execute_as_superuser cmds.join("\n")
+        foreign_table
       end
 
-      def list_tables_command(server_name, schema, foreign_prefix, limit)
+      def fdw_list_tables(server_name, schema, foreign_prefix, limit)
+        # Create auxiliar foreign tables for pg_class, pg_namespace
         ext_pg_class = fdw_adjusted_table_name("#{foreign_prefix}pg_class")
         ext_pg_namespace = fdw_adjusted_table_name("#{foreign_prefix}pg_namespace")
         commands = []
-        commands << fdw_create_foreign_table_if_not_exists(
+        commands << fdw_create_foreign_table_if_not_exists_sql(
           server_name, schema, ext_pg_class,
           ['relname name', 'relnamespace oid', 'relkind char'],
           schema_name: 'pg_catalog', table_name: 'pg_class'
         )
-        commands << fdw_create_foreign_table_if_not_exists(
+        commands << fdw_create_foreign_table_if_not_exists_sql(
           server_name, schema, ext_pg_namespace,
           ['nspname name', 'oid oid'],
           schema_name: 'pg_catalog', table_name: 'pg_namespace'
         )
         limit_clause = limit.to_i > 0 ? "LIMIT #{limit}" : ''
-        commands << %{
+        execute_as_superuser(commands.join("\n"))
+
+        execute_as_superuser %{
           SELECT n.nspname AS schema, c.relname AS name
           FROM #{fdw_qualified_table_name(schema, ext_pg_class)} c
           JOIN #{fdw_qualified_table_name(schema, ext_pg_namespace)} n ON n.oid = c.relnamespace
@@ -105,9 +112,12 @@ module Carto
             ORDER BY schema, name
             #{limit_clause};
         }
-        # Since we create foreign tables here this must be executed as superuser
-        # This leaves two foreign tables in schema: ext_pg_class and ext_pg_namespace
-        commands.join(";\n")
+      ensure
+        # Drop auxiliar foreign tables for pg_class, pg_namespace
+        commands = []
+        commands << fdw_drop_foreign_table_sql(schema, ext_pg_namespace) if ext_pg_namespace
+        commands << fdw_drop_foreign_table_sql(schema, ext_pg_class) if ext_pg_class
+        execute_as_superuser(commands.join("\n"))
       end
 
       def features_information

--- a/lib/tasks/connectors_api.rake
+++ b/lib/tasks/connectors_api.rake
@@ -1,5 +1,19 @@
 namespace :cartodb do
   namespace :connectors do
+
+    desc "Create Connector Providers for Provider Classes"
+    task create_providers: :environment do
+      Carto::Connector.providers.keys.each do |provider_name|
+        unless Carto::ConnectorProvider.where(name: provider_name).exists?
+          puts "Creating ConnectorProvider #{provider_name}"
+          Carto::ConnectorProvider.create! name: provider_name
+        end
+      end
+      providers = Carto::Connector.providers.keys.map { |name| "'#{name}'" }
+      Carto::ConnectorProvider.where("name NOT IN (#{providers.join(',')})").each do |provider|
+        puts "Provider #{provider.name} is not configured in the code!"
+      end
+    end
     desc 'Adapt connector synchronizations to the new API'
     task adapt_api: :environment do
 

--- a/lib/tasks/connectors_api.rake
+++ b/lib/tasks/connectors_api.rake
@@ -14,6 +14,177 @@ namespace :cartodb do
         puts "Provider #{provider.name} is not configured in the code!"
       end
     end
+
+    def find_by_uuid_or_name(id_or_name, klass, name_attribute = :name)
+      include Carto::UUIDHelper
+      if is_uuid?(id_or_name)
+        klass.find(id_or_name)
+      else
+        klass.where(name_attribute => id_or_name).first
+      end
+    end
+
+    def with_provider_user_config(args)
+      provider = find_by_uuid_or_name(args.provider, Carto::ConnectorProvider)
+      user     = find_by_uuid_or_name(args.user, Carto::User, :username)
+      puts "Provider not found: #{args.provider}" if provider.blank?
+      puts "User not found: #{args.user}" if user.blank?
+      if provider.present? && user.present?
+        active_config = user.connector_configuration(provider.name)
+        user_config = Carto::ConnectorConfiguration.where(connector_provider_id: provider.id, user_id: user.id).first
+        if user.organization.present?
+          org_config = Carto::ConnectorConfiguration.where(connector_provider_id: provider.id, organization_id: user.organization.id).first
+        end
+        provider_config = Carto::ConnectorConfiguration.default(provider)
+        yield provider, user, active_config, user_config, org_config, provider_config
+      end
+    end
+
+    def with_provider_org_config(args)
+      provider = find_by_uuid_or_name(args.provider, Carto::ConnectorProvider)
+      org      = find_by_uuid_or_name(args.user, Carto::Organization)
+      puts "Provider not found: #{args.provider}" if provider.blank?
+      puts "Organization not found: #{args.org}" if org.blank?
+      if provider.present? && org.present?
+        org_config = Carto::ConnectorConfiguration.where(connector_provider_id: provider.id, organization_id: user.organization.id).first
+        provider_config = Carto::ConnectorConfiguration.default(provider)
+        yield provider, org, org_config, provider_config
+      end
+    end
+
+    def with_provider_config(args)
+      provider = find_by_uuid_or_name(args.provider, Carto::ConnectorProvider)
+      puts "Provider not found: #{args.provider}" if provider.blank?
+      if provider.present?
+        provider_config = Carto::ConnectorConfiguration.default(provider)
+        yield provider, provider_config
+      end
+    end
+
+    def max_rows_description(max_rows)
+      max_rows.to_i == 0 ? '(unlimited)' : max_rows.to_s
+    end
+
+    desc "Check user connector configuration"
+    task :show_user_config, [:provider, :user] => :environment do |_task, args|
+      with_provider_user_config(args) do |provider, user, config, user_config, org_config, provider_config|
+        puts "Connector #{provider.name} configuration for user #{user.username}:"
+        puts "  Enabled: #{config.enabled?}"
+        puts "  Max. Rows: #{max_rows_description config.max_rows}"
+        if user_config
+          puts "Using user-specific configuration"
+        elsif org_config
+          puts "Using organization #{org_config.organization.name} configuration"
+        elsif provider_config
+          puts "Using #{provider_config.connector_provider.name} defaults"
+        else
+          puts "Using default configuration"
+        end
+      end
+    end
+
+    desc "Set user connector configuration"
+    task :set_user_config, [:provider, :user, :enabled, :max_rows] => :environment do |_task, args|
+      with_provider_user_config(args) do |provider, user, config, user_config, org_config, provider_config|
+        if args.enabled.casecmp('default').zero? && !args.max_rows
+          # rake cartodb:connectors:user_config[provider,user,default] will reset to the default configuration
+          puts "Will reset configuration for #{provider.name} and user #{user.username}"
+          if user_config
+            puts "  Removing existing configuration: #{user_config.enabled.inspect} max_rows: #{user_config.max_rows.inspect}"
+            user_config.destroy
+          else
+            puts "  User didn't have specific configuration"
+          end
+        else
+          enabled = args.enabled.casecmp('true').zero?
+          max_rows = args.max_rows.to_i
+          max_rows = nil if max_rows == 0
+          if user_config
+            puts "Will update configuration for #{provider.name} and user #{user.username}"
+            puts "  New configuration: enabled: #{enabled.inspect} max_rows: #{max_rows_description max_rows}"
+            puts "  Existing configuration: enabled: #{user_config.enabled.inspect} max_rows: #{max_rows_description user_config.max_rows}"
+            user_config.update_attributes! enabled: enabled, max_rows: max_rows
+          else
+            puts "Will create a new configuration for #{provider.name} and user #{user.username}"
+            puts "  New configuration: enabled: #{enabled.inspect} max_rows: #{max_rows_description max_rows}"
+            Carto::ConnectorConfiguration.create!(
+              connector_provider: provider,
+              user: user,
+              enabled: enabled,
+              max_rows: max_rows
+            )
+          end
+        end
+      end
+    end
+
+    desc "Check organization connector configuration"
+    task :show_org_config, [:provider, :org] => :environment do |_task, args|
+      with_provider_org_config(args) do |provider, org, org_config, provider_config|
+        puts "Connector #{provider.name} configuration for organization #{org.name}:"
+        if org_config
+          puts "Using organization-specific configuration:"
+          puts "  Enabled: #{org_config.enabled?}"
+          puts "  Max. Rows: #{max_rows_description org_config.max_rows}"
+        elsif provider_config
+          puts "Using #{provider_config.connector_provider.name} defaults:"
+          puts "  Enabled: #{provider_config.enabled?}"
+          puts "  Max. Rows: #{max_rows_description provider_config.max_rows}"
+        else
+          puts "Using default configuration"
+        end
+      end
+    end
+
+    desc "Set organization connector configuration"
+    task :set_org_config, [:provider, :org, :enabled, :max_rows] => :environment do |_task, args|
+      with_provider_org_config(args) do |provider, org, org_config, provider_config|
+        if args.enabled.casecmp('default').zero? && !args.max_rows
+          # rake cartodb:connectors:org_config[provider,org,default] will reset to the default configuration
+          puts "Will reset configuration for #{provider.name} and user #{org.name}"
+          if org_config
+            puts "  Removing existing configuration: #{org_config.enabled.inspect} max_rows: #{org_config.max_rows.inspect}"
+            org_config.destroy
+          else
+            puts "  Organization didn't have specific configuration"
+          end
+        else
+          enabled = args.enabled.casecmp('true').zero?
+          max_rows = args.max_rows.to_i
+          max_rows = nil if max_rows == 0
+          if org_config
+            puts "Will update configuration for #{provider.name} and org. #{org.name}"
+            puts "  New configuration: enabled: #{enabled.inspect} max_rows: #{max_rows_description max_rows}"
+            puts "  Existing configuration: enabled: #{org_config.enabled.inspect} max_rows: #{max_rows_description org_config.max_rows}"
+            org_config.update_attributes! enabled: enabled, max_rows: max_rows
+          else
+            puts "Will create a new configuration for #{provider.name} and org. #{org.name}"
+            puts "  New configuration: enabled: #{enabled.inspect} max_rows: #{max_rows_description max_rows}"
+            Carto::ConnectorConfiguration.create!(
+              connector_provider: provider,
+              organization: org,
+              enabled: enabled,
+              max_rows: max_rows
+            )
+          end
+        end
+      end
+    end
+
+    desc "Check connector configuration"
+    task :show_config, [:provider] => :environment do |_task, args|
+      with_provider_config(args) do |provider, provider_config|
+        puts "Connector #{provider.name} configuration:"
+        if provider_config
+          puts "Using #{provider_config.connector_provider.name} defaults:"
+          puts "  Enabled: #{provider_config.enabled?}"
+          puts "  Max. Rows: #{max_rows_description provider_config.max_rows}"
+        else
+          puts "Using default configuration"
+        end
+      end
+    end
+
     desc 'Adapt connector synchronizations to the new API'
     task adapt_api: :environment do
 

--- a/lib/tasks/connectors_api.rake
+++ b/lib/tasks/connectors_api.rake
@@ -31,9 +31,13 @@ namespace :cartodb do
       puts "User not found: #{args.user}" if user.blank?
       if provider.present? && user.present?
         active_config = user.connector_configuration(provider.name)
-        user_config = Carto::ConnectorConfiguration.where(connector_provider_id: provider.id, user_id: user.id).first
+        user_config = Carto::ConnectorConfiguration.where(
+          connector_provider_id: provider.id, user_id: user.id
+        ).first
         if user.organization.present?
-          org_config = Carto::ConnectorConfiguration.where(connector_provider_id: provider.id, organization_id: user.organization.id).first
+          org_config = Carto::ConnectorConfiguration.where(
+            connector_provider_id: provider.id, organization_id: user.organization.id
+          ).first
         end
         provider_config = Carto::ConnectorConfiguration.default(provider)
         yield provider, user, active_config, user_config, org_config, provider_config
@@ -46,7 +50,9 @@ namespace :cartodb do
       puts "Provider not found: #{args.provider}" if provider.blank?
       puts "Organization not found: #{args.org}" if org.blank?
       if provider.present? && org.present?
-        org_config = Carto::ConnectorConfiguration.where(connector_provider_id: provider.id, organization_id: user.organization.id).first
+        org_config = Carto::ConnectorConfiguration.where(
+          connector_provider_id: provider.id, organization_id: user.organization.id
+        ).first
         provider_config = Carto::ConnectorConfiguration.default(provider)
         yield provider, org, org_config, provider_config
       end
@@ -85,12 +91,14 @@ namespace :cartodb do
 
     desc "Set user connector configuration"
     task :set_user_config, [:provider, :user, :enabled, :max_rows] => :environment do |_task, args|
-      with_provider_user_config(args) do |provider, user, config, user_config, org_config, provider_config|
+      with_provider_user_config(args) do |provider, user, _config, user_config, _org_config, _provider_config|
         if args.enabled.casecmp('default').zero? && !args.max_rows
           # rake cartodb:connectors:user_config[provider,user,default] will reset to the default configuration
           puts "Will reset configuration for #{provider.name} and user #{user.username}"
           if user_config
-            puts "  Removing existing configuration: #{user_config.enabled.inspect} max_rows: #{user_config.max_rows.inspect}"
+            puts "  Removing existing configuration:"
+            puts "    Enabled: #{user_config.enabled.inspect}"
+            puts "    Max. Rows: #{max_rows_description user_config.max_rows}"
             user_config.destroy
           else
             puts "  User didn't have specific configuration"
@@ -101,12 +109,18 @@ namespace :cartodb do
           max_rows = nil if max_rows == 0
           if user_config
             puts "Will update configuration for #{provider.name} and user #{user.username}"
-            puts "  New configuration: enabled: #{enabled.inspect} max_rows: #{max_rows_description max_rows}"
-            puts "  Existing configuration: enabled: #{user_config.enabled.inspect} max_rows: #{max_rows_description user_config.max_rows}"
+            puts "  New configuration:"
+            puts "    Enabled: #{enabled.inspect}"
+            puts "    Max. Rows: #{max_rows_description max_rows}"
+            puts "  Existing configuration:"
+            puts "    Enabled: #{user_config.enabled.inspect}"
+            puts "    Max. Rows: #{max_rows_description user_config.max_rows}"
             user_config.update_attributes! enabled: enabled, max_rows: max_rows
           else
             puts "Will create a new configuration for #{provider.name} and user #{user.username}"
-            puts "  New configuration: enabled: #{enabled.inspect} max_rows: #{max_rows_description max_rows}"
+            puts "  New configuration: enabled:"
+            puts "    Enabled: #{enabled.inspect}"
+            puts "    Max. Rows: #{max_rows_description max_rows}"
             Carto::ConnectorConfiguration.create!(
               connector_provider: provider,
               user: user,
@@ -143,7 +157,9 @@ namespace :cartodb do
           # rake cartodb:connectors:org_config[provider,org,default] will reset to the default configuration
           puts "Will reset configuration for #{provider.name} and user #{org.name}"
           if org_config
-            puts "  Removing existing configuration: #{org_config.enabled.inspect} max_rows: #{org_config.max_rows.inspect}"
+            puts "  Removing existing configuration:"
+            puts "    Enabled: #{org_config.enabled?}"
+            puts "    Max. Rows: #{max_rows_description org_config.max_rows}"
             org_config.destroy
           else
             puts "  Organization didn't have specific configuration"
@@ -154,12 +170,18 @@ namespace :cartodb do
           max_rows = nil if max_rows == 0
           if org_config
             puts "Will update configuration for #{provider.name} and org. #{org.name}"
-            puts "  New configuration: enabled: #{enabled.inspect} max_rows: #{max_rows_description max_rows}"
-            puts "  Existing configuration: enabled: #{org_config.enabled.inspect} max_rows: #{max_rows_description org_config.max_rows}"
+            puts "  New configuration: enabled:"
+            puts "    Enabled: #{enabled.inspect}"
+            puts "    Max. Rows: #{max_rows_description max_rows}"
+            puts "  Existing configuration: enabled:"
+            puts "    Enabled: #{org_config.enabled?}"
+            puts "    Max. Rows: #{max_rows_description org_config.max_rows}"
             org_config.update_attributes! enabled: enabled, max_rows: max_rows
           else
             puts "Will create a new configuration for #{provider.name} and org. #{org.name}"
-            puts "  New configuration: enabled: #{enabled.inspect} max_rows: #{max_rows_description max_rows}"
+            puts "  New configuration: enabled:"
+            puts "    Enabled: #{enabled.inspect}"
+            puts "    Max. Rows: #{max_rows_description max_rows}"
             Carto::ConnectorConfiguration.create!(
               connector_provider: provider,
               organization: org,

--- a/services/importer/lib/importer/connector_runner.rb
+++ b/services/importer/lib/importer/connector_runner.rb
@@ -92,8 +92,8 @@ module CartoDB
         # but we have no meaningful data to return here.
       end
 
-      def connector_name
-        @connector.name
+      def provider_name
+        @connector.provider_name
       end
 
       private

--- a/services/importer/spec/unit/connector_runner_spec.rb
+++ b/services/importer/spec/unit/connector_runner_spec.rb
@@ -72,7 +72,7 @@ describe CartoDB::Importer2::ConnectorRunner do
             connector = CartoDB::Importer2::ConnectorRunner.new(parameters.merge(provider: provider).to_json, options)
             connector.run
             connector.success?.should be true
-            connector.connector_name.should eq provider
+            connector.provider_name.should eq provider
           end
         end
       end
@@ -102,7 +102,7 @@ describe CartoDB::Importer2::ConnectorRunner do
             connector = CartoDB::Importer2::ConnectorRunner.new(parameters.merge(provider: provider).to_json, options)
             connector.run
             connector.success?.should be false
-            connector.connector_name.should eq provider
+            connector.provider_name.should eq provider
             @fake_log.to_s.should match /Invalid parameters: invalid_parameter/m
           end
         end
@@ -198,7 +198,7 @@ describe CartoDB::Importer2::ConnectorRunner do
             connector = CartoDB::Importer2::ConnectorRunner.new(parameters.merge(provider: provider).to_json, options)
             connector.run
             connector.success?.should be false
-            connector.connector_name.should eq provider
+            connector.provider_name.should eq provider
             @fake_log.to_s.should match /SQL EXECUTION ERROR/m
           end
         end

--- a/services/importer/spec/unit/connector_runner_spec.rb
+++ b/services/importer/spec/unit/connector_runner_spec.rb
@@ -45,8 +45,8 @@ describe CartoDB::Importer2::ConnectorRunner do
   describe 'with working connectors' do
     before(:all) do
       # Simulate connector success by ignoring all db opeartions
-      Carto::Connector.any_instance.stubs(:execute_as_superuser).returns(nil)
-      Carto::Connector.any_instance.stubs(:execute).returns(nil)
+      Carto::Connector::Context.any_instance.stubs(:execute_as_superuser).returns(nil)
+      Carto::Connector::Context.any_instance.stubs(:execute).returns(nil)
     end
 
     it "Succeeds if parameters are correct" do
@@ -171,8 +171,8 @@ describe CartoDB::Importer2::ConnectorRunner do
   describe 'with failing connectors' do
     before(:all) do
       # Simulate connector success when executing non-privileged SQL
-      Carto::Connector.any_instance.stubs(:execute_as_superuser).returns(nil)
-      Carto::Connector.any_instance.stubs(:execute).raises("SQL EXECUTION ERROR")
+      Carto::Connector::Context.any_instance.stubs(:execute_as_superuser).returns(nil)
+      Carto::Connector::Context.any_instance.stubs(:execute).raises("SQL EXECUTION ERROR")
     end
 
     it "Always fails" do
@@ -207,8 +207,8 @@ describe CartoDB::Importer2::ConnectorRunner do
   end
 
   describe 'with invalid provider' do
-    Carto::Connector.any_instance.stubs(:execute_as_superuser).returns(nil)
-    Carto::Connector.any_instance.stubs(:execute).returns(nil)
+    Carto::Connector::Context.any_instance.stubs(:execute_as_superuser).returns(nil)
+    Carto::Connector::Context.any_instance.stubs(:execute).returns(nil)
 
     it "Fails at creation" do
       with_feature_flag @user, 'carto-connectors', true do

--- a/services/importer/spec/unit/connector_runner_spec.rb
+++ b/services/importer/spec/unit/connector_runner_spec.rb
@@ -239,11 +239,11 @@ describe CartoDB::Importer2::ConnectorRunner do
 
     @providers.each do |provider|
       connector_provider = Carto::ConnectorProvider.find_by_name(provider)
-      config = Carto::ConnectorConfiguration.create!(
+      Carto::ConnectorConfiguration.create!(
         connector_provider_id: connector_provider.id,
         user_id: @user.id,
         enabled: false
-      );
+      )
     end
 
     with_feature_flag @user, 'carto-connectors', true do
@@ -276,7 +276,6 @@ describe CartoDB::Importer2::ConnectorRunner do
 
     Carto::ConnectorConfiguration.where(user_id: @user.id).destroy_all
   end
-
 
   # TODO: check Runner compatibility
 end

--- a/services/importer/spec/unit/connector_spec.rb
+++ b/services/importer/spec/unit/connector_spec.rb
@@ -1141,7 +1141,7 @@ describe Carto::Connector do
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-            }]
+          }]
         }, {
           # DROP USER MAPPING
           mode: :superuser,

--- a/services/importer/spec/unit/connector_spec.rb
+++ b/services/importer/spec/unit/connector_spec.rb
@@ -160,7 +160,7 @@ describe Carto::Connector do
       connector = Carto::Connector.new(parameters, context)
       connector.copy_table schema_name: 'xyz', table_name: 'abc'
 
-      @executed_commands.size.should eq 7
+      @executed_commands.size.should eq 9
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
       user_name = @user.username
@@ -189,7 +189,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'odbc_uid' => 'theuser', 'odbc_pwd' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -234,13 +238,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -276,7 +284,7 @@ describe Carto::Connector do
       connector = Carto::Connector.new(parameters, context)
       connector.copy_table schema_name: 'xyz', table_name: 'abc'
 
-      @executed_commands.size.should eq 7
+      @executed_commands.size.should eq 9
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       user_role = @user.database_username
 
@@ -363,7 +371,7 @@ describe Carto::Connector do
       }.to raise_error('SQL EXECUTION ERROR')
 
       # When something fails during table copy the foreign table, user mappings and server should be cleaned up
-      @executed_commands.size.should eq 6
+      @executed_commands.size.should eq 8
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
       user_role = @user.database_username
@@ -391,7 +399,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'odbc_uid' => 'theuser', 'odbc_pwd' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -427,13 +439,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -472,7 +488,7 @@ describe Carto::Connector do
         result = connector.copy_table schema_name: 'xyz', table_name: 'abc'
         result.should be_empty
 
-        @executed_commands.size.should eq 7
+        @executed_commands.size.should eq 9
         server_name = match_sql_command(@executed_commands[0][1])[:server_name]
         foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
         user_name = @user.username
@@ -501,7 +517,11 @@ describe Carto::Connector do
               server_name: server_name,
               user_name: user_role,
               options: { 'odbc_uid' => 'theuser', 'odbc_pwd' => 'thepassword' }
-            }, {
+            }]
+          }, {
+            # CREATE USER MAPPING
+            mode: :superuser,
+            sql: [{
               command: :create_user_mapping,
               server_name: server_name,
               user_name: 'postgres',
@@ -547,13 +567,17 @@ describe Carto::Connector do
               table_name: foreign_table_name
             }]
           }, {
-            # DROP USERMAP
+            # DROP USER MAPPING
             mode: :superuser,
             sql: [{
               command: :drop_usermapping_if_exists,
               server_name: server_name,
               user_name: 'postgres'
-            }, {
+            }]
+          }, {
+            # DROP USER MAPPING
+            mode: :superuser,
+            sql: [{
               command: :drop_usermapping_if_exists,
               server_name: server_name,
               user_name: user_role
@@ -593,7 +617,7 @@ describe Carto::Connector do
         result = connector.copy_table schema_name: 'xyz', table_name: 'abc'
         result[:max_rows_per_connection].should eq 10
 
-        @executed_commands.size.should eq 7
+        @executed_commands.size.should eq 9
         server_name = match_sql_command(@executed_commands[0][1])[:server_name]
         foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
         user_name = @user.username
@@ -622,7 +646,11 @@ describe Carto::Connector do
               server_name: server_name,
               user_name: user_role,
               options: { 'odbc_uid' => 'theuser', 'odbc_pwd' => 'thepassword' }
-            }, {
+            }]
+          }, {
+            # CREATE USER MAPPING
+            mode: :superuser,
+            sql: [{
               command: :create_user_mapping,
               server_name: server_name,
               user_name: 'postgres',
@@ -668,13 +696,17 @@ describe Carto::Connector do
               table_name: foreign_table_name
             }]
           }, {
-            # DROP USERMAP
+            # DROP USER MAPPING
             mode: :superuser,
             sql: [{
               command: :drop_usermapping_if_exists,
               server_name: server_name,
               user_name: 'postgres'
-            }, {
+            }]
+          }, {
+            # DROP USER MAPPING
+            mode: :superuser,
+            sql: [{
               command: :drop_usermapping_if_exists,
               server_name: server_name,
               user_name: user_role
@@ -711,7 +743,7 @@ describe Carto::Connector do
 
       tables.should eq [{ schema: 'abc', name: 'xyz' }]
 
-      @executed_commands.size.should eq 5
+      @executed_commands.size.should eq 7
 
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       user_name = @user.username
@@ -740,7 +772,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'odbc_uid' => 'theuser', 'odbc_pwd' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -748,20 +784,24 @@ describe Carto::Connector do
           }]
         }, {
           # FETCH TABLES LIST
-          mode: :superuser,
+          mode: :user,
           user: user_name,
           sql: [{
             command: :select_all,
             from: /ODBCTablesList\('#{Regexp.escape server_name}'\s*,\d+\s*\)/
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -867,7 +907,7 @@ describe Carto::Connector do
       connector = Carto::Connector.new(parameters, context)
       connector.copy_table schema_name: 'xyz', table_name: 'abc'
 
-      @executed_commands.size.should eq 7
+      @executed_commands.size.should eq 9
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
       user_name = @user.username
@@ -896,7 +936,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'odbc_UID' => 'theuser', 'odbc_PWD' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -941,13 +985,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -1011,7 +1059,7 @@ describe Carto::Connector do
       connector = Carto::Connector.new(parameters, context)
       connector.copy_table schema_name: 'xyz', table_name: 'abc'
 
-      @executed_commands.size.should eq 7
+      @executed_commands.size.should eq 9
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
       user_name = @user.username
@@ -1040,7 +1088,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'odbc_UID' => 'theuser', 'odbc_PWD' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -1083,13 +1135,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+            }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -1152,7 +1208,7 @@ describe Carto::Connector do
       connector = Carto::Connector.new(parameters, context)
       connector.copy_table schema_name: 'xyz', table_name: 'abc'
 
-      @executed_commands.size.should eq 7
+      @executed_commands.size.should eq 9
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
       user_name = @user.username
@@ -1180,7 +1236,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'odbc_UID' => 'theuser', 'odbc_PWD' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -1223,13 +1283,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -1327,7 +1391,7 @@ describe Carto::Connector do
       connector = Carto::Connector.new(parameters, context)
       connector.copy_table schema_name: 'xyz', table_name: 'abc'
 
-      @executed_commands.size.should eq 7
+      @executed_commands.size.should eq 9
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
       user_name = @user.username
@@ -1355,7 +1419,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'odbc_uid' => 'theuser', 'odbc_pwd' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -1398,13 +1466,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -1445,7 +1517,7 @@ describe Carto::Connector do
       connector = Carto::Connector.new(parameters, context)
       connector.copy_table schema_name: 'xyz', table_name: 'abc'
 
-      @executed_commands.size.should eq 7
+      @executed_commands.size.should eq 9
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
       user_name = @user.username
@@ -1473,7 +1545,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'odbc_uid' => 'theuser', 'odbc_pwd' => '{the;password}' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -1516,13 +1592,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -1569,7 +1649,7 @@ describe Carto::Connector do
       connector = Carto::Connector.new(parameters, context)
       connector.copy_table schema_name: 'xyz', table_name: 'abc'
 
-      @executed_commands.size.should eq 7
+      @executed_commands.size.should eq 9
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       unqualified_foreign_table_name = %{"#{server_name}_thetable"}
       foreign_table_name = %{"cdb_importer".#{unqualified_foreign_table_name}}
@@ -1597,14 +1677,18 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'user' => 'theuser', 'password' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
             options: { 'user' => 'theuser', 'password' => 'thepassword' }
           }]
         }, {
-          # IMPORT FOREIGH SCHEMA; GRANT SELECT
+          # IMPORT FOREIGN SCHEMA; GRANT SELECT
           mode: :superuser,
           sql: [{
             command: :import_foreign_schema_limited,
@@ -1638,13 +1722,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role
@@ -1704,7 +1792,7 @@ describe Carto::Connector do
       }.to raise_error('SQL EXECUTION ERROR')
 
       # When something fails during table copy the foreign table, user mappings and server should be cleaned up
-      @executed_commands.size.should eq 6
+      @executed_commands.size.should eq 8
       server_name = match_sql_command(@executed_commands[0][1])[:server_name]
       unqualified_foreign_table_name = %{"#{server_name}_thetable"}
       foreign_table_name = %{"cdb_importer".#{unqualified_foreign_table_name}}
@@ -1731,7 +1819,11 @@ describe Carto::Connector do
             server_name: server_name,
             user_name: user_role,
             options: { 'user' => 'theuser', 'password' => 'thepassword' }
-          }, {
+          }]
+        }, {
+          # CREATE USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :create_user_mapping,
             server_name: server_name,
             user_name: 'postgres',
@@ -1763,13 +1855,17 @@ describe Carto::Connector do
             table_name: foreign_table_name
           }]
         }, {
-          # DROP USERMAP
+          # DROP USER MAPPING
           mode: :superuser,
           sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: 'postgres'
-          }, {
+          }]
+        }, {
+          # DROP USER MAPPING
+          mode: :superuser,
+          sql: [{
             command: :drop_usermapping_if_exists,
             server_name: server_name,
             user_name: user_role

--- a/services/importer/spec/unit/connector_spec.rb
+++ b/services/importer/spec/unit/connector_spec.rb
@@ -1893,7 +1893,7 @@ describe Carto::Connector do
           'table'      => { required: true  },
           'schema'     => { required: false },
           'username'   => { required: true  },
-          'password'   => { required: false },
+          'password'   => { required: true },
           'server'     => { required: true  },
           'port'       => { required: false },
           'database'   => { required: true  }

--- a/services/importer/spec/unit/connector_spec.rb
+++ b/services/importer/spec/unit/connector_spec.rb
@@ -78,7 +78,7 @@ end
 
 describe Carto::Connector do
   before(:all) do
-    Cartodb.config.merge! connectors: {}
+    Cartodb.config[:connectors] = {}
     @user = create_user
     @user.save
     @fake_log = CartoDB::Importer2::Doubles::Log.new(@user)
@@ -1003,7 +1003,6 @@ describe Carto::Connector do
       foreign_table_name = %{"cdb_importer"."#{server_name}_thetable"}
       user_name = @user.username
       user_role = @user.database_username
-
 
       expect_executed_commands(
         connector.executed_commands,

--- a/services/importer/spec/unit/sql_helper.rb
+++ b/services/importer/spec/unit/sql_helper.rb
@@ -34,7 +34,7 @@ def match_sql_command(sql)
     import_foreign_schema_limited: %r{
       IMPORT\s+FOREIGN\s+SCHEMA\s+\"?(?<remote_schema_name>[^\s\"]+)\"?
         \s+
-        LIMIT\s+TO\s+(?<limited_to>.+)
+        LIMIT\s+TO\s+\((?<limited_to>.+)\)
         \s+
         FROM\s+SERVER\s+(?<server_name>[^\s]+)
         \s+


### PR DESCRIPTION
# Connectors configuration

This uses two tables to keep Connector configuration. The migration to create the tables is in #9847

Configuration for a connector determines if it is available (`enabled` configuration parameter) and will also hold its limits (currently only maximum number of rows, `max_rows`).

There are three levels of configuration:

* A default configuration for each connector (technically for each connector provider, such as 'mysql')
* A configuration for an organization and provider; overrides the default configuration of the provider, and
  applies to all the org users which don't have specific configuration.
* A user-specific configuration for a user and provider. Overrides any other configuration.

The configurations are stored in a metadata table `connector_configurations`.
The provider default configuration is stored in `app_config`. If we need more dynamic provider-defaults, we could use the connector_configurations table to override this provider defaults too,
but to avoid complexity/possible confusions we'll use app_config for the moment.

## Rake tasks

There are some rake tasks to show and change the organization and user configuration. (to specify providers, users or organization either the name or id can be used).

show configuration of a user:

```
rake cartodb:connectors:show_user_config[provider,user]
```
show configuration for an organization:

```
rake cartodb:connectors:show_org_config[provider,organization]
```

show default configuration for a connector:

```
rake cartodb:connectors:show_org_config[provider]
```

change configuration for a user: (enabled values: true or false; max_rows: leave empty (or 0) for unlimited)

```
 rake cartodb:connectors:set_user_config[provider,user,enabled,max_rows]
````

remove user configuration (reset to organization or provider defaults):

```
rake cartodb:connectors:set_user_config[provider,user,default]
```

change configuration for an organization

```
rake cartodb:connectors:set_org_config[provider,organization,enabled,max_rows]
```

remove org configuration (reset to provider defaults):

```
rake cartodb:connectors:set_org_config[provider,organization,default]
````

### Example

If connector `sqlserver` is disabled by default, and we need to make it
available for members of organization 'team', except for 'unreliable_staff', and available too for user 'big_customer':

```
rake cartodb:connector:set_org_config[mysql,team,true,1000000]
rake cartodb:connector:set_user_config[mysql,unreliable_staff,false,1000000]
rake cartodb:connector:set_user_config[mysql,big_customer,true,10000000]
````
