### PR TITLE
Fix js tests

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/data/legends/legends-metadata.js
+++ b/lib/assets/core/javascripts/cartodb3/data/legends/legends-metadata.js
@@ -1,29 +1,18 @@
-var CategoryModel = require('./legend-category-definition-model');
-var BubbleModel = require('./legend-bubble-definition-model');
-var ChoroplethModel = require('./legend-choropleth-definition-model');
-var CustomChoroplethModel = require('./legend-custom-choropleth-definition-model');
-var CustomhModel = require('./legend-custom-definition-model');
-
 var LEGENDS_METADATA = {
   bubble: {
-    legendType: 'size',
-    model: BubbleModel
+    legendType: 'size'
   },
   category: {
-    legendType: 'color',
-    model: CategoryModel
+    legendType: 'color'
   },
   choropleth: {
-    legendType: 'color',
-    model: ChoroplethModel
+    legendType: 'color'
   },
   custom: {
-    legendType: 'color',
-    model: CustomhModel
+    legendType: 'color'
   },
   custom_choropleth: {
-    legendType: 'color',
-    model: CustomChoroplethModel
+    legendType: 'color'
   }
 };
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-factory.js
@@ -1,7 +1,19 @@
 var _ = require('underscore');
+var CategoryModel = require('../../../../data/legends/legend-category-definition-model');
+var BubbleModel = require('../../../../data/legends/legend-bubble-definition-model');
+var ChoroplethModel = require('../../../../data/legends/legend-choropleth-definition-model');
+var CustomChoroplethModel = require('../../../../data/legends/legend-custom-choropleth-definition-model');
+var CustomhModel = require('../../../../data/legends/legend-custom-definition-model');
 var Validations = require('./legend-validations');
 var Buffer = require('./legend-buffer');
-var legendsMetadata = require('../../../../data/legends/legends-metadata');
+
+var LEGEND_MODEL_TYPE = {
+  'bubble': BubbleModel,
+  'category': CategoryModel,
+  'choropleth': ChoroplethModel,
+  'custom_choropleth': CustomChoroplethModel,
+  'custom': CustomhModel
+};
 
 var manager = (function () {
   return {
@@ -60,7 +72,7 @@ var manager = (function () {
       }
 
       if (!model) {
-        Klass = legendsMetadata[type].model;
+        Klass = LEGEND_MODEL_TYPE[type];
         model = new Klass(attrs, {
           layerDefinitionModel: layerDefModel,
           configModel: this.legendDefinitionsCollection.configModel,
@@ -103,6 +115,11 @@ var manager = (function () {
       _.each(legends, function (legend) {
         legend.get('type') !== 'custom' && this.remove(legend);
       }, this);
+    },
+
+    hasMigratedLegend: function (layerDefModel) {
+      var legend = this.legendDefinitionsCollection.findByLayerDefModelAndType(layerDefModel, 'html');
+      return !!legend;
     },
 
     disableLegend: function (type) {

--- a/lib/assets/core/test/spec/cartodb3/editor/editor-map-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/editor-map-view.spec.js
@@ -152,7 +152,6 @@ describe('editor/editor-map-view', function () {
   it('should render correctly', function () {
     expect(this.view.$el.text()).toContain('My super fun vis');
     expect(this.view.$el.text()).toContain('editor.tab-pane.layers.title-label');
-    expect(this.view.$el.text()).toContain('editor.tab-pane.elements.title-label');
     expect(this.view.$el.text()).toContain('editor.tab-pane.widgets.title-label');
   });
 

--- a/lib/build/tasks/copy.js
+++ b/lib/build/tasks/copy.js
@@ -303,9 +303,9 @@
         files: [
           {
             expand: true,
-            cwd: 'lib/assets/test/jasmine/cartodb3/',
+            cwd: 'lib/assets/core/test/jasmine/cartodb3/',
             src: ['**/*'],
-            dest: 'lib/assets/test/spec/cartodb3/'
+            dest: 'lib/assets/test/jasmine/cartodb3/'
           }
         ]
       },
@@ -314,9 +314,9 @@
         files: [
           {
             expand: true,
-            cwd: 'lib/assets/test/jasmine/cartodb3/',
+            cwd: 'lib/assets/core/test/jasmine/cartodb3/',
             src: ['**/*'],
-            dest: 'lib/assets/test/spec/cartodb3/'
+            dest: 'lib/assets/test/jasmine/cartodb3/'
           }
         ]
       },


### PR DESCRIPTION
We lost both the npm-tests and Builder frontend tests.

### npm-tests

After the pluggable frontend shift, no proper paths in grunt copy path were done. Check for the fix in  `lib/build/tasks/copy.js` file

### frontend tests

After a refactor, we introduced a circular dependency in `legends-metadata` to use it in `legend-factory`. That provoked that Jasmine stopped test run when referencing any legend model.

The fix has been reverting to old `legend-factory`