### PR TITLE
11215 wrong session after signup

### DIFF
--- a/app/controllers/carto/api/user_creations_controller.rb
+++ b/app/controllers/carto/api/user_creations_controller.rb
@@ -15,7 +15,7 @@ module Carto
       def show
         if @user_creation.autologin?
           params[:username] = @user_creation.username
-          authenticate!(:user_creation, scope: @user_creation.subdomain)
+          authenticate!(:user_creation, scope: @user_creation.username)
         end
         render_jsonp(UserCreationPresenter.new(@user_creation).to_poro)
       end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,8 +32,8 @@ class SessionsController < ApplicationController
   before_filter :api_authorization_required, only: :show
 
   def new
-    if logged_in?(CartoDB.extract_subdomain(request))
-      redirect_to(CartoDB.path(self, 'dashboard', trailing_slash: true))
+    if current_viewer.try(:subdomain) == CartoDB.extract_subdomain(request)
+      redirect_to(CartoDB.url(self, 'dashboard', { trailing_slash: true }, current_viewer))
     elsif saml_authentication? && !user
       # Automatically trigger SAML request on login view load -- could easily trigger this elsewhere
       redirect_to(saml_service.authentication_request)

--- a/spec/requests/carto/api/user_creations_controller_spec.rb
+++ b/spec/requests/carto/api/user_creations_controller_spec.rb
@@ -44,7 +44,8 @@ describe Carto::Api::UserCreationsController do
       user_data.organization = @organization
       user_data.google_sign_in = true
 
-      Carto::Api::UserCreationsController.any_instance.expects(:authenticate!).with(:user_creation, scope: user_data.organization.name).once
+      Carto::Api::UserCreationsController.any_instance.expects(:authenticate!)
+                                         .with(:user_creation, scope: user_data.username).once
 
       user_creation = Carto::UserCreation.new_user_signup(user_data)
       user_creation.next_creation_step until user_creation.finished?


### PR DESCRIPTION
Fixes #11215 

Currently, after first signing up into an organization using Google or SAML, the first load of the page is incorrect, as the session is not correctly initialized.

The problem is that the session is opened under the organization scope, instead of the user scope.

Aceptance should test signup into an org using all methods (password, google, github, ldap, saml). Most likely to be affected by this change are the ones that do not require confirmation email (google, ldap, saml).

As this also changes a redirection from the login page, we should try to break it by trying to open multiple simultaneous sessions (multiple domains) and see that nothing breaks (specially infinite loops of redirections).