### PR TITLE
9918 drop indices concurrently

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1144,7 +1144,7 @@ class Table
 
   def drop_index(column, prefix = '', concurrent: false)
     concurrently = concurrent ? 'CONCURRENTLY' : ''
-    owner.in_database.execute(%{DROP INDEX "#{concurrently} #{index_name(column, prefix)}"})
+    owner.in_database.execute(%{DROP INDEX #{concurrently} "#{index_name(column, prefix)}"})
   end
 
   def cartodbfy

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1122,7 +1122,7 @@ class Table
   def pg_indexes
     owner.in_database(as: :superuser).fetch(%{
       SELECT
-        a.attname as column, i.relname as name, i.indisvalid as valid
+        a.attname as column, i.relname as name, ix.indisvalid as valid
       FROM
         pg_class t, pg_class i, pg_index ix, pg_attribute a, pg_namespace n
       WHERE

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1122,7 +1122,7 @@ class Table
   def pg_indexes
     owner.in_database(as: :superuser).fetch(%{
       SELECT
-        a.attname as column, i.relname as name
+        a.attname as column, i.relname as name, i.indisvalid as valid
       FROM
         pg_class t, pg_class i, pg_index ix, pg_attribute a, pg_namespace n
       WHERE

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1142,8 +1142,9 @@ class Table
     owner.in_database.execute(%{CREATE INDEX #{concurrently} "#{index_name(column, prefix)}" ON "#{name}"("#{column}")})
   end
 
-  def drop_index(column, prefix = '')
-    owner.in_database.execute(%{DROP INDEX "#{index_name(column, prefix)}"})
+  def drop_index(column, prefix = '', concurrent: false)
+    concurrently = concurrent ? 'CONCURRENTLY' : ''
+    owner.in_database.execute(%{DROP INDEX "#{concurrently} #{index_name(column, prefix)}"})
   end
 
   def cartodbfy

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -30,6 +30,11 @@ module Carto
     private
 
     def generate_indices
+      auto_indices(valid: false).each do |idx|
+        CartoDB::Logger.debug(message: 'Auto index', action: 'drop invalid', table: @user_table, column: idx[:column])
+        @table.drop_index(idx[:column], AUTO_INDEX_PREFIX, concurrent: true)
+      end
+
       widget_columns = (@table.estimated_row_count > MINIMUM_ROW_COUNT_TO_INDEX) ? columns_with_widgets : []
       columns_to_index = widget_columns.select { |c| indexable_column?(c) }
 
@@ -79,8 +84,8 @@ module Carto
       false
     end
 
-    def auto_indices
-      indices.select { |i| i[:name].starts_with?(AUTO_INDEX_PREFIX) }
+    def auto_indices(valid: true)
+      indices.select { |i| i[:name].starts_with?(AUTO_INDEX_PREFIX) && i[:valid] == valid }
     end
 
     def indices

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -44,7 +44,7 @@ module Carto
       drop_index_on = auto_indexed_columns - columns_to_index
       drop_index_on.each do |col|
         CartoDB::Logger.debug(message: 'Auto index', action: 'drop', table: @user_table, column: col)
-        @table.drop_index(col, AUTO_INDEX_PREFIX)
+        @table.drop_index(col, AUTO_INDEX_PREFIX, concurrent: true)
       end
     rescue => e
       CartoDB::Logger.error(exception: e, message: 'Error auto-indexing table', table: @user_table)

--- a/app/services/carto/user_table_index_service.rb
+++ b/app/services/carto/user_table_index_service.rb
@@ -38,7 +38,7 @@ module Carto
       widget_columns = (@table.estimated_row_count > MINIMUM_ROW_COUNT_TO_INDEX) ? columns_with_widgets : []
       columns_to_index = widget_columns.select { |c| indexable_column?(c) }
 
-      indexed_columns = indices.map { |i| i[:column] }
+      indexed_columns = valid_indices.map { |i| i[:column] }
       create_index_on = columns_to_index - indexed_columns
       create_index_on.each do |col|
         CartoDB::Logger.debug(message: 'Auto index', action: 'create', table: @user_table, column: col)
@@ -86,6 +86,10 @@ module Carto
 
     def auto_indices(valid: true)
       indices.select { |i| i[:name].starts_with?(AUTO_INDEX_PREFIX) && i[:valid] == valid }
+    end
+
+    def valid_indices
+      indices.select { |i| i[:valid] }
     end
 
     def indices

--- a/spec/services/carto/user_table_index_service_spec.rb
+++ b/spec/services/carto/user_table_index_service_spec.rb
@@ -120,7 +120,7 @@ describe Carto::UserTableIndexService do
     end
 
     it 'does not create indices for indexed columns' do
-      @table1.service.stubs(:pg_indexes).returns([{ name: 'wadus', column: 'number' }])
+      @table1.service.stubs(:pg_indexes).returns([{ name: 'wadus', column: 'number', valid: true }])
       @table1.service.stubs(:estimated_row_count).returns(100000)
       create_widget(@analysis1, column: 'number')
       create_widget(@analysis12_1, column: 'date', type: 'time-series')
@@ -131,7 +131,8 @@ describe Carto::UserTableIndexService do
     end
 
     it 'does not create indices for indexed columns (in multi-column indexes)' do
-      @table1.service.stubs(:pg_indexes).returns([{ name: 'idx', column: 'number' }, { name: 'idx', column: 'date' }])
+      @table1.service.stubs(:pg_indexes).returns([{ name: 'idx', column: 'number', valid: true },
+                                                  { name: 'idx', column: 'date', valid: true }])
       @table1.service.stubs(:estimated_row_count).returns(100000)
       create_widget(@analysis1, column: 'number')
       create_widget(@analysis12_1, column: 'date', type: 'time-series')
@@ -159,7 +160,8 @@ describe Carto::UserTableIndexService do
     end
 
     it 'does not drop manual indices' do
-      @table1.service.stubs(:pg_indexes).returns([{ name: 'idx', column: 'number' }, { name: 'idx', column: 'date' }])
+      @table1.service.stubs(:pg_indexes).returns([{ name: 'idx', column: 'number', valid: true },
+                                                  { name: 'idx', column: 'date', valid: true }])
       @table1.service.stubs(:estimated_row_count).returns(100)
       create_widget(@analysis1, column: 'number')
 
@@ -266,7 +268,11 @@ describe Carto::UserTableIndexService do
   private
 
   def automatic_index_record(table, column)
-    { name: table.service.send(:index_name, column, Carto::UserTableIndexService::AUTO_INDEX_PREFIX), column: column }
+    {
+      name: table.service.send(:index_name, column, Carto::UserTableIndexService::AUTO_INDEX_PREFIX),
+      column: column,
+      valid: true
+    }
   end
 
   def stub_create_index(column)

--- a/spec/services/carto/user_table_index_service_spec.rb
+++ b/spec/services/carto/user_table_index_service_spec.rb
@@ -274,7 +274,7 @@ describe Carto::UserTableIndexService do
   end
 
   def stub_drop_index(column)
-    @table1.service.stubs(:drop_index).with(column, Carto::UserTableIndexService::AUTO_INDEX_PREFIX)
+    @table1.service.stubs(:drop_index).with(column, Carto::UserTableIndexService::AUTO_INDEX_PREFIX, concurrent: true)
   end
 
   def create_widget(analysis, child: false, column: 'col', type: 'histogram')


### PR DESCRIPTION
 - Makinf DROP INDEX concurrent fixes #9918. It's slower but does not lock the table.
 - Deleting invalid concurrent indices (a growing problem) fixes #9537. This is done in every run.