### PR TITLE
Fix reversed ramps

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
@@ -88,7 +88,7 @@ module.exports = CoreView.extend({
         isSelected = ramp.join().toLowerCase() === range.join().toLowerCase();
 
         if (!isSelected) {
-          isSelected = ramp.reverse().join().toLowerCase() === range.join().toLowerCase();
+          isSelected = _.clone(ramp).reverse().join().toLowerCase() === range.join().toLowerCase();
           isInverted = isSelected;
         }
       }

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.spec.js
@@ -40,13 +40,20 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
       expect(this.view.collection.at(2).get('val').join(',').toLowerCase()).toBe('#f6d2a9,#f5b78e,#f19c7c,#ea8171,#dd686c,#ca5268,#b13f64');
       this.view.$('.js-listItem:eq(2) .js-listItemLink').click();
       this.view.$('.js-listItem:eq(2) .js-invert').click();
+
+      var firstRamp = _.toArray(rampList)[1];
       var selectedRamp = _.toArray(rampList)[2];
+      var thirdRamp = _.toArray(rampList)[3];
+
       var ramp = selectedRamp[7];
       var tags = selectedRamp.tags;
+
       expect(tags).toContain('quantitative');
       expect(this.model.get('range').join(',').toLowerCase()).toBe('#b13f64,#ca5268,#dd686c,#ea8171,#f19c7c,#f5b78e,#f6d2a9');
       expect(this.view.collection.at(2).get('val').join(',').toLowerCase()).toBe('#b13f64,#ca5268,#dd686c,#ea8171,#f19c7c,#f5b78e,#f6d2a9');
+      expect(this.view.$('.js-listItem:eq(1)').data('val')).toContain(firstRamp[7].join(','));
       expect(this.view.$('.js-listItem:eq(2)').data('val')).toContain(ramp.reverse().join(','));
+      expect(this.view.$('.js-listItem:eq(3)').data('val')).toContain(thirdRamp[7].join(','));
       expect(this.view.$('.js-listItem.is-selected').length).toBe(1);
       expect(this.view.$('.js-listItem.is-inverted').length).toBe(1);
     });


### PR DESCRIPTION
This PR fixes an issue where ramps got reversed every time the fill component was open. The reason: I forgot that `.reverse()` overwrites the object is applied to :( 

Closes #10007 

CR: @xavijam 