### PR TITLE
Fix google auth

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -21,6 +21,8 @@ class SignupController < ApplicationController
   before_filter :initialize_google_plus_config,
                 :initialize_github_config
 
+  skip_before_filter :verify_authenticity_token, only: :create
+
   def signup
     email = params[:email].present? ? params[:email] : nil
     @user = ::User.new(email: email)

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -21,8 +21,6 @@ class SignupController < ApplicationController
   before_filter :initialize_google_plus_config,
                 :initialize_github_config
 
-  skip_before_filter :verify_authenticity_token, only: :create
-
   def signup
     email = params[:email].present? ? params[:email] : nil
     @user = ::User.new(email: email)

--- a/app/views/google_plus/_google_plus_button.html.erb
+++ b/app/views/google_plus/_google_plus_button.html.erb
@@ -66,4 +66,5 @@
 
 <form action="<%= config.signup_action %>" method="POST">
   <input type="hidden" value="<%= config.unauthenticated_valid_access_token %>" id="google_signup_access_token" name="google_signup_access_token" />
+  <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
 </form>

--- a/app/views/google_plus/google_plus.html.erb
+++ b/app/views/google_plus/google_plus.html.erb
@@ -7,6 +7,10 @@
       function signinCallback(authResult) {
         if(inIframe() && parentInSameDomain()) {
           parent.signinCallback(authResult);
+
+          document.getElementById("signinButton").onclick = function() {
+            parent.signinCallbackClick && parent.signinCallbackClick(authResult);
+          };
         }
       }
 


### PR DESCRIPTION
Fixes #11227

## Context

This issue fixes two distinct problems:

1. The "Log in with Google" button was not properly hooked (as it is in central)
2. In case that the Google user didn't exist in CARTO, the redirection to signup yielded 401 due to lack of CSRF token.

## Acceptance

Acceptance should test that Google sing in + auto create (creation of a user from Google in CARTO when it doesn't exists) works in local (ask for the config) and specifically for organization signups.