### PR TITLE
Fix timeseries widget height in responsive.

### DIFF
--- a/app/assets/stylesheets/editor-3/editor.css.scss
+++ b/app/assets/stylesheets/editor-3/editor.css.scss
@@ -113,6 +113,7 @@
     }
     .CDB-Widget.CDB-Widget--timeSeries {
       padding: 12px 0;
+      min-height: auto;
       .CDB-Widget-content {
         margin-right: 12px;
         margin-left: 12px;


### PR DESCRIPTION
This PR fix a minor issue with timeseries widget in responsive state.

Before:

![screen shot 2016-12-15 at 18 18 04](https://cloud.githubusercontent.com/assets/1366843/21234492/20c7fb3c-c2f3-11e6-8c78-f2ae497770a3.png)

After:

![screen shot 2016-12-15 at 18 18 20](https://cloud.githubusercontent.com/assets/1366843/21234502/29446caa-c2f3-11e6-905a-2905ae5cde8f.png)

cc @piensaenpixel 