### PR TITLE
rename tests suites

### DIFF
--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
@@ -3,7 +3,7 @@ var CDB = require('cartodb.js');
 var InputColorCategories = require('../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories');
 var ConfigModel = require('../../../../../../../../../javascripts/cartodb3/data/config-model');
 
-describe('components/form-components/editors/fill/input-color/input-ramps/input-color-ramps', function () {
+describe('components/form-components/editors/fill/input-color/input-categories/input-color-categories', function () {
   beforeEach(function () {
     CDB.SQL.prototype.execute = function (query, vars, params) {
       params && params.success();

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.spec.js
@@ -2,7 +2,7 @@ var Backbone = require('backbone');
 var ConfigModel = require('../../../../../../../../javascripts/cartodb3/data/config-model');
 var InputColorFileView = require('../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view');
 
-describe('components/form-components/editors/fill/input-color/input-categories/input-color-categories', function () {
+describe('components/form-components/editors/fill/input-color/input-color-file-view', function () {
   describe('on model with a range', function () {
     beforeEach(function () {
       this.model = new Backbone.Model({

--- a/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.spec.js
+++ b/lib/assets/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.spec.js
@@ -2,7 +2,7 @@ var Backbone = require('backbone');
 var ConfigModel = require('../../../../../../../../javascripts/cartodb3/data/config-model');
 var InputColorFileView = require('../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view');
 
-describe('components/form-components/editors/fill/input-color/input-ramps/input-color-ramps', function () {
+describe('components/form-components/editors/fill/input-color/input-categories/input-color-categories', function () {
   describe('on model with a range', function () {
     beforeEach(function () {
       this.model = new Backbone.Model({


### PR DESCRIPTION
doing another issue I realized some test suites were called the same, so they would be overriden at the time of pass the specs :(
