### PR TITLE
9981 builder redirections

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -82,7 +82,7 @@ class Admin::VisualizationsController < Admin::AdminController
     elsif !@visualization.has_write_permission?(current_user)
       return redirect_to CartoDB.url(self, 'public_visualizations_public_map',
                                      id: request.params[:id], redirected: true)
-    elsif current_user.force_builder?
+    elsif current_user.force_builder? && !@visualization.open_in_editor?
       return redirect_to CartoDB.url(self, 'builder_visualization', id: request.params[:id])
     end
 

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -39,8 +39,7 @@ class Admin::VisualizationsController < Admin::AdminController
   before_filter :redirect_to_builder_embed_if_v3, only: [:embed_map, :show_organization_public_map,
                                                          :show_organization_embed_map, :show_protected_public_map,
                                                          :show_protected_embed_map,
-                                                         :public_map, :show_protected_public_map
-                                                        ]
+                                                         :public_map, :show_protected_public_map]
 
   after_filter :update_user_last_activity, only: [:index, :show]
   after_filter :track_dashboard_visit, only: :index

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -36,6 +36,9 @@ class Admin::VisualizationsController < Admin::AdminController
                                                          :show_protected_public_map, :show_protected_embed_map]
 
   before_filter :resolve_visualization_and_table_if_not_cached, only: [:embed_map]
+  before_filter :redirect_to_builder_embed_if_v3, only: [:embed_map, :show_organization_public_map,
+                                                         :show_organization_embed_map, :show_protected_public_map,
+                                                         :show_protected_embed_map]
 
   after_filter :update_user_last_activity, only: [:index, :show]
   after_filter :track_dashboard_visit, only: :index
@@ -692,5 +695,13 @@ class Admin::VisualizationsController < Admin::AdminController
     Carto::Tracking::Events::VisitedPrivatePage.new(current_user_id,
                                                     user_id: current_user_id,
                                                     page: 'dashboard').report
+  end
+
+  def redirect_to_builder_embed_if_v3
+    # @visualization is not loaded if the embed is cached
+    # Changing version invalidates the embed cache
+    if @visualization && @visualization.version == 3
+      redirect_to CartoDB.url(self, 'builder_visualization_public_embed', visualization_id: @visualization.id)
+    end
   end
 end

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -38,7 +38,9 @@ class Admin::VisualizationsController < Admin::AdminController
   before_filter :resolve_visualization_and_table_if_not_cached, only: [:embed_map]
   before_filter :redirect_to_builder_embed_if_v3, only: [:embed_map, :show_organization_public_map,
                                                          :show_organization_embed_map, :show_protected_public_map,
-                                                         :show_protected_embed_map]
+                                                         :show_protected_embed_map,
+                                                         :public_map, :show_protected_public_map
+                                                        ]
 
   after_filter :update_user_last_activity, only: [:index, :show]
   after_filter :track_dashboard_visit, only: :index

--- a/app/controllers/carto/admin/visualization_public_map_adapter.rb
+++ b/app/controllers/carto/admin/visualization_public_map_adapter.rb
@@ -20,7 +20,8 @@ module Carto
         :password_protected?, :varnish_key, :related_tables, :password_valid?, :get_auth_tokens, :table, :name,
         :overlays, :created_at, :updated_at, :description, :mapviews, :geometry_types, :privacy, :tags,
         :surrogate_key, :has_password?, :total_mapviews, :is_viewable_by_user?, :is_accesible_by_user?,
-        :can_be_cached?, :is_privacy_private?, :source, :kind_raster?, :has_read_permission?, :has_write_permission?
+        :can_be_cached?, :is_privacy_private?, :source, :kind_raster?, :has_read_permission?, :has_write_permission?,
+        :open_in_editor?
       ] => :visualization
 
       attr_reader :visualization

--- a/app/controllers/carto/admin/visualization_public_map_adapter.rb
+++ b/app/controllers/carto/admin/visualization_public_map_adapter.rb
@@ -21,7 +21,7 @@ module Carto
         :overlays, :created_at, :updated_at, :description, :mapviews, :geometry_types, :privacy, :tags,
         :surrogate_key, :has_password?, :total_mapviews, :is_viewable_by_user?, :is_accesible_by_user?,
         :can_be_cached?, :is_privacy_private?, :source, :kind_raster?, :has_read_permission?, :has_write_permission?,
-        :open_in_editor?
+        :open_in_editor?, :version
       ] => :visualization
 
       attr_reader :visualization

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -67,7 +67,7 @@ module Carto
         end
 
         def redirect_to_old_embed_if_v2
-          if @visualization.version == 2
+          if @visualization.version != 3
             redirect_to CartoDB.url(self, 'public_visualizations_embed_map', id: @visualization.id)
           end
         end

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -8,7 +8,8 @@ module Carto
 
         ssl_required :show, :show_protected
 
