### PR TITLE
9482 private datasets warning

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -201,6 +201,7 @@ class Admin::VisualizationsController < Admin::AdminController
   end
 
   def public_map
+
     if current_user.nil? && !request.params[:redirected].present?
       redirect_url = get_corrected_url_if_proceeds(for_table=false)
       unless redirect_url.nil?
@@ -273,7 +274,10 @@ class Admin::VisualizationsController < Admin::AdminController
 
     @public_tables_count    = @visualization.user.public_table_count
     @nonpublic_tables_count = @related_tables.select{|t| !t.public? }.count
-
+    @private_datasets = @nonpublic_tables_count > 0
+    @owning_private_datasets = @related_tables.select {
+      |table| !current_user.nil? && table.user_id == current_user.id 
+    }.count > 0
     @is_liked    = is_liked(@visualization)
     @likes_count = @visualization.likes.count
 

--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -77,7 +77,9 @@
                   </li>
 
                   <li class="Navmenu-subItem">
-                    <a href="#" class="Navmenu-link js-Navmenu-link--download-map">
+                    <a href="#" class="Navmenu-link js-Navmenu-link--download-map"
+                      data-private-datasets="<%= @private_datasets %>" 
+                      data-owning-private-datasets="<%= @owning_private_datasets %>">
                       <i class="CDB-IconFont CDB-IconFont-downloadCircle Navmenu-icon"></i>
                     </a>
                   </li>

--- a/lib/assets/javascripts/cartodb/common/dialogs/export_map/export_map_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/export_map/export_map_view.js
@@ -42,7 +42,10 @@ module.exports = BaseDialog.extend({
         quote: randomQuote()
       });
     } else {
-      return cdb.templates.getTemplate('common/dialogs/export_map/templates/confirm');
+      return cdb.templates.getTemplate('common/dialogs/export_map/templates/confirm')({
+        privateDatasets: this.model.get('private_datasets'),
+        owningPrivateDatasets: this.model.get('owning_private_datasets')
+      });
     }
   },
 

--- a/lib/assets/javascripts/cartodb/common/dialogs/export_map/templates/confirm.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/export_map/templates/confirm.jst.ejs
@@ -1,9 +1,35 @@
 <div class="Dialog-header u-inner">
-  <div class="Dialog-headerIcon Dialog-headerIcon--neutral">
+  <div class="Dialog-headerIcon 
+    <% if (privateDatasets) { %>
+      Dialog-headerIcon--alert
+    <% } else { %>
+      Dialog-headerIcon--neutral
+    <% } %>  
+    ">
     <i class="CDB-IconFont CDB-IconFont-map"></i>
   </div>
-  <p class="CDB-Text CDB-Size-large u-mainTextColor u-secondaryTextColor u-bSpace--m">Export map</p>
-  <p class="CDB-Text CDB-Size-medium u-altTextColor">This map, and the connected data, will be exported as a .carto file</p>
+  <p class="CDB-Text CDB-Size-large u-mainTextColor 
+    <% if (privateDatasets) { %>
+      u-alertTextColor 
+    <% } else { %>
+      u-secondaryTextColor  
+    <% } %>
+    u-bSpace--m">
+    <% if (!privateDatasets) { %>
+    Export map
+    <% } else { %>
+    You're about to export a map with Private Datasets
+    <% } %>
+  </p>
+  <p class="CDB-Text CDB-Size-medium u-altTextColor">
+    <% if (!privateDatasets) { %>
+    This map, and the connected data, will be exported as a .carto file.
+    <% } else if (owningPrivateDatasets) { %>
+    Private Dataset will be exported. Be careful when sharing it, your whole data is there.
+    <% } else { %>
+    This map contents one or more Private Dataset. Only public datasets will be exported.
+    <% } %>
+  </p>
 </div>
 
 <div class="Dialog-footer Dialog-footer--simple u-inner">

--- a/lib/assets/javascripts/cartodb/models/export_map_model.js
+++ b/lib/assets/javascripts/cartodb/models/export_map_model.js
@@ -64,5 +64,7 @@ cdb.admin.ExportMapModel = cdb.core.Model.extend({
     if (!attrs.visualization_id) throw new Error('\'visualization_id\' is required');
 
     this.visualization_id = attrs.visualization_id;
+    this.private_datasets = attrs.private_datasets || false;
+    this.owning_private_datasets = attrs.owning_private_datasets || false;
   }
 });

