### PR TITLE
10321 batch queries statement timeout

### DIFF
--- a/app/models/carto/helpers/batch_queries_statement_timeout.rb
+++ b/app/models/carto/helpers/batch_queries_statement_timeout.rb
@@ -2,31 +2,31 @@
 
 module Carto
   module BatchQueriesStatementTimeout
-      def batch_queries_statement_timeout
-        if !defined?(@batch_queries_statement_timeout)
-          timeout_str = $users_metadata.HMGET(batch_limits_key, 'timeout').first
-          @batch_queries_statement_timeout = timeout_str.nil? ? nil : timeout_str.to_i
-        end
-        @batch_queries_statement_timeout
+    def batch_queries_statement_timeout
+      if !defined?(@batch_queries_statement_timeout)
+        timeout_str = $users_metadata.HMGET(batch_limits_key, 'timeout').first
+        @batch_queries_statement_timeout = timeout_str.nil? ? nil : timeout_str.to_i
       end
+      @batch_queries_statement_timeout
+    end
 
-      def batch_queries_statement_timeout=(timeout_ms)
-        unless !timeout_ms.present? || timeout_ms.to_i > 0
-          raise 'batch_queries_statement_timeout must be nil or an integer greater than 0'
-        end
-        if !timeout_ms.present?
-          # NOTE: nil is cast to the empty string in redis (""), which can be cast to 0 in
-          # the SQL API. In order to prevent undesired behavior, just delete this key.
-          @batch_queries_statement_timeout = nil
-          $users_metadata.HDEL batch_limits_key, 'timeout'
-        else
-          @batch_queries_statement_timeout = timeout_ms.to_i
-          $users_metadata.HMSET batch_limits_key, 'timeout', @batch_queries_statement_timeout
-        end
+    def batch_queries_statement_timeout=(timeout_ms)
+      unless !timeout_ms.present? || timeout_ms.to_i > 0
+        raise 'batch_queries_statement_timeout must be nil or an integer greater than 0'
       end
+      if !timeout_ms.present?
+        # NOTE: nil is cast to the empty string in redis (""), which can be cast to 0 in
+        # the SQL API. In order to prevent undesired behavior, just delete this key.
+        @batch_queries_statement_timeout = nil
+        $users_metadata.HDEL batch_limits_key, 'timeout'
+      else
+        @batch_queries_statement_timeout = timeout_ms.to_i
+        $users_metadata.HMSET batch_limits_key, 'timeout', @batch_queries_statement_timeout
+      end
+    end
 
-      def batch_limits_key
-        "limits:batch:#{username}"
-      end
+    def batch_limits_key
+      "limits:batch:#{username}"
+    end
   end
 end

--- a/app/models/carto/helpers/batch_queries_statement_timeout.rb
+++ b/app/models/carto/helpers/batch_queries_statement_timeout.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+
+module Carto
+  module BatchQueriesStatementTimeout
+      def batch_queries_statement_timeout
+        if !defined?(@batch_queries_statement_timeout)
+          timeout_str = $users_metadata.HMGET(batch_limits_key, 'timeout').first
+          @batch_queries_statement_timeout = timeout_str.nil? ? nil : timeout_str.to_i
+        end
+        @batch_queries_statement_timeout
+      end
+
+      def batch_queries_statement_timeout=(timeout_ms)
+        unless !timeout_ms.present? || timeout_ms.to_i > 0
+          raise 'batch_queries_statement_timeout must be nil or an integer greater than 0'
+        end
+        if !timeout_ms.present?
+          # NOTE: nil is cast to the empty string in redis (""), which can be cast to 0 in
+          # the SQL API. In order to prevent undesired behavior, just delete this key.
+          @batch_queries_statement_timeout = nil
+          $users_metadata.HDEL batch_limits_key, 'timeout'
+        else
+          @batch_queries_statement_timeout = timeout_ms.to_i
+          $users_metadata.HMSET batch_limits_key, 'timeout', @batch_queries_statement_timeout
+        end
+      end
+
+      def batch_limits_key
+        "limits:batch:#{username}"
+      end
+  end
+end

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -7,6 +7,7 @@ require_relative 'synchronization_oauth'
 require_relative '../../helpers/data_services_metrics_helper'
 require_dependency 'carto/helpers/auth_token_generator'
 require_dependency 'carto/helpers/has_connector_configuration'
+require_dependency 'carto/helpers/batch_queries_statement_timeout'
 
 # TODO: This probably has to be moved as the service of the proper User Model
 class Carto::User < ActiveRecord::Base
