### PR TITLE
Fixes analysis error tooltip

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/analyses-tooltip-error.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/analyses-tooltip-error.js
@@ -1,25 +1,24 @@
 var $ = require('jquery');
+var cdb = require('cartodb.js');
+var CoreView = require('backbone/core-view');
 var TipsyTooltipView = require('../../../components/tipsy-tooltip-view.js');
 
-var AnalysisTooltip = {
-  track: function (analysisNode, element, triggerSelector) {
-    this.$el = element;
-    this.selector = triggerSelector;
-    this.analysisNode = analysisNode;
+module.exports = CoreView.extend({
+  initialize: function (opts) {
+    if (!opts.analysisNode) throw new Error('analysisNode is required');
+    if (!opts.element) throw new Error('element is required');
+    if (!opts.triggerSelector) throw new Error('triggerSelector is required');
 
-    this.$el.on('mouseover', this.selector, this.showTooltip.bind(this));
-    this.$el.on('mouseout', this.selector, this.destroyTooltip.bind(this));
-    this.$el.on('mouseleave', this.selector, this.destroyTooltip.bind(this));
+    this.analysisNode = opts.analysisNode;
+    this.$el = opts.element;
+    this.selector = opts.triggerSelector;
+
+    this.$el.on('mouseover', this.selector, this._showTooltip.bind(this));
+    this.$el.on('mouseout', this.selector, this._destroyTooltip.bind(this));
+    this.$el.on('mouseleave', this.selector, this._destroyTooltip.bind(this));
   },
 
-  destroy: function () {
-    this.$el.off('mouseover', this.selector);
-    this.$el.off('mouseout', this.selector);
-    this.$el.off('mouseleave', this.selector);
-    this.destroyTooltip();
-  },
-
-  showTooltip: function (e) {
+  _showTooltip: function (e) {
     var status = this.analysisNode.get('status');
     var error = this.analysisNode.get('error');
     var message;
@@ -36,7 +35,7 @@ var AnalysisTooltip = {
 
       $el = $(e.target);
 
-      this.tooltip = this.createTooltip({
+      this.tooltip = this._createTooltip({
         $el: $el,
         msg: message
       });
@@ -45,7 +44,7 @@ var AnalysisTooltip = {
     }
   },
 
-  createTooltip: function (opts) {
+  _createTooltip: function (opts) {
     return new TipsyTooltipView({
       el: opts.$el,
       title: function () {
@@ -54,12 +53,20 @@ var AnalysisTooltip = {
     });
   },
 
-  destroyTooltip: function () {
+  _destroyTooltip: function () {
     if (this.tooltip) {
       this.tooltip.hideTipsy();
       this.tooltip.destroyTipsy();
+      delete this.tooltip;
     }
-  }
-};
+  },
 
-module.exports = AnalysisTooltip;
+  clean: function () {
+    this.$el.off('mouseover', this.selector);
+    this.$el.off('mouseout', this.selector);
+    this.$el.off('mouseleave', this.selector);
+
+    this._destroyTooltip();
+    cdb.core.View.prototype.clean.call(this);
+  }
+});

--- a/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/default-layer-analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/analysis-views/default-layer-analysis-view.js
@@ -14,6 +14,7 @@ module.exports = CoreView.extend({
 
   tagName: 'li',
   className: 'Editor-ListAnalysis-item Editor-ListAnalysis-layer CDB-Text is-semibold CDB-Size-small js-analysis-node',
+
   initialize: function (opts) {
     if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
     if (!opts.analysisNode) throw new Error('analysisNode is required');
@@ -24,7 +25,13 @@ module.exports = CoreView.extend({
     this._analysisNode.on('change:status', this.render, this);
     this.add_related_model(this._analysisNode);
 
-    AnalysisTooltip.track(this._analysisNode, this.$el, '.Editor-ListAnalysis-itemError');
+    this._analysisTooltip = new AnalysisTooltip({
+      analysisNode: this._analysisNode,
+      element: this.$el,
+      triggerSelector: '.Editor-ListAnalysis-itemError'
+    });
+
+    this.addView(this._analysisTooltip);
   },
 
   render: function () {
@@ -47,10 +54,5 @@ module.exports = CoreView.extend({
   _bgColor: function () {
     var letter = nodeIds.letter(this._analysisNode.id);
     return layerColors.getColorForLetter(letter);
-  },
-
-  clean: function () {
-    AnalysisTooltip.destroy();
-    CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -24,7 +24,13 @@ module.exports = CoreView.extend({
     this._analysisNode.on('change:status', this.render, this);
     this.add_related_model(this._analysisNode);
 
-    AnalysisTooltip.track(this._analysisNode, this.$el, '.Editor-ListAnalysis-itemError');
+    this._analysisTooltip = new AnalysisTooltip({
+      analysisNode: this._analysisNode,
+      element: this.$el,
+      triggerSelector: '.Editor-ListAnalysis-itemError'
+    });
+
+    this.addView(this._analysisTooltip);
   },
 
   render: function () {
@@ -57,10 +63,5 @@ module.exports = CoreView.extend({
 
   _onNodeClick: function () {
     this._viewModel.set('selectedNodeId', this._analysisNode.id);
-  },
-
-  clean: function () {
-    AnalysisTooltip.destroy();
-    CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/analysis-tooltip-error.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/analysis-view/analysis-tooltip-error.spec.js
@@ -1,14 +1,12 @@
-var AnalysisTooltip = require('../../../../../../javascripts/cartodb3/editor/layers/analysis-views/analyses-tooltip-error');
 var $ = require('jquery');
+var AnalysisTooltip = require('../../../../../../javascripts/cartodb3/editor/layers/analysis-views/analyses-tooltip-error');
 
 describe('editor/layers/analysis-views/analysis-tooltip-error', function () {
-  var view;
-  var analysisNode;
-
   beforeEach(function () {
-    view = $('<div></div>');
+    this.view = $('<div class="view"><div class="Error" style="width:10px; height: 10px; background: red; "></div></div>');
+    $('body').append(this.view);
 
-    analysisNode = {
+    this.analysisNode = {
       get: function (what) {
         if (what === 'status') return 'failed';
         if (what === 'error') return false;
@@ -16,30 +14,30 @@ describe('editor/layers/analysis-views/analysis-tooltip-error', function () {
       }
     };
 
-    spyOn(AnalysisTooltip, 'showTooltip').and.callThrough();
-    spyOn(AnalysisTooltip, 'destroyTooltip').and.callThrough();
-    spyOn(AnalysisTooltip, 'createTooltip').and.callThrough();
-
-    AnalysisTooltip.track(analysisNode, view, null);
-  });
-
-  it('should create the tooltip on mouseover', function () {
-    view.trigger('mouseover');
-    expect(AnalysisTooltip.showTooltip).toHaveBeenCalled();
-    expect(AnalysisTooltip.createTooltip).toHaveBeenCalled();
-    expect(AnalysisTooltip.tooltip).toBeDefined();
-  });
-
-  it('should destroy the tooltip on mouseout', function () {
-    view.trigger('mouseover');
-    expect(AnalysisTooltip.tooltip).toBeDefined();
-    view.trigger('mouseout');
-    expect(AnalysisTooltip.destroyTooltip).toHaveBeenCalled();
+    this._analysisTooltip = new AnalysisTooltip({
+      analysisNode: this.analysisNode,
+      element: this.view,
+      triggerSelector: '.Error'
+    });
   });
 
   it('should not have any leaks', function () {
-    AnalysisTooltip.destroy();
-    view.trigger('mouseover');
-    expect(AnalysisTooltip.showTooltip).not.toHaveBeenCalled();
+    expect(this._analysisTooltip).toHaveNoLeaks();
+  });
+
+  it('should create the tooltip on mouseover', function () {
+    this.view.find('.Error').trigger('mouseover');
+    expect(this._analysisTooltip.tooltip).toBeDefined();
+  });
+
+  it('should destroy the tooltip on mouseout', function () {
+    this.view.find('.Error').trigger('mouseover');
+    expect(this._analysisTooltip.tooltip).toBeDefined();
+    this.view.find('.Error').trigger('mouseout');
+    expect(this._analysisTooltip.tooltip).not.toBeDefined();
+  });
+
+  afterEach(function () {
+    $('.view').remove();
   });
 });


### PR DESCRIPTION
Closes #10222 

![screen shot 2016-10-24 at 14 07 38](https://cloud.githubusercontent.com/assets/4933/19645077/45c54170-99f3-11e6-906b-4a6dce832f5e.png)

This PR fixes an issue with the error tooltip of the analyses. The problem with the original code was that each time the object `AnalysisTooltip` [was used](https://github.com/CartoDB/cartodb/pull/10311/files#diff-e9bc12d36aa74c9775586d3b37b1a9aaL27), the status message was being overwritten (we weren't creating a new instance, but using the same object every time). 

The solution is transform the object to a regular Backbone view and create a new instance when needed. This way, every tooltip is independent and linked to each analysis.