### PR TITLE
10128 style migrations

### DIFF
--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -548,11 +548,12 @@ module Carto
           color['domain'] = wpp['categories'].map { |c| c['title'] }
         end
 
-        color['attribute'] = if wpp['property_cat']
-                               wpp['property_cat']
-                             elsif @source_type == 'density'
-                               'agg_value'
-                             end
+        color_attribute = if wpp['property_cat']
+                           wpp['property_cat']
+                          elsif @source_type == 'density'
+                            'agg_value'
+                          end
+        color['attribute'] = color_attribute if color_attribute
 
         color.merge!(TORQUE_HEAT_COLOR_DEFAULTS) if @source_type == 'torque_heat'
 

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -349,7 +349,7 @@ module Carto
           'properties' => wizard_properties_properties_to_style_properties_properties(wpp, type)
         }
 
-        merge_into_if_present(options['style_properties'], 'aggregation', generate_aggregation(wpp))
+        merge_into_if_present(options['style_properties']['properties'], 'aggregation', generate_aggregation(wpp))
 
         if SOURCE_TYPES_WITH_SQL_WRAP.include?(@source_type)
           options['sql_wrap'] = options['query_wrapper']

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -546,6 +546,7 @@ module Carto
         if wpp['categories'].present?
           color['range'] = wpp['categories'].map { |c| c['color'] }
           color['domain'] = wpp['categories'].map { |c| c['title'] }
+          color['attribute'] = wpp['property_cat'] if wpp['property_cat']
         end
 
         color.merge!(TORQUE_HEAT_COLOR_DEFAULTS) if @source_type == 'torque_heat'

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -358,6 +358,10 @@ module Carto
         if @source_type == 'cluster'
           options['cartocss_custom'] = true
         end
+
+        if type == 'animation' && @layer.widgets.where(type: 'time-series').none?
+          create_time_series_widget(wpp)
+        end
       end
 
       private
@@ -806,6 +810,23 @@ module Carto
         apply_default_opacity(color)
 
         color
+      end
+
+      def create_time_series_widget(wpp)
+        if wpp['property'] && @layer.options[:source]
+          @layer.widgets.create(
+            type: 'time-series',
+            order: 0,
+            title: 'time_date__t',
+            options: {
+              column: wpp['property'],
+              bins: 256,
+              sync_on_data_change: true,
+              sync_on_bbox_change: true
+            },
+            source_id: @layer.options[:source]
+          )
+        end
       end
     end
   end

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -372,7 +372,7 @@ module Carto
         'cluster' => 'simple'
       }.freeze
 
-      SOURCE_TYPES_WITH_SQL_WRAP = ['cluster', 'density'].freeze
+      SOURCE_TYPES_WITH_SQL_WRAP = ['cluster', 'density', 'torque_cat'].freeze
 
       def set_if_present(hash, key, value)
         # Dirty check because `false` is a valid `value`

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -514,7 +514,11 @@ module Carto
       }.freeze
 
       def generate_stroke(wpp)
-        stroke_mapping = wpp['geometry_type'] == 'point' ? STROKE_FROM_POINT_MAPPING : STROKE_FROM_NON_POINT_MAPPING
+        stroke_mapping = if wpp['geometry_type'] == 'point' && @source_type != 'density'
+                           STROKE_FROM_POINT_MAPPING
+                         else
+                           STROKE_FROM_NON_POINT_MAPPING
+                         end
 
         stroke = {}
 

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -546,8 +546,13 @@ module Carto
         if wpp['categories'].present?
           color['range'] = wpp['categories'].map { |c| c['color'] }
           color['domain'] = wpp['categories'].map { |c| c['title'] }
-          color['attribute'] = wpp['property_cat'] if wpp['property_cat']
         end
+
+        color['attribute'] = if wpp['property_cat']
+                               wpp['property_cat']
+                             elsif @source_type == 'density'
+                               'agg_value'
+                             end
 
         color.merge!(TORQUE_HEAT_COLOR_DEFAULTS) if @source_type == 'torque_heat'
 

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -553,7 +553,7 @@ module Carto
         end
 
         color_attribute = if wpp['property_cat']
-                           wpp['property_cat']
+                            wpp['property_cat']
                           elsif @source_type == 'density'
                             'agg_value'
                           end

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -349,7 +349,7 @@ module Carto
 
         torque[:cartocss] = layer_options[:tile_style]
         torque[:cartocss_version] = layer_options[:style_version]
-        torque[:sql] = wrap(sql_from(@layer), @layer.options)
+        torque[:sql] = sql_from(@layer)
 
         if @layer.options['source'].present?
           torque[:source] = @layer.options['source']
@@ -390,7 +390,7 @@ module Carto
           data[:source] = source
           data.delete(:sql)
         else
