### PR TITLE
Fixing broken torque-categories for string columns with more than 10 results

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
@@ -472,6 +472,7 @@ function animation (style, mapContext) {
   var columnType = color.attribute_type;
   var columnName = color.attribute;
   var hasOthers = color.range && color.range.length > InputColorCategories.MAX_VALUES;
+  var categoryCount = color.domain && color.domain.length;
 
   var s = ['select *, (CASE'];
 
@@ -482,8 +483,6 @@ function animation (style, mapContext) {
   function _normalizeValue (v) {
     return v.replace(/\n/g, '\\n').replace(/\"/g, '\\"').replace();
   }
-
-  var categoryCount = hasOthers ? color.domain.length - 1 : color.domain.length;
 
   for (var i = 0, l = categoryCount; i < l; i++) {
     var categoryName = color.domain[i];
@@ -504,7 +503,7 @@ function animation (style, mapContext) {
   }
 
   if (hasOthers) {
-    s.push(' ELSE ' + color.domain[color.domain.length - 1]);
+    s.push(' ELSE ' + (categoryCount + 1));
   }
 
   s.push(' END) as value FROM (<%= sql %>) __wrapped');

--- a/lib/assets/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
@@ -702,7 +702,7 @@ module.exports = [
             attribute: 'columnA',
             attribute_type: 'number',
             range: ['#555', '#5B3F95', '#1D6996', '#129C63', '#73AF48', '#EDAD08', '#E17C05', '#C94034', '#BA0040', '#8E1966', '#6F3072'],
-            domain: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            domain: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             opacity: 1
           },
           size: {
@@ -733,12 +733,62 @@ module.exports = [
     },
     result: {
       point: {
-        cartocss: 'Map {\n-torque-frame-count: 256;\n-torque-animation-duration: 30;\n-torque-time-attribute: "test";\n-torque-aggregation-function: "CDB_Math_Mode(value)";\n-torque-resolution: 4;\n-torque-data-aggregation: linear;\n}\n#layer {\nmarker-width: 7;\nmarker-fill: ramp([value], (#555, #5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040, #8E1966, #6F3072), (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), "=");\nmarker-fill-opacity: 1;\nmarker-line-width: 1;\nmarker-line-color: #FFF;\nmarker-line-opacity: 1;\ncomp-op: lighter;\n}\n#layer[frame-offset=1] {\nmarker-width: 9;\nmarker-fill-opacity: 0.5;\n}\n#layer[frame-offset=2] {\nmarker-width: 11;\nmarker-fill-opacity: 0.25;\n}',
+        cartocss: 'Map {\n-torque-frame-count: 256;\n-torque-animation-duration: 30;\n-torque-time-attribute: "test";\n-torque-aggregation-function: "CDB_Math_Mode(value)";\n-torque-resolution: 4;\n-torque-data-aggregation: linear;\n}\n#layer {\nmarker-width: 7;\nmarker-fill: ramp([value], (#555, #5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040, #8E1966, #6F3072), (1, 2, 3, 4, 5, 6, 7, 8, 9, 10), "=");\nmarker-fill-opacity: 1;\nmarker-line-width: 1;\nmarker-line-color: #FFF;\nmarker-line-opacity: 1;\ncomp-op: lighter;\n}\n#layer[frame-offset=1] {\nmarker-width: 9;\nmarker-fill-opacity: 0.5;\n}\n#layer[frame-offset=2] {\nmarker-width: 11;\nmarker-fill-opacity: 0.25;\n}',
         sql: 'select *, (CASE WHEN "columnA" = 1 THEN 1 WHEN "columnA" = 2 THEN 2 WHEN "columnA" = 3 THEN 3 WHEN "columnA" = 4 THEN 4 WHEN "columnA" = 5 THEN 5 WHEN "columnA" = 6 THEN 6 WHEN "columnA" = 7 THEN 7 WHEN "columnA" = 8 THEN 8 WHEN "columnA" = 9 THEN 9 WHEN "columnA" = 10 THEN 10  ELSE 11  END) as value FROM (<%= sql %>) __wrapped',
         type: 'torque'
       }
     }
   },
+  {
+    // Animated with others, string columns for fill
+    style: {
+      type: 'animation',
+      properties: {
+        style: 'simple',
+        fill: {
+          color: {
+            attribute: 'columnA',
+            attribute_type: 'string',
+            range: ['#555', '#5B3F95', '#1D6996', '#129C63', '#73AF48', '#EDAD08', '#E17C05', '#C94034', '#BA0040', '#8E1966', '#6F3072'],
+            domain: ['"1"', '"2"', '"3"', '"4"', '"5"', '"6"', '"7"', '"8"', '"9"', '"10"'],
+            opacity: 1
+          },
+          size: {
+            fixed: 7
+          },
+          image: null
+        },
+        stroke: {
+          color: {
+            fixed: '#FFF',
+            opacity: 1
+          },
+          size: {
+            fixed: 1
+          }
+        },
+        blending: 'lighter',
+        aggregation: {},
+        animated: {
+          attribute: 'test',
+          overlap: false,
+          duration: 30,
+          steps: 256,
+          resolution: 4,
+          trails: 2
+        }
+      }
+    },
+    result: {
+      point: {
+        cartocss: 'Map {\n-torque-frame-count: 256;\n-torque-animation-duration: 30;\n-torque-time-attribute: "test";\n-torque-aggregation-function: "CDB_Math_Mode(value)";\n-torque-resolution: 4;\n-torque-data-aggregation: linear;\n}\n#layer {\nmarker-width: 7;\nmarker-fill: ramp([value], (#555, #5B3F95, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040, #8E1966, #6F3072), (1, 2, 3, 4, 5, 6, 7, 8, 9, 10), "=");\nmarker-fill-opacity: 1;\nmarker-line-width: 1;\nmarker-line-color: #FFF;\nmarker-line-opacity: 1;\ncomp-op: lighter;\n}\n#layer[frame-offset=1] {\nmarker-width: 9;\nmarker-fill-opacity: 0.5;\n}\n#layer[frame-offset=2] {\nmarker-width: 11;\nmarker-fill-opacity: 0.25;\n}',
+        sql: 'select *, (CASE WHEN "columnA" = \'1\' THEN 1 WHEN "columnA" = \'2\' THEN 2 WHEN "columnA" = \'3\' THEN 3 WHEN "columnA" = \'4\' THEN 4 WHEN "columnA" = \'5\' THEN 5 WHEN "columnA" = \'6\' THEN 6 WHEN "columnA" = \'7\' THEN 7 WHEN "columnA" = \'8\' THEN 8 WHEN "columnA" = \'9\' THEN 9 WHEN "columnA" = \'10\' THEN 10  ELSE 11  END) as value FROM (<%= sql %>) __wrapped',
+        type: 'torque'
+      }
+    }
+  },
+
+  // Heatmap animated
   {
     style: {
       type: 'animation',


### PR DESCRIPTION
Looks like with the last changes over the styles rendering and how we manage the occurrences with ramps and so on, we broke the case with torque-categories for string columns, always having more than 10 results (others case).
Also fixed the problem with others for any other type of column, the `ELSE` of the query wrapper should always point to the `Others` value number, in this case `11`.

CR: @javierarce 
Fixes #10433