### PR TITLE
11164 widget reordering fix

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-view.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var $ = require('jquery');
 var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
@@ -55,7 +56,7 @@ module.exports = CoreView.extend({
       } else {
         if (this._widgetDefinitionsCollection.size() > 0) {
           this.$el.append(template);
-          this._widgetDefinitionsCollection.each(this._addWidgetItem, this);
+          _.each(this._widgetDefinitionsCollection.sortBy('order'), this._addWidgetItem, this);
           this._initSortable();
         } else {
           this.$el.append(widgetPlaceholderTemplate());

--- a/lib/assets/core/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/widgets/widgets-view.spec.js
@@ -100,7 +100,7 @@ describe('editor/widgets/widgets-view', function () {
         layer_id: 'l-100',
         column: 'areas',
         operation: 'avg',
-        order: 0
+        order: 1
       }, {
         configModel: this.configModel,
         mapId: 'm-123'
@@ -110,7 +110,7 @@ describe('editor/widgets/widgets-view', function () {
         title: 'histogram example',
         layer_id: 'l-100',
         column: 'population',
-        order: 1
+        order: 0
       }, {
         configModel: this.configModel,
         mapId: 'm-123'
@@ -126,18 +126,24 @@ describe('editor/widgets/widgets-view', function () {
       expect(this.view.$('.js-widgets').data('ui-sortable')).not.toBeUndefined();
     });
 
+    it('should be show the widgets in the right order', function () {
+      this.view.render();
+      expect(this.view.$('.js-widgets li:nth-child(1) .js-title').text()).toBe('histogram example');
+      expect(this.view.$('.js-widgets li:nth-child(2) .js-title').text()).toBe('formula example');
+    });
+
     it('should update the order of the models when sort has finished', function () {
       this.view.render();
-      expect(this.widgetDefModel2.get('order')).toBe(1);
-      expect(this.widgetDefModel1.get('order')).toBe(0);
+      expect(this.widgetDefModel2.get('order')).toBe(0);
+      expect(this.widgetDefModel1.get('order')).toBe(1);
 
       // Impossible to fake sortable behaviour so...
       this.view.$('.js-widgetItem:eq(1)').insertBefore(this.view.$('.js-widgetItem:eq(0)'));
       this.view._onSortableFinish();
 
       // End of fake sortable
-      expect(this.widgetDefModel2.get('order')).toBe(0);
-      expect(this.widgetDefModel1.get('order')).toBe(1);
+      expect(this.widgetDefModel1.get('order')).toBe(0);
+      expect(this.widgetDefModel2.get('order')).toBe(1);
       expect(this.userActions.saveWidget).toHaveBeenCalled();
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.92-staging-11164",
+  "version": "4.5.93",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.92",
+  "version": "4.5.92-staging-11164",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #11164

The problem with the widget ordering was simply that we weren't showing the ordered list on the render. This [change](https://github.com/CartoDB/cartodb/pull/11209/files#diff-52565c47401bf1643f8c19e818495248R59) fixes that.

This PR also incorporates @ivanmalagon fix for the specs: #11208 (**we should wait until that PR is merged to merge this one, just in case something new comes up**)

Edit: The PR was just merged to master, so I've merge master in this branch. Ready to deploy if CR and acceptance are both OK.