### PR TITLE
Cm2885 retrieve mapviews es

### DIFF
--- a/lib/carto/metrics/mapviews_usage_metrics.rb
+++ b/lib/carto/metrics/mapviews_usage_metrics.rb
@@ -9,13 +9,13 @@ module Carto::Metrics
       :mapviews_es
     ].freeze
 
-    def initialize(user, orgname)
-      @user = user
+    def initialize(username, orgname)
+      @user = Carto::User.where(username: username).first
       @organization = Carto::Organization.where(name: orgname).first
     end
 
     def get(_service, _metric, date)
-      (@organization ? @organization.users : @user).sum do |user|
+      (@organization ? @organization.users : [@user]).sum do |user|
         VALID_SERVICES.sum do |service|
           CartoDB::Stats::APICalls.new.get_api_calls_from_redis_source(
             user.username, service.to_s, from: date, to: date

--- a/lib/carto/metrics/mapviews_usage_metrics.rb
+++ b/lib/carto/metrics/mapviews_usage_metrics.rb
@@ -5,7 +5,8 @@ module Carto::Metrics
     ].freeze
 
     VALID_SERVICES = [
-      :mapviews
+      :mapviews,
+      :mapviews_es
     ].freeze
 
     def initialize(user, orgname)

--- a/lib/carto/metrics/mapviews_usage_metrics.rb
+++ b/lib/carto/metrics/mapviews_usage_metrics.rb
@@ -10,15 +10,15 @@ module Carto::Metrics
     ].freeze
 
     def initialize(username, orgname)
-      @user = Carto::User.where(username: username).first
+      @username = username
       @organization = Carto::Organization.where(name: orgname).first
     end
 
     def get(_service, _metric, date)
-      (@organization ? @organization.users : [@user]).sum do |user|
+      (@organization ? @organization.users.map(&:username) : [@username]).sum do |username|
         VALID_SERVICES.sum do |service|
           CartoDB::Stats::APICalls.new.get_api_calls_from_redis_source(
-            user.username, service.to_s, from: date, to: date
+            username, service.to_s, from: date, to: date
           ).values.first
         end
       end

--- a/lib/carto/metrics/mapviews_usage_metrics.rb
+++ b/lib/carto/metrics/mapviews_usage_metrics.rb
@@ -15,14 +15,12 @@ module Carto::Metrics
     end
 
     def get(_service, _metric, date)
-      if @organization
-        @organization.users.map { |user|
+      (@organization ? @organization.users : @user).sum do |user|
+        VALID_SERVICES.sum do |service|
           CartoDB::Stats::APICalls.new.get_api_calls_from_redis_source(
-            user.username, 'mapviews', from: date, to: date
-          ).values[0]
-        }.sum
-      else
-        CartoDB::Stats::APICalls.new.get_api_calls_from_redis_source(@user, 'mapviews', from: date, to: date).values[0]
+            user.username, service.to_s, from: date, to: date
+          ).values.first
+        end
       end
     end
   end

--- a/lib/carto/metrics/mapviews_usage_metrics.rb
+++ b/lib/carto/metrics/mapviews_usage_metrics.rb
@@ -5,8 +5,12 @@ module Carto::Metrics
     ].freeze
 
     VALID_SERVICES = [
-      :mapviews,
-      :mapviews_es
+      :mapviews
+    ].freeze
+
+    MAPVIEWS_REDIS_KEYS = [
+      'mapviews',
+      'mapviews_es'
     ].freeze
 
     def initialize(username, orgname)
@@ -16,9 +20,9 @@ module Carto::Metrics
 
     def get(_service, _metric, date)
       (@organization ? @organization.users.map(&:username) : [@username]).sum do |username|
-        VALID_SERVICES.sum do |service|
+        MAPVIEWS_REDIS_KEYS.sum do |redis_key|
           CartoDB::Stats::APICalls.new.get_api_calls_from_redis_source(
-            username, service.to_s, from: date, to: date
+            username, redis_key, from: date, to: date
           ).values.first
         end
       end

--- a/spec/requests/carto/superadmin/users_controller_spec.rb
+++ b/spec/requests/carto/superadmin/users_controller_spec.rb
@@ -168,10 +168,12 @@ describe Carto::Superadmin::UsersController do
 
     it 'returns mapviews' do
       key = CartoDB::Stats::APICalls.new.redis_api_call_key(@user.username, 'mapviews')
-      $users_metadata.ZADD(key, 23, "20160915")
+      $users_metadata.ZADD(key, 1, "20160915")
+      key = CartoDB::Stats::APICalls.new.redis_api_call_key(@user.username, 'mapviews_es')
+      $users_metadata.ZADD(key, 1, "20160915")
       get_json(usage_superadmin_user_url(@user.id), { from: "2016-09-14" }, superadmin_headers) do |response|
         mapviews = response.body[:mapviews][:total_views]
-        mapviews.find { |h| h['date'] == "2016-09-15" }['value'].should eq 23
+        mapviews.find { |h| h['date'] == "2016-09-15" }['value'].should eq 2
       end
     end
 


### PR DESCRIPTION
Fixes part of https://github.com/CartoDB/cartodb-platform/issues/2885

This PR is focused on offering `mapviews_es` (from elastic search) in addition to `mapviews` in mapviews metrics endpoint. 
