### PR TITLE
Don't require password validation for SAML user deletion

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -120,13 +120,8 @@ class Admin::UsersController < Admin::AdminController
 
     @user.delete_in_central
     @user.destroy
-    cdb_logout
 
-    if Cartodb::Central.sync_data_with_cartodb_central?
-      redirect_to "https://carto.com"
-    else
-      render(file: "public/404.html", layout: false, status: 404)
-    end
+    redirect_to logout_url
   rescue CartoDB::CentralCommunicationFailure => e
     CartoDB::Logger.error(exception: e, message: 'Central error deleting user at CartoDB', user: @user)
     flash.now[:error] = "Error deleting user: #{e.user_message}"

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -114,7 +114,7 @@ class Admin::UsersController < Admin::AdminController
 
   def delete
     deletion_password_confirmation = params[:deletion_password_confirmation]
-    if !@user.validate_old_password(deletion_password_confirmation)
+    if @user.needs_password_confirmation? && !@user.validate_old_password(deletion_password_confirmation)
       raise PASSWORD_DOES_NOT_MATCH_MESSAGE
     end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -28,6 +28,7 @@ class Admin::UsersController < Admin::AdminController
   before_filter :setup_user
   before_filter :initialize_google_plus_config, only: [:profile, :account]
   before_filter :load_services, only: [:account, :account_update, :delete]
+  before_filter :load_account_deletion_info, only: [:account, :delete]
 
   layout 'application'
 
@@ -42,7 +43,6 @@ class Admin::UsersController < Admin::AdminController
   end
 
   def account
-    @can_be_deleted, @cant_be_deleted_reason = can_be_deleted?(@user)
     respond_to do |format|
       format.html { render 'account' }
     end
@@ -156,6 +156,10 @@ class Admin::UsersController < Admin::AdminController
 
   def load_services
     @services = get_oauth_services
+  end
+
+  def load_account_deletion_info
+    @can_be_deleted, @cant_be_deleted_reason = can_be_deleted?(@user)
   end
 
   def get_oauth_services

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -299,6 +299,14 @@ class SessionsController < ApplicationController
   end
 
   def default_logout_url
-    CartoDB.url(self, 'public_visualizations_home')
+    # User could've been just deleted
+    username = CartoDB.subdomain_from_request(request)
+    if username && (Carto::User.exists?(username: username) || Carto::Organization.exists?(name: username))
+      CartoDB.url(self, 'public_visualizations_home')
+    elsif Cartodb::Central.sync_data_with_cartodb_central?
+      "https://carto.com"
+    else
+      "/404.html"
+    end
   end
 end

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -468,8 +468,8 @@ class Carto::User < ActiveRecord::Base
   # Some operations, such as user deletion, won't ask for password confirmation if password is not set (because of Google sign in, for example)
   def needs_password_confirmation?
     (!oauth_signin? || !last_password_change_date.nil?) &&
-        !created_with_http_authentication? &&
-        !organization.try(:auth_saml_enabled?)
+      !created_with_http_authentication? &&
+      !organization.try(:auth_saml_enabled?)
   end
 
   def oauth_signin?

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -467,7 +467,17 @@ class Carto::User < ActiveRecord::Base
 
   # Some operations, such as user deletion, won't ask for password confirmation if password is not set (because of Google sign in, for example)
   def needs_password_confirmation?
-    google_sign_in.nil? || !google_sign_in || !last_password_change_date.nil?
+    (!oauth_signin? || !last_password_change_date.nil?) &&
+        !created_with_http_authentication? &&
+        !organization.try(:auth_saml_enabled?)
+  end
+
+  def oauth_signin?
+    google_sign_in || github_user_id.present?
+  end
+
+  def created_with_http_authentication?
+    Carto::UserCreation.http_authentication.find_by_user_id(id).present?
   end
 
   def organization_owner?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -489,8 +489,8 @@ class User < Sequel::Model
   # (because of Google/Github sign in, for example)
   def needs_password_confirmation?
     (!oauth_signin? || last_password_change_date.present?) &&
-        !created_with_http_authentication? &&
-        !organization.try(:auth_saml_enabled?)
+      !created_with_http_authentication? &&
+      !organization.try(:auth_saml_enabled?)
   end
 
   def oauth_signin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -488,14 +488,17 @@ class User < Sequel::Model
   # Some operations, such as user deletion, won't ask for password confirmation if password is not set
   # (because of Google/Github sign in, for example)
   def needs_password_confirmation?
-    (
-      (!oauth_signin? || last_password_change_date.present?) &&
-      Carto::UserCreation.http_authentication.find_by_user_id(id).nil?
-    )
+    (!oauth_signin? || last_password_change_date.present?) &&
+        !created_with_http_authentication? &&
+        !organization.try(:auth_saml_enabled?)
   end
 
   def oauth_signin?
     google_sign_in || github_user_id.present?
+  end
+
+  def created_with_http_authentication?
+    Carto::UserCreation.http_authentication.find_by_user_id(id).present?
   end
 
   def password_confirmation

--- a/app/views/admin/users/account.html.erb
+++ b/app/views/admin/users/account.html.erb
@@ -145,7 +145,7 @@
       <% end %>
 
       <div class="FormAccount-footer <%= !@can_be_deleted ? 'FormAccount-footer--noMarginBottom' : '' %>">
-        <% unless @can_be_deleted -%>
+        <% if (!@can_be_deleted && @cant_be_deleted_reason) -%>
           <p class="FormAccount-footerText">
             <i class="CDB-IconFont CDB-IconFont-info FormAccount-footerIcon"></i>
             <span><%= @cant_be_deleted_reason %></span>

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -23,6 +23,45 @@ describe Admin::UsersController do
     login_as(@user, scope: @user.username)
   end
 
+  describe '#delete' do
+    let(:password) { 'abcdefgh' }
+    before(:all) do
+      @user2 = create_user(password: password)
+      @saml_organization = FactoryGirl.create(:saml_organization)
+      @saml_user = create_user(password: password, organization_id: @saml_organization.id)
+      @saml_user.reload
+    end
+
+    after(:all) do
+      @saml_organization.destroy_cascade
+    end
+
+    it 'requires password' do
+      host! "#{@user2.username}.localhost.lan"
+      login_as(@user2, scope: @user2.username)
+      delete account_user_url
+      Carto::User.where(id: @user2.id).first.should_not be_nil
+      last_response.status.should eq 200
+      last_response.body.include?('Password does not match').should be_true
+    end
+
+    it 'does not require password for SAML organizations' do
+      host! "#{@saml_organization.name}.localhost.lan"
+      login_as(@saml_user, scope: @saml_organization.name)
+      delete account_user_url(scope: @saml_organization.name)
+      Carto::User.where(id: @saml_user.id).first.should be_nil
+      last_response.body.include?('Password does not match').should be_false
+    end
+
+    it 'deletes if password match' do
+      host! "#{@user2.username}.localhost.lan"
+      login_as(@user2, scope: @user2.username)
+      delete account_user_url(deletion_password_confirmation: password)
+      Carto::User.where(id: @user2.id).first.should be_nil
+      last_response.body.include?('Password does not match').should be_false
+    end
+  end
+
   describe '#update' do
     describe '#account' do
       it 'updates password' do


### PR DESCRIPTION
This closes #11240.

Acceptance:
- Try to delete a SAML account (by himself). It should work without prompting for password.
- Try to delete a Google login account (same).
- Try to delete a normal account. It should ask for password and fail with wrong password.