### PR TITLE
add exception to update_row! trace

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -867,13 +867,15 @@ class Table
                                     user_id: user_id,
                                     qualified_table_name: qualified_table_name,
                                     row_id: row_id,
-                                    raw_attributes: raw_attributes)
+                                    raw_attributes: raw_attributes,
+                                    exception: e)
               if (retries += 1) > MAX_UPDATE_ROW_RETRIES
                 CartoDB::Logger.error(message: 'Max update_row! retries reached',
                                       user_id: user_id,
                                       qualified_table_name: qualified_table_name,
                                       row_id: row_id,
-                                      raw_attributes: raw_attributes)
+                                      raw_attributes: raw_attributes,
+                                      exception: e)
               else
                 retry
               end


### PR DESCRIPTION
Fixes #10576 

## Context

In CARTO, when you update a row from a dataset from the UI, the RecordsController endpoint is used. This endpoint will retry the operation a number of times before giving up if any issue arises. This PR is adding the Sequel exception to that trace so we can have more detail regarding _why_ it failed.

## Acceptance

Try to add some rows to a dataset using the UI.