### PR TITLE
disable hover state for labels block in layers list

### DIFF
--- a/app/assets/stylesheets/editor-3/block-list.css.scss
+++ b/app/assets/stylesheets/editor-3/block-list.css.scss
@@ -29,6 +29,10 @@
 }
 .BlockList-item.BlockList-item--noAction {
   cursor: default;
+
+  .BlockList-titleText {
+    cursor: default;
+  }
 }
 .BlockList-item.BlockList-item--noAction:hover {
   border: 1px solid $cSecondaryLine;

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-views/labels-layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-views/labels-layer-view.js
@@ -5,7 +5,7 @@ module.exports = CoreView.extend({
 
   tagName: 'li',
 
-  className: 'BlockList-item js-layer ui-state-disabled',
+  className: 'BlockList-item BlockList-item--noAction js-layer ui-state-disabled',
 
   initialize: function (opts) {
     this.listenTo(this.model, 'change', this.render);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.13",
+  "version": "4.2.16",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
close https://github.com/CartoDB/cartodb/issues/9875

prevented title to have pointer cursor, besides the block itself

![labels](https://cloud.githubusercontent.com/assets/36676/18871140/4e656d04-84b4-11e6-8cc2-3203c926d796.gif)

CR @xavijam 