-        before_filter :load_visualization, only: [:show, :show_protected]
+        before_filter :load_visualization,
+                      :redirect_to_old_embed_if_v2, only: [:show, :show_protected]
         before_filter :load_vizjson,
                       :load_state, only: [:show, :show_protected]
         before_filter :ensure_viewable, only: [:show]
@@ -63,6 +64,12 @@ module Carto
 
         def visualization_for_presentation
           @visualization_for_presentation ||= @visualization.for_presentation
+        end
+
+        def redirect_to_old_embed_if_v2
+          if @visualization.version == 2
+            redirect_to CartoDB.url(self, 'public_visualizations_embed_map', id: @visualization.id)
+          end
         end
       end
     end

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -12,8 +12,8 @@ module Carto
 
       ssl_required :show
 
-      before_filter :redirect_to_editor_if_forced,
-                    :load_derived_visualization,
+      before_filter :load_derived_visualization,
+                    :redirect_to_editor_if_forced,
                     :auto_migrate_visualization_if_possible, only: :show
       before_filter :authors_only
       before_filter :editable_visualizations_only, only: :show
@@ -50,7 +50,9 @@ module Carto
       end
 
       def redirect_to_editor_if_forced
-        redirect_to CartoDB.url(self, 'public_visualizations_show_map', id: params[:id]) if current_user.force_editor?
+        if current_user.force_editor? || @visualization.uses_vizjson2?
+          redirect_to CartoDB.url(self, 'public_visualizations_show_map', id: params[:id])
+        end
       end
 
       def load_derived_visualization

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -13,7 +13,8 @@ module Carto
       ssl_required :show
 
       before_filter :redirect_to_editor_if_forced,
-                    :load_derived_visualization, only: :show
+                    :load_derived_visualization,
+                    :auto_migrate_visualization_if_possible, only: :show
       before_filter :authors_only
       before_filter :editable_visualizations_only, only: :show
 
@@ -83,6 +84,13 @@ module Carto
         Carto::Tracking::Events::VisitedPrivatePage.new(current_viewer_id,
                                                         user_id: current_viewer_id,
                                                         page: 'builder').report
+      end
+
+      def auto_migrate_visualization_if_possible
+        if @visualization.can_be_automatically_migrated?
+          @visualization.version = 3
+          @visualization.save
+        end
       end
     end
   end

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -50,7 +50,7 @@ module Carto
       end
 
       def redirect_to_editor_if_forced
-        if current_user.force_editor? || @visualization.uses_vizjson2?
+        if current_user.force_editor? || @visualization.open_in_editor?
           redirect_to CartoDB.url(self, 'public_visualizations_show_map', id: params[:id])
         end
       end

--- a/app/models/carto/overlay.rb
+++ b/app/models/carto/overlay.rb
@@ -23,6 +23,9 @@ module Carto
       'header', 'search', 'layer_selector', 'share', 'zoom', 'logo', 'loader', 'fullscreen'
     ].freeze
 
+    BUILDER_COMPATIBLE_TYPES = ['search', 'layer_selector', 'share', 'fullscreen', 'loader', 'logo', 'zoom'].freeze
+    scope :builder_incompatible, where('type NOT IN (?)', BUILDER_COMPATIBLE_TYPES)
+
     def hide
       options['display'] = false
       self

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -449,6 +449,10 @@ class Carto::Visualization < ActiveRecord::Base
     $tables_metadata.SISMEMBER(V2_VISUALIZATIONS_REDIS_KEY, id) > 0
   end
 
+  def can_be_automatically_migrated?
+    overlays.builder_incompatible.none?
+  end
+
   private
 
   def build_state

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -449,6 +449,10 @@ class Carto::Visualization < ActiveRecord::Base
     $tables_metadata.SISMEMBER(V2_VISUALIZATIONS_REDIS_KEY, id) > 0
   end
 
+  def open_in_editor?
+    version < 3 && uses_vizjson2?
+  end
+
   def can_be_automatically_migrated?
     overlays.builder_incompatible.none?
   end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -450,7 +450,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def open_in_editor?
-    version < 3 && uses_vizjson2?
+    version != 3 && uses_vizjson2?
   end
 
   def can_be_automatically_migrated?

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -364,6 +364,11 @@ module CartoDB
         super(tags)
       end
 
+      def version=(version)
+        self.dirty = true
+        super(version)
+      end
+
       def public?
         privacy == PRIVACY_PUBLIC
       end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -736,9 +736,9 @@ describe Table do
 
     id = table.table_visualization.id
     CartoDB::Varnish.any_instance.expects(:purge)
