### PR TITLE
Shows a custom message when the longitude is out of bounds

### DIFF
--- a/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
+++ b/lib/assets/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
@@ -17,6 +17,9 @@ var getCoordinatesFromGeoJSON = function (geoJSON) {
   }
 };
 
+var MIN_LNG = -180;
+var MAX_LNG = 180;
+
 module.exports = EditFeatureGeometryFormModel.extend({
 
   initialize: function () {
@@ -76,18 +79,33 @@ module.exports = EditFeatureGeometryFormModel.extend({
     }
   },
 
+  _validateLongitude: function (value, formValues) {
+    var numericValue = +value;
+    var error = {
+      type: 'lng',
+      message: _t('editor.edit-feature.valid-lng')
+    };
+
+    if (_.isNumber(numericValue) && numericValue >= MIN_LNG && numericValue <= MAX_LNG) {
+      return null;
+    }
+
+    if (numericValue > MAX_LNG || numericValue < MIN_LNG) {
+      error.message = _t('editor.edit-feature.out-of-bounds-lng');
+    }
+
+    return error;
+  },
+
   _generateSchema: function () {
     this.schema = {};
 
     this.schema.lng = {
       type: 'Number',
-      validators: ['required', {
-        type: 'regexp',
-        regexp: /^(\+|-)?(?:180(?:(?:\.0{1,})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,})?))$/, // https://www.debuggex.com/r/S82QD5uQ6hoQ1LvE
-        message: _t('editor.edit-feature.valid-lng')
-      }],
+      validators: ['required', this._validateLongitude],
       showSlider: false
     };
+
     this.schema.lat = {
       type: 'Number',
       validators: ['required', {

--- a/lib/assets/locale/en.json
+++ b/lib/assets/locale/en.json
@@ -2049,6 +2049,7 @@
       "cancel": "Cancel",
       "geometry": "Geometry",
       "geometry-edit": "You can also edit it on the map",
+      "out-of-bounds-lng": "Longitude is out of bounds [-180, 180]",
       "valid-lng": "Must be a valid longitude",
       "valid-lat": "Must be a valid latitude",
       "valid": "Only numbers allowed",

--- a/lib/assets/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
+++ b/lib/assets/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
@@ -1,4 +1,6 @@
 var Backbone = require('backbone');
+require('backbone-forms');
+
 var EditFeatureGeometryFormModel = require('../../../../../../javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model');
 var EditFeatureGeometryPointFormModel = require('../../../../../../javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model');
 
@@ -25,6 +27,23 @@ describe('editor/layers/edit-feature-content-views/edit-feature-geometry-form-mo
       expect(Object.keys(this.formModel.schema).length).toEqual(2);
       expect(this.formModel.schema.lng.type).toEqual('Number');
       expect(this.formModel.schema.lat.type).toEqual('Number');
+    });
+
+    describe('when longitude is erroneous', function () {
+      it('should return regular error if lng is not a number', function () {
+        this.formModel.set({ lng: 'Look at me!', lat: 10 });
+        var form = new Backbone.Form({ model: this.formModel });
+        var validation = form.getEditor('lng').validate();
+        expect(validation.message).toBe('editor.edit-feature.valid-lng');
+      });
+
+      it('should return custom error if lng is out of bounds', function () {
+        this.formModel.set({ lng: -5000, lat: 10 });
+        var form = new Backbone.Form({ model: this.formModel });
+
+        var validation = form.getEditor('lng').validate();
+        expect(validation.message).toBe('editor.edit-feature.out-of-bounds-lng');
+      });
     });
 
     describe('when form data changes', function () {


### PR DESCRIPTION
### How to test this feature

![point](https://cloud.githubusercontent.com/assets/4933/21144913/b866013a-c14c-11e6-8a59-f55d216e859f.gif)



1. Create a map
2. Make sure you are in a small zoom level (1 or 2, for example)
3. Place a point in one of the maps of the sides

a. Check that the error message in the form is not the default one (`Must be a valid longitude`) but   `Longitude is out of bounds [-180, 180]`
b. Check that the custom error still appears whenever you introduce a different erroneous value (eg: a letter).


Closes #10881