### PR TITLE
11234 add public uploads path

### DIFF
--- a/lib/carto/storage_options/local.rb
+++ b/lib/carto/storage_options/local.rb
@@ -7,8 +7,7 @@ class Carto::StorageOptions::Local
 
   def upload(path, file)
     filename = Pathname.new(file.path).basename
-    target_directory = File.join(Rails.public_path,
-                                 'uploads',
+    target_directory = File.join('public/uploads',
                                  @location,
                                  path)
 

--- a/lib/carto/storage_options/local.rb
+++ b/lib/carto/storage_options/local.rb
@@ -7,7 +7,8 @@ class Carto::StorageOptions::Local
 
   def upload(path, file)
     filename = Pathname.new(file.path).basename
-    target_directory = File.join('public/uploads',
+    target_directory = File.join(Rails.public_path,
+                                 'uploads',
                                  @location,
                                  path)
 

--- a/lib/carto/storage_options/local.rb
+++ b/lib/carto/storage_options/local.rb
@@ -1,13 +1,15 @@
 # encoding utf-8
 
 class Carto::StorageOptions::Local
+  include Carto::Configuration
+
   def initialize(location)
     @location = location
   end
 
   def upload(path, file)
     filename = Pathname.new(file.path).basename
-    target_directory = File.join('public/uploads',
+    target_directory = File.join(public_uploads_path,
                                  @location,
                                  path)
 

--- a/lib/carto/storage_options/local.rb
+++ b/lib/carto/storage_options/local.rb
@@ -7,7 +7,7 @@ class Carto::StorageOptions::Local
 
   def upload(path, file)
     filename = Pathname.new(file.path).basename
-    target_directory = File.join(public_uploads_path,
+    target_directory = File.join('public/uploads',
                                  @location,
                                  path)
 

--- a/lib/carto/storage_options/local.rb
+++ b/lib/carto/storage_options/local.rb
@@ -9,7 +9,7 @@ class Carto::StorageOptions::Local
 
   def upload(path, file)
     filename = Pathname.new(file.path).basename
-    target_directory = File.join(public_uploads_path,
+    target_directory = File.join(public_uploaded_assets_path,
                                  @location,
                                  path)
 


### PR DESCRIPTION
Fixes #11234

## Context

This is fixes a bug related exclusively with organization assets when they're stored in local.

## Acceptance

Acceptance should make sure that the `s3` part of their configuration is commented (to force local storage) and check uploading an asset. The url produced should yield the asset. Only upload needs be tested.