### PR TITLE
10501 add widget added event

### DIFF
--- a/app/controllers/carto/api/widgets_controller.rb
+++ b/app/controllers/carto/api/widgets_controller.rb
@@ -33,7 +33,8 @@ module Carto
           source_id: source_id_from_params)
         widget.save!
 
-        Carto::Tracking::Events::CreatedWidget.new(user_id: current_viewer.id,
+        Carto::Tracking::Events::CreatedWidget.new(current_viewer.id,
+                                                   user_id: current_viewer.id,
                                                    visualization_id: @layer.visualization.id,
                                                    widget_id: widget.id).report
 
@@ -53,10 +54,6 @@ module Carto
         @widget.style = params[:style]
         @widget.save!
 
-        Carto::Tracking::Events::ModifiedWidget.new(user_id: current_viewer.id,
-                                                    visualization_id: @layer.visualization.id,
-                                                    widget_id: @widget.id).report
-
         render_jsonp(WidgetPresenter.new(@widget).to_poro)
       rescue => e
         CartoDB::Logger.error(exception: e, message: "Error updating widget", widget: @widget)
@@ -65,10 +62,6 @@ module Carto
 
       def destroy
         @widget.destroy
-
-        Carto::Tracking::Events::DeletedWidget.new(user_id: current_viewer.id,
-                                                   visualization_id: @layer.visualization.id,
-                                                   widget_id: @widget.id).report
 
         render_jsonp(WidgetPresenter.new(@widget).to_poro)
       rescue => e

--- a/app/controllers/carto/api/widgets_controller.rb
+++ b/app/controllers/carto/api/widgets_controller.rb
@@ -32,6 +32,11 @@ module Carto
           style: params[:style],
           source_id: source_id_from_params)
         widget.save!
+
+        Carto::Tracking::Events::CreatedWidget.new(user_id: current_viewer.id,
+                                                   visualization_id: @layer.visualization.id,
+                                                   widget_id: widget.id).report!
+
         render_jsonp(WidgetPresenter.new(widget).to_poro, 201)
       rescue ActiveRecord::RecordInvalid
         render json: { errors: widget.errors }, status: 422
@@ -48,6 +53,10 @@ module Carto
         @widget.style = params[:style]
         @widget.save!
 
+        Carto::Tracking::Events::ModifiedWidget.new(user_id: current_viewer.id,
+                                                    visualization_id: @layer.visualization.id,
+                                                    widget_id: @widget.id).report!
+
         render_jsonp(WidgetPresenter.new(@widget).to_poro)
       rescue => e
         CartoDB::Logger.error(exception: e, message: "Error updating widget", widget: @widget)
@@ -56,6 +65,11 @@ module Carto
 
       def destroy
         @widget.destroy
+
+        Carto::Tracking::Events::DeletedWidget.new(user_id: current_viewer.id,
+                                                   visualization_id: @layer.visualization.id,
+                                                   widget_id: @widget.id).report!
+
         render_jsonp(WidgetPresenter.new(@widget).to_poro)
       rescue => e
         CartoDB::Logger.error(exception: e, message: "Error destroying widget", widget: @widget)

--- a/app/controllers/carto/api/widgets_controller.rb
+++ b/app/controllers/carto/api/widgets_controller.rb
@@ -35,7 +35,7 @@ module Carto
 
         Carto::Tracking::Events::CreatedWidget.new(user_id: current_viewer.id,
                                                    visualization_id: @layer.visualization.id,
-                                                   widget_id: widget.id).report!
+                                                   widget_id: widget.id).report
 
         render_jsonp(WidgetPresenter.new(widget).to_poro, 201)
       rescue ActiveRecord::RecordInvalid
@@ -55,7 +55,7 @@ module Carto
 
         Carto::Tracking::Events::ModifiedWidget.new(user_id: current_viewer.id,
                                                     visualization_id: @layer.visualization.id,
-                                                    widget_id: @widget.id).report!
+                                                    widget_id: @widget.id).report
 
         render_jsonp(WidgetPresenter.new(@widget).to_poro)
       rescue => e
