### PR TITLE
10919 migrator migrates to custom instead of html

### DIFF
--- a/lib/carto/legend_migrator.rb
+++ b/lib/carto/legend_migrator.rb
@@ -48,15 +48,15 @@ module Carto
 
     def definition_and_type
       if template.present?
-        [{ html: template }, 'html']
+        [{ html: template }, 'custom']
       elsif type == 'custom'
         [build_custom_definition_from_custom_type, 'custom']
       elsif type == 'category'
         [build_custom_definition_from_custom_type, 'custom']
       elsif type == 'bubble'
-        [build_html_definition_from_bubble, 'html']
+        [build_html_definition_from_bubble, 'custom']
       elsif HTML_RAMP_TYPES.include?(type)
-        [build_html_definition_from_ramp_type, 'html']
+        [build_html_definition_from_ramp_type, 'custom']
       else
         [nil, nil]
       end

--- a/lib/carto/legend_migrator.rb
+++ b/lib/carto/legend_migrator.rb
@@ -48,17 +48,15 @@ module Carto
 
     def definition
       if template.present?
-        [{ html: template }, 'custom']
+        { html: template }
       elsif type == 'custom'
-        [build_custom_definition_from_custom_type, 'custom']
+        build_custom_definition_from_custom_type
       elsif type == 'category'
-        [build_custom_definition_from_custom_type, 'custom']
+        build_custom_definition_from_custom_type
       elsif type == 'bubble'
-        [build_custom_definition_from_bubble, 'custom']
+        build_custom_definition_from_bubble
       elsif HTML_RAMP_TYPES.include?(type)
-        [build_custom_definition_from_ramp_type, 'custom']
-      else
-        [nil, nil]
+        build_custom_definition_from_ramp_type
       end
     end
 

--- a/lib/carto/legend_migrator.rb
+++ b/lib/carto/legend_migrator.rb
@@ -10,13 +10,10 @@ module Carto
     end
 
     def build
