### PR TITLE
Force nonempty infowindow and tooltip migration

### DIFF
--- a/app/controllers/carto/api/infowindow_generator.rb
+++ b/app/controllers/carto/api/infowindow_generator.rb
@@ -41,9 +41,11 @@ module Carto
       ).freeze
 
       def whitelisted_infowindow(infowindow)
-        infowindow.nil? ? nil : infowindow.select do |key, _|
-                                                    INFOWINDOW_KEYS.include?(key) || INFOWINDOW_KEYS.include?(key.to_s)
-                                                  end
+        if infowindow.nil?
+          nil
+        else
+          infowindow.select { |key, _| INFOWINDOW_KEYS.include?(key) || INFOWINDOW_KEYS.include?(key.to_s) }
+        end
       end
 
       def with_template(infowindow, path)
@@ -51,17 +53,24 @@ module Carto
         # - nil means absolutely no infowindow (e.g. a torque)
         # - path = nil or template filled: either pre-filled or custom infowindow, nothing to do here
         # - template and path not nil but template not filled: stay and fill
-        return nil if infowindow.nil?
+        return nil unless infowindow
 
         template = infowindow['template']
-        return infowindow if (!template.nil? && !template.empty?) || path.nil?
+        return infowindow if template.present? || path.nil?
 
         infowindow[:template] = File.read(path)
         infowindow
       end
 
       def default_templated
-        { "fields" => [], "template_name" => "none", "template" => "", "alternative_names" => {}, "width" => 226, "maxHeight" => 180 }
+        {
+          "fields" => [],
+          "template_name" => "none",
+          "template" => "",
+          "alternative_names" => {},
+          "width" => 226,
+          "maxHeight" => 180
+        }
       end
     end
   end

--- a/app/controllers/carto/api/infowindow_generator.rb
+++ b/app/controllers/carto/api/infowindow_generator.rb
@@ -8,21 +8,21 @@ module Carto
       def infowindow_data_v1
         with_template(@layer.infowindow, @layer.infowindow_template_path)
       rescue => e
-        CartoDB::Logger.error(exception: e)
+        CartoDB::Logger.error(exception: e, message: 'infowindow_data_v1 error', layer: @layer)
         throw e
       end
 
       def infowindow_data_v2
         whitelisted_infowindow(with_template(@layer.infowindow, @layer.infowindow_template_path))
       rescue => e
-        CartoDB::Logger.error(exception: e)
+        CartoDB::Logger.error(exception: e, message: 'infowindow_data_v2 error', layer: @layer)
         throw e
       end
 
       def tooltip_data_v2
         whitelisted_infowindow(with_template(@layer.tooltip, @layer.tooltip_template_path))
       rescue => e
-        CartoDB::Logger.error(exception: e)
+        CartoDB::Logger.error(exception: e, message: 'tooltip_data_v2 error', layer: @layer)
         throw e
       end
 
@@ -38,12 +38,12 @@ module Carto
 
       INFOWINDOW_KEYS = %w(
         fields template_name template alternative_names width maxHeight
-      )
+      ).freeze
 
       def whitelisted_infowindow(infowindow)
-        infowindow.nil? ? nil : infowindow.select { |key, value|
+        infowindow.nil? ? nil : infowindow.select do |key, _|
                                                     INFOWINDOW_KEYS.include?(key) || INFOWINDOW_KEYS.include?(key.to_s)
-                                                  }
+                                                  end
       end
 
       def with_template(infowindow, path)