@@ -68,7 +68,7 @@ module Carto
 
         Carto::Tracking::Events::DeletedWidget.new(user_id: current_viewer.id,
                                                    visualization_id: @layer.visualization.id,
-                                                   widget_id: @widget.id).report!
+                                                   widget_id: @widget.id).report
 
         render_jsonp(WidgetPresenter.new(@widget).to_poro)
       rescue => e

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -1,11 +1,11 @@
 # encoding: utf-8
 
-require 'carto/tracking/formats/internal'
-require 'carto/tracking/services/segment'
-require 'carto/tracking/services/hubspot'
-require 'carto/tracking/validators/visualization'
-require 'carto/tracking/validators/user'
-require 'carto/tracking/validators/widget'
+require_dependency 'carto/tracking/formats/internal'
+require_dependency 'carto/tracking/services/segment'
+require_dependency 'carto/tracking/services/hubspot'
+require_dependency 'carto/tracking/validators/visualization'
+require_dependency 'carto/tracking/validators/user'
+require_dependency 'carto/tracking/validators/widget'
 
 module Carto
   module Tracking

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -205,6 +205,19 @@ module Carto
 
         required_properties :user_id, :visualization_id
       end
+
+      class WidgetEvent < Event
+        include Carto::Tracking::Services::Segment
+
+        include Carto::Tracking::Validators::Visualization::Writable
+        include Carto::Tracking::Validators::User
+
+        required_properties :user_id, :visualization_id
+      end
+
+      class AddedWidget < AnalysisEvent; end
+      class RemovedWidget < AnalysisEvent; end
+      class ModifiedWidget < AnalysisEvent; end
     end
   end
 end

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -19,6 +19,17 @@ module Carto
           self.class.name.demodulize.underscore.humanize.capitalize
         end
 
+        def self.required_properties(*required_properties)
+          @required_properties ||= []
+          @required_properties += required_properties
+        end
+
+        def required_properties
+          these_required_properties = self.class.instance_eval { @required_properties }
+
+          these_required_properties || self.class.superclass.required_properties
+        end
+
         def report
           report!
         rescue => exception
@@ -27,6 +38,8 @@ module Carto
                                 name: name,
                                 properties: @format.to_hash)
         end
+
+        private
 
         def report!
           check_required_properties!
@@ -40,19 +53,6 @@ module Carto
             send(report_method)
           end
         end
-
-        def self.required_properties(*required_properties)
-          @required_properties ||= []
-          @required_properties += required_properties
-        end
-
-        def required_properties
-          these_required_properties = self.class.instance_eval { @required_properties }
-
-          these_required_properties || self.class.superclass.required_properties
-        end
-
-        private
 
         def check_required_properties!
           missing_properties = required_properties - @format.to_hash.symbolize_keys.keys

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -215,7 +215,7 @@ module Carto
         required_properties :user_id, :visualization_id, :widget_id
       end
 
-      class AddedWidget < AnalysisEvent
+      class CreatedWidget < AnalysisEvent
         include Carto::Tracking::Validators::Widget::Existence
       end
 

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -1,10 +1,11 @@
 # encoding: utf-8
 
-require_dependency 'carto/tracking/formats/internal'
-require_dependency 'carto/tracking/services/segment'
-require_dependency 'carto/tracking/services/hubspot'
-require_dependency 'carto/tracking/validators/visualization'
-require_dependency 'carto/tracking/validators/user'
+require 'carto/tracking/formats/internal'
+require 'carto/tracking/services/segment'
+require 'carto/tracking/services/hubspot'
+require 'carto/tracking/validators/visualization'
+require 'carto/tracking/validators/user'
+require 'carto/tracking/validators/widget'
 
 module Carto
   module Tracking

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -65,6 +65,12 @@ module Carto
           end
         end
 
+        # Validators are modules that should be included in Event classes. These
+        # modules contain methods that start with 'check_'. They raise an
+        # exception if whatever condition they validate is not met. All methods
+        # that match this criteria in validator modules included in an Event
+        # class will be run automatically when .report or .report! is called for
+        # that same class.
         def authorize!
           check_methods = methods.select do |method_name|
             method_name.to_s.start_with?('check_')

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -40,8 +40,6 @@ module Carto
                                 properties: @format.to_hash)
         end
 
