### PR TITLE
10861 migrate html to custom

### DIFF
--- a/lib/formats/legends/custom.json
+++ b/lib/formats/legends/custom.json
@@ -1,8 +1,5 @@
 {
   "type": "object",
-  "required": [
-    "categories"
-  ],
   "additionalProperties": false,
   "properties": {
     "categories": {

--- a/lib/tasks/legends.rake
+++ b/lib/tasks/legends.rake
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+namespace :carto do
+  namespace :legends do
+    namespace :migration do
+      desc 'Migrate html type legends to custom'
+      task :migrate_html_to_custom do
+        
+      end
+    end
+  end
+end

--- a/lib/tasks/legends.rake
+++ b/lib/tasks/legends.rake
@@ -4,8 +4,28 @@ namespace :carto do
   namespace :legends do
     namespace :migration do
       desc 'Migrate html type legends to custom'
-      task :migrate_html_to_custom do
-        
+      task migrate_html_to_custom: :environment do
+        html_legends = Carto::Legend.where(type: 'html')
+        html_legends_count = html_legends.count
+
+        errored = []
+        puts "#{html_legends_count} html type legends..."
+        html_legends.each_with_index do |legend, index|
+          if Carto::Layer.exists?(legend.layer_id) && !legend.update_attributes(type: 'custom')
+            errored << legend
+          end
+
+          printf "(#{index}/#{html_legends_count})"
+        end
+
+        2.times { puts }
+
+        unless errored.empty?
+          puts "Errored legend migrations (#{errored.count}):"
+          errored.each do |legend|
+            puts "#{legend.id}: #{legend.errors.full_messages.join(',')}"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #10861 

Rake to change type from `html` to `custom`. This will be used once the migrator is updated to migrate to custom instead of html in https://github.com/CartoDB/cartodb/pull/10923. After that we'll drop the html type entirely.