### PR TITLE
11154 saml logout optional

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,7 +52,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    saml_authentication? ? saml_logout : do_logout
+    saml_authentication? && saml_service.try(:logout_url_configured?) ? saml_logout : do_logout
   end
 
   def show

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -21,15 +21,19 @@ module Carto
       response.is_valid? ? email_from_saml_response(response) : debug_response("Invalid SAML response", response)
     end
 
+    def logout_url_configured?
+      saml_settings.idp_slo_target_url.present?
+    end
+
     # SLO (Single Log Out) request initiated from CARTO
     # Returns the SAML logout request that to be redirected to
     def sp_logout_request
       settings = saml_settings
 
-      if settings.idp_slo_target_url.nil?
-        raise "SLO IdP Endpoint not found in settings for #{@organization}"
-      else
+      if logout_url_configured?
         OneLogin::RubySaml::Logoutrequest.new.create(settings)
+      else
+        raise "SLO IdP Endpoint not found in settings for #{@organization}"
       end
     end
 

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -16,12 +16,13 @@ namespace :cartodb do
       configuration = {
         saml_issuer: ENV['SAML_ISSUER'],
         idp_sso_target_url: ENV['SAML_IDP_SSO_TARGET_URL'],
-        idp_slo_target_url: ENV['SAML_IDP_SLO_TARGET_URL'],
         idp_cert_fingerprint: ENV['SAML_IDP_CERT_FINGERPRINT'],
         assertion_consumer_service_url: ENV['SAML_ASSERTION_CONSUMER_SERVICE_URL'],
         name_identifier_format: ENV['SAML_NAME_IDENTIFIER_FORMAT'],
         email_attribute: ENV['SAML_EMAIL_ATTRIBUTE']
       }
+
+      configuration[:idp_slo_target_url] = ENV['SAML_IDP_SLO_TARGET_URL'] if ENV['SAML_IDP_SLO_TARGET_URL'].present?
 
       raise "Missing parameter: #{configuration}" unless configuration.values.all?(&:present?)
 

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -279,6 +279,18 @@ describe SessionsController do
         get logout_url(user_domain: user_domain)
       end
 
+      it 'does not call SamlService#sp_logout_request if logout URL is not configured' do
+        stub_saml_service(@user)
+        SessionsController.any_instance.expects(:authenticate!).with(:saml, scope: @user.username).returns(@user).once
+
+        post create_session_url(user_domain: user_domain, SAMLResponse: 'xx')
+
+        # needs returning an url to do a redirection
+        Carto::SamlService.any_instance.stubs(:logout_url_configured?).returns(false)
+        Carto::SamlService.any_instance.stubs(:sp_logout_request).returns('http://carto.com').never
+        get logout_url(user_domain: user_domain)
+      end
+
       it 'calls SamlService#idp_logout_request if SAMLRequest is present' do
         # needs returning an url to do a redirection
         Carto::SamlService.any_instance.stubs(:idp_logout_request).returns('http://carto.com').once


### PR DESCRIPTION
Closes #11154 

Acceptance (you will have to do it locally):
 - Configure SAML
 - Manually delete `idp_slo_target_url` from `auth_saml_configuration` in the organization model
 - Test that logging in and out via SAML works

If you logout and then login again, the login will be automatic (as the user has not been logged out from the IdP as it is missing configuration). That's to be expected. The important part is that it doesn't crash.