### PR TITLE
Widget definition should be removed before layer definition in order to not break things

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -523,7 +523,7 @@ module.exports = function (params) {
 
               widgetDefinitionsCollection.each(function (widget) {
                 if (!_.contains(toDestroy, widget) && widget.containsNode(nodeDefModel)) {
-                  toDestroy.push(widget);
+                  toDestroy.unshift(widget);
                 }
               });
             }

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -517,6 +517,8 @@ module.exports = function (params) {
 
         // No parent layer? delete all dependent objects, since can't move current nodeDefModel elsewhere
         if (!parentLayer) {
+          toDestroy.push(nodeDefModel);
+
           layerDefinitionsCollection.each(function (layer) {
             if (!_.contains(toDestroy, layer) && layer.containsNode(nodeDefModel)) {
               toDestroy.push(layer);
@@ -527,8 +529,6 @@ module.exports = function (params) {
                 }
               });
             }
-
-            toDestroy.push(nodeDefModel);
           });
 
           continue; // to process all sequent nodes in the linekd list, and their (possibly) dependent objects
@@ -586,7 +586,7 @@ module.exports = function (params) {
       }
 
       if (!_.contains(toDestroy, layerToDelete)) {
-        toDestroy.unshift(layerToDelete);
+        toDestroy.push(layerToDelete);
       }
 
       var promise = $.when.apply($, // http://api.jquery.com/jQuery.when/

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -520,8 +520,10 @@ module.exports = function (params) {
           toDestroy.push(nodeDefModel);
 
           layerDefinitionsCollection.each(function (layer) {
-            if (!_.contains(toDestroy, layer) && layer.containsNode(nodeDefModel)) {
-              toDestroy.push(layer);
+            if (layer.containsNode(nodeDefModel)) {
+              if (!_.contains(toDestroy, layer)) {
+                toDestroy.push(layer);
+              }
 
               widgetDefinitionsCollection.each(function (widget) {
                 if (!_.contains(toDestroy, widget) && widget.containsNode(nodeDefModel)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.25",
+  "version": "4.2.31",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.31",
+  "version": "4.2.32",
   "description": "CartoDB UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
So, the problem is, we have to remove a layer, but if there is a widget that points to any of its sources, CartoDB.js fails because layer definition is removed before widget is removed.

## STR
- Create a map with a dataset of points (A0).
- Add a widget pointing to that source A0.
- Add another layer, just to be able to remove the layer A.
- Open the chrome console.
- Remove that layer A.
- Check errors in the console.

So, preventing future problems, the queue of the removal objects will be:

```js
[
  widgets,
  nodes,
  layers
]
// things affected by the remove operation
```

cc @nobuti