### PR TITLE
Legends pixel aggregation

### DIFF
--- a/app/models/carto/legend.rb
+++ b/app/models/carto/legend.rb
@@ -10,7 +10,7 @@ module Carto
 
     belongs_to :layer, class_name: Carto::Layer
 
-    VALID_LEGEND_TYPES = %(html category bubble choropleth custom).freeze
+    VALID_LEGEND_TYPES = %(html category bubble choropleth custom custom_choropleth).freeze
 
     serialize :definition, ::Carto::CartoJsonSerializer
 

--- a/lib/assets/javascripts/cartodb3/data/legends/legend-custom-choropleth-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/legends/legend-custom-choropleth-definition-model.js
@@ -4,7 +4,7 @@ var LegendBaseDefModel = require('./legend-base-definition-model');
 module.exports = LegendBaseDefModel.extend({
   defaults: _.extend({}, LegendBaseDefModel.prototype.defaults,
     {
-      type: 'customChoropleth',
+      type: 'custom_choropleth',
       prefix: '',
       suffix: '',
       colors: []
@@ -16,8 +16,6 @@ module.exports = LegendBaseDefModel.extend({
     var fill;
     var stroke;
     var color;
-
-    attrs.type = 'customChoropleth';
 
     if (r.definition) {
       attrs.colors = r.definition.colors;
@@ -35,10 +33,7 @@ module.exports = LegendBaseDefModel.extend({
   toJSON: function () {
     return _.extend(
       {},
-      _.omit(this.attributes, 'type', 'prefix', 'suffix', 'colors', 'postHTMLSnippet', 'preHTMLSnippet'),
-      {
-        type: 'custom_choropleth'
-      },
+      _.omit(this.attributes, 'prefix', 'suffix', 'colors', 'postHTMLSnippet', 'preHTMLSnippet'),
       {
         pre_html: this.get('preHTMLSnippet'),
         post_html: this.get('postHTMLSnippet')

--- a/lib/assets/javascripts/cartodb3/data/legends/legend-custom-choropleth-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/legends/legend-custom-choropleth-definition-model.js
@@ -1,0 +1,76 @@
+var _ = require('underscore');
+var LegendBaseDefModel = require('./legend-base-definition-model');
+
+module.exports = LegendBaseDefModel.extend({
+  defaults: _.extend({}, LegendBaseDefModel.prototype.defaults,
+    {
+      type: 'customChoropleth',
+      prefix: '',
+      suffix: '',
+      colors: []
+    }
+  ),
+
+  parse: function (r, opts) {
+    var attrs = LegendBaseDefModel.prototype.parse.call(this, r);
+    var fill;
+    var stroke;
+    var color;
+
+    attrs.type = 'customChoropleth';
+
+    if (r.definition) {
+      attrs.colors = r.definition.colors;
+      attrs.prefix = r.definition.prefix;
+      attrs.suffix = r.definition.suffix;
+    } else {
+      fill = opts.layerDefinitionModel.styleModel.get('fill');
+      stroke = opts.layerDefinitionModel.styleModel.get('stroke');
+      color = fill.color || stroke.color;
+      attrs.colors = this._inheritStyleColors(color);
+    }
+    return attrs;
+  },
+
+  toJSON: function () {
+    return _.extend(
+      {},
+      _.omit(this.attributes, 'type', 'prefix', 'suffix', 'colors', 'postHTMLSnippet', 'preHTMLSnippet'),
+      {
+        type: 'custom_choropleth'
+      },
+      {
+        pre_html: this.get('preHTMLSnippet'),
+        post_html: this.get('postHTMLSnippet')
+      },
+      {
+        definition: {
+          colors: this.get('colors').map(function (item) {
+            return {
+              color: item.color
+            };
+          }),
+          prefix: this.get('prefix'),
+          suffix: this.get('suffix')
+        }
+      }
+    );
+  },
+
+  _inheritStyleColors: function (color) {
+    var range = 0;
+    var colors = [];
+
+    if (color.range) {
+      range = color.range.length;
+
+      colors = _.range(range).map(function (v, index) {
+        return {
+          color: color.range[index]
+        };
+      });
+    }
+
+    return colors;
+  }
+});

--- a/lib/assets/javascripts/cartodb3/data/legends/legend-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/legends/legend-definitions-collection.js
@@ -6,6 +6,7 @@ var layerTypesAndKinds = require('../layer-types-and-kinds');
 var CategoryModel = require('./legend-category-definition-model');
 var BubbleModel = require('./legend-bubble-definition-model');
 var ChoroplethModel = require('./legend-choropleth-definition-model');
+var CustomChoroplethModel = require('./legend-custom-choropleth-definition-model');
 var CustomhModel = require('./legend-custom-definition-model');
 var BasehModel = require('./legend-base-definition-model');
 
@@ -13,6 +14,7 @@ var LEGEND_MODEL_TYPE = {
   'bubble': BubbleModel,
   'category': CategoryModel,
   'choropleth': ChoroplethModel,
+  'custom_choropleth': CustomChoroplethModel,
   'custom': CustomhModel,
   'html': BasehModel
 };

--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
@@ -17,7 +17,7 @@ var onChange = function (layerDefModel) {
         LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
       });
     } else {
-      if (color.attribute_type && color.attribute_type === 'string') {
+      if (color.attribute_type && (color.attribute_type === 'string' || color.quantification === 'category')) {
         LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
           LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
         });

--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
@@ -21,7 +21,7 @@ var onChange = function (layerDefModel) {
     } else if (styleModel.get('type') === 'heatmap') {
       LegendFactory.removeLegend(layerDefModel, 'category', function () {
         LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-          LegendFactory.createLegend(layerDefModel, 'custom_choropleth', {title: color.attribute});
+          LegendFactory.createLegend(layerDefModel, 'custom_choropleth', {title: _t('editor.legend.pixel-title')});
         });
       });
     } else {

--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
@@ -14,16 +14,28 @@ var onChange = function (layerDefModel) {
 
     if (styleModel.get('type') === 'animation') {
       LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-        LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
+        LegendFactory.removeLegend(layerDefModel, 'customChoropleth', function () {
+          LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
+        });
+      });
+    } else if (styleModel.get('type') === 'heatmap') {
+      LegendFactory.removeLegend(layerDefModel, 'category', function () {
+        LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
+          LegendFactory.createLegend(layerDefModel, 'customChoropleth', {title: color.attribute});
+        });
       });
     } else {
       if (color.attribute_type && (color.attribute_type === 'string' || color.quantification === 'category')) {
         LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-          LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
+          LegendFactory.removeLegend(layerDefModel, 'customChoropleth', function () {
+            LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
+          });
         });
       } else {
         LegendFactory.removeLegend(layerDefModel, 'category', function () {
-          LegendFactory.createLegend(layerDefModel, 'choropleth', {title: color.attribute});
+          LegendFactory.removeLegend(layerDefModel, 'customChoropleth', function () {
+            LegendFactory.createLegend(layerDefModel, 'choropleth', {title: color.attribute});
+          });
         });
       }
     }
@@ -54,6 +66,7 @@ var onChange = function (layerDefModel) {
     } else {
       LegendFactory.removeLegend(layerDefModel, 'category');
       LegendFactory.removeLegend(layerDefModel, 'choropleth');
+      LegendFactory.removeLegend(layerDefModel, 'customChoropleth');
     }
   }
 };

--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/legend-manager.js
@@ -14,26 +14,26 @@ var onChange = function (layerDefModel) {
 
     if (styleModel.get('type') === 'animation') {
       LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-        LegendFactory.removeLegend(layerDefModel, 'customChoropleth', function () {
+        LegendFactory.removeLegend(layerDefModel, 'custom_choropleth', function () {
           LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
         });
       });
     } else if (styleModel.get('type') === 'heatmap') {
       LegendFactory.removeLegend(layerDefModel, 'category', function () {
         LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-          LegendFactory.createLegend(layerDefModel, 'customChoropleth', {title: color.attribute});
+          LegendFactory.createLegend(layerDefModel, 'custom_choropleth', {title: color.attribute});
         });
       });
     } else {
       if (color.attribute_type && (color.attribute_type === 'string' || color.quantification === 'category')) {
         LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-          LegendFactory.removeLegend(layerDefModel, 'customChoropleth', function () {
+          LegendFactory.removeLegend(layerDefModel, 'custom_choropleth', function () {
             LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
           });
         });
       } else {
         LegendFactory.removeLegend(layerDefModel, 'category', function () {
-          LegendFactory.removeLegend(layerDefModel, 'customChoropleth', function () {
+          LegendFactory.removeLegend(layerDefModel, 'custom_choropleth', function () {
             LegendFactory.createLegend(layerDefModel, 'choropleth', {title: color.attribute});
           });
         });
@@ -66,7 +66,7 @@ var onChange = function (layerDefModel) {
     } else {
       LegendFactory.removeLegend(layerDefModel, 'category');
       LegendFactory.removeLegend(layerDefModel, 'choropleth');
-      LegendFactory.removeLegend(layerDefModel, 'customChoropleth');
+      LegendFactory.removeLegend(layerDefModel, 'custom_choropleth');
     }
   }
 };

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/color/legend-color-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/color/legend-color-types.js
@@ -31,11 +31,26 @@ module.exports = [
       var stroke = styleModel.get('stroke');
       var color;
 
-      if (type === 'animation') return false;
+      if (type === 'animation' || type === 'heatmap') return false;
       if (!fill && !stroke || _.isEmpty(fill) && _.isEmpty(stroke)) return false;
 
       color = fill && fill.color || stroke && stroke.color;
       return color && color.attribute && (color.attribute_type === undefined || color.attribute_type && color.attribute_type !== 'string');
+    }
+  }, {
+    value: 'customChoropleth',
+    legendIcon: require('../carousel-icons/gradient.tpl'),
+    label: _t('editor.legend.types.gradient'),
+    isStyleCompatible: function (styleModel) {
+      var type = styleModel.get('type');
+      var fill = styleModel.get('fill');
+      var stroke = styleModel.get('stroke');
+      var color;
+
+      if (!fill && !stroke || _.isEmpty(fill) && _.isEmpty(stroke)) return false;
+
+      color = fill && fill.color || stroke && stroke.color;
+      return type === 'heatmap' && color && color.attribute && (color.attribute_type === undefined || color.attribute_type && color.attribute_type !== 'string');
     }
   }, {
     value: 'custom',

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/color/legend-color-types.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/color/legend-color-types.js
@@ -38,7 +38,7 @@ module.exports = [
       return color && color.attribute && (color.attribute_type === undefined || color.attribute_type && color.attribute_type !== 'string');
     }
   }, {
-    value: 'customChoropleth',
+    value: 'custom_choropleth',
     legendIcon: require('../carousel-icons/gradient.tpl'),
     label: _t('editor.legend.types.gradient'),
     isStyleCompatible: function (styleModel) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/form/legend-custom-choropleth-definition-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/form/legend-custom-choropleth-definition-form-model.js
@@ -1,0 +1,10 @@
+var _ = require('underscore');
+var LegendBaseDefModel = require('./legend-choropleth-definition-form-model');
+
+module.exports = LegendBaseDefModel.extend({
+  defaults: _.extend({}, LegendBaseDefModel.prototype.defaults,
+    {
+      type: 'customChoropleth'
+    }
+  )
+});

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/form/legend-custom-choropleth-definition-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/form/legend-custom-choropleth-definition-form-model.js
@@ -4,7 +4,7 @@ var LegendBaseDefModel = require('./legend-choropleth-definition-form-model');
 module.exports = LegendBaseDefModel.extend({
   defaults: _.extend({}, LegendBaseDefModel.prototype.defaults,
     {
-      type: 'customChoropleth'
+      type: 'custom_choropleth'
     }
   )
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-buffer.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-buffer.js
@@ -1,0 +1,18 @@
+var map = {};
+
+module.exports = {
+  add: function (model) {
+    var key = model.layerDefinitionModel.id + ':' + model.get('type');
+    map[key] = model;
+  },
+
+  find: function (layerDefModel, type) {
+    var key = layerDefModel.id + ':' + type;
+    return map[key];
+  },
+
+  remove: function (model) {
+    var key = model.layerDefinitionModel.id + ':' + model.get('type');
+    delete map[key];
+  }
+};

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-content-view.js
@@ -9,6 +9,7 @@ var CustomFormModel = require('./form/legend-custom-definition-form-model');
 var CategoryFormModel = require('./form/legend-category-definition-form-model');
 var BubbleFormModel = require('./form/legend-bubble-definition-form-model');
 var ChoroplethFormModel = require('./form/legend-choropleth-definition-form-model');
+var CustomChoroplethFormModel = require('./form/legend-custom-choropleth-definition-form-model');
 
 var template = require('./legend-content.tpl');
 var LegendFactory = require('./legend-factory');
@@ -30,7 +31,8 @@ var LEGEND_MODEL_TYPE = {
   bubble: BubbleFormModel,
   custom: CustomFormModel,
   category: CategoryFormModel,
-  choropleth: ChoroplethFormModel
+  choropleth: ChoroplethFormModel,
+  customChoropleth: CustomChoroplethFormModel
 };
 
 module.exports = CoreView.extend({

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-content-view.js
@@ -32,7 +32,7 @@ var LEGEND_MODEL_TYPE = {
   custom: CustomFormModel,
   category: CategoryFormModel,
   choropleth: ChoroplethFormModel,
-  customChoropleth: CustomChoroplethFormModel
+  custom_choropleth: CustomChoroplethFormModel
 };
 
 module.exports = CoreView.extend({

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var CategoryModel = require('../../../../data/legends/legend-category-definition-model');
 var BubbleModel = require('../../../../data/legends/legend-bubble-definition-model');
 var ChoroplethModel = require('../../../../data/legends/legend-choropleth-definition-model');
+var CustomChoroplethModel = require('../../../../data/legends/legend-custom-choropleth-definition-model');
 var CustomhModel = require('../../../../data/legends/legend-custom-definition-model');
 var Validations = require('./legend-validations');
 var Buffer = require('./legend-buffer');
@@ -10,6 +11,7 @@ var LEGEND_MODEL_TYPE = {
   'bubble': BubbleModel,
   'category': CategoryModel,
   'choropleth': ChoroplethModel,
+  'customChoropleth': CustomChoroplethModel,
   'custom': CustomhModel
 };
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
@@ -11,7 +11,7 @@ var LEGEND_MODEL_TYPE = {
   'bubble': BubbleModel,
   'category': CategoryModel,
   'choropleth': ChoroplethModel,
-  'customChoropleth': CustomChoroplethModel,
+  'custom_choropleth': CustomChoroplethModel,
   'custom': CustomhModel
 };
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
@@ -4,6 +4,7 @@ var BubbleModel = require('../../../../data/legends/legend-bubble-definition-mod
 var ChoroplethModel = require('../../../../data/legends/legend-choropleth-definition-model');
 var CustomhModel = require('../../../../data/legends/legend-custom-definition-model');
 var Validations = require('./legend-validations');
+var Buffer = require('./legend-buffer');
 
 var LEGEND_MODEL_TYPE = {
   'bubble': BubbleModel,
@@ -29,6 +30,7 @@ var manager = (function () {
       var self = this;
       model.save(null, {
         success: function (model) {
+          Buffer.remove(model);
           self.legendDefinitionsCollection.add(model);
         },
         complete: function () {
@@ -57,10 +59,15 @@ var manager = (function () {
 
     createLegend: function (layerDefModel, type, attrs, callback) {
       var model = this.legendDefinitionsCollection.findByLayerDefModelAndType(layerDefModel, type);
+      var inQueue = Buffer.find(layerDefModel, type);
       var Klass;
       var validation = Validations[type];
       var isValid = validation(layerDefModel.styleModel);
       attrs = attrs || {};
+
+      if (inQueue) {
+        return inQueue;
+      }
 
       if (!model) {
         Klass = LEGEND_MODEL_TYPE[type];
@@ -71,6 +78,7 @@ var manager = (function () {
           parse: true
         });
 
+        Buffer.add(model);
         isValid && this.add(model, callback);
       } else {
         if (!isValid) {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-validations.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-validations.js
@@ -43,7 +43,7 @@ var validations = {
   bubble: validateSizeRange,
   category: validateRangeAndDomain,
   choropleth: validateColorRange,
-  customChoropleth: validateColorRange,
+  custom_choropleth: validateColorRange,
   custom: noOp
 };
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-validations.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-validations.js
@@ -43,6 +43,7 @@ var validations = {
   bubble: validateSizeRange,
   category: validateRangeAndDomain,
   choropleth: validateColorRange,
+  customChoropleth: validateColorRange,
   custom: noOp
 };
 

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1742,7 +1742,8 @@
         "by-size": "By Size",
         "by-color": "By Color",
         "untitled": "Untitled"
-      }
+      },
+      "pixel-title": "Amount"
     },
     "style": {
       "types": {

--- a/lib/assets/test/spec/cartodb3/legend-manager.spec.js
+++ b/lib/assets/test/spec/cartodb3/legend-manager.spec.js
@@ -110,6 +110,28 @@ describe('deep-insights-integrations/legend-manager', function () {
       expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
       expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
     });
+
+    it('styles color category quantification', function () {
+      this.styleModel.set('fill', {
+        color: {
+          attribute: 'number',
+          attribute_type: 'number',
+          bins: '3',
+          quantification: 'category',
+          range: ['#ffc6c4', '#cc607d', '#672044']
+        },
+        size: {
+          fixed: 7
+        }
+      });
+
+      this.layerDefinitionModel.set({
+        cartocss: 'wadus'
+      });
+
+      expect(LegendFactory.createLegend).toHaveBeenCalledTimes(1);
+      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
+    });
   });
 
   describe('lines', function () {

--- a/lib/formats/legends/custom_choropleth.json
+++ b/lib/formats/legends/custom_choropleth.json
@@ -7,14 +7,11 @@
     "suffix": { "type": "string" },
     "colors": {
       "type": "array",
-      "required": [
-        "title"
-      ],
       "additionalProperties": false,
       "items": {
         "type": "object",
         "required": [
-          "title"
+          "color"
         ],
         "additionalProperties": false,
         "properties": {

--- a/lib/formats/legends/custom_choropleth.json
+++ b/lib/formats/legends/custom_choropleth.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "required": ["prefix", "suffix", "colors"],
+  "additionalProperties": false,
+  "properties": {
+    "prefix": { "type": "string" },
+    "suffix": { "type": "string" },
+    "colors": {
+      "type": "array",
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false,
+      "items": {
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "color": {
+            "type": "string",
+            "pattern": "^#(?:[0-9a-fA-F]{3}){1,2}$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -964,7 +964,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
@@ -1150,7 +1150,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#4f13603b18ab5fdb5ca87ab77ca35cf89045d06a",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#eb47c6ecbecb870ddaade2b9590dd3c2e93cfdf5",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1445,7 +1445,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#4f13603b18ab5fdb5ca87ab77ca35cf89045d06a",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#eb47c6ecbecb870ddaade2b9590dd3c2e93cfdf5",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -86,7 +86,7 @@
                             },
                             "readable-stream": {
                               "version": "2.0.6",
-                              "from": "readable-stream@>=2.0.0 <2.1.0",
+                              "from": "readable-stream@>=2.0.5 <2.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                               "dependencies": {
                                 "core-util-is": {
@@ -964,7 +964,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
@@ -1010,7 +1010,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
@@ -1150,7 +1150,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#eb47c6ecbecb870ddaade2b9590dd3c2e93cfdf5",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#9b01ba87f03003f339ef50bf13d1d995c60e908e",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1286,7 +1286,7 @@
             "torque.js": {
               "version": "2.15.2",
               "from": "cartodb/torque#master",
-              "resolved": "git://github.com/cartodb/torque.git#fca222a05bdaa0073c3f6ecaa5aa486ed932420f",
+              "resolved": "git://github.com/cartodb/torque.git#47f02ce23d6f5de5c26c6bb891f67828ea116338",
               "dependencies": {
                 "carto": {
                   "version": "0.15.1-cdb1",
@@ -1445,7 +1445,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#eb47c6ecbecb870ddaade2b9590dd3c2e93cfdf5",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#9b01ba87f03003f339ef50bf13d1d995c60e908e",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1586,7 +1586,7 @@
         "torque.js": {
           "version": "2.15.2",
           "from": "cartodb/torque#master",
-          "resolved": "git://github.com/cartodb/torque.git#fca222a05bdaa0073c3f6ecaa5aa486ed932420f",
+          "resolved": "git://github.com/cartodb/torque.git#47f02ce23d6f5de5c26c6bb891f67828ea116338",
           "dependencies": {
             "carto": {
               "version": "0.15.1-cdb1",
@@ -1808,7 +1808,7 @@
     "torque.js": {
       "version": "2.15.2",
       "from": "cartodb/torque#master",
-      "resolved": "git://github.com/cartodb/torque.git#fca222a05bdaa0073c3f6ecaa5aa486ed932420f",
+      "resolved": "git://github.com/cartodb/torque.git#47f02ce23d6f5de5c26c6bb891f67828ea116338",
       "dependencies": {
         "carto": {
           "version": "0.15.1-cdb1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.3.24",
+  "version": "4.3.33",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -1145,12 +1145,12 @@
     "cartodb-deep-insights.js": {
       "version": "0.0.2",
       "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#85702d8c9b98417d9c19ad7a9e9da5720954d695",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#749dd786f626f384a5bbb97cbaa15e88a935b2e3",
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#1937ab3bd024acdf74d7501ee3746ed5ab30ab97",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#4f13603b18ab5fdb5ca87ab77ca35cf89045d06a",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1445,7 +1445,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#1937ab3bd024acdf74d7501ee3746ed5ab30ab97",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#4f13603b18ab5fdb5ca87ab77ca35cf89045d06a",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",

--- a/spec/requests/carto/api/legends_controller_spec.rb
+++ b/spec/requests/carto/api/legends_controller_spec.rb
@@ -73,6 +73,24 @@ module Carto
         }
       end
 
+      let(:custom_choropleth_legend_payload) do
+        {
+          pre_html: "<h3>Es acaso</h3>",
+          post_html: "<h3>el mejor artista del mundo?</h3>",
+          title: "La verdad",
+          type: "custom_choropleth",
+          definition: {
+            prefix: "123",
+            suffix: "foo",
+            colors: [
+              { color: '#fff' },
+              { color: '#fabada' },
+              { color: '#CCC' }
+            ]
+          }
+        }
+      end
+
       let(:fake_uuid) { 'aaaaaaaa-0000-bbbb-1111-cccccccccccc' }
 
       before(:all) do
@@ -190,6 +208,10 @@ module Carto
           it 'for choropleth' do
             @payload = choropleth_legend_payload
           end
+
+          it 'for custom_choropleth' do
+            @payload = custom_choropleth_legend_payload
+          end
         end
 
         describe 'with spammy definitions' do
@@ -224,6 +246,10 @@ module Carto
 
           it 'banned for choropleth' do
             @payload = choropleth_legend_payload
+          end
+
+          it 'banned for custom_choropleth' do
+            @payload = custom_choropleth_legend_payload
           end
         end
 


### PR DESCRIPTION
This PR fixes #10224 and fixes #10247

![category-map](https://cloud.githubusercontent.com/assets/1366843/19528138/2ac621ee-962b-11e6-9b7c-adbd74f729b3.gif)

We look at quantification in order to generate color legends.

![custom-choropleth](https://cloud.githubusercontent.com/assets/1366843/19527992/8fec35f0-962a-11e6-8d73-fe493d981156.gif)

It implements a custom choropleth legend in builder side. The form associated is the same as a regular choropleth, keeping the prefix and suffix fields. Could you confirm @saleiva?

Also, I've observed some race conditions when changing the map aggregation carousel. In order to minimize them, a buffer strategy is implemented between the saving in the backend and operating with the legend model.

CR @xavijam 