### PR TITLE
Reduce the maximum number of vertices of editable features

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integration/edit-feature-overlay.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integration/edit-feature-overlay.js
@@ -6,7 +6,7 @@ var templateConfirmation = require('./start-edition-confirmation.tpl');
 
 var EditFeatureOverlay = CoreView.extend({
 
-  MAX_VERTEXES: 2000,
+  MAX_VERTEXES: 1000,
 
   className: 'CDB-Overlay',
   type: 'custom',


### PR DESCRIPTION
Fixes #10841.

The new limit is 1000 vertices. Take into account that a geometry with 1000 vertices will also render ~1000 extra markers between each vertex so that users can expand the geometry (and that is the reason why we're changing this).

@matallo 👍 ?

cc: @xavijam 