### PR TITLE
Fixed organizatin signup view disposition depending on org auth options

### DIFF
--- a/app/views/signup/signup.html.erb
+++ b/app/views/signup/signup.html.erb
@@ -48,27 +48,29 @@
 
               <input type="hidden" value="<%= params[:invitation_token] %>" id="invitation_token" name="invitation_token" />
 
-              <div class="Sessions-fieldsGroup">
-                <div class="Sessions-field">
-                  <%= f.text_field :username, class: "CDB-Size-medium Sessions-input topBorderRadius", placeholder: 'Username' %>
-                  <% if !@user.errors[:username].blank? %>
-                    <div class="Sessions-fieldError js-Sessions-fieldError" data-content="<%= @user.errors[:username] %>">!</div>
-                  <% end %>
-                </div>
+              <% if @organization.auth_username_password_enabled %>
+                <div class="Sessions-fieldsGroup">
+                  <div class="Sessions-field">
+                    <%= f.text_field :username, class: "CDB-Size-medium Sessions-input topBorderRadius", placeholder: 'Username' %>
+                    <% if !@user.errors[:username].blank? %>
+                      <div class="Sessions-fieldError js-Sessions-fieldError" data-content="<%= @user.errors[:username] %>">!</div>
+                    <% end %>
+                  </div>
 
-                <div class="Sessions-field">
-                  <%= f.email_field :email, class: "CDB-Size-medium Sessions-input", placeholder: 'email', readonly: params[:invitation_token].present? %>
-                  <% if !@user.errors[:email].blank? %>
-                    <div class="Sessions-fieldError js-Sessions-fieldError" data-content="<%= @user.errors[:email] %>">!</div>
-                  <% end %>
-                </div>
+                  <div class="Sessions-field">
+                    <%= f.email_field :email, class: "CDB-Size-medium Sessions-input", placeholder: 'email', readonly: params[:invitation_token].present? %>
+                    <% if !@user.errors[:email].blank? %>
+                      <div class="Sessions-fieldError js-Sessions-fieldError" data-content="<%= @user.errors[:email] %>">!</div>
+                    <% end %>
+                  </div>
+                <% end %>
 
                 <% if @user.google_sign_in && @organization.auth_google_enabled %>
                   <%= f.hidden_field :google_sign_in %>
                 <% elsif @user.github_user_id && @organization.auth_github_enabled %>
-                <%= f.hidden_field :github_user_id %>
+                  <%= f.hidden_field :github_user_id %>
                   <input type="hidden" name="github_access_token" value="<%= @github_access_token %>" />
-                <% else %>
+                <% elsif @organization.auth_username_password_enabled %>
                   <div class="Sessions-field">
                     <%= f.password_field :password, class: "CDB-Size-medium Sessions-input bottomBorderRadius", placeholder: 'Password' %>
                     <% if !@user.errors[:password].blank? %>
@@ -115,7 +117,10 @@
                 <% end %>
               </div>
             <% end %>
-            <p class="CDB-Text CDB-Size-medium u-altTextColor u-tSpace--m u-flex u-justifyCenter Sessions-description">Please, use an email address belonging to this organization.</p>
+
+            <% if @organization.auth_username_password_enabled %>
+              <p class="CDB-Text CDB-Size-medium u-altTextColor u-tSpace--m u-flex u-justifyCenter Sessions-description">Please, use an email address belonging to this organization.</p>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/signup/signup.html.erb
+++ b/app/views/signup/signup.html.erb
@@ -8,6 +8,11 @@
 
 <div class="CDB-Text <%= @organization.present? ? 'Sessions' : 'Sessions-navy' %>" style="<%= @organization.present? ? background : '' %>">
   <div class="Sessions-content">
+
+    <div class="Sessions-loggedin <%= "is-active" if @google_plus_config.present? %>">
+      <div class="Spinner"></div>
+    </div>
+
     <div class="Sessions-inner">
       <div class="Sessions-notloggedin <%= "is-active" unless @google_plus_config.present? %>">
         <div class="Sessions-left">
@@ -79,26 +84,28 @@
                   </div>
                 <% end %>
 
-                <div class="Sessions-field">
-                  <p>
-                    <button type="submit" class="Sessions-submitButton js-Sessions-button js-Loading">
-                      <span class="js-Loading-text">Sign up</span>
-                      <span class="js-Loading-anim" style="display: none;">
-                        <span class="Loading-item">
-                          <span class="Loading-itemInner Loading-itemInner--01"></span>
-                        </span>
+                <% if @organization.auth_username_password_enabled %>
+                  <div class="Sessions-field">
+                    <p>
+                      <button type="submit" class="Sessions-submitButton js-Sessions-button js-Loading">
+                        <span class="js-Loading-text">Sign up</span>
+                        <span class="js-Loading-anim" style="display: none;">
+                          <span class="Loading-item">
+                            <span class="Loading-itemInner Loading-itemInner--01"></span>
+                          </span>
 
-                        <span class="Loading-item">
-                          <span class="Loading-itemInner Loading-itemInner--02"></span>
-                        </span>
+                          <span class="Loading-item">
+                            <span class="Loading-itemInner Loading-itemInner--02"></span>
+                          </span>
 
-                        <span class="Loading-item">
-                          <span class="Loading-itemInner Loading-itemInner--03"></span>
+                          <span class="Loading-item">
+                            <span class="Loading-itemInner Loading-itemInner--03"></span>
+                          </span>
                         </span>
-                      </span>
-                    </button>
-                  </p>
-                </div>
+                      </button>
+                    </p>
+                  </div>
+                <% end %>
               </div>
               </div>
 
@@ -106,13 +113,14 @@
                 <%= f.check_box :terms, { checked: true } %>
               </div>
             <% end %>
-            <% unless @user.google_sign_in || @user.github_user_id %>
+
+            <% if @organization.auth_google_enabled || @organization.auth_github_enabled %>
               <div class="Sessions-field Sessions-oauthContainer">
-                <% if @google_plus_config.present? %>
+                <% if @organization.auth_google_enabled && @google_plus_config.present? %>
                   <%= render partial: 'google_plus/google_plus_button',  locals: { config: @google_plus_config } %>
                 <% end %>
 
-                <% if @github_config.present? %>
+                <% if @organization.auth_github_enabled && @github_config.present? %>
                   <%= render partial: 'github/github_button',  locals: { config: @github_config } %>
                 <% end %>
               </div>
@@ -123,10 +131,6 @@
             <% end %>
           </div>
         </div>
-      </div>
-
-      <div class="Sessions-loggedin <%= "is-active" if @google_plus_config.present? %>">
-        <div class="Spinner"></div>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #10518 

- Fixed signup options that were not shown/hidden properly.
- Fixed spinner position that previously was appearing in the bottom of the page.

P.D. It would be awesome to refactor signup and login pages in the near future ✨ 

CR @nobuti cc @juanignaciosl 