### PR TITLE
Fixes local string in the DO analysis

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analyses/data-observatory-measure.tpl
+++ b/lib/assets/javascripts/cartodb3/components/onboardings/analysis/analyses/data-observatory-measure.tpl
@@ -5,7 +5,7 @@
 <ul class="Onboarding-list">
   <li class="Onboarding-listItem">
     <div class="Onboarding-listItemValue"><%- final_column %></div>
-    <p class="CDB-Text Onboarding-description"><%- _t('analyses-onboarding.data-observatory-measure.the-geom') %></p>
+    <p class="CDB-Text Onboarding-description"><%- _t('analyses-onboarding.data-observatory-measure.custom-column') %></p>
   </li>
 </ul>
 


### PR DESCRIPTION
Fixes #10609

The original template was using a string (`data-observatory-measure.the-geom`) that wasn't defined. This PR fixes that and uses `data-observatory-measure.custom-column` instead.

Related to: #9022