### PR TITLE
Return dates in consistent tz format

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -27,8 +27,8 @@ class Table
 
   # TODO Part of a service along with schema
   # INFO: created_at and updated_at cannot be dropped from existing tables without dropping the triggers first
-  CARTODB_REQUIRED_COLUMNS = %{cartodb_id the_geom}.freeze
-  CARTODB_COLUMNS = %{cartodb_id created_at updated_at the_geom}.freeze
+  CARTODB_REQUIRED_COLUMNS = %w{cartodb_id the_geom}.freeze
+  CARTODB_COLUMNS = %w{cartodb_id created_at updated_at the_geom}.freeze
   THE_GEOM_WEBMERCATOR = :the_geom_webmercator
   THE_GEOM = :the_geom
   CARTODB_ID = :cartodb_id

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1080,10 +1080,8 @@ class Table
 
     db_schema = schema.map { |i| i.first(2) }.to_h
     row.map { |name, value|
-      if db_schema[name] == DATATYPE_DATE && !value.nil?
-        value = DateTime.parse(value)
-      end
-      [name, value]
+      parsed_value = (db_schema[name] == DATATYPE_DATE && !value.nil?) ? DateTime.parse(value) : value
+      [name, parsed_value]
     }.to_h
   end
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1081,7 +1081,7 @@ class Table
     # `.schema` returns [name, type] pairs, except for geometry types where it returns additional data we don't need
     db_schema = schema.map { |col_data| col_data.first(2) }.to_h
     row.map { |name, value|
-      parsed_value = (db_schema[name] == DATATYPE_DATE && !value.nil?) ? DateTime.parse(value) : value
+      parsed_value = (db_schema[name] == DATATYPE_DATE && value) ? DateTime.parse(value) : value
       [name, parsed_value]
     }.to_h
   end

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1078,7 +1078,8 @@ class Table
     end
     raise if row.nil?
 
-    db_schema = schema.map { |i| i.first(2) }.to_h
+    # `.schema` returns [name, type] pairs, except for geometry types where it returns additional data we don't need
+    db_schema = schema.map { |col_data| col_data.first(2) }.to_h
     row.map { |name, value|
       parsed_value = (db_schema[name] == DATATYPE_DATE && !value.nil?) ? DateTime.parse(value) : value
       [name, parsed_value]

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -32,6 +32,7 @@ class Table
   THE_GEOM_WEBMERCATOR = :the_geom_webmercator
   THE_GEOM = :the_geom
   CARTODB_ID = :cartodb_id
+  DATATYPE_DATE = 'date'
 
   NO_GEOMETRY_TYPES_CACHING_TIMEOUT = 5.minutes
   GEOMETRY_TYPES_PRESENT_CACHING_TIMEOUT = 24.hours
@@ -629,7 +630,7 @@ class Table
           ALTER COLUMN #{column}
           SET DEFAULT now()
         })
