### PR TITLE
Modified links to docs and learn

### DIFF
--- a/app/views/admin/shared/_footer.html.erb
+++ b/app/views/admin/shared/_footer.html.erb
@@ -4,8 +4,8 @@
   <div class="u-inner Footer-inner">
     <ul class="Footer-list Footer-list--primary">
       <% unless cartodb_com_hosted? %>
-      <li class="Footer-listItem CDB-Text CDB-Size-medium"><a href="https://carto.com/gallery/">Gallery</a></li>
-      <li class="Footer-listItem CDB-Text CDB-Size-medium"><a href="https://carto.com/docs/tutorials/">Getting started</a></li>
+        <li class="Footer-listItem CDB-Text CDB-Size-medium"><a href="https://carto.com/learn/guides/">Guides</a></li>
+        <li class="Footer-listItem CDB-Text CDB-Size-medium"><a href="https://carto.com/docs">Documentation</a></li>
       <% end %>
       <% unless cartodb_onpremise_version.blank? %>
       <li class="Footer-listItem CDB-Text CDB-Size-medium">Version: <%= cartodb_onpremise_version %></li>
@@ -13,7 +13,6 @@
     </ul>
 
     <ul class="Footer-list Footer-list--secondary">
-      <li class="Footer-listItem CDB-Text CDB-Size-medium"><a href="https://carto.com/docs">Documentation</a></li>
       <% unless cartodb_com_hosted? %>
         <li class="Footer-listItem CDB-Text CDB-Size-medium"><a href="mailto:support@carto.com">Support</a></li>
       <% else %>

--- a/app/views/admin/shared/_old_public_header.html.erb
+++ b/app/views/admin/shared/_old_public_header.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <h1><%= link_to "CARTO", "https://carto.com", :id => "the_logo", :class => "logo" %></h1>
     <ul class="options">
-      <li><a href="https://carto.com/gallery/" class="gallery">Gallery</a><li>
+      <li><a href="https://carto.com/learn/guides" class="guides">Guides</a><li>
       <% unless cartodb_com_hosted? %>
         <li><a class="signup" href="https://carto.com/signup">Sign up</a><li>
       <% end %>

--- a/app/views/admin/shared/_private_header.erb
+++ b/app/views/admin/shared/_private_header.erb
@@ -29,17 +29,17 @@
     <div class="Header-settings">
       <ul class="Header-settingsList CDB-Text CDB-Size-medium">
         <% unless cartodb_com_hosted? %>
-        <li class="Header-settingsItem">
-          <a target="_blank" href="https://carto.com/gallery/" class="CDB-Text is-semibold Header-settingsLink Header-settingsLink--dashboard">Gallery</a>
-        </li>
-        <li class="Header-settingsItem">
-          <a target="_blank" href="https://carto.com/docs" class="CDB-Text is-semibold Header-settingsLink Header-settingsLink--dashboard">Documentation</a>
-        </li>
-        <li class="Header-settingsItem Header-settingsItemNotifications js-user-notifications">
-          <a href="#/notifications" class="UserNotifications">
-            <i class="UserNotifications-Icon CDB-IconFont CDB-IconFont-Alert"></i>
-          </a>
-        </li>
+          <li class="Header-settingsItem">
+            <a target="_blank" href="https://carto.com/learn/guides" class="CDB-Text is-semibold Header-settingsLink Header-settingsLink--dashboard">Guides</a>
+          </li>
+          <li class="Header-settingsItem">
+            <a target="_blank" href="https://carto.com/docs" class="CDB-Text is-semibold Header-settingsLink Header-settingsLink--dashboard">Documentation</a>
+          </li>
+          <li class="Header-settingsItem Header-settingsItemNotifications js-user-notifications">
+            <a href="#/notifications" class="UserNotifications">
+              <i class="UserNotifications-Icon CDB-IconFont CDB-IconFont-Alert"></i>
+            </a>
+          </li>
         <% end %>
         <li class="Header-settingsItem Header-settingsItem--avatar">
           <button class="UserAvatar js-settings-dropdown">

--- a/app/views/admin/shared/_public_footer.html.erb
+++ b/app/views/admin/shared/_public_footer.html.erb
@@ -214,6 +214,7 @@
           <li class="Grid-cell Grid-cell--col2 Grid-cell--col4--tablet Grid-cell--col6--mobile Footer-column">
             <dl>
               <dt class="Footer-title u-vspace-xs">Learn</dt>
+              <dd class="Footer-item"><a class="Footer-link" href="https://carto.com/learn/guides">Guides</a></dd>
               <dd class="Footer-item"><a class="Footer-link" href="https://carto.com/docs">Documentation</a></dd>
               <dd class="Footer-item"><a class="Footer-link" href="https://carto.com/academy">The Map Academy</a></dd>
               <dd class="Footer-item"><a class="Footer-link" href="https://carto.com/resources/">Resources Center</a></dd>

--- a/app/views/organization_mailer/invitation.html.erb
+++ b/app/views/organization_mailer/invitation.html.erb
@@ -5,7 +5,7 @@
     <p>CARTO is an open, powerful, and intuitive platform for discovering and predicting the key insights underlying the location data in our world.</p>
     <p>Here are some resources to get you up and running:</p>
     <ul>
