### PR TITLE
Cm2892 limit download size

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -838,12 +838,10 @@ class DataImport < Sequel::Model
       log.append "File will be downloaded from #{resource_url}"
 
       http_options = { http_timeout: ::DataImport.http_timeout_for(current_user) }
-      options = {
-        importer_config: Cartodb.config[:importer],
-        user_id: current_user.id
-      }
-
-      CartoDB::Importer2::Downloader.new(resource_url, http_options, options)
+      CartoDB::Importer2::Downloader.new(current_user.id,
+                                         resource_url,
+                                         http_options,
+                                         importer_config: Cartodb.config[:importer])
     else
       log.append 'Downloading file data from datasource'
 

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -337,12 +337,11 @@ module CartoDB
             checksum: checksum,
             verify_ssl_cert: false
           }
-          options = {
-            importer_config: Cartodb.config[:importer],
-            user_id: user.id
-          }
 
-          CartoDB::Importer2::Downloader.new(resource_url, http_options, options)
+          CartoDB::Importer2::Downloader.new(user.id,
+                                             resource_url,
+                                             http_options,
+                                             importer_config: Cartodb.config[:importer])
         else
           log.append 'Downloading file data from datasource'
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -178,7 +178,7 @@ module CartoDB
       def download_and_store
         file = Tempfile.new(FILENAME_PREFIX, encoding: 'ascii-8bit')
 
-        bound_request(@translated_url, file).run
+        bound_request(file).run
 
         file_path = if @filename
                       new_file_path = File.join(Pathname.new(file.path).dirname, @filename)
@@ -195,8 +195,8 @@ module CartoDB
         file.unlink
       end
 
-      def bound_request(url, file)
-        request = Typhoeus::Request.new(url, typhoeus_options)
+      def bound_request(file)
+        request = http_client.request(@translated_url, typhoeus_options)
 
         request.on_headers do |response|
           @http_response_code = response.code

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -139,7 +139,7 @@ module CartoDB
                    filename_from_url ||
                    SecureRandom.urlsafe_base64
 
-        @filename = name_with_extension(basename)
+        @filename = filename_with_extension(basename)
         @etag = etag
         @last_modified = last_modified
       end
@@ -208,7 +208,7 @@ module CartoDB
         end
 
         request.on_complete do |response|
-          raise_error_for_response(response) unless response.success?
+          response.success? ? process_headers(response.headers) : raise_error_for_response(response)
         end
 
         request
@@ -378,7 +378,7 @@ module CartoDB
         end
       end
 
-      def name_with_extension(filename)
+      def filename_with_extension(filename)
         return filename unless extensions_from_headers
 
         pathname = Pathname.new(filename)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -264,6 +264,15 @@ module CartoDB
                          end
       end
 
+      def content_type
+        return @content_type if @content_type
+
+        headers_content_type = headers['Content-Type']
+        return nil unless headers_content_type.present?
+
+        @content_type = headers_content_type.split(';').first
+      end
+
       URL_TRANSLATORS = [
         UrlTranslator::OSM2,
         UrlTranslator::OSM,
@@ -276,15 +285,6 @@ module CartoDB
 
       def supported_translator(url)
         URL_TRANSLATORS.map(&:new).find { |translator| translator.supported?(url) }
-      end
-
-      def content_type
-        return @content_type if @content_type
-
-        headers_content_type = headers['Content-Type']
-        return nil unless headers_content_type.present?
-
-        @content_type = headers_content_type.split(';').first
       end
 
       CONTENT_DISPOSITION_RE  = %r{;\s*filename=(.*;|.*)}

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -138,11 +138,11 @@ module CartoDB
           raise_if_url_invalid(response.effective_url || @translated_url)
           @headers = response.headers
 
-          process_headers
+          set_headers
         end
       end
 
-      def process_headers
+      def set_headers
         basename = @custom_filename ||
                    filename_from_headers ||
                    filename_from_url ||
@@ -202,7 +202,7 @@ module CartoDB
 
           raise_if_url_invalid(response.effective_url || @translated_url)
 
-          response.success? ? process_headers(response.headers) : raise_error_for_response(response)
+          response.success? ? set_headers(response.headers) : raise_error_for_response(response)
         end
 
         request.on_body do |chunk|
@@ -214,7 +214,7 @@ module CartoDB
         end
 
         request.on_complete do |response|
-          response.success? ? process_headers(response.headers) : raise_error_for_response(response)
+          response.success? ? set_headers(response.headers) : raise_error_for_response(response)
         end
 
         request

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -244,6 +244,7 @@ module CartoDB
 
       def content_length
         return @content_length if @content_length
+        return nil unless headers
 
         header_content_length = headers['Content-Length']
 
@@ -252,6 +253,7 @@ module CartoDB
 
       def etag
         return @etag if @etag
+        return nil unless headers
 
         header_etag = headers['ETag']
         header_etag = header_etag.delete('"').delete("'") if header_etag
@@ -261,6 +263,7 @@ module CartoDB
 
       def last_modified
         return @last_modified if @last_modified
+        return nil unless headers
 
         header_last_modified = headers['Last-Modified']
         @last_modified = if header_last_modified
@@ -274,6 +277,7 @@ module CartoDB
 
       def content_type
         return @content_type if @content_type
+        return nil unless headers
 
         headers_content_type = headers['Content-Type']
         return nil unless headers_content_type.present?
@@ -298,6 +302,8 @@ module CartoDB
       CONTENT_DISPOSITION_RE = %r{;\s*filename=(.*;|.*)}
 
       def filename_from_headers
+        return nil unless headers
+
         disposition = headers['Content-Disposition']
         return false unless disposition
         filename = disposition.match(CONTENT_DISPOSITION_RE).to_a[1]

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -115,7 +115,7 @@ module CartoDB
                     url
                   end
 
-        raw_url.try(:is_a?, String) ? URI.escape(raw_url.strip, URL_ESCAPED_CHARACTERS) : raw_url
+        raw_url.is_a?(String) ? URI.escape(raw_url.strip, URL_ESCAPED_CHARACTERS) : raw_url
       end
 
       def raise_if_url_invalid(url)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -176,7 +176,7 @@ module CartoDB
       def download_and_store
         file = Tempfile.new(FILENAME_PREFIX, encoding: 'ascii-8bit')
 
-        binded_request(@translated_url, file).run
+        bound_request(@translated_url, file).run
 
         file_path = if @filename
                       new_file_path = File.join(Pathname.new(file.path).dirname, @filename)
@@ -193,7 +193,7 @@ module CartoDB
         file.unlink
       end
 
-      def binded_request(url, file)
+      def bound_request(url, file)
         request = Typhoeus::Request.new(url, typhoeus_options)
 
         request.on_headers do |response|

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -290,7 +290,7 @@ module CartoDB
         URL_TRANSLATORS.map(&:new).find { |translator| translator.supported?(url) }
       end
 
-      CONTENT_DISPOSITION_RE  = %r{;\s*filename=(.*;|.*)}
+      CONTENT_DISPOSITION_RE = %r{;\s*filename=(.*;|.*)}
 
       def filename_from_headers
         disposition = headers['Content-Disposition']

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -136,13 +136,14 @@ module CartoDB
         @http_response_code = response.code
         if response.success?
           raise_if_url_invalid(response.effective_url || @translated_url)
-          @headers = response.headers
 
-          set_headers
+          set_headers(response.headers)
         end
       end
 
-      def set_headers
+      def set_headers(headers)
+        @headers = headers
+
         basename = @custom_filename ||
                    filename_from_headers ||
                    filename_from_url ||

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -240,6 +240,10 @@ module CartoDB
         end
       end
 
+      def http_client
+        @http_client ||= Carto::Http::Client.get('downloader', log_requests: true)
+      end
+
       def content_length
         return @content_length if @content_length
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -55,7 +55,7 @@ module CartoDB
 
       attr_reader :source_file, :etag, :last_modified, :http_response_code, :datasource
 
-      def initialize(url, http_options = {}, options = {})
+      def initialize(user_id, url, http_options = {}, options = {})
         raise UploadError if url.nil?
 
         @http_options = http_options
@@ -63,7 +63,6 @@ module CartoDB
         @downloaded_bytes = 0
         @translated_url = translate_url(url)
 
-        user_id = options[:user_id]
         @user = Carto::User.find(user_id) if user_id
 
         @downloaded_bytes = 0

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -71,7 +71,7 @@ module CartoDB
           if available_quota_in_bytes
             raise_if_over_storage_quota(requested_quota: content_length,
                                         available_quota: available_quota_in_bytes.to_i,
-                                        user_id: @user.try(:id))
+                                        user_id: @user.id)
           end
 
           modified? ? download_and_store : @source_file = nil

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -127,7 +127,8 @@ module CartoDB
       def headers
         return @headers if @headers
 
