### PR TITLE
popups: fix infowindows tabs issues

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
@@ -165,6 +165,7 @@ module.exports = Backbone.Model.extend({
 
   getTemplate: function () {
     var template_name = this.get('template_name');
+
     if (template_name !== '') {
       return this.TEMPLATES['custom_' + template_name];
     } else {
@@ -173,7 +174,7 @@ module.exports = Backbone.Model.extend({
   },
 
   hasTemplate: function () {
-    return this.get('template_name') && this.TEMPLATES[this.get('template_name')];
+    return !!this.get('template_name') && this.TEMPLATES[this.get('template_name')];
   },
 
   isCustomTemplate: function () {

--- a/lib/assets/javascripts/cartodb3/data/infowindow-hover-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-hover-model.js
@@ -18,7 +18,7 @@ module.exports = InfowindowDefinitionModel.extend({
   },
 
   setDefault: function () {
-    this.set({template_name: this.defaults.template_name});
+    this.setTemplate(this.defaults.template_name);
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-view.js
@@ -56,7 +56,7 @@ module.exports = CoreView.extend({
     // in case none template is applied
     this._editorModel.set({
       edition: this.model.isCustomTemplate(),
-      disabled: !this.model.hasTemplate()
+      disabled: !this.model.hasTemplate() && !this.model.isCustomTemplate()
     });
   },
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindows-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindows-view.js
@@ -81,6 +81,21 @@ module.exports = CoreView.extend({
   _initViews: function () {
     var self = this;
 
+    var clickTemplate = _t('editor.layers.infowindow.style.none');
+    var hoverTemplate = _t('editor.layers.tooltip.style.none');
+
+    if (this._layerInfowindowModel.isCustomTemplate()) {
+      clickTemplate = _t('editor.layers.infowindow.style.custom');
+    } else if (this._layerInfowindowModel.hasTemplate()) {
+      clickTemplate = _t('editor.layers.infowindow.style.' + this._layerInfowindowModel.get('template_name'));
+    }
+
+    if (this._layerTooltipModel.isCustomTemplate()) {
+      hoverTemplate = _t('editor.layers.tooltip.style.custom');
+    } else if (this._layerTooltipModel.hasTemplate()) {
+      hoverTemplate = _t('editor.layers.tooltip.style.' + this._layerTooltipModel.get('template_name'));
+    }
+
     var tabPaneTabs = [{
       name: 'click',
       label: _t('editor.layers.infowindow-menu-tab-pane-labels.click'),
@@ -94,7 +109,7 @@ module.exports = CoreView.extend({
           layerDefinitionModel: self._layerDefinitionModel
         });
       },
-      selectedChild: this._layerInfowindowModel.hasTemplate() ? _t('editor.layers.infowindow.style.' + this._layerInfowindowModel.get('template_name')) : _t('editor.layers.infowindow.style.none')
+      selectedChild: clickTemplate
     }, {
       name: 'hover',
       label: _t('editor.layers.infowindow-menu-tab-pane-labels.hover'),
@@ -108,7 +123,7 @@ module.exports = CoreView.extend({
           layerDefinitionModel: self._layerDefinitionModel
         });
       },
-      selectedChild: this._layerTooltipModel.hasTemplate() ? _t('editor.layers.tooltip.style.' + this._layerTooltipModel.get('template_name')) : _t('editor.layers.tooltip.style.none')
+      selectedChild: hoverTemplate
     }];
 
     var tabPaneOptions = {
@@ -141,21 +156,25 @@ module.exports = CoreView.extend({
     switch (this._layerTabPaneView.getSelectedTabPaneName()) {
       case 'click':
         selectedChild = this._layerInfowindowModel.get('template_name');
+        selectedChildTxt = _t('editor.layers.infowindow.style.none');
 
-        if (this._layerInfowindowModel.hasTemplate()) {
+        if (this._layerInfowindowModel.isCustomTemplate()) {
+          selectedChildTxt = _t('editor.layers.infowindow.style.custom');
+        } else if (this._layerInfowindowModel.hasTemplate()) {
           selectedChildTxt = _t('editor.layers.infowindow.style.' + selectedChild);
-        } else {
-          selectedChildTxt = this._layerInfowindowModel.isCustomTemplate() ? _t('editor.layers.infowindow.style.custom') : _t('editor.layers.infowindow.style.none');
         }
+
         break;
       case 'hover':
         selectedChild = this._layerTooltipModel.get('template_name');
+        selectedChildTxt = _t('editor.layers.tooltip.style.none');
 
-        if (this._layerTooltipModel.hasTemplate()) {
+        if (this._layerTooltipModel.isCustomTemplate()) {
+          selectedChildTxt = _t('editor.layers.tooltip.style.custom');
+        } else if (this._layerTooltipModel.hasTemplate()) {
           selectedChildTxt = _t('editor.layers.tooltip.style.' + selectedChild);
-        } else {
-          selectedChildTxt = this._layerTooltipModel.isCustomTemplate() ? _t('editor.layers.tooltip.style.custom') : _t('editor.layers.tooltip.style.none');
         }
+
         break;
     }
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindows-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/infowindows-view.js
@@ -29,7 +29,6 @@ module.exports = CoreView.extend({
   },
 
   render: function () {
-    this._unbindEvents();
     this.clearSubViews();
     this.$el.empty();
 
@@ -183,23 +182,11 @@ module.exports = CoreView.extend({
     this._layerTabPaneView.$('.js-list .Carousel-item.js-' + selectedChild).addClass('is-selected');
   },
 
-  _unbindEvents: function () {
-    if (this._layerTabPaneView && this._layerTabPaneView.collection) {
-      this._layerTabPaneView.collection.off('change:selected', this._quitEditing, this);
-    }
-  },
-
   _bindEvents: function () {
-    this._layerTabPaneView.collection.on('change:selected', this._quitEditing, this);
-    this.add_related_model(this._layerTabPaneView.collection);
     this._layerInfowindowModel.on('change:template', this._onChangeTemplate, this);
     this.add_related_model(this._layerInfowindowModel);
     this._layerTooltipModel.on('change:template', this._onChangeTemplate, this);
     this.add_related_model(this._layerTooltipModel);
-  },
-
-  _quitEditing: function () {
-    this._editorModel.set({edition: false});
   },
 
   _onChangeTemplate: function () {

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/infowindows-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/infowindows-view.spec.js
@@ -7,11 +7,23 @@ var TooltipView = require('../../../../../../javascripts/cartodb3/editor/layers/
 var InfowindowDefinitionModel = require('../../../../../../javascripts/cartodb3/data/infowindow-definition-model');
 var _ = require('underscore');
 var EditorModel = require('../../../../../../javascripts/cartodb3/data/editor-model');
+var UserActions = require('../../../../../../javascripts/cartodb3/data/user-actions');
+var AnalysisDefinitionNodesCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
+var AnalysisDefinitionsCollection = require('../../../../../../javascripts/cartodb3/data/analysis-definitions-collection');
 
 describe('editor/layers/layer-content-view/infowindows-view', function () {
   beforeEach(function () {
     this.configModel = new ConfigModel({
       base_url: '/u/pepe'
+    });
+
+    this.analysisDefinitionNodesCollection = new AnalysisDefinitionNodesCollection(null, {
+      configModel: this.configModel
+    });
+    this.analysisDefinitionsCollection = new AnalysisDefinitionsCollection(null, {
+      configModel: this.configModel,
+      vizId: 'viz-123',
+      analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection
     });
 
     this.querySchemaModel = new QuerySchemaModel({
@@ -42,8 +54,14 @@ describe('editor/layers/layer-content-view/infowindows-view', function () {
           cartocss: 'asd',
           source: 'a0'
         },
-        infowindow: {},
-        tooltip: {}
+        infowindow: {
+          template_name: '',
+          template: ''
+        },
+        tooltip: {
+          template_name: '',
+          template: ''
+        }
       }, {
         parse: true,
         configModel: this.configModel
@@ -53,7 +71,13 @@ describe('editor/layers/layer-content-view/infowindows-view', function () {
       this.view = new InfowindowsView({
         configModel: this.configModel,
         editorModel: new EditorModel(),
-        userActions: {},
+        userActions: new UserActions({
+          userModel: {},
+          analysisDefinitionsCollection: this.analysisDefinitionsCollection,
+          analysisDefinitionNodesCollection: this.analysisDefinitionNodesCollection,
+          layerDefinitionsCollection: {},
+          widgetDefinitionsCollection: {}
+        }),
         layerDefinitionModel: this.layerDefinitionModel,
         querySchemaModel: this.querySchemaModel
       });
@@ -71,18 +95,25 @@ describe('editor/layers/layer-content-view/infowindows-view', function () {
       expect(this.view.$('.CDB-NavSubmenu-item:eq(1) .CDB-NavSubmenu-status').text()).toContain('editor.layers.tooltip.style.none');
     });
 
-    // it('should change tab if infowindow (and tooltip) changes', function () {
-    //   expect(this.view.$('.CDB-NavSubmenu-item:eq(0) .CDB-NavSubmenu-status').text()).toBe('editor.layers.infowindow.style.none');
-    //   expect(this.view.$('.CDB-NavSubmenu-item:eq(1) .CDB-NavSubmenu-status').text()).toBe('editor.layers.tooltip.style.none');
-    //   this.view._layerInfowindowModel.set('template_name', 'infowindow_dark');
-    //   expect(this.view.$('.CDB-NavSubmenu-item:eq(0) .CDB-NavSubmenu-status').text()).toBe('editor.layers.infowindow.style.infowindow_dark');
-    //   expect(this.view.$('.CDB-NavSubmenu-item:eq(1) .CDB-NavSubmenu-status').text()).toBe('editor.layers.tooltip.style.none');
-    //   // change tab and change template_name, '.js-menu .CDB-NavSubmenu-item.is-selected .js-NavSubmenu-status' is needed
-    //   this.view._layerTabPaneView.collection.at(1).set('selected', true);
-    //   this.view._layerTooltipModel.set('template_name', 'tooltip_dark');
-    //   expect(this.view.$('.CDB-NavSubmenu-item:eq(0) .CDB-NavSubmenu-status').text()).toBe('editor.layers.infowindow.style.infowindow_dark');
-    //   expect(this.view.$('.CDB-NavSubmenu-item:eq(1) .CDB-NavSubmenu-status').text()).toBe('editor.layers.tooltip.style.tooltip_dark');
-    // });
+    it('should change tab if infowindow (and tooltip) changes', function () {
+      expect(this.view.$('.CDB-NavSubmenu-item:eq(0) .CDB-NavSubmenu-status').text()).toBe('editor.layers.infowindow.style.none');
+      expect(this.view.$('.CDB-NavSubmenu-item:eq(1) .CDB-NavSubmenu-status').text()).toBe('editor.layers.tooltip.style.none');
+      this.view._layerInfowindowModel.set('template_name', 'infowindow_dark');
+
+      this.view.render();
+
+      expect(this.view.$('.CDB-NavSubmenu-item:eq(0) .CDB-NavSubmenu-status').text()).toBe('editor.layers.infowindow.style.infowindow_dark');
+      expect(this.view.$('.CDB-NavSubmenu-item:eq(1) .CDB-NavSubmenu-status').text()).toBe('editor.layers.tooltip.style.none');
+
+      // change tab and change template_name, '.js-menu .CDB-NavSubmenu-item.is-selected .js-NavSubmenu-status' is needed
+      this.view._layerTabPaneView.collection.at(1).set('selected', true);
+      this.view._layerTooltipModel.set('template_name', 'tooltip_dark');
+
+      this.view.render();
+
+      expect(this.view.$('.CDB-NavSubmenu-item:eq(0) .CDB-NavSubmenu-status').text()).toBe('editor.layers.infowindow.style.infowindow_dark');
+      expect(this.view.$('.CDB-NavSubmenu-item:eq(1) .CDB-NavSubmenu-status').text()).toBe('editor.layers.tooltip.style.tooltip_dark');
+    });
 
     describe('infowindows tabs', function () {
       var model;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.3.11",
+  "version": "4.3.12",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
close https://github.com/CartoDB/cartodb/issues/9993

several popups fixes:

- fix tabs titles and details when loading popups panel, as well as changing between click/hover
- revert quitediting when changing tab (further explanation in the comments)
- hover: set default none template when removing custom template: working in click but for some reason didn't make the change for hover

CR @nobuti 