-      new_definition, new_type = definition_and_type
-      legend_title = title if title.present? && legend['show_title']
-
       Legend.new(layer_id: layer_id,
-                 title: legend_title,
-                 type: new_type,
-                 definition: new_definition)
+                 title: title.present? && legend['show_title'] ? title : nil,
+                 type: 'custom',
+                 definition: definition)
     rescue => exception
       CartoDB::Logger.debug(message: 'Carto::LegendMigrator: couldn\'t migrate',
                             exception: exception,

--- a/lib/carto/legend_migrator.rb
+++ b/lib/carto/legend_migrator.rb
@@ -54,9 +54,9 @@ module Carto
       elsif type == 'category'
         [build_custom_definition_from_custom_type, 'custom']
       elsif type == 'bubble'
-        [build_html_definition_from_bubble, 'custom']
+        [build_custom_definition_from_bubble, 'custom']
       elsif HTML_RAMP_TYPES.include?(type)
-        [build_html_definition_from_ramp_type, 'custom']
+        [build_custom_definition_from_ramp_type, 'custom']
       else
         [nil, nil]
       end
@@ -85,7 +85,7 @@ module Carto
       { categories: categories }
     end
 
-    def build_html_definition_from_ramp_type
+    def build_custom_definition_from_ramp_type
       left_label, right_label = labels_for_items
       style = style_for_gradient
 
@@ -115,7 +115,7 @@ module Carto
       "background: linear-gradient(90deg, #{gradient_stops})"
     end
 
-    def build_html_definition_from_bubble(steps: 6)
+    def build_custom_definition_from_bubble(steps: 6)
       left, right = labels_for_items
       heights, values = heights_and_values(left, right, steps)
 

--- a/lib/carto/legend_migrator.rb
+++ b/lib/carto/legend_migrator.rb
@@ -46,7 +46,7 @@ module Carto
 
     HTML_RAMP_TYPES = %w(choropleth intensity density).freeze
 
-    def definition_and_type
+    def definition
       if template.present?
         [{ html: template }, 'custom']
       elsif type == 'custom'

--- a/lib/formats/legends/custom.json
+++ b/lib/formats/legends/custom.json
@@ -1,6 +1,10 @@
 {
   "type": "object",
   "additionalProperties": false,
+  "anyOf": [
+    { "required": ["categories"] },
+    { "required": ["html"] }
+  ],
   "properties": {
     "categories": {
       "type": "array",

--- a/lib/formats/legends/custom.json
+++ b/lib/formats/legends/custom.json
@@ -1,8 +1,5 @@
 {
   "type": "object",
-  "required": [
-    "categories"
-  ],
   "additionalProperties": false,
   "properties": {
     "categories": {

--- a/spec/lib/carto/legend_migrator_spec.rb
+++ b/spec/lib/carto/legend_migrator_spec.rb
@@ -192,292 +192,292 @@ module Carto
           category_keys.should include(:icon)
         end
       end
-    end
 
-    describe('#html types') do
-      let(:old_custom) do
-        {
-          "type" => "custom",
-          "show_title" => true,
-          "title" => "",
-          "template" => "<h1>Manolo Escobar</h1>",
-          "visible" => true,
-          "items" => []
-        }
-      end
-
-      let(:old_bubble) do
-        {
-          "type" => "bubble",
-          "show_title" => false,
-          "title" => "",
-          "template" => "",
-          "visible" => true,
-          "items" => [
-            {
-              "name" => "Left label",
-              "visible" => true,
-              "value" => 787.5,
-              "legend_type" => "bubble",
-              "type" => "text",
-              "sync" => false
-            },
-            {
-              "name" => "Right Label",
-              "visible" => true,
-              "value" => 6273765,
-              "legend_type" => "bubble",
-              "type" => "text",
-              "sync" => false
-            },
-            {
-              "name" => "Color",
-              "visible" => true,
-              "value" => "#FF5C00",
-              "type" => "color"
-            }
-          ]
-        }
-      end
-
-      let(:old_bubble_with_custom_labels) do
-        {
-          "type" => "bubble",
-          "show_title" => false,
-          "title" => "",
-          "template" => "",
-          "visible" => true,
-          "items" => [
-            {
-              "name" => "Left label",
-              "visible" => true,
-              "value" => "few",
-              "legend_type" => "bubble",
-              "type" => "text",
-              "sync" => false
-            },
-            {
-              "name" => "Right Label",
-              "visible" => true,
-              "value" => "many",
-              "legend_type" => "bubble",
-              "type" => "text",
-              "sync" => false
-            },
-            {
-              "name" => "Color",
-              "visible" => true,
-              "value" => "#FF5C00",
-              "type" => "color"
-            }
-          ]
-        }
-      end
-
-      let(:old_choropleth) do
-        {
-          "type" => "choropleth",
-          "show_title" => false,
-          "title" => "",
-          "template" => "",
-          "visible" => true,
-          "items" => [
-            {
-              "name" => "Left label",
-              "visible" => true, "value" => "1350.00",
-              "type" => "text"
-            },
-            {
-              "name" => "Right label",
-              "visible" => true,
-              "value" => "6273765.00",
-              "type" => "text"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FFFFB2",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FED976",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FEB24C",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FD8D3C",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FC4E2A",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#E31A1C",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#B10026",
-              "type" => "color"
-            }
-          ]
-        }
-      end
-
-      let(:old_density) do
-        {
-          "type" => "density",
-          "show_title" => false,
-          "title" => "",
-          "template" => "",
-          "visible" => true,
-          "items" => [
-            {
-              "name" => "Less",
-              "visible" => true,
-              "value" => "less",
-              "legend_type" => "density",
-              "type" => "text",
-              "sync" => true
-            },
-            {
-              "name" => "More",
-              "visible" => true,
-              "value" => "more",
-              "legend_type" => "density",
-              "type" => "text",
-              "sync" => true
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FFFFB2",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FECC5C",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FD8D3C",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#F03B20",
-              "type" => "color"
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#BD0026",
-              "type" => "color"
-            }
-          ]
-        }
-      end
-
-      let(:old_intensity) do
-        {
-          "type" => "intensity",
-          "show_title" => false,
-          "title" => "",
-          "template" => "",
-          "visible" => true,
-          "items" => [
-            {
-              "name" => "Left label",
-              "visible" => true,
-              "value" => "Less",
-              "legend_type" => "intensity",
-              "type" => "text",
-              "sync" => true
-            },
-            {
-              "name" => "Right label",
-              "visible" => true,
-              "value" => "More",
-              "legend_type" => "intensity",
-              "type" => "text",
-              "sync" => true
-            },
-            {
-              "name" => "Color",
-              "visible" => true, "value" => "#FFCC00",
-              "type" => "color"
-            }
-          ]
-        }
-      end
-
-      it 'migrates old bubble with custom labels to new html' do
-        @old_legend = old_bubble_with_custom_labels
-      end
-
-      it 'migrates old custom with template to new html' do
-        @old_legend = old_custom
-      end
-
-      it 'migrates old bubble to new html' do
-        @old_legend = old_bubble
-      end
-
-      it 'migrates old choropleth to new html' do
-        @old_legend = old_choropleth
-      end
-
-      it 'migrates old density to new html' do
-        @old_legend = old_density
-      end
-
-      it 'migrates old density without labels to new html' do
-        truncated = old_density.dup
-        truncated['items'].delete_at(0)
-        truncated['items'].delete_at(0)
-
-        @old_legend = truncated
-      end
-
-      it 'migrates old intensity to new html' do
-        @old_legend = old_intensity
-      end
-
-      it 'migrates old intensity without labels to new html' do
-        truncated = old_intensity.dup
-        truncated['items'].delete_at(0)
-        truncated['items'].delete_at(0)
-
-        @old_legend = truncated
-      end
-
-      after(:each) do
-        new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
-
-        new_legend.type.should eq 'html'
-        new_legend.valid?.should be_true
-
-        unless @old_legend['type'] == 'bubble' || @old_legend['type'] == 'custom'
-          html = new_legend.definition[:html]
-
-          # Result should have labels, colors, and icons somewhere in generated
-          # html
-          @old_legend['items'].map { |item| item['value'] }.each do |value|
-            html.downcase.should include(value.to_s.downcase)
-          end
-
-          # No incomplete gradients allowed
-          html.scan(/#(?:[0-9a-fA-F]{3}){1,2}/).size.should be >= 2
+      describe('#with html') do
+        let(:old_custom) do
+          {
+            "type" => "custom",
+            "show_title" => true,
+            "title" => "",
+            "template" => "<h1>Manolo Escobar</h1>",
+            "visible" => true,
+            "items" => []
+          }
         end
 
-        @old_legend = nil
+        let(:old_bubble) do
+          {
+            "type" => "bubble",
+            "show_title" => false,
+            "title" => "",
+            "template" => "",
+            "visible" => true,
+            "items" => [
+              {
+                "name" => "Left label",
+                "visible" => true,
+                "value" => 787.5,
+                "legend_type" => "bubble",
+                "type" => "text",
+                "sync" => false
+              },
+              {
+                "name" => "Right Label",
+                "visible" => true,
+                "value" => 6273765,
+                "legend_type" => "bubble",
+                "type" => "text",
+                "sync" => false
+              },
+              {
+                "name" => "Color",
+                "visible" => true,
+                "value" => "#FF5C00",
+                "type" => "color"
+              }
+            ]
+          }
+        end
+
+        let(:old_bubble_with_custom_labels) do
+          {
+            "type" => "bubble",
+            "show_title" => false,
+            "title" => "",
+            "template" => "",
+            "visible" => true,
+            "items" => [
+              {
+                "name" => "Left label",
+                "visible" => true,
+                "value" => "few",
+                "legend_type" => "bubble",
+                "type" => "text",
+                "sync" => false
+              },
+              {
+                "name" => "Right Label",
+                "visible" => true,
+                "value" => "many",
+                "legend_type" => "bubble",
+                "type" => "text",
+                "sync" => false
+              },
+              {
+                "name" => "Color",
+                "visible" => true,
+                "value" => "#FF5C00",
+                "type" => "color"
+              }
+            ]
+          }
+        end
+
+        let(:old_choropleth) do
+          {
+            "type" => "choropleth",
+            "show_title" => false,
+            "title" => "",
+            "template" => "",
+            "visible" => true,
+            "items" => [
+              {
+                "name" => "Left label",
+                "visible" => true, "value" => "1350.00",
+                "type" => "text"
+              },
+              {
+                "name" => "Right label",
+                "visible" => true,
+                "value" => "6273765.00",
+                "type" => "text"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FFFFB2",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FED976",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FEB24C",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FD8D3C",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FC4E2A",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#E31A1C",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#B10026",
+                "type" => "color"
+              }
+            ]
+          }
+        end
+
+        let(:old_density) do
+          {
+            "type" => "density",
+            "show_title" => false,
+            "title" => "",
+            "template" => "",
+            "visible" => true,
+            "items" => [
+              {
+                "name" => "Less",
+                "visible" => true,
+                "value" => "less",
+                "legend_type" => "density",
+                "type" => "text",
+                "sync" => true
+              },
+              {
+                "name" => "More",
+                "visible" => true,
+                "value" => "more",
+                "legend_type" => "density",
+                "type" => "text",
+                "sync" => true
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FFFFB2",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FECC5C",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FD8D3C",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#F03B20",
+                "type" => "color"
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#BD0026",
+                "type" => "color"
+              }
+            ]
+          }
+        end
+
+        let(:old_intensity) do
+          {
+            "type" => "intensity",
+            "show_title" => false,
+            "title" => "",
+            "template" => "",
+            "visible" => true,
+            "items" => [
+              {
+                "name" => "Left label",
+                "visible" => true,
+                "value" => "Less",
+                "legend_type" => "intensity",
+                "type" => "text",
+                "sync" => true
+              },
+              {
+                "name" => "Right label",
+                "visible" => true,
+                "value" => "More",
+                "legend_type" => "intensity",
+                "type" => "text",
+                "sync" => true
+              },
+              {
+                "name" => "Color",
+                "visible" => true, "value" => "#FFCC00",
+                "type" => "color"
+              }
+            ]
+          }
+        end
+
+        it 'migrates old bubble with custom labels to new html' do
+          @old_legend = old_bubble_with_custom_labels
+        end
+
+        it 'migrates old custom with template to new html' do
+          @old_legend = old_custom
+        end
+
+        it 'migrates old bubble to new html' do
+          @old_legend = old_bubble
+        end
+
+        it 'migrates old choropleth to new html' do
+          @old_legend = old_choropleth
+        end
+
+        it 'migrates old density to new html' do
+          @old_legend = old_density
+        end
+
+        it 'migrates old density without labels to new html' do
+          truncated = old_density.dup
+          truncated['items'].delete_at(0)
+          truncated['items'].delete_at(0)
+
+          @old_legend = truncated
+        end
+
+        it 'migrates old intensity to new html' do
+          @old_legend = old_intensity
+        end
+
+        it 'migrates old intensity without labels to new html' do
+          truncated = old_intensity.dup
+          truncated['items'].delete_at(0)
+          truncated['items'].delete_at(0)
+
+          @old_legend = truncated
+        end
+
+        after(:each) do
+          new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
+
+          new_legend.type.should eq 'html'
+          new_legend.valid?.should be_true
+
+          unless @old_legend['type'] == 'bubble' || @old_legend['type'] == 'custom'
+            html = new_legend.definition[:html]
+
+            # Result should have labels, colors, and icons somewhere in generated
+            # html
+            @old_legend['items'].map { |item| item['value'] }.each do |value|
+              html.downcase.should include(value.to_s.downcase)
+            end
+
+            # No incomplete gradients allowed
+            html.scan(/#(?:[0-9a-fA-F]{3}){1,2}/).size.should be >= 2
+          end
+
+          @old_legend = nil
+        end
       end
     end
 

--- a/spec/lib/carto/legend_migrator_spec.rb
+++ b/spec/lib/carto/legend_migrator_spec.rb
@@ -417,27 +417,27 @@ module Carto
           }
         end
 
-        it 'migrates old bubble with custom labels to new html' do
+        it 'migrates old bubble with custom labels to new custom' do
           @old_legend = old_bubble_with_custom_labels
         end
 
-        it 'migrates old custom with template to new html' do
+        it 'migrates old custom with template to new custom' do
           @old_legend = old_custom
         end
 
-        it 'migrates old bubble to new html' do
+        it 'migrates old bubble to new custom' do
           @old_legend = old_bubble
         end
 
-        it 'migrates old choropleth to new html' do
+        it 'migrates old choropleth to new custom' do
           @old_legend = old_choropleth
         end
 
-        it 'migrates old density to new html' do
+        it 'migrates old density to new custom' do
           @old_legend = old_density
         end
 
-        it 'migrates old density without labels to new html' do
+        it 'migrates old density without labels to new custom' do
           truncated = old_density.dup
           truncated['items'].delete_at(0)
           truncated['items'].delete_at(0)
@@ -445,11 +445,11 @@ module Carto
           @old_legend = truncated
         end
 
-        it 'migrates old intensity to new html' do
+        it 'migrates old intensity to new custom' do
           @old_legend = old_intensity
         end
 
-        it 'migrates old intensity without labels to new html' do
+        it 'migrates old intensity without labels to new custom' do
           truncated = old_intensity.dup
           truncated['items'].delete_at(0)
           truncated['items'].delete_at(0)
@@ -460,7 +460,7 @@ module Carto
         after(:each) do
           new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
 
-          new_legend.type.should eq 'html'
+          new_legend.type.should eq 'custom'
           new_legend.valid?.should be_true
 
           unless @old_legend['type'] == 'bubble' || @old_legend['type'] == 'custom'

--- a/spec/lib/carto/legend_migrator_spec.rb
+++ b/spec/lib/carto/legend_migrator_spec.rb
@@ -57,138 +57,140 @@ module Carto
     end
 
     describe('#custom types') do
-      let(:old_category) do
-        {
-          "type" => "category",
-          "show_title" => false,
-          "title" => "",
-          "template" => "",
-          "visible" => true,
-          "items" => [
-            {
-              "name" => 0,
-              "visible" => true,
-              "value" => "super.png"
-            },
-            {
-              "name" => 1350,
-              "visible" => true,
-              "value" => "#1F78B4"
-            },
-            {
-              "name" => 1440,
-              "visible" => true,
-              "value" => "#B2DF8A"
-            },
-            {
-              "name" => 1800,
-              "visible" => true,
-              "value" => "#33A02C"
-            },
-            {
-              "name" => 2250,
-              "visible" => true,
-              "value" => "#FB9A99"
-            },
-            {
-              "name" => 2700,
-              "visible" => true,
-              "value" => "#E31A1C"
-            },
-            {
-              "name" => 4500,
-              "visible" => true,
-              "value" => "#FDBF6F"
-            },
-            {
-              "name" => 450000,
-              "visible" => true,
-              "value" => "#FF7F00"
-            },
-            {
-              "name" => 900,
-              "visible" => true,
-              "value" => "duper.png"
-            },
-            {
-              "name" => 90000,
-              "visible" => true,
-              "value" => "#6A3D9A"
-            },
-            {
-              "name" => "Others",
-              "visible" => true,
-              "value" => "#DDDDDD"
-            }
-          ]
-        }
-      end
+      describe('#with categories') do
+        let(:old_category) do
+          {
+            "type" => "category",
+            "show_title" => false,
+            "title" => "",
+            "template" => "",
+            "visible" => true,
+            "items" => [
+              {
+                "name" => 0,
+                "visible" => true,
+                "value" => "super.png"
+              },
+              {
+                "name" => 1350,
+                "visible" => true,
+                "value" => "#1F78B4"
+              },
+              {
+                "name" => 1440,
+                "visible" => true,
+                "value" => "#B2DF8A"
+              },
+              {
+                "name" => 1800,
+                "visible" => true,
+                "value" => "#33A02C"
+              },
+              {
+                "name" => 2250,
+                "visible" => true,
+                "value" => "#FB9A99"
+              },
+              {
+                "name" => 2700,
+                "visible" => true,
+                "value" => "#E31A1C"
+              },
+              {
+                "name" => 4500,
+                "visible" => true,
+                "value" => "#FDBF6F"
+              },
+              {
+                "name" => 450000,
+                "visible" => true,
+                "value" => "#FF7F00"
+              },
+              {
+                "name" => 900,
+                "visible" => true,
+                "value" => "duper.png"
+              },
+              {
+                "name" => 90000,
+                "visible" => true,
+                "value" => "#6A3D9A"
+              },
+              {
+                "name" => "Others",
+                "visible" => true,
+                "value" => "#DDDDDD"
+              }
+            ]
+          }
+        end
 
-      let(:old_custom) do
-        {
-          "type" => "custom",
-          "show_title" => true,
-          "title" => "",
-          "template" => "",
-          "visible" => true,
-          "items" => [
-            {
-              "name" => "preta",
-              "visible" => true,
-              "value" => "#41006D",
-              "sync" => true
-            },
-            {
-              "name" => "Untitled",
-              "visible" => true,
-              "value" => "superduper.png",
-              "sync" => true
-            },
-            {
-              "name" => "patata",
-              "visible" => true,
-              "value" => "#cccccc",
-              "sync" => true
-            },
-            {
-              "name" => "Untitled",
-              "visible" => true,
-              "value" => "#cccccc",
-              "sync" => true
-            }
-          ]
-        }
-      end
+        let(:old_custom) do
+          {
+            "type" => "custom",
+            "show_title" => true,
+            "title" => "",
+            "template" => "",
+            "visible" => true,
+            "items" => [
+              {
+                "name" => "preta",
+                "visible" => true,
+                "value" => "#41006D",
+                "sync" => true
+              },
+              {
+                "name" => "Untitled",
+                "visible" => true,
+                "value" => "superduper.png",
+                "sync" => true
+              },
+              {
+                "name" => "patata",
+                "visible" => true,
+                "value" => "#cccccc",
+                "sync" => true
+              },
+              {
+                "name" => "Untitled",
+                "visible" => true,
+                "value" => "#cccccc",
+                "sync" => true
+              }
+            ]
+          }
+        end
 
-      it 'omits badly formatted colors' do
-        truncated = old_category.dup
-        truncated['items'].first['value'] = '#fatal#fatal#fatal'
+        it 'omits badly formatted colors' do
+          truncated = old_category.dup
+          truncated['items'].first['value'] = '#fatal#fatal#fatal'
 
-        @old_legend = truncated
-      end
+          @old_legend = truncated
+        end
 
-      it 'migrates old category to new custom' do
-        @old_legend = old_category
-      end
+        it 'migrates old category to new custom' do
+          @old_legend = old_category
+        end
 
-      it 'migrates old custom to new custom with no template' do
-        @old_legend = old_custom
-      end
+        it 'migrates old custom to new custom with no template' do
+          @old_legend = old_custom
+        end
 
-      after(:each) do
-        new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
+        after(:each) do
+          new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
 
-        new_legend.type.should eq 'custom'
-        new_legend.valid?.should be_true
+          new_legend.type.should eq 'custom'
+          new_legend.valid?.should be_true
 
-        category_keys = new_legend.definition[:categories]
-                                  .map(&:keys)
-                                  .flatten
-                                  .uniq
+          category_keys = new_legend.definition[:categories]
+                                    .map(&:keys)
+                                    .flatten
+                                    .uniq
 
-        category_keys.should include(:title)
-        category_keys.should include(:color)
-        category_keys.should include(:icon)
+          category_keys.should include(:title)
+          category_keys.should include(:color)
+          category_keys.should include(:icon)
+        end
       end
     end
 

--- a/spec/lib/carto/legend_migrator_spec.rb
+++ b/spec/lib/carto/legend_migrator_spec.rb
@@ -24,27 +24,27 @@ module Carto
         }
       end
 
-      it 'should migrate to html for type custom' do
+      it 'should migrate to custom for type custom' do
         @old_legend = old_legend_with_template.merge(type: 'custom')
       end
 
-      it 'should migrate to html for type category' do
+      it 'should migrate to custom for type category' do
         @old_legend = old_legend_with_template.merge(type: 'category')
       end
 
-      it 'should migrate to html for type bubble' do
+      it 'should migrate to custom for type bubble' do
         @old_legend = old_legend_with_template.merge(type: 'bubble')
       end
 
-      it 'should migrate to html for type choropleth' do
+      it 'should migrate to custom for type choropleth' do
         @old_legend = old_legend_with_template.merge(type: 'choropleth')
       end
 
-      it 'should migrate to html for type intensity' do
+      it 'should migrate to custom for type intensity' do
         @old_legend = old_legend_with_template.merge(type: 'intensity')
       end
 
-      it 'should migrate to html for type density' do
+      it 'should migrate to custom for type density' do
         @old_legend = old_legend_with_template.merge(type: 'density')
       end
 
@@ -52,7 +52,7 @@ module Carto
         new_legend = Carto::LegendMigrator.new(@layer.id, @old_legend).build
 
         new_legend.definition[:html].should include('<h1>Manolo Escobar</h1>')
-        new_legend.type.should eq 'html'
+        new_legend.type.should eq 'custom'
       end
     end
 

--- a/spec/models/carto/legend_spec.rb
+++ b/spec/models/carto/legend_spec.rb
@@ -113,6 +113,13 @@ module Carto
         legend.errors[:definition].should_not be_empty
         legend.errors[:definition].should_not include('could not be validated')
       end
+
+      it 'rejects empty definitions for custom' do
+        legend = Legend.new(layer_id: @layer.id, type: 'custom', definition: {})
+
+        legend.valid?.should be_false
+        legend.errors[:definition].should_not be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #10919 

This RP changes how the legend migrator behaves: Instead of using an HTML type, it uses a custom type (that now supports an html field).