### PR TITLE
NULL version maps should be published

### DIFF
--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -325,7 +325,7 @@ class Carto::VisualizationQueryBuilder
       query = query.where(%{
             visualizations.privacy <> '#{Carto::Visualization::PRIVACY_PRIVATE}'
         and (
-               visualizations.version <> #{Carto::Visualization::VERSION_BUILDER}
+               ((visualizations.version <> #{Carto::Visualization::VERSION_BUILDER}) or (visualizations.version is null))
             or
                visualizations.type <> '#{Carto::Visualization::TYPE_DERIVED}'
             or

--- a/spec/queries/carto/visualization_query_builder_spec.rb
+++ b/spec/queries/carto/visualization_query_builder_spec.rb
@@ -352,6 +352,18 @@ describe Carto::VisualizationQueryBuilder do
       destroy_full_visualization(map, table, table_visualization, visualization)
     end
 
+    it 'selects nil version maps' do
+      map, table, table_visualization, visualization = create_full_visualization(@carto_user1, visualization_attributes: { version: nil, privacy: Carto::Visualization::PRIVACY_PUBLIC })
+
+      visualization.update_column(:version, nil)
+
+      visualizations = @vqb.with_published.build
+      visualization.published?.should be true
+      visualizations.map(&:id).should include visualization.id
+
+      destroy_full_visualization(map, table, table_visualization, visualization)
+    end
+
     it 'selects public v3 datasets' do
       map, table, table_visualization, visualization = create_full_visualization(@carto_user1, visualization_attributes: { version: 3, privacy: Carto::Visualization::PRIVACY_PUBLIC, type: Carto::Visualization::TYPE_CANONICAL })
 


### PR DESCRIPTION
@javitonino CR this, please. We were probably misled on tests by model defaults. Setting `visualization.version = nil` won't clear it. I had to force it with `update_column` for test to fail.