### PR TITLE
Remove supefluous encoding of ArcGIS service parameters

### DIFF
--- a/services/datasources/lib/datasources/url/arcgis.rb
+++ b/services/datasources/lib/datasources/url/arcgis.rb
@@ -409,7 +409,7 @@ module CartoDB
             end
           end
 
-          prepared_fields = Addressable::URI.encode(fields.map { |field| "#{field[:name]}" }.join(','))
+          prepared_fields = fields.map { |field| "#{field[:name]}" }.join(',')
 
           prepared_url = FEATURE_DATA_POST_URL % [url]
           # @see http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Query_Map_Service_Layer/02r3000000p1000000/


### PR DESCRIPTION
The http client (Typhoeus) should be provided with a UTF-8 payload and handle itself any further encoding required by HTTP.

Fixes #10556