### PR TITLE
Start analysis animation when hovering the whole element + adds link to breadcrumb

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/add-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/add-analysis-view.js
@@ -67,7 +67,7 @@ module.exports = CoreView.extend({
   _renderStackView: function () {
     var stackViewCollection = new Backbone.Collection([{
       createStackView: function (stackLayoutModel, opts) {
-        return new AnalysisViewPane({
+        var view = new AnalysisViewPane({
           modalModel: this._modalModel,
           stackLayoutModel: stackLayoutModel,
           analysisOptions: this._analysisOptions,
@@ -75,15 +75,24 @@ module.exports = CoreView.extend({
           layerDefinitionModel: this._layerDefinitionModel,
           queryGeometryModel: this._queryGeometryModel
         });
+        this._analysisViewPane = view;
+        return view;
       }.bind(this)
     }, {
       createStackView: function (stackLayoutModel, opts) {
-        return new AnalysisInfoPane({
+        var view = new AnalysisInfoPane({
           stackLayoutModel: stackLayoutModel,
           modalModel: this._modalModel,
           layerDefinitionModel: this._layerDefinitionModel,
           collection: this._analysisOptionsCollection
         });
+
+        view.bind('backToCategory', function (categoryName) {
+          stackLayoutModel.prevStep();
+          this._analysisViewPane.goToTabItem(categoryName);
+        }, this);
+
+        return view;
       }.bind(this)
     }]);
 

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-info-pane.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-info-pane.js
@@ -10,6 +10,7 @@ module.exports = CoreView.extend({
 
   events: {
     'click .js-back': '_onClickBack',
+    'click .js-backToCategory': '_onClickBackToCategory',
     'click .js-add': '_onAddAnalysis'
   },
 
@@ -43,10 +44,12 @@ module.exports = CoreView.extend({
         analysisParams = animationTemplate.params || {};
       }
 
+      this._analysisCategoryName = selectedAnalysis.get('category');
+
       opts = {
         type: analysisType,
         genericType: genericType,
-        category: selectedAnalysis.get('category').replace(/_/g, '-'),
+        category: this._analysisCategoryName.replace(/_/g, '-'),
         title: selectedAnalysis.get('title'),
         analysisParams: analysisParams
       };
@@ -59,6 +62,10 @@ module.exports = CoreView.extend({
     }
 
     return this;
+  },
+
+  _onClickBackToCategory: function () {
+    this.trigger('backToCategory', this._analysisCategoryName, this);
   },
 
   _onClickBack: function () {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-info-pane.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-info-pane.tpl
@@ -19,6 +19,9 @@
         <div class="Modal-analysisContainer">
           <ul class="CDB-NavMenu-inner CDB-Text is-semibold CDB-Size-small SubmenuModal u-flex u-alignCenter">
             <li class="CDB-NavMenu-item SubmenuModal-item u-flex u-alignCenter">
+              <button class="js-back u-mainTextColor u-upperCase"><%- _t('analysis-category.all') %></button>
+            </li>
+            <li class="CDB-NavMenu-item SubmenuModal-item u-flex u-alignCenter">
               <button class="js-backToCategory u-mainTextColor u-upperCase"><%- _t('analysis-category.' + category) %></button>
             </li>
             <li class="CDB-NavMenu-item u-upperCase SubmenuModal-item u-flex u-alignCenter">

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-info-pane.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-info-pane.tpl
@@ -18,8 +18,8 @@
       <div class="ScrollView-content">
         <div class="Modal-analysisContainer">
           <ul class="CDB-NavMenu-inner CDB-Text is-semibold CDB-Size-small SubmenuModal u-flex u-alignCenter">
-            <li class="CDB-NavMenu-item u-upperCase u-secondaryTextColor SubmenuModal-item u-flex u-alignCenter">
-              <%= _t('analysis-category.' + category) %>
+            <li class="CDB-NavMenu-item SubmenuModal-item u-flex u-alignCenter">
+              <button class="js-backToCategory u-mainTextColor u-upperCase"><%- _t('analysis-category.' + category) %></button>
             </li>
             <li class="CDB-NavMenu-item u-upperCase SubmenuModal-item u-flex u-alignCenter">
               <%- title %>

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-option-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-option-view.js
@@ -12,6 +12,8 @@ module.exports = CoreView.extend({
   className: 'ModalBlockList-item',
 
   events: {
+    'mouseenter': '_onMouseEnter',
+    'mouseleave': '_onMouseLeave',
     'click': '_onClick'
   },
 
@@ -48,6 +50,18 @@ module.exports = CoreView.extend({
     this.$el.toggleClass('is-disabled', !props.enabled);
 
     return this;
+  },
+
+  _onMouseEnter: function () {
+    if (this._acceptsInputGeometry()) {
+      this.$('.js-animation').addClass('has-autoplay');
+    }
+  },
+
+  _onMouseLeave: function () {
+    if (this._acceptsInputGeometry()) {
+      this.$('.js-animation').removeClass('has-autoplay');
+    }
   },
 
   _onClick: function (e) {

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-option.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-option.tpl
@@ -1,4 +1,4 @@
-<div class="Analysis-animation <% if (type) { %>is-<%- type %><% } %> js-animation u-flex u-alignCenter u-justifyCenter"></div>
+<div class="Analysis-animation <% if (enabled) { %>is-enabled<% } %> <% if (type) { %>is-<%- type %><% } %> js-animation u-flex u-alignCenter u-justifyCenter"></div>
 <div class="Analysis-info u-flex">
   <div class="ModalBlockList-itemInput CDB-Size-large">
     <input class="CDB-Radio" type="radio" value="true"

--- a/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-view-pane.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-analysis/analysis-view-pane.js
@@ -56,10 +56,17 @@ module.exports = CoreView.extend({
       }
     };
 
-    var view = createTemplateTabPane(this._tabPaneItems, options);
-    this.addView(view);
-    this._$body().append(view.render().el);
+    this._tabPane = createTemplateTabPane(this._tabPaneItems, options);
+    this.addView(this._tabPane);
+    this._$body().append(this._tabPane.render().el);
     return this;
+  },
+
+  goToTabItem: function (tabItemName) {
+    var tabItem = _.first(this._tabPane.collection.where({ name: tabItemName }));
+    if (tabItem) {
+      tabItem.set('selected', true);
+    }
   },
 
   _generateTabPaneItems: function () {

--- a/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-info-pane.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-info-pane.spec.js
@@ -1,0 +1,50 @@
+var Backbone = require('backbone');
+var cdb = require('cartodb.js');
+var AnalysisInfoPane = require('../../../../../../javascripts/cartodb3/components/modals/add-analysis/analysis-info-pane');
+
+fdescribe('components/modals/add-analysis/analysis-info-pane', function () {
+  beforeEach(function () {
+    this.view = new AnalysisInfoPane({
+      stackLayoutModel: new cdb.core.Model(),
+      modalModel: new cdb.core.Model(),
+      layerDefinitionModel: new cdb.core.Model(),
+      collection: new Backbone.Collection([
+        { selected: true,
+          title: 'Intersection',
+          category: 'category-name',
+          type: 'intersection',
+          genericType: 'intersection',
+          analysisParams: {}
+        }
+      ])
+    });
+    this.view.render();
+  });
+
+  it('should not have any leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
+  it('should render the info', function () {
+    expect(this.view.$el.html()).toContain('analysis-category.category-name');
+    expect(this.view.$('.Analysis-moreInfoTitle').text()).toContain('analysis-category.intersection');
+    expect(this.view.$('.Analysis-moreInfo p').text()).toContain('analyses-onboarding.intersection.description');
+  });
+
+  it('should render the breadcrumb', function () {
+    expect(this.view.$('.CDB-NavMenu-inner li:nth-child(1)').text()).toContain('analysis-category.all');
+    expect(this.view.$('.CDB-NavMenu-inner li:nth-child(2)').text()).toContain('analysis-category.intersection');
+    expect(this.view.$('.CDB-NavMenu-inner li:nth-child(3)').text()).toContain('Intersection');
+  });
+
+  it('should triggger a back to category event', function () {
+    var category;
+
+    this.view.bind('backToCategory', function (categoryName) {
+      category = categoryName;
+    }, this);
+
+    this.view.$('.js-backToCategory').click();
+    expect(category).toBe('intersection');
+  });
+});

--- a/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-info-pane.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-info-pane.spec.js
@@ -2,7 +2,7 @@ var Backbone = require('backbone');
 var cdb = require('cartodb.js');
 var AnalysisInfoPane = require('../../../../../../javascripts/cartodb3/components/modals/add-analysis/analysis-info-pane');
 
-fdescribe('components/modals/add-analysis/analysis-info-pane', function () {
+describe('components/modals/add-analysis/analysis-info-pane', function () {
   beforeEach(function () {
     this.view = new AnalysisInfoPane({
       stackLayoutModel: new cdb.core.Model(),
@@ -11,7 +11,7 @@ fdescribe('components/modals/add-analysis/analysis-info-pane', function () {
       collection: new Backbone.Collection([
         { selected: true,
           title: 'Intersection',
-          category: 'category-name',
+          category: 'analyze-and-predict',
           type: 'intersection',
           genericType: 'intersection',
           analysisParams: {}
@@ -26,14 +26,14 @@ fdescribe('components/modals/add-analysis/analysis-info-pane', function () {
   });
 
   it('should render the info', function () {
-    expect(this.view.$el.html()).toContain('analysis-category.category-name');
-    expect(this.view.$('.Analysis-moreInfoTitle').text()).toContain('analysis-category.intersection');
+    expect(this.view.$el.html()).toContain('analysis-category.analyze-and-predict');
+    expect(this.view.$('.Analysis-moreInfoTitle').text()).toContain('Intersection');
     expect(this.view.$('.Analysis-moreInfo p').text()).toContain('analyses-onboarding.intersection.description');
   });
 
   it('should render the breadcrumb', function () {
     expect(this.view.$('.CDB-NavMenu-inner li:nth-child(1)').text()).toContain('analysis-category.all');
-    expect(this.view.$('.CDB-NavMenu-inner li:nth-child(2)').text()).toContain('analysis-category.intersection');
+    expect(this.view.$('.CDB-NavMenu-inner li:nth-child(2)').text()).toContain('analysis-category.analyze-and-predict');
     expect(this.view.$('.CDB-NavMenu-inner li:nth-child(3)').text()).toContain('Intersection');
   });
 
@@ -45,6 +45,6 @@ fdescribe('components/modals/add-analysis/analysis-info-pane', function () {
     }, this);
 
     this.view.$('.js-backToCategory').click();
-    expect(category).toBe('intersection');
+    expect(category).toBe('analyze-and-predict');
   });
 });

--- a/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-option-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-option-view.spec.js
@@ -1,6 +1,5 @@
 var AnalysisOptionModel = require('../../../../../../javascripts/cartodb3/components/modals/add-analysis/analysis-option-models/analysis-option-model');
 var AnalysisOptionView = require('../../../../../../javascripts/cartodb3/components/modals/add-analysis/analysis-option-view');
-
 describe('components/modals/add-analysis/analysis-option-view', function () {
   beforeEach(function () {
     this.model = new AnalysisOptionModel({

--- a/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-option-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-option-view.spec.js
@@ -48,8 +48,17 @@ describe('components/modals/add-analysis/analysis-option-view', function () {
     });
 
     it('should render the animation', function () {
-      console.log(this.view.$el.html());
       expect(this.view.$('.js-animation').length).toBe(1);
+    });
+
+    it('should launch the animation on hover', function () {
+      this.view._acceptsInputGeometry = function () { return true; };
+
+      this.view.$el.trigger('mouseenter');
+      expect(this.view.$('.js-animation').hasClass('has-autoplay')).toBeTruthy();
+
+      this.view.$el.trigger('mouseleave');
+      expect(this.view.$('.js-animation').hasClass('has-autoplay')).toBeFalsy();
     });
 
     describe('when selected', function () {


### PR DESCRIPTION
Start analysis animation when hovering the whole element + adds link to breadcrumb.

I've decided to add a link to "All" in the breadcrumb:

![screen shot 2016-10-17 at 17 11 40](https://cloud.githubusercontent.com/assets/4933/19443375/cd27dd6a-948c-11e6-9556-af13741fcc3a.png)

Closes #10211 