### PR TITLE
10962 drop html type support

### DIFF
--- a/app/models/carto/legend.rb
+++ b/app/models/carto/legend.rb
@@ -10,7 +10,7 @@ module Carto
 
     belongs_to :layer, class_name: Carto::Layer
 
-    VALID_LEGEND_TYPES = %(html category bubble choropleth custom custom_choropleth).freeze
+    VALID_LEGEND_TYPES = %(category bubble choropleth custom custom_choropleth).freeze
 
     serialize :definition, ::Carto::CartoJsonSerializer
 

--- a/lib/formats/legends/html.json
+++ b/lib/formats/legends/html.json
@@ -1,8 +1,0 @@
-{
-  "type": "object",
-  "required": ["html"],
-  "additionalProperties": false,
-  "properties": {
-    "html": { "type": "string" }
-  }
-}

--- a/spec/lib/carto/legend_definition_validator_spec.rb
+++ b/spec/lib/carto/legend_definition_validator_spec.rb
@@ -19,39 +19,6 @@ module Carto
                        .load_from_file(definition_location)
     end
 
-    describe '#html' do
-      let(:definition) do
-        {
-          html: '<h1>Manolo Escobar</h1>'
-        }
-      end
-
-      it 'accepts a correct definition' do
-        validator = LegendDefinitionValidator.new(:html, definition)
-        validator.errors.should be_empty
-      end
-
-      it 'rejects spammy definitions' do
-        spammed_definition = definition.merge(spam: 'the ham')
-
-        validator = LegendDefinitionValidator.new(:html, spammed_definition)
-
-        validator.errors.should_not be_empty
-        joint_errors = validator.errors.join(', ')
-        joint_errors.should include('additional properties')
-      end
-
-      it 'rejects incomplete definitions' do
-        incomplete_definition = definition.except(:html)
-
-        validator = LegendDefinitionValidator.new(:html, incomplete_definition)
-
-        validator.errors.should_not be_empty
-        joint_errors = validator.errors.join(', ')
-        joint_errors.should include('did not contain a required property')
-      end
-    end
-
     describe '#bubble' do
       let(:definition) do
         {

--- a/spec/models/carto/legend_spec.rb
+++ b/spec/models/carto/legend_spec.rb
@@ -100,7 +100,7 @@ module Carto
         @legend.errors[:pre_html].should be_empty
       end
 
-      it 'requies a definition' do
+      it 'requires a definition' do
         @legend.errors[:definition].should_not be_empty
         @legend.errors[:definition].should include('could not be validated')
       end
@@ -119,6 +119,13 @@ module Carto
 
         legend.valid?.should be_false
         legend.errors[:definition].should_not be_empty
+      end
+
+      it 'rejects html type' do
+        legend = Legend.new(layer_id: @layer.id, type: 'html', definition: {})
+
+        legend.valid?.should be_false
+        legend.errors[:type].should_not be_empty
       end
     end
   end

--- a/spec/requests/carto/api/legends_controller_spec.rb
+++ b/spec/requests/carto/api/legends_controller_spec.rb
@@ -9,18 +9,6 @@ module Carto
     describe Carto::Api::LegendsController do
       include Carto::Factories::Visualizations, HelperMethods
 
-      let(:html_legend_payload) do
-        {
-          pre_html: "<h3>Es acaso</h3>",
-          post_html: "<h3>el mejor artista del mundo?</h3>",
-          title: "La verdad",
-          type: "html",
-          definition: {
-            html: '<h1>Manolo Escobar</h1>'
-          }
-        }
-      end
-
       let(:category_legend_payload) do
         {
           pre_html: "<h3>Es acaso</h3>",
@@ -145,7 +133,7 @@ module Carto
         it 'should reject non data layers' do
           base_layer = @visualization.layers.first
 
-          post_json create_lengend_url(layer: base_layer), html_legend_payload do |response|
+          post_json create_lengend_url(layer: base_layer), custom_legend_payload do |response|
             response.status.should eq 422
 
             response.body[:errors].should include("'#{base_layer.kind}' layers can't have legends")
@@ -154,14 +142,14 @@ module Carto
 
         it 'should reject more that Legend:MAX_LEGENDS_PER_LAYER legends per layer' do
           Legend::MAX_LEGENDS_PER_LAYER.times do
-            post_json create_lengend_url, html_legend_payload do |response|
+            post_json create_lengend_url, custom_legend_payload do |response|
               response.status.should eq 201
 
               legend_is_correct(response.body)
             end
           end
 
-          post_json create_lengend_url, html_legend_payload do |response|
+          post_json create_lengend_url, custom_legend_payload do |response|
             response.status.should eq 422
 
             response.body[:errors].should include('Maximum number of legends per layer reached')
@@ -187,10 +175,6 @@ module Carto
 
           after(:all) do
             @payload = nil
-          end
-
-          it 'for html' do
-            @payload = html_legend_payload
           end
 
           it 'for category' do
@@ -226,10 +210,6 @@ module Carto
 
           after(:all) do
             @payload = nil
-          end
-
-          it 'banned for html' do
-            @payload = html_legend_payload
           end
 
           it 'banned for category' do
@@ -278,7 +258,7 @@ module Carto
       end
 
       describe '#show' do
-        before (:all) { @legend = Legend.create!(html_legend_payload.merge(layer_id: @layer.id)) }
+        before (:all) { @legend = Legend.create!(custom_legend_payload.merge(layer_id: @layer.id)) }
         after  (:all) { @legend.destroy }
 
         def show_lengend_url(user: @user, visualization: @visualization, layer: @layer, legend: @legend)
@@ -318,7 +298,7 @@ module Carto
       end
 
       describe '#update' do
-        before (:all) { @legend = Legend.create!(html_legend_payload.merge(layer_id: @layer.id)) }
+        before (:all) { @legend = Legend.create!(custom_legend_payload.merge(layer_id: @layer.id)) }
         after  (:all) { @legend.destroy }
 
         def update_lengend_url(user: @user, visualization: @visualization, layer: @layer, legend: @legend)
@@ -330,8 +310,8 @@ module Carto
         end
 
         it 'updates a legend' do
-          html_legend_payload[:definition][:html] = '<p>modified</p>'
-          put_json update_lengend_url, html_legend_payload do |response|
+          custom_legend_payload[:definition][:html] = '<p>modified</p>'
+          put_json update_lengend_url, custom_legend_payload do |response|
             response.status.should eq 200
 
             legend_is_correct(response.body)
@@ -340,11 +320,11 @@ module Carto
 
         it 'updates a legend when max legends reached' do
           (Legend::MAX_LEGENDS_PER_LAYER - 1).times do
-            Legend.create!(html_legend_payload.merge(layer_id: @layer.id))
+            Legend.create!(custom_legend_payload.merge(layer_id: @layer.id))
           end
 
-          html_legend_payload[:definition][:html] = '<p>modified</p>'
-          put_json update_lengend_url, html_legend_payload do |response|
+          custom_legend_payload[:definition][:html] = '<p>modified</p>'
+          put_json update_lengend_url, custom_legend_payload do |response|
             response.status.should eq 200
 
             legend_is_correct(response.body)
@@ -352,7 +332,7 @@ module Carto
 
           @layer.reload.legends.map(&:destroy)
 
-          @legend = Legend.create!(html_legend_payload.merge(layer_id: @layer.id))
+          @legend = Legend.create!(custom_legend_payload.merge(layer_id: @layer.id))
         end
 
         it 'should let others update a legend' do
@@ -378,8 +358,8 @@ module Carto
       describe '#index' do
         before(:all) do
           @layer.reload.legends.map(&:destroy)
-          Legend.create!(html_legend_payload.merge(layer_id: @layer.id))
-          Legend.create!(html_legend_payload.merge(layer_id: @layer.id))
+          Legend.create!(custom_legend_payload.merge(layer_id: @layer.id))
+          Legend.create!(custom_legend_payload.merge(layer_id: @layer.id))
         end
 
         after(:all) do
@@ -411,7 +391,7 @@ module Carto
       end
 
       describe '#delete' do
-        before (:each) { @legend = Legend.create!(html_legend_payload.merge(layer_id: @layer.id)) }
+        before (:each) { @legend = Legend.create!(custom_legend_payload.merge(layer_id: @layer.id)) }
         after  (:each) { @legend.destroy }
 
         def delete_lengend_url(user: @user, visualization: @visualization, layer: @layer, legend: @legend)


### PR DESCRIPTION
Fixes #10962 by dropping support for html legends.

HTML legends are no longer used, instead we use `custom` type with an `html` field. 