### PR TITLE
Fix for prefer detect over find Hound message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,6 +115,7 @@ Style/CollectionMethods:
     collect: map
     collect!: map!
     find_all: select
+    find:
     detect: find
     inject: reduce
 Style/CommentAnnotation:


### PR DESCRIPTION
This fixes the annoying "prefer detect over find" message issue. Seen in houndci/hound/issues/540 and verified in another PR.

cc @CartoDB/builder-backend @CartoDB/dataservices 