--- a/app/controllers/carto/api/infowindow_generator.rb
+++ b/app/controllers/carto/api/infowindow_generator.rb
@@ -1,0 +1,68 @@
+module Carto
+  module Api
+    class InfowindowGenerator
+      def initialize(layer)
+        @layer = layer
+      end
+
+      def infowindow_data_v1
+        with_template(@layer.infowindow, @layer.infowindow_template_path)
+      rescue => e
+        CartoDB::Logger.error(exception: e)
+        throw e
+      end
+
+      def infowindow_data_v2
+        whitelisted_infowindow(with_template(@layer.infowindow, @layer.infowindow_template_path))
+      rescue => e
+        CartoDB::Logger.error(exception: e)
+        throw e
+      end
+
+      def tooltip_data_v2
+        whitelisted_infowindow(with_template(@layer.tooltip, @layer.tooltip_template_path))
+      rescue => e
+        CartoDB::Logger.error(exception: e)
+        throw e
+      end
+
+      def default_infowindow
+        default_templated
+      end
+
+      def default_tooltip
+        default_templated
+      end
+
+      private
+
+      INFOWINDOW_KEYS = %w(
+        fields template_name template alternative_names width maxHeight
+      )
+
+      def whitelisted_infowindow(infowindow)
+        infowindow.nil? ? nil : infowindow.select { |key, value|
+                                                    INFOWINDOW_KEYS.include?(key) || INFOWINDOW_KEYS.include?(key.to_s)
+                                                  }
+      end
+
+      def with_template(infowindow, path)
+        # Careful with this logic:
+        # - nil means absolutely no infowindow (e.g. a torque)
+        # - path = nil or template filled: either pre-filled or custom infowindow, nothing to do here
+        # - template and path not nil but template not filled: stay and fill
+        return nil if infowindow.nil?
+
+        template = infowindow['template']
+        return infowindow if (!template.nil? && !template.empty?) || path.nil?
+
+        infowindow[:template] = File.read(path)
+        infowindow
+      end
+
+      def default_templated
+        { "fields" => [], "template_name" => "none", "template" => "", "alternative_names" => {}, "width" => 226, "maxHeight" => 180 }
+      end
+    end
+  end
+end

--- a/app/controllers/carto/api/infowindow_migrator.rb
+++ b/app/controllers/carto/api/infowindow_migrator.rb
@@ -6,13 +6,13 @@ module Carto
       def migrate_builder_infowindow(layer, alternate_infowindow = nil)
         return default_infowindow(layer) if needs_default?(layer, layer.infowindow, alternate_infowindow)
 
-        migrate_templated(alternate_infowindow || layer.infowindow, layer.kind, 'infowindows')
+        migrate_templated(alternate_infowindow || layer.infowindow, 'infowindows')
       end
 
       def migrate_builder_tooltip(layer, alternate_tooltip = nil)
         return default_tooltip(layer) if needs_default?(layer, layer.tooltip, alternate_tooltip)
 
-        migrate_templated(alternate_tooltip || layer.tooltip, layer.kind, 'tooltips')
+        migrate_templated(alternate_tooltip || layer.tooltip, 'tooltips')
       end
 
       private
@@ -29,7 +29,7 @@ module Carto
         Carto::Api::InfowindowGenerator.new(layer).default_tooltip
       end
 
-      def migrate_templated(templated_element, layer_kind, mustache_dir)
+      def migrate_templated(templated_element, mustache_dir)
         return nil if templated_element.nil?
 
         template = templated_element['template']

--- a/app/controllers/carto/api/infowindow_migrator.rb
+++ b/app/controllers/carto/api/infowindow_migrator.rb
@@ -3,7 +3,33 @@ module Carto
     module InfowindowMigrator
       MUSTACHE_ROOT_PATH = 'lib/assets/javascripts/cartodb3/mustache-templates'.freeze
 
-      def migrate_builder_infowindow(templated_element, mustache_dir: 'infowindows')
+      def migrate_builder_infowindow(layer, alternate_infowindow = nil)
+        return default_infowindow(layer) if needs_default?(layer, layer.infowindow, alternate_infowindow)
+
+        migrate_templated(alternate_infowindow || layer.infowindow, layer.kind, 'infowindows')
+      end
+
+      def migrate_builder_tooltip(layer, alternate_tooltip = nil)
+        return default_tooltip(layer) if needs_default?(layer, layer.tooltip, alternate_tooltip)
+
+        migrate_templated(alternate_tooltip || layer.tooltip, layer.kind, 'tooltips')
+      end
+
+      private
+
+      def needs_default?(layer, templated_element, alternate_templated_element)
+        layer.data_layer? && templated_element.blank? && alternate_templated_element.blank?
+      end
+
+      def default_infowindow(layer)
+        Carto::Api::InfowindowGenerator.new(layer).default_infowindow
+      end
+
+      def default_tooltip(layer)
+        Carto::Api::InfowindowGenerator.new(layer).default_tooltip
+      end
+
+      def migrate_templated(templated_element, layer_kind, mustache_dir)
         return nil if templated_element.nil?
 
         template = templated_element['template']