-        private
-
         def report!
           check_required_properties!
           authorize!
@@ -54,6 +52,8 @@ module Carto
             send(report_method)
           end
         end
+
+        private
 
         def check_required_properties!
           missing_properties = required_properties - @format.to_hash.symbolize_keys.keys

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -212,12 +212,20 @@ module Carto
         include Carto::Tracking::Validators::Visualization::Writable
         include Carto::Tracking::Validators::User
 
-        required_properties :user_id, :visualization_id
+        required_properties :user_id, :visualization_id, :widget_id
       end
 
-      class AddedWidget < AnalysisEvent; end
-      class DeletedWidget < AnalysisEvent; end
-      class ModifiedWidget < AnalysisEvent; end
+      class AddedWidget < AnalysisEvent
+        include Carto::Tracking::Validators::Widget::Existence
+      end
+
+      class ModifiedWidget < AnalysisEvent
+        include Carto::Tracking::Validators::Widget::Existence
+      end
+
+      class DeletedWidget < AnalysisEvent
+        include Carto::Tracking::Validators::Widget::NonExistence
+      end
     end
   end
 end

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -207,25 +207,14 @@ module Carto
         required_properties :user_id, :visualization_id
       end
 
-      class WidgetEvent < Event
+      class CreatedWidget < Event
         include Carto::Tracking::Services::Segment
 
+        include Carto::Tracking::Validators::Widget::Existence
         include Carto::Tracking::Validators::Visualization::Writable
         include Carto::Tracking::Validators::User
 
         required_properties :user_id, :visualization_id, :widget_id
-      end
-
-      class CreatedWidget < AnalysisEvent
-        include Carto::Tracking::Validators::Widget::Existence
-      end
-
-      class ModifiedWidget < AnalysisEvent
-        include Carto::Tracking::Validators::Widget::Existence
-      end
-
-      class DeletedWidget < AnalysisEvent
-        include Carto::Tracking::Validators::Widget::NonExistence
       end
     end
   end

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -216,7 +216,7 @@ module Carto
       end
 
       class AddedWidget < AnalysisEvent; end
-      class RemovedWidget < AnalysisEvent; end
+      class DeletedWidget < AnalysisEvent; end
       class ModifiedWidget < AnalysisEvent; end
     end
   end

--- a/lib/carto/tracking/formats/internal.rb
+++ b/lib/carto/tracking/formats/internal.rb
@@ -33,9 +33,11 @@ module Carto
         def to_segment
           user = fetch_record!(:user)
           visualization = fetch_record!(:visualization)
+          widget = fetch_record!(:widget)
 
           Carto::Tracking::Formats::Segment.new(user: user,
                                                 visualization: visualization,
+                                                widget: widget,
                                                 hash: @hash).to_hash
         end
 

--- a/lib/carto/tracking/formats/segment.rb
+++ b/lib/carto/tracking/formats/segment.rb
@@ -4,9 +4,10 @@ module Carto
   module Tracking
     module Formats
       class Segment
-        def initialize(user: nil, visualization: nil, hash: {})
+        def initialize(user: nil, visualization: nil, widget: nil, hash: {})
           @user = user
           @visualization = visualization
+          @widget = widget
           @connection = hash[:connection]
           @origin = hash[:origin]
           @page = hash[:page]
@@ -25,6 +26,7 @@ module Carto
           properties.merge!(map_liking_properties) if @action
           properties.merge!(trending_map_properties) if @mapviews
           properties.merge!(analysis_properties) if @analysis
+          properties.merge!(widget_properties) if @widget
 
           properties[:page] = @page if @page
           properties[:quota_overage] = @quota_overage if @quota_overage
@@ -103,6 +105,10 @@ module Carto
             vis_author_email: visualization_user.email,
             vis_author_id: visualization_user.id
           }
+        end
+
+        def widget_properties
+          { widget_type: @widget.type }
         end
 
         def event_properties

