### PR TITLE
Fix mapzen_routing_quota default being replaced by 0

### DIFF
--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -289,7 +289,7 @@ class Carto::User < ActiveRecord::Base
     if organization.present?
       remaining = organization.remaining_mapzen_routing_quota(options)
     else
-      remaining = mapzen_routing_quota - get_mapzen_routing_calls(options)
+      remaining = mapzen_routing_quota.to_i - get_mapzen_routing_calls(options)
     end
     (remaining > 0 ? remaining : 0)
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -53,7 +53,7 @@ class Organization < Sequel::Model
   DEFAULT_HERE_ISOLINES_QUOTA = 0
   DEFAULT_OBS_SNAPSHOT_QUOTA = 0
   DEFAULT_OBS_GENERAL_QUOTA = 0
-  DEFAULT_MAPZEN_ROUTING_QUOTA = 0
+  DEFAULT_MAPZEN_ROUTING_QUOTA = nil
 
   def validate
     super
@@ -65,8 +65,6 @@ class Organization < Sequel::Model
     validates_integer :here_isolines_quota, allow_nil: false, message: 'here_isolines_quota cannot be nil'
     validates_integer :obs_snapshot_quota, allow_nil: false, message: 'obs_snapshot_quota cannot be nil'
     validates_integer :obs_general_quota, allow_nil: false, message: 'obs_general_quota cannot be nil'
-    validates_integer :mapzen_routing_quota, allow_nil: false, message: 'mapzen_routing_quota cannot be nil'
-
 
     if default_quota_in_bytes
       errors.add(:default_quota_in_bytes, 'Default quota must be positive') if default_quota_in_bytes <= 0
@@ -264,7 +262,7 @@ class Organization < Sequel::Model
   end
 
   def remaining_mapzen_routing_quota
-    remaining = mapzen_routing_quota - get_mapzen_routing_calls
+    remaining = mapzen_routing_quota.to_i - get_mapzen_routing_calls
     (remaining > 0 ? remaining : 0)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,7 +92,7 @@ class User < Sequel::Model
 
   DEFAULT_GEOCODING_QUOTA = 0
   DEFAULT_HERE_ISOLINES_QUOTA = 0
-  DEFAULT_MAPZEN_ROUTING_QUOTA = 0
+  DEFAULT_MAPZEN_ROUTING_QUOTA = nil
   DEFAULT_OBS_SNAPSHOT_QUOTA = 0
   DEFAULT_OBS_GENERAL_QUOTA = 0
 
@@ -143,7 +143,6 @@ class User < Sequel::Model
     errors.add(:here_isolines_quota, "cannot be nil") if here_isolines_quota.nil?
     errors.add(:obs_snapshot_quota, "cannot be nil") if obs_snapshot_quota.nil?
     errors.add(:obs_general_quota, "cannot be nil") if obs_general_quota.nil?
-    errors.add(:mapzen_routing_quota, "cannot be nil") if mapzen_routing_quota.nil?
   end
 
   def organization_validation
@@ -1089,7 +1088,7 @@ class User < Sequel::Model
     if organization.present?
       remaining = organization.remaining_mapzen_routing_quota
     else
-      remaining = mapzen_routing_quota - get_mapzen_routing_calls
+      remaining = mapzen_routing_quota.to_i - get_mapzen_routing_calls
     end
     (remaining > 0 ? remaining : 0)
   end


### PR DESCRIPTION
Two kind of fixes here:
* Applying to_i when a numerical quota value is needed (so the default nil is taken as 0)
* Not requiring a non null quota for users/orgs and avoiding setting a default of 0 before saving