### PR TITLE
Added title value to column name element in dataset view

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/table/head/table-head-item.tpl
+++ b/lib/assets/javascripts/cartodb3/components/table/head/table-head-item.tpl
@@ -3,7 +3,7 @@
     <%- name === 'cartodb_id' || (type === 'geometry' && geometry !== 'point') ? 'Table-headItemWrapper--short' : '' %>
   ">
   <div class="u-flex u-justifySpace">
-    <input class="Table-headItemName CDB-Text CDB-Size-medium is-semibold u-ellipsis js-attribute" value="<%- name %>" readonly />
+    <input class="Table-headItemName CDB-Text CDB-Size-medium is-semibold u-ellipsis js-attribute" value="<%- name %>" title="<%- name %>" readonly />
 
     <% if (isOrderBy) { %>
       <i class="CDB-Size CDB-Size-small CDB-IconFont CDB-IconFont-arrowNext


### PR DESCRIPTION
Fixes #9880 

In cases where the column name is too long and the text is truncated with `...` it wil be still accessible with the `title` tag.

<img width="487" alt="screen shot 2016-09-28 at 09 32 33" src="https://cloud.githubusercontent.com/assets/2141690/18904544/d71272c8-855e-11e6-863b-2ab6b46a2e9d.png">

CR @nobuti please :)