--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -31,10 +31,6 @@ module Carto
         visible
       )
 
-      INFOWINDOW_KEYS = %w(
-        fields template_name template alternative_names width maxHeight
-      )
-
       # Options:
       # - viewer_user
       # - user: owner user
@@ -53,12 +49,8 @@ module Carto
       def to_poro(migrate_builder_infowindows: false)
         poro = base_poro(@layer)
         if migrate_builder_infowindows
-          if poro['infowindow'].present?
-            poro['infowindow'] = migrate_builder_infowindow(poro['infowindow'])
-          end
-          if poro['tooltip'].present?
-            poro['tooltip'] = migrate_builder_infowindow(poro['tooltip'], mustache_dir: 'tooltips')
-          end
+          poro['infowindow'] = migrate_builder_infowindow(@layer, poro['infowindow'])
+          poro['tooltip'] = migrate_builder_tooltip(@layer, poro['tooltip'])
         end
         poro
       end
@@ -73,11 +65,13 @@ module Carto
         elsif torque?(@layer)
           as_torque
         else
+          infowindow_generator = InfowindowGenerator.new(@layer)
+
           {
             id:         @layer.id,
             type:       'CartoDB',
-            infowindow: infowindow_data_v2,
-            tooltip:    tooltip_data_v2,
+            infowindow: infowindow_generator.infowindow_data_v2,
+            tooltip:    infowindow_generator.tooltip_data_v2,
             legend:     @layer.legend,
             order:      @layer.order,
             visible:    public_values(@layer).symbolize_keys[:options]['visible'],
@@ -91,7 +85,7 @@ module Carto
         {
           id:         @layer.id,
           kind:       'CartoDB',
-          infowindow: infowindow_data_v1,
+          infowindow: InfowindowGenerator.new(@layer).infowindow_data_v1,
           order:      @layer.order,
           options:    options_data_v1
         }
@@ -158,20 +152,6 @@ module Carto
 
       def torque?(layer)
         layer.kind == 'torque'
-      end
-
-      def with_template(infowindow, path)
-        # Careful with this logic:
-        # - nil means absolutely no infowindow (e.g. a torque)
-        # - path = nil or template filled: either pre-filled or custom infowindow, nothing to do here
-        # - template and path not nil but template not filled: stay and fill
-        return nil if infowindow.nil?
-
-        template = infowindow['template']
-        return infowindow if (!template.nil? && !template.empty?) || path.nil?
-
-        infowindow[:template] = File.read(path)
-        infowindow
       end
 
       def layer_options
@@ -252,27 +232,6 @@ module Carto
         }
       end
 
-      def infowindow_data_v1
-        with_template(@layer.infowindow, @layer.infowindow_template_path)
-      rescue => e
-        CartoDB::Logger.error(exception: e)
-        throw e
-      end
-
-      def infowindow_data_v2
-        whitelisted_infowindow(with_template(@layer.infowindow, @layer.infowindow_template_path))
-      rescue => e
-        CartoDB::Logger.error(exception: e)
-        throw e
-      end
-
-      def tooltip_data_v2
-        whitelisted_infowindow(with_template(@layer.tooltip, @layer.tooltip_template_path))
-      rescue => e
-        CartoDB::Logger.error(exception: e)
-        throw e
-      end
-
       def name_for(layer)
         layer_alias = layer.options.fetch('table_name_alias', nil)
         table_name  = layer.options['table_name']
@@ -309,12 +268,6 @@ module Carto
       def public_options
         return @configuration if @configuration.empty?
         @configuration.fetch(:layer_opts).fetch('public_opts')
