### PR TITLE
Update cartodb.js to get rid of old layer_selector.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.3.2",
+  "version": "4.4.6",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -818,7 +818,7 @@
             },
             "map-obj": {
               "version": "1.0.1",
-              "from": "map-obj@>=1.0.1 <1.1.0",
+              "from": "map-obj@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
             },
             "replace-requires": {
@@ -1151,7 +1151,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#df9edaaa51ca7313f44b414d7bc129058f2eb065",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#594ebc4c4bf3923f269007fe66ec06fe3cdbbcb1",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1383,7 +1383,7 @@
                 },
                 "turf-jenks": {
                   "version": "1.0.1",
-                  "from": "turf-jenks@>=1.0.1 <1.1.0",
+                  "from": "turf-jenks@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/turf-jenks/-/turf-jenks-1.0.1.tgz",
                   "dependencies": {
                     "simple-statistics": {
@@ -1451,7 +1451,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#df9edaaa51ca7313f44b414d7bc129058f2eb065",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#594ebc4c4bf3923f269007fe66ec06fe3cdbbcb1",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1688,7 +1688,7 @@
             },
             "turf-jenks": {
               "version": "1.0.1",
-              "from": "turf-jenks@>=1.0.1 <1.1.0",
+              "from": "turf-jenks@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/turf-jenks/-/turf-jenks-1.0.1.tgz",
               "dependencies": {
                 "simple-statistics": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.4.6.staging",
+  "version": "4.4.6666",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.4.6666",
+  "version": "4.4.6",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.4.6",
+  "version": "4.4.6.staging",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This way we remove the old layer selector in the Builder. The migration is still pending of development.

cc @xavijam 