### PR TITLE
Correctly rewrite username on import

### DIFF
--- a/app/models/carto/analysis_node.rb
+++ b/app/models/carto/analysis_node.rb
@@ -61,6 +61,7 @@ class Carto::AnalysisNode
   def fix_analysis_node_queries(old_username, new_user, renamed_tables)
     if options && options.key?(:table_name)
       old_table_name = options[:table_name]
+      old_username, old_table_name = old_table_name.split('.') if old_table_name.include?('.')
       options[:table_name] = renamed_tables.fetch(old_table_name, old_table_name)
     end
 

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -213,7 +213,7 @@ module Carto
       new_username = new_user.username
 
       if options.key?(:user_name)
-        old_username ||= options[:user_name]
+        old_username = options[:user_name] || old_username
         options[:user_name] = new_username
       end
 


### PR DESCRIPTION
Fixes #10156

Basically, we incorrectly used the map owner as the old username, which is not correct for layers that come from shared datasets. This inverts the priority, so the map username is only used when the layer username is missing.