### PR TITLE
Fix firefox scroll in new modal layout #9859

### DIFF
--- a/app/assets/stylesheets/editor-3/modals-layout.css.scss
+++ b/app/assets/stylesheets/editor-3/modals-layout.css.scss
@@ -18,6 +18,7 @@
   @include justify-content(center);
   @include flex(1 1 auto);
   padding: 32px 0 0;
+  overflow: hidden;
 }
 .Modal-container .ScrollView {
   @include align-items(center);


### PR DESCRIPTION
@xavijam could you take a look?

Firefox:
![image](https://cloud.githubusercontent.com/assets/1214201/18830791/98f62796-83e2-11e6-8070-34042a503b04.png)


Chrome
![image](https://cloud.githubusercontent.com/assets/1214201/18830813/b37916a0-83e2-11e6-81ba-9ea55fde7c89.png)



Fix - https://github.com/CartoDB/cartodb/issues/9859