--- a/lib/carto/tracking/validators/widget.rb
+++ b/lib/carto/tracking/validators/widget.rb
@@ -1,0 +1,25 @@
+# encoding: utf-8
+
+module Carto
+  module Tracking
+    module Validators
+      module Widget
+        module Existence
+          def check_widget_exists!
+            unless @format.fetch_record!(:widget)
+              raise Carto::LoadError.new('Widget not found')
+            end
+          end
+        end
+
+        module NonExistence
+          def check_widget_doesnt_exists!
+            if @format.fetch_record!(:widget)
+              raise Carto::UnprocesableEntityError.new('Widget exists')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/carto/tracking/validators/widget.rb
+++ b/lib/carto/tracking/validators/widget.rb
@@ -11,14 +11,6 @@ module Carto
             end
           end
         end
-
-        module NonExistence
-          def check_widget_doesnt_exists!
-            if @format.fetch_record!(:widget)
-              raise Carto::UnprocesableEntityError.new('Widget exists')
-            end
-          end
-        end
       end
     end
   end

--- a/spec/lib/carto/tracking/events_spec.rb
+++ b/spec/lib/carto/tracking/events_spec.rb
@@ -41,7 +41,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -59,7 +59,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -71,7 +71,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -79,7 +79,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -88,7 +88,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -98,7 +98,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:is_accesible_by_user?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -130,7 +130,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -148,7 +148,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -160,7 +160,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -168,7 +168,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -177,7 +177,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -187,7 +187,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -221,7 +221,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -239,7 +239,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -251,7 +251,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -259,7 +259,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -268,7 +268,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -278,7 +278,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -310,7 +310,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -328,7 +328,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -340,7 +340,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -348,7 +348,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -357,7 +357,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -367,7 +367,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -409,7 +409,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -429,7 +429,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -441,7 +441,7 @@ module Carto
                                         user_id: @user.id,
                                         connection: connection)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -450,7 +450,7 @@ module Carto
                                      user_id: @user.id,
                                      connection: connection)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -490,7 +490,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -508,7 +508,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -520,7 +520,7 @@ module Carto
                                         user_id: @user.id,
                                         connection: connection)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -529,7 +529,7 @@ module Carto
                                      user_id: @user.id,
                                      connection: connection)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -560,7 +560,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -574,7 +574,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -584,14 +584,14 @@ module Carto
             it 'must be reported by user' do
               @event = @event_class.new(@intruder.id, user_id: @user.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
           it 'reports' do
             event = @event_class.new(@user.id, user_id: @user.id)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -617,7 +617,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -645,7 +645,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -658,7 +658,7 @@ module Carto
                                         user_id: @intruder.id,
                                         mapviews: 123)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -667,7 +667,7 @@ module Carto
                                         user_id: @user.id,
                                         mapviews: 123)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -677,7 +677,7 @@ module Carto
                                      user_id: @user.id,
                                      mapviews: 123)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -688,7 +688,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -723,7 +723,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -741,7 +741,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -753,7 +753,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -761,7 +761,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -770,7 +770,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -780,7 +780,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -814,7 +814,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -832,7 +832,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -844,7 +844,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -852,7 +852,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -861,7 +861,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -871,7 +871,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -903,7 +903,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -931,7 +931,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -944,7 +944,7 @@ module Carto
                                         user_id: @intruder.id,
                                         action: 'like')
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -953,7 +953,7 @@ module Carto
                                         user_id: @user.id,
                                         action: 'like')
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -963,7 +963,7 @@ module Carto
                                      user_id: @user.id,
                                      action: 'like')
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -977,7 +977,7 @@ module Carto
                                 .with(@intruder)
                                 .returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -1020,7 +1020,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -1048,7 +1048,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -1061,7 +1061,7 @@ module Carto
                                         user_id: @intruder.id,
                                         analysis: analysis)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -1070,7 +1070,7 @@ module Carto
                                         user_id: @user.id,
                                         analysis: analysis)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -1080,7 +1080,7 @@ module Carto
                                      user_id: @user.id,
                                      analysis: analysis)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -1091,7 +1091,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -1135,7 +1135,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -1163,7 +1163,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -1176,7 +1176,7 @@ module Carto
                                         user_id: @intruder.id,
                                         analysis: analysis)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -1185,7 +1185,7 @@ module Carto
                                         user_id: @user.id,
                                         analysis: analysis)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -1195,7 +1195,7 @@ module Carto
                                      user_id: @user.id,
                                      analysis: analysis)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -1206,7 +1206,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -1278,7 +1278,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -1306,7 +1306,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -1319,7 +1319,7 @@ module Carto
                                         user_id: @intruder.id,
                                         analysis: analysis)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -1328,7 +1328,7 @@ module Carto
                                         user_id: @user.id,
                                         analysis: analysis)
 
