### PR TITLE
Use correct layout for embed_map for orgs

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -324,7 +324,7 @@ class Admin::VisualizationsController < Admin::AdminController
     @protected_map_tokens = current_user.get_auth_tokens
 
     respond_to do |format|
-      format.html { render 'embed_map' }
+      format.html { render 'embed_map', layout: 'application_public_visualization_layout' }
     end
   end
 


### PR DESCRIPTION
This fixes an error in development that for some reason doesn't happen in production.

STR:
 1. Create a map with editor
 2. Open the embed
 3. It shows the dashboard header but no embed (and this incorrect version is cached)

Alternatively:
 1. Reset the embed cached (e.g: change privacy)
 2. Open the embed in private browsing mode
 3. The embed loads (and cached the correct version)

cc @donflopez @javisantana 