### PR TITLE
Rolled back to 1px minimum

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
@@ -191,10 +191,6 @@ module.exports = {
       animationType: params.animationType
     });
 
-    if (params.styleType === 'simple') {
-      editorAttrs.size.min = 5;
-    }
-
     if (params.styleType === 'heatmap') {
       editorAttrs.size.hidePanes = ['value'];
       editorAttrs.color = {

--- a/lib/assets/test/spec/cartodb3/editor/style/style-form/style-form-components-dictionary.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-form/style-form-components-dictionary.spec.js
@@ -54,25 +54,11 @@ describe('editor/style/style-form/style-form-components-dictionary', function ()
       expect(componentDef.options.length).toBe(4);
       expect(componentDef.editorAttrs).toEqual(jasmine.objectContaining({
         size: {
-          min: 5,
+          min: 1,
           max: 45,
           step: 0.5
         }
       }));
-    });
-
-    it('should generate min size 1 for every style except for simple, that should be five', function () {
-      var styles = ['simple', 'heatmap', 'animation', 'regions', 'hexabins', 'squeares'];
-
-      _.each(styles, function (styleType) {
-        var expectedMin = styleType === 'simple' ? 5 : 1;
-        var componentDef = Dictionary['fill']({
-          querySchemaModel: this.querySchemaModel,
-          configModel: this.configModel,
-          styleType: styleType
-        });
-        expect(componentDef.editorAttrs.size.min).toEqual(expectedMin);
-      }, this);
     });
 
     it('should provide proper options with aggregation types', function () {


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/10634

This PR rolls back the changes made in https://github.com/CartoDB/cartodb/pull/10597 for https://github.com/CartoDB/cartodb/issues/10358

Now reverted to the previous behaviour.