### PR TITLE
Add webgl vizjson flag and tangram script tag

### DIFF
--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -25,6 +25,10 @@
 <% end %>
 
 <%= content_for(:js) do %>
+  <% if params[:vector] %>
+    <%= javascript_include_tag 'tangram.min.js' %>
+  <% end %>
+  
   <script>
     var vizJSON = <%= safe_js_object @vizjson.to_hash.to_json %>;
     var layersData = <%= safe_js_object @layers_data.to_json %>;

--- a/config/application.rb
+++ b/config/application.rb
@@ -99,6 +99,7 @@ module CartoDB
       table.js
       public_dashboard.js
       public_like.js
+      tangram.min.js
       common.js
       old_common.js
       old_common_without_core.js

--- a/lib/build/files/js_files.js
+++ b/lib/build/files/js_files.js
@@ -394,6 +394,10 @@ var files = {
     'lib/assets/javascripts/cartodb/old_common/urls/**/*.js'
   ],
 
+  'tangram.min': [
+    'node_modules/tangram/dist/tangram.min.js'
+  ],
+
   public_like: [
     'lib/assets/javascripts/cartodb/models/like.js',
     'lib/assets/javascripts/cartodb/public/public_like.js'

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,11 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.117",
+  "version": "4.5.134",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
       "from": "backbone@1.2.3",
-      "resolved": "http://registry.npmjs.org/backbone/-/backbone-1.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.3.tgz"
     },
     "backbone-forms": {
       "version": "0.14.0",
@@ -121,17 +121,17 @@
                         "debug": {
                           "version": "0.7.4",
                           "from": "debug@0.7.4",
-                          "resolved": "http://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                         },
                         "mkdirp": {
                           "version": "0.5.0",
                           "from": "mkdirp@0.5.0",
-                          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.8",
                               "from": "minimist@0.0.8",
-                              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                             }
                           }
                         },
@@ -366,7 +366,7 @@
                                 "lodash": {
                                   "version": "4.17.4",
                                   "from": "lodash@>=4.14.0 <5.0.0",
-                                  "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
                                 }
                               }
                             }
@@ -380,12 +380,12 @@
                         "mime-types": {
                           "version": "2.1.14",
                           "from": "mime-types@>=2.1.7 <2.2.0",
-                          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.26.0",
                               "from": "mime-db@>=1.26.0 <1.27.0",
-                              "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
                             }
                           }
                         },
