### PR TITLE
table/views/ template migration fix

### DIFF
--- a/app/controllers/carto/api/infowindow_migrator.rb
+++ b/app/controllers/carto/api/infowindow_migrator.rb
@@ -39,7 +39,7 @@ module Carto
             }
           }
         else
-          new_template_name = Pathname.new(old_template_name).basename.to_s
+          new_template_name = parse_old_template_name(old_template_name)
 
           templated_element[:template] = get_template(
             old_template_name,

--- a/app/controllers/carto/api/infowindow_migrator.rb
+++ b/app/controllers/carto/api/infowindow_migrator.rb
@@ -72,6 +72,12 @@ module Carto
 
       def parse_old_template_name(old_template_name)
         Pathname.new(old_template_name).basename.to_s
+      rescue => exception
+        CartoDB::Logger.error(message: "#{self.class}: Error parsing template",
+                              exception: exception,
+                              parsing: old_template_name)
+
+        old_template_name
       end
 
       def get_template_name(name)

--- a/app/controllers/carto/api/infowindow_migrator.rb
+++ b/app/controllers/carto/api/infowindow_migrator.rb
@@ -39,7 +39,7 @@ module Carto
             }
           }
         else
-          new_template_name = ALIASED_TEMPLATES.fetch(old_template_name, old_template_name)
+          new_template_name = Pathname.new(old_template_name).basename.to_s
 
           templated_element[:template] = get_template(
             old_template_name,
@@ -58,11 +58,6 @@ module Carto
 
       MIGRATED_TEMPLATES = %w{ infowindow_light_header_blue infowindow_light_header_yellow
                                infowindow_light_header_orange infowindow_light_header_green }.freeze
-
-      ALIASED_TEMPLATES = {
-        'table/views/infowindow_light' => 'infowindow_light',
-        'table/views/infowindow_dark' => 'infowindow_dark'
-      }.freeze
 
       COLOR_MAP = {
         'blue' => '#35AAE5',

--- a/app/controllers/carto/api/infowindow_migrator.rb
+++ b/app/controllers/carto/api/infowindow_migrator.rb
@@ -70,6 +70,10 @@ module Carto
         COLOR_MAP[old_template_name.split('_').last]
       end
 
+      def parse_old_template_name(old_template_name)
+        Pathname.new(old_template_name).basename.to_s
+      end
+
       def get_template_name(name)
         Carto::Layer::TEMPLATES_MAP.fetch(name, name)
       end


### PR DESCRIPTION
Fixes traces like https://rollbar.com/vizzuality/CartoDB/items/21088/

Some names are provided to the migrator with the `table/views/` prefix.

This change make the `else` clause a bit more robust. I'm not sure we would actually want that. The other option is to add the light orange template to the map.

cc/ @CartoDB/builder-backend 