### PR TITLE
Fixes custom ramp selection

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-item-view.js
@@ -56,7 +56,11 @@ module.exports = CoreView.extend({
 
   _onClick: function (ev) {
     this.killEvent(ev);
-    this.model.set('selected', true);
+    if (this.model.get('selected')) {
+      this.trigger('customEvent', 'customize', this.model.get('val'), this);
+    } else {
+      this.model.set('selected', true);
+    }
   },
 
   _onClickInvert: function (e) {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-item-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-item-view.js
@@ -56,6 +56,7 @@ module.exports = CoreView.extend({
 
   _onClick: function (ev) {
     this.killEvent(ev);
+
     if (this.model.get('selected')) {
       this.trigger('customEvent', 'customize', this.model.get('val'), this);
     } else {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
@@ -135,6 +135,9 @@ module.exports = CoreView.extend({
     });
 
     this._listView.bind('invert', this._invertRamp, this);
+    this._listView.bind('customize', function (ramp) {
+      this.trigger('customize', ramp, this);
+    }, this);
   },
 
   _invertRamp: function (item) {
@@ -175,9 +178,14 @@ module.exports = CoreView.extend({
 
   _onClickCustomRamp: function (e) {
     this.killEvent(e);
-    this.$('.js-listItemLink').removeClass('is-selected');
-    this.$('.js-customRamp').addClass('is-selected');
-    this.model.set('range', this._customRamp.get('range'));
+
+    if (this.model.get('range') === this._customRamp.get('range')) {
+      this.trigger('customize', this.collection.getSelectedItem(), this);
+    } else {
+      this.$('.js-listItemLink').removeClass('is-selected');
+      this.$('.js-customRamp').addClass('is-selected');
+      this.model.set('range', this._customRamp.get('range'));
+    }
   },
 
   _onClickCustomize: function (e) {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
@@ -182,10 +182,11 @@ module.exports = CoreView.extend({
     if (this.model.get('range') === this._customRamp.get('range')) {
       this.trigger('customize', this.collection.getSelectedItem(), this);
     } else {
-      this.$('.js-listItemLink').removeClass('is-selected');
-      this.$('.js-customRamp').addClass('is-selected');
       this.model.set('range', this._customRamp.get('range'));
     }
+
+    this.$('.js-listItemLink').removeClass('is-selected');
+    this.$('.js-customRamp').addClass('is-selected');
   },
 
   _onClickCustomize: function (e) {

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.spec.js
@@ -92,6 +92,20 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
       expect(this.view.$('.js-customRamp').hasClass('is-selected')).toBeTruthy();
     });
 
+    it('should start the customization process clicking on the customized ramp again', function () {
+      var customizeEventTriggered = false;
+
+      this.view.$('.js-listItemLink:eq(0)').click();
+      this.view.$('.js-customRamp').click();
+
+      this.view.bind('customize', function () {
+        customizeEventTriggered = true;
+      }, this);
+
+      this.view.$('.js-customRamp').click();
+      expect(customizeEventTriggered).toBeTruthy();
+    });
+
     it('should clear the custom ramp', function () {
       expect(this.view.$('.js-customRamp .ColorBar').length).toBe(3);
       this.view.$('.js-clear').click();


### PR DESCRIPTION
From the issue description: 

> It seems that a previous enhancement of the Fill component (the removal of the "Custom color set" link) broke the possibility of editing the custom ramps.

> The solution would be this: after a ramp is selected, a new click will send users to the editing form.

See solution in action: 

![gradient](https://cloud.githubusercontent.com/assets/4933/19232139/69985d0a-8ede-11e6-8729-5ee04b066a66.gif)

Closes #10089
