### PR TITLE
Parse fillColor only if layerDefModel is present as an option.

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
@@ -18,10 +18,12 @@ module.exports = LegendBaseDefModel.extend({
   parse: function (r, opts) {
     var attrs = LegendBaseDefModel.prototype.parse.call(this, r);
 
-    if (r.definition && opts.layerDefinitionModel) {
-      attrs.fillColor = r.definition.color;
-    } else if (!r.definition && opts.layerDefinitionModel) {
-      attrs.fillColor = this._inheritStyleColor(opts.layerDefinitionModel.styleModel);
+    if (opts.layerDefinitionModel) {
+      if (r.definition) {
+        attrs.fillColor = r.definition.color;
+      } else {
+        attrs.fillColor = this._inheritStyleColor(opts.layerDefinitionModel.styleModel);
+      }
     }
     return attrs;
   },

--- a/lib/assets/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
@@ -18,9 +18,9 @@ module.exports = LegendBaseDefModel.extend({
   parse: function (r, opts) {
     var attrs = LegendBaseDefModel.prototype.parse.call(this, r);
 
-    if (r.definition) {
+    if (r.definition && opts.layerDefinitionModel) {
       attrs.fillColor = r.definition.color;
-    } else {
+    } else if (!r.definition && opts.layerDefinitionModel) {
       attrs.fillColor = this._inheritStyleColor(opts.layerDefinitionModel.styleModel);
     }
     return attrs;


### PR DESCRIPTION
This PR avoid overwriting fill color when saving. Related to #10626.

cc @javierarce  
