### PR TITLE
Fix edition of new features with new data

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/feature-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/feature-definition-model.js
@@ -139,7 +139,11 @@ var FeatureDefinitionModel = Backbone.Model.extend({
   },
 
   _getQueryRowModel: function () {
-    this._queryRowModel = this._queryRowModel || new QueryRowModel({ cartodb_id: this.get('cartodb_id') }, {
+    var attrs = {};
+    if (this.has('cartodb_id')) {
+      attrs.cartodb_id = this.get('cartodb_id');
+    }
+    this._queryRowModel = this._queryRowModel || new QueryRowModel(attrs, {
       tableName: this._layerDefinitionModel.getTableName(),
       configModel: this._configModel
     });

--- a/lib/assets/test/jasmine/cartodb3/data/feature-definition-model.spec.js
+++ b/lib/assets/test/jasmine/cartodb3/data/feature-definition-model.spec.js
@@ -54,12 +54,12 @@ describe('data/feature-definition-model', function () {
       });
 
       it('should update the cartodb_id of the feature when creating a new row', function () {
-        this.feature.unset('cartodb_id');
+        this.feature.set('cartodb_id', null);
 
         expect(this.feature.isNew()).toBeTruthy();
 
         this.fakeQueryRowModel.save.and.callFake(function (attrs, options) {
-          attrs = _.extend(attrs, {
+          attrs = _.extend({}, attrs, {
             cartodb_id: '56789'
           });
           options && options.success(new Backbone.Model(attrs));
@@ -67,6 +67,10 @@ describe('data/feature-definition-model', function () {
 
         this.feature.save();
 
+        expect(this.fakeQueryRowModel.save.calls.mostRecent().args[0]).toEqual({
+          name: 'Madrid',
+          country: 'Spain'
+        });
         expect(this.feature.get('cartodb_id')).toEqual('56789');
       });
 
@@ -76,7 +80,7 @@ describe('data/feature-definition-model', function () {
         // Row is updated and it returns a different cartodb_id. This will never happen
         // in The Real World, but it helps in this test
         this.fakeQueryRowModel.save.and.callFake(function (attrs, options) {
-          attrs = _.extend(attrs, {
+          attrs = _.extend({}, attrs, {
             cartodb_id: '56789'
           });
           options && options.success(new Backbone.Model(attrs));
@@ -84,6 +88,10 @@ describe('data/feature-definition-model', function () {
 
         this.feature.save();
 
+        expect(this.fakeQueryRowModel.save.calls.mostRecent().args[0]).toEqual({
+          name: 'Madrid',
+          country: 'Spain'
+        });
         expect(this.feature.get('cartodb_id')).toEqual('12345');
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.00",
+  "version": "4.5.01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/10666.

The problem: We're passing a null `cartodb_id` attribute to queryRowModel, and this causing the following error (only when you edited any field in the feature form):

```
{"errors":["PG::Error: ERROR:  null value in column \"cartodb_id\" violates not-null constraint\nDETAIL:  Failing row contains (null, null, null, a, b).\n"]}
```

With these changes, `queryRowModel` doesn't get a `cartodb_id` when creating a new feature/row.

@matallo makes sense? Thanks! 💋 