### PR TITLE
Temporarily deactivate GME error logging

### DIFF
--- a/services/table-geocoder/lib/gme/client.rb
+++ b/services/table-geocoder/lib/gme/client.rb
@@ -88,10 +88,11 @@ module Carto
       # Takes a typhoeus response object and returns a hash
       def get_body(resp)
         if resp.code != 200
-          CartoDB::Logger.warning(message: 'Error response from GME client',
-                                  client_id: @client_id,
-                                  code: resp.code,
-                                  response_body: resp.response_body)
+          # Remove temporarily from rollbar because it's flooding the logs
+          # CartoDB::Logger.warning(message: 'Error response from GME client',
+          #                         client_id: @client_id,
+          #                         code: resp.code,
+          #                         response_body: resp.response_body)
           raise HttpError.new(resp.code)
         end
 

--- a/services/table-geocoder/lib/gme/client.rb
+++ b/services/table-geocoder/lib/gme/client.rb
@@ -89,10 +89,12 @@ module Carto
       def get_body(resp)
         if resp.code != 200
           # Remove temporarily from rollbar because it's flooding the logs
-          # CartoDB::Logger.warning(message: 'Error response from GME client',
-          #                         client_id: @client_id,
-          #                         code: resp.code,
-          #                         response_body: resp.response_body)
+          if resp.code != 400
+            CartoDB::Logger.warning(message: 'Error response from GME client',
+                                    client_id: @client_id,
+                                    code: resp.code,
+                                    response_body: resp.response_body)
+          end
           raise HttpError.new(resp.code)
         end
 

--- a/services/table-geocoder/lib/gme/table_geocoder.rb
+++ b/services/table-geocoder/lib/gme/table_geocoder.rb
@@ -168,8 +168,9 @@ module Carto
       def fetch_from_gme(search_text)
         @geocoder_client.geocode(search_text)
       rescue => e
-        @log.append_and_store "Error geocoding using GME for text #{search_text}: #{e.message}"
-        CartoDB.notify_error('Error geocoding using GME', error: e.backtrace.join('\n'), search_text: search_text)
+        # Remove temporarily because it's flooding the logs
+        # @log.append_and_store "Error geocoding using GME for text #{search_text}: #{e.message}"
+        # CartoDB.notify_error('Error geocoding using GME', error: e.backtrace.join('\n'), search_text: search_text)
         @failed_processed_rows += 1
         nil
       end


### PR DESCRIPTION
Remove GME (Google geocoding) errors sent to rollback or production.log
We're having a problem being flooded with those messages ATM.