### PR TITLE
Improve error message from Observatory

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/notification-error-messages.json
+++ b/lib/assets/javascripts/cartodb3/editor/layers/notification-error-messages.json
@@ -12,6 +12,9 @@
     "match": "canceling statement due to statement timeout.",
     "replaceWith": "timeout"
   }, {
+    "match": "^.*?PQconnectPoll: FATAL: no pg_hba.conf entry for host.*",
+    "replaceWith": "connect-poll",
+  }, {
     "match": "^.*?column \"the_geom_webmercator\" does not exist.*",
     "replaceWith": "without-geom-webmercator",
     "errorType": "warning"


### PR DESCRIPTION
Closes #10615

The error message I propose is: 

```No pg_hba.conf entry for host. Please, contact us at <a href='mailto:support@carto.com'>support@carto.com</a>```

Feel free to suggest anything else if you want :)
