### PR TITLE
editors: multiselect, tests, first commit

### DIFF
--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/select/multi-select-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/select/multi-select-view.spec.js
@@ -1,0 +1,34 @@
+var $ = require('jquery');
+var Backbone = require('backbone');
+require('backbone-forms');
+Backbone.$ = $;
+require('../../../../../../../javascripts/cartodb3/components/form-components/editors/base.js');
+require('../../../../../../../javascripts/cartodb3/components/form-components/editors/select/select-view.js');
+
+describe('components/form-components/editors/select/multi-select-view', function () {
+  beforeEach(function () {
+    this.model = new Backbone.Model({
+      names: 'pepe'
+    });
+
+    this.view = new Backbone.Form.editors.MultiSelect({
+      key: 'names',
+      schema: {
+        options: ['pepe', 'paco', 'juan']
+      },
+      model: this.model
+    });
+    this.view.render();
+  });
+
+  describe('render', function () {
+    it('should render properly', function () {
+      expect(this.view.$('.js-button').length).toBe(1);
+      expect(this.view.$('.js-button').text()).toContain('components.backbone-forms.select.selected');
+    });
+  });
+
+  afterEach(function () {
+    this.view.remove();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.35",
+  "version": "4.5.36",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
added first test for multiselect editor ("should render properly"), still pending the rest of the spec

![screen shot 2016-11-28 at 18 24 04](https://cloud.githubusercontent.com/assets/36676/20678672/e1a456fc-b597-11e6-9a36-a30e9ff0d368.png)

this is going to be tricky to test, because of the interpolation in _t, i.e.

```
  _getLabel: function () {
    var itemCount = _.compact(this.collection.pluck('selected')).length;
    return _t('components.backbone-forms.select.selected', { count: itemCount });
  },
```

CR @xavijam 