### PR TITLE
Failing spec for user deletion with geocodings

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1673,26 +1673,26 @@ class User < Sequel::Model
 
   # INFO: assigning to owner is necessary because of payment reasons
   def assign_search_tweets_to_organization_owner
-    return if self.organization.nil? || self.organization.owner.nil? || self.id == self.organization.owner.id
-    self.search_tweets_dataset.each { |st|
-      st.user = self.organization.owner
-      st.save
-    }
+    return if organization.nil? || organization.owner.nil? || organization_owner?
+    search_tweets_dataset.each do |st|
+      st.user = organization.owner
+      st.save(raise_on_failure: true)
+    end
   rescue => e
     CartoDB::Logger.error(exception: e, message: 'Error assigning search tweets to org owner', user: self)
   end
 
   # INFO: assigning to owner is necessary because of payment reasons
   def assign_geocodings_to_organization_owner
-    return if self.organization.nil? || self.organization.owner.nil? || self.id == self.organization.owner.id
-    self.geocodings.each { |g|
-      g.user = self.organization.owner
+    return if organization.nil? || organization.owner.nil? || organization_owner?
+    geocodings_dataset.each do |g|
+      g.user = organization.owner
       g.data_import_id = nil
-      g.save
-    }
+      g.save(raise_on_failure: true)
+    end
   rescue => e
     CartoDB::Logger.error(exception: e, message: 'Error assigning geocodings to org owner', user: self)
-    self.geocodings.each { |g| g.destroy }
+    geocodings.each(&:destroy)
   end
 
   def name_exists_in_organizations?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1674,7 +1674,7 @@ class User < Sequel::Model
   # INFO: assigning to owner is necessary because of payment reasons
   def assign_search_tweets_to_organization_owner
     return if organization.nil? || organization.owner.nil? || organization_owner?
-    search_tweets_dataset.each do |st|
+    search_tweets_dataset.all.each do |st|
       st.user = organization.owner
       st.save(raise_on_failure: true)
     end
@@ -1685,7 +1685,7 @@ class User < Sequel::Model
   # INFO: assigning to owner is necessary because of payment reasons
   def assign_geocodings_to_organization_owner
     return if organization.nil? || organization.owner.nil? || organization_owner?
