### PR TITLE
Add check_connection method to Connector

### DIFF
--- a/lib/carto/connector.rb
+++ b/lib/carto/connector.rb
@@ -33,6 +33,10 @@ module Carto
       @provider.list_tables(limits: limits.merge(max_listed_tables: limit))
     end
 
+    def check_connection
+      @provider.check_connection
+    end
+
     def remote_data_updated?
       @provider.remote_data_updated?
     end

--- a/lib/carto/connector/context.rb
+++ b/lib/carto/connector/context.rb
@@ -49,6 +49,14 @@ module Carto
                end
         data.map(&:with_indifferent_access)
       end
+
+      def username
+        @user.username
+      end
+
+      def database_username
+        @user.database_username
+      end
     end
   end
 end

--- a/lib/carto/connector/providers/base.rb
+++ b/lib/carto/connector/providers/base.rb
@@ -7,6 +7,7 @@
 #
 # * `copy_table(schema_name:, table_name:, limits:)`
 # * `list_tables(limits:)`
+# * `check_connection`
 # * `remote_data_updated?`
 # * `table_name`
 # * `required_parameters`
@@ -40,6 +41,10 @@ module Carto
 
       def list_tables(limits:)
         must_be_defined_in_derived_class limits: limits
+      end
+
+      def check_connection
+        must_be_defined_in_derived_class
       end
 
       def remote_data_updated?

--- a/lib/carto/connector/providers/fdw.rb
+++ b/lib/carto/connector/providers/fdw.rb
@@ -12,6 +12,7 @@ require_relative './base'
 # * `fdw_create_usermap(server_name, user_name)`
 # * `fdw_create_foreign_table(server_name, schema_name, foreign_prefix, username)`
 # * `fdw_list_tables(limits:)`
+# * `fdw_check_connection(server_name)`
 #
 module Carto
   class Connector
@@ -48,6 +49,16 @@ module Carto
         with_server do
           fdw_list_tables server_name, foreign_table_schema, foreign_prefix, limit
         end
+      end
+
+      def check_connection
+        ok = false
+        validate! only: [:connection]
+        with_server do
+          ok = fdw_check_connection server_name, foreign_prefix, @connector_context.user.database_username
+        end
+        ok
+        # TODO: rescue exceptions and return false?
       end
 
       def remote_data_updated?
@@ -124,6 +135,12 @@ module Carto
       # Create the foreign table used for importing
       # Must return the name of the created foreign table
       def fdw_create_foreign_table(_server_name, _schema_name, _foreign_prefix, _username)
+        must_be_defined_in_derived_class
+      end
+
+      # Check the connection with a server: returns OK for valid connections;
+      # otherwise it either raises an exception or returns false.
+      def fdw_check_connection(_server_name)
         must_be_defined_in_derived_class
       end
 

--- a/lib/carto/connector/providers/odbc.rb
+++ b/lib/carto/connector/providers/odbc.rb
@@ -103,12 +103,12 @@ module Carto
 
       def fdw_create_server(server_name)
         sql = fdw_create_server_sql 'odbc_fdw', server_name, server_options
-        @connector_context.execute_as_superuser sql
+        execute_as_superuser sql
       end
 
       def fdw_create_usermap(server_name, username)
         sql = fdw_create_usermap_sql server_name, username, user_options
-        @connector_context.execute_as_superuser sql
+        execute_as_superuser sql
       end
 
       def fdw_create_foreign_table(server_name, foreign_table_schema, foreign_prefix, username)
@@ -123,17 +123,17 @@ module Carto
           cmds << fdw_import_foreign_schema_sql(server_name, remote_schema_name, foreign_table_schema, options)
         end
         cmds << fdw_grant_select_sql(foreign_table_schema, foreign_table_name, username)
-        @connector_context.execute_as_superuser cmds.join("\n")
+        execute_as_superuser cmds.join("\n")
         foreign_table_name
       end
 
       def fdw_list_tables(server_name, _foreign_table_schema, _foreign_prefix, limit)
