### PR TITLE
Legend fixes

### DIFF
--- a/app/assets/stylesheets/editor-3/color-bar.css.scss
+++ b/app/assets/stylesheets/editor-3/color-bar.css.scss
@@ -94,6 +94,10 @@
   border-width: 1px 1px 1px 0;
   border-radius: 0 $baseSize - 2 $baseSize - 2 0;
 }
+.ColorBar.ColorBar--spaceless:only-child {
+  border-width: 1px;
+  border-radius: $baseSize - 2;
+}
 .ColorBar.ColorBar--spaceSmall {
   margin-right: 2px;
   border-radius: 2px;

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
@@ -45,6 +45,8 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
+    var range = this.model.get('range');
+
     this.model.bind('change:bins', this._updateRange, this);
     this.model.bind('change:attribute', this.render, this);
 
@@ -52,9 +54,14 @@ module.exports = CoreView.extend({
 
     this.model.unset('fixed');
 
-    if (!this.model.get('range')) {
+    if (!range || !this._isValidRange(range)) {
       this.model.set('range', this._getDefaultRamp());
     }
+  },
+
+  // range minimun size should be 2
+  _isValidRange: function (range) {
+    return range.length >= 2;
   },
 
   _initViews: function () {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
@@ -61,7 +61,7 @@ module.exports = CoreView.extend({
 
   // range minimun size should be 2
   _isValidRange: function (range) {
-    return range.length >= 2;
+    return range && range.length > 1 || false;
   },
 
   _initViews: function () {

--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
@@ -12,11 +12,11 @@ var onChange = function (layerDefModel) {
   function createColorLegend (layerDefModel, color) {
     if (color.attribute_type && color.attribute_type === 'string') {
       LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-        LegendFactory.createLegend(layerDefModel, 'category');
+        LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
       });
     } else {
       LegendFactory.removeLegend(layerDefModel, 'category', function () {
-        LegendFactory.createLegend(layerDefModel, 'choropleth');
+        LegendFactory.createLegend(layerDefModel, 'choropleth', {title: color.attribute});
       });
     }
   }
@@ -34,7 +34,7 @@ var onChange = function (layerDefModel) {
 
   if (LegendFactory.isEnabledType('size')) {
     if (size && size.attribute !== undefined) {
-      LegendFactory.createLegend(layerDefModel, 'bubble');
+      LegendFactory.createLegend(layerDefModel, 'bubble', {title: size.attribute});
     } else {
       LegendFactory.removeLegend(layerDefModel, 'bubble');
     }

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -371,7 +371,10 @@ F.prototype._onLegendDefinitionChanged = function (m) {
   var legend;
   if (layer && layer.legends) {
     legend = layer.legends[type];
-    legend && legend.set(m.getAttributes());
+    if (legend) {
+      legend.reset();
+      legend.set(m.getAttributes());
+    }
   }
 };
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
@@ -55,15 +55,16 @@ var manager = (function () {
       });
     },
 
-    createLegend: function (layerDefModel, type, callback) {
+    createLegend: function (layerDefModel, type, attrs, callback) {
       var model = this.legendDefinitionsCollection.findByLayerDefModelAndType(layerDefModel, type);
       var Klass;
       var validation = Validations[type];
       var isValid = validation(layerDefModel.styleModel);
+      attrs = attrs || {};
 
       if (!model) {
         Klass = LEGEND_MODEL_TYPE[type];
-        model = new Klass({}, {
+        model = new Klass(attrs, {
           layerDefinitionModel: layerDefModel,
           configModel: this.legendDefinitionsCollection.configModel,
           vizId: this.legendDefinitionsCollection.vizId,
@@ -75,6 +76,7 @@ var manager = (function () {
         if (!isValid) {
           this.remove(model, callback);
         } else {
+          model.set(attrs);
           this.save(model, callback);
         }
       }

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
@@ -80,4 +80,25 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
       this.view.remove();
     });
   });
+
+  describe('model without valid range', function () {
+    beforeEach(function () {
+      this.model = new Backbone.Model({
+        range: ['#F1EEF6']
+      });
+
+      this.view = new InputColorRamps(({
+        model: this.model
+      }));
+    });
+
+    it('should set a default ramp list', function () {
+      expect(this.model.get('bins')).toBe('3');
+      expect(this.model.get('range').length).toBe(3);
+    });
+
+    afterEach(function () {
+      this.view.remove();
+    });
+  });
 });

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -1156,8 +1156,8 @@ describe('deep-insights-integrations', function () {
 
       this.legendDefinitionsCollection.resetByData(vizJSON);
 
-      this.bubble = jasmine.createSpyObj('bubble', ['show', 'hide', 'set']);
-      this.choropleth = jasmine.createSpyObj('choropleth', ['show', 'hide', 'set']);
+      this.bubble = jasmine.createSpyObj('bubble', ['show', 'hide', 'set', 'reset']);
+      this.choropleth = jasmine.createSpyObj('choropleth', ['show', 'hide', 'set', 'reset']);
       spyOn(DeepInsightsIntegrations.prototype, '_linkLayerErrors');
 
       spyOn(DeepInsightsIntegrations.prototype, '_getLayer').and.returnValue({

--- a/lib/assets/test/spec/cartodb3/legend-manager.spec.js
+++ b/lib/assets/test/spec/cartodb3/legend-manager.spec.js
@@ -83,7 +83,7 @@ describe('deep-insights-integrations/legend-manager', function () {
       this.layerDefinitionModel.set({
         cartocss: 'wadus'
       });
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble');
+      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
     });
 
     it('styles color', function () {
@@ -107,8 +107,8 @@ describe('deep-insights-integrations/legend-manager', function () {
       });
 
       expect(LegendFactory.createLegend).toHaveBeenCalledTimes(2);
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble');
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth');
+      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
     });
   });
 
@@ -144,7 +144,7 @@ describe('deep-insights-integrations/legend-manager', function () {
       this.layerDefinitionModel.set({
         cartocss: 'wadus'
       });
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble');
+      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
     });
 
     it('styles color', function () {
@@ -168,8 +168,8 @@ describe('deep-insights-integrations/legend-manager', function () {
       });
 
       expect(LegendFactory.createLegend).toHaveBeenCalledTimes(2);
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble');
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth');
+      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
     });
   });
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.3.16-legends2",
+  "version": "4.3.20",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -1145,7 +1145,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#d45a245d9d7e7371558470a5b657786de6fbf711",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#ec74a77d69b1b1814b009dc511cfc096c32358a5",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1438,7 +1438,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#d45a245d9d7e7371558470a5b657786de6fbf711",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#ec74a77d69b1b1814b009dc511cfc096c32358a5",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",


### PR DESCRIPTION
This PR fixes a few more legend bugs.

Fixes #10135, including the shrinkwrap to update cartodb.js version.
Fixes #4608.
Fixes #10138.

https://www.dropbox.com/s/5xx9aqat745s4zx/legends.gif?dl=0

CR @xavijam 

Also @javierarce if you could take a look at https://github.com/CartoDB/cartodb/commit/792b7e2196518b81e1ea7e886ff24fc3d41d9cb1 would be great. I think it's ok, but not completely sure about the implications. Basically it introduces a validation for ramps. Maps api cries if a ramp length is less than two, and I feel it makes sense to have ramps of at least two colors.

https://www.dropbox.com/s/bu878ota3wpnx3s/Screen%20Shot%202016-10-11%20at%2016.49.06.png?dl=0

(Sorry for the links, file uploading seems to be broken right now).