### PR TITLE
Avoid relaunching the analysis onboarding by interacting with a widget

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
@@ -16,6 +16,8 @@ module.exports = Backbone.Model.extend({
   initialize: function (attrs, opts) {
     if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
 
+    this.USER_SAVED = false;
+
     this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
   },
 

--- a/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/analysis-definition-model.js
@@ -16,7 +16,7 @@ module.exports = Backbone.Model.extend({
   initialize: function (attrs, opts) {
     if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
 
-    this.USER_SAVED = false;
+    this.USER_SAVED = false; // flag to indicate if the user saved the node and avoid triggering the onboarding model if they didn't
 
     this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
   },

--- a/lib/assets/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/javascripts/cartodb3/data/user-actions.js
@@ -178,6 +178,7 @@ module.exports = function (params) {
       var nodeDefModel = analysisDefinitionNodesCollection.get(analysisFormModel.id);
 
       if (nodeDefModel) {
+        nodeDefModel.USER_SAVED = true;
         analysisFormModel.updateNodeDefinition(nodeDefModel);
         var layerDefModel = layerDefinitionsCollection.findOwnerOfAnalysisNode(nodeDefModel);
         analysisDefinitionsCollection.saveAnalysisForLayer(layerDefModel);

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -195,8 +195,9 @@ F.prototype._tryToSetupDefinitionNodeSync = function (m) {
     m.listenTo(node, 'change:status', function (model, status) {
       m.set('status', status);
 
-      if (status === 'ready') {
+      if (status === 'ready' && m.USER_SAVED) {
         AnalysisOnboardingLauncher.launch(node.get('type'), model);
+        delete m.USER_SAVED;
       }
     });
 

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -197,7 +197,7 @@ F.prototype._tryToSetupDefinitionNodeSync = function (m) {
 
       if (status === 'ready' && m.USER_SAVED) {
         AnalysisOnboardingLauncher.launch(node.get('type'), model);
-        delete m.USER_SAVED;
+        m.USER_SAVED = false;
       }
     });
 

--- a/lib/assets/test/spec/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/user-actions.spec.js
@@ -357,6 +357,11 @@ describe('cartodb3/data/user-actions', function () {
           expect(this.analysisDefinitionsCollection.pluck('node_id')).toEqual(['a1']);
           expect(this.layerAnalysis.save).toHaveBeenCalled();
         });
+
+        it('should set the USER_SAVED flag', function () {
+          var node = this.analysisDefinitionNodesCollection.get('a1');
+          expect(node.USER_SAVED).toBeTruthy();
+        });
       });
     });
   });

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -59,6 +59,9 @@ describe('deep-insights-integrations', function () {
       };
     });
 
+    spyOn(AnalysisOnboardingLauncher, 'launch');
+    spyOn(AnalysisOnboardingLauncher, 'init');
+
     var configModel = new ConfigModel({
       base_url: 'pepito'
     });
