### PR TITLE
Do not load take tasks when running resque

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,11 @@ require 'rake/dsl_definition'
 require 'rake'
 require 'resque/tasks'
 
+# Do not load take tasks when running resque: https://github.com/CartoDB/cartodb/issues/11046
+if Rake.application.top_level_tasks.reject { |t| ['environment', 'resque:work'].include?(t) }.empty?
+  CartoDB::Application.paths['lib/tasks'] = []
+end
+
 CartoDB::Application.load_tasks
 
 Rake.application.instance_variable_get('@tasks').delete('default')


### PR DESCRIPTION
**Risky deploy: NOT FRIDAY**

Fixes #11046 

Criteria for acceptance (deployed to ded09): All queued tasks should work:
 - Imports (data and .carto)
 - Exports (.carto)
 - User migration
 - Metrics
 - Geocodings
 - Ghost tables
 - Autoindexing
 - Loading common data
 - Emails. e.g: map liked, org invitations, quotas reached
 - User creation/signup