### PR TITLE
select editor: add columnrowdata option

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/select/select-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/select/select-view.js
@@ -35,12 +35,34 @@ Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
     this._setOptions(opts);
 
     this.template = opts.template || template;
-    this.collection = new CustomListCollection(this.options.options);
-    this._initViews();
 
+    this._setupCollection();
     this.setValue(this.model.get(this.options.keyAttr));
-
     this._initBinds();
+  },
+
+  render: function () {
+    this.setValue(this.value);
+
+    return this;
+  },
+
+  _setupCollection: function () {
+    this.collection = new CustomListCollection(this.options.options);
+
+    if (this.options.editorAttrs && this.options.editorAttrs.columnRowData) {
+      var columnRowData = this.options.editorAttrs.columnRowData;
+      columnRowData.fetch();
+      columnRowData.bind('columnsFetched', function (rows) {
+        var categories = _.map(rows, function (d) {
+          return { label: d, val: d };
+        });
+
+        this.collection.reset(categories);
+      }, this);
+    } else {
+
+    }
   },
 
   _initViews: function () {
@@ -81,6 +103,9 @@ Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
 
   _initBinds: function () {
     this.collection.bind('change:selected', this._onItemSelected, this);
+    this.collection.bind('reset', function () {
+      this.render();
+    }, this);
     this.applyESCBind(function () {
       this._listView.hide();
     });
@@ -111,17 +136,25 @@ Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
 
   getValue: function () {
     var item = this.collection.getSelectedItem();
+
     if (item) {
       return item.getValue();
     }
+
     return;
   },
 
   setValue: function (value) {
     var selectedModel = this.collection.setSelected(value);
-    if (selectedModel) {
-      this._renderButton(selectedModel);
+
+    if (!selectedModel) {
+      this.collection.add({ label: value, val: value });
+      selectedModel = this.collection.setSelected(value);
     }
+
+    this._initViews();
+    this._renderButton(selectedModel);
+
     this.value = value;
   },
 

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/select/select-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/select/select-view.js
@@ -50,18 +50,12 @@ Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
   _setupCollection: function () {
     this.collection = new CustomListCollection(this.options.options);
 
-    if (this.options.editorAttrs && this.options.editorAttrs.columnRowData) {
-      var columnRowData = this.options.editorAttrs.columnRowData;
-      columnRowData.fetch();
-      columnRowData.bind('columnsFetched', function (rows) {
-        var categories = _.map(rows, function (d) {
-          return { label: d, val: d };
-        });
+    if (this.options.editorAttrs && this.options.editorAttrs.collectionData) {
+      var categories = _.map(this.options.editorAttrs.collectionData, function (d) {
+        return { label: d, val: d };
+      });
 
-        this.collection.reset(categories);
-      }, this);
-    } else {
-
+      this.collection.reset(categories);
     }
   },
 
@@ -103,9 +97,7 @@ Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
 
   _initBinds: function () {
     this.collection.bind('change:selected', this._onItemSelected, this);
-    this.collection.bind('reset', function () {
-      this.render();
-    }, this);
+    this.collection.bind('reset', this.render, this);
     this.applyESCBind(function () {
       this._listView.hide();
     });

--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/select/suggest-view.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/select/suggest-view.js
@@ -8,7 +8,7 @@ var itemListTemplate = require('../../../custom-list/custom-list-item.tpl');
 var template = require('./select.tpl');
 var ENTER_KEY_CODE = 13;
 
-Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
+Backbone.Form.editors.Suggest = Backbone.Form.editors.Base.extend({
 
   tagName: 'div',
   className: 'u-ellipsis Editor-formSelect',
@@ -35,12 +35,28 @@ Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
     this._setOptions(opts);
 
     this.template = opts.template || template;
-    this.collection = new CustomListCollection(this.options.options);
-    this._initViews();
 
+    this._setupCollection();
     this.setValue(this.model.get(this.options.keyAttr));
-
     this._initBinds();
+  },
+
+  render: function () {
+    this.setValue(this.value);
+
+    return this;
+  },
+
+  _setupCollection: function () {
+    this.collection = new CustomListCollection(this.options.options);
+
+    if (this.options.editorAttrs && this.options.editorAttrs.collectionData) {
+      var categories = _.map(this.options.editorAttrs.collectionData, function (d) {
+        return { label: d, val: d };
+      });
+
+      this.collection.reset(categories);
+    }
   },
 
   _initViews: function () {
@@ -81,6 +97,7 @@ Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
 
   _initBinds: function () {
     this.collection.bind('change:selected', this._onItemSelected, this);
+    this.collection.bind('reset', this.render, this);
     this.applyESCBind(function () {
       this._listView.hide();
     });
@@ -111,28 +128,40 @@ Backbone.Form.editors.Select = Backbone.Form.editors.Base.extend({
 
   getValue: function () {
     var item = this.collection.getSelectedItem();
+
     if (item) {
       return item.getValue();
     }
+
     return;
   },
 
   setValue: function (value) {
     var selectedModel = this.collection.setSelected(value);
-    if (selectedModel) {
-      this._renderButton(selectedModel);
+
+    if (!selectedModel) {
+      this.collection.add({ label: value, val: value });
+      selectedModel = this.collection.setSelected(value);
     }
+
+    this._initViews();
+    this._renderButton(selectedModel);
+
     this.value = value;
   },
 
   _renderButton: function (mdl) {
     var button = this.$('.js-button');
-    var data = _.extend({}, {label: mdl.getName()}, mdl.attributes);
+    var name = mdl.getName();
+    var isNull = name === null;
+    var label = isNull ? 'null' : name;
+
+    var data = _.extend({}, { label: label }, mdl.attributes);
     var $html = this.options.selectedItemTemplate(data);
 
     button
-      .removeClass('is-empty')
-      .html($html);
+      .html($html)
+      .toggleClass('is-empty', isNull);
 
     return button;
   },

--- a/lib/assets/javascripts/cartodb3/components/form-components/index.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/index.js
@@ -33,3 +33,4 @@ require('./editors/textarea.js');
 require('./editors/fill.js');
 require('./editors/taglist.js');
 require('./editors/datetime.js');
+require('./editors/select/suggest-view.js');

--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
@@ -3,7 +3,7 @@ var _ = require('underscore');
 var ColumnRowData = require('../../../data/column-row-data');
 
 var FIELDTYPE_TO_FORMTYPE = {
-  string: 'Text',
+  string: 'Select',
   boolean: 'Radio',
   number: 'Number',
   date: 'DateTime',
@@ -39,18 +39,6 @@ module.exports = Backbone.Model.extend({
     }, this);
   },
 
-  _getInputType: function (rows, columnType) {
-    var inputType = FIELDTYPE_TO_FORMTYPE[columnType];
-
-    if (rows && rows.length) {
-      if (rows.length === 1 && rows[0] !== null || rows.length > 1) {
-        inputType = 'Select';
-      }
-    }
-
-    return inputType;
-  },
-
   _generateSchema: function () {
     var self = this;
 
@@ -73,22 +61,12 @@ module.exports = Backbone.Model.extend({
             nodeDefModel: this._nodeDefModel,
             configModel: this._configModel
           });
-          columnRowData.fetch();
 
-          columnRowData.bind('columnsFetched', function (rows) {
-            self.schema[columnName] = {
-              type: self._getInputType(rows, columnType),
-              options: _.map(rows, function (d) {
-                return { label: d, val: d };
-              }),
-              editorAttrs: {
-                showSearch: true,
-                allowFreeTextInput: true
-              }
-            };
-
-            self.trigger('changeSchema');
-          });
+          self.schema[columnName].editorAttrs = {
+            showSearch: true,
+            allowFreeTextInput: true,
+            columnRowData: columnRowData
+          };
         }
 
         if (columnType === 'number') {
@@ -99,7 +77,7 @@ module.exports = Backbone.Model.extend({
         if (columnType === 'boolean') {
           this.schema[columnName].options = [
             {
-              label: 'True',
+              label: 'True', // TODO: translate
               val: true
             }, {
               label: 'False',

--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
@@ -44,7 +44,7 @@ module.exports = Backbone.Model.extend({
 
     if (rows && rows.length) {
       if (rows.length === 1 && rows[0] !== null || rows.length > 1) {
-        inputType = 'Select';
+        inputType = 'Suggest';
       }
     }
 

--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
@@ -3,7 +3,7 @@ var _ = require('underscore');
 var ColumnRowData = require('../../../data/column-row-data');
 
 var FIELDTYPE_TO_FORMTYPE = {
-  string: 'Select',
+  string: 'Text',
   boolean: 'Radio',
   number: 'Number',
   date: 'DateTime',
@@ -39,6 +39,18 @@ module.exports = Backbone.Model.extend({
     }, this);
   },
 
+  _getInputType: function (rows) {
+    var inputType = 'Text';
+
+    if (rows && rows.length) {
+      if (rows.length === 1 && rows[0] !== null || rows.length > 1) {
+        inputType = 'Select';
+      }
+    }
+
+    return inputType;
+  },
+
   _generateSchema: function () {
     var self = this;
 
@@ -61,12 +73,19 @@ module.exports = Backbone.Model.extend({
             nodeDefModel: this._nodeDefModel,
             configModel: this._configModel
           });
+          columnRowData.bind('columnsFetched', function (rows) {
+            if (self.schema[columnName].type !== self._getInputType(rows)) {
+              self.schema[columnName].type = self._getInputType(rows);
+              self.schema[columnName].editorAttrs = {
+                showSearch: true,
+                allowFreeTextInput: true,
+                collectionData: rows
+              };
 
-          self.schema[columnName].editorAttrs = {
-            showSearch: true,
-            allowFreeTextInput: true,
-            columnRowData: columnRowData
-          };
+              self.trigger('changeSchema');
+            }
+          });
+          columnRowData.fetch();
         }
 
         if (columnType === 'number') {


### PR DESCRIPTION
before moving on with the tests, I fixed the issue of filling the select editor with the results from `columnRowData` passing it as an option (instead of going full new component)

if the item selected isn't in the `columnRowData` results it's added to the collection

CR @xavijam (I'd add the tests for this along https://github.com/CartoDB/cartodb/pull/10713 PR)