### PR TITLE
Don't require user for viewer check

### DIFF
--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -206,7 +206,7 @@ class UserTable < Sequel::Model
   end
 
   def before_destroy
-    raise CartoDB::InvalidMember.new(user: "Viewer users can't destroy tables") if user.viewer
+    raise CartoDB::InvalidMember.new(user: "Viewer users can't destroy tables") if user && user.viewer
     service.before_destroy
     super
   end


### PR DESCRIPTION
@gfiorav As we don't enforce `user_tables` -> `users` relationship I think that the proper fix is not failing because of a simple viewer check. CR?