@@ -698,10 +701,6 @@ describe('deep-insights-integrations', function () {
         it('should not affect the query-schema-model if its a source', function () {
           expect(this.a0.querySchemaModel.set).not.toHaveBeenCalled();
         });
-
-        it('should not reset styles if layer doesn\'t have none styles', function () {
-          expect(this.layerDefModel.styleModel.setDefaultPropertiesByType).not.toHaveBeenCalled();
-        });
       });
 
       describe('when analysis-definition-node is removed', function () {
@@ -739,10 +738,6 @@ describe('deep-insights-integrations', function () {
 
       describe('when analysis node has finished executing', function () {
         beforeEach(function () {
-
-          spyOn(AnalysisOnboardingLauncher, 'launch');
-          spyOn(AnalysisOnboardingLauncher, 'init');
-
           this.node = this.analysisDefinitionNodesCollection.get('a1');
           this.node.USER_SAVED = true;
           this.analysis.findNodeById('a1').set({

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -59,9 +59,6 @@ describe('deep-insights-integrations', function () {
       };
     });
 
-    spyOn(AnalysisOnboardingLauncher, 'launch');
-    spyOn(AnalysisOnboardingLauncher, 'init');
-
     var configModel = new ConfigModel({
       base_url: 'pepito'
     });
@@ -705,7 +702,6 @@ describe('deep-insights-integrations', function () {
         it('should not reset styles if layer doesn\'t have none styles', function () {
           expect(this.layerDefModel.styleModel.setDefaultPropertiesByType).not.toHaveBeenCalled();
         });
-
       });
 
       describe('when analysis-definition-node is removed', function () {
@@ -743,6 +739,10 @@ describe('deep-insights-integrations', function () {
 
       describe('when analysis node has finished executing', function () {
         beforeEach(function () {
+
+          spyOn(AnalysisOnboardingLauncher, 'launch');
+          spyOn(AnalysisOnboardingLauncher, 'init');
+
           this.node = this.analysisDefinitionNodesCollection.get('a1');
           this.node.USER_SAVED = true;
           this.analysis.findNodeById('a1').set({

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var Backbone = require('backbone');
 var ConfigModel = require('../../../javascripts/cartodb3/data/config-model');
 var deepInsights = require('cartodb-deep-insights.js');
+var AnalysisOnboardingLauncher = require('../../../javascripts/cartodb3/components/onboardings/analysis/analysis-launcher');
 var AnalysisDefinitionNodesCollection = require('../../../javascripts/cartodb3/data/analysis-definition-nodes-collection');
 var AnalysisDefinitionsCollection = require('../../../javascripts/cartodb3/data/analysis-definitions-collection');
 var DeepInsightsIntegrations = require('../../../javascripts/cartodb3/deep-insights-integrations');
@@ -57,6 +58,9 @@ describe('deep-insights-integrations', function () {
         func.apply(this, arguments);
       };
     });
+
+    spyOn(AnalysisOnboardingLauncher, 'launch');
+    spyOn(AnalysisOnboardingLauncher, 'init');
 
     var configModel = new ConfigModel({
       base_url: 'pepito'
@@ -697,6 +701,11 @@ describe('deep-insights-integrations', function () {
         it('should not affect the query-schema-model if its a source', function () {
           expect(this.a0.querySchemaModel.set).not.toHaveBeenCalled();
         });
+
+        it('should not reset styles if layer doesn\'t have none styles', function () {
+          expect(this.layerDefModel.styleModel.setDefaultPropertiesByType).not.toHaveBeenCalled();
+        });
+
       });
 
       describe('when analysis-definition-node is removed', function () {
@@ -730,6 +739,22 @@ describe('deep-insights-integrations', function () {
         expect(this.a1.querySchemaModel.get('query')).toEqual(undefined);
         expect(this.a1.queryGeometryModel.get('query')).toEqual(undefined);
         expect(this.a1.queryGeometryModel.get('ready')).toBe(false);
+      });
+
+      describe('when analysis node has finished executing', function () {
+        beforeEach(function () {
+          this.node = this.analysisDefinitionNodesCollection.get('a1');
+          this.node.USER_SAVED = true;
+          this.analysis.findNodeById('a1').set({
+            query: 'SELECT buffer FROM tmp_result_table_123',
+            status: 'ready'
+          });
+        });
+
+        it('should launch the onboarding analysis if the user saved the node', function () {
+          expect(AnalysisOnboardingLauncher.launch).toHaveBeenCalled();
+          expect(this.node.USER_SAVED).toBeUndefined();
+        });
       });
 
       describe('when analysis node has finished executing', function () {

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -748,7 +748,7 @@ describe('deep-insights-integrations', function () {
 
         it('should launch the onboarding analysis if the user saved the node', function () {
           expect(AnalysisOnboardingLauncher.launch).toHaveBeenCalled();
-          expect(this.node.USER_SAVED).toBeUndefined();
+          expect(this.node.USER_SAVED).toBeFalsy();
         });
       });
 


### PR DESCRIPTION
Closes #10316 

This PR fixes an issue where an analysis onboarding appeared after a widget attached to the layer with the analysis was changed.

The difficulty of solving this issue is that both widgets and user interactions can trigger the analysis [changed binding](https://github.com/CartoDB/cartodb/compare/10316-onboarding-reopen?expand=1#diff-3d74f8298f087839dd188fe931ea5322L195), and we can't really guess which of them did it by just looking to the analysis node definition. 

The solution I propose is to set a flag (`USER_SAVED`) to indicate that the user updated the analysis. This way, anytime we need to show the onboarding, we can check that this flag was set (I'm using a flag instead of setting a property to the model to avoid storing it permanently in the model).

Are you OK with this approach @xavijam & @javisantana?