### PR TITLE
Upgrade cartodb extension to 0.18.3

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -518,7 +518,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.18.2'
+          cdb_extension_target_version = '0.18.3'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|


### PR DESCRIPTION
This version of the extension excludes analysis cache tables from the user's quota.