### PR TITLE
Fixed in package dependencies.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.23",
+  "version": "4.2.25",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -14,8 +14,8 @@
     },
     "backbone-model-file-upload": {
       "version": "1.0.0",
-      "from": "git://github.com/CartoDB/backbone-model-file-upload.git#1.0.0",
-      "resolved": "git://github.com/CartoDB/backbone-model-file-upload.git#ff2c75cdf7e8e8e7dd651b4f69f14d13abe23a19",
+      "from": "cartodb/backbone-model-file-upload#1.0.0",
+      "resolved": "git://github.com/cartodb/backbone-model-file-upload.git#ff2c75cdf7e8e8e7dd651b4f69f14d13abe23a19",
       "dependencies": {
         "bower": {
           "version": "1.7.9",
@@ -86,7 +86,7 @@
                             },
                             "readable-stream": {
                               "version": "2.0.6",
-                              "from": "readable-stream@>=2.0.0 <2.1.0",
+                              "from": "readable-stream@>=2.0.5 <2.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                               "dependencies": {
                                 "core-util-is": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.21",
+  "version": "4.2.23",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -14,8 +14,8 @@
     },
     "backbone-model-file-upload": {
       "version": "1.0.0",
-      "from": "backbone-model-file-upload@1.0.0",
-      "resolved": "https://registry.npmjs.org/backbone-model-file-upload/-/backbone-model-file-upload-1.0.0.tgz",
+      "from": "git://github.com/CartoDB/backbone-model-file-upload.git#1.0.0",
+      "resolved": "git://github.com/CartoDB/backbone-model-file-upload.git#ff2c75cdf7e8e8e7dd651b4f69f14d13abe23a19",
       "dependencies": {
         "bower": {
           "version": "1.7.9",
@@ -750,12 +750,12 @@
         },
         "grunt-run": {
           "version": "0.3.0",
-          "from": "grunt-run@>=0.3.0 <0.4.0",
+          "from": "grunt-run@0.3.0",
           "resolved": "https://registry.npmjs.org/grunt-run/-/grunt-run-0.3.0.tgz"
         },
         "grunt-run-node": {
           "version": "0.1.3",
-          "from": "grunt-run-node@>=0.1.0 <0.2.0",
+          "from": "grunt-run-node@0.1.3",
           "resolved": "https://registry.npmjs.org/grunt-run-node/-/grunt-run-node-0.1.3.tgz"
         },
         "grunt-template-jasmine-requirejs": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "backbone-forms": "0.14.0",
-    "backbone-model-file-upload": "git://github.com/CartoDB/backbone-model-file-upload.git#1.0.0",
+    "backbone-model-file-upload": "CartoDB/backbone-model-file-upload#1.0.0",
     "backbone-undo": "cartodb/Backbone.Undo.js#c10e997",
     "bootstrap-colorpicker": "2.3.3",
     "browserify-shim": "3.8.12",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "backbone-forms": "0.14.0",
-    "backbone-model-file-upload": "1.0.0",
+    "backbone-model-file-upload": "git://github.com/CartoDB/backbone-model-file-upload.git#1.0.0",
     "backbone-undo": "cartodb/Backbone.Undo.js#c10e997",
     "bootstrap-colorpicker": "2.3.3",
     "browserify-shim": "3.8.12",


### PR DESCRIPTION
This PR fixes the dev dependencies of a dependency 🙉  🔫 

We had to fork [backbone-model-file-upload](https://github.com/CartoDB/backbone-model-file-upload/tree/1.0.0)  in order to fix the version, then to update the package pointing to that branch.

cc @xavijam @rochoa 