### PR TITLE
Remove decimals from the min/max input values in the fill component

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
@@ -26,11 +26,13 @@ module.exports = CoreView.extend({
 
   _calculateRangeFromFixed: function (fixed, percent) {
     percent = percent || 30;
+
     var span = this.options.max - this.options.min;
     var delta = fixed / span;
+
     return [
-      +Math.max(this.options.min, fixed - percent * delta).toFixed(2),
-      +Math.min(this.options.max, fixed + percent * delta).toFixed(2)
+      Math.floor(Math.max(this.options.min, fixed - percent * delta)),
+      Math.floor(Math.min(this.options.max, fixed + percent * delta))
     ];
   },
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
@@ -29,8 +29,8 @@ module.exports = CoreView.extend({
     var span = this.options.max - this.options.min;
     var delta = fixed / span;
     return [
-      Math.max(this.options.min, fixed - percent * delta),
-      Math.min(this.options.max, fixed + percent * delta)
+      +Math.max(this.options.min, fixed - percent * delta).toFixed(2),
+      +Math.min(this.options.max, fixed + percent * delta).toFixed(2)
     ];
   },
 

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.spec.js
@@ -1,0 +1,39 @@
+var cdb = require('cartodb.js');
+var Backbone = require('backbone');
+var InputNumberContentView = require('../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view');
+
+describe('components/form-components/editors/fill/input-number/input-number-content-view', function () {
+  describe('on model with a range', function () {
+    beforeEach(function () {
+      this.model = new Backbone.Model({
+        bins: 7,
+        range: [1, 100],
+        attribute: 'age',
+        quantification: 'jenks',
+        selected: true,
+        type: 'size'
+      });
+
+      this.min = 1;
+      this.max = 45;
+
+      this.view = new InputNumberContentView({
+        stackLayoutModel: new cdb.core.Model(),
+        model: this.model,
+        min: this.min,
+        max: this.max
+      });
+
+      this.view.render();
+    });
+
+    it('should calculate the right range', function () {
+      var range = this.view._calculateRangeFromFixed(13.5);
+      expect(range).toEqual([4, 22]);
+    });
+
+    afterEach(function () {
+      this.view.remove();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #8011 

This PR remove decimals from the min/max input values in the fill component that were getting added because of [the method we use](https://github.com/CartoDB/cartodb/compare/8011-styles-decimals?expand=1#diff-535e96ef55f51f38739ebcb2373ecdc0L29) to calc those numbers from the fixed value in the form. 