### PR TITLE
Remove layer_selector from overlays.

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -68,6 +68,8 @@ var mapcapsData = window.mapcapsData;
 var overlaysData = window.overlaysData;
 var basemaps = window.basemaps;
 
+vizJSON.overlays = _.reject(vizJSON.overlays, {type: 'layer_selector'});
+
 var configModel = new ConfigModel(
   _.defaults(
     {

--- a/lib/assets/javascripts/cartodb3/public_editor.js
+++ b/lib/assets/javascripts/cartodb3/public_editor.js
@@ -2,6 +2,8 @@ var deepInsights = require('cartodb-deep-insights.js');
 var _ = require('underscore');
 var URLStateHelper = require('cartodb-deep-insights.js/src/api/url-helper.js');
 var vizJSON = window.vizJSON;
+vizJSON.overlays = _.reject(vizJSON.overlays, {type: 'layer_selector'});
+
 var cartoLogoOption = _.findWhere(vizJSON.overlays, {type: 'logo'});
 var dashboardOpts = {
   no_cdn: false,


### PR DESCRIPTION
This PR fixes #10551 at Builder's side. This is a hotfix, I guess the optimal solution was to not include it from the source.

cc @xavijam 