-              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -1338,7 +1338,7 @@ module Carto
                                      user_id: @user.id,
                                      analysis: analysis)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -1349,7 +1349,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.report! }.to_not raise_error
+            expect { event.send(:report!) }.to_not raise_error
           end
 
           it 'matches current prod properites' do

--- a/spec/lib/carto/tracking/events_spec.rb
+++ b/spec/lib/carto/tracking/events_spec.rb
@@ -41,7 +41,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -59,7 +59,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -71,7 +71,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -79,7 +79,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -88,7 +88,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -98,7 +98,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:is_accesible_by_user?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -130,7 +130,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -148,7 +148,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -160,7 +160,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -168,7 +168,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -177,7 +177,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -187,7 +187,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -221,7 +221,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -239,7 +239,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -251,7 +251,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -259,7 +259,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -268,7 +268,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -278,7 +278,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -310,7 +310,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -328,7 +328,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -340,7 +340,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -348,7 +348,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -357,7 +357,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -367,7 +367,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -409,7 +409,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -429,7 +429,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -441,7 +441,7 @@ module Carto
                                         user_id: @user.id,
                                         connection: connection)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -450,7 +450,7 @@ module Carto
                                      user_id: @user.id,
                                      connection: connection)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -490,7 +490,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -508,7 +508,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -520,7 +520,7 @@ module Carto
                                         user_id: @user.id,
                                         connection: connection)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -529,7 +529,7 @@ module Carto
                                      user_id: @user.id,
                                      connection: connection)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -560,7 +560,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -574,7 +574,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -584,14 +584,14 @@ module Carto
             it 'must be reported by user' do
               @event = @event_class.new(@intruder.id, user_id: @user.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
           it 'reports' do
             event = @event_class.new(@user.id, user_id: @user.id)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -617,7 +617,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -645,7 +645,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -658,7 +658,7 @@ module Carto
                                         user_id: @intruder.id,
                                         mapviews: 123)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -667,7 +667,7 @@ module Carto
                                         user_id: @user.id,
                                         mapviews: 123)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -677,7 +677,7 @@ module Carto
                                      user_id: @user.id,
                                      mapviews: 123)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -688,7 +688,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -723,7 +723,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -741,7 +741,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -753,7 +753,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -761,7 +761,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -770,7 +770,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -780,7 +780,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -814,7 +814,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -832,7 +832,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -844,7 +844,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @intruder.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -852,7 +852,7 @@ module Carto
                                         visualization_id: @visualization.id,
                                         user_id: @user.id)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -861,7 +861,7 @@ module Carto
                                      visualization_id: @visualization.id,
                                      user_id: @user.id)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -871,7 +871,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -903,7 +903,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -931,7 +931,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -944,7 +944,7 @@ module Carto
                                         user_id: @intruder.id,
                                         action: 'like')
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -953,7 +953,7 @@ module Carto
                                         user_id: @user.id,
                                         action: 'like')
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -963,7 +963,7 @@ module Carto
                                      user_id: @user.id,
                                      action: 'like')
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -977,7 +977,7 @@ module Carto
                                 .with(@intruder)
                                 .returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -1020,7 +1020,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -1048,7 +1048,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -1061,7 +1061,7 @@ module Carto
                                         user_id: @intruder.id,
                                         analysis: analysis)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -1070,7 +1070,7 @@ module Carto
                                         user_id: @user.id,
                                         analysis: analysis)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -1080,7 +1080,7 @@ module Carto
                                      user_id: @user.id,
                                      analysis: analysis)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -1091,7 +1091,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -1135,7 +1135,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -1163,7 +1163,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -1176,7 +1176,7 @@ module Carto
                                         user_id: @intruder.id,
                                         analysis: analysis)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -1185,7 +1185,7 @@ module Carto
                                         user_id: @user.id,
                                         analysis: analysis)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -1195,7 +1195,7 @@ module Carto
                                      user_id: @user.id,
                                      analysis: analysis)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -1206,7 +1206,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do
