### PR TITLE
Fix DB create/drop problems

### DIFF
--- a/app/models/carto/overlay.rb
+++ b/app/models/carto/overlay.rb
@@ -24,7 +24,7 @@ module Carto
     ].freeze
 
     BUILDER_COMPATIBLE_TYPES = ['search', 'layer_selector', 'share', 'fullscreen', 'loader', 'logo', 'zoom'].freeze
-    scope :builder_incompatible, where('type NOT IN (?)', BUILDER_COMPATIBLE_TYPES)
+    scope :builder_incompatible, where("type NOT IN ('#{BUILDER_COMPATIBLE_TYPES.join("','")}')")
 
     def hide
       options['display'] = false


### PR DESCRIPTION
The use of the `?` parameter was breaking the execution of the `db:drop` and `db:create` rakes (breaking CI in the process). Why? I can't tell you, but this fixes it.

CR @juanignaciosl 
cc @xavijam (you can merge this into your branch for your tests to run)