### PR TITLE
Sets 5 as the default bins count for the color-ramps input component too

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/default-fill-settings.json
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/default-fill-settings.json
@@ -2,28 +2,27 @@
   "number": {
     "quantifications": {
       "items": ["quantiles", "jenks", "equal", "headtails"],
-      "default_index": 0
+      "defaultIndex": 0
     },
     "bins": {
       "items": ["2", "3", "4", "5", "6", "7"],
-      "default_index": 3
+      "defaultIndex": 3
     }
   },
   "color": {
     "quantifications": {
       "items": ["jenks", "equal", "headtails", "quantiles", "category"],
-      "default_index": 0
+      "defaultIndex": 0
     }
   },
   "color-ramps": {
     "quantifications": {
       "items": ["quantiles", "jenks", "equal", "headtails", "category"],
-      "default_index": 0
+      "defaultIndex": 0
     },
     "bins": {
       "items": ["2", "3", "4", "5", "6", "7"],
-      "default_index": 3
+      "defaultIndex": 3
     }
   }
 }
-

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/default-fill-settings.json
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/default-fill-settings.json
@@ -22,7 +22,7 @@
     },
     "bins": {
       "items": ["2", "3", "4", "5", "6", "7"],
-      "default_index": 1
+      "default_index": 3
     }
   }
 }

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
@@ -30,11 +30,11 @@ module.exports = CoreView.extend({
     var options = {};
 
     if (!this.model.get('quantification')) {
-      options.quantification = this._settings.quantifications.items[this._settings.quantifications.default_index];
+      options.quantification = this._settings.quantifications.items[this._settings.quantifications.defaultIndex];
     }
 
     if (!this.model.get('bins')) {
-      options.bins = this._settings.bins.items[this._settings.bins.default_index];
+      options.bins = this._settings.bins.items[this._settings.bins.defaultIndex];
     }
 
     if (+this.model.get('bins') > +this._settings.bins.items[this._settings.bins.items.length - 1]) {

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
@@ -42,11 +42,11 @@ module.exports = CoreView.extend({
     var options = {};
 
     if (!this.model.get('quantification')) {
-      options.quantification = this._settings.quantifications.items[this._settings.quantifications.default_index];
+      options.quantification = this._settings.quantifications.items[this._settings.quantifications.defaultIndex];
     }
 
     if (!this.model.get('bins')) {
-      options.bins = this._settings.bins.items[this._settings.bins.default_index];
+      options.bins = this._settings.bins.items[this._settings.bins.defaultIndex];
     }
 
     if (+this.model.get('bins') > +this._settings.bins.items[this._settings.bins.items.length - 1]) {

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
@@ -25,8 +25,8 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
     });
 
     it('should pick a similar ramp when changing bins', function () {
-      this.model.set('bins', 3);
-      expect(this.model.get('range').join(',').toLowerCase()).toBe('#e7e1ef,#c994c7,#dd1c77');
+      this.model.set('bins', 5);
+      expect(this.model.get('range').join(',').toLowerCase()).toBe('#f1eef6,#d7b5d8,#df65b0,#dd1c77,#980043');
     });
 
     it('should refresh when the attribute is changed', function () {
@@ -52,7 +52,7 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
 
     it('should initialize the model with default values', function () {
       expect(this.model.get('quantification')).toBe('quantiles');
-      expect(this.model.get('bins')).toBe('3');
+      expect(this.model.get('bins')).toBe('5');
       expect(this.model.get('fixed')).toBe(undefined);
     });
 
@@ -93,8 +93,8 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
     });
 
     it('should set a default ramp list', function () {
-      expect(this.model.get('bins')).toBe('3');
-      expect(this.model.get('range').length).toBe(3);
+      expect(this.model.get('bins')).toBe('5');
+      expect(this.model.get('range').length).toBe(5);
     });
 
     afterEach(function () {


### PR DESCRIPTION
I misread [this issue](https://github.com/CartoDB/cartodb/issues/10357) and forgot to set the default value for the bins count to 5 for the color ramps. This PR fixes that (sorry, @makella).
