### PR TITLE
Tested if defined when checking wether is custom template.

### DIFF
--- a/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
@@ -178,7 +178,7 @@ module.exports = Backbone.Model.extend({
   },
 
   isCustomTemplate: function () {
-    return this.get('template_name') !== undefined && this.get('template_name') === '' && this.get('template') !== undefined && this.get('template') !== '';
+    return this.get('template_name') === '' && this.get('template') !== '';
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
@@ -178,7 +178,7 @@ module.exports = Backbone.Model.extend({
   },
 
   isCustomTemplate: function () {
-    return this.get('template_name') === '' && this.get('template') !== '';
+    return this.get('template_name') === undefined && this.get('template_name') === '' && this.get('template') !== undefined && this.get('template') !== '';
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-definition-model.js
@@ -178,7 +178,7 @@ module.exports = Backbone.Model.extend({
   },
 
   isCustomTemplate: function () {
-    return this.get('template_name') === undefined && this.get('template_name') === '' && this.get('template') !== undefined && this.get('template') !== '';
+    return this.get('template_name') !== undefined && this.get('template_name') === '' && this.get('template') !== undefined && this.get('template') !== '';
   }
 
 });

--- a/lib/assets/javascripts/cartodb3/data/infowindow-hover-model.js
+++ b/lib/assets/javascripts/cartodb3/data/infowindow-hover-model.js
@@ -7,7 +7,8 @@ module.exports = InfowindowDefinitionModel.extend({
     vertical_offset: 0,
     horizontal_offset: 0,
     position: 'top|center',
-    template_name: ''
+    template_name: '',
+    template: ''
   },
 
   TEMPLATES: {

--- a/lib/assets/test/spec/cartodb3/data/infowindow-hover-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/data/infowindow-hover-model.spec.js
@@ -1,0 +1,36 @@
+var ConfigModel = require('../../../../javascripts/cartodb3/data/config-model');
+var InfowindowHoverModel = require('../../../../javascripts/cartodb3/data/infowindow-hover-model');
+
+describe('data/infowindow-hover-model', function () {
+  describe('model', function () {
+    var model;
+
+    beforeEach(function () {
+      this.configModel = new ConfigModel({
+        base_url: '/u/pepe'
+      });
+
+      model = new InfowindowHoverModel({}, {
+        configModel: this.configModel
+      });
+    });
+
+    it('should relay in default attributes properly', function () {
+      expect(model.get('template_name')).toBe('');
+      expect(model.get('template')).toBe('');
+    });
+
+    it('should check isCustomTemplate properly', function () {
+      expect(model.isCustomTemplate()).toBe(false);
+
+      model.set({template: 'foo', template_name: ''});
+      expect(model.isCustomTemplate()).toBe(true);
+
+      model.set({template: '', template_name: 'foo'});
+      expect(model.isCustomTemplate()).toBe(false);
+
+      model.set({template: '', template_name: ''});
+      expect(model.isCustomTemplate()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes #10988.

@CartoDB/frontend I'm not an expert on infowindows, but I've observed that sometimes the infowindow model has no `template` attribute. Not sure if this an issue coming from anywhere else, but this makes `isCustomTemplate` method to fail:
```
isCustomTemplate: function () {
    return this.get('template_name') === '' && this.get('template') !== '';
  }
```
In this case, if `template` is not defined as it's happening in this case, this function returns `true`, so it tries to get the content of the custom template, that it doesn't exist. Because Builder thinks it has custom template, it loads the editor view, but it fails because content is undefined.

I feel maybe something else is going on here, and template can't be undefined, but this fixes the issue in the front.

In order to test it, follow the steps described in the issue's description.
