### PR TITLE
Fixes overlap in the analysis onboarding

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-view.js
@@ -37,18 +37,18 @@ module.exports = CoreView.extend({
     var html = this._typeDef().template(this.model.attributes);
     this.$('.js-content').html(html);
 
-    this._changeEdition();
+    this._onChangeEditorModelEdition(this._editorModel);
 
     return this;
   },
 
   _initBinds: function () {
     this.listenTo(this.model, 'destroy', this._close);
-    this.listenTo(this._editorModel, 'change:edition', this._changeEdition);
+    this.listenTo(this._editorModel, 'change:edition', this._onChangeEditorModelEdition);
     this.add_related_model(this._editorModel);
   },
 
-  _changeEdition: function (mdl) {
+  _onChangeEditorModelEdition: function (mdl) {
     var isEditing = !!mdl.get('edition');
     this.$el.toggleClass('is-editing', isEditing);
   },

--- a/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-view.js
+++ b/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analysis-view.js
@@ -37,6 +37,8 @@ module.exports = CoreView.extend({
     var html = this._typeDef().template(this.model.attributes);
     this.$('.js-content').html(html);
 
+    this._changeEdition();
+
     return this;
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.63-dev",
+  "version": "4.2.63",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.2.63",
+  "version": "4.2.63-dev",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #10512

![screen shot 2016-11-04 at 13 02 59](https://cloud.githubusercontent.com/assets/4933/20004875/0f707b86-a28f-11e6-8fb1-3bbe0ce85e63.png)


This PR sets the `.is-editing` class to the onboarding pane if the editor is being used. Previously, that class was only set after the onboarding appeared. 