### PR TITLE
Fixed styles for password protected editor map

### DIFF
--- a/app/views/admin/visualizations/embed_map_password.html.erb
+++ b/app/views/admin/visualizations/embed_map_password.html.erb
@@ -2,13 +2,23 @@
   Protected embed
 <% end %>
 
-<%= content_for(:pass) do %>
+<%= content_for(:header_title) do %>
+  This embed is protected with password
+<% end %>
+
+<%= content_for(:password_form) do %>
   <%= form_tag(CartoDB.url(self, 'protected_embed_map', {:protocol => Rails.env.development? ? 'http' : 'https'}) + '?' + request.query_string, {:method=>'POST',:authenticity_token=>false}) do %>
-    <input type="password" name="password" placeholder="Insert your password" <% if (flash[:placeholder]) %>value="<%= flash[:placeholder] %>"<% end %> />
-    <span class="icon"></span>
-    <% if (flash[:error]) %>
-      <span class="icon error" original-title="The password is not ok"></span>
-    <% end %>
+
+    <div class='PublicPage-field-withTooltip'>
+      <%= password_field_tag 'password', params[:password], class: "PublicPage-form--inputText RoundBorders-all CDB-Text CDB-Size-medium is-light u-whiteTextColor #{ flash[:error].present? ? 'is-alert' : ''}", placeholder: 'Insert your password'%>
+
+      <%- if flash[:error].present? %>
+        <div class="PublicPage-inputTooltip CDB-InfoTooltip CDB-InfoTooltip--left u-lSpace--xl is-error">
+          <p class='CDB-Text CDB-Size-medium CDB-InfoTooltip-text'><%= flash[:error] %></p>
+        </div>
+      <% end %>
+    </div>
+
   <% end %>
 <% end %>
 

--- a/app/views/admin/visualizations/public_map_password.html.erb
+++ b/app/views/admin/visualizations/public_map_password.html.erb
@@ -2,13 +2,23 @@
   Protected map
 <% end %>
 
-<%= content_for(:pass) do %>
+<%= content_for(:header_title) do %>
+  This map is protected with password
+<% end %>
+
+<%= content_for(:password_form) do %>
   <%= form_tag(CartoDB.url(self, 'protected_public_map', {:protocol => Rails.env.development? ? 'http' : 'https'}) + '?' + request.query_string, {:method=>'POST',:authenticity_token=>false}) do %>
-    <input type="password" name="password" placeholder="Insert your password" <% if (flash[:placeholder]) %>value="<%= flash[:placeholder] %>"<% end %> />
-    <span class="icon"></span>
-    <% if (flash[:error]) %>
-      <span class="icon error" original-title="The password is not ok"></span>
-    <% end %>
+
+    <div class='PublicPage-field-withTooltip'>
+      <%= password_field_tag 'password', params[:password], class: "PublicPage-form--inputText RoundBorders-all CDB-Text CDB-Size-medium is-light u-whiteTextColor #{ flash[:error].present? ? 'is-alert' : ''}", placeholder: 'Insert your password'%>
+
+      <%- if flash[:error].present? %>
+        <div class="PublicPage-inputTooltip CDB-InfoTooltip CDB-InfoTooltip--left u-lSpace--xl is-error">
+          <p class='CDB-Text CDB-Size-medium CDB-InfoTooltip-text'><%= flash[:error] %></p>
+        </div>
+      <% end %>
+    </div>
+
   <% end %>
 <% end %>
 

--- a/app/views/layouts/application_password_layout.html.erb
+++ b/app/views/layouts/application_password_layout.html.erb
@@ -2,7 +2,9 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <title><%= yield :title %> | CARTO</title>
+    <%= favicon_link_tag "/favicons/favicon.ico" %>
     <%= stylesheet_link_tag 'password_protected.css' %>
   </head>
 

--- a/app/views/layouts/application_password_layout.html.erb
+++ b/app/views/layouts/application_password_layout.html.erb
@@ -1,41 +1,30 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
   <head>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-    <%= favicon_link_tag "/favicons/favicon.ico" %>
+    <meta charset="utf-8">
     <title><%= yield :title %> | CARTO</title>
     <%= stylesheet_link_tag 'password_protected.css' %>
-    <!--[if gte IE 9]>
-    <style type="text/css">
-      .gradient { filter: none; }
-    </style>
-    <![endif]-->
   </head>
-  <body class="protected">
-    <div class="bkg"></div>
-    <div class="block modal creation">
-      <div class="head">
-        <h3>This map is protected by password</h3>
-      </div>
 
-      <div class="content">
-        <%= yield :pass %>
-      </div>
+  <body class='PublicPage-body PublicPage-background--navyBlue'>
+    <div class='PublicPage-centerContainer'>
+      <div class='PublicPage-container'>
 
-      <div class="foot">Contact with the owner in case you want access to it.</div>
+        <div class='PublicPage-header'>
+          <a href="<%= cartodb_com_hosted? ? CartoDB.url(self, 'root') : "https://carto.com" %>">
+            <img src="<%= image_path "layout/carto-logo.svg" %>" alt="CARTO">
+          </a>
+        </div>
+
+        <p class='CDB-Text CDB-Size-large is-light u-whiteTextColor u-bSpace--xl'><%= yield :header_title %></p>
+
+        <div class='PublicPage-form'>
+          <%= yield :password_form %>
+        </div>
+
+        <p class='CDB-Text CDB-Size-medium is-light u-hintTextColor u-tSpace-xl'>Contact with the owner in case you want access to it.</p>
+      </div>
     </div>
-
-    <%= javascript_include_tag 'cdb.js' %>
-
-    <% if (flash[:error]) %>
-      <%= javascript_include_tag "tipsy.js" %>
-      <script type="text/javascript">
-        $(function() {
-          $("span.icon.error").tipsy({ gravity: "s", fade: true });
-        });
-      </script>
-    <% end %>
 
     <%= insert_trackjs('embeds') %>
     <%= insert_google_analytics('embeds', true) %>


### PR DESCRIPTION
Fixes #10058

Added missing styles for password protected visualizations and embeds in editor.

CR @xavijam 