### PR TITLE
Upgrade cdb extension to v0.18.0 #10218

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -518,7 +518,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.17.1'
+          cdb_extension_target_version = '0.18.0'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|


### PR DESCRIPTION
Modifications to get `0.18.0` installed for new users.

https://github.com/CartoDB/cartodb-postgresql/releases/tag/0.18.0
https://github.com/CartoDB/cartodb-postgresql/blob/master/NEWS.md#0180-2016-10-17