-          data[:sql] = wrap(sql_from(@layer), @layer.options)
+          data[:sql] = sql_from(@layer)
         end
 
         sql_wrap = @layer.options['sql_wrap'] || @layer.options['query_wrapper']
@@ -414,12 +414,6 @@ module Carto
       def css_from(options)
         style = options.include?('tile_style') ? options['tile_style'] : nil
         (style.nil? || style.strip.empty?) ? EMPTY_CSS : options.fetch('tile_style')
-      end
-
-      def wrap(query, options)
-        wrapper = options.fetch('query_wrapper', nil)
-        return query if wrapper.nil? || wrapper.empty?
-        EJS.evaluate(wrapper, sql: query)
       end
 
       def public_options

--- a/spec/requests/carto/api/layer_presenter_spec.rb
+++ b/spec/requests/carto/api/layer_presenter_spec.rb
@@ -697,6 +697,10 @@ describe Carto::Api::LayerPresenter do
         it 'type is animated' do
           expect(@style).to include('type' => 'animation')
         end
+
+        it 'generates a timeseries widget' do
+          @layer.widgets.where(type: 'time-series').any?
+        end
       end
 
       describe 'torque' do
@@ -738,8 +742,8 @@ describe Carto::Api::LayerPresenter do
         end
 
         before(:each) do
-          layer = build_layer_with_wizard_properties(torque_wizard_properties)
-          options = presenter_with_style_properties(layer).to_poro['options']
+          @layer = build_layer_with_wizard_properties(torque_wizard_properties)
+          options = presenter_with_style_properties(@layer).to_poro['options']
           @style = options['style_properties']
           @properties = @style['properties']
           @animated = @properties['animated']
@@ -820,8 +824,8 @@ describe Carto::Api::LayerPresenter do
       end
 
       before(:each) do
-        layer = build_layer_with_wizard_properties(torque_cat_wizard_properties)
-        options = presenter_with_style_properties(layer).to_poro['options']
+        @layer = build_layer_with_wizard_properties(torque_cat_wizard_properties)
+        options = presenter_with_style_properties(@layer).to_poro['options']
         @style = options['style_properties']
         @properties = @style['properties']
         @animated = @properties['animated']
@@ -993,8 +997,8 @@ describe Carto::Api::LayerPresenter do
       end
 
       before(:each) do
-        layer = build_layer_with_wizard_properties(heatmap_wizard_properties)
-        options = presenter_with_style_properties(layer).to_poro['options']
+        @layer = build_layer_with_wizard_properties(heatmap_wizard_properties)
+        options = presenter_with_style_properties(@layer).to_poro['options']
 
         @style = options['style_properties']
         @properties = @style['properties']

--- a/spec/requests/carto/api/layer_presenter_spec.rb
+++ b/spec/requests/carto/api/layer_presenter_spec.rb
@@ -868,9 +868,10 @@ describe Carto::Api::LayerPresenter do
         @options = presenter_with_style_properties(layer).to_poro['options']
 
         @style = @options['style_properties']
-        @aggregation = @style['aggregation']
         @properties = @style['properties']
+        @aggregation = @properties['aggregation']
         @fill_color = @properties['fill']['color']
+        @stroke = @properties['stroke']
       end
 
       it 'sets query_wrapper at sql_wrap' do
@@ -909,13 +910,27 @@ describe Carto::Api::LayerPresenter do
           expect(@fill_color).to include('range' => color_ramp)
         end
       end
+
+      describe 'stroke' do
+        it 'takes width from line-width' do
+          expect(@stroke['size']).to include('fixed' => 0.5)
+        end
+
+        it 'takes color from line-color' do
+          expect(@stroke['color']).to include('fixed' => '#FFF')
+        end
+
+        it 'takes opacity from line-opacity' do
+          expect(@stroke['color']).to include('opacity' => 1)
+        end
+      end
     end
 
     describe 'heatmap' do
       shared_examples_for 'heatmap' do
         describe 'aggregation' do
           before(:each) do
-            @aggregation = @style['aggregation']
+            @aggregation = @style['properties']['aggregation']
           end
 
           it 'takes size from torque-resolution' do

--- a/spec/requests/carto/api/layer_presenter_spec.rb
+++ b/spec/requests/carto/api/layer_presenter_spec.rb
@@ -833,6 +833,10 @@ describe Carto::Api::LayerPresenter do
       it 'generates color range from categories colors' do
         expect(@fill_color).to include('range' => [COLOR_1, COLOR_2])
       end
+
+      it 'generates color range based on attribute' do
+        expect(@fill_color).to include('attribute' => 'aforo')
+      end
     end
 
     describe 'density' do


### PR DESCRIPTION
Several fixes for style migration. Highlights:
 - In vizjson3, layers.options.sql is now the base query (not wrapped). This is the same as in named maps, and it is what cartodb.js expects.
 - Creates time-series widget when migrating an animated layer

Fixes #10128