### PR TITLE
Add rakes to set user and org quotas for services

### DIFF
--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -2,7 +2,7 @@ namespace :cartodb do
   namespace :services do
 
     # usage example:
-    #   bundle exec rake cartodb:service:set_user_provider['username','geocoder','mapzen']
+    #   bundle exec rake cartodb:services:set_user_provider['username','geocoder','mapzen']
     desc 'Set the provider for a service'
     task :set_user_provider, [:username, :service, :provider] => [:environment] do |task, args|
       SERVICES=['geocoder', 'routing', 'isolines']
@@ -30,7 +30,7 @@ namespace :cartodb do
     end
 
     # usage example:
-    #   bundle exec rake cartodb:service:set_organization_provider['orgname','geocoder','mapzen']
+    #   bundle exec rake cartodb:services:set_organization_provider['orgname','geocoder','mapzen']
     desc 'Set the provider for a service'
     task :set_organization_provider, [:orgname, :service, :provider] => [:environment] do |task, args|
       SERVICES=['geocoder', 'routing', 'isolines']
@@ -55,6 +55,59 @@ namespace :cartodb do
       org.save
 
       puts "Changed the organization service provider for #{service} to #{provider}."
+    end
+
+
+    # usage example:
+    #   bundle exec rake cartodb:services:set_user_quota['username','geocoding',900]
+    desc 'Set the quota for a service'
+    task :set_user_quota, [:username, :service, :quota] => [:environment] do |task, args|
+      SERVICES=['geocoding', 'here_isolines', 'obs_snapshot', 'obs_general']
+
+      username = args[:username]
+      service = args[:service]
+      quota = args[:quota]
+
+      raise 'Please specify the user to be modified' if args[:username].blank?
+      raise 'Please specify the service to set the provider' if args[:service].blank?
+      raise "Unkown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
+      raise 'Please specify a valid quota' if args[:quota].to_i < 0
+
+      user = ::User.find(username: username)
+
+      raise "The name '#{username}' does not correspond to any user" if user.nil?
+
+      sevrice_quota_key = "#{service}_quota="
+      user.send(sevrice_quota_key, quota)
+      user.save
+
+      puts "Changed the user quota for service #{service} to #{quota}."
+    end
+
+    # usage example:
+    #   bundle exec rake cartodb:services:set_org_quota['orgname','geocoding',900]
+    desc 'Set the quota for a service'
+    task :set_org_quota, [:orgname, :service, :quota] => [:environment] do |task, args|
+      SERVICES=['geocoding', 'here_isolines', 'obs_snapshot', 'obs_general']
+
+      orgname = args[:orgname]
+      service = args[:service]
+      quota = args[:quota]
+
+      raise 'Please specify the organization to be modified' if args[:orgname].blank?
+      raise 'Please specify the service to set the provider' if args[:service].blank?
+      raise "Unkown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
+      raise 'Please specify a valid quota' if args[:quota].to_i < 0
+
+      org = ::Organization.find(name: orgname)
+
+      raise "The name '#{orgname}' does not correspond to any organization" if org.nil?
+
+      sevrice_quota_key = "#{service}_quota="
+      org.send(sevrice_quota_key, quota)
+      org.save
+
+      puts "Changed the organization quota for service #{service} to #{quota}."
     end
   end
 end

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -14,9 +14,9 @@ namespace :cartodb do
 
       raise 'Please specify the username of the user to be modified' if args[:username].blank?
       raise 'Please specify the service to set the provider' if args[:service].blank?
-      raise "Unkown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
+      raise "Unknown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
       raise 'Please specify the provider to be set' if args[:provider].blank?
-      raise "Unkown provider. Please use one of the accepted providers: #{PROVIDERS.join(',')}" if not PROVIDERS.include? args[:provider]
+      raise "Unknown provider. Please use one of the accepted providers: #{PROVIDERS.join(',')}" if not PROVIDERS.include? args[:provider]
 
       user = ::User.find(username: username)
 
@@ -42,9 +42,9 @@ namespace :cartodb do
 
       raise 'Please specify the organization to be modified' if args[:orgname].blank?
       raise 'Please specify the service to set the provider' if args[:service].blank?
-      raise "Unkown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
+      raise "Unknown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
       raise 'Please specify the provider to be set' if args[:provider].blank?
-      raise "Unkown provider. Please use one of the accepted providers: #{PROVIDERS.join(',')}" if not PROVIDERS.include? args[:provider]
+      raise "Unknown provider. Please use one of the accepted providers: #{PROVIDERS.join(',')}" if not PROVIDERS.include? args[:provider]
 
       org = ::Organization.find(name: orgname)
 
@@ -70,15 +70,15 @@ namespace :cartodb do
 
       raise 'Please specify the user to be modified' if args[:username].blank?
       raise 'Please specify the service to set the provider' if args[:service].blank?
-      raise "Unkown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
+      raise "Unknown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
       raise 'Please specify a valid quota' if args[:quota].to_i < 0
 
       user = ::User.find(username: username)
 
       raise "The name '#{username}' does not correspond to any user" if user.nil?
 
-      sevrice_quota_key = "#{service}_quota="
-      user.send(sevrice_quota_key, quota)
+      service_quota_key = "#{service}_quota="
+      user.send(service_quota_key, quota)
       user.save
 
       puts "Changed the user quota for service #{service} to #{quota}."
@@ -96,15 +96,15 @@ namespace :cartodb do
 
       raise 'Please specify the organization to be modified' if args[:orgname].blank?
       raise 'Please specify the service to set the provider' if args[:service].blank?
-      raise "Unkown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
+      raise "Unknown service. Please use one of the accepted services: #{SERVICES.join(',')}" if not SERVICES.include? args[:service]
       raise 'Please specify a valid quota' if args[:quota].to_i < 0
 
       org = ::Organization.find(name: orgname)
 
       raise "The name '#{orgname}' does not correspond to any organization" if org.nil?
 
-      sevrice_quota_key = "#{service}_quota="
-      org.send(sevrice_quota_key, quota)
+      service_quota_key = "#{service}_quota="
+      org.send(service_quota_key, quota)
       org.save
 
       puts "Changed the organization quota for service #{service} to #{quota}."


### PR DESCRIPTION
Hey @ethervoid, could you please review?

The `here_isolines` service thing is a bit weird because it's directly related to the provider, but as we don't have a generic `isolines_quota` yet... :)


I tested the different options in local (different services, error for quota < 0, error for missing params...) for org and users.

cc @jvillarf 