### PR TITLE
Fix connectors rake

### DIFF
--- a/app/controllers/carto/api/connectors_controller.rb
+++ b/app/controllers/carto/api/connectors_controller.rb
@@ -11,7 +11,7 @@ module Carto
       before_filter :check_availability
 
       def index
-        render_jsonp(Carto::Connector.providers(current_user))
+        render_jsonp(Carto::Connector.providers(user: current_user))
       end
 
       def show

--- a/lib/tasks/connectors_api.rake
+++ b/lib/tasks/connectors_api.rake
@@ -3,13 +3,13 @@ namespace :cartodb do
 
     desc "Create Connector Providers for Provider Classes"
     task create_providers: :environment do
-      Carto::Connector.providers.keys.each do |provider_name|
+      Carto::Connector.providers(all: true).keys.each do |provider_name|
         unless Carto::ConnectorProvider.where(name: provider_name).exists?
           puts "Creating ConnectorProvider #{provider_name}"
           Carto::ConnectorProvider.create! name: provider_name
         end
       end
-      providers = Carto::Connector.providers.keys.map { |name| "'#{name}'" }
+      providers = Carto::Connector.providers(all: true).keys.map { |name| "'#{name}'" }
       Carto::ConnectorProvider.where("name NOT IN (#{providers.join(',')})").each do |provider|
         puts "Provider #{provider.name} is not configured in the code!"
       end

--- a/lib/tasks/connectors_api.rake
+++ b/lib/tasks/connectors_api.rake
@@ -46,7 +46,7 @@ namespace :cartodb do
 
     def with_provider_org_config(args)
       provider = find_by_uuid_or_name(args.provider, Carto::ConnectorProvider)
-      org      = find_by_uuid_or_name(args.user, Carto::Organization)
+      org      = find_by_uuid_or_name(args.org, Carto::Organization)
       puts "Provider not found: #{args.provider}" if provider.blank?
       puts "Organization not found: #{args.org}" if org.blank?
       if provider.present? && org.present?

--- a/services/importer/spec/unit/connector_runner_spec.rb
+++ b/services/importer/spec/unit/connector_runner_spec.rb
@@ -22,7 +22,7 @@ describe CartoDB::Importer2::ConnectorRunner do
     @fake_log = CartoDB::Importer2::Doubles::Log.new(@user)
     @providers = %w(mysql postgres sqlserver hive)
     @fake_log.clear
-    Carto::Connector.providers.keys.each do |provider_name|
+    Carto::Connector.providers(all: true).keys.each do |provider_name|
       Carto::ConnectorProvider.create! name: provider_name
     end
   end
@@ -35,7 +35,7 @@ describe CartoDB::Importer2::ConnectorRunner do
   after(:all) do
     @user.destroy
     @feature_flag.destroy
-    Carto::Connector.providers.keys.each do |provider_name|
+    Carto::Connector.providers(all: true).keys.each do |provider_name|
       Carto::ConnectorProvider.find_by_name(provider_name).destroy
     end
   end

--- a/services/importer/spec/unit/connector_spec.rb
+++ b/services/importer/spec/unit/connector_spec.rb
@@ -111,7 +111,7 @@ describe Carto::Connector do
   it "Should list providers available for a user with default configuration" do
     default_config = { 'mysql' => { 'enabled' => true }, 'postgres' => { 'enabled' => false } }
     Cartodb.with_config connectors: default_config do
-      Carto::Connector.providers(@user).should eq(
+      Carto::Connector.providers(user: @user).should eq(
         "postgres"  => { name: "PostgreSQL", enabled: false, description: nil },
         "mysql"     => { name: "MySQL",      enabled: true,  description: nil },
         "sqlserver" => { name: "Microsoft SQL Server", enabled: false, description: nil },
@@ -129,7 +129,7 @@ describe Carto::Connector do
       enabled: true
     )
     Cartodb.with_config connectors: default_config do
-      Carto::Connector.providers(@user).should eq(
+      Carto::Connector.providers(user: @user).should eq(
         "postgres"  => { name: "PostgreSQL", enabled: true, description: nil },
         "mysql"     => { name: "MySQL",      enabled: true,  description: nil },
         "sqlserver" => { name: "Microsoft SQL Server", enabled: false, description: nil },


### PR DESCRIPTION
Fix a couple of issues with the rake tasks for connectors:

* bug with organizations task, not being recognized
* failure to create provider records for non public providers (that we need also to configure for internal use)