### PR TITLE
Point edition

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -188,8 +188,6 @@ F.prototype._onMapModeChanged = function (mapModeModel) {
     featureDefinition.on('save', function () {
       if (featureDefinition.hasChanged('the_geom') || featureDefinition.hasChanged('cartodb_id')) {
         this._invalidateMap();
-      }
-      if (featureDefinition.hasChanged('the_geom')) {
         geometry.setCoordinatesFromGeoJSON(JSON.parse(featureDefinition.get('the_geom')));
       }
     }, this);

--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
@@ -2,6 +2,22 @@ var _ = require('underscore');
 var EditFeatureGeometryFormModel = require('./edit-feature-geometry-form-model');
 var DEBOUNCE_TIME = 350;
 
+var formatCoordinate = function (coordinate) {
+  if (isValidCoordinate(coordinate)) {
+    return parseFloat(parseFloat(coordinate).toFixed(8));
+  }
+};
+
+var isValidCoordinate = function (coordinate) {
+  return _.isNumber(coordinate) || _.isString(coordinate);
+};
+
+var getCoordinatesFromGeoJSON = function (geoJSON) {
+  if (geoJSON && geoJSON.coordinates && geoJSON.coordinates.length === 2) {
+    return geoJSON.coordinates;
+  }
+};
+
 module.exports = EditFeatureGeometryFormModel.extend({
 
   initialize: function () {
@@ -11,33 +27,55 @@ module.exports = EditFeatureGeometryFormModel.extend({
   },
 
   _initBinds: function () {
-    this.bind('change', _.debounce(this._onChange.bind(this), DEBOUNCE_TIME), this);
+    _.bindAll(this, '_onLatLngChange');
+    this.bind('change:lat', _.debounce(this._onLatLngChange, DEBOUNCE_TIME), this);
+    this.bind('change:lng', _.debounce(this._onLatLngChange, DEBOUNCE_TIME), this);
   },
 
-  _onChange: function () {
-    _.each(this.changed, function (val, key) {
-      if (key === 'lng' || key === 'lat') {
-        var geojson = null;
+  _onLatLngChange: function () {
+    var newGeoJSON = this._toGeoJSON();
+    var currentGeoJSON = JSON.parse(this._featureModel.get('the_geom'));
+    // Only set `the_geom` if there's new geoJSON
+    if (!_.isEqual(newGeoJSON, currentGeoJSON)) {
+      this._featureModel.set('the_geom', JSON.stringify(newGeoJSON));
+    }
+  },
 
-        try {
-          geojson = JSON.parse(this._featureModel.get('the_geom'));
-        } catch (err) {
-          // if the geom is not a valid json value
-        }
+  _toGeoJSON: function () {
+    var latitude = this._getLatitude();
+    var longitude = this._getLongitude();
+    if (isValidCoordinate(latitude) && isValidCoordinate(longitude)) {
+      return {
+        'type': 'Point',
+        'coordinates': [ longitude, latitude ]
+      };
+    }
+  },
 
-        var lng = geojson && geojson.coordinates[0];
-        var lat = geojson && geojson.coordinates[1];
-        var val_ = Number(parseFloat(val).toFixed(8));
+  _getLatitude: function () {
+    if (this.has('lat')) {
+      return formatCoordinate(this.get('lat'));
+    }
 
-        if (key === 'lng') {
-          lng = val_;
-        } else if (key === 'lat') {
-          lat = val_;
-        }
+    var geoJSON = JSON.parse(this._featureModel.get('the_geom'));
+    var geoJSONCoordinates = getCoordinatesFromGeoJSON(geoJSON);
+    var latitudeFromGeoJSON = geoJSONCoordinates && geoJSONCoordinates[1];
+    if (latitudeFromGeoJSON) {
+      return formatCoordinate(latitudeFromGeoJSON);
+    }
+  },
 
-        this._featureModel.set('the_geom', JSON.stringify({ 'type': 'Point', 'coordinates': [lng, lat] }));
-      }
-    }, this);
+  _getLongitude: function () {
+    if (this.has('lng')) {
+      return formatCoordinate(this.get('lng'));
+    }
+
+    var geoJSON = JSON.parse(this._featureModel.get('the_geom'));
+    var geoJSONCoordinates = getCoordinatesFromGeoJSON(geoJSON);
+    var longitudeFromGeoJSON = geoJSONCoordinates && geoJSONCoordinates[1];
+    if (longitudeFromGeoJSON) {
+      return formatCoordinate(longitudeFromGeoJSON);
+    }
   },
 
   _generateSchema: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
@@ -27,9 +27,8 @@ module.exports = EditFeatureGeometryFormModel.extend({
   },
 
   _initBinds: function () {
-    _.bindAll(this, '_onLatLngChange');
-    this.bind('change:lat', _.debounce(this._onLatLngChange, DEBOUNCE_TIME), this);
-    this.bind('change:lng', _.debounce(this._onLatLngChange, DEBOUNCE_TIME), this);
+    this.bind('change:lat', this._onLatLngChange, this);
+    this.bind('change:lng', this._onLatLngChange, this);
   },
 
   _onLatLngChange: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
@@ -1,6 +1,5 @@
 var _ = require('underscore');
 var EditFeatureGeometryFormModel = require('./edit-feature-geometry-form-model');
-var DEBOUNCE_TIME = 350;
 
 var formatCoordinate = function (coordinate) {
   if (isValidCoordinate(coordinate)) {

--- a/lib/assets/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
@@ -1,11 +1,9 @@
-var _ = require('underscore');
 var Backbone = require('backbone');
 var EditFeatureGeometryFormModel = require('../../../../../../javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model');
 var EditFeatureGeometryPointFormModel = require('../../../../../../javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model');
 
 describe('editor/layers/edit-feature-content-views/edit-feature-geometry-form-model', function () {
   beforeEach(function () {
-    spyOn(_, 'debounce').and.callFake(function (func) { return function () { func.apply(this, arguments); }; });
     this.featureModel = new Backbone.Model({
       the_geom: '{"type":"Point","coordinates":[0,0]}',
       name: '',

--- a/lib/assets/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
@@ -32,8 +32,36 @@ describe('editor/layers/edit-feature-content-views/edit-feature-geometry-form-mo
     describe('when form data changes', function () {
       it('should update feature model', function () {
         expect(this.featureModel.get('the_geom')).toBe('{"type":"Point","coordinates":[0,0]}');
+
         this.formModel.set('lat', 3.141592653);
+
         expect(this.featureModel.get('the_geom')).toBe('{"type":"Point","coordinates":[0,3.14159265]}');
+
+        this.formModel.set({
+          'lat': -90,
+          'lng': 180
+        });
+
+        expect(this.featureModel.get('the_geom')).toBe('{"type":"Point","coordinates":[180,-90]}');
+
+        this.formModel.set({
+          'lat': 0,
+          'lng': 0
+        });
+
+        expect(this.featureModel.get('the_geom')).toBe('{"type":"Point","coordinates":[0,0]}');
+      });
+
+      it('should only update the_geom once when lat and lng change so that changes can be detected', function () {
+        expect(this.featureModel.get('the_geom')).toBe('{"type":"Point","coordinates":[0,0]}');
+
+        this.formModel.set({
+          'lat': -89.0123456789,
+          'lng': 179.0123456789
+        });
+
+        expect(this.featureModel.get('the_geom')).toBe('{"type":"Point","coordinates":[179.01234568,-89.01234568]}');
+        expect(this.featureModel.hasChanged('the_geom')).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/10672.

Geometry wasn't being updated because we're setting a new `cartodb_id` on the featureDefinitionModel after the new `the_geom` had been set, and `featureDefinitionModel.hasChanged('the_geom')` was returning `false`

I also did a little refactoring to make sure `the_geom` is only set once when both `lat` and `lng` change at the same time (eg: when the marker is dragged and dropped). Otherwise, `featureDefinitionModel.hasChanged('the_geom')` was returning `false` too.

@matallo 👍 ?

