### PR TITLE
Set the layer name correctly in cdb.js models

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -317,7 +317,7 @@ F.prototype._adaptAttrsToCDBjs = function (attrs) {
   _.each(CARTODBJS_TO_CARTODB_ATTRIBUTE_MAPPINGS, function (cdbAttrs, cdbjsAttr) {
     _.each(cdbAttrs, function (cdbAttr) {
       attrs[cdbjsAttr] = attrs[cdbjsAttr] || attrs[cdbAttr];
-      delete attrs[cdbAttrs];
+      delete attrs[cdbAttr];
     });
   });
 

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -317,7 +317,6 @@ F.prototype._adaptAttrsToCDBjs = function (attrs) {
   _.each(CARTODBJS_TO_CARTODB_ATTRIBUTE_MAPPINGS, function (cdbAttrs, cdbjsAttr) {
     _.each(cdbAttrs, function (cdbAttr) {
       attrs[cdbjsAttr] = attrs[cdbjsAttr] || attrs[cdbAttr];
-      delete attrs[cdbAttr];
     });
   });
 

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -302,10 +302,26 @@ F.prototype._onLayerDefinitionChanged = function (m, changedAttributes) {
       if (m.get('source') && !layer.get('source')) {
         attrs.source = m.get('source');
       }
+      attrs = this._adaptAttrsToCDBjs(attrs);
       layer.update(attrs);
     }
     this._manageTimeSeriesForTorque(m);
   }
+};
+
+var CARTODBJS_TO_CARTODB_ATTRIBUTE_MAPPINGS = {
+  'layer_name': ['table_name_alias', 'table_name']
+};
+
+F.prototype._adaptAttrsToCDBjs = function (attrs) {
+  _.each(CARTODBJS_TO_CARTODB_ATTRIBUTE_MAPPINGS, function (cdbAttrs, cdbjsAttr) {
+    _.each(cdbAttrs, function (cdbAttr) {
+      attrs[cdbjsAttr] = attrs[cdbjsAttr] || attrs[cdbAttr];
+      delete attrs[cdbAttrs];
+    });
+  });
+
+  return attrs;
 };
 
 F.prototype._onLegendDefinitionAdded = function (m) {
@@ -435,18 +451,19 @@ F.prototype._onLayerDefinitionMoved = function (m) {
   this._createLayer(m);
 };
 
-var LAYER_TYPE_TO_LAYER_CREATE_METHOD;
+var LAYER_TYPE_TO_LAYER_CREATE_METHOD = {
+  'cartodb': 'createCartoDBLayer',
+  'gmapsbase': 'createGMapsBaseLayer',
+  'plain': 'createPlainLayer',
+  'tiled': 'createTileLayer',
+  'torque': 'createTorqueLayer',
+  'wms': 'createWMSLayer'
+};
+
 F.prototype._createLayer = function (layerDefModel) {
   var attrs = JSON.parse(JSON.stringify(layerDefModel.attributes)); // deep clone
+  attrs = this._adaptAttrsToCDBjs(attrs);
 
-  LAYER_TYPE_TO_LAYER_CREATE_METHOD = LAYER_TYPE_TO_LAYER_CREATE_METHOD || {
-    'cartodb': 'createCartoDBLayer',
-    'gmapsbase': 'createGMapsBaseLayer',
-    'plain': 'createPlainLayer',
-    'tiled': 'createTileLayer',
-    'torque': 'createTorqueLayer',
-    'wms': 'createWMSLayer'
-  };
   var createMethodName = LAYER_TYPE_TO_LAYER_CREATE_METHOD[attrs.type.toLowerCase()];
   if (!createMethodName) throw new Error('no create method name found for type ' + attrs.type);
 

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -400,8 +400,6 @@ describe('deep-insights-integrations', function () {
       var l = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
       expect(l).toBeDefined();
       expect(l.get('layer_name')).toEqual('My FOO');
-      expect(l.get('table_name')).toBeUndefined();
-      expect(l.get('table_name_alias')).toBeUndefined();
     });
 
     it('should insert the layer at the given position (order)', function () {
@@ -466,8 +464,6 @@ describe('deep-insights-integrations', function () {
         this.layerDefinitionModel.set('table_name', 'My TABLE');
 
         expect(l.get('layer_name')).toEqual('My TABLE');
-        expect(l.get('table_name')).toBeUndefined();
-        expect(l.get('table_name_alias')).toBeUndefined();
       });
     });
 

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -400,6 +400,8 @@ describe('deep-insights-integrations', function () {
       var l = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
       expect(l).toBeDefined();
       expect(l.get('layer_name')).toEqual('My FOO');
+      expect(l.get('table_name')).toBeUndefined();
+      expect(l.get('table_name_alias')).toBeUndefined();
     });
 
     it('should insert the layer at the given position (order)', function () {
@@ -464,6 +466,8 @@ describe('deep-insights-integrations', function () {
         this.layerDefinitionModel.set('table_name', 'My TABLE');
 
         expect(l.get('layer_name')).toEqual('My TABLE');
+        expect(l.get('table_name')).toBeUndefined();
+        expect(l.get('table_name_alias')).toBeUndefined();
       });
     });
 

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -385,6 +385,23 @@ describe('deep-insights-integrations', function () {
       expect(l.get('order')).toEqual(0);
     });
 
+    it('should adapt attributes to cartodb.js names', function () {
+      this.layerDefinitionModel = this.layerDefinitionsCollection.add({
+        id: 'integration-test-2',
+        kind: 'carto',
+        options: {
+          sql: 'SELECT * FROM foo',
+          cartocss: '...',
+          table_name: 'foo',
+          table_name_alias: 'My FOO'
+        }
+      }, { at: 1 }); // <- this is what actually determines the right order
+
+      var l = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
+      expect(l).toBeDefined();
+      expect(l.get('layer_name')).toEqual('My FOO');
+    });
+
     it('should insert the layer at the given position (order)', function () {
       this.layerDefinitionModel = this.layerDefinitionsCollection.add({
         id: 'integration-test-2',
@@ -428,6 +445,25 @@ describe('deep-insights-integrations', function () {
       it('should update the equivalent layer', function () {
         var l = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
         expect(l.get('color')).toEqual('pink');
+      });
+
+      it('should adapt attributes to cartodb.js names', function () {
+        this.layerDefinitionModel = this.layerDefinitionsCollection.add({
+          id: 'integration-test-2',
+          kind: 'carto',
+          options: {
+            sql: 'SELECT * FROM foo',
+            cartocss: '...'
+          }
+        }, { at: 1 }); // <- this is what actually determines the right order
+
+        var l = this.integrations.visMap().layers.get(this.layerDefinitionModel.id);
+        expect(l).toBeDefined();
+        expect(l.get('layer_name')).toBeUndefined();
+
+        this.layerDefinitionModel.set('table_name', 'My TABLE');
+
+        expect(l.get('layer_name')).toEqual('My TABLE');
       });
     });
 


### PR DESCRIPTION
CDB.js layer models expect `layer_name` (which is also the name of this "option" in the viz.json), but attributes are called `table_name_alias` or `table_name` in layer definition models. This is the reason why layer names in the legends container are empty or are not updated when layers are added or changed.

This PR (hopefully) fixes that.

@nobuti what do you think?