-    geocodings_dataset.each do |g|
+    geocodings_dataset.all.each do |g|
       g.user = organization.owner
       g.data_import_id = nil
       g.save(raise_on_failure: true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -726,27 +726,30 @@ describe User do
       u2 = create_user(email: 'u2@exampleb.com', username: 'ub2', password: 'admin123', organization: org)
 
       FactoryGirl.create(:geocoding, user: u2, kind: 'high-resolution', created_at: Time.now, processed_rows: 1, formatter: 'b')
+      FactoryGirl.create(:geocoding, user: u2, kind: 'high-resolution', created_at: Time.now, processed_rows: 2, formatter: 'c')
 
-      st = SearchTweet.new
-      st.user = u2
-      st.table_id = '96a86fb7-0270-4255-a327-15410c2d49d4'
-      st.data_import_id = '96a86fb7-0270-4255-a327-15410c2d49d4'
-      st.service_item_id = '555'
-      st.retrieved_items = 5
-      st.state = ::SearchTweet::STATE_COMPLETE
-      st.save
+      tweet_attributes = {
+        user: u2,
+        table_id: '96a86fb7-0270-4255-a327-15410c2d49d4',
+        data_import_id: '96a86fb7-0270-4255-a327-15410c2d49d4',
+        service_item_id: '555',
+        state: ::SearchTweet::STATE_COMPLETE
+      }
+
+      SearchTweet.create(tweet_attributes.merge(retrieved_items: 5))
+      SearchTweet.create(tweet_attributes.merge(retrieved_items: 10))
 
       u1.reload
       u2.reload
-      u2.get_geocoding_calls.should == 1
-      u2.get_twitter_imports_count.should == 5
+      u2.get_geocoding_calls.should == 3
+      u2.get_twitter_imports_count.should == 15
       u1.get_geocoding_calls.should == 0
       u1.get_twitter_imports_count.should == 0
 
       u2.destroy
       u1.reload
-      u1.get_geocoding_calls.should == 1
-      u1.get_twitter_imports_count.should == 5
+      u1.get_geocoding_calls.should == 3
+      u1.get_twitter_imports_count.should == 15
 
       org.destroy
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -725,8 +725,15 @@ describe User do
 
       u2 = create_user(email: 'u2@exampleb.com', username: 'ub2', password: 'admin123', organization: org)
 
-      FactoryGirl.create(:geocoding, user: u2, kind: 'high-resolution', created_at: Time.now, processed_rows: 1, formatter: 'b')
-      FactoryGirl.create(:geocoding, user: u2, kind: 'high-resolution', created_at: Time.now, processed_rows: 2, formatter: 'c')
+      geocoding_attributes = {
+        user: u2,
+        kind: 'high-resolution',
+        created_at: Time.now,
+        formatter: 'b'
+      }
+
+      FactoryGirl.create(:geocoding, geocoding_attributes.merge(processed_rows: 1))
+      FactoryGirl.create(:geocoding, geocoding_attributes.merge(processed_rows: 2))
 
       tweet_attributes = {
         user: u2,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -732,8 +732,8 @@ describe User do
         formatter: 'b'
       }
 
-      FactoryGirl.create(:geocoding, geocoding_attributes.merge(processed_rows: 1))
-      FactoryGirl.create(:geocoding, geocoding_attributes.merge(processed_rows: 2))
+      gc1 = FactoryGirl.create(:geocoding, geocoding_attributes.merge(processed_rows: 1))
+      gc2 = FactoryGirl.create(:geocoding, geocoding_attributes.merge(processed_rows: 2))
 
       tweet_attributes = {
         user: u2,
@@ -743,20 +743,21 @@ describe User do
         state: ::SearchTweet::STATE_COMPLETE
       }
 
-      SearchTweet.create(tweet_attributes.merge(retrieved_items: 5))
-      SearchTweet.create(tweet_attributes.merge(retrieved_items: 10))
+      st1 = SearchTweet.create(tweet_attributes.merge(retrieved_items: 5))
+      st2 = SearchTweet.create(tweet_attributes.merge(retrieved_items: 10))
 
       u1.reload
       u2.reload
-      u2.get_geocoding_calls.should == 3
-      u2.get_twitter_imports_count.should == 15
+      byebug
+      u2.get_geocoding_calls.should == gc1.processed_rows + gc2.processed_rows
+      u2.get_twitter_imports_count.should == st1.retrieved_items + st2.retrieved_items
       u1.get_geocoding_calls.should == 0
       u1.get_twitter_imports_count.should == 0
 
       u2.destroy
       u1.reload
-      u1.get_geocoding_calls.should == 3
-      u1.get_twitter_imports_count.should == 15
+      u1.get_geocoding_calls.should == gc1.processed_rows + gc2.processed_rows
+      u1.get_twitter_imports_count.should == st1.retrieved_items + st2.retrieved_items
 
       org.destroy
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -748,7 +748,7 @@ describe User do
 
       u1.reload
       u2.reload
-      byebug
+
       u2.get_geocoding_calls.should == gc1.processed_rows + gc2.processed_rows
       u2.get_twitter_imports_count.should == st1.retrieved_items + st2.retrieved_items
       u1.get_geocoding_calls.should == 0


### PR DESCRIPTION
Fixes #11011

Changes `geocodings` to `geocodings_dataset`. The first one is an array (called association cache in the docs) kept by Sequel which updates as geocodings are associated/disassociated from the user. Due to how the iterator works, this was making it iterate only over half the elements.

The `_dataset` returns a Dataset object (representds a query). Calling `.each` on it,, executes the query (internally, calls `. all`) and returns an array of results, which is static, so iterating over it is safe.

Doc: http://sequel.jeremyevans.net/rdoc/files/doc/association_basics_rdoc.html#label-Dataset+Method

A little cleanup as an extra.