-      end
-
-      def whitelisted_infowindow(infowindow)
-        infowindow.nil? ? nil : infowindow.select { |key, value|
-                                                    INFOWINDOW_KEYS.include?(key) || INFOWINDOW_KEYS.include?(key.to_s)
-                                                  }
       end
     end
 

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -385,8 +385,8 @@ module Carto
       def as_carto
         {
           type:       'CartoDB',
-          infowindow: whitelisted_attrs(migrate_builder_infowindow(@layer.infowindow, mustache_dir: 'infowindows')),
-          tooltip:    whitelisted_attrs(migrate_builder_infowindow(@layer.tooltip, mustache_dir: 'tooltips')),
+          infowindow: whitelisted_attrs(migrate_builder_infowindow(@layer)),
+          tooltip:    whitelisted_attrs(migrate_builder_tooltip(@layer)),
           visible:    @layer.options['visible'],
           options:    options_data
         }

--- a/app/models/layer/presenter.rb
+++ b/app/models/layer/presenter.rb
@@ -71,7 +71,7 @@ module CartoDB
         {
           id:         layer.id,
           kind:       'CartoDB',
-          infowindow: InfowindowGenerator.new(layer).infowindow_data_v1,
+          infowindow: Carto::Api::InfowindowGenerator.new(layer).infowindow_data_v1,
           order:      layer.order,
           options:    options_data_v1
         }

--- a/app/models/layer/presenter.rb
+++ b/app/models/layer/presenter.rb
@@ -45,11 +45,13 @@ module CartoDB
         elsif torque?(layer)
           as_torque
         else
+          infowindow_generator = Carto::Api::InfowindowGenerator.new(@layer)
+
           {
             id:         layer.id,
             type:       'CartoDB',
-            infowindow: infowindow_data_v2,
-            tooltip:    tooltip_data_v2,
+            infowindow: infowindow_generator.infowindow_data_v2,
+            tooltip:    infowindow_generator.tooltip_data_v2,
             legend:     layer.legend,
             order:      layer.order,
             visible:    layer.public_values['options']['visible'],
@@ -69,7 +71,7 @@ module CartoDB
         {
           id:         layer.id,
           kind:       'CartoDB',
-          infowindow: infowindow_data_v1,
+          infowindow: InfowindowGenerator.new(layer).infowindow_data_v1,
           order:      layer.order,
           options:    options_data_v1
         }
@@ -157,40 +159,6 @@ module CartoDB
           }.merge(
             layer_options.select { |k| TORQUE_ATTRS.include? k })
         }
-      end
-
-      def infowindow_data_v1
-        with_template(layer.infowindow, layer.infowindow_template_path)
-      rescue => e
-        CartoDB::Logger.error(exception: e)
-        throw e
-      end
-
-      def infowindow_data_v2
-        whitelisted_infowindow(with_template(layer.infowindow, layer.infowindow_template_path))
-      rescue => e
-        CartoDB::Logger.error(exception: e)
-        throw e
-      end
-
-      def tooltip_data_v2
-        whitelisted_infowindow(with_template(layer.tooltip, layer.tooltip_template_path))
-      rescue => e
-        CartoDB::Logger.error(exception: e)
-        throw e
-      end
-
-      def with_template(infowindow, path)
-        # Careful with this logic:
-        # - nil means absolutely no infowindow (e.g. a torque)
-        # - path = nil or template filled: either pre-filled or custom infowindow, nothing to do here
-        # - template and path not nil but template not filled: stay and fill
-        return nil if infowindow.nil?
-        template = infowindow['template']
-        return infowindow if (!template.nil? && !template.empty?) || path.nil?
-
-        infowindow.merge!(template: File.read(path))
-        infowindow
       end
 
       def options_data_v2

--- a/spec/requests/carto/api/infowindow_migrator_spec.rb
+++ b/spec/requests/carto/api/infowindow_migrator_spec.rb
@@ -53,9 +53,9 @@ describe Carto::Api::InfowindowMigrator do
       migrated = migrator.migrate_builder_infowindow(tiled_layer)
       migrated.should be_nil
     end
-    
+
     let(:default_infowindow) do
-      {"fields"=>[], "template_name"=>"none", "template"=>"", "alternative_names"=>{}, "width"=>226, "maxHeight"=>180}
+      { "fields" => [], "template_name" => "none", "template" => "", "alternative_names" => {}, "width" => 226, "maxHeight" => 180 }
     end
 
     it 'returns the default infowindow if parameter is nil and layer_kind is carto' do