-                                 .times(4)
-                                 .with(".*#{id}:vizjson")
-                                 .returns(true)
+                    .at_least_once
+                    .with(".*#{id}:vizjson")
+                    .returns(true)
 
     CartoDB::TablePrivacyManager.any_instance.expects(:update_cdb_tablemetadata)
     table.privacy = UserTable::PRIVACY_PUBLIC
@@ -2298,7 +2298,7 @@ describe Table do
       CartoDB::Visualization::Member.stubs(:new).with(has_entry(id: derived.id)).returns(derived)
       CartoDB::Visualization::Member.stubs(:new).with(has_entry(type: 'table')).returns(table.table_visualization)
 
-      derived.expects(:invalidate_cache).once
+      derived.expects(:invalidate_cache).at_least_once
 
       table.privacy = UserTable::PRIVACY_PUBLIC
       table.save

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -736,7 +736,7 @@ describe Table do
 
     id = table.table_visualization.id
     CartoDB::Varnish.any_instance.expects(:purge)
-                    .at_least_once
+                    .times(6)
                     .with(".*#{id}:vizjson")
                     .returns(true)
 

--- a/spec/requests/admin/visualizations_spec.rb
+++ b/spec/requests/admin/visualizations_spec.rb
@@ -168,7 +168,7 @@ describe Admin::VisualizationsController do
           Carto::Visualization::any_instance.stubs(:uses_vizjson2?).returns(true)
 
           login_as(@user, scope: @user.username)
-          get "/viz/#{@id}", {}, @headers
+          get public_visualizations_show_path(id: @id), {}, @headers
           last_response.status.should eq 200
         end
 
@@ -181,14 +181,14 @@ describe Admin::VisualizationsController do
           visualization.store
 
           login_as(@user, scope: @user.username)
-          get "/viz/#{@id}/embed_map", {}, @headers
+          get public_visualizations_embed_map_path(id: @id), {}, @headers
           last_response.status.should eq 200
 
           visualization.version = 3
           visualization.store
 
           login_as(@user, scope: @user.username)
-          get "/viz/#{@id}/embed_map", {}, @headers
+          get public_visualizations_embed_map_path(id: @id), {}, @headers
           last_response.status.should eq 302
         end
       end

--- a/spec/requests/admin/visualizations_spec.rb
+++ b/spec/requests/admin/visualizations_spec.rb
@@ -161,6 +161,16 @@ describe Admin::VisualizationsController do
           get "/viz/#{@id}", {}, @headers
           last_response.status.should eq 200
         end
+
+        it 'never for vizjson2 visualizations' do
+          @user.stubs(:builder_enabled).returns(true)
+          @user.stubs(:builder_enabled?).returns(true)
+          Carto::Visualization::any_instance.stubs(:uses_vizjson2?).returns(true)
+
+          login_as(@user, scope: @user.username)
+          get "/viz/#{@id}", {}, @headers
+          last_response.status.should eq 200
+        end
       end
     end
   end # GET /viz/:id

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -29,6 +29,14 @@ describe Carto::Builder::Public::EmbedsController do
       response.body.include?(@visualization.name).should be true
     end
 
+    it 'redirects to builder for v2 visualizations' do
+      @visualization.version = 2
+      @visualization.save
+      get builder_visualization_public_embed_url(visualization_id: @visualization.id)
+
+      response.status.should == 302
+    end
+
     it 'defaults to generate vizjson with vector=false' do
       get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -7,7 +7,7 @@ describe Carto::Builder::Public::EmbedsController do
   before(:all) do
     @user = FactoryGirl.create(:valid_user)
     @map = FactoryGirl.create(:map, user_id: @user.id)
-    @visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: @map.id)
+    @visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: @map.id, version: 3)
   end
 
   before(:each) do
@@ -30,8 +30,7 @@ describe Carto::Builder::Public::EmbedsController do
     end
 
     it 'redirects to builder for v2 visualizations' do
-      @visualization.version = 2
-      @visualization.save
+      Carto::Visualization.any_instance.stubs(:version).returns(2)
       get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 
       response.status.should == 302
@@ -117,7 +116,7 @@ describe Carto::Builder::Public::EmbedsController do
 
       before(:each) do
         @org_map = FactoryGirl.create(:map, user_id: @org_user_owner.id)
-        @org_visualization = FactoryGirl.create(:carto_visualization, user: @carto_org_user_owner, map_id: @org_map.id)
+        @org_visualization = FactoryGirl.create(:carto_visualization, user: @carto_org_user_owner, map_id: @org_map.id, version: 3)
         @org_visualization.privacy = Carto::Visualization::PRIVACY_PRIVATE
         @org_visualization.save
 


### PR DESCRIPTION
 - Embed redirections (based on visualization version flag)
 - Auto migration (version update) for safe visualizations
 - Open vizjson2 visualizations in editor

Closes #9981 