### PR TITLE
Fix Creation of oembed url

### DIFF
--- a/app/controllers/carto/api/oembed_controller.rb
+++ b/app/controllers/carto/api/oembed_controller.rb
@@ -40,7 +40,7 @@ module Carto
         else
           url = CartoDB.base_url(fields[:organization_name], fields[:username])
         end
-        url += CartoDB.path(self, 'public_visualizations_embed_map', {id: uuid})
+        url += CartoDB.path(self, 'public_visualizations_embed_map', {id: uuid, user_domain: nil})
 
         # force the schema
         if fields[:protocol] == 'https' && !url.include?('https')


### PR DESCRIPTION
The Iframe Part of the oemed response looks like this atm: 

```html
<iframe 
    width='100%' height='520px' frameborder='0'     
    src='https://<domain_host>/user/<username>/u/<username>/user/<username>/viz/379ccc4c-a611-11e6-89be-0242ac110002/embed_map' 
    allowfullscreen webkitallowfullscreen 
    mozallowfullscreen oallowfullscreen msallowfullscreen></iframe>
```

so username gets triplicated and the url is broken. A fix seems to be to set the `user_domain` to `nil` for the controllers call to `CartoDB.path`.

See also the comment [here](https://github.com/CartoDB/cartodb/blob/e278e7dbd4fc873d8a64d118617c2b8161b5d4ae/app/services/visualization/common_data_service.rb#L36)