### PR TITLE
Adding an error notification when layer has errors

### DIFF
--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -61,7 +61,6 @@
   border: 2px solid $cWhite;
   border-radius: 50px;
   background-color: $cError;
-  content: ' ';
 }
 
 .Editor-ListLayer-item--placeholder {

--- a/app/assets/stylesheets/editor-3/layers-list.css.scss
+++ b/app/assets/stylesheets/editor-3/layers-list.css.scss
@@ -51,19 +51,17 @@
   margin-top: 1px;
 }
 
-.Editor-ListLayer-item.has-error {
-  &::after {
-    display: block;
-    position: absolute;
-    top: -5px;
-    right: -5px;
-    width: 8px;
-    height: 8px;
-    border: 2px solid $cWhite;
-    border-radius: 50px;
-    background-color: $cError;
-    content: ' ';
-  }
+.Editor-ListLayer-itemError {
+  display: block;
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid $cWhite;
+  border-radius: 50px;
+  background-color: $cError;
+  content: ' ';
 }
 
 .Editor-ListLayer-item--placeholder {

--- a/lib/assets/javascripts/cartodb3/components/background-importer/background-import-limit-view.js
+++ b/lib/assets/javascripts/cartodb3/components/background-importer/background-import-limit-view.js
@@ -16,7 +16,7 @@ module.exports = CoreView.extend({
     this._configModel = opts.configModel;
 
     this._notification = Notifier.addNotification({
-      state: 'error',
+      status: 'error',
       closable: true,
       button: false,
       info: this._getInfo()

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -6,6 +6,7 @@ var AnalysisNotifications = require('./analysis-notifications');
 var WidgetsNotifications = require('./widgets-notifications');
 var AnalysisOnboardingLauncher = require('./components/onboardings/analysis/analysis-launcher');
 var VisNotifications = require('./vis-notifications');
+var Notifier = require('./components/notifier/notifier');
 
 /**
  * Integration between various data collections/models with cartodb.js and deep-insights.
@@ -545,10 +546,15 @@ F.prototype._linkLayerErrors = function (m) {
 };
 
 F.prototype._setLayerError = function (layerDefinitionModel, cdbError) {
+  var notification = Notifier.getNotification(layerDefinitionModel.id);
+  var mainErrorMessage = layerDefinitionModel.getName() + ': ' + cdbError.message;
+
   if (!cdbError) {
     layerDefinitionModel.unset('error');
+    notification && Notifier.removeNotification(notification);
     return;
   }
+
   if (cdbError.type === 'turbo-carto') {
     var line;
     try {
@@ -558,6 +564,21 @@ F.prototype._setLayerError = function (layerDefinitionModel, cdbError) {
       type: cdbError.type,
       line: line,
       message: cdbError.message
+    });
+  }
+
+  if (notification) {
+    notification.update({
+      status: 'error',
+      info: mainErrorMessage
+    });
+  } else {
+    Notifier.addNotification({
+      id: layerDefinitionModel.id,
+      status: 'error',
+      closable: true,
+      button: false,
+      info: mainErrorMessage
     });
   }
 };

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -547,7 +547,7 @@ F.prototype._linkLayerErrors = function (m) {
 
 F.prototype._setLayerError = function (layerDefinitionModel, cdbError) {
   var notification = Notifier.getNotification(layerDefinitionModel.id);
-  var mainErrorMessage = layerDefinitionModel.getName() + ': ' + cdbError.message;
+  var mainErrorMessage = layerDefinitionModel.getName() + ': ' + (cdbError && cdbError.message);
 
   if (!cdbError) {
     layerDefinitionModel.unset('error');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
@@ -75,6 +75,7 @@ module.exports = CoreView.extend({
       isVisible: m.get('visible'),
       isAnimated: isAnimation,
       isTorque: isTorque,
+      hasError: this._hasError(),
       isCollapsed: this._isCollapsed(),
       numberOfAnalyses: m.getNumberOfAnalyses()
     }));
@@ -95,7 +96,6 @@ module.exports = CoreView.extend({
     this.$('.js-header').append(this._inlineEditor.render().el);
 
     this.$el.toggleClass('is-unavailable', m.isNew());
-    this.$el.toggleClass('has-error', this._hasError());
     this.$el.toggleClass('js-sortable-item', !isTorque);
     this.$el.toggleClass('is-animated', isTorque);
     this.$('.js-thumbnail').toggleClass('is-hidden', this._isHidden());
@@ -122,6 +122,18 @@ module.exports = CoreView.extend({
       var analysesView = this._newAnalysesView(this.$('.js-analyses'), m);
       this.addView(analysesView);
       analysesView.render();
+    }
+
+    if (this._hasError()) {
+      var errorTooltip = new TipsyTooltipView({
+        el: this.$('.js-error'),
+        gravity: 's',
+        offset: 0,
+        title: function () {
+          return this.model.get('error') && this.model.get('error').message;
+        }.bind(this)
+      });
+      this.addView(errorTooltip);
     }
 
     return this;

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-views/data-layer.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-views/data-layer.tpl
@@ -1,3 +1,7 @@
+<% if (hasError) { %>
+  <div class="Editor-ListLayer-itemError js-error"></div>
+<% } %>
+
 <% if (!isTorque) { %>
   <div class="Editor-ListLayer-dragIcon">
     <div class="CDB-Shape">

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -13,6 +13,7 @@ var VisDefinitionModel = require('../../../javascripts/cartodb3/data/vis-definit
 var LegendDefinitionsCollection = require('../../../javascripts/cartodb3/data/legends/legend-definitions-collection');
 var LegendDefinitionModel = require('../../../javascripts/cartodb3/data/legends/legend-base-definition-model');
 var LegendFactory = require('../../../javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory');
+var Notifier = require('../../../javascripts/cartodb3/components/notifier/notifier');
 
 var createOnboardings = function () {
   return {
@@ -1098,6 +1099,14 @@ describe('deep-insights-integrations', function () {
         line: 199,
         message: 'something went totally wrong'
       });
+    });
+
+    it('should add an error in the notifier with the same id as the layer', function () {
+      var notifications = Notifier.getCollection();
+      var notification = notifications.pop();
+      expect(notification.id).toBe('layer-id');
+      expect(notification.get('status')).toBe('error');
+      expect(notification.get('info')).toBe('infowindow_stuff: something went wrong');
     });
   });
 

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-views/data-layer-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-views/data-layer-view.spec.js
@@ -120,12 +120,10 @@ describe('editor/layers/data-layer-view', function () {
     expect(this.view.$('.js-title').hasClass('is-hidden')).toBe(true);
   });
 
-  it('should be displayed as hidden when layer has errors', function () {
-    expect(this.view.$el.hasClass('has-error')).toBe(false);
-
+  it('should be with errors when layer has errors', function () {
+    expect(this.view.$('.js-error').length).toBe(0);
     this.model.set('error', 'an error');
-
-    expect(this.view.$el.hasClass('has-error')).toBe(true);
+    expect(this.view.$('.js-error').length).toBe(1);
   });
 
   it('should not add js-sortable-item class if layer is torque', function () {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.3.51",
+  "version": "4.3.53",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -210,7 +210,7 @@
                                 },
                                 "inherits": {
                                   "version": "2.0.3",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                                 },
                                 "minimatch": {
@@ -1147,12 +1147,12 @@
     "cartodb-deep-insights.js": {
       "version": "0.0.2",
       "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#a16cd816a4754264e730c4fef666d450940bfa8a",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#3da7df845dfa769e3650dfca29327f99ffd3581b",
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#94cda9ff5a6e1544dffa3854c1ab87d543e4aa28",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#ef8f7c79d70824349b06f16d744927b5448968ba",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1263,7 +1263,7 @@
                 },
                 "turf-jenks": {
                   "version": "1.0.1",
-                  "from": "turf-jenks@>=1.0.1 <1.1.0",
+                  "from": "turf-jenks@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/turf-jenks/-/turf-jenks-1.0.1.tgz",
                   "dependencies": {
                     "simple-statistics": {
@@ -1432,10 +1432,15 @@
           "from": "d3@3.5.17",
           "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
         },
+        "tinycolor2": {
+          "version": "1.4.1",
+          "from": "tinycolor2@1.4.1",
+          "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz"
+        },
         "urijs": {
-          "version": "1.18.2",
-          "from": "urijs@>=1.17.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.2.tgz"
+          "version": "1.17.1",
+          "from": "urijs@1.17.1",
+          "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.17.1.tgz"
         }
       }
     },
@@ -1447,7 +1452,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#94cda9ff5a6e1544dffa3854c1ab87d543e4aa28",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#ef8f7c79d70824349b06f16d744927b5448968ba",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1563,7 +1568,7 @@
             },
             "turf-jenks": {
               "version": "1.0.1",
-              "from": "turf-jenks@>=1.0.1 <1.1.0",
+              "from": "turf-jenks@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/turf-jenks/-/turf-jenks-1.0.1.tgz",
               "dependencies": {
                 "simple-statistics": {


### PR DESCRIPTION
So, in short, we weren't getting the error state from the map instantiation (https://github.com/CartoDB/cartodb.js/pull/1478) and the error was not displayed in the proper layer. That's fixed, and the tooltip is appearing, but one important thing I've noticed is we should show the error in the notification, why? Because the error could belong to the Style panel but it could be "triggered" from the SQL panel, as @ramiroaznar has pointed in https://github.com/CartoDB/cartodb/issues/10432. Of course, once the layer is ok and the map is rendering again, the notification would disappear.

So, the things would look like:

![screen shot 2016-10-28 at 18 29 25](https://cloud.githubusercontent.com/assets/132146/19814789/1a126a1c-9d40-11e6-8822-18787d5b932f.png)
![screen shot 2016-10-28 at 18 33 29](https://cloud.githubusercontent.com/assets/132146/19814790/1a15809e-9d40-11e6-871f-001eb48142ca.png)
![screen shot 2016-10-28 at 18 33 38](https://cloud.githubusercontent.com/assets/132146/19814791/1a1e2294-9d40-11e6-81df-c05325ec029a.png)


Closes #10432
CR: @nobuti 

cc @saleiva and @javisantana (any smoke test related to that?)