### PR TITLE
Removed elements tab from Builder

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/editor-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-view.js
@@ -13,7 +13,6 @@ var LayersView = require('./layers/layers-view');
 var ScrollView = require('../components/scroll/scroll-view');
 var PanelWithOptionsView = require('../components/view-options/panel-with-options-view');
 var ShareButtonView = require('./layers/share-button-view');
-var ViewFactory = require('../components/view-factory');
 var PublishView = require('../components/modals/publish/publish-view');
 
 module.exports = CoreView.extend({

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-view.js
@@ -14,7 +14,6 @@ var ScrollView = require('../components/scroll/scroll-view');
 var PanelWithOptionsView = require('../components/view-options/panel-with-options-view');
 var ShareButtonView = require('./layers/share-button-view');
 var ViewFactory = require('../components/view-factory');
-var elementsTemplate = require('./elements/empty.tpl');
 var PublishView = require('../components/modals/publish/publish-view');
 
 module.exports = CoreView.extend({
@@ -103,35 +102,6 @@ module.exports = CoreView.extend({
         return new StackLayoutView({
           className: 'Editor-content',
           collection: layersStackViewCollection
-        });
-      }
-    }, {
-      name: 'elements',
-      label: _t('editor.tab-pane.elements.title-label'),
-      selected: this.options.selectedTabItem === 'elements',
-      createContentView: function () {
-        return new PanelWithOptionsView({
-          className: 'Editor-content',
-          editorModel: self._editorModel,
-          createContentView: function () {
-            return new ScrollView({
-              createContentView: function () {
-                return ViewFactory.createByTemplate(
-                  elementsTemplate,
-                  null,
-                  {
-                    className: 'Editor-content'
-                  }
-                );
-              }
-            });
-          },
-          createActionView: function () {
-            return new ShareButtonView({
-              visDefinitionModel: self._visDefinitionModel,
-              onClickAction: self._share.bind(self)
-            });
-          }
         });
       }
     }, {

--- a/lib/assets/core/javascripts/cartodb3/editor/elements/empty.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/elements/empty.tpl
@@ -1,3 +1,0 @@
-<h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor">
-  <%- _t('editor.elements.message') %>
-</h2>


### PR DESCRIPTION
Closes #11186

### How to test
1. Go to a map in Builder.
2. In the menu there should only be 'Layers' and 'Widgets' tabs.

<img width="413" alt="screen shot 2017-01-05 at 11 53 43" src="https://cloud.githubusercontent.com/assets/2141690/21678189/03bb324c-d33e-11e6-8828-5e36d4bad097.png">