### PR TITLE
Recreate layer including legends as attributes.

### DIFF
--- a/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/javascripts/cartodb3/deep-insights-integrations.js
@@ -47,6 +47,7 @@ var F = function (opts) {
   this._widgetDefinitionsCollection = opts.widgetDefinitionsCollection;
   this._editorModel = opts.editorModel;
   this._editFeatureOverlay = opts.editFeatureOverlay;
+  this._legendsDefinitionCollection = opts.legendDefinitionsCollection;
 
   this._layerDefinitionsCollection.each(this._linkLayerErrors, this);
 
@@ -635,6 +636,14 @@ var LAYER_TYPE_TO_LAYER_CREATE_METHOD = {
 F.prototype._createLayer = function (layerDefModel) {
   var attrs = JSON.parse(JSON.stringify(layerDefModel.attributes)); // deep clone
   attrs = this._adaptAttrsToCDBjs(attrs);
+
+  // create the legends for the new layer
+  var legends = this._legendsDefinitionCollection.findByLayerDefModel(layerDefModel);
+  if (legends.length > 0) {
+    attrs.legends = _.map(legends, function (legend) {
+      return legend.toJSON();
+    });
+  }
 
   var createMethodName = LAYER_TYPE_TO_LAYER_CREATE_METHOD[attrs.type.toLowerCase()];
   if (!createMethodName) throw new Error('no create method name found for type ' + attrs.type);

--- a/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -843,6 +843,33 @@ describe('deep-insights-integrations', function () {
           cartocss: ''
         }
       });
+
+      var vizJSON = {
+        options: {
+          scrollwheel: false
+        },
+        layers: [
+          {
+            id: 'hello',
+            type: 'CartoDB',
+            legends: [
+              {
+                type: 'bubble',
+                title: 'My Bubble Legend',
+                fill_color: '#FABADA'
+              },
+              {
+                type: 'choropleth',
+                title: 'My Choropleth Legend',
+                prefix: 'prefix',
+                sufix: 'sufix'
+              }
+            ]
+          }
+        ]
+      };
+
+      this.legendDefinitionsCollection.resetByData(vizJSON);
     });
 
     it('should remove model and create a new one with the same id', function () {
@@ -851,6 +878,16 @@ describe('deep-insights-integrations', function () {
       var newModel = this.integrations._getLayer(this.newLayer);
       expect(newModel.cid).not.toBe(currentModel.cid);
       expect(newModel.attributes.source).toEqual('a0');
+    });
+
+    it('should create a new one with legends', function () {
+      this.layerDefinitionsCollection.trigger('layerMoved', this.newLayer);
+      var newModel = this.integrations._getLayer(this.newLayer);
+      expect(newModel.legends.choropleth.get('visible')).toBe(true);
+      expect(newModel.legends.choropleth.get('title')).toBe('My Choropleth Legend');
+      expect(newModel.legends.bubble.get('visible')).toBe(true);
+      expect(newModel.legends.bubble.get('title')).toBe('My Bubble Legend');
+      expect(newModel.legends.custom.get('visible')).toBe(false);
     });
   });
 


### PR DESCRIPTION
This PR fixes #11037.

When moving a layer, we silently remove the layer and insert it again in the layers collection. When this happens, we were copying the all the layers attributes, but not the legends of this layer. So cartodb.js thinks it has no legends to show. This PR solves it, adding the layer's legends to the attributes when the new layer is created in cartodb.js.