### PR TITLE
10640 owner builder enabled check fix

### DIFF
--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -510,7 +510,7 @@ class Carto::User < ActiveRecord::Base
   end
 
   def builder_enabled?
-    if has_organization? && builder_enabled.nil?
+    if has_organization?
       organization.builder_enabled
     else
       !!builder_enabled

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1640,7 +1640,7 @@ class User < Sequel::Model
   end
 
   def builder_enabled?
-    if has_organization? && builder_enabled.nil?
+    if has_organization?
       organization.builder_enabled
     else
       !!builder_enabled


### PR DESCRIPTION
Fixes #10640 

Basically if an owner was editor and his org gets builder, he will still be editor because of former `builder_enabled?`check. 

It looks like there was a good reason for this to be how it was, so please explain @javitonino :)