### PR TITLE
Load initialization code for resque

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'rake/dsl_definition'
 require 'rake'
 require 'resque/tasks'
 
-# Do not load take tasks when running resque: https://github.com/CartoDB/cartodb/issues/11046
+# Do not load rake tasks when running resque: https://github.com/CartoDB/cartodb/issues/11046
 if Rake.application.top_level_tasks.reject { |t| ['environment', 'resque:work'].include?(t) }.empty?
   CartoDB::Application.paths['lib/tasks'] = []
   load 'lib/tasks/resque.rake'

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ require 'resque/tasks'
 # Do not load take tasks when running resque: https://github.com/CartoDB/cartodb/issues/11046
 if Rake.application.top_level_tasks.reject { |t| ['environment', 'resque:work'].include?(t) }.empty?
   CartoDB::Application.paths['lib/tasks'] = []
+  load 'lib/tasks/resque.rake'
 end
 
 CartoDB::Application.load_tasks


### PR DESCRIPTION
Fixes #11211 

Some necessary initialization files were not being loaded when executing the resque workers. This manifested itself as random problems trying to connect to the database from resque.

The easiest way to test it is to try to create a bunch of users, in current master this randomly fails, but this should fix it.

cc @rporres 