--- a/spec/requests/carto/api/infowindow_migrator_spec.rb
+++ b/spec/requests/carto/api/infowindow_migrator_spec.rb
@@ -7,6 +7,7 @@ describe Carto::Api::InfowindowMigrator do
   end
 
   let(:migrator) { TestInfowindowMigrator.new }
+
   let(:infowindow) do
     {
       "fields" => [],
@@ -17,6 +18,7 @@ describe Carto::Api::InfowindowMigrator do
       "maxHeight" => 180
     }
   end
+
   let(:tooltip) do
     {
       "fields" => [],
@@ -28,14 +30,39 @@ describe Carto::Api::InfowindowMigrator do
   end
 
   describe '#migrate_builder_infowindow' do
+    let(:carto_layer) do
+      FactoryGirl.build(:carto_layer, infowindow: infowindow, tooltip: tooltip)
+    end
+
+    let(:tiled_layer) do
+      FactoryGirl.build(:carto_tiled_layer, infowindow: infowindow, tooltip: tooltip)
+    end
+
     it 'sets template_name "none" if fields are empty' do
-      migrated = migrator.migrate_builder_infowindow(infowindow)
+      migrated = migrator.migrate_builder_infowindow(carto_layer)
       migrated['template_name'].should eq 'none'
       migrated['template'].should eq ''
 
-      migrated = migrator.migrate_builder_infowindow(tooltip)
+      migrated = migrator.migrate_builder_tooltip(carto_layer)
       migrated['template_name'].should eq 'none'
       migrated['template'].should eq ''
+    end
+
+    it 'returns nil if nil is passed and kind is tiled' do
+      tiled_layer.infowindow = nil
+      migrated = migrator.migrate_builder_infowindow(tiled_layer)
+      migrated.should be_nil
+    end
+    
+    let(:default_infowindow) do
+      {"fields"=>[], "template_name"=>"none", "template"=>"", "alternative_names"=>{}, "width"=>226, "maxHeight"=>180}
+    end
+
+    it 'returns the default infowindow if parameter is nil and layer_kind is carto' do
+      carto_layer.infowindow = nil
+      migrated = migrator.migrate_builder_infowindow(carto_layer)
+      migrated.should_not be_nil
+      migrated.should eq default_infowindow
     end
   end
 end

--- a/spec/requests/carto/api/infowindow_migrator_spec.rb
+++ b/spec/requests/carto/api/infowindow_migrator_spec.rb
@@ -55,7 +55,14 @@ describe Carto::Api::InfowindowMigrator do
     end
 
     let(:default_infowindow) do
-      { "fields" => [], "template_name" => "none", "template" => "", "alternative_names" => {}, "width" => 226, "maxHeight" => 180 }
+      {
+        "fields" => [],
+        "template_name" => "none",
+        "template" => "",
+        "alternative_names" => {},
+        "width" => 226,
+        "maxHeight" => 180
+      }
     end
 
     it 'returns the default infowindow if parameter is nil and layer_kind is carto' do
@@ -63,6 +70,13 @@ describe Carto::Api::InfowindowMigrator do
       migrated = migrator.migrate_builder_infowindow(carto_layer)
       migrated.should_not be_nil
       migrated.should eq default_infowindow
+    end
+
+    it 'returns the alternate for data layers without infowindow' do
+      carto_layer.infowindow = nil
+      alternate = { 'template' => { wadus: true } }
+      migrated = migrator.migrate_builder_infowindow(carto_layer, alternate)
+      migrated.should eq alternate
     end
   end
 end


### PR DESCRIPTION
This closes #10688.

For the moment this will be kept on hold until we check that this is an actual problem. @xavijam has a similar patch for frontend.

@gfiorav CR this, please. As you see there's a refactor that is not actually related. I first thought that I could extract the generator piece of code from the layer presenter but it wasn't finally true, so I added a hardcoded default which is enough for frontend (confirmed by @xavijam ) but kept the refactor anywway.