### PR TITLE
Update install.rst

### DIFF
--- a/doc/manual/source/install.rst
+++ b/doc/manual/source/install.rst
@@ -156,7 +156,7 @@ PostGIS
   .. code-block:: bash
 
     sudo apt-get install libxml2-dev
-    sudo apt-get install liblwgeom-2.1.8 postgis postgresql-9.5-postgis-2.2 postgresql-9.5-postgis-scripts
+    sudo apt-get install liblwgeom-2.2.2 postgis postgresql-9.5-postgis-2.2 postgresql-9.5-postgis-scripts
 
 * Initialize template postgis database. We create a template database in postgresql that will contain the postgis extension. This way, every time CartoDB creates a new user database it just clones this template database
 


### PR DESCRIPTION
Per [this recommendation](https://groups.google.com/forum/#!searchin/cartodb/liblwgeom%7Csort:relevance/cartodb/-7hdvF8KJzE/iHN1wvu2AQAJ), liblwgeom should be 2.2.2?  Using 2.1.8 causes a dependency error