-      elsif column_type == 'date' || column_type == 'timestamptz'
+      elsif column_type == DATATYPE_DATE || column_type == 'timestamptz'
         database.run(%Q{
           ALTER TABLE #{qualified_table_name}
           ALTER COLUMN #{column}
@@ -1065,7 +1066,7 @@ class Table
         name, type = column
         if name == THE_GEOM
           "ST_AsGeoJSON(the_geom,8) as the_geom"
-        elsif type == "date"
+        elsif type == DATATYPE_DATE
           %{CAST("#{name}" AS text) AS "#{name}"}
         else
           %{"#{name}"}
@@ -1079,7 +1080,7 @@ class Table
 
     db_schema = schema.map { |i| i.first(2) }.to_h
     row.map { |name, value|
-      if db_schema[name] == 'date' && !value.nil?
+      if db_schema[name] == DATATYPE_DATE && !value.nil?
         value = DateTime.parse(value)
       end
       [name, value]

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -25,18 +25,18 @@ class Table
   extend Forwardable
   include Carto::TableUtils
 
-   # TODO Part of a service along with schema
+  # TODO Part of a service along with schema
   # INFO: created_at and updated_at cannot be dropped from existing tables without dropping the triggers first
-  CARTODB_REQUIRED_COLUMNS = %W{ cartodb_id the_geom }
-  CARTODB_COLUMNS = %W{ cartodb_id created_at updated_at the_geom }
+  CARTODB_REQUIRED_COLUMNS = %{cartodb_id the_geom}.freeze
+  CARTODB_COLUMNS = %{cartodb_id created_at updated_at the_geom}.freeze
   THE_GEOM_WEBMERCATOR = :the_geom_webmercator
   THE_GEOM = :the_geom
   CARTODB_ID = :cartodb_id
-  DATATYPE_DATE = 'date'
+  DATATYPE_DATE = 'date'.freeze
 
   NO_GEOMETRY_TYPES_CACHING_TIMEOUT = 5.minutes
   GEOMETRY_TYPES_PRESENT_CACHING_TIMEOUT = 24.hours
-  STATEMENT_TIMEOUT = 1.hour*1000
+  STATEMENT_TIMEOUT = 1.hour * 1000
 
   # See http://www.postgresql.org/docs/9.5/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
   PG_IDENTIFIER_MAX_LENGTH = 63
@@ -1081,7 +1081,7 @@ class Table
     # `.schema` returns [name, type] pairs, except for geometry types where it returns additional data we don't need
     db_schema = schema.map { |col_data| col_data.first(2) }.to_h
     row.map { |name, value|
-      parsed_value = (db_schema[name] == DATATYPE_DATE && value) ? DateTime.parse(value) : value
+      parsed_value = db_schema[name] == DATATYPE_DATE && value ? DateTime.parse(value) : value
       [name, parsed_value]
     }.to_h
   end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1188,7 +1188,7 @@ describe Table do
     end
 
     it 'correctly returns dates' do
-      table = create_table(:user_id => @user.id)
+      table = create_table(user_id: @user.id)
       table.add_column!(name: "without_tz", type: "timestamp without time zone")
       table.add_column!(name: "with_tz", type: "timestamp with time zone")
       table.add_column!(name: "date", type: "date ") # Add a space to avoid auto-conversion to timestampz

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1186,6 +1186,29 @@ describe Table do
       @user.in_database.run("CREATE TABLE cdb_importer.repeated_table (id integer)")
       expect { create_table(user_id: @user.id, name: 'repeated_table') }.to_not raise_error
     end
+
+    it 'correctly returns dates' do
+      table = create_table(:user_id => @user.id)
+      table.add_column!(name: "without_tz", type: "timestamp without time zone")
+      table.add_column!(name: "with_tz", type: "timestamp with time zone")
+      table.add_column!(name: "date", type: "date ") # Add a space to avoid auto-conversion to timestampz
+
+      table.insert_row!(
+        with_tz: '2016-12-02T10:10:10+01:00',
+        without_tz: '2016-12-02T10:10:10',
+        date: '2016-12-02'
+      )
+
+      record = table.record(1)
+      record[:with_tz].is_a?(DateTime).should be_true
+      record[:with_tz].to_s.should eq '2016-12-02T10:10:10+01:00'
+
+      record[:without_tz].is_a?(DateTime).should be_true
+      record[:without_tz].to_s.should eq '2016-12-02T10:10:10+00:00'
+
+      record[:date].is_a?(DateTime).should be_true
+      record[:date].to_s.should eq '2016-12-02T00:00:00+00:00'
+    end
   end
 
   context "insert and update rows" do

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1201,7 +1201,7 @@ describe Table do
 
       record = table.record(1)
       record[:with_tz].is_a?(DateTime).should be_true
-      record[:with_tz].to_s.should eq '2016-12-02T10:10:10+01:00'
+      record[:with_tz].should eq DateTime.parse('2016-12-02T10:10:10+01:00')
 
       record[:without_tz].is_a?(DateTime).should be_true
       record[:without_tz].to_s.should eq '2016-12-02T10:10:10+00:00'


### PR DESCRIPTION
Fixes #10903 

Fixes the return format of records from the records controller. Instead of relying in Sequel to do the parsing of dates, we return a string and parse it using Ruby which does the right thing regarding timezones.