### PR TITLE
Fixes an issue that prevented running an analysis after an error

### DIFF
--- a/lib/assets/javascripts/cartodb3/analysis-notifications.js
+++ b/lib/assets/javascripts/cartodb3/analysis-notifications.js
@@ -87,16 +87,20 @@ var AnalysisNotifications = {
     var message = _t('notifications.analysis.failed', {
       nodeId: analysisNode.get('id').toUpperCase()
     });
+
     var error = analysisNode.get('error');
-    if (error && error.message) {
-      message += ': ' + error.message;
+
+    if ((error && error.message) || analysisNode.get('error_message')) {
+      message += ': ' + ((error && error.message) || analysisNode.get('error_message'));
     }
+
     var notificationAttrs = {
       status: 'error',
       info: message,
       closable: true,
       delay: DEFAULT_DELAY
     };
+
     this._addOrUpdateNotification(analysisNode.cid, notificationAttrs);
   },
 

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-node-model.js
@@ -111,6 +111,10 @@ module.exports = Backbone.Model.extend({
     return this.hasPrimarySource();
   },
 
+  hasFailed: function () {
+    return this.get('status') === 'failed';
+  },
+
   isDone: function () {
     return this.get('status') === 'ready';
   },

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -184,7 +184,7 @@ module.exports = CoreView.extend({
   },
 
   _canSave: function () {
-    var isAnalysisDone = this._analysisNode && this._analysisNode.isDone() || false;
+    var isAnalysisDone = this._analysisNode && (this._analysisNode.isDone() || this._analysisNode.hasFailed());
     var isDone = this._viewModel.get('isNewAnalysis') || isAnalysisDone;
     var hasChanges = this._viewModel.get('hasChanges');
     return this._formModel.isValid() && isDone && hasChanges;

--- a/lib/assets/test/jasmine/cartodb3/analysis-notifications.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/analysis-notifications.spec.js
@@ -151,18 +151,35 @@ describe('AnalysisNotifications.track', function () {
         });
       });
 
-      it('should update the notification if analysis failed and has errors', function () {
-        this.analysisNode.set({
-          'error': { message: 'something went wrong!' },
-          'status': 'failed'
+      describe('when an analysis node has errors', function () {
+        it('should update the notification if analysis failed and has errors', function () {
+          this.analysisNode.set({
+            'error': { message: 'something went wrong!' },
+            'status': 'failed'
+          });
+
+          expect(Notifier.addNotification).toHaveBeenCalledWith({
+            status: 'error',
+            info: 'notifications.analysis.failed: something went wrong!',
+            closable: true,
+            delay: Notifier.DEFAULT_DELAY,
+            id: this.analysisNode.cid
+          });
         });
 
-        expect(Notifier.addNotification).toHaveBeenCalledWith({
-          status: 'error',
-          info: 'notifications.analysis.failed: something went wrong!',
-          closable: true,
-          delay: Notifier.DEFAULT_DELAY,
-          id: this.analysisNode.cid
+        it('should update the notification if analysis failed and has errors in error_message', function () {
+          this.analysisNode.set({
+            'error_message': 'something went a little bit wrong!',
+            'status': 'failed'
+          });
+
+          expect(Notifier.addNotification).toHaveBeenCalledWith({
+            status: 'error',
+            info: 'notifications.analysis.failed: something went a little bit wrong!',
+            closable: true,
+            delay: Notifier.DEFAULT_DELAY,
+            id: this.analysisNode.cid
+          });
         });
       });
     });

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
@@ -8,6 +8,10 @@ var analyses = require('../../../../../../../javascripts/cartodb3/data/analyses'
 describe('editor/layers/layer-content-view/analyses/analysis-controls-view', function () {
   beforeEach(function () {
     this.analysisNode = new Backbone.Model();
+    this.analysisNode.hasFailed = function () {
+      return this.analysisNode.get('status') === 'failed';
+    }.bind(this);
+
     this.analysisNode.isDone = function () {
       return this.analysisNode.get('status');
     }.bind(this);
@@ -98,6 +102,30 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
       describe('when save button is clicked', function () {
         beforeEach(function () {
           this.analysisNode.set('status', 'ready');
+          this.view.$('.js-save').click();
+        });
+
+        it('should save changes', function () {
+          expect(this.userActions.saveAnalysis).toHaveBeenCalledWith(this.formModel);
+        });
+      });
+    });
+
+    describe('when the analysis failed', function () {
+      beforeEach(function () {
+        this.formModel.isValid.and.returnValue(true);
+        this.formModel.set('foo', 'just to trigger re-render');
+      });
+
+      it('should enable button when analysis node\'s status is ready', function () {
+        expect(this.view.$el.html()).toContain('is-disabled');
+        this.analysisNode.set('status', 'failed');
+        expect(this.view.$el.html()).not.toContain('is-disabled');
+      });
+
+      describe('when save button is clicked', function () {
+        beforeEach(function () {
+          this.analysisNode.set('status', 'failed');
           this.view.$('.js-save').click();
         });
 


### PR DESCRIPTION
Closes #10280

This PR fixes one of the reported errors: 
> I would like to apply the analysis with different parameters, with and without reloading the builder.
> I would like to see the failed status error message without reloading.

Please, read this thread to understand the reason of the second issue and the solution to fix it.