### PR TITLE
Fixes adding a point geometry using the form

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-point-form-model.js
@@ -38,7 +38,12 @@ module.exports = EditFeatureGeometryFormModel.extend({
 
   _onLatLngChange: function () {
     var newGeoJSON = this._toGeoJSON();
-    var currentGeoJSON = JSON.parse(this._featureModel.get('the_geom'));
+    var currentGeoJSON = {};
+
+    if (this._featureModel.get('the_geom')) {
+      currentGeoJSON = JSON.parse(this._featureModel.get('the_geom'));
+    }
+
     // Only set `the_geom` if there's new geoJSON
     if (!_.isEqual(newGeoJSON, currentGeoJSON)) {
       this._featureModel.set('the_geom', JSON.stringify(newGeoJSON));

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-geometry-form-model.spec.js
@@ -97,6 +97,12 @@ describe('editor/layers/edit-feature-content-views/edit-feature-geometry-form-mo
         expect(this.featureModel.get('the_geom')).toBe('{"type":"Point","coordinates":[179.01234568,-89.01234568]}');
         expect(this.featureModel.hasChanged('the_geom')).toBeTruthy();
       });
+
+      it('should set the_geom\'s feature without setting a previous one', function () {
+        this.featureModel.unset('the_geom');
+        this.formModel.set({ lat: 10, lng: 20 });
+        expect(this.featureModel.get('the_geom')).toEqual('{"type":"Point","coordinates":[20,10]}');
+      });
     });
   });
 


### PR DESCRIPTION
Implements fix for #11189

Check out the original issue and [this comment](https://github.com/CartoDB/cartodb/issues/11189#issuecomment-272893457) to see how to test this fix.

The bug occurred because using the mouse to create the point, initialized the `the_geom` property of the `featureModel`. If the user created the point just with the form, the `the_geom` param wasn't created and [this line](https://github.com/CartoDB/cartodb/pull/11260/files#diff-be8d54efcc479909f418fd540159222cR44) produced an error.

My fix is simply making sure that, whenever `the_geom` is not present in the feature model, the data used comes from the `the_geom` from the form (`newGeoJSON`).