### PR TITLE
9869 sql clear view

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/dataset/dataset-base-view.js
+++ b/lib/assets/javascripts/cartodb3/components/dataset/dataset-base-view.js
@@ -92,33 +92,6 @@ module.exports = CoreView.extend({
     }
   },
 
-  _runQuery: function (query, callback) {
-    this._querySchemaModel.set({
-      query: query,
-      status: 'unfetched'
-    });
-
-    this._queryGeometryModel.set({
-      query: query
-    });
-
-    SQLNotifications.showNotification({
-      status: 'loading',
-      info: _t('notifications.sql.applying'),
-      closable: false
-    });
-
-    var saveSQL = _.after(2, callback);
-    this._querySchemaModel.fetch({ success: saveSQL,
-      complete: function (model, response, options) {
-        if (response === 'abort') {
-          SQLNotifications.removeNotification();
-        }
-      }
-    });
-    this._queryGeometryModel.fetch({ complete: saveSQL });
-  },
-
   _checkClearButton: function () {
     var customSql = this._codemirrorModel.get('content');
     var isDefaultQuery = SQLUtils.isSameQuery(customSql, this._defaultSQL());
@@ -135,6 +108,7 @@ module.exports = CoreView.extend({
     this._querySchemaModel.set('query_errors', []);
     this._clearSQLModel.set({ visible: false });
     this._querySchemaModel.resetDueToAlteredData();
+    this._clearSQL();
   },
 
   _clearSQL: function () {
@@ -143,7 +117,7 @@ module.exports = CoreView.extend({
       content: originalQuery,
       errors: []
     });
-    this._parseSQL();
+    this._runQuery(originalQuery, this._saveSQL.bind(this));
   },
 
   _showErrors: function (model) {

--- a/lib/assets/javascripts/cartodb3/components/dataset/dataset-base-view.js
+++ b/lib/assets/javascripts/cartodb3/components/dataset/dataset-base-view.js
@@ -22,7 +22,7 @@ module.exports = CoreView.extend({
     this._clearSQLModel = new Backbone.Model({
       visible: false
     });
-    
+
     this._sqlModel = this._layerDefinitionModel.sqlModel;
 
     this._SQL = new cdb.SQL({
@@ -39,7 +39,7 @@ module.exports = CoreView.extend({
     SQLNotifications.track(this);
   },
 
-  _parseSQL: function (callbackAfterAlterSuccess) {
+  _internalParseSQL: function (callbackAfterAlterSuccess) {
     var appliedQuery = this._querySchemaModel.get('query');
     var currentQuery = this._codemirrorModel.get('content');
 
@@ -52,7 +52,7 @@ module.exports = CoreView.extend({
     var isSameQuery = SQLUtils.isSameQuery(currentQuery, appliedQuery);
     var altersData = SQLUtils.altersData(currentQuery);
 
-    if (currentQuery === '' || isSameQuery) {
+    if (currentQuery === '' || isSameQuery) {
       SQLNotifications.removeNotification();
       return false;
     }
@@ -86,9 +86,9 @@ module.exports = CoreView.extend({
           SQLNotifications.showErrorNotification(parsedErrors);
           this._checkClearButton();
         }.bind(this)
-      });      
+      });
     } else {
-        this._runQuery(currentQuery, this._saveSQL.bind(this));
+      this._runQuery(currentQuery, this._saveSQL.bind(this));
     }
   },
 
@@ -99,10 +99,8 @@ module.exports = CoreView.extend({
     });
 
     this._queryGeometryModel.set({
-      query: query,
-      simple_geom: '',
-      status: 'unfetched'
-    }, { silent: true });
+      query: query
+    });
 
     SQLNotifications.showNotification({
       status: 'loading',
@@ -119,15 +117,15 @@ module.exports = CoreView.extend({
       }
     });
     this._queryGeometryModel.fetch({ complete: saveSQL });
-  },    
-  
+  },
+
   _checkClearButton: function () {
     var customSql = this._codemirrorModel.get('content');
     var isDefaultQuery = SQLUtils.isSameQuery(customSql, this._defaultSQL());
     this._clearSQLModel.set({ visible: !isDefaultQuery });
   },
 
-  _applyDefaultSQLAfterAlteringData () {
+  _applyDefaultSQLAfterAlteringData: function () {
     var originalQuery = this._defaultSQL();
     this._codemirrorModel.set({
       content: originalQuery,
@@ -136,7 +134,7 @@ module.exports = CoreView.extend({
     this._sqlModel.set('content', originalQuery);
     this._querySchemaModel.set('query_errors', []);
     this._clearSQLModel.set({ visible: false });
-    this._querySchemaModel.resetDueToAlteredData();    
+    this._querySchemaModel.resetDueToAlteredData();
   },
 
   _clearSQL: function () {
@@ -159,7 +157,7 @@ module.exports = CoreView.extend({
     }
 
     this._checkClearButton();
-  },   
+  },
 
   _parseErrors: function (errors) {
     return errors.map(function (error) {

--- a/lib/assets/javascripts/cartodb3/components/dataset/dataset-base-view.js
+++ b/lib/assets/javascripts/cartodb3/components/dataset/dataset-base-view.js
@@ -1,12 +1,45 @@
-var SQLNotifications = require('../sql-notifications');
-var SQLUtils = require('./sql-utils');
-var Notifier = require('../components/notifier/notifier');
+var _ = require('underscore');
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
+var SQLNotifications = require('../../sql-notifications');
+var SQLUtils = require('../../helpers/sql-utils');
+var Notifier = require('../../components/notifier/notifier');
+var cdb = require('cartodb.js');
 
-var sqlEditorViewHelper = {
+module.exports = CoreView.extend({
+
+  initialize: function (opts) {
+    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
+    if (!opts.editorModel) throw new Error('editorModel is required');
+    if (!opts.configModel) throw new Error('configModel is required');
+    if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
+
+    this._layerDefinitionModel = opts.layerDefinitionModel;
+    this._editorModel = opts.editorModel;
+    this._configModel = opts.configModel;
+    this._querySchemaModel = opts.querySchemaModel;
+
+    this._clearSQLModel = new Backbone.Model({
+      visible: false
+    });
+    
+    this._sqlModel = this._layerDefinitionModel.sqlModel;
+
+    this._SQL = new cdb.SQL({
+      user: this._configModel.get('user_name'),
+      sql_api_template: this._configModel.get('sql_api_template'),
+      api_key: this._configModel.get('api_key')
+    });
+
+    this._codemirrorModel = new Backbone.Model({
+      content: this._querySchemaModel.get('query'),
+      readonly: false
+    });
+
+    SQLNotifications.track(this);
+  },
 
   _parseSQL: function (callbackAfterAlterSuccess) {
-    if (typeof callbackAfterAlterSuccess !== 'function') throw new Error('callbackAfterAlterSuccess is required');
-
     var appliedQuery = this._querySchemaModel.get('query');
     var currentQuery = this._codemirrorModel.get('content');
 
@@ -20,6 +53,7 @@ var sqlEditorViewHelper = {
     var altersData = SQLUtils.altersData(currentQuery);
 
     if (currentQuery === '' || isSameQuery) {
+      SQLNotifications.removeNotification();
       return false;
     }
 
@@ -40,7 +74,10 @@ var sqlEditorViewHelper = {
             closable: true,
             delay: Notifier.DEFAULT_DELAY
           });
-          callbackAfterAlterSuccess();
+          this._applyDefaultSQLAfterAlteringData();
+          if (typeof callbackAfterAlterSuccess === 'function') {
+            callbackAfterAlterSuccess.call(this);
+          }
         }.bind(this),
         error: function (errors) {
           errors = errors.responseJSON.error;
@@ -74,14 +111,41 @@ var sqlEditorViewHelper = {
     });
 
     var saveSQL = _.after(2, callback);
-    this._querySchemaModel.fetch({ success: saveSQL });
+    this._querySchemaModel.fetch({ success: saveSQL,
+      complete: function (model, response, options) {
+        if (response === 'abort') {
+          SQLNotifications.removeNotification();
+        }
+      }
+    });
     this._queryGeometryModel.fetch({ complete: saveSQL });
-  },
-
+  },    
+  
   _checkClearButton: function () {
     var customSql = this._codemirrorModel.get('content');
     var isDefaultQuery = SQLUtils.isSameQuery(customSql, this._defaultSQL());
     this._clearSQLModel.set({ visible: !isDefaultQuery });
+  },
+
+  _applyDefaultSQLAfterAlteringData () {
+    var originalQuery = this._defaultSQL();
+    this._codemirrorModel.set({
+      content: originalQuery,
+      errors: []
+    });
+    this._sqlModel.set('content', originalQuery);
+    this._querySchemaModel.set('query_errors', []);
+    this._clearSQLModel.set({ visible: false });
+    this._querySchemaModel.resetDueToAlteredData();    
+  },
+
+  _clearSQL: function () {
+    var originalQuery = this._defaultSQL();
+    this._codemirrorModel.set({
+      content: originalQuery,
+      errors: []
+    });
+    this._parseSQL();
   },
 
   _showErrors: function (model) {
@@ -95,7 +159,7 @@ var sqlEditorViewHelper = {
     }
 
     this._checkClearButton();
-  },
+  },   
 
   _parseErrors: function (errors) {
     return errors.map(function (error) {
@@ -103,19 +167,5 @@ var sqlEditorViewHelper = {
         message: error
       };
     });
-  },
-
-  _clearSQL: function () {
-    var sql = this._defaultSQL();
-    this._codemirrorModel.set({
-      content: sql,
-      errors: []
-    });
-    this._clearSQLModel.set({ visible: false });
-    this._querySchemaModel.set('query_errors', []);
-    SQLNotifications.removeNotification();  
-    this._parseSQLFunction();
   }
-};
-
-module.exports = sqlEditorViewHelper;
+});

--- a/lib/assets/javascripts/cartodb3/components/dataset/dataset-base-view.js
+++ b/lib/assets/javascripts/cartodb3/components/dataset/dataset-base-view.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 var SQLNotifications = require('../../sql-notifications');

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -1,8 +1,8 @@
-var Backbone = require('backbone');
 var $ = require('jquery');
 var CoreView = require('backbone/core-view');
 var VisDefinitionModel = require('../../data/vis-definition-model');
 var CreationModalView = require('../../components/modals/creation/modal-creation-view');
+var DatasetBaseView = require('../../components/dataset/dataset-base-view');
 var errorParser = require('../../helpers/error-parser');
 var PanelWithOptionsView = require('../../components/view-options/panel-with-options-view');
 var TabPaneView = require('../../components/tab-pane/tab-pane-view');
@@ -14,13 +14,10 @@ var PreviewMapView = require('./preview-map-view');
 var ActionViewEdition = require('./dataset-actions-edition-view');
 var DataSQLModel = require('../data-sql-model');
 var SQLUtils = require('../../helpers/sql-utils');
-var sqlEditorViewHelper = require('../../helpers/sql-editor-view-helper');
-var Notifier = require('../../components/notifier/notifier');
-var cdb = require('cartodb.js');
 var SQLNotifications = require('../../sql-notifications');
 var MetricsTracker = require('../../components/metrics/metrics-tracker');
 
-module.exports = CoreView.extend({
+module.exports = DatasetBaseView.extend({
 
   initialize: function (opts) {
     if (!opts.router) throw new Error('router is required');
@@ -31,29 +28,23 @@ module.exports = CoreView.extend({
     if (!opts.userModel) throw new Error('userModel is required');
     if (!opts.queryGeometryModel) throw new Error('queryGeometryModel is required');
     if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
-    if (!opts.configModel) throw new Error('configModel is required');
-    if (!opts.editorModel) throw new Error('editorModel is required');
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
+
+    DatasetBaseView.prototype.initialize.call(this, {
+      layerDefinitionModel: opts.layerDefinitionModel,
+      editorModel: opts.editorModel,
+      configModel: opts.configModel,
+      querySchemaModel: opts.querySchemaModel
+    });
 
     this._tableModel = opts.tableModel;
-    this._configModel = opts.configModel;
     this._userModel = opts.userModel;
     this._modals = opts.modals;
     this._queryGeometryModel = opts.queryGeometryModel;
-    this._querySchemaModel = opts.querySchemaModel;
     this._syncModel = opts.syncModel;
     this._visModel = opts.visModel;
     this._router = opts.router;
-    this._editorModel = opts.editorModel;
-    this._layerDefinitionModel = opts.layerDefinitionModel;
 
     this._canCreateMap = this._userModel.hasCreateMapsFeature();
-
-    this._SQL = new cdb.SQL({
-      user: this._configModel.get('user_name'),
-      sql_api_template: this._configModel.get('sql_api_template'),
-      api_key: this._configModel.get('api_key')
-    });
 
     if (!this._layerDefinitionModel.sqlModel) {
       var sqlHistory = this._layerDefinitionModel.options && this._layerDefinitionModel.options.sql_history;
@@ -63,20 +54,6 @@ module.exports = CoreView.extend({
         history: sqlHistory || []
       });
     }
-
-    this._codemirrorModel = new Backbone.Model({
-      content: this._querySchemaModel.get('query'),
-      readonly: false
-    });
-
-    this._clearSQLModel = new Backbone.Model({
-      visible: false
-    });
-
-    this._sqlModel = this._layerDefinitionModel.sqlModel;
-
-    _.extend(this, sqlEditorViewHelper);
-    this._parseSQLFunction = this._parseSQL.bind(this, this._clearSQL),
 
     SQLNotifications.track(this);
 
@@ -171,7 +148,7 @@ module.exports = CoreView.extend({
         return new DatasetEditorView({
           editorModel: self._editorModel,
           codemirrorModel: self._codemirrorModel,
-          onApplyEvent: self._parseSQLFunction,
+          onApplyEvent: self._parseSQL.bind(self),
           layerDefinitionModel: self._layerDefinitionModel,
           querySchemaModel: self._querySchemaModel
         });
@@ -182,7 +159,7 @@ module.exports = CoreView.extend({
           trackModel: self._sqlModel,
           editorModel: self._editorModel,
           queryGeometryModel: self._queryGeometryModel,
-          onApply: self._parseSQLFunction,
+          onApply: self._parseSQL.bind(self),
           previewAction: self._previewMap.bind(self),
           onClear: self._clearSQL.bind(self)
         };

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -179,6 +179,27 @@ module.exports = DatasetBaseView.extend({
     this._collectionPane = new TabPaneCollection(tabPaneTabs);
   },
 
+  _runQuery: function (query, callback) {
+    this._querySchemaModel.set({
+      query: query,
+      status: 'unfetched'
+    });
+
+    this._queryGeometryModel.set({
+      query: query,
+      simple_geom: '',
+      status: 'unfetched'
+    }, {
+      silent: true
+    });
+
+    this._querySchemaModel.fetch({
+      success: callback
+    });
+
+    this._queryGeometryModel.fetch();
+  },
+
   _saveSQL: function () {
     var content = this._codemirrorModel.get('content');
     this._sqlModel.set('content', content);

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -20,6 +20,7 @@ var MetricsTracker = require('../../components/metrics/metrics-tracker');
 module.exports = DatasetBaseView.extend({
 
   initialize: function (opts) {
+    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
     if (!opts.router) throw new Error('router is required');
     if (!opts.tableModel) throw new Error('tableModel is required');
     if (!opts.modals) throw new Error('modals is required');
@@ -28,6 +29,18 @@ module.exports = DatasetBaseView.extend({
     if (!opts.userModel) throw new Error('userModel is required');
     if (!opts.queryGeometryModel) throw new Error('queryGeometryModel is required');
     if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
+
+    this._layerDefinitionModel = opts.layerDefinitionModel;
+    this._querySchemaModel = opts.querySchemaModel;
+
+    if (!this._layerDefinitionModel.sqlModel) {
+      var sqlHistory = this._layerDefinitionModel.options && this._layerDefinitionModel.options.sql_history;
+      this._layerDefinitionModel.sqlModel = new DataSQLModel({
+        content: this._querySchemaModel.get('query')
+      }, {
+        history: sqlHistory || []
+      });
+    }
 
     DatasetBaseView.prototype.initialize.call(this, {
       layerDefinitionModel: opts.layerDefinitionModel,
@@ -46,14 +59,7 @@ module.exports = DatasetBaseView.extend({
 
     this._canCreateMap = this._userModel.hasCreateMapsFeature();
 
-    if (!this._layerDefinitionModel.sqlModel) {
-      var sqlHistory = this._layerDefinitionModel.options && this._layerDefinitionModel.options.sql_history;
-      this._layerDefinitionModel.sqlModel = new DataSQLModel({
-        content: this._querySchemaModel.get('query')
-      }, {
-        history: sqlHistory || []
-      });
-    }
+    this._parseSQL = this._internalParseSQL.bind(this);
 
     SQLNotifications.track(this);
 
@@ -148,7 +154,7 @@ module.exports = DatasetBaseView.extend({
         return new DatasetEditorView({
           editorModel: self._editorModel,
           codemirrorModel: self._codemirrorModel,
-          onApplyEvent: self._parseSQL.bind(self),
+          onApplyEvent: self._parseSQL,
           layerDefinitionModel: self._layerDefinitionModel,
           querySchemaModel: self._querySchemaModel
         });
@@ -159,7 +165,7 @@ module.exports = DatasetBaseView.extend({
           trackModel: self._sqlModel,
           editorModel: self._editorModel,
           queryGeometryModel: self._queryGeometryModel,
-          onApply: self._parseSQL.bind(self),
+          onApply: self._parseSQL,
           previewAction: self._previewMap.bind(self),
           onClear: self._clearSQL.bind(self)
         };

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -14,6 +14,7 @@ var PreviewMapView = require('./preview-map-view');
 var ActionViewEdition = require('./dataset-actions-edition-view');
 var DataSQLModel = require('../data-sql-model');
 var SQLUtils = require('../../helpers/sql-utils');
+var sqlEditorViewHelper = require('../../helpers/sql-editor-view-helper');
 var Notifier = require('../../components/notifier/notifier');
 var cdb = require('cartodb.js');
 var SQLNotifications = require('../../sql-notifications');
@@ -73,6 +74,9 @@ module.exports = CoreView.extend({
     });
 
     this._sqlModel = this._layerDefinitionModel.sqlModel;
+
+    _.extend(this, sqlEditorViewHelper);
+    this._parseSQLFunction = this._parseSQL.bind(this, this._clearSQL),
 
     SQLNotifications.track(this);
 
@@ -167,7 +171,7 @@ module.exports = CoreView.extend({
         return new DatasetEditorView({
           editorModel: self._editorModel,
           codemirrorModel: self._codemirrorModel,
-          onApplyEvent: self._parseSQL.bind(self),
+          onApplyEvent: self._parseSQLFunction,
           layerDefinitionModel: self._layerDefinitionModel,
           querySchemaModel: self._querySchemaModel
         });
@@ -178,7 +182,7 @@ module.exports = CoreView.extend({
           trackModel: self._sqlModel,
           editorModel: self._editorModel,
           queryGeometryModel: self._queryGeometryModel,
-          onApply: self._parseSQL.bind(self),
+          onApply: self._parseSQLFunction,
           previewAction: self._previewMap.bind(self),
           onClear: self._clearSQL.bind(self)
         };
@@ -192,94 +196,18 @@ module.exports = CoreView.extend({
     this._collectionPane = new TabPaneCollection(tabPaneTabs);
   },
 
-  _parseSQL: function () {
-    var appliedQuery = this._querySchemaModel.get('query');
-    var currentQuery = this._codemirrorModel.get('content');
-
-    // Remove last character if it has ';'
-    if (currentQuery && currentQuery.slice(-1) === ';') {
-      currentQuery = currentQuery.slice(0, currentQuery.length - 1);
-      this._codemirrorModel.set('content', currentQuery);
-    }
-
-    var isSameQuery = SQLUtils.isSameQuery(currentQuery, appliedQuery);
-    var altersData = SQLUtils.altersData(currentQuery);
-
-    if (currentQuery === '' || isSameQuery) {
-      return false;
-    }
-
-    if (altersData) {
-      SQLNotifications.showNotification({
-        status: 'loading',
-        info: _t('notifications.sql.alter-loading'),
-        closable: false
-      });
-
-      this._sqlModel.set('content', currentQuery);
-
-      this._SQL.execute(currentQuery, null, {
-        success: function () {
-          SQLNotifications.showNotification({
-            status: 'success',
-            info: _t('notifications.sql.alter-success'),
-            closable: true,
-            delay: Notifier.DEFAULT_DELAY
-          });
-          // Clean SQL editor (with original query) and make a fetch
-          this._clearSQL();
-        }.bind(this),
-        error: function (errors) {
-          errors = errors.responseJSON.error;
-          var parsedErrors = this._parseErrors(errors);
-          this._codemirrorModel.set('errors', parsedErrors);
-          SQLNotifications.showErrorNotification(parsedErrors);
-        }.bind(this)
-      });
-    } else {
-      this._runQuery(currentQuery, this._saveSQL.bind(this));
-    }
-  },
-
-  _runQuery: function (query, callback) {
-    this._querySchemaModel.set({
-      query: query,
-      status: 'unfetched'
-    });
-
-    this._queryGeometryModel.set({
-      query: query,
-      simple_geom: '',
-      status: 'unfetched'
-    }, { silent: true });
-
-    this._querySchemaModel.fetch({
-      success: callback
-    });
-
-    this._queryGeometryModel.fetch();
-  },
-
-  _showErrors: function (model) {
-    var errors = this._querySchemaModel.get('query_errors');
-    this._codemirrorModel.set('errors', this._parseErrors(errors));
-    this._checkClearButton();
-  },
-
-  _parseErrors: function (errors) {
-    return errors.map(function (error) {
-      return {
-        message: error
-      };
-    });
-  },
-
   _saveSQL: function () {
     var content = this._codemirrorModel.get('content');
     this._sqlModel.set('content', content);
     this._querySchemaModel.set('query_errors', []);
     this._layerDefinitionModel.save({
       sql: content
+    });
+
+    SQLNotifications.showNotification({
+      status: 'success',
+      info: _t('notifications.sql.success'),
+      closable: true
     });
 
     this._checkClearButton();
@@ -290,25 +218,12 @@ module.exports = CoreView.extend({
     });
   },
 
-  _clearSQL: function () {
-    var sql = this._defaultSQL();
-    this._codemirrorModel.set({content: sql});
-    this._querySchemaModel.set('query_errors', []);
-    this._runQuery(sql, this._saveSQL.bind(this));
-  },
-
   _defaultSQL: function (tableName) {
     return SQLUtils.getDefaultSQL(
       tableName || this._tableModel.getUnqualifiedName(),
       this._tableModel.get('permission').owner.username,
       this._userModel.isInsideOrg()
     );
-  },
-
-  _checkClearButton: function () {
-    var custom_sql = this._codemirrorModel.get('content').toLowerCase();
-    var default_sql = this._defaultSQL().toLowerCase();
-    this._clearSQLModel.set({visible: custom_sql !== default_sql});
   },
 
   _previewMap: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -3,6 +3,7 @@ var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 var PanelWithOptionsView = require('../../../../components/view-options/panel-with-options-view');
 var ScrollView = require('../../../../components/scroll/scroll-view');
+var DatasetBaseView = require('../../../../components/dataset/dataset-base-view');
 var DataContentView = require('./data-content-view');
 var DataSQLView = require('./data-sql-view');
 var TabPaneView = require('../../../../components/tab-pane/tab-pane-view');
@@ -14,46 +15,33 @@ var InfoboxModel = require('../../../../components/infobox/infobox-model');
 var InfoboxCollection = require('../../../../components/infobox/infobox-collection');
 var TableStats = require('../../../../components/modals/add-widgets/tablestats');
 var DataColumnsModel = require('./data-columns-model');
-var Notifier = require('../../../../components/notifier/notifier');
 var SQLUtils = require('../../../../helpers/sql-utils');
-var sqlEditorViewHelper = require('../../../../helpers/sql-editor-view-helper');
-var cdb = require('cartodb.js');
 var SQLNotifications = require('../../../../sql-notifications');
 var MetricsTracker = require('../../../../components/metrics/metrics-tracker');
 
-module.exports = CoreView.extend({
+module.exports = DatasetBaseView.extend({
 
   initialize: function (opts) {
     if (!opts.widgetDefinitionsCollection) throw new Error('widgetDefinitionsCollection is required');
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-    if (!opts.editorModel) throw new Error('editorModel is required');
-    if (!opts.configModel) throw new Error('configModel is required');
     if (!opts.stackLayoutModel) throw new Error('StackLayoutModel is required');
     if (!opts.userActions) throw new Error('userActions is required');
+    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
 
-    this._layerDefinitionModel = opts.layerDefinitionModel;
-    this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
-
-    this._userActions = opts.userActions;
-    this._userModel = opts.userModel;
-    this._configModel = opts.configModel;
-    this._editorModel = opts.editorModel;
-    this._stackLayoutModel = opts.stackLayoutModel;
-    this._nodeModel = this._layerDefinitionModel.getAnalysisDefinitionNodeModel();
+    this._nodeModel = opts.layerDefinitionModel.getAnalysisDefinitionNodeModel();
     this._querySchemaModel = this._nodeModel.querySchemaModel;
     this._queryGeometryModel = this._nodeModel.queryGeometryModel;
 
-    this._clearSQLModel = new Backbone.Model({
-      visible: false
+    DatasetBaseView.prototype.initialize.call(this, {
+      layerDefinitionModel: opts.layerDefinitionModel,
+      editorModel: opts.editorModel,
+      configModel: opts.configModel,
+      querySchemaModel: this._querySchemaModel
     });
 
-    this._sqlModel = this._layerDefinitionModel.sqlModel;
-
-    this._SQL = new cdb.SQL({
-      user: this._configModel.get('user_name'),
-      sql_api_template: this._configModel.get('sql_api_template'),
-      api_key: this._configModel.get('api_key')
-    });
+    this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
+    this._userActions = opts.userActions;
+    this._userModel = opts.userModel;
+    this._stackLayoutModel = opts.stackLayoutModel;
 
     this._infoboxModel = new InfoboxModel({
       state: this._isLayerHidden() ? 'layer-hidden' : ''
@@ -74,15 +62,9 @@ module.exports = CoreView.extend({
       tableStats: this._tableStats
     });
 
-    this._codemirrorModel = new Backbone.Model({
-      content: this._querySchemaModel.get('query'),
-      readonly: false
-    });
-
-    _.extend(this, sqlEditorViewHelper);
-    this._parseSQLFunction = this._parseSQL.bind(this, this._applyDefaultSQL);
-
     SQLNotifications.track(this);
+
+    this._parseSQLFunction = this._parseSQL.bind(this, this._afterAlterDataSuccess);
 
     this._configPanes();
     this._initBinds();
@@ -178,23 +160,17 @@ module.exports = CoreView.extend({
     });
   },
 
-  _applyDefaultSQL: function () {
-    var originalQuery = this._defaultSQL();
-    this._codemirrorModel.set({ content: originalQuery });
-    this._clearSQLModel.set({ visible: false });
-    this._querySchemaModel.set('query_errors', []);
-
-    this._sqlModel.set('content', originalQuery);
-    this._userActions.saveAnalysisSourceQuery(originalQuery, this._nodeModel, this._layerDefinitionModel);
-    this._querySchemaModel.resetDueToAlteredData();
-  },
-
   _defaultSQL: function () {
     return SQLUtils.getDefaultSQL(
       this._layerDefinitionModel.getTableName(),
       this._layerDefinitionModel.get('user_name'),
       this._userModel.isInsideOrg()
     );
+  },
+
+  _afterAlterDataSuccess: function () {
+    var originalQuery = this._defaultSQL();
+    this._userActions.saveAnalysisSourceQuery(originalQuery, this._nodeModel, this._layerDefinitionModel);
   },
 
   _hasAnalysisApplied: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -16,6 +16,7 @@ var TableStats = require('../../../../components/modals/add-widgets/tablestats')
 var DataColumnsModel = require('./data-columns-model');
 var Notifier = require('../../../../components/notifier/notifier');
 var SQLUtils = require('../../../../helpers/sql-utils');
+var sqlEditorViewHelper = require('../../../../helpers/sql-editor-view-helper');
 var cdb = require('cartodb.js');
 var SQLNotifications = require('../../../../sql-notifications');
 var MetricsTracker = require('../../../../components/metrics/metrics-tracker');
@@ -78,6 +79,9 @@ module.exports = CoreView.extend({
       readonly: false
     });
 
+    _.extend(this, sqlEditorViewHelper);
+    this._parseSQLFunction = this._parseSQL.bind(this, this._applyDefaultSQL);
+
     SQLNotifications.track(this);
 
     this._configPanes();
@@ -139,96 +143,6 @@ module.exports = CoreView.extend({
     this.add_related_model(this._sqlModel);
   },
 
-  _parseSQL: function () {
-    var appliedQuery = this._querySchemaModel.get('query');
-    var currentQuery = this._codemirrorModel.get('content');
-
-    // Remove last character if it has ';'
-    if (currentQuery && currentQuery.slice(-1) === ';') {
-      currentQuery = currentQuery.slice(0, currentQuery.length - 1);
-      this._codemirrorModel.set('content', currentQuery);
-    }
-
-    var isSameQuery = SQLUtils.isSameQuery(currentQuery, appliedQuery);
-    var altersData = SQLUtils.altersData(currentQuery);
-
-    if (currentQuery === '' || isSameQuery) {
-      SQLNotifications.removeNotification();
-      return false;
-    }
-
-    if (altersData) {
-      SQLNotifications.showNotification({
-        status: 'loading',
-        info: _t('notifications.sql.alter-loading'),
-        closable: false
-      });
-
-      this._sqlModel.set('content', currentQuery);
-
-      this._SQL.execute(currentQuery, null, {
-        success: function () {
-          SQLNotifications.showNotification({
-            status: 'success',
-            info: _t('notifications.sql.alter-success'),
-            closable: true,
-            delay: Notifier.DEFAULT_DELAY
-          });
-
-          this._applyDefaultSQL();
-        }.bind(this),
-        error: function (errors) {
-          errors = errors.responseJSON.error;
-          var parsedErrors = this._parseErrors(errors);
-          this._codemirrorModel.set('errors', parsedErrors);
-          SQLNotifications.showErrorNotification(parsedErrors);
-          this._checkClearButton();
-        }.bind(this)
-      });
-    } else {
-      // Parser errors SQL here and saving
-      this._querySchemaModel.set({
-        status: 'unfetched',
-        query: currentQuery
-      });
-
-      this._queryGeometryModel.set({
-        query: currentQuery
-      });
-
-      SQLNotifications.showNotification({
-        status: 'loading',
-        info: _t('notifications.sql.applying'),
-        closable: false
-      });
-
-      var saveSQL = _.after(2, this._saveSQL.bind(this));
-      this._querySchemaModel.fetch({ success: saveSQL });
-      this._queryGeometryModel.fetch({ complete: saveSQL });
-    }
-  },
-
-  _showErrors: function (model) {
-    var errors = this._querySchemaModel.get('query_errors');
-    var hasErrors = errors && errors.length > 0;
-    this._codemirrorModel.set('errors', this._parseErrors(errors));
-    this._editorModel.set('disabled', hasErrors);
-
-    if (hasErrors) {
-      SQLNotifications.showErrorNotification(this._parseErrors(errors));
-    }
-
-    this._checkClearButton();
-  },
-
-  _parseErrors: function (errors) {
-    return errors.map(function (error) {
-      return {
-        message: error
-      };
-    });
-  },
-
   _saveSQL: function () {
     var query = this._codemirrorModel.get('content');
 
@@ -267,27 +181,12 @@ module.exports = CoreView.extend({
   _applyDefaultSQL: function () {
     var originalQuery = this._defaultSQL();
     this._codemirrorModel.set({ content: originalQuery });
+    this._clearSQLModel.set({ visible: false });
+    this._querySchemaModel.set('query_errors', []);
+
     this._sqlModel.set('content', originalQuery);
     this._userActions.saveAnalysisSourceQuery(originalQuery, this._nodeModel, this._layerDefinitionModel);
-    this._querySchemaModel.set('query_errors', []);
-    this._clearSQLModel.set({ visible: false });
     this._querySchemaModel.resetDueToAlteredData();
-  },
-
-  _clearSQL: function () {
-    var sql = this._defaultSQL();
-    this._codemirrorModel.set({
-      content: sql,
-      errors: []
-    });
-    this._clearSQLModel.set({ visible: false });
-    this._parseSQL();
-  },
-
-  _checkClearButton: function () {
-    var custom_sql = this._codemirrorModel.get('content');
-    var isDefaultQuery = SQLUtils.isSameQuery(custom_sql, this._defaultSQL());
-    this._clearSQLModel.set({ visible: !isDefaultQuery });
   },
 
   _defaultSQL: function () {
@@ -341,7 +240,7 @@ module.exports = CoreView.extend({
           layerDefinitionModel: self._layerDefinitionModel,
           querySchemaModel: self._querySchemaModel,
           codemirrorModel: self._codemirrorModel,
-          onApplyEvent: self._parseSQL.bind(self)
+          onApplyEvent: self._parseSQLFunction
         });
       },
       createActionView: function () {
@@ -354,7 +253,7 @@ module.exports = CoreView.extend({
             clearModel: self._clearSQLModel,
             applyButton: true,
             clearButton: true,
-            onApplyClick: self._parseSQL.bind(self),
+            onApplyClick: self._parseSQLFunction,
             onClearClick: self._clearSQL.bind(self)
           });
         }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -182,6 +182,7 @@ module.exports = CoreView.extend({
           var parsedErrors = this._parseErrors(errors);
           this._codemirrorModel.set('errors', parsedErrors);
           SQLNotifications.showErrorNotification(parsedErrors);
+          this._checkClearButton();
         }.bind(this)
       });
     } else {
@@ -216,6 +217,8 @@ module.exports = CoreView.extend({
     if (hasErrors) {
       SQLNotifications.showErrorNotification(this._parseErrors(errors));
     }
+
+    this._checkClearButton();
   },
 
   _parseErrors: function (errors) {
@@ -273,14 +276,18 @@ module.exports = CoreView.extend({
 
   _clearSQL: function () {
     var sql = this._defaultSQL();
-    this._codemirrorModel.set({content: sql});
+    this._codemirrorModel.set({
+      content: sql,
+      errors: []
+    });
+    this._clearSQLModel.set({ visible: false });
     this._parseSQL();
   },
 
   _checkClearButton: function () {
-    var custom_sql = this._codemirrorModel.get('content').toLowerCase();
-    var default_sql = this._defaultSQL().toLowerCase();
-    this._clearSQLModel.set({visible: custom_sql !== default_sql});
+    var custom_sql = this._codemirrorModel.get('content');
+    var isDefaultQuery = SQLUtils.isSameQuery(custom_sql, this._defaultSQL());
+    this._clearSQLModel.set({ visible: !isDefaultQuery });
   },
 
   _defaultSQL: function () {

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -125,6 +125,27 @@ module.exports = DatasetBaseView.extend({
     this.add_related_model(this._sqlModel);
   },
 
+  _runQuery: function (query, callback) {
+    this._querySchemaModel.set({
+      query: query,
+      status: 'unfetched'
+    });
+
+    this._queryGeometryModel.set({
+      query: query
+    });
+
+    SQLNotifications.showNotification({
+      status: 'loading',
+      info: _t('notifications.sql.applying'),
+      closable: false
+    });
+
+    var saveSQL = _.after(2, callback);
+    this._querySchemaModel.fetch({ success: saveSQL });
+    this._queryGeometryModel.fetch({ complete: saveSQL });
+  },
+
   _saveSQL: function () {
     var query = this._codemirrorModel.get('content');
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -64,7 +64,7 @@ module.exports = DatasetBaseView.extend({
 
     SQLNotifications.track(this);
 
-    this._parseSQLFunction = this._parseSQL.bind(this, this._afterAlterDataSuccess);
+    this._parseSQL = this._internalParseSQL.bind(this, this._afterAlterDataSuccess);
 
     this._configPanes();
     this._initBinds();
@@ -216,7 +216,7 @@ module.exports = DatasetBaseView.extend({
           layerDefinitionModel: self._layerDefinitionModel,
           querySchemaModel: self._querySchemaModel,
           codemirrorModel: self._codemirrorModel,
-          onApplyEvent: self._parseSQLFunction
+          onApplyEvent: self._parseSQL
         });
       },
       createActionView: function () {
@@ -229,7 +229,7 @@ module.exports = DatasetBaseView.extend({
             clearModel: self._clearSQLModel,
             applyButton: true,
             clearButton: true,
-            onApplyClick: self._parseSQLFunction,
+            onApplyClick: self._parseSQL,
             onClearClick: self._clearSQL.bind(self)
           });
         }

--- a/lib/assets/javascripts/cartodb3/helpers/sql-editor-view-helper.js
+++ b/lib/assets/javascripts/cartodb3/helpers/sql-editor-view-helper.js
@@ -1,0 +1,121 @@
+var SQLNotifications = require('../sql-notifications');
+var SQLUtils = require('./sql-utils');
+var Notifier = require('../components/notifier/notifier');
+
+var sqlEditorViewHelper = {
+
+  _parseSQL: function (callbackAfterAlterSuccess) {
+    if (typeof callbackAfterAlterSuccess !== 'function') throw new Error('callbackAfterAlterSuccess is required');
+
+    var appliedQuery = this._querySchemaModel.get('query');
+    var currentQuery = this._codemirrorModel.get('content');
+
+    // Remove last character if it has ';'
+    if (currentQuery && currentQuery.slice(-1) === ';') {
+      currentQuery = currentQuery.slice(0, currentQuery.length - 1);
+      this._codemirrorModel.set('content', currentQuery);
+    }
+
+    var isSameQuery = SQLUtils.isSameQuery(currentQuery, appliedQuery);
+    var altersData = SQLUtils.altersData(currentQuery);
+
+    if (currentQuery === '' || isSameQuery) {
+      return false;
+    }
+
+    if (altersData) {
+      SQLNotifications.showNotification({
+        status: 'loading',
+        info: _t('notifications.sql.alter-loading'),
+        closable: false
+      });
+
+      this._sqlModel.set('content', currentQuery);
+
+      this._SQL.execute(currentQuery, null, {
+        success: function () {
+          SQLNotifications.showNotification({
+            status: 'success',
+            info: _t('notifications.sql.alter-success'),
+            closable: true,
+            delay: Notifier.DEFAULT_DELAY
+          });
+          callbackAfterAlterSuccess();
+        }.bind(this),
+        error: function (errors) {
+          errors = errors.responseJSON.error;
+          var parsedErrors = this._parseErrors(errors);
+          this._codemirrorModel.set('errors', parsedErrors);
+          SQLNotifications.showErrorNotification(parsedErrors);
+          this._checkClearButton();
+        }.bind(this)
+      });      
+    } else {
+        this._runQuery(currentQuery, this._saveSQL.bind(this));
+    }
+  },
+
+  _runQuery: function (query, callback) {
+    this._querySchemaModel.set({
+      query: query,
+      status: 'unfetched'
+    });
+
+    this._queryGeometryModel.set({
+      query: query,
+      simple_geom: '',
+      status: 'unfetched'
+    }, { silent: true });
+
+    SQLNotifications.showNotification({
+      status: 'loading',
+      info: _t('notifications.sql.applying'),
+      closable: false
+    });
+
+    var saveSQL = _.after(2, callback);
+    this._querySchemaModel.fetch({ success: saveSQL });
+    this._queryGeometryModel.fetch({ complete: saveSQL });
+  },
+
+  _checkClearButton: function () {
+    var customSql = this._codemirrorModel.get('content');
+    var isDefaultQuery = SQLUtils.isSameQuery(customSql, this._defaultSQL());
+    this._clearSQLModel.set({ visible: !isDefaultQuery });
+  },
+
+  _showErrors: function (model) {
+    var errors = this._querySchemaModel.get('query_errors');
+    var hasErrors = errors && errors.length > 0;
+    this._codemirrorModel.set('errors', this._parseErrors(errors));
+    this._editorModel.set('disabled', hasErrors);
+
+    if (hasErrors) {
+      SQLNotifications.showErrorNotification(this._parseErrors(errors));
+    }
+
+    this._checkClearButton();
+  },
+
+  _parseErrors: function (errors) {
+    return errors.map(function (error) {
+      return {
+        message: error
+      };
+    });
+  },
+
+  _clearSQL: function () {
+    var sql = this._defaultSQL();
+    this._codemirrorModel.set({
+      content: sql,
+      errors: []
+    });
+    this._clearSQLModel.set({ visible: false });
+    this._querySchemaModel.set('query_errors', []);
+    SQLNotifications.removeNotification();  
+    this._parseSQLFunction();
+  }
+};
+
+module.exports = sqlEditorViewHelper;


### PR DESCRIPTION
Fixes #9869 

Now, if the query throws an error in the first edition, the 'Clear' button appears.

![sql clear view](https://cloud.githubusercontent.com/assets/1078228/20482251/f89fc1b8-afeb-11e6-8189-f8e1a671605b.gif)

Furthermore, this PR has a refactor for creating a base view with common behaviours shared between the SQL views on the Builder and on the Dataset window.