-        @connector_context.execute %{
+        execute %{
           SELECT * FROM ODBCTablesList('#{server_name}',#{limit.to_i});
         }
       end
 
-      def fdw_check_connection(server_name, foreign_prefix, username) # avoid username (use @connector_context...)
+      def fdw_check_connection(server_name, foreign_prefix, username)
         cmds = []
         foreign_table_name = self.foreign_table_name(foreign_prefix, 'check')
         columns = ['ok int']

--- a/lib/carto/connector/providers/odbc.rb
+++ b/lib/carto/connector/providers/odbc.rb
@@ -116,7 +116,7 @@ module Carto
         execute_as_superuser fdw_create_usermap_sql(server_name, 'postgres', user_options)
       end
 
-      def fdw_create_foreign_table(server_name, foreign_table_schema)
+      def fdw_create_foreign_table(server_name)
         cmds = []
         foreign_table_name = foreign_table_name_for(server_name)
         if @columns.present?
@@ -132,7 +132,7 @@ module Carto
         foreign_table_name
       end
 
-      def fdw_list_tables(server_name, _foreign_table_schema, limit)
+      def fdw_list_tables(server_name, limit)
         execute %{
           SELECT * FROM ODBCTablesList('#{server_name}',#{limit.to_i});
         }

--- a/lib/carto/connector/providers/pg_fdw.rb
+++ b/lib/carto/connector/providers/pg_fdw.rb
@@ -67,11 +67,12 @@ module Carto
         execute_as_superuser fdw_create_server_sql('postgres_fdw', server_name, server_options)
       end
 
-      def fdw_create_usermap(server_name, username)
-        execute_as_superuser fdw_create_usermap_sql(server_name, username, user_options)
+      def fdw_create_usermaps(server_name)
+        execute_as_superuser fdw_create_usermap_sql(server_name, @connector_context.database_username, user_options)
+        execute_as_superuser fdw_create_usermap_sql(server_name, 'postgres', user_options)
       end
 
-      def fdw_create_foreign_table(server_name, schema, foreign_prefix, username)
+      def fdw_create_foreign_table(server_name, schema, foreign_prefix)
         remote_table = table_name
         foreign_table = foreign_table_name(foreign_prefix)
         options = table_options
@@ -80,7 +81,7 @@ module Carto
         if remote_table != foreign_table
           cmds << fdw_rename_foreign_table_sql(schema, remote_table, foreign_table)
         end
-        cmds << fdw_grant_select_sql(schema, foreign_table_name(foreign_prefix), username)
+        cmds << fdw_grant_select_sql(schema, foreign_table_name(foreign_prefix), @connector_context.database_username)
         execute_as_superuser cmds.join("\n")
         foreign_table
       end
@@ -120,7 +121,7 @@ module Carto
         execute_as_superuser(commands.join("\n"))
       end
 
-      def fdw_check_connection(server_name, foreign_prefix, _username)
+      def fdw_check_connection(server_name, foreign_prefix)
         fdw_list_tables(server_name, 'public', foreign_prefix, 1)
         true
       end

--- a/lib/carto/connector/providers/pg_fdw.rb
+++ b/lib/carto/connector/providers/pg_fdw.rb
@@ -77,10 +77,11 @@ module Carto
         execute_as_superuser fdw_create_usermap_sql(server_name, 'postgres', user_options)
       end
 
-      def fdw_create_foreign_table(server_name, schema)
+      def fdw_create_foreign_table(server_name)
         remote_table = table_name
         foreign_table = foreign_table_name_for(server_name)
         options = table_options
+        schema = foreign_table_schema
         cmds = []
         cmds << fdw_import_foreign_schema_limited_sql(server_name, remote_schema_name, schema, remote_table, options)
         if remote_table != foreign_table
@@ -91,18 +92,18 @@ module Carto
         foreign_table
       end
 
-      def fdw_list_tables(server_name, schema, limit)
+      def fdw_list_tables(server_name, limit)
         # Create auxiliar foreign tables for pg_class, pg_namespace
         ext_pg_class = foreign_table_name_for(server_name, 'pg_class')
         ext_pg_namespace = foreign_table_name_for(server_name, 'pg_namespace')
         commands = []
         commands << fdw_create_foreign_table_if_not_exists_sql(
-          server_name, schema, ext_pg_class,
+          server_name, foreign_table_schema, ext_pg_class,
           ['relname name', 'relnamespace oid', 'relkind char'],
           schema_name: 'pg_catalog', table_name: 'pg_class'
         )
         commands << fdw_create_foreign_table_if_not_exists_sql(
-          server_name, schema, ext_pg_namespace,
+          server_name, foreign_table_schema, ext_pg_namespace,
           ['nspname name', 'oid oid'],
           schema_name: 'pg_catalog', table_name: 'pg_namespace'
         )
@@ -121,8 +122,8 @@ module Carto
       ensure
         # Drop auxiliar foreign tables for pg_class, pg_namespace
         commands = []
-        commands << fdw_drop_foreign_table_sql(schema, ext_pg_namespace) if ext_pg_namespace
-        commands << fdw_drop_foreign_table_sql(schema, ext_pg_class) if ext_pg_class
+        commands << fdw_drop_foreign_table_sql(foreign_table_schema, ext_pg_namespace) if ext_pg_namespace
+        commands << fdw_drop_foreign_table_sql(foreign_table_schema, ext_pg_class) if ext_pg_class
         execute_as_superuser(commands.join("\n"))
       end
 

--- a/lib/carto/connector/providers/pg_fdw.rb
+++ b/lib/carto/connector/providers/pg_fdw.rb
@@ -120,6 +120,11 @@ module Carto
         execute_as_superuser(commands.join("\n"))
       end
 
+      def fdw_check_connection(server_name, foreign_prefix, _username)
+        fdw_list_tables(server_name, 'public', foreign_prefix, 1)
+        true
+      end
+
       def features_information
         {
           "sql_queries":    false,

--- a/lib/carto/connector/providers/pg_fdw.rb
+++ b/lib/carto/connector/providers/pg_fdw.rb
@@ -112,8 +112,8 @@ module Carto
 
         execute_as_superuser %{
           SELECT n.nspname AS schema, c.relname AS name
-          FROM #{fdw_qualified_table_name(schema, ext_pg_class)} c
-          JOIN #{fdw_qualified_table_name(schema, ext_pg_namespace)} n ON n.oid = c.relnamespace
+          FROM #{fdw_qualified_table_name(foreign_table_schema, ext_pg_class)} c
+          JOIN #{fdw_qualified_table_name(foreign_table_schema, ext_pg_namespace)} n ON n.oid = c.relnamespace
             WHERE c.relkind = 'r'
             AND n.nspname NOT IN ('pg_catalog', 'information_schema')
             ORDER BY schema, name
@@ -128,7 +128,7 @@ module Carto
       end
 
       def fdw_check_connection(server_name)
-        fdw_list_tables(server_name, 'public', 1)
+        fdw_list_tables(server_name, 1)
         true
       end
 

--- a/services/importer/lib/importer/connector_runner.rb
+++ b/services/importer/lib/importer/connector_runner.rb
@@ -60,7 +60,7 @@ module CartoDB
       end
 
       def remote_data_updated?
-        @connecctor.remote_data_updated?
+        @connector.remote_data_updated?
       end
 
       def tracker


### PR DESCRIPTION
This adds a method to check a connection intended to validate the parameters without needed to fetch the list of available tables (which could not be implemented for some providers).
