### PR TITLE
9984 show hide named map layers

### DIFF
--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -41,6 +41,7 @@ module Carto
               dataviews: dataviews,
               analyses: analyses_definitions
             },
+            preview_layers: preview_layers,
             view: view
           }
         end
@@ -193,6 +194,10 @@ module Carto
 
       def analyses_definitions
         @visualization.analyses.map(&:analysis_definition_for_api)
+      end
+
+      def preview_layers
+        []
       end
 
       def stats_aggregator

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -197,7 +197,13 @@ module Carto
       end
 
       def preview_layers
-        []
+        preview_layers = {}
+
+        @visualization.carto_and_torque_layers.each do |layer|
+          preview_layers[:"#{layer.id}"] = layer.options[:visible] || false
+        end
+
+        preview_layers
       end
 
       def stats_aggregator

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -619,8 +619,6 @@ module Carto
           end
 
           it 'should generate preview_layers correctly' do
-            @preview_layers[0].key.should eq @visualization.data_layers.first
-
             @visualization.data_layers.each_with_index do |layer, index|
               expected_visibility = {
                 "#{layer.id}": layer.options[:visible]

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -596,6 +596,41 @@ module Carto
           end
         end
 
+        describe '#preview_layers' do
+          before(:all) do
+            template = Carto::NamedMaps::Template.new(@visualization)
+            @preview_layers = template.to_hash[:preview_layers]
+          end
+
+          after(:all) do
+            @preview_layers = nil
+          end
+
+          it 'should contain preview_layers' do
+            @preview_layers.should be
+          end
+
+          it 'should not generate preview_layers for basemaps' do
+            preview_layers_ids = @preview_layers.map(&:keys).flatten
+
+            @visualization.base_layers.map(&:id).each do |id|
+              preview_layers_ids.should_not include(id)
+            end
+          end
+
+          it 'should generate preview_layers correctly' do
+            @preview_layers[0].key.should eq @visualization.data_layers.first
+
+            @visualization.data_layers.each_with_index do |layer, index|
+              expected_visibility = {
+                "#{layer.id}": layer.options[:visible]
+              }
+
+              @preview_layers[index].should eq expected_visibility
+            end
+          end
+        end
+
         describe '#analyses' do
           before(:all) do
             @analysis = FactoryGirl.create(:source_analysis, visualization_id: @visualization.id, user_id: @user.id)


### PR DESCRIPTION
Fixes #9984

Adds visibility options using the new `preview_layers` (previously placeholders were used) as described in https://github.com/CartoDB/Windshaft-cartodb/blob/master/docs/named_maps.md.

Please CR @juanignaciosl 

cc/ @dgaubert 