@@ -14,6 +15,7 @@ class Carto::User < ActiveRecord::Base
   include DataServicesMetricsHelper
   include Carto::AuthTokenGenerator
   include Carto::HasConnectorConfiguration
+  include Carto::BatchQueriesStatementTimeout
 
   MIN_PASSWORD_LENGTH = 6
   MAX_PASSWORD_LENGTH = 64

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -145,7 +145,7 @@ module Concerns
           attrs.delete(:organization_id)
           return attrs
         when :update
-          attrs[:batch_queries_statement_timeout] = self.batch_queries_statement_timeout
+          attrs[:batch_queries_statement_timeout] = batch_queries_statement_timeout
           attrs
         end
       end

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -95,6 +95,7 @@ module Concerns
          :period_end_date, :private_tables_enabled, :quota_in_bytes, :salt,
          :sync_tables_enabled, :table_quota, :twitter_username, :upgraded_at,
          :user_timeout, :username, :website, :soft_geocoding_limit,
+         :batch_queries_statement_timeout,
          :twitter_datasource_enabled, :twitter_datasource_block_size,
          :twitter_datasource_block_price, :twitter_datasource_quota,
          :soft_twitter_datasource_limit,
@@ -144,6 +145,7 @@ module Concerns
           attrs.delete(:organization_id)
           return attrs
         when :update
+          attrs[:batch_queries_statement_timeout] = self.batch_queries_statement_timeout
           attrs
         end
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ require_dependency 'cartodb/redis_vizjson_cache'
 require_dependency 'carto/bolt'
 require_dependency 'carto/helpers/auth_token_generator'
 require_dependency 'carto/helpers/has_connector_configuration'
+require_dependency 'carto/helpers/batch_queries_statement_timeout'
 
 class User < Sequel::Model
   include CartoDB::MiniSequel
@@ -29,6 +30,7 @@ class User < Sequel::Model
   include DataServicesMetricsHelper
   include Carto::AuthTokenGenerator
   include Carto::HasConnectorConfiguration
+  include Carto::BatchQueriesStatementTimeout
 
   self.strict_param_setting = false
 
@@ -1649,33 +1651,6 @@ class User < Sequel::Model
     builder_enabled? ? 3 : 2
   end
 
-  def batch_queries_statement_timeout
-    if !defined?(@batch_queries_statement_timeout)
-      timeout_str = $users_metadata.HMGET(batch_limits_key, 'timeout').first
-      @batch_queries_statement_timeout = timeout_str.nil? ? nil : timeout_str.to_i
-    end
-    @batch_queries_statement_timeout
-  end
-
-  def batch_queries_statement_timeout=(timeout_ms)
-    unless !timeout_ms.present? || timeout_ms.to_i > 0
-       raise 'batch_queries_statement_timeout must be nil or an integer greater than 0'
-    end
-    if !timeout_ms.present?
-      # NOTE: nil is cast to the empty string in redis (""), which can be cast to 0 in
-      # the SQL API. In order to prevent undesired behavior, just delete this key.
-      @batch_queries_statement_timeout = nil
-      $users_metadata.HDEL batch_limits_key, 'timeout'
-    else
-      @batch_queries_statement_timeout = timeout_ms.to_i
-      $users_metadata.HMSET batch_limits_key, 'timeout', @batch_queries_statement_timeout
-    end
-  end
-
-  def batch_limits_key
-    "limits:batch:#{username}"
-  end
-
   private
 
   def common_data_outdated?
@@ -1783,5 +1758,4 @@ class User < Sequel::Model
       db_service.connect_to_aggregation_tables
     end
   end
-
 end

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -581,8 +581,8 @@ shared_examples_for "user models" do
     end
 
     it 'synces with central upon update_to_central' do
-      cartodb_central_client_mock = mock()
-      cartodb_central_client_mock.expects(:update_user).once.with() { |username, attributes|
+      cartodb_central_client_mock = mock
+      cartodb_central_client_mock.expects(:update_user).once.with { |username, attributes|
         username == @user1.username && attributes[:batch_queries_statement_timeout] == 42
       }
       @user1.expects(:sync_data_with_cartodb_central?).once.returns(true)


### PR DESCRIPTION
This change uses redis as storage directly, avoiding duplication and potential de-syncing with the metadata DB. Therefore this PR does not require a migration.

Check how it is used from the batch api:
https://github.com/CartoDB/CartoDB-SQL-API/blob/861b9bb037c1c17a9c0cdd1c2c98839bc893978e/batch/job_runner.js#L65-L79

I can write a few tests for this but prefer to get a first pass through your :eyes: before going any further

@jgoizueta and/or @ethervoid can you please review?