### PR TITLE
10645 zero buckets bug

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model.js
@@ -36,7 +36,7 @@ module.exports = WidgetsFormBaseSchema.extend({
         type: 'Number',
         validators: ['required', {
           type: 'interval',
-          min: 0,
+          min: 2,
           max: 30
         }]
       }

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model.spec.js
@@ -1,0 +1,47 @@
+var Backbone = require('backbone');
+var _ = require('underscore');
+var WidgetsFormColumnOptionsFactory = require('../../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-column-options-factory');
+var WidgetsFormHistogramSchemaModel = require('../../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model');
+
+describe('editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model', function () {
+
+  beforeEach(function () {
+    var querySchemaModel = new Backbone.Model();
+    this.widgetsFormColumnOptionsFactory = new WidgetsFormColumnOptionsFactory(querySchemaModel);
+    spyOn(this.widgetsFormColumnOptionsFactory, 'create').and.returnValue([{
+      val: 'col',
+      label: 'col',
+      type: 'number'
+    }, {
+      val: 'col2',
+      label: 'col2',
+      type: 'string'
+    }]);
+
+    this.model = new WidgetsFormHistogramSchemaModel({
+      type: 'histogram'
+    }, {
+      columnOptionsFactory: this.widgetsFormColumnOptionsFactory
+    });
+  });
+
+  describe('.updateSchema', function () {
+    it('bins validator is correct', function () {
+      // Arrange
+      var expectedValidator = {
+        type: 'interval',
+        min: 2,
+        max: 30
+      };
+
+      // Act
+      this.model.updateSchema();
+
+      // Assert
+      expect(this.model.schema.bins).toBeDefined();
+      expect(this.model.schema.bins.validators).toBeDefined();
+      expect(this.model.schema.bins.validators[0]).toEqual('required');
+      expect(_.isMatch(this.model.schema.bins.validators[1], expectedValidator)).toBe(true);
+    });
+  });
+});

--- a/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model.spec.js
@@ -1,10 +1,8 @@
 var Backbone = require('backbone');
-var _ = require('underscore');
 var WidgetsFormColumnOptionsFactory = require('../../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-column-options-factory');
 var WidgetsFormHistogramSchemaModel = require('../../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model');
 
 describe('editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model', function () {
-
   beforeEach(function () {
     var querySchemaModel = new Backbone.Model();
     this.widgetsFormColumnOptionsFactory = new WidgetsFormColumnOptionsFactory(querySchemaModel);
@@ -41,7 +39,7 @@ describe('editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model
       expect(this.model.schema.bins).toBeDefined();
       expect(this.model.schema.bins.validators).toBeDefined();
       expect(this.model.schema.bins.validators[0]).toEqual('required');
-      expect(_.isMatch(this.model.schema.bins.validators[1], expectedValidator)).toBe(true);
+      expect(this.model.schema.bins.validators[1]).toEqual(expectedValidator);
     });
   });
 });


### PR DESCRIPTION
Fixes #10645 

![zero buckets bug](https://cloud.githubusercontent.com/assets/1078228/20519505/7c98dfce-b0a3-11e6-9eb9-afaa7934c781.gif)

Now the minimum number of buckets for a histogram widget is 2.

CR @javierarce 