-      <li><a href="https://carto.com/docs/carto-builder/">CARTO Docs</a>: Guides, FAQs and tutorials</li>
+      <li><a href="https://carto.com/docs/">CARTO Docs</a>: Guides, FAQs and tutorials</li>
       <li><a href="https://carto.com/resources/">Resource Center</a>: Case studies and white papers for inspiration</li>
       <li>Builder training videos: <a href="https://vimeo.com/173657117/340039d93f">UI</a>, <a href="https://vimeo.com/173657596/572660d9d2">Styling</a>, <a href="https://vimeo.com/173657654/970529bced">Analysis</a>, <a href="https://vimeo.com/173658241/dd37f7ea8c">Widgets</a>, <a href="https://vimeo.com/173658333/21259b1d37">Publishing</a></li>
     </ul>

--- a/app/views/user_mailer/new_organization_user.html.erb
+++ b/app/views/user_mailer/new_organization_user.html.erb
@@ -3,7 +3,7 @@
     <p>You have been invited to CARTO as part of the <strong><%= @organization.name_to_display %></strong> organization. Please login to your dashboard with your organization username (<%= @user.username %>) and the password <%= @user_needs_password ? 'provided by your administrator' : 'you entered' %><%= ' as soon as you activate your account' unless @enable_account_link.nil? %>.</p>
     <p>Here are some resources to get you up and running:</p>
     <ul>
-      <li><a href="https://carto.com/docs/carto-builder/">CARTO Docs</a>: Guides, FAQs and tutorials</li>
+      <li><a href="https://carto.com/docs/">CARTO Docs</a>: Guides, FAQs and tutorials</li>
       <li><a href="https://carto.com/resources/">Resource Center</a>: Case studies and white papers for inspiration</li>
       <li>Builder training videos: <a href="https://vimeo.com/173657117/340039d93f">UI</a>, <a href="https://vimeo.com/173657596/572660d9d2">Styling</a>, <a href="https://vimeo.com/173657654/970529bced">Analysis</a>, <a href="https://vimeo.com/173658241/dd37f7ea8c">Widgets</a>, <a href="https://vimeo.com/173658333/21259b1d37">Publishing</a></li>
     </ul>

--- a/lib/assets/javascripts/cartodb/public/views/public_header.jst.ejs
+++ b/lib/assets/javascripts/cartodb/public/views/public_header.jst.ejs
@@ -2,7 +2,7 @@
   <h1><a href='https://carto.com' class='logo' id='the_logo'>CARTO</a></h1>
   <ul class='options'>
     <% if (!username && !isMobileDevice) { %>
-      <li><a href='https://carto.com/gallery/' class='gallery'>gallery</a></li>
+      <li><a href='https://carto.com/learn/guides' class='guides'>Guides</a></li>
     <% } %>
 
     <% if (!username) { %>

--- a/lib/assets/javascripts/cartodb3/components/code-mirror/code-mirror-error.tpl
+++ b/lib/assets/javascripts/cartodb3/components/code-mirror/code-mirror-error.tpl
@@ -2,7 +2,4 @@
   <li class="CodeMirror-errorMessage u-lSpace--xl u-rSpace--xl">
     <%- _t('components.codemirror.syntax-error') %>. <%- _t('components.codemirror.line') %> <%- line %>: <span><%- message %></span>
   </li>
-  <li class="CodeMirror-errorDocs">
-    <a href="https://carto.com/docs/cartodb-platform/cartocss/" target="_black"><%- _t('components.codemirror.docs') %></a>
-  </li>
 </ul>

--- a/lib/assets/javascripts/cartodb3/components/modals/add-basemap/wms/enter-url.tpl
+++ b/lib/assets/javascripts/cartodb3/components/modals/add-basemap/wms/enter-url.tpl
@@ -8,7 +8,7 @@
       <i class="Spinner XYZPanel-inputIcon XYZPanel-inputIcon--loader Spinner--formIcon Form-inputIcon js-validating" style="display: none;"></i>
       <div class="XYZPanel-error CDB-InfoTooltip CDB-InfoTooltip--left is-error CDB-Text CDB-Size-medium CDB-InfoTooltip-text js-error <%- (layersFetched && layers.length === 0) ? 'is-visible' : '' %>">
         <% if (layersFetched && layers.length === 0) { %>
-          <%- _t('components.modals.add-basemap.wms.invalid') %> <a target="_blank" href="https://carto.com/docs/carto-editor/maps/#including-an-external-basemap">(<%- _t('components.modals.add-basemap.wms.see-docs') %>)</a>
+          <%- _t('components.modals.add-basemap.wms.invalid') %>
         <% } %>
       </div>
     </div>


### PR DESCRIPTION
Closes #10285

- Removed links to editor documentation present in Builder until we have its own docs ready.
- Replaced [Getting started](https://carto.com/docs/tutorials/) links by [Documentation](https://carto.com/docs/).
- Replaced [Gallery](https://carto.com/gallery/) links by [Guides](https://carto.com/learn/guides).

<img width="1001" alt="screen shot 2016-11-07 at 12 03 42" src="https://cloud.githubusercontent.com/assets/2141690/20055624/47dfc742-a4e2-11e6-944e-f16add51c2aa.png">

CR @xavijam cc @beloneys @saleiva 
