### PR TITLE
GRANT TO _CDB_UserQuotaInBytes() so it can be used in shared dataset updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,7 @@ sudo make install
 * Support for export visualizations with characters outside iso-8859-1
 * Forward compatibility for infowindows at Builder
 * Correctly copy map privacy from source tables
+* Fix permissions in quota trigger for shared datasets. Run `bundle exec rake cartodb:db:reset_trigger_check_quota_for_user[<username>]` to fix existing users.
 * Several auth_token related fixes
 * Fix issue importing/duplicating maps where the original had an incomplete map.options
 * New builder default geometry styles are now properly initialized at the backend upon dataset import.

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -595,11 +595,11 @@ module CartoDB
           user_database.transaction do
             schemas = [@user.database_schema].uniq
             schemas.each do |schema|
-              revoke_privileges(user_database, schema, 'PUBLIC')
+              revoke_privileges(user_database, schema, 'PUBLIC', functions: false)
 
               # _CDB_UserQuotaInBytes is called by the quota trigger, and need to be open so
               # other users in the organization can run it (when updating shared datasets)
-              user_database.run("GRANT ALL ON FUNCTION \"#{schema}\"._CDB_UserQuotaInBytes() TO PUBLIC")
+              revoke_function_privileges(user_database, schema, 'PUBLIC', skip: ['_cdb_userquotainbytes()'])
             end
             yield(user_database) if block_given?
           end
@@ -946,11 +946,27 @@ module CartoDB
         !db.fetch("SELECT 1 FROM pg_roles WHERE rolname='#{role}'").first.nil?
       end
 
-      def revoke_privileges(db, schema, user)
+      def revoke_privileges(db, schema, user, functions: true)
         db.run("REVOKE ALL ON SCHEMA \"#{schema}\" FROM #{user} CASCADE")
         db.run("REVOKE ALL ON ALL SEQUENCES IN SCHEMA \"#{schema}\" FROM #{user} CASCADE")
-        db.run("REVOKE ALL ON ALL FUNCTIONS IN SCHEMA \"#{schema}\" FROM #{user} CASCADE")
         db.run("REVOKE ALL ON ALL TABLES IN SCHEMA \"#{schema}\" FROM #{user} CASCADE")
+        db.run("REVOKE ALL ON ALL FUNCTIONS IN SCHEMA \"#{schema}\" FROM #{user} CASCADE") if functions
+      end
+
+      def revoke_function_privileges(db, schema, user, skip: [])
+        get_database_functions(db, schema).reject { |f| skip.include?(f) }.each do |f|
+          db.run("REVOKE ALL ON FUNCTION \"#{schema}\".#{f} FROM #{user} CASCADE")
+        end
+      end
+
+      def get_database_functions(db, schema)
+        functions = db.fetch(%{
+          SELECT proname || '(' || oidvectortypes(proargtypes) || ')'
+          AS signature
+          FROM pg_proc INNER JOIN pg_namespace ns ON (pg_proc.pronamespace = ns.oid)
+          WHERE ns.nspname = '#{schema}'
+        })
+        functions.map { |f| f[:signature] }
       end
 
       def organization_member_group_role_member_name

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -596,6 +596,10 @@ module CartoDB
             schemas = [@user.database_schema].uniq
             schemas.each do |schema|
               revoke_privileges(user_database, schema, 'PUBLIC')
+
+              # _CDB_UserQuotaInBytes is called by the quota trigger, and need to be open so
+              # other users in the organization can run it (when updating shared datasets)
+              user_database.run("GRANT ALL ON FUNCTION \"#{schema}\"._CDB_UserQuotaInBytes() TO PUBLIC")
             end
             yield(user_database) if block_given?
           end


### PR DESCRIPTION
Fixes #10979 

The rake `cartodb:db:set_permissions` should fix it for existing problems.

 - Needs acceptance in onpremises, SaaS and dev, creating an organization with owner and attaching an existing user to an organization.
 - Need to be merged into onpremises branch 4.0.x as well