### PR TITLE
Fixed builder delete map modal

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/delete-map-confirmation.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/delete-map-confirmation.tpl
@@ -11,14 +11,14 @@
       <p class="CDB-Text CDB-Size-medium u-altTextColor"><%- _t('editor.maps.delete.desc') %></p>
       <ul class="Modal-listActions u-flex u-alignCenter">
         <li class="Modal-listActionsitem">
-          <button class="CDB-Button CDB-Button--secondary CDB-Button--big js-close">
+          <button class="CDB-Button CDB-Button--secondary CDB-Button--big js-cancel">
             <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-medium u-upperCase">
               <%- _t('editor.maps.delete.cancel') %>
             </span>
           </button>
         </li>
         <li class="Modal-listActionsitem">
-          <button class="CDB-Button CDB-Button--primary CDB-Button--big">
+          <button class="CDB-Button CDB-Button--primary CDB-Button--big js-confirm">
             <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-medium u-upperCase">
               <%- _t('editor.maps.delete.confirm') %>
             </span>

--- a/lib/assets/test/spec/cartodb3/components/modals/modal-confirmation-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/modal-confirmation-view.spec.js
@@ -48,6 +48,11 @@ describe('components/modals/modal-confirmation-view', function () {
     });
   });
 
+  it('should have .js-confirm and .js-cancel present in the template', function () {
+    expect(this.view.$('.js-confirm').length).toBe(1);
+    expect(this.view.$('.js-cancel').length).toBe(1);
+  });
+
   afterEach(function () {
     this.view.clean();
   });


### PR DESCRIPTION
Fixes #9856 

Markdown selectors responsible for triggering the actions to cancel or confirm the action were missing, so I restored them.

CR @xavijam 