### PR TITLE
11153 simplify fix saml configuration rake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/requests/carto/superadmin/users_controller_spec.rb \
 	spec/requests/carto/superadmin/user_migration_imports_spec.rb \
 	spec/requests/carto/superadmin/user_migration_exports_spec.rb \
+	spec/requests/carto/saml_controller_spec.rb \
 	spec/requests/admin/users_controller_spec.rb \
 	spec/services/carto/user_table_index_service_spec.rb \
 	spec/lib/carto/strong_password_validator_spec.rb \

--- a/app/controllers/carto/saml_controller.rb
+++ b/app/controllers/carto/saml_controller.rb
@@ -4,8 +4,12 @@ require_dependency 'carto/controller_helper'
 
 module Carto
   class SamlController < ApplicationController
+    include Carto::ControllerHelper
+
     ssl_required  :metadata
-    before_filter :load_organization
+    before_filter :load_organization, :ensure_saml_enabled
+
+    rescue_from LoadError, UnauthorizedError, with: :rescue_from_carto_error
 
     # Callback from Github Oauth
     def metadata

--- a/app/controllers/carto/saml_controller.rb
+++ b/app/controllers/carto/saml_controller.rb
@@ -1,0 +1,26 @@
+# encoding: UTF-8
+
+require_dependency 'carto/controller_helper'
+
+module Carto
+  class SamlController < ApplicationController
+    ssl_required  :metadata
+    before_filter :load_organization
+
+    # Callback from Github Oauth
+    def metadata
+      render(xml: Carto::SamlService.new(@organization).saml_metadata)
+    end
+
+    private
+
+    def load_organization
+      @organization = Carto::Organization.where(name: CartoDB.extract_subdomain(request)).first
+      raise LoadError.new('Organization does not exist') unless @organization
+    end
+
+    def ensure_saml_enabled
+      raise UnauthorizedError.new('SAML not enabled') unless @organization.auth_saml_enabled?
+    end
+  end
+end

--- a/app/controllers/carto/saml_controller.rb
+++ b/app/controllers/carto/saml_controller.rb
@@ -11,7 +11,6 @@ module Carto
 
     rescue_from LoadError, UnauthorizedError, with: :rescue_from_carto_error
 
-    # Callback from Github Oauth
     def metadata
       render(xml: Carto::SamlService.new(@organization).saml_metadata)
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ CartoDB::Application.routes.draw do
     end
 
     get '/github' => 'github#github', as: :github
+    get '/saml/metadata' => 'saml#metadata'
   end
 
   # Internally, some of this methods will forcibly rewrite to the org-url if user belongs to an organization

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -67,6 +67,10 @@ module Carto
       end
     end
 
+    def saml_metadata
+      OneLogin::RubySaml::Metadata.new.generate(saml_settings, true)
+    end
+
     private
 
     def email_from_saml_response(saml_response)

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -6,8 +6,8 @@ namespace :cartodb do
     # SAML_IDP_SSO_TARGET_URL: SAML Identity Provider login URL. Example: 'http://192.168.20.2/simplesaml/saml2/idp/SSOService.php'.
     # SAML_IDP_SLO_TARGET_URL: SAML Identity Provider logout URL. Example: 'http://192.168.20.2/simplesaml/saml2/idp/SingleLogoutService.php'.
     # SAML_IDP_CERT_FINGERPRINT: SAML server certificate fingerprint. Command: `openssl x509 -noout -fingerprint -in "./cert/server.crt`. Example: '8C:47:97:B1:E2:E4:6C:06:B5:56:11:8A:5A:8B:53:5C:01:05:CB:05'.
-    # SAML_ASSERTION_CONSUMER_SERVICE_URL: CARTO URL for SAML, including organization name. Examples: 'http://192.168.20.2/user/orgname/saml/finalize'.
-    # SAML_NAME_IDENTIFIER_FORMAT: Format of the name identifier parameter. Example: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'. Defaults to 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+    # SAML_ASSERTION_CONSUMER_SERVICE_URL: CARTO URL for SAML, including organization name. Examples: 'http://192.168.20.2/user/orgname/saml/finalize'. Optional, defaults to the URL built from configuration and organization name
+    # SAML_NAME_IDENTIFIER_FORMAT: Format of the name identifier parameter. Example: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'. Optional, defaults to 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
     # SAML_EMAIL_ATTRIBUTE: attribute with the user email. Example: 'email'.
     task :create_saml_configuration, [] => :environment do |_t, _args|
       organization = Carto::Organization.where(name: ENV['ORGANIZATION_NAME']).first
