### PR TITLE
Ensure notify_map_change works

### DIFF
--- a/spec/models/map_spec.rb
+++ b/spec/models/map_spec.rb
@@ -351,6 +351,27 @@ describe Map do
     end
   end
 
+  describe '#notify_map_change' do
+    before(:each) do
+      @map = Map.create(user_id: @user.id, table_id: @table.id)
+    end
+
+    after(:each) do
+      @map.destroy
+    end
+
+    it 'invalidates vizjson cache' do
+      @map.visualization.expects(:invalidate_varnish_vizjson_cache).once
+      @map.notify_map_change
+      @map.visualization.stubs(:invalidate_varnish_vizjson_cache) # Needed to avoid counting the call from destroy
+    end
+
+    it 'updates_named_maps' do
+      @map.visualization.expects(:save_named_map).once
+      @map.notify_map_change
+    end
+  end
+
   describe '#updated_at' do
     it 'is updated after saving the map' do
       map         = Map.create(user_id: @user.id, table_id: @table.id)


### PR DESCRIPTION
See https://github.com/CartoDB/cartodb-management/issues/4760

There are tests for Widgets, Analyses, and Layers to ensure that `notify_map_change` is called on save, but that method was not checked. This PR ensures that the method correctly invalidates cache.

Not the greatest solution, and it does not add integration tests of the whole process. This is more of a band-aid, and after working a bit on this, I don't think it is worth it to spend much more time on this, I think we'd rather work on refactoring than on adding tests.