@@ -437,14 +437,14 @@
                                 "verror": {
                                   "version": "1.3.6",
                                   "from": "verror@1.3.6",
-                                  "resolved": "http://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                                 }
                               }
                             },
                             "sshpk": {
                               "version": "1.10.2",
                               "from": "sshpk@>=1.7.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
                               "dependencies": {
                                 "asn1": {
                                   "version": "0.2.3",
@@ -474,7 +474,7 @@
                                 "tweetnacl": {
                                   "version": "0.14.5",
                                   "from": "tweetnacl@>=0.14.0 <0.15.0",
-                                  "resolved": "http://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                                 },
                                 "jodid25519": {
                                   "version": "1.0.2",
@@ -587,7 +587,7 @@
                                     "ansi-regex": {
                                       "version": "2.1.1",
                                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                     }
                                   }
                                 },
@@ -599,7 +599,7 @@
                                     "ansi-regex": {
                                       "version": "2.1.1",
                                       "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                     }
                                   }
                                 },
@@ -647,7 +647,7 @@
                                 "jsonpointer": {
                                   "version": "4.0.1",
                                   "from": "jsonpointer@>=4.0.0 <5.0.0",
-                                  "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                                 },
                                 "xtend": {
                                   "version": "4.0.1",
@@ -771,12 +771,12 @@
     "bootstrap-colorpicker": {
       "version": "2.3.3",
       "from": "bootstrap-colorpicker@2.3.3",
-      "resolved": "http://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-2.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-2.3.3.tgz"
     },
     "browserify-shim": {
       "version": "3.8.12",
       "from": "browserify-shim@3.8.12",
-      "resolved": "http://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.12.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.8.12.tgz",
       "dependencies": {
         "exposify": {
           "version": "0.4.3",
@@ -895,7 +895,7 @@
                             "fast-levenshtein": {
                               "version": "2.0.6",
                               "from": "fast-levenshtein@>=2.0.4 <2.1.0",
-                              "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+                              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
                             }
                           }
                         },
@@ -1135,7 +1135,7 @@
     "cartocolor": {
       "version": "4.0.0",
       "from": "cartocolor@4.0.0",
-      "resolved": "http://registry.npmjs.org/cartocolor/-/cartocolor-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/cartocolor/-/cartocolor-4.0.0.tgz",
       "dependencies": {
         "colorbrewer": {
           "version": "1.0.0",
@@ -1152,7 +1152,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#9d005ddc8046e2a4c513372bdeb86bd62282a008",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#b3aca680ae1c92c792d189da55fda07688475780",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1230,7 +1230,7 @@
                 "turbo-carto": {
                   "version": "0.19.0",
                   "from": "turbo-carto@0.19.0",
-                  "resolved": "http://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
+                  "resolved": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
                   "dependencies": {
                     "colorbrewer": {
                       "version": "1.0.0",
@@ -1245,24 +1245,24 @@
                         "ms": {
                           "version": "0.7.1",
                           "from": "ms@0.7.1",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "es6-promise": {
                       "version": "3.1.2",
                       "from": "es6-promise@3.1.2",
-                      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
                     },
                     "postcss": {
                       "version": "5.0.19",
                       "from": "postcss@5.0.19",
-                      "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
+                      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
                       "dependencies": {
                         "supports-color": {
                           "version": "3.2.3",
                           "from": "supports-color@>=3.1.2 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                           "dependencies": {
                             "has-flag": {
                               "version": "1.0.0",
@@ -1305,9 +1305,9 @@
               }
             },
             "tangram.cartodb": {
-              "version": "0.2.2",
+              "version": "0.2.3",
               "from": "cartodb/tangram.cartodb#master",
-              "resolved": "git://github.com/cartodb/tangram.cartodb.git#f3b44701e10f578b48d0854720ab70d7a6f4a03f",
+              "resolved": "git://github.com/cartodb/tangram.cartodb.git#26f29544d7c5337312a657097e25e604e50d8577",
               "dependencies": {
                 "babel-runtime": {
                   "version": "6.18.0",
@@ -1327,9 +1327,9 @@
                   }
                 },
                 "tangram-cartocss": {
-                  "version": "0.3.2",
+                  "version": "0.3.3",
                   "from": "cartodb/tangram-carto#master",
-                  "resolved": "git://github.com/cartodb/tangram-carto.git#571f04f42e87706ce1aa7d12ed206380f471694b",
+                  "resolved": "git://github.com/cartodb/tangram-carto.git#b882e6b8c82d02ac953d4f4604bb67b388b19f37",
                   "dependencies": {
                     "babel-runtime": {
                       "version": "6.11.6",
@@ -1431,7 +1431,7 @@
                     "glob": {
                       "version": "7.1.1",
                       "from": "glob@>=7.0.5 <8.0.0",
-                      "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                       "dependencies": {
                         "fs.realpath": {
                           "version": "1.0.0",
@@ -1441,7 +1441,7 @@
                         "inflight": {
                           "version": "1.0.6",
                           "from": "inflight@>=1.0.4 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
@@ -1473,7 +1473,7 @@
                                 "concat-map": {
                                   "version": "0.0.1",
                                   "from": "concat-map@0.0.1",
-                                  "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
                             }
@@ -1494,7 +1494,7 @@
                         "path-is-absolute": {
                           "version": "1.0.1",
                           "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                         }
                       }
                     }
@@ -1505,12 +1505,12 @@
             "leaflet": {
               "version": "0.7.3",
               "from": "leaflet@0.7.3",
-              "resolved": "http://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
+              "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
             },
             "mustache": {
               "version": "1.1.0",
               "from": "mustache@1.1.0",
-              "resolved": "http://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
             },
             "perfect-scrollbar": {
               "version": "0.6.16",
@@ -1554,7 +1554,7 @@
                 "turbo-carto": {
                   "version": "0.19.0",
                   "from": "turbo-carto@0.19.0",
-                  "resolved": "http://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
+                  "resolved": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
                   "dependencies": {
                     "colorbrewer": {
                       "version": "1.0.0",
@@ -1569,24 +1569,24 @@
                         "ms": {
                           "version": "0.7.1",
                           "from": "ms@0.7.1",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
                     "es6-promise": {
                       "version": "3.1.2",
                       "from": "es6-promise@3.1.2",
-                      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
                     },
                     "postcss": {
                       "version": "5.0.19",
                       "from": "postcss@5.0.19",
-                      "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
+                      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
                       "dependencies": {
                         "supports-color": {
                           "version": "3.2.3",
                           "from": "supports-color@>=3.1.2 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                           "dependencies": {
                             "has-flag": {
                               "version": "1.0.0",
@@ -1633,17 +1633,17 @@
         "d3": {
           "version": "3.5.17",
           "from": "d3@3.5.17",
-          "resolved": "http://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
+          "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
         },
         "d3-interpolate": {
           "version": "1.1.2",
           "from": "d3-interpolate@1.1.2",
-          "resolved": "http://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.2.tgz",
           "dependencies": {
             "d3-color": {
               "version": "1.0.2",
               "from": "d3-color@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/d3-color/-/d3-color-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.2.tgz"
             }
           }
         },
@@ -1660,7 +1660,7 @@
         "urijs": {
           "version": "1.17.1",
           "from": "urijs@1.17.1",
-          "resolved": "http://registry.npmjs.org/urijs/-/urijs-1.17.1.tgz"
+          "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.17.1.tgz"
         }
       }
     },
@@ -1672,7 +1672,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#9d005ddc8046e2a4c513372bdeb86bd62282a008",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#b3aca680ae1c92c792d189da55fda07688475780",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1711,7 +1711,7 @@
         "d3": {
           "version": "3.5.17",
           "from": "d3@3.5.17",
-          "resolved": "http://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
+          "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
         },
         "d3.cartodb": {
           "version": "1.2.1",
@@ -1755,7 +1755,7 @@
             "turbo-carto": {
               "version": "0.19.0",
               "from": "turbo-carto@0.19.0",
-              "resolved": "http://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
+              "resolved": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
               "dependencies": {
                 "colorbrewer": {
                   "version": "1.0.0",
@@ -1770,24 +1770,24 @@
                     "ms": {
                       "version": "0.7.1",
                       "from": "ms@0.7.1",
-                      "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "es6-promise": {
                   "version": "3.1.2",
                   "from": "es6-promise@3.1.2",
-                  "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
                 },
                 "postcss": {
                   "version": "5.0.19",
                   "from": "postcss@5.0.19",
-                  "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
+                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
                   "dependencies": {
                     "supports-color": {
                       "version": "3.2.3",
                       "from": "supports-color@>=3.1.2 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                       "dependencies": {
                         "has-flag": {
                           "version": "1.0.0",
@@ -1830,9 +1830,9 @@
           }
         },
         "tangram.cartodb": {
-          "version": "0.2.2",
+          "version": "0.2.3",
           "from": "cartodb/tangram.cartodb#master",
-          "resolved": "git://github.com/cartodb/tangram.cartodb.git#f3b44701e10f578b48d0854720ab70d7a6f4a03f",
+          "resolved": "git://github.com/cartodb/tangram.cartodb.git#26f29544d7c5337312a657097e25e604e50d8577",
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
@@ -1852,9 +1852,9 @@
               }
             },
             "tangram-cartocss": {
-              "version": "0.3.2",
+              "version": "0.3.3",
               "from": "cartodb/tangram-carto#master",
-              "resolved": "git://github.com/cartodb/tangram-carto.git#571f04f42e87706ce1aa7d12ed206380f471694b",
+              "resolved": "git://github.com/cartodb/tangram-carto.git#b882e6b8c82d02ac953d4f4604bb67b388b19f37",
               "dependencies": {
                 "babel-runtime": {
                   "version": "6.11.6",
@@ -1956,7 +1956,7 @@
                 "glob": {
                   "version": "7.1.1",
                   "from": "glob@>=7.0.5 <8.0.0",
-                  "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
@@ -1966,7 +1966,7 @@
                     "inflight": {
                       "version": "1.0.6",
                       "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
@@ -1998,7 +1998,7 @@
                             "concat-map": {
                               "version": "0.0.1",
                               "from": "concat-map@0.0.1",
-                              "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
                         }
@@ -2019,7 +2019,7 @@
                     "path-is-absolute": {
                       "version": "1.0.1",
                       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     }
                   }
                 }
@@ -2030,12 +2030,12 @@
         "leaflet": {
           "version": "0.7.3",
           "from": "leaflet@0.7.3",
-          "resolved": "http://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
+          "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.3.tgz"
         },
         "mustache": {
           "version": "1.1.0",
           "from": "mustache@1.1.0",
-          "resolved": "http://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/mustache/-/mustache-1.1.0.tgz"
         },
         "perfect-scrollbar": {
           "version": "0.6.16",
@@ -2079,7 +2079,7 @@
             "turbo-carto": {
               "version": "0.19.0",
               "from": "turbo-carto@0.19.0",
-              "resolved": "http://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
+              "resolved": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
               "dependencies": {
                 "colorbrewer": {
                   "version": "1.0.0",
@@ -2094,24 +2094,24 @@
                     "ms": {
                       "version": "0.7.1",
                       "from": "ms@0.7.1",
-                      "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "es6-promise": {
                   "version": "3.1.2",
                   "from": "es6-promise@3.1.2",
-                  "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
                 },
                 "postcss": {
                   "version": "5.0.19",
                   "from": "postcss@5.0.19",
-                  "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
+                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
                   "dependencies": {
                     "supports-color": {
                       "version": "3.2.3",
                       "from": "supports-color@>=3.1.2 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                       "dependencies": {
                         "has-flag": {
                           "version": "1.0.0",
@@ -2158,17 +2158,17 @@
     "clipboard": {
       "version": "1.5.12",
       "from": "clipboard@1.5.12",
-      "resolved": "http://registry.npmjs.org/clipboard/-/clipboard-1.5.12.tgz",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.12.tgz",
       "dependencies": {
         "good-listener": {
           "version": "1.2.1",
           "from": "good-listener@>=1.1.6 <2.0.0",
-          "resolved": "http://registry.npmjs.org/good-listener/-/good-listener-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.1.tgz",
           "dependencies": {
             "delegate": {
               "version": "3.1.1",
               "from": "delegate@>=3.1.1 <4.0.0",
-              "resolved": "http://registry.npmjs.org/delegate/-/delegate-3.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.1.tgz"
             }
           }
         },
@@ -2187,7 +2187,7 @@
     "codemirror": {
       "version": "5.14.2",
       "from": "codemirror@5.14.2",
-      "resolved": "http://registry.npmjs.org/codemirror/-/codemirror-5.14.2.tgz"
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.14.2.tgz"
     },
     "jquery": {
       "version": "2.1.4",
@@ -2213,6 +2213,191 @@
       "version": "1.2.1",
       "from": "queue-async@1.2.1",
       "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz"
+    },
+    "tangram": {
+      "version": "0.11.7",
+      "from": "cartodb/tangram-1#fork",
+      "resolved": "git://github.com/cartodb/tangram-1.git#e119da9510f9665b41e04726993dba84d791ad10",
+      "dependencies": {
+        "csscolorparser": {
+          "version": "1.0.3",
+          "from": "csscolorparser@1.0.3",
+          "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz"
+        },
+        "earcut": {
+          "version": "2.1.1",
+          "from": "earcut@2.1.1",
+          "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.1.tgz"
+        },
+        "fontfaceobserver": {
+          "version": "2.0.7",
+          "from": "fontfaceobserver@2.0.7",
+          "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.0.7.tgz"
+        },
+        "geojson-vt": {
+          "version": "2.1.6",
+          "from": "geojson-vt@2.1.6",
+          "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-2.1.6.tgz"
+        },
+        "gl-mat3": {
+          "version": "1.0.0",
+          "from": "gl-mat3@1.0.0",
+          "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz"
+        },
+        "gl-mat4": {
+          "version": "1.1.4",
+          "from": "gl-mat4@1.1.4",
+          "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.1.4.tgz"
+        },
+        "gl-shader-errors": {
+          "version": "1.0.3",
+          "from": "gl-shader-errors@1.0.3",
+          "resolved": "https://registry.npmjs.org/gl-shader-errors/-/gl-shader-errors-1.0.3.tgz"
+        },
+        "js-yaml": {
+          "version": "3.5.3",
+          "from": "tangrams/js-yaml#read-only",
+          "resolved": "git://github.com/tangrams/js-yaml.git#1637976c6f593bed33ed088aedb6d01390a947c0",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.9",
+              "from": "argparse@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "from": "esprima@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+            }
+          }
+        },
+        "jszip": {
+          "version": "3.0.0",
+          "from": "tangrams/jszip#read-only",
+          "resolved": "git://github.com/tangrams/jszip.git#856ff081cd4a03884fa04a60f3a1998ca51d7b3c",
+          "dependencies": {
+            "es6-promise": {
+              "version": "3.0.2",
+              "from": "es6-promise@>=3.0.2 <3.1.0",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
+            },
+            "pako": {
+              "version": "1.0.4",
+              "from": "pako@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.4.tgz"
+            },
+            "readable-stream": {
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.6 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            },
+            "asap": {
+              "version": "2.0.5",
+              "from": "asap@>=2.0.3 <2.1.0",
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+            }
+          }
+        },
+        "pbf": {
+          "version": "1.3.7",
+          "from": "pbf@1.3.7",
+          "resolved": "https://registry.npmjs.org/pbf/-/pbf-1.3.7.tgz",
+          "dependencies": {
+            "ieee754": {
+              "version": "1.1.8",
+              "from": "ieee754@>=1.1.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+            },
+            "resolve-protobuf-schema": {
+              "version": "2.0.0",
+              "from": "resolve-protobuf-schema@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.0.0.tgz",
+              "dependencies": {
+                "protocol-buffers-schema": {
+                  "version": "2.2.0",
+                  "from": "protocol-buffers-schema@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-2.2.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "strip-comments": {
+          "version": "0.3.2",
+          "from": "strip-comments@0.3.2",
+          "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-0.3.2.tgz"
+        },
+        "topojson-client": {
+          "version": "2.1.0",
+          "from": "tangrams/topojson-client#read-only",
+          "resolved": "git://github.com/tangrams/topojson-client.git#1068f4f2e03ddf8236499bbc896cec98d7a342b7",
+          "dependencies": {
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "vector-tile": {
+          "version": "1.3.0",
+          "from": "vector-tile@1.3.0",
+          "resolved": "https://registry.npmjs.org/vector-tile/-/vector-tile-1.3.0.tgz",
+          "dependencies": {
+            "point-geometry": {
+              "version": "0.0.0",
+              "from": "point-geometry@0.0.0",
+              "resolved": "https://registry.npmjs.org/point-geometry/-/point-geometry-0.0.0.tgz"
+            }
+          }
+        }
+      }
     },
     "torque.js": {
       "version": "2.16.1",
@@ -2251,12 +2436,12 @@
         "d3": {
           "version": "3.5.17",
           "from": "d3@3.5.17",
-          "resolved": "http://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
+          "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
         },
         "turbo-carto": {
           "version": "0.19.0",
           "from": "turbo-carto@0.19.0",
-          "resolved": "http://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
+          "resolved": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
           "dependencies": {
             "colorbrewer": {
               "version": "1.0.0",
@@ -2271,24 +2456,24 @@
                 "ms": {
                   "version": "0.7.1",
                   "from": "ms@0.7.1",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "es6-promise": {
               "version": "3.1.2",
               "from": "es6-promise@3.1.2",
-              "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
             },
             "postcss": {
               "version": "5.0.19",
               "from": "postcss@5.0.19",
-              "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
               "dependencies": {
                 "supports-color": {
                   "version": "3.2.3",
                   "from": "supports-color@>=3.1.2 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                   "dependencies": {
                     "has-flag": {
                       "version": "1.0.0",
@@ -2333,7 +2518,7 @@
     "underscore": {
       "version": "1.8.3",
       "from": "underscore@1.8.3",
-      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -86,7 +86,7 @@
                             },
                             "readable-stream": {
                               "version": "2.0.6",
-                              "from": "readable-stream@>=2.0.0 <2.1.0",
+                              "from": "readable-stream@>=2.0.5 <2.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                               "dependencies": {
                                 "core-util-is": {
@@ -1151,8 +1151,8 @@
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
-          "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#b3aca680ae1c92c792d189da55fda07688475780",
+          "from": "cartodb/cartodb.js#tangram-integration",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#12a7f790d7a5ff516f7e8170a55a7ee7f4d71901",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1671,8 +1671,8 @@
     },
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
-      "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#b3aca680ae1c92c792d189da55fda07688475780",
+      "from": "cartodb/cartodb.js#tangram-integration",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#12a7f790d7a5ff516f7e8170a55a7ee7f4d71901",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1712,122 +1712,6 @@
           "version": "3.5.17",
           "from": "d3@3.5.17",
           "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
-        },
-        "d3.cartodb": {
-          "version": "1.2.1",
-          "from": "cartodb/d3.cartodb#gh-pages",
-          "resolved": "git://github.com/cartodb/d3.cartodb.git#abbe91d099a6d77fc9ee1d37b770f9bc83cf0a1e",
-          "dependencies": {
-            "carto": {
-              "version": "0.15.1-cdb1",
-              "from": "cartodb/carto#master",
-              "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
-              "dependencies": {
-                "mapnik-reference": {
-                  "version": "6.0.5",
-                  "from": "mapnik-reference@>=6.0.2 <6.1.0",
-                  "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
-                },
-                "optimist": {
-                  "version": "0.6.1",
-                  "from": "optimist@>=0.6.0 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                  "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                    },
-                    "minimist": {
-                      "version": "0.0.10",
-                      "from": "minimist@>=0.0.1 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "crossfilter": {
-              "version": "1.3.12",
-              "from": "crossfilter@>=1.3.12 <2.0.0",
-              "resolved": "https://registry.npmjs.org/crossfilter/-/crossfilter-1.3.12.tgz"
-            },
-            "turbo-carto": {
-              "version": "0.19.0",
-              "from": "turbo-carto@0.19.0",
-              "resolved": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
-              "dependencies": {
-                "colorbrewer": {
-                  "version": "1.0.0",
-                  "from": "colorbrewer@1.0.0",
-                  "resolved": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz"
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "debug@2.2.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "ms@0.7.1",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "es6-promise": {
-                  "version": "3.1.2",
-                  "from": "es6-promise@3.1.2",
-                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
-                },
-                "postcss": {
-                  "version": "5.0.19",
-                  "from": "postcss@5.0.19",
-                  "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
-                  "dependencies": {
-                    "supports-color": {
-                      "version": "3.2.3",
-                      "from": "supports-color@>=3.1.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                      "dependencies": {
-                        "has-flag": {
-                          "version": "1.0.0",
-                          "from": "has-flag@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "source-map": {
-                      "version": "0.5.6",
-                      "from": "source-map@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                    },
-                    "js-base64": {
-                      "version": "2.1.9",
-                      "from": "js-base64@>=2.1.9 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-                    }
-                  }
-                },
-                "postcss-value-parser": {
-                  "version": "3.3.0",
-                  "from": "postcss-value-parser@3.3.0",
-                  "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-                }
-              }
-            },
-            "turf-jenks": {
-              "version": "1.0.1",
-              "from": "turf-jenks@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/turf-jenks/-/turf-jenks-1.0.1.tgz",
-              "dependencies": {
-                "simple-statistics": {
-                  "version": "0.9.2",
-                  "from": "simple-statistics@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/simple-statistics/-/simple-statistics-0.9.2.tgz"
-                }
-              }
-            }
-          }
         },
         "tangram.cartodb": {
           "version": "0.2.3",
@@ -2216,8 +2100,8 @@
     },
     "tangram": {
       "version": "0.11.7",
-      "from": "cartodb/tangram-1#fork",
-      "resolved": "git://github.com/cartodb/tangram-1.git#e119da9510f9665b41e04726993dba84d791ad10",
+      "from": "cartodb/tangram-1#race-cond",
+      "resolved": "git://github.com/cartodb/tangram-1.git#c795a2e446c2000a916ca69b90d443b5bc7e7c6b",
       "dependencies": {
         "csscolorparser": {
           "version": "1.0.3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.134",
+  "version": "4.5.137",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -86,7 +86,7 @@
                             },
                             "readable-stream": {
                               "version": "2.0.6",
-                              "from": "readable-stream@>=2.0.5 <2.1.0",
+                              "from": "readable-stream@>=2.0.0 <2.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                               "dependencies": {
                                 "core-util-is": {
@@ -487,9 +487,9 @@
                                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                                 },
                                 "bcrypt-pbkdf": {
-                                  "version": "1.0.0",
+                                  "version": "1.0.1",
                                   "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                                 }
                               }
                             }
@@ -1106,7 +1106,7 @@
     "carto": {
       "version": "0.15.1-cdb1",
       "from": "cartodb/carto#master",
-      "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
+      "resolved": "git://github.com/cartodb/carto.git#b6186d884cc1e3876adedf8a1654cb1a26275c6b",
       "dependencies": {
         "mapnik-reference": {
           "version": "6.0.5",
@@ -1147,12 +1147,12 @@
     "cartodb-deep-insights.js": {
       "version": "0.0.2",
       "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#2a42cb74df5081613a19e016d3eef1c04323e750",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#09ce26314f89f946cf31644085bf0b35e12eb586",
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
-          "from": "cartodb/cartodb.js#tangram-integration",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#12a7f790d7a5ff516f7e8170a55a7ee7f4d71901",
+          "from": "cartodb/cartodb.js#v4",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#023901c3aa8c21742903f501c7bba69bc164168c",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1162,7 +1162,7 @@
             "carto": {
               "version": "0.15.1-cdb1",
               "from": "cartodb/carto#master",
-              "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
+              "resolved": "git://github.com/cartodb/carto.git#b6186d884cc1e3876adedf8a1654cb1a26275c6b",
               "dependencies": {
                 "mapnik-reference": {
                   "version": "6.0.5",
@@ -1188,126 +1188,10 @@
                 }
               }
             },
-            "d3.cartodb": {
-              "version": "1.2.1",
-              "from": "cartodb/d3.cartodb#gh-pages",
-              "resolved": "git://github.com/cartodb/d3.cartodb.git#abbe91d099a6d77fc9ee1d37b770f9bc83cf0a1e",
-              "dependencies": {
-                "carto": {
-                  "version": "0.15.1-cdb1",
-                  "from": "cartodb/carto#master",
-                  "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
-                  "dependencies": {
-                    "mapnik-reference": {
-                      "version": "6.0.5",
-                      "from": "mapnik-reference@>=6.0.2 <6.1.0",
-                      "resolved": "https://registry.npmjs.org/mapnik-reference/-/mapnik-reference-6.0.5.tgz"
-                    },
-                    "optimist": {
-                      "version": "0.6.1",
-                      "from": "optimist@>=0.6.0 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                      "dependencies": {
-                        "wordwrap": {
-                          "version": "0.0.3",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                        },
-                        "minimist": {
-                          "version": "0.0.10",
-                          "from": "minimist@>=0.0.1 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "crossfilter": {
-                  "version": "1.3.12",
-                  "from": "crossfilter@>=1.3.12 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/crossfilter/-/crossfilter-1.3.12.tgz"
-                },
-                "turbo-carto": {
-                  "version": "0.19.0",
-                  "from": "turbo-carto@0.19.0",
-                  "resolved": "https://registry.npmjs.org/turbo-carto/-/turbo-carto-0.19.0.tgz",
-                  "dependencies": {
-                    "colorbrewer": {
-                      "version": "1.0.0",
-                      "from": "colorbrewer@1.0.0",
-                      "resolved": "https://registry.npmjs.org/colorbrewer/-/colorbrewer-1.0.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.2.0",
-                      "from": "debug@2.2.0",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "from": "ms@0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                        }
-                      }
-                    },
-                    "es6-promise": {
-                      "version": "3.1.2",
-                      "from": "es6-promise@3.1.2",
-                      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
-                    },
-                    "postcss": {
-                      "version": "5.0.19",
-                      "from": "postcss@5.0.19",
-                      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz",
-                      "dependencies": {
-                        "supports-color": {
-                          "version": "3.2.3",
-                          "from": "supports-color@>=3.1.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                          "dependencies": {
-                            "has-flag": {
-                              "version": "1.0.0",
-                              "from": "has-flag@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "source-map": {
-                          "version": "0.5.6",
-                          "from": "source-map@>=0.5.1 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                        },
-                        "js-base64": {
-                          "version": "2.1.9",
-                          "from": "js-base64@>=2.1.9 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-                        }
-                      }
-                    },
-                    "postcss-value-parser": {
-                      "version": "3.3.0",
-                      "from": "postcss-value-parser@3.3.0",
-                      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-                    }
-                  }
-                },
-                "turf-jenks": {
-                  "version": "1.0.1",
-                  "from": "turf-jenks@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/turf-jenks/-/turf-jenks-1.0.1.tgz",
-                  "dependencies": {
-                    "simple-statistics": {
-                      "version": "0.9.2",
-                      "from": "simple-statistics@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/simple-statistics/-/simple-statistics-0.9.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "tangram.cartodb": {
-              "version": "0.2.3",
+              "version": "0.2.4",
               "from": "cartodb/tangram.cartodb#master",
-              "resolved": "git://github.com/cartodb/tangram.cartodb.git#26f29544d7c5337312a657097e25e604e50d8577",
+              "resolved": "git://github.com/cartodb/tangram.cartodb.git#59127727dd2b58996ff5355c77e2032be643b6e9",
               "dependencies": {
                 "babel-runtime": {
                   "version": "6.18.0",
@@ -1329,7 +1213,7 @@
                 "tangram-cartocss": {
                   "version": "0.3.3",
                   "from": "cartodb/tangram-carto#master",
-                  "resolved": "git://github.com/cartodb/tangram-carto.git#b882e6b8c82d02ac953d4f4604bb67b388b19f37",
+                  "resolved": "git://github.com/cartodb/tangram-carto.git#3ffe62b5a585dcd12f3c43e489950ac4ce83582e",
                   "dependencies": {
                     "babel-runtime": {
                       "version": "6.11.6",
@@ -1351,7 +1235,7 @@
                     "carto": {
                       "version": "0.15.1-cdb1",
                       "from": "cartodb/carto#master",
-                      "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
+                      "resolved": "git://github.com/cartodb/carto.git#b6186d884cc1e3876adedf8a1654cb1a26275c6b",
                       "dependencies": {
                         "mapnik-reference": {
                           "version": "6.0.5",
@@ -1525,7 +1409,7 @@
                 "carto": {
                   "version": "0.15.1-cdb1",
                   "from": "cartodb/carto#master",
-                  "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
+                  "resolved": "git://github.com/cartodb/carto.git#b6186d884cc1e3876adedf8a1654cb1a26275c6b",
                   "dependencies": {
                     "mapnik-reference": {
                       "version": "6.0.5",
@@ -1671,8 +1555,8 @@
     },
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
-      "from": "cartodb/cartodb.js#tangram-integration",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#12a7f790d7a5ff516f7e8170a55a7ee7f4d71901",
+      "from": "cartodb/cartodb.js#v4",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#023901c3aa8c21742903f501c7bba69bc164168c",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1682,7 +1566,7 @@
         "carto": {
           "version": "0.15.1-cdb1",
           "from": "cartodb/carto#master",
-          "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
+          "resolved": "git://github.com/cartodb/carto.git#b6186d884cc1e3876adedf8a1654cb1a26275c6b",
           "dependencies": {
             "mapnik-reference": {
               "version": "6.0.5",
@@ -1714,9 +1598,9 @@
           "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
         },
         "tangram.cartodb": {
-          "version": "0.2.3",
+          "version": "0.2.4",
           "from": "cartodb/tangram.cartodb#master",
-          "resolved": "git://github.com/cartodb/tangram.cartodb.git#26f29544d7c5337312a657097e25e604e50d8577",
+          "resolved": "git://github.com/cartodb/tangram.cartodb.git#59127727dd2b58996ff5355c77e2032be643b6e9",
           "dependencies": {
             "babel-runtime": {
               "version": "6.18.0",
@@ -1738,7 +1622,7 @@
             "tangram-cartocss": {
               "version": "0.3.3",
               "from": "cartodb/tangram-carto#master",
-              "resolved": "git://github.com/cartodb/tangram-carto.git#b882e6b8c82d02ac953d4f4604bb67b388b19f37",
+              "resolved": "git://github.com/cartodb/tangram-carto.git#3ffe62b5a585dcd12f3c43e489950ac4ce83582e",
               "dependencies": {
                 "babel-runtime": {
                   "version": "6.11.6",
@@ -1760,7 +1644,7 @@
                 "carto": {
                   "version": "0.15.1-cdb1",
                   "from": "cartodb/carto#master",
-                  "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
+                  "resolved": "git://github.com/cartodb/carto.git#b6186d884cc1e3876adedf8a1654cb1a26275c6b",
                   "dependencies": {
                     "mapnik-reference": {
                       "version": "6.0.5",
@@ -1934,7 +1818,7 @@
             "carto": {
               "version": "0.15.1-cdb1",
               "from": "cartodb/carto#master",
-              "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
+              "resolved": "git://github.com/cartodb/carto.git#b6186d884cc1e3876adedf8a1654cb1a26275c6b",
               "dependencies": {
                 "mapnik-reference": {
                   "version": "6.0.5",
@@ -2291,7 +2175,7 @@
         "carto": {
           "version": "0.15.1-cdb1",
           "from": "cartodb/carto#master",
-          "resolved": "git://github.com/cartodb/carto.git#4f792fbeadd883479bee7b5350893ca63b1cdd99",
+          "resolved": "git://github.com/cartodb/carto.git#b6186d884cc1e3876adedf8a1654cb1a26275c6b",
           "dependencies": {
             "mapnik-reference": {
               "version": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "carto": "cartodb/carto#master",
     "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "CartoDB/cartodb.js#v4",
+    "cartodb.js": "CartoDB/cartodb.js#tangram-integration",
     "cartocolor": "4.0.0",
     "clipboard": "1.5.12",
     "codemirror": "5.14.2",
@@ -34,7 +34,7 @@
     "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
     "queue-async": "1.2.1",
     "torque.js": "CartoDB/torque#master",
-    "tangram": "cartodb/tangram-1#fork",
+    "tangram": "cartodb/tangram-1#race-cond",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.134",
+  "version": "4.5.140",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "carto": "cartodb/carto#master",
     "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "CartoDB/cartodb.js#tangram-integration",
+    "cartodb.js": "CartoDB/cartodb.js#v4",
     "cartocolor": "4.0.0",
     "clipboard": "1.5.12",
     "codemirror": "5.14.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.121",
+  "version": "4.5.134",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
     "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
     "queue-async": "1.2.1",
     "torque.js": "CartoDB/torque#master",
+    "tangram": "cartodb/tangram-1#fork",
     "underscore": "1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR add the webgl flag to the vizjson and the tangram script.

I've added the tangram script as a new script tag because Tangram workers fails if it is not isolated from other scripts. A more detailed explanation [here](https://github.com/tangrams/tangram/issues/251) and [here](https://github.com/tangrams/tangram/issues/252)

Let me know if it is a better place where put the script tag :)

Fix #11266 