@@ -22,7 +22,8 @@ namespace :cartodb do
         email_attribute: ENV['SAML_EMAIL_ATTRIBUTE']
       }
 
-      configuration[:assertion_consumer_service_url] ||= 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+      configuration[:assertion_consumer_service_url] ||= CartoDB.base_url(organization.name) + '/saml/finalize'
+      configuration[:name_identifier_format] ||= 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
       configuration[:idp_slo_target_url] = ENV['SAML_IDP_SLO_TARGET_URL'] if ENV['SAML_IDP_SLO_TARGET_URL'].present?
 
       raise "Missing parameter: #{configuration}" unless configuration.values.all?(&:present?)

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -7,7 +7,7 @@ namespace :cartodb do
     # SAML_IDP_SLO_TARGET_URL: SAML Identity Provider logout URL. Example: 'http://192.168.20.2/simplesaml/saml2/idp/SingleLogoutService.php'.
     # SAML_IDP_CERT_FINGERPRINT: SAML server certificate fingerprint. Command: `openssl x509 -noout -fingerprint -in "./cert/server.crt`. Example: '8C:47:97:B1:E2:E4:6C:06:B5:56:11:8A:5A:8B:53:5C:01:05:CB:05'.
     # SAML_ASSERTION_CONSUMER_SERVICE_URL: CARTO URL for SAML, including organization name. Examples: 'http://192.168.20.2/user/orgname/saml/finalize'.
-    # SAML_NAME_IDENTIFIER_FORMAT: Format of the name identifier parameter. Example: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'.
+    # SAML_NAME_IDENTIFIER_FORMAT: Format of the name identifier parameter. Example: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'. Defaults to 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
     # SAML_EMAIL_ATTRIBUTE: attribute with the user email. Example: 'email'.
     task :create_saml_configuration, [] => :environment do |_t, _args|
       organization = Carto::Organization.where(name: ENV['ORGANIZATION_NAME']).first
@@ -22,6 +22,7 @@ namespace :cartodb do
         email_attribute: ENV['SAML_EMAIL_ATTRIBUTE']
       }
 
+      configuration[:assertion_consumer_service_url] ||= 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
       configuration[:idp_slo_target_url] = ENV['SAML_IDP_SLO_TARGET_URL'] if ENV['SAML_IDP_SLO_TARGET_URL'].present?
 
       raise "Missing parameter: #{configuration}" unless configuration.values.all?(&:present?)

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -49,7 +49,7 @@ namespace :cartodb do
 
       organization.update_attribute(:auth_saml_configuration, configuration)
 
-      puts Carto::SamlService.new(organization).saml_metadata
+      puts "Configuration metadata is available at #{base_url}/saml/metadata"
     end
   end
 end

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -2,33 +2,54 @@ namespace :cartodb do
   namespace :saml do
     # Sets (inserts or overrides) SAML configuration for an organization. The following environments variables are needed:
     # ORGANIZATION_NAME: name of the organization. Example: 'orgname'.
-    # SAML_ISSUER: Name of the service provider in the SAML server. Example: 'CARTO_SAML_Test'.
-    # SAML_IDP_SSO_TARGET_URL: SAML Identity Provider login URL. Example: 'http://192.168.20.2/simplesaml/saml2/idp/SSOService.php'.
-    # SAML_IDP_SLO_TARGET_URL: SAML Identity Provider logout URL. Example: 'http://192.168.20.2/simplesaml/saml2/idp/SingleLogoutService.php'.
-    # SAML_IDP_CERT_FINGERPRINT: SAML server certificate fingerprint. Command: `openssl x509 -noout -fingerprint -in "./cert/server.crt`. Example: '8C:47:97:B1:E2:E4:6C:06:B5:56:11:8A:5A:8B:53:5C:01:05:CB:05'.
-    # SAML_ASSERTION_CONSUMER_SERVICE_URL: CARTO URL for SAML, including organization name. Examples: 'http://192.168.20.2/user/orgname/saml/finalize'. Optional, defaults to the URL built from configuration and organization name
-    # SAML_NAME_IDENTIFIER_FORMAT: Format of the name identifier parameter. Example: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'. Optional, defaults to 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+    # SAML_ISSUER: [OPTIONAL] Name of the service provider in the SAML server. Example: 'CARTO_SAML_Test'. Defaults are based on organization name and domain.
     # SAML_EMAIL_ATTRIBUTE: attribute with the user email. Example: 'email'.
