### PR TITLE
Fixed published date too long copy

### DIFF
--- a/app/assets/stylesheets/editor-3/header.css.scss
+++ b/app/assets/stylesheets/editor-3/header.css.scss
@@ -104,7 +104,4 @@
 }
 .Editor-HeaderInfo-publishDate {
   max-width: 160px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
 }

--- a/app/assets/stylesheets/editor-3/header.css.scss
+++ b/app/assets/stylesheets/editor-3/header.css.scss
@@ -103,8 +103,8 @@
   }
 }
 .Editor-HeaderInfo-publishDate {
+  max-width: 160px;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  max-width: 160px;
 }

--- a/app/assets/stylesheets/editor-3/header.css.scss
+++ b/app/assets/stylesheets/editor-3/header.css.scss
@@ -102,3 +102,9 @@
     color: $cWhite;
   }
 }
+.Editor-HeaderInfo-publishDate {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 160px;
+}

--- a/lib/assets/javascripts/cartodb3/editor/editor-header.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/editor-header.tpl
@@ -11,7 +11,7 @@
       <% if (!isSimple) { %>
       <div class="js-share-users"></div>
       <% } %>
-      <div class="CDB-Text CDB-Size-medium u-altTextColor"><%- published %></div>
+      <div class="Editor-HeaderInfo-publishDate CDB-Text CDB-Size-medium u-altTextColor"><%- published %></div>
     </div>
   </div>
 </div>

--- a/lib/assets/javascripts/cartodb3/editor/editor-header.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/editor-header.tpl
@@ -11,7 +11,7 @@
       <% if (!isSimple) { %>
       <div class="js-share-users"></div>
       <% } %>
-      <div class="Editor-HeaderInfo-publishDate CDB-Text CDB-Size-medium u-altTextColor"><%- published %></div>
+      <div class="Editor-HeaderInfo-publishDate u-ellipsis CDB-Text CDB-Size-medium u-altTextColor"><%- published %></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #9804 

Added ellipsis and max width to the div containing the text for `'Published x time ago'` text.

<img width="330" alt="screen shot 2016-09-27 at 17 18 25" src="https://cloud.githubusercontent.com/assets/2141690/18879969/903eca32-84d6-11e6-8e46-4aa19b4a4a46.png">

CR @piensaenpixel 