### PR TITLE
Reload map when polygons/lines are saved

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.js
@@ -1,5 +1,4 @@
 var Backbone = require('backbone');
-var _ = require('underscore');
 
 module.exports = Backbone.Model.extend({
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.js
@@ -9,27 +9,6 @@ module.exports = Backbone.Model.extend({
     this._featureModel = opts.featureModel;
 
     this._generateSchema();
-    this._initBinds();
-  },
-
-  _initBinds: function () {
-    this.bind('change', this._onChange, this);
-  },
-
-  _onChange: function () {
-    _.each(this.changed, function (val, key) {
-      if (key === 'the_geom') {
-        var the_geom = null;
-
-        try {
-          the_geom = JSON.parse(val);
-        } catch (err) {
-          // if the geom is not a valid json value
-        }
-
-        this._featureModel.set('the_geom', JSON.stringify(the_geom));
-      }
-    }, this);
   },
 
   _generateSchema: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
@@ -4,6 +4,12 @@ var DEBOUNCE_TIME = 350;
 
 module.exports = EditFeatureGeometryFormModel.extend({
 
+  initialize: function () {
+    EditFeatureGeometryFormModel.prototype.initialize.apply(this, arguments);
+
+    this._initBinds();
+  },
+
   _initBinds: function () {
     this.bind('change', _.debounce(this._onChange.bind(this), DEBOUNCE_TIME), this);
   },

--- a/lib/assets/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
@@ -76,13 +76,5 @@ describe('editor/layers/edit-feature-content-views/edit-feature-geometry-form-mo
         expect(formModel.schema.the_geom.hasCopyButton).toEqual(false);
       });
     });
-
-    describe('when form data changes', function () {
-      it('should update feature model', function () {
-        expect(featureModel.get('the_geom')).toBe('{"type":"LineString","coordinates":[[0,0],[0,1]]}');
-        formModel.set('the_geom', '{"type":"LineString","coordinates":[[0,0],[1,1]]}');
-        expect(featureModel.get('the_geom')).toBe('{"type":"LineString","coordinates":[[0,0],[1,1]]}');
-      });
-    });
   });
 });


### PR DESCRIPTION
The problem was:

1. When the geometry changed in CartoDB.js, we're updating the `the_geom` attribute of feature definition model [here](https://github.com/CartoDB/cartodb/blob/4dc10ec49518253bf8dc9811023b1ff0b0cb9e73/lib/assets/javascripts/cartodb3/deep-insights-integrations.js#L209-L212).
2. We're then updating `the_geom` of the geometry form model [here](https://github.com/CartoDB/cartodb/blob/4dc10ec49518253bf8dc9811023b1ff0b0cb9e73/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-view.js#L117).
3. This change, was causing the `the_geom` attribute of the feature definition model to be updated again [here](https://github.com/CartoDB/cartodb/blob/4dc10ec49518253bf8dc9811023b1ff0b0cb9e73/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.js#L30). We're setting the same `the_geom` **again**.
4. Because we had set the same `the_geom` twice, when the form was Saved, we detected the "save" event, but `the_geom` had not changed, so the map wasn't being invalidated [here](https://github.com/CartoDB/cartodb/blob/4dc10ec49518253bf8dc9811023b1ff0b0cb9e73/lib/assets/javascripts/cartodb3/deep-insights-integrations.js#L188-L193).

My fix works now because `the_geom` is not editable from the UI, but it we made it editable we'll need to change this approach.

@matallo @xavijam 👍 ?