+    # SAML_ASSERTION_CONSUMER_SERVICE_URL: [OPTIONAL] CARTO URL for SAML, including organization name. Examples: 'http://192.168.20.2/user/orgname/saml/finalize'. Defaults to the URL built from configuration and organization name
+    # SAML_SINGLE_LOGOUT_SERVICE_URL: [OPTIONAL] CARTO URL for SAML logout, including organization name. Examples: 'http://192.168.20.2/user/orgname/logout'. Defaults to the URL built from configuration and organization name
+    #
+    # Option 1. Manual configuration
+    # SAML_IDP_SSO_TARGET_URL: SAML Identity Provider login URL. Example: 'http://192.168.20.2/simplesaml/saml2/idp/SSOService.php'.
+    # SAML_IDP_SLO_TARGET_URL: [OPTIONAL] SAML Identity Provider logout URL. Example: 'http://192.168.20.2/simplesaml/saml2/idp/SingleLogoutService.php'.
+    # SAML_IDP_CERT_FINGERPRINT: SAML server certificate fingerprint. Command: `openssl x509 -noout -fingerprint -in "./cert/server.crt`. Example: '8C:47:97:B1:E2:E4:6C:06:B5:56:11:8A:5A:8B:53:5C:01:05:CB:05'.
+    # SAML_NAME_IDENTIFIER_FORMAT: [OPTIONAL] Format of the name identifier parameter. Example: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'. Defaults to 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+    #
+    # Option 2. Metadata parsing
+    # SAML_IDP_METADATA_FILE: Url or file that contains metadata about the IdP. Example: 'http://192.168.20.2/saml2/idp/metadata.php'.
     task :create_saml_configuration, [] => :environment do |_t, _args|
       organization = Carto::Organization.where(name: ENV['ORGANIZATION_NAME']).first
       raise "Organization not found: #{ENV['ORGANIZATION_NAME']}" unless organization
 
-      configuration = {
-        issuer: ENV['SAML_ISSUER'],
-        idp_sso_target_url: ENV['SAML_IDP_SSO_TARGET_URL'],
-        idp_cert_fingerprint: ENV['SAML_IDP_CERT_FINGERPRINT'],
-        assertion_consumer_service_url: ENV['SAML_ASSERTION_CONSUMER_SERVICE_URL'],
-        name_identifier_format: ENV['SAML_NAME_IDENTIFIER_FORMAT'],
-        email_attribute: ENV['SAML_EMAIL_ATTRIBUTE']
-      }
+      configuration = if ENV['SAML_IDP_METADATA_FILE'].present?
+                        idp_metadata_parser = OneLogin::RubySaml::IdpMetadataParser.new
+                        settings = idp_metadata_parser.parse_remote(ENV['SAML_IDP_METADATA_FILE'])
+                        {
+                          idp_sso_target_url: settings.idp_sso_target_url,
+                          idp_slo_target_url: settings.idp_slo_target_url,
+                          idp_cert_fingerprint: settings.idp_cert_fingerprint,
+                          name_identifier_format: settings.name_identifier_format
+                        }
+                      else
+                        config = {
+                          idp_sso_target_url: ENV['SAML_IDP_SSO_TARGET_URL'],
+                          idp_cert_fingerprint: ENV['SAML_IDP_CERT_FINGERPRINT'],
+                          name_identifier_format: ENV['SAML_NAME_IDENTIFIER_FORMAT']
+                        }
+                        config[:idp_slo_target_url] = ENV['SAML_IDP_SLO_TARGET_URL'] if ENV['SAML_IDP_SLO_TARGET_URL'].present?
+                        config
+                      end
 
-      configuration[:assertion_consumer_service_url] ||= CartoDB.base_url(organization.name) + '/saml/finalize'
+      base_url = CartoDB.base_url(organization.name)
+      configuration[:issuer] = ENV['SAML_ISSUER'] || base_url + '/saml/metadata'
+      configuration[:email_attribute] = ENV['SAML_EMAIL_ATTRIBUTE']
+      configuration[:assertion_consumer_service_url] = ENV['SAML_ASSERTION_CONSUMER_SERVICE_URL'] || base_url + '/saml/finalize'
+      configuration[:single_logout_service_url] = ENV['SAML_SINGLE_LOGOUT_SERVICE_URL'] || base_url + '/logout'
       configuration[:name_identifier_format] ||= 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
