### PR TITLE
Correctly generate empty mapcaps collection

### DIFF
--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -39,7 +39,8 @@ module Carto
         @overlays_data = @visualization.overlays.map do |overlay|
           Carto::Api::OverlayPresenter.new(overlay).to_poro
         end
-        @mapcaps_data = Carto::Api::MapcapPresenter.new(@visualization.latest_mapcap).to_poro
+        latest_mapcap = @visualization.latest_mapcap
+        @mapcaps_data = latest_mapcap ? [Carto::Api::MapcapPresenter.new(latest_mapcap).to_poro] : []
       end
 
       private

--- a/app/views/carto/builder/visualizations/show.html.erb
+++ b/app/views/carto/builder/visualizations/show.html.erb
@@ -12,7 +12,7 @@
   var analysesData = <%= safe_js_object @analyses_data.to_json %>;
   var basemaps = <%= safe_js_object @basemaps.to_json %>;
   var overlaysData = <%= safe_js_object @overlays_data.to_json %>;
-  var mapcapsData = [<%= safe_js_object @mapcaps_data.to_json %>];
+  var mapcapsData = <%= safe_js_object @mapcaps_data.to_json %>;
   var builderNotifications = <%= safe_js_object @builder_notifications.to_json %>;
   var ACTIVE_LOCALE = 'en';
 </script>


### PR DESCRIPTION
Fixes #10206

With no mapcap, it incorrectly generated `[{}]`. Now it generates `[]`.