### PR TITLE
Fixing problem when an auto-styled polygon layer adds a new analysis

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/layer-definition-model.js
@@ -106,7 +106,7 @@ module.exports = Backbone.Model.extend({
   save: function (attrs, options) {
     // If the layer is saved by any circunstance, we should disable
     // autostyle if it was enabled and remove any style from it
-    this.styleModel.resetPropertiesFromAutoStyle();
+    this.styleModel && this.styleModel.resetPropertiesFromAutoStyle();
 
     attrs = _.extend(
       {},

--- a/lib/assets/core/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/layer-definition-model.js
@@ -103,11 +103,20 @@ module.exports = Backbone.Model.extend({
     }
   },
 
-  save: function () {
+  save: function (attrs, options) {
     // If the layer is saved by any circunstance, we should disable
-    // autostyle if it was enabled
-    this.set('autoStyle', false);
-    return Backbone.Model.prototype.save.apply(this, arguments);
+    // autostyle if it was enabled and remove any style from it
+    this.styleModel.resetPropertiesFromAutoStyle();
+
+    attrs = _.extend(
+      {},
+      {
+        autoStyle: false
+      },
+      attrs
+    );
+
+    return Backbone.Model.prototype.save.apply(this, [attrs, options]);
   },
 
   toJSON: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-converter.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-converter.js
@@ -400,10 +400,10 @@ function isTypeTorque (type) {
 function isCategoryType (styleDef, geometryType) {
   if (geometryType === 'line') {
     var stroke = styleDef.stroke;
-    return stroke && stroke.color.fixed == null;
+    return stroke && stroke.color && stroke.color.fixed == null;
   } else {
     var fill = styleDef.fill;
-    return fill && fill.color.fixed == null;
+    return fill && fill.color && fill.color.fixed == null;
   }
 }
 

--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-defaults/animation-style-defaults.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-defaults/animation-style-defaults.js
@@ -1,6 +1,5 @@
 var _ = require('underscore');
 var SimpleStyleDefaults = require('./simple-style-defaults');
-var defaultStyleValue = require('../../../data/default-cartography.json');
 
 module.exports = _.defaults({
 
@@ -21,14 +20,6 @@ module.exports = _.defaults({
     return {
       style: 'simple'
     };
-  },
-
-  _getStrokeAttrs: function (geometryType) {
-    return _.pick(defaultStyleValue['simple'][geometryType], 'stroke');
-  },
-
-  _getFillAttrs: function (geometryType) {
-    return _.pick(defaultStyleValue['simple'][geometryType], 'fill');
   },
 
   _getAnimatedAttrs: function (geometryType) {

--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-defaults/hexabins-aggregation-style-defaults.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-defaults/hexabins-aggregation-style-defaults.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var SimpleStyleDefaults = require('./simple-style-defaults');
-var defaultFormValues = require('../../../data/default-form-styles.json');
+var DefaultFormValues = require('../../../data/default-form-styles.json');
+var Utils = require('../../../helpers/utils');
 var rampList = require('cartocolor');
 
 module.exports = _.defaults({
@@ -18,12 +19,14 @@ module.exports = _.defaults({
   },
 
   _getStrokeAttrs: function (geometryType) {
+    var strokeAttrs = DefaultFormValues['stroke'];
     return {
-      stroke: defaultFormValues.stroke
+      stroke: Utils.cloneObject(strokeAttrs)
     };
   },
 
   _getFillAttrs: function (geometryType) {
+    var colors = rampList['ag_GrnYl'][5];
     return {
       fill: {
         'color': {
@@ -32,7 +35,7 @@ module.exports = _.defaults({
           quantification: 'quantiles',
           // TODO: flip the ramp when basemap is black
           // range: rampList.ag_GrnYl[5].reverse()
-          range: _.clone(rampList.ag_GrnYl[5])
+          range: Utils.cloneObject(colors)
         }
       }
     };

--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-defaults/simple-style-defaults.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-defaults/simple-style-defaults.js
@@ -1,7 +1,8 @@
 var _ = require('underscore');
 var StyleDefaults = require('./style-defaults');
-var defaultStyleValue = require('../../../data/default-cartography.json');
-var defaultFormValues = require('../../../data/default-form-styles.json');
+var DefaultCartography = require('../../../data/default-cartography.json');
+var DefaultFormValues = require('../../../data/default-form-styles.json');
+var Utils = require('../../../helpers/utils');
 
 module.exports = _.defaults({
 
@@ -11,7 +12,7 @@ module.exports = _.defaults({
       this._getFillAttrs(geometryType),
       this._getStrokeAttrs(geometryType),
       {
-        blending: defaultFormValues.blending
+        blending: DefaultFormValues['blending']
       },
       this._getAggrAttrs(geometryType),
       this._getLabelsAttrs()
@@ -19,22 +20,30 @@ module.exports = _.defaults({
   },
 
   _getFillAttrs: function (geometryType) {
-    return _.pick(defaultStyleValue['simple'][geometryType], 'fill');
+    var fillAttrs = DefaultCartography['simple'][geometryType]['fill'];
+    return {
+      fill: Utils.cloneObject(fillAttrs)
+    };
   },
 
   _getStrokeAttrs: function (geometryType) {
-    return _.pick(defaultStyleValue['simple'][geometryType], 'stroke');
+    var strokeAttrs = DefaultCartography['simple'][geometryType]['stroke'];
+    return {
+      stroke: Utils.cloneObject(strokeAttrs)
+    };
   },
 
   _getAggrAttrs: function () {
+    var aggrAttrs = DefaultFormValues['aggregation'];
     return {
-      aggregation: defaultFormValues.aggregation
+      aggregation: Utils.cloneObject(aggrAttrs)
     };
   },
 
   _getLabelsAttrs: function () {
+    var labelsAttrs = DefaultFormValues['labels'];
     return {
-      labels: defaultFormValues.labels
+      labels: Utils.cloneObject(labelsAttrs)
     };
   }
 }, StyleDefaults);

--- a/lib/assets/core/javascripts/cartodb3/helpers/utils.js
+++ b/lib/assets/core/javascripts/cartodb3/helpers/utils.js
@@ -286,5 +286,12 @@ module.exports = {
    */
   endsWith: function (str, suffix) {
     return str.indexOf(suffix, str.length - suffix.length) !== -1;
+  },
+
+  cloneObject: function (obj) {
+    if (!obj) {
+      return obj;
+    }
+    return JSON.parse(JSON.stringify(obj));
   }
 };

--- a/lib/assets/core/test/jasmine/cartodb3/data/layer-definition-model.spec.js
+++ b/lib/assets/core/test/jasmine/cartodb3/data/layer-definition-model.spec.js
@@ -52,11 +52,21 @@ describe('cartodb3/data/layer-definition-model', function () {
     expect(this.model.get('query')).toBeUndefined();
   });
 
-  it('should "remove" autoStyle attribute when model is saved', function () {
-    this.model.sync = function () {};
-    this.model.set('autoStyle', '8888-7777-6666-1111');
-    this.model.save();
-    expect(this.model.get('autoStyle')).toBeFalsy();
+  describe('.save', function () {
+    beforeEach(function () {
+      spyOn(this.model.styleModel, 'resetPropertiesFromAutoStyle');
+      this.model.sync = function () {};
+      this.model.set('autoStyle', '8888-7777-6666-1111');
+      this.model.save();
+    });
+
+    it('should "remove" the autoStyle attribute when model is saved', function () {
+      expect(this.model.get('autoStyle')).toBeFalsy();
+    });
+
+    it('should reset styleModel styles from autostyle properties', function () {
+      expect(this.model.styleModel.resetPropertiesFromAutoStyle).toHaveBeenCalled();
+    });
   });
 
   describe('.toJSON', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.102-staging",
+  "version": "4.5.103-staging",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.99-staging",
+  "version": "4.5.102-staging",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Ticket: #11252.

**THINGS TO BE TESTED:**
First, steps to be done before:
- Create a map with a layer of each geometry (points, lines and polygons).
- Add a widget with auto-style for each layer.

I would try to make the thing fail with each type of geometry. So, in short:
- Add the layer.
- Create a widget with autostyle powers.
- Autostyle it.
- Add a new analysis, no matter the type.

Also, I'd test when user re-uses the autostyle styles, in order to check everything works as expected:
- Create a map with one layer (no matter which geometry).
- Add a widget with autostyle powers.
- Autostyle it.
- Go to the layer style.
- Change something in the style.
- Check that autostyle style now is removed.

Check that the autostyle state disappears and a non-desired legend appears in the map.

cc @nobuti