### PR TITLE
10657 better check for mapcaps

### DIFF
--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -388,7 +388,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def mapcapped?
-    mapcaps.exists?
+    mapcaps.present?
   end
 
   def latest_mapcap

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -388,7 +388,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def mapcapped?
-    mapcaps.present?
+    latest_mapcap.present?
   end
 
   def latest_mapcap


### PR DESCRIPTION
Not sure it fixes #10657, but it makes since anyway.

This check should be safer. Previous `.exists?` depends on how the relation is constructed and I don't trust it since `Carto::Mapcap.exists?` (so a non-scoped relation build) returns `true`. So theres a chance that this defaults to `true` in some weird RAILish situation which is not good. I prefer to fetch `LIMIT 1` (i.e: `.first`) and check presence. For that I just reuse `latest_mapcap`.

See if it makes sense to you @juanignaciosl. 