### PR TITLE
Legend placeholders

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/legends/legend-custom-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/legends/legend-custom-definition-model.js
@@ -39,7 +39,7 @@ module.exports = LegendBaseDefModel.extend({
         definition: {
           categories: this.get('items').map(function (item) {
             return {
-              title: item.title,
+              title: item.title || _t('editor.legend.legend-form.untitled'),
               color: item.color
             };
           })

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/form/legend-bubble-definition-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/form/legend-bubble-definition-form-model.js
@@ -54,7 +54,10 @@ module.exports = LegendBaseDefModel.extend({
           title: '',
           label: _t('editor.legend.legend-form.top-label'),
           editor: {
-            type: 'Text'
+            type: 'Text',
+            editorAttrs: {
+              placeholder: _t('editor.legend.legend-form.custom-label-placeholder')
+            }
           }
         },
         bottomLabel: {
@@ -62,7 +65,10 @@ module.exports = LegendBaseDefModel.extend({
           title: '',
           label: _t('editor.legend.legend-form.bottom-label'),
           editor: {
-            type: 'Text'
+            type: 'Text',
+            editorAttrs: {
+              placeholder: _t('editor.legend.legend-form.custom-label-placeholder')
+            }
           }
         }
       }

--- a/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/form/legend-choropleth-definition-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/layer-content-views/legend/form/legend-choropleth-definition-form-model.js
@@ -22,6 +22,28 @@ module.exports = LegendBaseDefModel.extend({
     return _.extend(
       schema,
       {
+        leftLabel: {
+          type: 'EnablerEditor',
+          title: '',
+          label: _t('editor.legend.legend-form.left-label'),
+          editor: {
+            type: 'Text',
+            editorAttrs: {
+              placeholder: _t('editor.legend.legend-form.custom-label-placeholder')
+            }
+          }
+        },
+        rightLabel: {
+          type: 'EnablerEditor',
+          title: '',
+          label: _t('editor.legend.legend-form.right-label'),
+          editor: {
+            type: 'Text',
+            editorAttrs: {
+              placeholder: _t('editor.legend.legend-form.custom-label-placeholder')
+            }
+          }
+        },
         suffix: {
           type: 'EnablerEditor',
           title: '',
@@ -34,22 +56,6 @@ module.exports = LegendBaseDefModel.extend({
           type: 'EnablerEditor',
           title: '',
           label: _t('editor.legend.legend-form.prefix'),
-          editor: {
-            type: 'Text'
-          }
-        },
-        leftLabel: {
-          type: 'EnablerEditor',
-          title: '',
-          label: _t('editor.legend.legend-form.left-label'),
-          editor: {
-            type: 'Text'
-          }
-        },
-        rightLabel: {
-          type: 'EnablerEditor',
-          title: '',
-          label: _t('editor.legend.legend-form.right-label'),
           editor: {
             type: 'Text'
           }

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -1779,7 +1779,8 @@
         "left-label": "Left Label",
         "right-label": "Right Label",
         "top-label": "Top Label",
-        "bottom-label": "Bottom Label"
+        "bottom-label": "Bottom Label",
+        "custom-label-placeholder": "Override dynamic value"
       },
       "pixel-title": "Amount"
     },

--- a/lib/assets/test/spec/cartodb3/data/legends/legend-custom-definition-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/legends/legend-custom-definition-model.spec.js
@@ -1,0 +1,43 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+var ConfigModel = require('../../../../../javascripts/cartodb3/data/config-model');
+var LegendDefinitionModel = require('../../../../../javascripts/cartodb3/data/legends/legend-custom-definition-model');
+
+describe('data/legends/legend-custom-defintion-model', function () {
+  beforeEach(function () {
+    var configModel = new ConfigModel({
+      base_url: '/u/pepe'
+    });
+
+    var layerDef1 = new Backbone.Model({
+      id: 'fa6cf872-fffa-4301-9a60-849cedba7864',
+      table_name: 'foo'
+    });
+
+    this.model = new LegendDefinitionModel({
+      items: [
+        {
+          title: '',
+          color: '#fabada'
+        },
+        {
+          title: 'Foo',
+          color: '#f4b4d4'
+        }
+      ]
+    }, {
+      configModel: configModel,
+      layerDefinitionModel: layerDef1,
+      vizId: 'v-123'
+    });
+  });
+
+  it('should toJSON properly', function () {
+    var attrs = this.model.toJSON();
+    expect(attrs.definition).toBeDefined();
+    expect(_.isArray(attrs.definition.categories)).toBe(true);
+    expect(attrs.definition.categories.length).toBe(2);
+    expect(attrs.definition.categories[0].title).toContain('editor.legend.legend-form.untitled');
+    expect(attrs.definition.categories[1].title).toContain('Foo');
+  });
+});


### PR DESCRIPTION
This PR fixes #10789. It also adds the placeholder for the custom label fields.

![legend-item-name](https://cloud.githubusercontent.com/assets/1366843/20558941/bcda011a-b172-11e6-838f-3c9df5782882.gif)

CR @hacheka 
cc @saleiva @xavijam 