### PR TITLE
Modified editor attrs for the fill simple style

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
@@ -191,6 +191,10 @@ module.exports = {
       animationType: params.animationType
     });
 
+    if (params.styleType === 'simple') {
+      editorAttrs.size.min = 5;
+    }
+
     if (params.styleType === 'heatmap') {
       editorAttrs.size.hidePanes = ['value'];
       editorAttrs.color = {

--- a/lib/assets/test/spec/cartodb3/editor/style/style-form/style-form-components-dictionary.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-form/style-form-components-dictionary.spec.js
@@ -54,11 +54,25 @@ describe('editor/style/style-form/style-form-components-dictionary', function ()
       expect(componentDef.options.length).toBe(4);
       expect(componentDef.editorAttrs).toEqual(jasmine.objectContaining({
         size: {
-          min: 1,
+          min: 5,
           max: 45,
           step: 0.5
         }
       }));
+    });
+
+    it('should generate min size 1 for every style except for simple, that should be five', function () {
+      var styles = ['simple', 'heatmap', 'animation', 'regions', 'hexabins', 'squeares'];
+
+      _.each(styles, function (styleType) {
+        var expectedMin = styleType === 'simple' ? 5 : 1;
+        var componentDef = Dictionary['fill']({
+          querySchemaModel: this.querySchemaModel,
+          configModel: this.configModel,
+          styleType: styleType
+        });
+        expect(componentDef.editorAttrs.size.min).toEqual(expectedMin);
+      }, this);
     });
 
     it('should provide proper options with aggregation types', function () {


### PR DESCRIPTION
Fixes #10358 

For the simple fill style, now the minimum size is 5 instead of 2.

This way, the bubbles are shown **now** like this ->

![screen shot 2016-11-07 at 18 43 55](https://cloud.githubusercontent.com/assets/1078228/20068807/5d3dc160-a51a-11e6-9cd3-96f973a79ff7.png)

The former value (2px) showed the map like this ->

![screen shot 2016-11-07 at 18 44 31](https://cloud.githubusercontent.com/assets/1078228/20068812/6491a6ac-a51a-11e6-87c0-95b558e4eeb9.png)

CR @javierarce 
