### PR TITLE
add feature: buttons positions timeseries and animatedtimeseries

### DIFF
--- a/app/assets/stylesheets/editor-3/context-switcher.css.scss
+++ b/app/assets/stylesheets/editor-3/context-switcher.css.scss
@@ -20,7 +20,7 @@
 .Editor-contextSwitcher.has-timeSeries {
   bottom: 167px;
 }
-.Editor-contextSwitcher.has-animatedtimeSeries {
+.Editor-contextSwitcher.has-animatedTimeSeries {
   bottom: 190px;
 }
 .Editor-contextSwitcher--geom {

--- a/app/assets/stylesheets/editor-3/context-switcher.css.scss
+++ b/app/assets/stylesheets/editor-3/context-switcher.css.scss
@@ -18,6 +18,9 @@
   right: 392px;
 }
 .Editor-contextSwitcher.has-timeSeries {
+  bottom: 167px;
+}
+.Editor-contextSwitcher.has-animatedtimeSeries {
   bottom: 190px;
 }
 .Editor-contextSwitcher--geom {

--- a/app/assets/stylesheets/editor-3/context-switcher.css.scss
+++ b/app/assets/stylesheets/editor-3/context-switcher.css.scss
@@ -20,7 +20,7 @@
 .Editor-contextSwitcher.has-timeSeries {
   bottom: 167px;
 }
-.Editor-contextSwitcher.has-animatedTimeSeries {
+.Editor-contextSwitcher.has-timeSeries.has-timeSeries--animated {
   bottom: 190px;
 }
 .Editor-contextSwitcher--geom {

--- a/lib/assets/javascripts/cartodb3/data/widget-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/widget-definitions-collection.js
@@ -70,6 +70,12 @@ module.exports = Backbone.Collection.extend({
     return !!this.findWhere({ type: 'time-series' });
   },
 
+  isThereAnimatedTimeSeries: function () {
+    var timeSeries = this.findWhere({ type: 'time-series' });
+
+    return timeSeries && timeSeries.get('animated');
+  },
+
   isThereOtherWidgets: function () {
     return !!this.find(function (widgetModel) {
       return widgetModel.get('type') !== 'time-series';

--- a/lib/assets/javascripts/cartodb3/data/widget-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/widget-definitions-collection.js
@@ -69,8 +69,8 @@ module.exports = Backbone.Collection.extend({
   isThereTimeSeries: function (opts) {
     opts = opts || {};
 
-    var timeSeries = this.findWhere({ type: 'time-series' });
-    return opts.animated ? !!timeSeries : timeSeries && timeSeries.get('animated');
+    var timeSeries = opts.animated ? this.findWhere({ type: 'time-series', animated: opts.animated }) : this.findWhere({ type: 'time-series' });
+    return !!timeSeries;
   },
 
   isThereOtherWidgets: function () {

--- a/lib/assets/javascripts/cartodb3/data/widget-definitions-collection.js
+++ b/lib/assets/javascripts/cartodb3/data/widget-definitions-collection.js
@@ -66,14 +66,11 @@ module.exports = Backbone.Collection.extend({
     return this._attrsForThisTypeMap[newType](m);
   },
 
-  isThereTimeSeries: function () {
-    return !!this.findWhere({ type: 'time-series' });
-  },
+  isThereTimeSeries: function (opts) {
+    opts = opts || {};
 
-  isThereAnimatedTimeSeries: function () {
     var timeSeries = this.findWhere({ type: 'time-series' });
-
-    return timeSeries && timeSeries.get('animated');
+    return opts.animated ? !!timeSeries : timeSeries && timeSeries.get('animated');
   },
 
   isThereOtherWidgets: function () {

--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -555,7 +555,7 @@ F.prototype._manageTimeSeriesForTorque = function (m) {
     }
 
     if (persistWidget) {
-      recreateWidget.call(this, currentTimeseries, newLayer, _.extend({}, animatedChanged, { attribute: animatedAttribute }));
+      recreateWidget.call(this, currentTimeseries, newLayer, _.extend({ animated: false }, animatedChanged, { attribute: animatedAttribute }));
     }
     this._lastType = type;
     this._lastTSAnimateChange = '';
@@ -567,7 +567,7 @@ F.prototype._manageTimeSeriesForTorque = function (m) {
     }
 
     if (newLayer.get('type') === 'torque' || m.get('type') === 'torque' || persistWidget) {
-      recreateWidget.call(this, currentTimeseries, newLayer, _.extend({}, animatedChanged, { attribute: animatedAttribute }));
+      recreateWidget.call(this, currentTimeseries, newLayer, _.extend({ animated: true }, animatedChanged, { attribute: animatedAttribute }));
     }
 
     this._lastType = type;
@@ -591,6 +591,7 @@ F.prototype._getTimeseriesDefinition = function () {
 F.prototype._createTimeseries = function (newLayer, animatedChanged, persist) {
   this._removeTimeseries();
   var attribute = animatedChanged && animatedChanged.attribute || '';
+  var animated = animatedChanged && animatedChanged.animated;
   if (attribute) {
     var baseAttrs = {
       type: 'time-series',
@@ -601,7 +602,8 @@ F.prototype._createTimeseries = function (newLayer, animatedChanged, persist) {
       options: {
         column: attribute,
         title: persist || 'time_date__t',
-        bins: 256
+        bins: 256,
+        animated: animated
       }
     };
     this._widgetDefinitionsCollection.create(baseAttrs);

--- a/lib/assets/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
@@ -1,6 +1,6 @@
 <ul class="u-flex u-alignCenter Editor-contextSwitcher js-mapTableView
   <% if (isThereOtherWidgets) { %>is-moved<% } %>
-  <% if (isThereTimeSeries) { %>has-timeSeries<% } %>
+  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-animatedtimeSeries<% } %><% } %>
   ">
   <li class="Editor-contextSwitcherItem">
     <div class="Editor-contextSwitcherButton js-showTable">
@@ -27,7 +27,7 @@
 
   <ul class="u-flex u-alignRight Editor-contextSwitcher Editor-contextSwitcher--geom js-mapTableView js-newGeometryView
   <% if (isThereOtherWidgets) { %>is-moved<% } %>
-  <% if (isThereTimeSeries) { %>has-timeSeries<% } %>
+  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-animatedtimeSeries<% } %><% } %>
   ">
     <% if (queryGeometryModel === 'point' || !queryGeometryModel) { %>
       <li class="Editor-contextSwitcherItem">

--- a/lib/assets/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
@@ -1,6 +1,6 @@
 <ul class="u-flex u-alignCenter Editor-contextSwitcher js-mapTableView
   <% if (isThereOtherWidgets) { %>is-moved<% } %>
-  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-animatedTimeSeries<% } %><% } %>
+  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-timeSeries--animated<% } %><% } %>
   ">
   <li class="Editor-contextSwitcherItem">
     <div class="Editor-contextSwitcherButton js-showTable">
@@ -27,7 +27,7 @@
 
   <ul class="u-flex u-alignRight Editor-contextSwitcher Editor-contextSwitcher--geom js-mapTableView js-newGeometryView
   <% if (isThereOtherWidgets) { %>is-moved<% } %>
-  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-animatedTimeSeries<% } %><% } %>
+  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-timeSeries--animated<% } %><% } %>
   ">
     <% if (queryGeometryModel === 'point' || !queryGeometryModel) { %>
       <li class="Editor-contextSwitcherItem">

--- a/lib/assets/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
+++ b/lib/assets/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
@@ -1,6 +1,6 @@
 <ul class="u-flex u-alignCenter Editor-contextSwitcher js-mapTableView
   <% if (isThereOtherWidgets) { %>is-moved<% } %>
-  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-animatedtimeSeries<% } %><% } %>
+  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-animatedTimeSeries<% } %><% } %>
   ">
   <li class="Editor-contextSwitcherItem">
     <div class="Editor-contextSwitcherButton js-showTable">
@@ -27,7 +27,7 @@
 
   <ul class="u-flex u-alignRight Editor-contextSwitcher Editor-contextSwitcher--geom js-mapTableView js-newGeometryView
   <% if (isThereOtherWidgets) { %>is-moved<% } %>
-  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-animatedtimeSeries<% } %><% } %>
+  <% if (isThereTimeSeries) { %>has-timeSeries <% if (isThereAnimatedTimeSeries) { %>has-animatedTimeSeries<% } %><% } %>
   ">
     <% if (queryGeometryModel === 'point' || !queryGeometryModel) { %>
       <li class="Editor-contextSwitcherItem">

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -302,6 +302,7 @@ module.exports = CoreView.extend({
       changeViewButtons({
         isThereOtherWidgets: this._widgetDefinitionsCollection.isThereOtherWidgets(),
         isThereTimeSeries: this._widgetDefinitionsCollection.isThereTimeSeries(),
+        isThereAnimatedTimeSeries: this._widgetDefinitionsCollection.isThereAnimatedTimeSeries(),
         queryGeometryModel: queryGeometryModel.get('simple_geom'),
         isSourceType: isSourceType,
         isCustomQueryApplied: this._layerDefinitionModel.hasCustomQueryApplied()

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -302,7 +302,7 @@ module.exports = CoreView.extend({
       changeViewButtons({
         isThereOtherWidgets: this._widgetDefinitionsCollection.isThereOtherWidgets(),
         isThereTimeSeries: this._widgetDefinitionsCollection.isThereTimeSeries(),
-        isThereAnimatedTimeSeries: this._widgetDefinitionsCollection.isThereAnimatedTimeSeries(),
+        isThereAnimatedTimeSeries: this._widgetDefinitionsCollection.isThereTimeSeries({ animated: true }),
         queryGeometryModel: queryGeometryModel.get('simple_geom'),
         isSourceType: isSourceType,
         isCustomQueryApplied: this._layerDefinitionModel.hasCustomQueryApplied()

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.0",
+  "version": "4.5.3",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -748,7 +748,8 @@
         },
         "grunt-run-node": {
           "version": "0.1.3",
-          "from": "grunt-run-node@0.1.3"
+          "from": "grunt-run-node@0.1.3",
+          "resolved": "https://registry.npmjs.org/grunt-run-node/-/grunt-run-node-0.1.3.tgz"
         },
         "grunt-template-jasmine-requirejs": {
           "version": "0.2.3",
@@ -965,7 +966,7 @@
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
@@ -1151,7 +1152,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#9e6bf5a3f4310d65ef48fecb1459b90df3a3d150",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#7ddb3928aa5997b41fda9476861acb6749b836d6",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1451,7 +1452,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#9e6bf5a3f4310d65ef48fecb1459b90df3a3d150",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#7ddb3928aa5997b41fda9476861acb6749b836d6",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.02",
+  "version": "4.5.03",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.01",
+  "version": "4.5.02",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`animatedChanged` is currently empty and we're not using any of those attributes to know later if the widget is an animated time series or not, we only have a `type: times-series` in both cases

timeseries
![7a0969ec-f0af-49e7-875f-3f6612cf4643](https://cloud.githubusercontent.com/assets/36676/20174774/dc95fb4a-a73f-11e6-9a05-4241bf1519d2.png)

animatedtimeseries
![8e6948b5-c8a0-4e19-8565-fed694ed31a9](https://cloud.githubusercontent.com/assets/36676/20174777/e2de19ba-a73f-11e6-9f46-6b18bbe528ed.png)

CR @nobuti  /cc @xavijam 