-        response = http_client.head(@translated_url, typhoeus_options)
+        response = Carto::Http::Client.get('downloader', log_requests: true)
+                                      .head(@translated_url, typhoeus_options)
 
         @http_response_code = response.code
         raise_if_url_invalid(response.effective_url || @translated_url)
@@ -308,10 +309,6 @@ module CartoDB
         url_name = self.class.url_filename_regex.match(URI.decode(@translated_url)).to_s
 
         url_name unless url_name.empty?
-      end
-
-      def http_client
-        @http_client ||= Carto::Http::Client.get('downloader', log_requests: true)
       end
 
       CONTENT_TYPES_MAPPING = [

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -68,7 +68,7 @@ module CartoDB
 
       def run(_available_quota_in_bytes = nil)
         if @translated_url =~ %r{://}
-          raise_if_over_storage_quota(requested_quota: content_length,
+          raise_if_over_storage_quota(requested_quota: content_length || 0,
                                       available_quota: size_limit_in_bytes,
                                       user_id: @user.id)
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -56,14 +56,12 @@ module CartoDB
       attr_reader :source_file, :etag, :last_modified, :http_response_code, :datasource
 
       def initialize(user_id, url, http_options = {}, options = {})
-        raise UploadError if url.nil?
-
-        @http_options = http_options
-        @options = options
-        @downloaded_bytes = 0
-        @translated_url = translate_url(url)
+        raise UploadError unless user_id && url
 
         @user = Carto::User.find(user_id) if user_id
+        @translated_url = translate_url(url)
+        @http_options = http_options
+        @options = options
 
         @downloaded_bytes = 0
       end

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -221,8 +221,6 @@ module CartoDB
       end
 
       def raise_error_for_response(response)
-        CartoDB::Logger.error(message: 'CartoDB::Importer2::Downloader: Error', response: response)
-
         if response.timed_out?
           raise DownloadTimeoutError.new("TIMEOUT ERROR: Body:#{response.body}")
         elsif response.headers['Error'] && response.headers['Error'] =~ /too many nodes/

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -301,7 +301,7 @@ module CartoDB
       end
 
       def filename_from_url
-        url_name = self.class.url_filename_regex.match(@translated_url).to_s
+        url_name = self.class.url_filename_regex.match(URI.decode(@translated_url)).to_s
 
         url_name unless url_name.empty?
       end

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -134,15 +134,15 @@ module CartoDB
         response = http_client.head(@translated_url, typhoeus_options)
 
         @http_response_code = response.code
-        raise_if_url_invalid(response.effective_url || @translated_url)
-        response.success? ? process_headers(response.headers) : raise_error_for_response(response)
+        if response.success?
+          raise_if_url_invalid(response.effective_url || @translated_url)
+          @headers = response.headers
 
-        @headers
+          process_headers
+        end
       end
 
-      def process_headers(headers)
-        @headers = headers
-
+      def process_headers
         basename = @custom_filename ||
                    filename_from_headers ||
                    filename_from_url ||

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -169,7 +169,9 @@ module CartoDB
 
       def download_and_store
         file = Tempfile.new(FILENAME_PREFIX, encoding: 'ascii-8bit')
-        binded_request(@translated_url, file, size_limit_in_bytes: @user.try(:max_import_file_size)).run
+
+        size_limit_in_bytes = @user.try(:max_import_file_size)
+        binded_request(@translated_url, file, size_limit_in_bytes: size_limit_in_bytes).run
 
         file_path = if @filename
                       new_file_path = File.join(Pathname.new(file.path).dirname, @filename)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -68,11 +68,9 @@ module CartoDB
 
       def run(available_quota_in_bytes = nil)
         if @translated_url =~ %r{://}
-          if available_quota_in_bytes
-            raise_if_over_storage_quota(requested_quota: content_length,
-                                        available_quota: available_quota_in_bytes.to_i,
-                                        user_id: @user.id)
-          end
+          raise_if_over_storage_quota(requested_quota: content_length,
+                                      available_quota: max_quota_in_bytes(available_quota_in_bytes),
+                                      user_id: @user.id)
 
           modified? ? download_and_store : @source_file = nil
         else
@@ -97,6 +95,10 @@ module CartoDB
       end
 
       private
+
+      def max_quota_in_bytes(available_quota_in_bytes)
+        [@user.max_import_file_size, available_quota_in_bytes.try(:to_i)].compact.min
+      end
 
       URL_ESCAPED_CHARACTERS = 'áéíóúÁÉÍÓÚñÑçÇàèìòùÀÈÌÒÙ'.freeze
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -16,6 +16,10 @@ require_relative '../../../../lib/carto/http/client'
 require_relative '../../../../lib/carto/url_validator'
 require_relative '../helpers/quota_check_helpers.rb'
 
+# NOTE: Beware that some methods and some parameters are kept since this class is supposed to be
+# interchangeable with CartoDB::Importer2::DatasourceDownloader. A better way to have managed
+# managed this might have been through inheritance, since Ruby doesn't provide interfaces.
+
 module CartoDB
   module Importer2
     class Downloader

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -191,7 +191,6 @@ module CartoDB
       end
 
       def binded_request(url, file)
-        size_limit_in_bytes = @user.try(:max_import_file_size)
         request = Typhoeus::Request.new(url, typhoeus_options)
 
         request.on_headers do |response|
@@ -203,6 +202,7 @@ module CartoDB
         end
 
         request.on_body do |chunk|
+          size_limit_in_bytes = @user.max_import_file_size
           if (@downloaded_bytes += chunk.bytesize) > size_limit_in_bytes
             raise FileTooBigError.new("download file too big (> #{size_limit_in_bytes} bytes)")
           else

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -146,8 +146,6 @@ module CartoDB
                    SecureRandom.urlsafe_base64
 
         @filename = filename_with_extension(basename)
-        @etag = etag
-        @last_modified = last_modified
       end
 
       MAX_REDIRECTS = 5

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -131,8 +131,7 @@ module CartoDB
       def headers
         return @headers if @headers
 
-        response = Carto::Http::Client.get('downloader', log_requests: true)
-                                      .head(@translated_url, typhoeus_options)
+        response = http_client.head(@translated_url, typhoeus_options)
 
         @http_response_code = response.code
         raise_if_url_invalid(response.effective_url || @translated_url)

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -66,10 +66,10 @@ module CartoDB
         @downloaded_bytes = 0
       end
 
-      def run(available_quota_in_bytes = nil)
+      def run(_available_quota_in_bytes = nil)
         if @translated_url =~ %r{://}
           raise_if_over_storage_quota(requested_quota: content_length,
-                                      available_quota: max_quota_in_bytes(available_quota_in_bytes),
+                                      available_quota: max_quota_in_bytes,
                                       user_id: @user.id)
 
           modified? ? download_and_store : @source_file = nil
@@ -96,8 +96,8 @@ module CartoDB
 
       private
 
-      def max_quota_in_bytes(available_quota_in_bytes)
-        [@user.max_import_file_size, available_quota_in_bytes.try(:to_i)].compact.min
+      def max_quota_in_bytes
+        [@user.max_import_file_size, @user.remaining_quota].compact.min
       end
 
       URL_ESCAPED_CHARACTERS = 'áéíóúÁÉÍÓÚñÑçÇàèìòùÀÈÌÒÙ'.freeze

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -172,7 +172,7 @@ module CartoDB
 
       def typhoeus_options
         verify_ssl = @http_options.fetch(:verify_ssl_cert, false)
-        cookiejar = Tempfile.new('cookiejar_').path
+        cookiejar = Tempfile.new('cookiejar_', '/tmp/importer').path
 
         {
           cookiefile:       cookiejar,
@@ -190,7 +190,7 @@ module CartoDB
       FILENAME_PREFIX = 'importer_'.freeze
 
       def download_and_store
-        file = Tempfile.new(FILENAME_PREFIX, encoding: 'ascii-8bit')
+        file = Tempfile.new(FILENAME_PREFIX, '/tmp/importer', encoding: 'ascii-8bit')
 
         bound_request(file).run
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -73,7 +73,7 @@ module CartoDB
 
       attr_reader :source_file, :etag, :last_modified, :http_response_code, :datasource
 
-      TMP_IMPORTER_PATH = TMP_IMPORTER_PATH.freeze
+      TMP_IMPORTER_PATH = '/tmp/importer'.freeze
 
       def initialize(user_id, url, http_options = {}, options = {})
         raise UploadError unless user_id && url

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -73,6 +73,8 @@ module CartoDB
 
       attr_reader :source_file, :etag, :last_modified, :http_response_code, :datasource
 
+      TMP_IMPORTER_PATH = TMP_IMPORTER_PATH.freeze
+
       def initialize(user_id, url, http_options = {}, options = {})
         raise UploadError unless user_id && url
 
@@ -82,6 +84,8 @@ module CartoDB
         @options = options
 
         @downloaded_bytes = 0
+
+        FileUtils.mkdir_p(TMP_IMPORTER_PATH)
       end
 
       def run(_available_quota_in_bytes = nil)
@@ -172,7 +176,7 @@ module CartoDB
 
       def typhoeus_options
         verify_ssl = @http_options.fetch(:verify_ssl_cert, false)
-        cookiejar = Tempfile.new('cookiejar_', '/tmp/importer').path
+        cookiejar = Tempfile.new('cookiejar_', TMP_IMPORTER_PATH).path
 
         {
           cookiefile:       cookiejar,
@@ -190,7 +194,7 @@ module CartoDB
       FILENAME_PREFIX = 'importer_'.freeze
 
       def download_and_store
-        file = Tempfile.new(FILENAME_PREFIX, '/tmp/importer', encoding: 'ascii-8bit')
+        file = Tempfile.new(FILENAME_PREFIX, TMP_IMPORTER_PATH, encoding: 'ascii-8bit')
 
         bound_request(file).run
 

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -295,7 +295,6 @@ module CartoDB
 
           @importer_stats.timing('cleanup') do
             unpacker.clean_up
-            @downloader.clean_up
           end
 
         end

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -295,6 +295,7 @@ module CartoDB
 
           @importer_stats.timing('cleanup') do
             unpacker.clean_up
+            @downloader.clean_up
           end
 
         end

--- a/services/importer/spec/acceptance/csv_spec.rb
+++ b/services/importer/spec/acceptance/csv_spec.rb
@@ -103,6 +103,7 @@ describe 'csv regression tests' do
 
   it 'imports files from Google Fusion Tables' do
     # From https://www.google.com/fusiontables/exporttable?query=select+*+from+1dimNIKKwROG1yTvJ6JlMm4-B4LxMs2YbncM4p9g
+    CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file 'spec/support/data/dec_2012_modis_forest_change_fusion_tables.csv' do |url|
       downloader  = Downloader.new(@user.id, url)
       runner      = Runner.new(

--- a/services/importer/spec/acceptance/csv_spec.rb
+++ b/services/importer/spec/acceptance/csv_spec.rb
@@ -29,7 +29,7 @@ describe 'csv regression tests' do
 
   it 'georeferences files with lat / lon columns' do
     filepath    = path_to('../../../../spec/support/data/csv_with_lat_lon.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -46,7 +46,7 @@ describe 'csv regression tests' do
 
   it 'imports XLS files' do
     filepath    = path_to('../../../../spec/support/data/ngos.xlsx')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -61,7 +61,7 @@ describe 'csv regression tests' do
 
   it 'imports files with duplicated column names' do
     filepath    = path_to('../fixtures/duplicated_column_name.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -89,7 +89,7 @@ describe 'csv regression tests' do
 
   it 'imports files exported from the SQL API' do
     filepath    = path_to('ne_10m_populated_places_simple.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -104,7 +104,7 @@ describe 'csv regression tests' do
   it 'imports files from Google Fusion Tables' do
     # From https://www.google.com/fusiontables/exporttable?query=select+*+from+1dimNIKKwROG1yTvJ6JlMm4-B4LxMs2YbncM4p9g
     serve_file 'spec/support/data/dec_2012_modis_forest_change_fusion_tables.csv' do |url|
-      downloader  = Downloader.new(url)
+      downloader  = Downloader.new(@user.id, url)
       runner      = Runner.new(
         pg: @user.db_service.db_configuration_for,
         downloader: downloader,
@@ -121,7 +121,7 @@ describe 'csv regression tests' do
 
   it 'imports files with a the_geom column in GeoJSON' do
     filepath    = path_to('csv_with_geojson.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -139,7 +139,7 @@ describe 'csv regression tests' do
 
   it 'imports files with & in the name' do
     filepath    = path_to('ne_10m_populated_places_&simple.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -176,7 +176,7 @@ describe 'csv regression tests' do
 
   it 'imports records with cell line breaks' do
     filepath    = path_to('in_cell_line_breaks.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -195,7 +195,7 @@ describe 'csv regression tests' do
 
   it 'imports records with cell line breaks in tables which require normalization' do
     filepath    = path_to('in_cell_line_breaks_needs_norm.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -214,7 +214,7 @@ describe 'csv regression tests' do
 
   it 'import records in ISO-8859-1 with Windows-style breaks' do
     filepath    = path_to('cp1252_with_crlf.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -233,7 +233,7 @@ describe 'csv regression tests' do
 
   it 'import records with cell cp1252 reverse line breaks' do
     filepath    = path_to('cp1252_with_rev_lf.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -258,7 +258,7 @@ describe 'csv regression tests' do
 
   it 'import records with cell utf8 reverse line breaks' do
     filepath    = path_to('utf8_with_rev_lf.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -290,7 +290,7 @@ describe 'csv regression tests' do
   it 'import records with escaped quotes' do
     %w(escaped_quotes_comma_sep.csv escaped_quotes_semi_sep.csv).each do |csv_file|
       filepath    = path_to(csv_file)
-      downloader  = Downloader.new(filepath)
+      downloader  = Downloader.new(@user.id, filepath)
       runner      = Runner.new({
                                  pg: @user.db_service.db_configuration_for,
                                  downloader: downloader,
@@ -328,7 +328,7 @@ describe 'csv regression tests' do
 
   it 'refuses to import csv with broken encoding' do
     filepath    = path_to('broken_encoding.csv')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -394,7 +394,7 @@ describe 'csv regression tests' do
 
   def runner_with_fixture(file, job=nil, add_ogr2ogr2_options=false)
     filepath = path_to(file)
-    downloader = Downloader.new(filepath)
+    downloader = Downloader.new(@user.id, filepath)
     runner = Runner.new({
                  pg: @user.db_service.db_configuration_for,
                  downloader: downloader,

--- a/services/importer/spec/acceptance/geojson_spec.rb
+++ b/services/importer/spec/acceptance/geojson_spec.rb
@@ -32,7 +32,7 @@ describe 'geojson regression tests' do
 
   it 'imports a file exported from CartoDB' do
     filepath    = path_to('tm_world_borders_simpl_0_8.geojson')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -45,7 +45,7 @@ describe 'geojson regression tests' do
   it 'imports a file from a url with params' do
     filepath    = 'https://raw.github.com/benbalter/dc-wifi-social/master' +
                   '/bars.geojson?foo=bar'
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -57,7 +57,7 @@ describe 'geojson regression tests' do
 
   it "raises if GeoJSON isn't valid" do
     filepath    = path_to('invalid.geojson')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,

--- a/services/importer/spec/acceptance/gpx_spec.rb
+++ b/services/importer/spec/acceptance/gpx_spec.rb
@@ -27,7 +27,7 @@ describe 'GPX regression tests' do
 
   it 'imports GPX files' do
     filepath    = path_to('route2.gpx')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new(pg: @user.db_service.db_configuration_for,
                                                  downloader: downloader,
                                                  log: CartoDB::Importer2::Doubles::Log.new(@user),
@@ -40,7 +40,7 @@ describe 'GPX regression tests' do
 
   it 'imports a multi layer GPX file' do
     filepath    = path_to('multiple_layer.gpx')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new(pg: @user.db_service.db_configuration_for,
                                                  downloader: downloader,
                                                  log: CartoDB::Importer2::Doubles::Log.new(@user),
@@ -54,7 +54,7 @@ describe 'GPX regression tests' do
 
   it 'imports a single layer GPX file that becomes two layer dataset' do
     filepath    = path_to('one_layer.gpx')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new(pg: @user.db_service.db_configuration_for,
                                                  downloader: downloader,
                                                  log: CartoDB::Importer2::Doubles::Log.new(@user),

--- a/services/importer/spec/acceptance/gz_tgz_spec.rb
+++ b/services/importer/spec/acceptance/gz_tgz_spec.rb
@@ -28,7 +28,7 @@ describe 'gz and tgz regression tests' do
 
   it 'returns ok with supported gzip file' do
     filepath    = path_to('ok_data.csv.gz')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -41,7 +41,7 @@ describe 'gz and tgz regression tests' do
 
   it 'returns ok with supported tgz file' do
     filepath    = path_to('ok_data.tgz')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -54,7 +54,7 @@ describe 'gz and tgz regression tests' do
 
   it 'process one of the two files inside TGZ' do
     filepath    = path_to('ok_and_wrong_data.tgz')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -69,7 +69,7 @@ describe 'gz and tgz regression tests' do
 
   it 'returns error if csv is invalid with supported gzip file' do
     filepath    = path_to('wrong_data.csv.gz')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,

--- a/services/importer/spec/acceptance/kml_spec.rb
+++ b/services/importer/spec/acceptance/kml_spec.rb
@@ -27,7 +27,7 @@ describe 'KML regression tests' do
 
   it 'imports KML files' do
     filepath    = path_to('counties_ny_export.kml')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -41,7 +41,7 @@ describe 'KML regression tests' do
 
   it 'imports KML files from url' do
     serve_file 'services/importer/spec/fixtures/one_layer.kml' do |filepath|
-      downloader  = CartoDB::Importer2::Downloader.new(filepath)
+      downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
       runner      = CartoDB::Importer2::Runner.new(
         pg: @user.db_service.db_configuration_for,
         downloader: downloader,
@@ -56,7 +56,7 @@ describe 'KML regression tests' do
 
   it 'imports KMZ in a 3D projection' do
     filepath    = path_to('usdm130806.kmz')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -70,7 +70,7 @@ describe 'KML regression tests' do
 
   it 'imports multi-layer KMLs' do
     filepath    = path_to('multiple_layer.kml')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -84,7 +84,7 @@ describe 'KML regression tests' do
 
   it 'raises if KML just contains a link to the actual KML url' do
     filepath    = path_to('abandoned.kml')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -99,7 +99,7 @@ describe 'KML regression tests' do
   it 'imports a maximum of Runner::MAX_TABLES_PER_IMPORT KMLs from a zip ok' do
     # https://developers.google.com/kml/documentation/KML_Samples.kml
     filepath    = path_to('kml_samples.zip')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -118,7 +118,7 @@ describe 'KML regression tests' do
 
   it 'raises exception if KML style tag dont have and ID' do
     filepath    = path_to('style_without_id.kml')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,

--- a/services/importer/spec/acceptance/kml_spec.rb
+++ b/services/importer/spec/acceptance/kml_spec.rb
@@ -40,6 +40,7 @@ describe 'KML regression tests' do
   end
 
   it 'imports KML files from url' do
+    CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file 'services/importer/spec/fixtures/one_layer.kml' do |filepath|
       downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
       runner      = CartoDB::Importer2::Runner.new(

--- a/services/importer/spec/acceptance/mapinfo_spec.rb
+++ b/services/importer/spec/acceptance/mapinfo_spec.rb
@@ -29,7 +29,7 @@ describe 'Mapinfo regression tests' do
   it 'imports Mapinfo files' do
     # Rails.root not loaded yet. This is a workaround
     filepath    = "#{File.expand_path('../..', __FILE__)}/fixtures/Ivanovo.zip"
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,

--- a/services/importer/spec/acceptance/osm_spec.rb
+++ b/services/importer/spec/acceptance/osm_spec.rb
@@ -29,7 +29,7 @@ describe 'OSM regression tests' do
 
   it 'imports OSM files' do
     filepath    = path_to('map2.osm')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,

--- a/services/importer/spec/acceptance/rar_spec.rb
+++ b/services/importer/spec/acceptance/rar_spec.rb
@@ -42,7 +42,7 @@ describe 'rar regression tests' do
 
   it 'ignores unsupported files in the bundle' do
     filepath    = path_to('one_unsupported_one_valid.rar')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner = Runner.new(
       pg:         @user.db_service.db_configuration_for,
       downloader: downloader,
@@ -56,7 +56,7 @@ describe 'rar regression tests' do
 
   it 'imports a rar with >1 file successfully' do
     filepath    = path_to('multiple_csvs.rar')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner = Runner.new(
       pg:         @user.db_service.db_configuration_for,
       downloader: downloader,
@@ -75,7 +75,7 @@ describe 'rar regression tests' do
 
   it 'imports a maximum of Runner::MAX_TABLES_PER_IMPORT files from a rar, but doesnt errors' do
     filepath    = path_to('more_than_10_files.rar')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner = Runner.new(
       pg:         @user.db_service.db_configuration_for,
       downloader: downloader,
@@ -95,7 +95,7 @@ describe 'rar regression tests' do
   it 'imports a shapefile that includes a xxx.VERSION.txt file skipping it' do
     # http://www.naturalearthdata.com/downloads/
     filepath    = path_to('shapefile_with_version_txt.rar')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner = Runner.new(
       pg:         @user.db_service.db_configuration_for,
       downloader: downloader,
@@ -114,7 +114,7 @@ describe 'rar regression tests' do
 
   it 'imports all non-failing items from a rar without failing the whole import' do
     filepath    = path_to('file_ok_and_file_ko.rar')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner = Runner.new(
       pg:         @user.db_service.db_configuration_for,
       downloader: downloader,

--- a/services/importer/spec/acceptance/rar_spec.rb
+++ b/services/importer/spec/acceptance/rar_spec.rb
@@ -28,7 +28,7 @@ describe 'rar regression tests' do
 
   it 'returns empty results if no supported files in the bundle' do
     filepath    = path_to('one_unsupported.rar')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner = Runner.new(
       pg:         @user.db_service.db_configuration_for,
       downloader: downloader,

--- a/services/importer/spec/acceptance/raster2pgsql_spec.rb
+++ b/services/importer/spec/acceptance/raster2pgsql_spec.rb
@@ -82,7 +82,7 @@ describe 'raster2pgsql acceptance tests' do
 
   it 'if there are some problem while importing should clean the temporary tables' do
       filepath    = path_to('raster_simple.tif')
-      downloader  = CartoDB::Importer2::Downloader.new(filepath)
+      downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
       log         = CartoDB::Importer2::Doubles::Log.new(@user)
       job         = Job.new({ logger: log, pg_options: @user.db_service.db_configuration_for })
       runner      = CartoDB::Importer2::Runner.new({
@@ -115,7 +115,7 @@ describe 'raster2pgsql acceptance tests' do
     TOLERANCE = 1e-6
 
     filepath    = path_to('raster_simple.tif')
-    downloader  = CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = CartoDB::Importer2::Downloader.new(@user.id, filepath)
     log         = CartoDB::Importer2::Doubles::Log.new(@user)
     job         = Job.new({ logger: log, pg_options: @user.db_service.db_configuration_for.with_indifferent_access })
     runner      = CartoDB::Importer2::Runner.new({

--- a/services/importer/spec/acceptance/shp_spec.rb
+++ b/services/importer/spec/acceptance/shp_spec.rb
@@ -29,7 +29,7 @@ describe 'SHP regression tests' do
 
   it 'imports SHP files' do
     filepath    = path_to('TM_WORLD_BORDERS_SIMPL-0.3.zip')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -45,7 +45,7 @@ describe 'SHP regression tests' do
 
   it 'imports shp files without .prj' do
     filepath    = path_to('shp_no_prj.zip')
-    downloader  = Downloader.new(filepath)
+    downloader  = Downloader.new(@user.id, filepath)
     runner      = Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,

--- a/services/importer/spec/acceptance/zip_spec.rb
+++ b/services/importer/spec/acceptance/zip_spec.rb
@@ -27,7 +27,7 @@ describe 'zip regression tests' do
 
   it 'returns empty results if no supported files in the bundle' do
     filepath    = path_to('one_unsupported.zip')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -41,7 +41,7 @@ describe 'zip regression tests' do
 
   it 'ignores unsupported files in the bundle' do
     filepath    = path_to('one_unsupported_one_valid.zip')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -55,7 +55,7 @@ describe 'zip regression tests' do
 
   it 'imports a zip with >1 file successfully' do
     filepath    = path_to('multiple_csvs.zip')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -74,7 +74,7 @@ describe 'zip regression tests' do
 
   it 'imports a maximum of Runner::MAX_TABLES_PER_IMPORT files from a zip, but doesnt errors' do
     filepath    = path_to('more_than_10_files.zip')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -94,7 +94,7 @@ describe 'zip regression tests' do
   it 'imports a shapefile that includes a xxx.VERSION.txt file skipping it' do
     # http://www.naturalearthdata.com/downloads/
     filepath    = path_to('shapefile_with_version_txt.zip')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -113,7 +113,7 @@ describe 'zip regression tests' do
 
     it 'imports all non-failing items from a zip without failing the whole import' do
     filepath    = path_to('file_ok_and_file_ko.zip')
-    downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+    downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
     runner      = ::CartoDB::Importer2::Runner.new({
                                pg: @user.db_service.db_configuration_for,
                                downloader: downloader,
@@ -135,7 +135,7 @@ describe 'zip regression tests' do
 
     it 'imports one table from a visualization export (ignoring the visualization json)' do
       filepath    = path_to('visualization_export_with_csv_table.carto')
-      downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+      downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
       runner      = ::CartoDB::Importer2::Runner.new(pg: @user.db_service.db_configuration_for,
                                                      downloader: downloader,
                                                      log: CartoDB::Importer2::Doubles::Log.new(@user),
@@ -158,7 +158,7 @@ describe 'zip regression tests' do
 
     it 'imports one table from a geopackage visualization export (ignoring the visualization json)' do
       filepath    = path_to('visualization_export_with_geopackage_tables.carto')
-      downloader  = ::CartoDB::Importer2::Downloader.new(filepath)
+      downloader  = ::CartoDB::Importer2::Downloader.new(@user.id, filepath)
       runner      = ::CartoDB::Importer2::Runner.new(pg: @user.db_service.db_configuration_for,
                                                      downloader: downloader,
                                                      log: CartoDB::Importer2::Doubles::Log.new(@user),

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -37,7 +37,7 @@ describe Downloader do
     it 'downloads a file from a url' do
       stub_download(url: @file_url, filepath: @file_filepath)
 
-      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url)
       downloader.run
       File.exists?(downloader.source_file.fullpath).should eq true
     end
@@ -45,7 +45,7 @@ describe Downloader do
     it 'extracts the source_file name from the URL' do
       stub_download(url: @file_url, filepath: @file_filepath, content_disposition: false)
 
-      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url)
       downloader.run
       downloader.source_file.name.should eq 'ne_110m_lakes'
     end
@@ -55,7 +55,7 @@ describe Downloader do
             '?AWSAccessKeyId=XXXXXXXXXXXXXXXXXXXX&Expires=1461934764&Signature=XXXXXXXXXXXXXXXXXXXXXXXXXXM%3D'
       stub_download(url: url, filepath: @file_filepath, content_disposition: false)
 
-      downloader = Downloader.new(@user.id, url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, url)
       downloader.run
       downloader.source_file.name.should eq 'ne_110m_lakes'
     end
@@ -64,14 +64,14 @@ describe Downloader do
       url = "http://s3.amazonaws.com/com.cartodb.imports.staging/XXXXXXXXXXXXXXXXXXXX/ne_110m_lakes.csv"
       stub_download(url: url, filepath: @file_filepath, content_disposition: false)
 
-      downloader = Downloader.new(@user.id, url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, url)
       downloader.run
       downloader.source_file.name.should eq 'ne_110m_lakes'
     end
 
     it 'uses Content-Type header for files without extension' do
       stub_download(url: @file_url_without_extension, filepath: @file_filepath_without_extension, headers: { 'Content-Type' => 'text/csv' })
-      downloader = Downloader.new(@user.id, @file_url_without_extension, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url_without_extension)
       downloader.run
       downloader.source_file.filename.should eq 'foowithoutextension.csv'
     end
@@ -82,7 +82,7 @@ describe Downloader do
           filepath: @file_filepath_without_extension,
           headers: { 'Content-Type' => 'application/octet-stream' }
       )
-      downloader = Downloader.new(@user.id, @file_url_without_extension, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url_without_extension)
       downloader.run
       downloader.source_file.filename.should eq 'foowithoutextension'
     end
@@ -95,14 +95,14 @@ describe Downloader do
           filepath: csv_filepath_with_extension,
           headers: { 'Content-Type' => 'application/octet-stream' }
       )
-      downloader = Downloader.new(@user.id, url_csv_with_extension, {}, Hash.new)
+      downloader = Downloader.new(@user.id, url_csv_with_extension)
       downloader.run
       downloader.source_file.filename.should eq 'ngos.csv'
     end
 
     it 'ignores extra type parameters in Content-Type header' do
       stub_download(url: @file_url_without_extension, filepath: @file_filepath_without_extension, headers: { 'Content-Type' => 'vnd.ms-excel;charset=UTF-8' })
-      downloader = Downloader.new(@user.id, @file_url_without_extension, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url_without_extension)
       downloader.run
       downloader.send(:content_type).should eq 'vnd.ms-excel'
     end
@@ -113,7 +113,7 @@ describe Downloader do
           filepath: @file_filepath_with_wrong_extension,
           headers: { 'Content-Type' => 'text/csv' }
       )
-      downloader = Downloader.new(@user.id, @file_url_with_wrong_extension, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url_with_wrong_extension)
       downloader.run
       downloader.source_file.filename.should eq 'csvwithwrongextension.csv'
     end
@@ -126,7 +126,7 @@ describe Downloader do
           filepath: tgz_filepath_without_extension,
           headers: { 'Content-Type' => 'text/csv' }
       )
-      downloader = Downloader.new(@user.id, url_tgz_without_extension, {}, Hash.new)
+      downloader = Downloader.new(@user.id, url_tgz_without_extension)
       downloader.run
       downloader.source_file.filename.should eq 'csvwithwrongextension.csv'
     end
@@ -139,7 +139,7 @@ describe Downloader do
           filepath: tgz_filepath_without_extension,
           headers: { 'Content-Type' => 'application/x-gzip' }
       )
-      downloader = Downloader.new(@user.id, url_tgz_without_extension, {}, Hash.new)
+      downloader = Downloader.new(@user.id, url_tgz_without_extension)
       downloader.run
       downloader.source_file.filename.should eq 'ok_data.csv.gz'
     end
@@ -152,7 +152,7 @@ describe Downloader do
           filepath: filepath_geojson,
           headers: { 'Content-Type' => 'text/plain' }
       )
-      downloader = Downloader.new(@user.id, url_geojson, {}, Hash.new)
+      downloader = Downloader.new(@user.id, url_geojson)
       downloader.run
       downloader.source_file.filename.should eq 'tm_world_borders_simpl_0_8.geojson'
     end
@@ -165,7 +165,7 @@ describe Downloader do
           filepath: filepath_kml,
           headers: { 'Content-Type' => 'text/plain' }
       )
-      downloader = Downloader.new(@user.id, url_kml, {}, Hash.new)
+      downloader = Downloader.new(@user.id, url_kml)
       downloader.run
       downloader.source_file.filename.should eq 'abandoned.kml'
     end
@@ -175,7 +175,7 @@ describe Downloader do
         url: @fusion_tables_url,
         filepath: @fusion_tables_filepath
       )
-      downloader = Downloader.new(@user.id, @fusion_tables_url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @fusion_tables_url)
 
       downloader.run
       downloader.source_file.name.should eq 'forest_change'
@@ -184,7 +184,7 @@ describe Downloader do
     it 'supports FTP urls' do
       stub_download(url: @ftp_url, filepath: @ftp_filepath)
 
-      downloader = Downloader.new(@user.id, @ftp_url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @ftp_url)
       downloader.run
       downloader.source_file.name.should eq 'INDEX'
     end
@@ -197,7 +197,7 @@ describe Downloader do
         { url: 'spec/fixtures/many_characters_áÁñÑçÇàÀ.csv', name: 'many_characters_áÁñÑçÇàÀ' }
       ].each do |url_and_name|
         serve_file url_and_name[:url] do |url|
-          downloader = Downloader.new(@user.id, url, {}, Hash.new)
+          downloader = Downloader.new(@user.id, url)
           downloader.run
           downloader.source_file.name.should eq url_and_name[:name]
         end
@@ -207,7 +207,7 @@ describe Downloader do
     it 'does not break urls with % on it' do
       # INFO: notice this URL is fake
       url_with_percentage = 'https://s3.amazonaws.com/com.cartodb.imports.staging/03b0c2199fc814ceeb75/a_file.zip?AWSAccessKeyId=AKIAIUI5FFFJIRAMEEMA&Expires=1433349484&Signature=t6m%2Bji%2BlKsnrOVqPsptXajPiozw%3D'
-      downloader = Downloader.new(@user.id, url_with_percentage, {}, Hash.new)
+      downloader = Downloader.new(@user.id, url_with_percentage)
       downloader.instance_variable_get("@translated_url").should == url_with_percentage
     end
 
@@ -219,7 +219,7 @@ describe Downloader do
         headers:  { "ETag" => etag }
       )
 
-      downloader = Downloader.new(@user.id, @file_url, { etag: etag }, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url, { etag: etag })
       downloader.run
       downloader.modified?.should be_false
     end
@@ -231,7 +231,7 @@ describe Downloader do
         headers:  {}
       )
 
-      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url)
       lambda { downloader.run }.should raise_error DownloadError
     end
 
@@ -245,19 +245,19 @@ describe Downloader do
       Typhoeus::Response.any_instance.stubs(:mock).returns(false)
       Typhoeus::Response.any_instance.stubs(:return_code).returns(:partial_file)
 
-      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url)
       lambda { downloader.run }.should raise_error PartialDownloadError
     end
   end
 
   describe '#source_file' do
     it 'returns nil if no download initiated' do
-      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url)
       downloader.source_file.should_not be
     end
 
     it 'returns a source file based on the path if passed a file path' do
-      downloader = Downloader.new(@user.id, '/foo/bar', {}, Hash.new)
+      downloader = Downloader.new(@user.id, '/foo/bar')
       downloader.run
       downloader.source_file.fullpath.should eq '/foo/bar'
     end
@@ -265,7 +265,7 @@ describe Downloader do
     it 'returns a source_file name' do
       CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
       serve_file 'spec/support/data/ne_110m_lakes.zip' do |url|
-        downloader = Downloader.new(@user.id, url, {}, Hash.new)
+        downloader = Downloader.new(@user.id, url)
         downloader.run
         downloader.source_file.name.should eq 'ne_110m_lakes'
       end
@@ -274,7 +274,7 @@ describe Downloader do
     it 'returns a local filepath' do
       CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
       serve_file 'spec/support/data/ne_110m_lakes.zip' do |url|
-        downloader = Downloader.new(@user.id, url, {}, Hash.new)
+        downloader = Downloader.new(@user.id, url)
         downloader.run
         downloader.source_file.fullpath.should match /#{@file_url.split('/').last}/
       end

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -219,7 +219,7 @@ describe Downloader do
         headers:  { "ETag" => etag }
       )
 
-      downloader = Downloader.new(@user.id, @file_url, { etag: etag })
+      downloader = Downloader.new(@user.id, @file_url, etag: etag)
       downloader.run
       downloader.modified?.should be_false
     end

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -310,26 +310,26 @@ describe Downloader do
     it 'gets the file name from the Content-Disposition header if present' do
       headers = { "Content-Disposition" => %{attachment; filename="bar.csv"} }
       downloader = Downloader.new(@user.id, @file_url, headers)
-      downloader.send(:process_headers, headers)
+      downloader.send(:set_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'bar.csv'
 
       headers = { "Content-Disposition" => %{attachment; filename=bar.csv} }
       downloader = Downloader.new(@user.id, @file_url, headers)
-      downloader.send(:process_headers, headers)
+      downloader.send(:set_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'bar.csv'
 
       disposition = "attachment; filename=map_gaudi3d.geojson; " +
                     'modification-date="Tue, 06 Aug 2013 15:05:35 GMT'
       headers = { "Content-Disposition" => disposition }
       downloader = Downloader.new(@user.id, @file_url, headers)
-      downloader.send(:process_headers, headers)
+      downloader.send(:set_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'map_gaudi3d.geojson'
     end
 
     it 'gets the file name from the URL if no Content-Disposition header' do
       downloader = Downloader.new(@user.id, @file_url)
 
-      downloader.send(:process_headers, Hash.new)
+      downloader.send(:set_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'ne_110m_lakes.zip'
     end
 
@@ -337,7 +337,7 @@ describe Downloader do
       hard_url = "https://manolo.escobar.es/param&myfilenameparam&zip_file.csv.zip&otherinfo"
 
       downloader = Downloader.new(@user.id, hard_url)
-      downloader.send(:process_headers, Hash.new)
+      downloader.send(:set_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'zip_file.csv.zip'
     end
 
@@ -345,13 +345,13 @@ describe Downloader do
       empty_url = "https://manolo.escobar.es/param&myfilenameparam&nothing&otherinfo"
 
       downloader = Downloader.new(@user.id, empty_url)
-      downloader.send(:process_headers, Hash.new)
+      downloader.send(:set_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should_not eq nil
     end
 
     it 'discards url query params' do
       downloader = Downloader.new(@user.id, "#{@file_url}?foo=bar&woo=wee")
-      downloader.send(:process_headers, Hash.new)
+      downloader.send(:set_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'ne_110m_lakes.zip'
     end
 
@@ -359,7 +359,7 @@ describe Downloader do
       hard_url = "https://cartofante.net/my_file.xlsx"
 
       downloader = Downloader.new(@user.id, hard_url)
-      downloader.send(:process_headers, Hash.new)
+      downloader.send(:set_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'my_file.xlsx'
     end
   end

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -22,16 +22,10 @@ describe Downloader do
     @fusion_tables_filepath = path_to('forest_change.csv')
     @ftp_url        = "ftp://ftp.nlm.nih.gov/nlmdata/sample/INDEX"
     @ftp_filepath   = path_to('INDEX.txt')
-    @user = FactoryGirl.create(:carto_user)
   end
 
-  after do
-    @user.destroy
-  end
-
-  after(:each) do
-    Typhoeus::Expectation.clear
-  end
+  before(:all) { @user = FactoryGirl.create(:carto_user) }
+  after(:all)  { @user.destroy }
 
   describe '#run' do
     it 'downloads a file from a url' do
@@ -250,13 +244,13 @@ describe Downloader do
     end
 
     describe('#quota_checks') do
-      before do
+      before(:all) do
         @old_max_import_file_size = @user.max_import_file_size
         @user.max_import_file_size = 1024
         @user.save
       end
 
-      after do
+      after(:all) do
         @user.max_import_file_size = @old_max_import_file_size
         @user.save
       end

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -37,7 +37,7 @@ describe Downloader do
     it 'downloads a file from a url' do
       stub_download(url: @file_url, filepath: @file_filepath)
 
-      downloader = Downloader.new(@file_url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
       downloader.run
       File.exists?(downloader.source_file.fullpath).should eq true
     end
@@ -45,7 +45,7 @@ describe Downloader do
     it 'extracts the source_file name from the URL' do
       stub_download(url: @file_url, filepath: @file_filepath, content_disposition: false)
 
-      downloader = Downloader.new(@file_url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
       downloader.run
       downloader.source_file.name.should eq 'ne_110m_lakes'
     end
@@ -55,7 +55,7 @@ describe Downloader do
             '?AWSAccessKeyId=XXXXXXXXXXXXXXXXXXXX&Expires=1461934764&Signature=XXXXXXXXXXXXXXXXXXXXXXXXXXM%3D'
       stub_download(url: url, filepath: @file_filepath, content_disposition: false)
 
-      downloader = Downloader.new(url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, url, {}, Hash.new)
       downloader.run
       downloader.source_file.name.should eq 'ne_110m_lakes'
     end
@@ -64,14 +64,14 @@ describe Downloader do
       url = "http://s3.amazonaws.com/com.cartodb.imports.staging/XXXXXXXXXXXXXXXXXXXX/ne_110m_lakes.csv"
       stub_download(url: url, filepath: @file_filepath, content_disposition: false)
 
-      downloader = Downloader.new(url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, url, {}, Hash.new)
       downloader.run
       downloader.source_file.name.should eq 'ne_110m_lakes'
     end
 
     it 'uses Content-Type header for files without extension' do
       stub_download(url: @file_url_without_extension, filepath: @file_filepath_without_extension, headers: { 'Content-Type' => 'text/csv' })
-      downloader = Downloader.new(@file_url_without_extension, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url_without_extension, {}, Hash.new)
       downloader.run
       downloader.source_file.filename.should eq 'foowithoutextension.csv'
     end
@@ -82,7 +82,7 @@ describe Downloader do
           filepath: @file_filepath_without_extension,
           headers: { 'Content-Type' => 'application/octet-stream' }
       )
-      downloader = Downloader.new(@file_url_without_extension, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url_without_extension, {}, Hash.new)
       downloader.run
       downloader.source_file.filename.should eq 'foowithoutextension'
     end
@@ -95,14 +95,14 @@ describe Downloader do
           filepath: csv_filepath_with_extension,
           headers: { 'Content-Type' => 'application/octet-stream' }
       )
-      downloader = Downloader.new(url_csv_with_extension, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, url_csv_with_extension, {}, Hash.new)
       downloader.run
       downloader.source_file.filename.should eq 'ngos.csv'
     end
 
     it 'ignores extra type parameters in Content-Type header' do
       stub_download(url: @file_url_without_extension, filepath: @file_filepath_without_extension, headers: { 'Content-Type' => 'vnd.ms-excel;charset=UTF-8' })
-      downloader = Downloader.new(@file_url_without_extension, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url_without_extension, {}, Hash.new)
       downloader.run
       downloader.send(:content_type).should eq 'vnd.ms-excel'
     end
@@ -113,7 +113,7 @@ describe Downloader do
           filepath: @file_filepath_with_wrong_extension,
           headers: { 'Content-Type' => 'text/csv' }
       )
-      downloader = Downloader.new(@file_url_with_wrong_extension, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url_with_wrong_extension, {}, Hash.new)
       downloader.run
       downloader.source_file.filename.should eq 'csvwithwrongextension.csv'
     end
@@ -126,7 +126,7 @@ describe Downloader do
           filepath: tgz_filepath_without_extension,
           headers: { 'Content-Type' => 'text/csv' }
       )
-      downloader = Downloader.new(url_tgz_without_extension, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, url_tgz_without_extension, {}, Hash.new)
       downloader.run
       downloader.source_file.filename.should eq 'csvwithwrongextension.csv'
     end
@@ -139,7 +139,7 @@ describe Downloader do
           filepath: tgz_filepath_without_extension,
           headers: { 'Content-Type' => 'application/x-gzip' }
       )
-      downloader = Downloader.new(url_tgz_without_extension, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, url_tgz_without_extension, {}, Hash.new)
       downloader.run
       downloader.source_file.filename.should eq 'ok_data.csv.gz'
     end
@@ -152,7 +152,7 @@ describe Downloader do
           filepath: filepath_geojson,
           headers: { 'Content-Type' => 'text/plain' }
       )
-      downloader = Downloader.new(url_geojson, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, url_geojson, {}, Hash.new)
       downloader.run
       downloader.source_file.filename.should eq 'tm_world_borders_simpl_0_8.geojson'
     end
@@ -165,7 +165,7 @@ describe Downloader do
           filepath: filepath_kml,
           headers: { 'Content-Type' => 'text/plain' }
       )
-      downloader = Downloader.new(url_kml, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, url_kml, {}, Hash.new)
       downloader.run
       downloader.source_file.filename.should eq 'abandoned.kml'
     end
@@ -175,7 +175,7 @@ describe Downloader do
         url: @fusion_tables_url,
         filepath: @fusion_tables_filepath
       )
-      downloader = Downloader.new(@fusion_tables_url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @fusion_tables_url, {}, Hash.new)
 
       downloader.run
       downloader.source_file.name.should eq 'forest_change'
@@ -184,7 +184,7 @@ describe Downloader do
     it 'supports FTP urls' do
       stub_download(url: @ftp_url, filepath: @ftp_filepath)
 
-      downloader = Downloader.new(@ftp_url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @ftp_url, {}, Hash.new)
       downloader.run
       downloader.source_file.name.should eq 'INDEX'
     end
@@ -197,7 +197,7 @@ describe Downloader do
         { url: 'spec/fixtures/many_characters_áÁñÑçÇàÀ.csv', name: 'many_characters_áÁñÑçÇàÀ' }
       ].each do |url_and_name|
         serve_file url_and_name[:url] do |url|
-          downloader = Downloader.new(url, {}, user_id: @user.id)
+          downloader = Downloader.new(@user.id, url, {}, Hash.new)
           downloader.run
           downloader.source_file.name.should eq url_and_name[:name]
         end
@@ -207,7 +207,7 @@ describe Downloader do
     it 'does not break urls with % on it' do
       # INFO: notice this URL is fake
       url_with_percentage = 'https://s3.amazonaws.com/com.cartodb.imports.staging/03b0c2199fc814ceeb75/a_file.zip?AWSAccessKeyId=AKIAIUI5FFFJIRAMEEMA&Expires=1433349484&Signature=t6m%2Bji%2BlKsnrOVqPsptXajPiozw%3D'
-      downloader = Downloader.new(url_with_percentage, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, url_with_percentage, {}, Hash.new)
       downloader.instance_variable_get("@translated_url").should == url_with_percentage
     end
 
@@ -219,7 +219,7 @@ describe Downloader do
         headers:  { "ETag" => etag }
       )
 
-      downloader = Downloader.new(@file_url, { etag: etag }, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, { etag: etag }, Hash.new)
       downloader.run
       downloader.modified?.should be_false
     end
@@ -231,7 +231,7 @@ describe Downloader do
         headers:  {}
       )
 
-      downloader = Downloader.new(@file_url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
       lambda { downloader.run }.should raise_error DownloadError
     end
 
@@ -245,19 +245,19 @@ describe Downloader do
       Typhoeus::Response.any_instance.stubs(:mock).returns(false)
       Typhoeus::Response.any_instance.stubs(:return_code).returns(:partial_file)
 
-      downloader = Downloader.new(@file_url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
       lambda { downloader.run }.should raise_error PartialDownloadError
     end
   end
 
   describe '#source_file' do
     it 'returns nil if no download initiated' do
-      downloader = Downloader.new(@file_url, {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, {}, Hash.new)
       downloader.source_file.should_not be
     end
 
     it 'returns a source file based on the path if passed a file path' do
-      downloader = Downloader.new('/foo/bar', {}, user_id: @user.id)
+      downloader = Downloader.new(@user.id, '/foo/bar', {}, Hash.new)
       downloader.run
       downloader.source_file.fullpath.should eq '/foo/bar'
     end
@@ -265,7 +265,7 @@ describe Downloader do
     it 'returns a source_file name' do
       CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
       serve_file 'spec/support/data/ne_110m_lakes.zip' do |url|
-        downloader = Downloader.new(url, {}, user_id: @user.id)
+        downloader = Downloader.new(@user.id, url, {}, Hash.new)
         downloader.run
         downloader.source_file.name.should eq 'ne_110m_lakes'
       end
@@ -274,7 +274,7 @@ describe Downloader do
     it 'returns a local filepath' do
       CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
       serve_file 'spec/support/data/ne_110m_lakes.zip' do |url|
-        downloader = Downloader.new(url, {}, user_id: @user.id)
+        downloader = Downloader.new(@user.id, url, {}, Hash.new)
         downloader.run
         downloader.source_file.fullpath.should match /#{@file_url.split('/').last}/
       end
@@ -284,25 +284,25 @@ describe Downloader do
   describe '#name inference' do
     it 'gets the file name from the Content-Disposition header if present' do
       headers = { "Content-Disposition" => %{attachment; filename="bar.csv"} }
-      downloader = Downloader.new(@file_url, headers, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, headers, Hash.new)
       downloader.send(:process_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'bar.csv'
 
       headers = { "Content-Disposition" => %{attachment; filename=bar.csv} }
-      downloader = Downloader.new(@file_url, headers, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, headers, Hash.new)
       downloader.send(:process_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'bar.csv'
 
       disposition = "attachment; filename=map_gaudi3d.geojson; " +
                     'modification-date="Tue, 06 Aug 2013 15:05:35 GMT'
       headers = { "Content-Disposition" => disposition }
-      downloader = Downloader.new(@file_url, headers, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, headers, Hash.new)
       downloader.send(:process_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'map_gaudi3d.geojson'
     end
 
     it 'gets the file name from the URL if no Content-Disposition header' do
-      downloader = Downloader.new(@file_url, Hash.new, user_id: @user.id)
+      downloader = Downloader.new(@user.id, @file_url, Hash.new, Hash.new)
 
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'ne_110m_lakes.zip'
@@ -311,7 +311,7 @@ describe Downloader do
     it 'gets the file name from the URL if no Content-Disposition header and custom params schema is used' do
       hard_url = "https://manolo.escobar.es/param&myfilenameparam&zip_file.csv.zip&otherinfo"
 
-      downloader = Downloader.new(hard_url, Hash.new, user_id: @user.id)
+      downloader = Downloader.new(@user.id, hard_url, Hash.new, Hash.new)
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'zip_file.csv.zip'
     end
@@ -319,13 +319,13 @@ describe Downloader do
     it 'uses random name in no name can be found in url or http headers' do
       empty_url = "https://manolo.escobar.es/param&myfilenameparam&nothing&otherinfo"
 
-      downloader = Downloader.new(empty_url, Hash.new, user_id: @user.id)
+      downloader = Downloader.new(@user.id, empty_url, Hash.new, Hash.new)
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should_not eq nil
     end
 
     it 'discards url query params' do
-      downloader = Downloader.new("#{@file_url}?foo=bar&woo=wee", Hash.new, user_id: @user.id)
+      downloader = Downloader.new(@user.id, "#{@file_url}?foo=bar&woo=wee", Hash.new, Hash.new)
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'ne_110m_lakes.zip'
     end
@@ -333,7 +333,7 @@ describe Downloader do
     it 'matches longer extension available from filename' do
       hard_url = "https://cartofante.net/my_file.xlsx"
 
-      downloader = Downloader.new(hard_url, Hash.new, user_id: @user.id)
+      downloader = Downloader.new(@user.id, hard_url, Hash.new, Hash.new)
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'my_file.xlsx'
     end

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -309,25 +309,25 @@ describe Downloader do
   describe '#name inference' do
     it 'gets the file name from the Content-Disposition header if present' do
       headers = { "Content-Disposition" => %{attachment; filename="bar.csv"} }
-      downloader = Downloader.new(@user.id, @file_url, headers, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url, headers)
       downloader.send(:process_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'bar.csv'
 
       headers = { "Content-Disposition" => %{attachment; filename=bar.csv} }
-      downloader = Downloader.new(@user.id, @file_url, headers, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url, headers)
       downloader.send(:process_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'bar.csv'
 
       disposition = "attachment; filename=map_gaudi3d.geojson; " +
                     'modification-date="Tue, 06 Aug 2013 15:05:35 GMT'
       headers = { "Content-Disposition" => disposition }
-      downloader = Downloader.new(@user.id, @file_url, headers, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url, headers)
       downloader.send(:process_headers, headers)
       downloader.instance_variable_get(:@filename).should eq 'map_gaudi3d.geojson'
     end
 
     it 'gets the file name from the URL if no Content-Disposition header' do
-      downloader = Downloader.new(@user.id, @file_url, Hash.new, Hash.new)
+      downloader = Downloader.new(@user.id, @file_url)
 
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'ne_110m_lakes.zip'
@@ -336,7 +336,7 @@ describe Downloader do
     it 'gets the file name from the URL if no Content-Disposition header and custom params schema is used' do
       hard_url = "https://manolo.escobar.es/param&myfilenameparam&zip_file.csv.zip&otherinfo"
 
-      downloader = Downloader.new(@user.id, hard_url, Hash.new, Hash.new)
+      downloader = Downloader.new(@user.id, hard_url)
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'zip_file.csv.zip'
     end
@@ -344,13 +344,13 @@ describe Downloader do
     it 'uses random name in no name can be found in url or http headers' do
       empty_url = "https://manolo.escobar.es/param&myfilenameparam&nothing&otherinfo"
 
-      downloader = Downloader.new(@user.id, empty_url, Hash.new, Hash.new)
+      downloader = Downloader.new(@user.id, empty_url)
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should_not eq nil
     end
 
     it 'discards url query params' do
-      downloader = Downloader.new(@user.id, "#{@file_url}?foo=bar&woo=wee", Hash.new, Hash.new)
+      downloader = Downloader.new(@user.id, "#{@file_url}?foo=bar&woo=wee")
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'ne_110m_lakes.zip'
     end
@@ -358,7 +358,7 @@ describe Downloader do
     it 'matches longer extension available from filename' do
       hard_url = "https://cartofante.net/my_file.xlsx"
 
-      downloader = Downloader.new(@user.id, hard_url, Hash.new, Hash.new)
+      downloader = Downloader.new(@user.id, hard_url)
       downloader.send(:process_headers, Hash.new)
       downloader.instance_variable_get(:@filename).should eq 'my_file.xlsx'
     end

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -190,19 +190,18 @@ describe Downloader do
     end
 
     it 'supports accented URLs' do
+      CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
+
       [
         { url: 'spec/fixtures/política_agraria_común.csv', name: 'política_agraria_común' },
-        # TODO: move to master branch
         { url: 'spec/fixtures/many_characters_áÁñÑçÇàÀ.csv', name: 'many_characters_áÁñÑçÇàÀ' }
       ].each do |url_and_name|
-        CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
         serve_file url_and_name[:url] do |url|
           downloader = Downloader.new(url, {}, user_id: @user.id)
           downloader.run
-          downloader.source_file.name.should eq(url_and_name[:name]), "Error downloading #{url_and_name[:url]}, name: #{downloader.source_file.name}"
+          downloader.source_file.name.should eq url_and_name[:name]
         end
       end
-
     end
 
     it 'does not break urls with % on it' do

--- a/services/importer/spec/unit/runner_spec.rb
+++ b/services/importer/spec/unit/runner_spec.rb
@@ -25,7 +25,7 @@ describe CartoDB::Importer2::Runner do
     @pg_options = @user.db_service.db_configuration_for
 
     @fake_log = CartoDB::Importer2::Doubles::Log.new(@user)
-    @downloader = CartoDB::Importer2::Downloader.new(@filepath)
+    @downloader = CartoDB::Importer2::Downloader.new(@user.id, @filepath)
     @fake_multiple_downloader_2 = CartoDB::Importer2::Doubles::MultipleDownloaderFake.instance(2)
   end
 

--- a/spec/helpers/url_validator_spec.rb
+++ b/spec/helpers/url_validator_spec.rb
@@ -44,6 +44,6 @@ describe 'UUIDHelper' do
   end
 
   it 'allows ftp' do
-    @url_validator.validate_url!("ftp://example.com").should be_true
+    expect { @url_validator.validate_url!("ftp://example.com") }.to_not raise_error
   end
 end

--- a/spec/helpers/url_validator_spec.rb
+++ b/spec/helpers/url_validator_spec.rb
@@ -41,7 +41,6 @@ describe 'UUIDHelper' do
     @url_validator.validate_url!("https://example.com/bar.kml")
     @url_validator.validate_url!("http://example.com/foo.csv:80")
     @url_validator.validate_url!("https://example.com/bar.kml:443")
-    @url_validator.validate_url!("ftp://example.com")
   end
 
   it 'allows ftp' do

--- a/spec/helpers/url_validator_spec.rb
+++ b/spec/helpers/url_validator_spec.rb
@@ -17,11 +17,6 @@ describe 'UUIDHelper' do
       .to raise_error(Carto::UrlValidator::InvalidUrlError)
   end
 
-  it 'raises an error if it is not of type http or https' do
-    expect { @url_validator.validate_url!("ftp://example.com") }
-      .to raise_error(Carto::UrlValidator::InvalidUrlError)
-  end
-
   it 'raises an error if it points to a non-standard port' do
     expect { @url_validator.validate_url!("http://example.com:8080") }
       .to raise_error(Carto::UrlValidator::InvalidUrlError)
@@ -46,6 +41,7 @@ describe 'UUIDHelper' do
     @url_validator.validate_url!("https://example.com/bar.kml")
     @url_validator.validate_url!("http://example.com/foo.csv:80")
     @url_validator.validate_url!("https://example.com/bar.kml:443")
+    @url_validator.validate_url!("ftp://example.com")
   end
 
   it 'allows ftp' do

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -144,6 +144,7 @@ describe DataImport do
 
   it 'should allow to create a table from a url' do
     data_import = nil
+    CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file Rails.root.join('db/fake_data/clubbing.csv') do |url|
       data_import = DataImport.create(
         user_id: @user.id,
@@ -159,6 +160,7 @@ describe DataImport do
 
   it 'should allow to create a table from a url with params' do
     data_import = nil
+    CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file Rails.root.join('db/fake_data/clubbing.csv?param=wadus'),
                headers: { "content-type" => "text/plain" } do |url|
       data_import = DataImport.create(

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -39,6 +39,7 @@ describe "Imports API" do
   end
 
   it 'performs asynchronous url imports' do
+    CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file Rails.root.join('db/fake_data/clubbing.csv') do |url|
       post api_v1_imports_create_url(params.merge(:url        => url,
                                        :table_name => "wadus"))
@@ -122,6 +123,7 @@ describe "Imports API" do
   it 'imports all the sample data' do
     @user.update table_quota: 10
 
+    CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file(Rails.root.join('spec/support/data/TM_WORLD_BORDERS_SIMPL-0.3.zip')) do |url|
       post api_v1_imports_create_url(params.merge(url: url, table_name: "wadus"))
 
@@ -146,6 +148,7 @@ describe "Imports API" do
     @user.update table_quota: 5
 
     # This file contains 10 data sources
+    CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file(Rails.root.join('spec/support/data/ESP_adm.zip')) do |url|
       post api_v1_imports_create_url, params.merge(:url        => url,
                                        :table_name => "wadus")
@@ -159,6 +162,7 @@ describe "Imports API" do
 
   it 'raises an error if the user attempts to import tables when being over disk quota' do
     @user.update quota_in_bytes: 1000, table_quota: 200
+    CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file(Rails.root.join('spec/support/data/ESP_adm.zip')) do |url|
       post api_v1_imports_create_url, params.merge(:url        => url,
                                        :table_name => "wadus")


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb-platform/issues/2892

For the CRing the `downloader.rb` file I suggest you click on "View" instead of the diff, since a lot of stuff has only been moved around, but the diffs is disastrous.

This comprises several parts and is bigger than expected:
1. It adds `user_id` as a hard dependency to the downloader.
2. It adds a `FileTooBigError` exception when a file being downloaded is too large for the user's quota.
3. It make URL validation work always and not only when there are redirection (probably a previous bug), fixes the tests that break because of this new validation really happening and modifies the validator to allow for FTP urls (which downloader specs verified and started failing when the validation was fixed to actually be applied).
4. It adds an arguably better way of checking the user quota taking advantage of the user hard requirement and by taking into account the user's quota and not only the max file import limit. It also takes advantage that the user is there, so no need for passing the available quota from outside.
5. It uses `Tempfile` for temporary files and drops `DataRepository` dependency.
6. It reorders, renames and rewrites about 12 methods, and deletes a whole bunch of extra/duplicated ones.
7. It adds test to check the quota exceptions are raised if detected by Content-Length or during download.

You can see that 5 and 6 weren't really necessary, but apart from the monstrous diff it's not really that bad, I promise 👼 

## Acceptance

This acceptance is going to be tough: all smoke test for importer and synchronisations.

Also, it would be nice for another pair of eyes to verify that `<rails root>/uploads/importer` and `/tmp/` are cleaned up after imports.