### PR TITLE
10768 namedmap with sources

### DIFF
--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -414,6 +414,10 @@ class Carto::Visualization < ActiveRecord::Base
         CartoDB::Logger.warning(message: 'Couldn\'t add source analysis for layer', user: user, layer: layer)
       end
     end
+
+    # This is needed because Carto::Layer does not yet triggers invalidations on save
+    # It can be safely removed once it does
+    map.notify_map_change
   end
 
   def ids_json

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -374,7 +374,11 @@ class Carto::Visualization < ActiveRecord::Base
   # - v3 (Builder): not derived or not private, mapcapped
   # This Ruby code should match the SQL code at Carto::VisualizationQueryBuilder#build section for @only_published.
   def published?
-    !is_privacy_private? && (version != VERSION_BUILDER || !derived? || mapcapped?)
+    !is_privacy_private? && (!builder? || !derived? || mapcapped?)
+  end
+
+  def builder?
+    version == VERSION_BUILDER
   end
 
   MAX_MAPCAPS_PER_VISUALIZATION = 1
@@ -474,7 +478,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def open_in_editor?
-    version != VERSION_BUILDER && (uses_vizjson2? || layers.any?(&:gmapsbase?))
+    !builder? && (uses_vizjson2? || layers.any?(&:gmapsbase?))
   end
 
   def can_be_automatically_migrated_to_v3?

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -91,11 +91,12 @@ module Carto
         layers = []
         layer_index = -1 # forgive me for I have sinned
 
+        is_builder = @visualization.builder?
         @visualization.named_map_layers.each do |layer|
           if layer.data_layer?
             layer_index += 1
 
-            layers.push(type: 'cartodb', options: options_for_carto_and_torque_layers(layer, layer_index))
+            layers.push(type: 'cartodb', options: options_for_carto_and_torque_layers(layer, layer_index, is_builder))
           elsif layer.base?
             layer_options = layer.options
 
@@ -109,7 +110,7 @@ module Carto
 
         @visualization.torque_layers.each do |layer|
           layer_index += 1
-          layers.push(type: 'torque', options: options_for_carto_and_torque_layers(layer, layer_index))
+          layers.push(type: 'torque', options: options_for_carto_and_torque_layers(layer, layer_index, is_builder))
         end
 
         layers
@@ -128,7 +129,7 @@ module Carto
         options
       end
 
-      def options_for_carto_and_torque_layers(layer, index)
+      def options_for_carto_and_torque_layers(layer, index, is_builder)
         layer_options = layer.options.with_indifferent_access
         tile_style = layer_options[:tile_style].strip if layer_options[:tile_style]
 
@@ -139,7 +140,7 @@ module Carto
         }
 
         layer_options_source = layer_options[:source]
-        if layer_options_source
+        if is_builder && layer_options_source
           options[:source] = { id: layer_options_source }
         else
           options[:sql] = visibility_wrapped_sql(layer.default_query(@visualization.user), index)

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -253,8 +253,6 @@ module Carto
 
               @carto_layer.options[:source] = @analysis.natural_id
               @carto_layer.save
-
-              @template_hash = Carto::NamedMaps::Template.new(@visualization).to_hash
             end
 
             after(:all) do
@@ -265,12 +263,34 @@ module Carto
               @template_hash = nil
             end
 
-            it 'should not contain sql' do
-              @template_hash[:layergroup][:layers].second[:options][:sql].should be_nil
+            describe 'and builder' do
+              before(:all) do
+                @visualization.stubs(:version).returns(3)
+                @template_hash = Carto::NamedMaps::Template.new(@visualization).to_hash
+              end
+
+              it 'should not contain sql' do
+                @template_hash[:layergroup][:layers].second[:options][:sql].should be_nil
+              end
+
+              it 'should contain source' do
+                @template_hash[:layergroup][:layers].second[:options][:source][:id].should eq @analysis.natural_id
+              end
             end
 
-            it 'should contain source' do
-              @template_hash[:layergroup][:layers].second[:options][:source][:id].should eq @analysis.natural_id
+            describe 'and editor' do
+              before(:all) do
+                @visualization.stubs(:version).returns(2)
+                @template_hash = Carto::NamedMaps::Template.new(@visualization).to_hash
+              end
+
+              it 'should contain sql' do
+                @template_hash[:layergroup][:layers].second[:options].should_not be_nil
+              end
+
+              it 'should not contain source' do
+                @template_hash[:layergroup][:layers].second[:options][:source].should be_nil
+              end
             end
           end
 


### PR DESCRIPTION
Fixes #10768 

Named maps for editor maps should never contain `layer.options[:source]`.