### PR TITLE
Adapt name of BUILDER attrs to CDB.js names, take 2

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -316,7 +316,7 @@ var CARTODBJS_TO_CARTODB_ATTRIBUTE_MAPPINGS = {
 F.prototype._adaptAttrsToCDBjs = function (attrs) {
   _.each(CARTODBJS_TO_CARTODB_ATTRIBUTE_MAPPINGS, function (cdbAttrs, cdbjsAttr) {
     _.each(cdbAttrs, function (cdbAttr) {
-      if (attrs[cdbAttr] || !attrs[cdbjsAttr]) {
+      if (attrs[cdbAttr] && !attrs[cdbjsAttr]) {
         attrs[cdbjsAttr] = attrs[cdbAttr];
       }
     });

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -316,7 +316,9 @@ var CARTODBJS_TO_CARTODB_ATTRIBUTE_MAPPINGS = {
 F.prototype._adaptAttrsToCDBjs = function (attrs) {
   _.each(CARTODBJS_TO_CARTODB_ATTRIBUTE_MAPPINGS, function (cdbAttrs, cdbjsAttr) {
     _.each(cdbAttrs, function (cdbAttr) {
-      attrs[cdbjsAttr] = attrs[cdbjsAttr] || attrs[cdbAttr];
+      if (attrs[cdbAttr] || !attrs[cdbjsAttr]) {
+        attrs[cdbjsAttr] = attrs[cdbAttr];
+      }
     });
   });
 


### PR DESCRIPTION
@nobuti I found a little BUG in this function. It was setting `{ layer_name: undefined }` when attributes other than `table_name` and `table_name_alias` were updated.