@@ -1251,7 +1251,7 @@ module Carto
                                                                visualization_id: @visualization.id,
                                                                widget_id: random_uuid)
 
-            expect { event.send(:report!) }.to raise_error(Carto::LoadError)
+            expect { event.report! }.to raise_error(Carto::LoadError)
           end
 
           it 'should report when valid widget' do
@@ -1260,7 +1260,7 @@ module Carto
                                                                visualization_id: @visualization.id,
                                                                widget_id: @widget.id)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
         end
 
@@ -1278,7 +1278,7 @@ module Carto
 
           describe '#properties validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnprocesableEntityError)
+              expect { @event.report! }.to raise_error(Carto::UnprocesableEntityError)
             end
 
             after(:all) do
@@ -1306,7 +1306,7 @@ module Carto
 
           describe '#security validation' do
             after(:each) do
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             after(:all) do
@@ -1319,7 +1319,7 @@ module Carto
                                         user_id: @intruder.id,
                                         analysis: analysis)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
 
             it 'must be reported by user' do
@@ -1328,7 +1328,7 @@ module Carto
                                         user_id: @user.id,
                                         analysis: analysis)
 
-              expect { @event.send(:report!) }.to raise_error(Carto::UnauthorizedError)
+              expect { @event.report! }.to raise_error(Carto::UnauthorizedError)
             end
           end
 
@@ -1338,7 +1338,7 @@ module Carto
                                      user_id: @user.id,
                                      analysis: analysis)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'reports by user with access' do
@@ -1349,7 +1349,7 @@ module Carto
 
             Carto::Visualization.any_instance.stubs(:writable_by?).with(@intruder).returns(true)
 
-            expect { event.send(:report!) }.to_not raise_error
+            expect { event.report! }.to_not raise_error
           end
 
           it 'matches current prod properites' do

--- a/spec/lib/carto/tracking/events_spec.rb
+++ b/spec/lib/carto/tracking/events_spec.rb
@@ -1236,6 +1236,34 @@ module Carto
           end
         end
 
+        describe CreatedWidget do
+          before(:all) do
+            @widget = FactoryGirl.create(:widget, layer: @visualization.data_layers.first)
+          end
+
+          after(:all) do
+            @widget.destroy
+          end
+
+          it 'should validate the widget exists' do
+            event = Carto::Tracking::Events::CreatedWidget.new(@user.id,
+                                                               user_id: @user.id,
+                                                               visualization_id: @visualization.id,
+                                                               widget_id: random_uuid)
+
+            expect { event.send(:report!) }.to raise_error(Carto::LoadError)
+          end
+
+          it 'should report when valid widget' do
+            event = Carto::Tracking::Events::CreatedWidget.new(@user.id,
+                                                               user_id: @user.id,
+                                                               visualization_id: @visualization.id,
+                                                               widget_id: @widget.id)
+
+            expect { event.send(:report!) }.to_not raise_error
+          end
+        end
+
         describe DeletedAnalysis do
           before (:all) { @event_class = self.class.description.constantize }
           after  (:all) { @event_class = nil }


### PR DESCRIPTION
Fixes #10501

This PR adds a new event: Created widget. This event is fired every time the widgets controller successfully creates a new widget.

## Acceptance info

You will have to test all the widget operations: create, delete and update. Check everything works as expected.

You need to check the event arrives at Segment (ask @gfiorav). The event is supposed to carry at least vis_id and widget_type (along with other info).