### PR TITLE
10440 template aware legend migrator

### DIFF
--- a/lib/carto/legend_migrator.rb
+++ b/lib/carto/legend_migrator.rb
@@ -47,8 +47,10 @@ module Carto
     HTML_RAMP_TYPES = %w(choropleth intensity density).freeze
 
     def definition_and_type
-      if type == 'custom'
-        definition_and_type_for_custom
+      if template.present?
+        [{ html: template }, 'html']
+      elsif type == 'custom'
+        [build_custom_definition_from_custom_type, 'custom']
       elsif type == 'category'
         [build_custom_definition_from_custom_type, 'custom']
       elsif type == 'bubble'
@@ -81,14 +83,6 @@ module Carto
       end
 
       { categories: categories }
-    end
-
-    def definition_and_type_for_custom
-      if template.present?
-        [{ html: template }, 'html']
-      else
-        [build_custom_definition_from_custom_type, 'custom']
-      end
     end
 
     def build_html_definition_from_ramp_type

--- a/spec/lib/carto/legend_migrator_spec.rb
+++ b/spec/lib/carto/legend_migrator_spec.rb
@@ -13,6 +13,49 @@ module Carto
       @layer.destroy
     end
 
+    describe('#with templates') do
+      let(:old_legend_with_template) do
+        {
+          "show_title" => false,
+          "title" => "",
+          "template" => "<h1>Manolo Escobar</h1>",
+          "visible" => true,
+          "items" => []
+        }
+      end
+
+      it 'should migrate to html for type custom' do
+        @old_legend = old_legend_with_template.merge(type: 'custom')
+      end
+
+      it 'should migrate to html for type category' do
+        @old_legend = old_legend_with_template.merge(type: 'category')
+      end
+
+      it 'should migrate to html for type bubble' do
+        @old_legend = old_legend_with_template.merge(type: 'bubble')
+      end
+
+      it 'should migrate to html for type choropleth' do
+        @old_legend = old_legend_with_template.merge(type: 'choropleth')
+      end
+
+      it 'should migrate to html for type intensity' do
+        @old_legend = old_legend_with_template.merge(type: 'intensity')
+      end
+
+      it 'should migrate to html for type density' do
+        @old_legend = old_legend_with_template.merge(type: 'density')
+      end
+
+      after(:each) do
+        new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
+
+        new_legend.definition[:html].should include('<h1>Manolo Escobar</h1>')
+        new_legend.type.should eq 'html'
+      end
+    end
+
     describe('#custom types') do
       let(:old_category) do
         {
@@ -128,10 +171,6 @@ module Carto
         @old_legend = old_category
       end
 
-      it 'migrates old custom to new custom with no template' do
-        @old_legend = old_custom
-      end
-
       after(:each) do
         new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
 
@@ -181,40 +220,6 @@ module Carto
               "name" => "Right Label",
               "visible" => true,
               "value" => 6273765,
-              "legend_type" => "bubble",
-              "type" => "text",
-              "sync" => false
-            },
-            {
-              "name" => "Color",
-              "visible" => true,
-              "value" => "#FF5C00",
-              "type" => "color"
-            }
-          ]
-        }
-      end
-
-      let(:old_bubble_with_custom_labels) do
-        {
-          "type" => "bubble",
-          "show_title" => false,
-          "title" => "",
-          "template" => "",
-          "visible" => true,
-          "items" => [
-            {
-              "name" => "Left label",
-              "visible" => true,
-              "value" => "few",
-              "legend_type" => "bubble",
-              "type" => "text",
-              "sync" => false
-            },
-            {
-              "name" => "Right Label",
-              "visible" => true,
-              "value" => "many",
               "legend_type" => "bubble",
               "type" => "text",
               "sync" => false
@@ -379,10 +384,6 @@ module Carto
 
       it 'migrates old bubble to new html' do
         @old_legend = old_bubble
-      end
-
-      it 'migrates old bubble with custom labels to new html' do
-        @old_legend = old_bubble_with_custom_labels
       end
 
       it 'migrates old choropleth to new html' do

--- a/spec/lib/carto/legend_migrator_spec.rb
+++ b/spec/lib/carto/legend_migrator_spec.rb
@@ -171,6 +171,10 @@ module Carto
         @old_legend = old_category
       end
 
+      it 'migrates old custom to new custom with no template' do
+        @old_legend = old_custom
+      end
+
       after(:each) do
         new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
 
@@ -220,6 +224,40 @@ module Carto
               "name" => "Right Label",
               "visible" => true,
               "value" => 6273765,
+              "legend_type" => "bubble",
+              "type" => "text",
+              "sync" => false
+            },
+            {
+              "name" => "Color",
+              "visible" => true,
+              "value" => "#FF5C00",
+              "type" => "color"
+            }
+          ]
+        }
+      end
+
+      let(:old_bubble_with_custom_labels) do
+        {
+          "type" => "bubble",
+          "show_title" => false,
+          "title" => "",
+          "template" => "",
+          "visible" => true,
+          "items" => [
+            {
+              "name" => "Left label",
+              "visible" => true,
+              "value" => "few",
+              "legend_type" => "bubble",
+              "type" => "text",
+              "sync" => false
+            },
+            {
+              "name" => "Right Label",
+              "visible" => true,
+              "value" => "many",
               "legend_type" => "bubble",
               "type" => "text",
               "sync" => false
@@ -376,6 +414,10 @@ module Carto
             }
           ]
         }
+      end
+
+      it 'migrates old bubble with custom labels to new html' do
+        @old_legend = old_bubble_with_custom_labels
       end
 
       it 'migrates old custom with template to new html' do


### PR DESCRIPTION
Ok so we have to choose. In the editor, any legend could be customized. If the user customised the legend, we have no option but to "copy and paste" the whole thing into a new place in the builder if we have to respect anything the user made. It's a shame, because I made the migrator to port non-custom old stuff to the new builder look and feel. 

So here is an example.

If we "respect" custom stuff:

![screen shot 2016-10-28 at 16 38 44](https://cloud.githubusercontent.com/assets/4222826/19810303/3b1c8ebc-9d2d-11e6-8b53-51253cae9e7f.png)

If we use the "intelligent" migrator I made and drop custom labels etc:

![screen shot 2016-10-28 at 16 39 48](https://cloud.githubusercontent.com/assets/4222826/19810320/4b1fe502-9d2d-11e6-9708-03268e59bb34.png)

I think that maybe we could respect custom stuff when the legend type is custom, but for bubbles, chropleths and so on we might want to "correct" them a bit. If not, it totally breaks the builder design.

What do you think?

cc/ @xavijam @javisantana @saleiva 
