### PR TITLE
11239 auto creation and strong passwords

### DIFF
--- a/spec/requests/signup_controller_spec.rb
+++ b/spec/requests/signup_controller_spec.rb
@@ -138,7 +138,7 @@ describe SignupController do
 
       Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(false)
       ::GooglePlusConfig.stubs(:instance).returns({})
-      email = "testemail@#{@organization.whitelisted_email_domains[0]}"
+      email = "#{unique_name('email')}@#{@organization.whitelisted_email_domains[0]}"
       user_data = { 'emails' => [{ 'type' => 'account', 'value' => email }] }
       GooglePlusAPI.any_instance.stubs(:get_user_data).returns(GooglePlusAPIUserData.new(user_data))
       host! "#{@organization.name}.localhost.lan"


### PR DESCRIPTION
Fixes #11239 

Skips checking password strength when the password is automatically generated.

Acceptance: Create an organization with google/github signup and strong password validation. Try to signup for the organization using google/github. Also check for regressions: that a user/password signup still checks password strength.