### PR TITLE
Wrap table creation in AR transaction (db locking issues)

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -85,7 +85,9 @@ class Table
   end
 
   def save
-    @user_table.save
+    ActiveRecord::Base.transaction do
+      @user_table.save
+    end
     self
   end
 


### PR DESCRIPTION
This fixes the locking issue we detected when running DB migrations. Might not solve everything (it probably won't), but it helps with the case where the importer is registering a table.

To be honest, I'm not sure this is a great idea, but seems to work fine in all my testing.

RFC @CartoDB/backend @luisbosque