-      configuration[:idp_slo_target_url] = ENV['SAML_IDP_SLO_TARGET_URL'] if ENV['SAML_IDP_SLO_TARGET_URL'].present?
 
       raise "Missing parameter: #{configuration}" unless configuration.values.all?(&:present?)
 
       organization.update_attribute(:auth_saml_configuration, configuration)
+
+      puts Carto::SamlService.new(organization).saml_metadata
     end
   end
 end

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -2,7 +2,8 @@ namespace :cartodb do
   namespace :saml do
     # Sets (inserts or overrides) SAML configuration for an organization. The following environments variables are needed:
     # ORGANIZATION_NAME: name of the organization. Example: 'orgname'.
-    # SAML_ISSUER: [OPTIONAL] Name of the service provider in the SAML server. Example: 'CARTO_SAML_Test'. Defaults are based on organization name and domain.
+    # SAML_ISSUER: [OPTIONAL] Name of the service provider in the SAML server. Example: 'CARTO_SAML_Test'.
+    #   Default: URL similar to `http://192.168.20.2/user/orgname/saml/metadata` or `http://orgname.domain.com/saml/metadata`, depending on your configuration.
     # SAML_EMAIL_ATTRIBUTE: attribute with the user email. Example: 'email'.
     # SAML_ASSERTION_CONSUMER_SERVICE_URL: [OPTIONAL] CARTO URL for SAML, including organization name. Examples: 'http://192.168.20.2/user/orgname/saml/finalize'. Defaults to the URL built from configuration and organization name
     # SAML_SINGLE_LOGOUT_SERVICE_URL: [OPTIONAL] CARTO URL for SAML logout, including organization name. Examples: 'http://192.168.20.2/user/orgname/logout'. Defaults to the URL built from configuration and organization name

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -14,7 +14,7 @@ namespace :cartodb do
       raise "Organization not found: #{ENV['ORGANIZATION_NAME']}" unless organization
 
       configuration = {
-        saml_issuer: ENV['SAML_ISSUER'],
+        issuer: ENV['SAML_ISSUER'],
         idp_sso_target_url: ENV['SAML_IDP_SSO_TARGET_URL'],
         idp_cert_fingerprint: ENV['SAML_IDP_CERT_FINGERPRINT'],
         assertion_consumer_service_url: ENV['SAML_ASSERTION_CONSUMER_SERVICE_URL'],

--- a/spec/requests/carto/saml_controller_spec.rb
+++ b/spec/requests/carto/saml_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper_min'
+
+describe Carto::SamlController do
+  before(:all) do
+    @organization = FactoryGirl.create(:saml_organization)
+  end
+
+  after(:all) do
+    @organization.destroy
+  end
+
+  it 'shows SAML metadata' do
+    get saml_metadata_url(user_domain: @organization.name)
+    response.status.should eq 200
+  end
+
+  it 'returns an error for non-existing organizations' do
+    get saml_metadata_url(user_domain: 'wadus')
+    response.status.should eq 404
+  end
+
+  it 'returns an error for non-configured organizations' do
+    Carto::Organization.any_instance.stubs(:auth_saml_enabled?).returns(false)
+    get saml_metadata_url(user_domain: @organization.name)
+    response.status.should eq 403
+  end
+end


### PR DESCRIPTION
Closes #11153
Fixes #11199 

Auto-configuration made easy.

Acceptance: test the rake and the new endpoint. Some suggestions (but feel free to experiment, the documentation is in a comment in the rake source):
- Run the rake as `ORGANIZATION_NAME=org SAML_EMAIL_ATTRIBUTE=username SAML_IDP_METADATA_FILE='http://localhost:5000/saml2/idp/metadata.php' bundle exec rake cartodb:saml:create_saml_configuration`
- Paste the generated XML file (from org.localhost.lan/saml/metadata) into http://localhost:5000/admin/metadata-converter.php and use it to configure the saml IdP (put the results of that PHP into the metadata config file, it is not automatic in simplesaml)
- Try to break the metadata endpoint (invalid organization)
- Try the rake the old way (specifying all parameters manually). Check for errors for required fields