### PR TITLE
Update cartodb.js shrinkwrap for on premises release

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1152,7 +1152,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#dde385b5d87454f64eb245d8a57ff9b59fe14435",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#be1da170e3e8a91f2b5565ef00a6ef4887612165",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1452,7 +1452,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#dde385b5d87454f64eb245d8a57ff9b59fe14435",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#be1da170e3e8a91f2b5565ef00a6ef4887612165",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",


### PR DESCRIPTION
Only updated CartoDB.js dependency in the shrinkwrap package. We have checked that last CartoDb.js commit was https://github.com/CartoDB/cartodb.js/commit/dde385b5d87454f64eb245d8a57ff9b59fe14435, and it turns out we didn't make any other change before new on-premises bugfixing, so safe and sound.

![screen shot 2016-12-14 at 09 13 15](https://cloud.githubusercontent.com/assets/132146/21174462/91b6a5bc-c1dd-11e6-958a-01b56b68e7c7.png)

Pointing to last commit by @ivanmalagon https://github.com/CartoDB/cartodb.js/commit/be1da170e3e8a91f2b5565ef00a6ef4887612165.

CR: @rochoa 
cc @ivanmalagon @luisbosque 