### PR TITLE
Changed way to set categories with turbo-carto in the Builder

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -12,7 +12,7 @@ var MAX_VALUES = 10;
 // max values + "others" color
 var DEFAULT_COLORS = _.clone(rampList.Prism[MAX_VALUES + 1]);
 
-var queryTemplate = _.template('SELECT <%= column %>, count(<%= column %>) FROM (<%= sql %>) _table_sql GROUP BY <%= column %> ORDER BY count DESC, <%= column %> DESC LIMIT <%= max_values %>');
+var queryTemplate = _.template('SELECT <%= column %>, count(<%= column %>) FROM (<%= sql %>) _table_sql GROUP BY <%= column %> ORDER BY count DESC, <%= column %> ASC LIMIT <%= max_values %>');
 
 function _quote (c) {
   if (c && c !== true) {

--- a/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
+++ b/lib/assets/javascripts/cartodb3/editor/style/style-converter.js
@@ -38,11 +38,19 @@ function makeColorRamp (props, isTorqueCategory) {
   }
   if (props.domain) {
     if (isTorqueCategory) {
-      c.push('(' + _.map(props.domain, function (r, i) {
+      c.push('(' + _.map(props.domain, function (val, i) {
         return i + 1;
       }).join(', ') + ')');
     } else {
-      c.push('category(' + props.domain.length + ')');
+      c.push('(' +
+        _.compact(
+          _.map(props.domain, function (val, i) {
+            return val;
+          })
+        ).join(', ') +
+        ')'
+      );
+      c.push('"="');
     }
   }
   if (props.quantification) {

--- a/lib/assets/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
@@ -33,7 +33,7 @@ module.exports = [
           'color': {
             attribute: 'address',
             range: ['#B2DF8A', '#FF2900', '#FF0011', '#CCC'],
-            domain: ['_', '"Albania"', '"Andorra"', 'Luxemburg'],
+            domain: ['"_"', '"Albania"', '"Andorra"', 'Luxemburg'],
             opacity: 0.4
           }
         }
@@ -41,11 +41,11 @@ module.exports = [
     },
     result: {
       point: {
-        cartocss: '#layer {\nmarker-fill: ramp([address], (#B2DF8A, #FF2900, #FF0011, #CCC), category(4));\nmarker-fill-opacity: 0.4;\nmarker-allow-overlap: true;\n}',
+        cartocss: '#layer {\nmarker-fill: ramp([address], (#B2DF8A, #FF2900, #FF0011, #CCC), ("_", "Albania", "Andorra", Luxemburg), "=");\nmarker-fill-opacity: 0.4;\nmarker-allow-overlap: true;\n}',
         type: 'CartoDB'
       },
       polygon: {
-        cartocss: '#layer {\npolygon-fill: ramp([address], (#B2DF8A, #FF2900, #FF0011, #CCC), category(4));\npolygon-opacity: 0.4;\n}',
+        cartocss: '#layer {\npolygon-fill: ramp([address], (#B2DF8A, #FF2900, #FF0011, #CCC), ("_", "Albania", "Andorra", Luxemburg), "=");\npolygon-opacity: 0.4;\n}',
         type: 'CartoDB'
       }
     }
@@ -57,7 +57,7 @@ module.exports = [
           'color': {
             attribute: 'address',
             range: ['#FFFFFF', '#1D6996', '#129C63', '#73AF48', '#EDAD08', '#E17C05', '#C94034', '#BA0040', '#8E1966', '#6F3072', '#DC1721'],
-            domain: ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'],
+            domain: ['"one"', '"two"', '"three"', '"four"', '"five"', '"six"', '"seven"', '"eight"', '"nine"', '"ten"'],
             opacity: 0.4
           }
         }
@@ -65,11 +65,11 @@ module.exports = [
     },
     result: {
       point: {
-        cartocss: '#layer {\nmarker-fill: ramp([address], (#FFFFFF, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040, #8E1966, #6F3072, #DC1721), category(10));\nmarker-fill-opacity: 0.4;\nmarker-allow-overlap: true;\n}',
+        cartocss: '#layer {\nmarker-fill: ramp([address], (#FFFFFF, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040, #8E1966, #6F3072, #DC1721), ("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"), "=");\nmarker-fill-opacity: 0.4;\nmarker-allow-overlap: true;\n}',
         type: 'CartoDB'
       },
       polygon: {
-        cartocss: '#layer {\npolygon-fill: ramp([address], (#FFFFFF, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040, #8E1966, #6F3072, #DC1721), category(10));\npolygon-opacity: 0.4;\n}',
+        cartocss: '#layer {\npolygon-fill: ramp([address], (#FFFFFF, #1D6996, #129C63, #73AF48, #EDAD08, #E17C05, #C94034, #BA0040, #8E1966, #6F3072, #DC1721), ("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"), "=");\npolygon-opacity: 0.4;\n}',
         type: 'CartoDB'
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.50-staging",
+  "version": "4.5.52",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.50",
+  "version": "4.5.50-staging",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We decided to use all the power of Turbo-carto :tm:, but we realized there are some exceptions described in #10805. So we have taken the conservative decision of setting the categories manually in the generation of the CartoCSS.

![screen shot 2016-12-05 at 18 50 08](https://cloud.githubusercontent.com/assets/132146/20895991/1d55fd5c-bb1c-11e6-8792-a512e8d822c0.png)

**What should we test?**

We should style per value over string columns:
- Using different geometries (point, line or polygon datasets).
- Setting the style over columns with less than 10 categories.
- Setting the style over columns with more than 10 categories.
- Setting the style over columns with `null` values.
