### PR TITLE
Use correct SQL query when renaming dataset

### DIFF
--- a/lib/assets/javascripts/cartodb3/dataset/dataset-content/dataset-content-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-content/dataset-content-view.js
@@ -35,7 +35,7 @@ module.exports = CoreView.extend({
     this._tableModel.bind('change:name', function () {
       this._querySchemaModel.set({
         status: 'unfetched',
-        query: 'SELECT * FROM ' + this._tableModel.getUnquotedName()
+        query: this._defaultSQL()
       });
       this.render();
     }, this);
@@ -85,5 +85,17 @@ module.exports = CoreView.extend({
 
     this.addView(datasetContentOptionsView);
     this.$el.prepend(datasetContentOptionsView.render().el);
+  },
+
+  _defaultSQL: function () {
+    var tableName = this._tableModel.getUnqualifiedName();
+    var defaultQuery = 'SELECT * FROM ' + tableName;
+
+    if (this._userModel.isInsideOrg()) {
+      var userName = this._tableModel.get('permission').owner.username;
+      defaultQuery = SQLUtils.prependTableName(defaultQuery, tableName, userName);
+    }
+
+    return defaultQuery;
   }
 });

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-header/dataset-header-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-header/dataset-header-view.js
@@ -334,9 +334,8 @@ module.exports = CoreView.extend({
     var name = this._visModel.get('name');
     this._tableModel.set('name', name);
 
-    var resetQuery = 'SELECT * FROM ' + this._tableModel.getUnquotedName();
     this._layerDefinitionModel.save({
-      sql: resetQuery
+      sql: this._defaultSQL()
     });
 
     this._router.navigate(name, {
@@ -377,7 +376,7 @@ module.exports = CoreView.extend({
     document.title = this._tableModel.get('name') + TITLE_SUFFIX;
   },
 
-  _isCustomQueryApplied: function () {
+  _defaultSQL: function () {
     var tableName = this._tableModel.getUnqualifiedName();
     var defaultQuery = 'SELECT * FROM ' + tableName;
 
@@ -386,7 +385,11 @@ module.exports = CoreView.extend({
       defaultQuery = SQLUtils.prependTableName(defaultQuery, tableName, userName);
     }
 
-    return !SQLUtils.isSameQuery(defaultQuery, this._querySchemaModel.get('query'));
+    return defaultQuery;
+  },
+
+  _isCustomQueryApplied: function () {
+    return !SQLUtils.isSameQuery(this._defaultSQL(), this._querySchemaModel.get('query'));
   },
 
   _isEditable: function () {

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -105,7 +105,7 @@ module.exports = CoreView.extend({
   },
 
   _onChangeName: function (model, name) {
-    this._codemirrorModel.set('content', this._defaultSQL());
+    this._codemirrorModel.set('content', this._defaultSQL(model.get('name')));
   },
 
   _initViews: function () {
@@ -296,8 +296,8 @@ module.exports = CoreView.extend({
     this._runQuery(sql, this._saveSQL.bind(this));
   },
 
-  _defaultSQL: function () {
-    var tableName = this._tableModel.getUnqualifiedName();
+  _defaultSQL: function (tableName) {
+    tableName = tableName || this._tableModel.getUnqualifiedName();
     var defaultQuery = 'SELECT * FROM ' + tableName;
 
     if (this._userModel.isInsideOrg()) {

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -105,8 +105,7 @@ module.exports = CoreView.extend({
   },
 
   _onChangeName: function (model, name) {
-    var newContent = 'SELECT * FROM ' + model.get('name');
-    this._codemirrorModel.set('content', newContent);
+    this._codemirrorModel.set('content', this._defaultSQL());
   },
 
   _initViews: function () {


### PR DESCRIPTION
Fixes #10385 

Basically, resets to the correct SQL query when renaming datasets.