--- a/lib/assets/javascripts/cartodb/public_map/public_map_window.js
+++ b/lib/assets/javascripts/cartodb/public_map/public_map_window.js
@@ -15,10 +15,17 @@ module.exports = cdb.core.View.extend({
   },
 
   _exportMap: function (e) {
+    var privateDatasets = (e.currentTarget.dataset.privateDatasets || 'false') === 'true';
+    var owningPrivateDatasets = (e.currentTarget.dataset.owningPrivateDatasets || 'false') === 'true';
+
     e.preventDefault();
 
     var view = new ExportMapView({
-      model: new cdb.admin.ExportMapModel({ 'visualization_id': vis_id }),
+      model: new cdb.admin.ExportMapModel({
+        'visualization_id': vis_id,
+        'private_datasets': privateDatasets,
+        'owning_private_datasets': owningPrivateDatasets
+      }),
       clean_on_hide: true,
       enter_to_confirm: true
     });

--- a/lib/assets/javascripts/cartodb3/editor/components/modals/export-map/export-map-confirmation.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/components/modals/export-map/export-map-confirmation.tpl
@@ -2,16 +2,34 @@
   <div class="Modal-inner Modal-inner--grid u-flex u-justifyCenter">
     <div class="Modal-icon">
       <svg width="24px" height="24px" viewbox="459 348 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-        <g id="Export-dataset" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(459.000000, 348.000000)">
-          <path d="M1,1 L11,1 L11,5.5 C11,5.776 11.224,6 11.5,6 L16,6 L16,9.5 L17,9.5 L17,5.502 C17,5.502 17,5.502 17,5.501 C17,5.5 17,5.501 17,5.5 C17,5.447 16.985,5.398 16.97,5.35 C16.966,5.337 16.967,5.323 16.962,5.311 C16.936,5.247 16.896,5.19 16.847,5.142 L11.854,0.147 C11.808,0.101 11.753,0.064 11.692,0.039 C11.632,0.014 11.567,0 11.5,0 L0.5,0 C0.224,0 0,0.224 0,0.5 L0,21.5 C0,21.776 0.224,22 0.5,22 L10.5,22 L10.5,21 L1,21 L1,1 L1,1 Z M12,1.708 L15.291,5 L12,5 L12,1.708 L12,1.708 Z" id="Shape" fill="#2E3C43"/>
-          <path d="M17.5,11 C13.916,11 11,13.916 11,17.5 C11,21.084 13.916,24 17.5,24 C21.084,24 24,21.084 24,17.5 C24,13.916 21.084,11 17.5,11 L17.5,11 Z M17.5,23 C14.467,23 12,20.533 12,17.5 C12,14.467 14.467,12 17.5,12 C20.533,12 23,14.467 23,17.5 C23,20.533 20.533,23 17.5,23 L17.5,23 Z" id="Shape" fill="#2E3C43"/>
-          <path d="M17.858,14.425 C17.767,14.331 17.641,14.272 17.5,14.272 C17.359,14.272 17.232,14.331 17.142,14.425 L14.965,16.602 C14.77,16.797 14.77,17.114 14.965,17.309 C15.16,17.504 15.477,17.504 15.672,17.309 L17,15.981 L17,20.226 C17,20.502 17.224,20.726 17.5,20.726 C17.776,20.726 18,20.502 18,20.226 L18,15.981 L19.328,17.309 C19.426,17.407 19.554,17.455 19.682,17.455 C19.81,17.455 19.938,17.406 20.036,17.309 C20.231,17.114 20.231,16.797 20.036,16.602 L17.858,14.425 L17.858,14.425 Z" id="Shape" fill="#2E3C43" transform="translate(17.500500, 17.499000) scale(1, -1) translate(-17.500500, -17.499000) "/>
+        <g id="Export-dataset" stroke="none" stroke-width="1" fill="
+          <% if (privateDatasets) { %>
+          #FFA500
+          <% } else { %>
+          #2E3C43
+          <% } %> 
+          " fill-rule="evenodd" transform="translate(459.000000, 348.000000)">
+          <path d="M1,1 L11,1 L11,5.5 C11,5.776 11.224,6 11.5,6 L16,6 L16,9.5 L17,9.5 L17,5.502 C17,5.502 17,5.502 17,5.501 C17,5.5 17,5.501 17,5.5 C17,5.447 16.985,5.398 16.97,5.35 C16.966,5.337 16.967,5.323 16.962,5.311 C16.936,5.247 16.896,5.19 16.847,5.142 L11.854,0.147 C11.808,0.101 11.753,0.064 11.692,0.039 C11.632,0.014 11.567,0 11.5,0 L0.5,0 C0.224,0 0,0.224 0,0.5 L0,21.5 C0,21.776 0.224,22 0.5,22 L10.5,22 L10.5,21 L1,21 L1,1 L1,1 Z M12,1.708 L15.291,5 L12,5 L12,1.708 L12,1.708 Z" id="Shape"/>
+          <path d="M17.5,11 C13.916,11 11,13.916 11,17.5 C11,21.084 13.916,24 17.5,24 C21.084,24 24,21.084 24,17.5 C24,13.916 21.084,11 17.5,11 L17.5,11 Z M17.5,23 C14.467,23 12,20.533 12,17.5 C12,14.467 14.467,12 17.5,12 C20.533,12 23,14.467 23,17.5 C23,20.533 20.533,23 17.5,23 L17.5,23 Z" id="Shape"/>
+          <path d="M17.858,14.425 C17.767,14.331 17.641,14.272 17.5,14.272 C17.359,14.272 17.232,14.331 17.142,14.425 L14.965,16.602 C14.77,16.797 14.77,17.114 14.965,17.309 C15.16,17.504 15.477,17.504 15.672,17.309 L17,15.981 L17,20.226 C17,20.502 17.224,20.726 17.5,20.726 C17.776,20.726 18,20.502 18,20.226 L18,15.981 L19.328,17.309 C19.426,17.407 19.554,17.455 19.682,17.455 C19.81,17.455 19.938,17.406 20.036,17.309 C20.231,17.114 20.231,16.797 20.036,16.602 L17.858,14.425 L17.858,14.425 Z" id="Shape" transform="translate(17.500500, 17.499000) scale(1, -1) translate(-17.500500, -17.499000) "/>
         </g>
       </svg>
     </div>
     <div>
-      <h2 class=" CDB-Text CDB-Size-huge is-light u-bSpace--m"><%- _t('editor.maps.export.confirmation.title', { name: name }) %></h2>
-      <p class="CDB-Text CDB-Size-medium u-altTextColor"><%- _t('editor.maps.export.confirmation.desc') %></p>
+      <h2 class=" CDB-Text CDB-Size-huge is-light u-bSpace--m 
+        <% if (privateDatasets) { %>
+        Dialog-headerTitle--warning
+        <% } %>
+      ">
+        <% if (privateDatasets) { %>
+        <%- _t('editor.maps.export.confirmation.privateTitle') %>
+        <% } else { %>
+        <%- _t('editor.maps.export.confirmation.title', { name: name }) %>
+        <% } %>
+      </h2>
+      <p class="CDB-Text CDB-Size-medium u-altTextColor">
+        <%- _t(privateDatasets ? 'editor.maps.export.confirmation.privateDesc' : 'editor.maps.export.confirmation.desc') %>
+      </p>
       <ul class="Modal-listActions u-flex u-alignCenter">
         <li class="Modal-listActionsitem">
           <button class="CDB-Button CDB-Button--secondary CDB-Button--big js-cancel">

--- a/lib/assets/javascripts/cartodb3/editor/components/modals/export-map/modal-export-map-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/components/modals/export-map/modal-export-map-view.js
@@ -82,7 +82,8 @@ module.exports = CoreView.extend({
   _renderConfirmationView: function () {
     this.$el.html(
       templateExportMapConfirmation({
-        name: this._renderOpts.name
+        name: this._renderOpts.name,
+        privateDatasets: this._renderOpts.privateDatasets
       })
     );
   },

--- a/lib/assets/javascripts/cartodb3/editor/editor-header.js
+++ b/lib/assets/javascripts/cartodb3/editor/editor-header.js
@@ -206,6 +206,9 @@ module.exports = CoreView.extend({
   _exportMap: function () {
     var mapName = this._visDefinitionModel.get('name');
     var visID = this._visDefinitionModel.get('id');
+    var privateDatasets = _.any(this._visDefinitionModel.get('related_tables'), function (dataset) {
+      return dataset.privacy === 'PRIVATE';
+    });
 
     var exportMapModel = new ExportMapModel({
       visualization_id: visID
@@ -218,7 +221,8 @@ module.exports = CoreView.extend({
         modalModel: modalModel,
         exportMapModel: exportMapModel,
         renderOpts: {
-          name: mapName
+          name: mapName,
+          privateDatasets: privateDatasets
         }
       });
     });

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1240,7 +1240,9 @@
           "confirm": "Ok, export",
           "cancel": "Cancel",
           "desc": "This map, and the connected data, will be exported as a .carto file",
-          "title": "Export \"%{name}\""
+          "title": "Export \"%{name}\"",
+          "privateDesc": "Private Dataset will be exported. Be careful when sharing it, your whole data is there.",
+          "privateTitle": "You're about to export a map with Private Datasets"
         },
         "download": {
           "confirm": "Download",

--- a/lib/assets/test/spec/cartodb/common/dialogs/export_map/export_map_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/export_map/export_map_view.spec.js
@@ -34,7 +34,7 @@ describe('common/dialogs/export/export_view', function () {
       }),
       clean_on_hide: true,
       enter_to_confirm: true
-    });    
+    });
     view.render();
 
     expect(view.$('.Dialog-headerIcon').hasClass('Dialog-headerIcon--alert')).toBeTruthy();

--- a/lib/assets/test/spec/cartodb/common/dialogs/export_map/export_map_view.spec.js
+++ b/lib/assets/test/spec/cartodb/common/dialogs/export_map/export_map_view.spec.js
@@ -12,10 +12,58 @@ describe('common/dialogs/export/export_view', function () {
     });
   });
 
-  it('should show confirmation', function () {
+  it('should show confirmation for public datasets', function () {
     view.render();
 
     expect(view.$('.js-ok').text()).toContain('Ok, export');
+    expect(view.$('.Dialog-headerIcon').hasClass('Dialog-headerIcon--neutral')).toBeTruthy();
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-large').hasClass('u-secondaryTextColor')).toBeTruthy();
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-large').text())
+      .toContain('Export map');
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-medium').text())
+      .toContain('This map, and the connected data, will be exported as a .carto file.');
+  });
+
+  it('should show private datasets warning while being owners', function () {
+    // Create view with a model with the proper flags
+    view = new ExportMapView({
+      model: new cdb.admin.ExportMapModel({
+        visualization_id: 'abcd-1234',
+        private_datasets: true,
+        owning_private_datasets: true
+      }),
+      clean_on_hide: true,
+      enter_to_confirm: true
+    });    
+    view.render();
+
+    expect(view.$('.Dialog-headerIcon').hasClass('Dialog-headerIcon--alert')).toBeTruthy();
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-large').hasClass('u-alertTextColor')).toBeTruthy();
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-large').text())
+      .toContain("You're about to export a map with Private Datasets");
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-medium').text())
+      .toContain("Private Dataset will be exported. Be careful when sharing it, your whole data is there.");
+  });
+
+  it('should show private datasets warning while not owning any', function () {
+    // Create view with a model with the proper flags
+    view = new ExportMapView({
+      model: new cdb.admin.ExportMapModel({
+        visualization_id: 'abcd-1234',
+        private_datasets: true,
+        owning_private_datasets: false
+      }),
+      clean_on_hide: true,
+      enter_to_confirm: true
+    });    
+    view.render();
+
+    expect(view.$('.Dialog-headerIcon').hasClass('Dialog-headerIcon--alert')).toBeTruthy();
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-large').hasClass('u-alertTextColor')).toBeTruthy();
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-large').text())
+      .toContain("You're about to export a map with Private Datasets");
+    expect(view.$('.Dialog-header > p.CDB-Text.CDB-Size-medium').text())
+      .toContain("This map contents one or more Private Dataset. Only public datasets will be exported.");
   });
 
   it('should show pending state loading window', function () {

--- a/lib/assets/test/spec/cartodb3/editor/components/modals/export-map/modal-export-map-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/components/modals/export-map/modal-export-map-view.spec.js
@@ -28,7 +28,8 @@ describe('editor/components/modals/export-map/modal-export-map-view', function (
       modalModel: new Backbone.Model(),
       exportMapModel: this.exportMapModel,
       renderOpts: {
-        name: this.visDefinitionModel.get('name')
+        name: this.visDefinitionModel.get('name'),
+        privateDatasets: false
       }
     });
 
@@ -47,6 +48,21 @@ describe('editor/components/modals/export-map/modal-export-map-view', function (
       expect(this.view.$el.html()).toContain(_t('editor.maps.export.confirmation.desc'));
       expect(this.view.$el.html()).toContain(_t('editor.maps.export.confirmation.cancel'));
       expect(this.view.$el.html()).toContain(_t('editor.maps.export.confirmation.confirm'));
+    });
+
+    it('should render confirmation view with private warning if state is undefined and privateDatasets true', function () {
+      this.view = new ExportView({
+        modalModel: new Backbone.Model(),
+        exportMapModel: this.exportMapModel,
+        renderOpts: {
+          name: this.visDefinitionModel.get('name'),
+          privateDatasets: true
+        }
+      });
+      this.view.render();
+
+      expect(this.view.$el.html()).toContain(_t('editor.maps.export.confirmation.privateTitle'));
+      expect(this.view.$el.html()).toContain(_t('editor.maps.export.confirmation.privateDesc'));
     });
 
     it('should render pending view when pending state', function () {

--- a/lib/assets/test/spec/cartodb3/editor/editor-header.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/editor-header.spec.js
@@ -64,6 +64,7 @@ describe('editor/editor-header', function () {
     var onRemoveMap = jasmine.createSpy('onRemoveMap');
 
     spyOn(Header.prototype, '_duplicateMap');
+    spyOn(Header.prototype, '_exportMap');
 
     this.view = new Header({
       editorModel: editorModel,
@@ -91,6 +92,12 @@ describe('editor/editor-header', function () {
     this.view.$('.js-toggle-menu').click();
     this.view._contextMenuFactory.getContextMenu().$('[data-val="duplicate-map"]').click();
     expect(Header.prototype._duplicateMap).toHaveBeenCalled();
+  });
+
+  it('should call exportMap when export map option is clicked', function () {    
+    this.view.$('.js-toggle-menu').click();
+    this.view._contextMenuFactory.getContextMenu().$('[data-val="export-map"]').click();
+    expect(Header.prototype._exportMap).toHaveBeenCalled();
   });
 
   it('should have no leaks', function () {


### PR DESCRIPTION
This pull request has been created as a result of a challenge sent by @javisantana and @xavijam 
It resolves CartoDB/cartodb#9482 

There are changes in two places:
- In private builder, when exporting a map with private datasets, a warning shows up.
- In a map public page, when exporting the map it shows different warning depending on the private datasets ownership: it they are yours, it warns you that the private datasets will be exported. If you don't own them, the dialog warns you that not all the data will be exported.

You can find the GIFs of the different scenarios below.

Some notes about this pull request:
- There are tests for the new view logic. Anyway, no tests have been created related to code where no previous tests exist. This code only makes minor changes in existing logic, so no new specs have been created because it'd been implied to write tests for logic not related to the issue.
- An iteration of this PR could be to apply these changes to organizations, where users can have access to datasets not owned by them.
## Changes explained

There have been changes in private builder page and map public page.
### Private builder

New render option passed to modal-export-map-view indicating if the map contains private datasets.

**Map with public datasets**

![public dataset](https://cloud.githubusercontent.com/assets/1078228/19223881/994a21fa-8e7a-11e6-9ef0-2407f463b182.gif)

**Map with private datasets**

![private dataset](https://cloud.githubusercontent.com/assets/1078228/19223893/a97246b6-8e7a-11e6-97d0-6f057575b2f6.gif)
### Map public page

Two data attributes rendered at the export map link: `data-private-datasets` and `data-owning-private-datasets` These attributes are filled at controller level and retrieved in the link event handling function. Passed to the modal view constructor.

**Map with public datasets**

![public export](https://cloud.githubusercontent.com/assets/1078228/19223910/bc5ba86c-8e7a-11e6-8c5d-49643f4ef5e4.gif)

**Map with private datasets owned by the current user**

![owning private](https://cloud.githubusercontent.com/assets/1078228/19223912/cffbe35a-8e7a-11e6-892a-1f1df61eb704.gif)

**Map with private datasets owned by another user**

![not owning private](https://cloud.githubusercontent.com/assets/1078228/19223914/e1069596-8e7a-11e6-9077-a153047ec920.gif)

I guess that @xavijam is the one to review this PR. Be nice! ;)

Regards,
Ivan
