### PR TITLE
Send aggregation info in the Group points into polygons analysis

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/group-points/bounding-box.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/group-points/bounding-box.js
@@ -25,7 +25,7 @@ module.exports = {
   },
 
   formatAttrs: function (formAttrs) {
-    formAttrs = _.pick(formAttrs, ['id'].concat(this.parametersDataFields.split(',')));
+    formAttrs = _.omit(formAttrs, 'aggregate');
 
     if (!formAttrs.aggregation_column) {
       formAttrs = _.omit(formAttrs, 'aggregation_column');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/group-points/bounding-circle.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/group-points/bounding-circle.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   formatAttrs: function (formAttrs) {
-    formAttrs = _.pick(formAttrs, ['id'].concat(this.parametersDataFields.split(',')));
+    formAttrs = _.omit(formAttrs, 'aggregate');
 
     if (!formAttrs.aggregation_column) {
       formAttrs = _.omit(formAttrs, 'aggregation_column');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/group-points/concave-hull.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/group-points/concave-hull.js
@@ -35,7 +35,7 @@ module.exports = {
   },
 
   formatAttrs: function (formAttrs) {
-    formAttrs = _.pick(formAttrs, ['id'].concat(this.parametersDataFields.split(',')));
+    formAttrs = _.omit(formAttrs, 'aggregate');
 
     formAttrs.target_percent = formAttrs.target_percentage / 100;
     formAttrs = _.omit(formAttrs, 'target_percentage');

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/group-points/convex-hull.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/group-points/convex-hull.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   formatAttrs: function (formAttrs) {
-    formAttrs = _.pick(formAttrs, ['id'].concat(this.parametersDataFields.split(',')));
+    formAttrs = _.omit(formAttrs, 'aggregate');
 
     if (!formAttrs.aggregation_column) {
       formAttrs = _.omit(formAttrs, 'aggregation_column');

--- a/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/group-points-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/group-points-form-model.spec.js
@@ -88,10 +88,14 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/group-
   });
 
   it('should format the attributes', function () {
+    this.model.set('aggregate', { operator: 'avg', attribute: 'wadus' });
+
     expect(this.model._formatAttrs(this.model.attributes)).toEqual({
       id: 'a1',
       source: 'a0',
-      type: 'bounding-box'
+      type: 'bounding-box',
+      aggregation: 'avg',
+      aggregation_column: 'wadus'
     });
   });
 
@@ -105,10 +109,16 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/group-
     });
 
     it('should format the attributes', function () {
+      this.model.set('category_column', 'cluster_no');
+      this.model.set('aggregate', { operator: 'avg', attribute: 'wadus' });
+
       expect(this.model._formatAttrs(this.model.attributes)).toEqual({
         id: 'a1',
         source: 'a0',
-        type: 'bounding-circle'
+        type: 'bounding-circle',
+        category_column: 'cluster_no',
+        aggregation: 'avg',
+        aggregation_column: 'wadus'
       });
     });
   });
@@ -123,10 +133,14 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/group-
     });
 
     it('should format the attributes', function () {
+      this.model.set('aggregate', { operator: 'sum', attribute: 'wadus' });
+
       expect(this.model._formatAttrs(this.model.attributes)).toEqual({
         id: 'a1',
         source: 'a0',
-        type: 'convex-hull'
+        type: 'convex-hull',
+        aggregation: 'sum',
+        aggregation_column: 'wadus'
       });
     });
   });
@@ -141,11 +155,15 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/group-
     });
 
     it('should format the attributes', function () {
+      this.model.set('aggregate', { operator: 'sum', attribute: 'wadus' });
+
       expect(this.model._formatAttrs(this.model.attributes)).toEqual({
         id: 'a1',
         source: 'a0',
         type: 'concave-hull',
-        target_percent: 0.7
+        target_percent: 0.7,
+        aggregation: 'sum',
+        aggregation_column: 'wadus'
       });
     });
   });


### PR DESCRIPTION
Fixes #10426 

This PR fixes an issue where the Group points into polygon analysis wasn't sending the aggregation information. 

The reason of the problem was [the omission of the aggregate properties](https://github.com/CartoDB/cartodb/pull/10578/files#diff-d725fef39a6d28774892d28da2dcdad2L28) for each analysis. We were effectively getting rid of the `aggregate`, `aggregation`, `aggregation_column` properties, when we just needed to remove the first one (which is used internally by the form and is not expected by camshaft).
