### PR TITLE
Method to go back to the previous layout

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/stack-layout/stack-layout-model.js
+++ b/lib/assets/javascripts/cartodb3/components/stack-layout/stack-layout-model.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var Backbone = require('backbone');
 
 /**
@@ -27,49 +26,35 @@ module.exports = Backbone.Model.extend({
       }, {
         silent: true
       });
+      this._rememberStep.apply(this, arguments);
       this._triggerPositionChanged(position, Array.prototype.slice.call(arguments, 1));
     }
   },
 
   nextStep: function () {
     var currentPos = this.get('position');
-    var stackLayoutItemsSize = this.stackLayoutItems.size();
     var nextPosition = ++currentPos;
-
-    var errorMsg;
-    if (nextPosition >= stackLayoutItemsSize) {
-      errorMsg = 'Already on last stack position! Staying on last step, but the caller should probably be using goToStep instead';
-    }
-
-    nextPosition = stackLayoutItemsSize - 1;
-    this.set({position: nextPosition}, {silent: true});
-    this._triggerPositionChanged(nextPosition, arguments);
-
-    if (errorMsg) {
-      _.defer(function () {
-        throw new Error(errorMsg);
-      });
-    }
+    this.goToStep.apply(this, Array.prototype.concat.apply([nextPosition], arguments));
   },
 
   prevStep: function () {
     var currentPos = this.get('position');
-    var prevPos = --currentPos;
+    var prevPosition = --currentPos;
+    this.goToStep.apply(this, Array.prototype.concat.apply([prevPosition], arguments));
+  },
 
-    if (prevPos < 0) {
-      throw new Error('There is no ' + prevPos + ' stack view in the collection');
-    } else {
-      this.set({
-        position: prevPos
-      }, {
-        silent: true
-      });
-      this._triggerPositionChanged(prevPos, arguments);
+  goBack: function () {
+    if (this._goBackToArguments) {
+      this.goToStep.apply(this, this._goBackToArguments);
     }
   },
 
   _triggerPositionChanged: function (position, args) {
     this.trigger('positionChanged', position, Array.prototype.slice.call(args));
-  }
+  },
 
+  _rememberStep: function () {
+    this._goBackToArguments = this._lastStepArguments || [ 0 ];
+    this._lastStepArguments = arguments;
+  }
 });

--- a/lib/assets/test/spec/cartodb3/components/stack-layout/stack-layout-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/stack-layout/stack-layout-model.spec.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var Backbone = require('backbone');
 var StackLayoutModel = require('../../../../../javascripts/cartodb3/components/stack-layout/stack-layout-model');
 
@@ -59,32 +58,17 @@ describe('stack-layout/model', function () {
       expect(this.model.get('position')).toBe(1);
     });
 
-    it('should trigger a positionChanged event', function () {
-      expect(this.positionChangedSpy).toHaveBeenCalledWith(1, ['hello', 'buddy']);
+    it('should not move to a non existant position', function () {
+      this.model.goToStep(1);
+      expect(this.model.get('position')).toBe(1);
+      expect(function () {
+        this.model.nextStep('hola', 'amigo');
+      }.bind(this)).toThrowError();
+      expect(this.model.get('position')).toBe(1);
     });
 
-    describe('when already on last position of the stack', function () {
-      beforeEach(function () {
-        this.positionChangedSpy.calls.reset();
-        spyOn(_, 'defer');
-
-        this.model.nextStep('hola', 'amigo');
-      });
-
-      it('should not move to a non existant position', function () {
-        expect(this.model.get('position')).toBe(1);
-      });
-
-      it('should trigger a positionChanged event though', function () {
-        expect(this.positionChangedSpy).toHaveBeenCalledWith(1, ['hola', 'amigo']);
-      });
-
-      it('should throw a deferred error with a helpful message for developer on how to fix the issue', function () {
-        expect(_.defer).toHaveBeenCalled();
-        expect(function () {
-          _.defer.calls.argsFor(0)[0]();
-        }).toThrowError(/goToStep instead/);
-      });
+    it('should trigger a positionChanged event', function () {
+      expect(this.positionChangedSpy).toHaveBeenCalledWith(1, ['hello', 'buddy']);
     });
   });
 
@@ -106,13 +90,51 @@ describe('stack-layout/model', function () {
       expect(this.model.prevStep).toThrowError();
     });
 
-    it('should trigger one position change', function () {
+    it('should trigger a positionChanged event', function () {
       this.model.prevStep('go back!');
       var args = this.model.trigger.calls.argsFor(0);
       expect(args[0]).toEqual('positionChanged');
       expect(args[1]).toEqual(0);
       expect(args[2][0]).toEqual('go back!');
       expect(this.model.trigger.calls.count()).toBe(1);
+    });
+  });
+
+  describe('.goBack', function () {
+    beforeEach(function () {
+      spyOn(this.model, 'trigger').and.callThrough();
+    });
+
+    it("should do nothing if position hasn't changed yet", function () {
+      expect(this.model.get('position')).toBe(0);
+      this.model.goBack();
+      expect(this.model.get('position')).toBe(0);
+      expect(this.model.trigger).not.toHaveBeenCalled();
+    });
+
+    describe('when position has previously changed', function () {
+      beforeEach(function () {
+        this.model.goToStep(1, 'hello', 'buddy');
+        this.model.goToStep(0, 'hola', 'amigo');
+        this.model.trigger.calls.reset();
+      });
+
+      it('should move to the "previous" position', function () {
+        this.model.goBack();
+        expect(this.model.get('position')).toBe(1);
+
+        this.model.goBack();
+        expect(this.model.get('position')).toBe(0);
+      });
+
+      it('should trigger a positionChanged event with the right args', function () {
+        this.model.goBack();
+        expect(this.model.trigger).toHaveBeenCalledWith('positionChanged', 1, [ 'hello', 'buddy' ]);
+        this.model.trigger.calls.reset();
+
+        this.model.goBack();
+        expect(this.model.trigger).toHaveBeenCalledWith('positionChanged', 0, [ 'hola', 'amigo' ]);
+      });
     });
   });
 });


### PR DESCRIPTION
Required for https://github.com/CartoDB/cartodb/issues/10472.

This PR implements a new method so that we can go back to the previous layout:

```
this.layoutModel.goBack();
```

Take a look at the tests for a better understanding of how it works...

I did some refactoring and `nextStep` and `prevStep` are now using `goToStep` internally.
Also:
- @matallo discovered that `nextStep` [was always going to the last step](https://github.com/CartoDB/cartodb/compare/go-back?expand=1#diff-7e62e2f46272af03a5083ad2923324a8L44) and we're fixing it here.
- `nextStep` always triggered a `positionChanged` event, even if the position didn't change. There was even [a test for this behaviour](https://github.com/CartoDB/cartodb/pull/10496/files#diff-67cd7945541b5e9eefbc127b2bc26b3cL78), but I don't quite get why (any idea @xavijam @javierarce?)

We could potentially use this in many "back" buttons that we display in the left side panel.

@xavijam would you please take look? Thanks 💋 