### PR TITLE
11262 keep mimetype in organization assets

### DIFF
--- a/app/models/carto/asset.rb
+++ b/app/models/carto/asset.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
-require 'carto/assets_service'
-require 'carto/organization_assets_service'
+require_dependency 'carto/assets_service'
+require_dependency 'carto/organization_assets_service'
 
 module Carto
   class Asset < ActiveRecord::Base

--- a/lib/carto/assets_service.rb
+++ b/lib/carto/assets_service.rb
@@ -4,6 +4,7 @@ require_dependency 'carto/storage'
 
 module Carto
   class AssetsService
+    VALID_EXTENSIONS = %w{.jpeg .jpg .gif .png .svg}.freeze
 
     # resource can be anything accepted by OpenURI#open as a parameter
     def upload(namespace, resource)
@@ -59,6 +60,7 @@ module Carto
       # Filename might include a postfix hash -- Rack::Test::UploadedFile adds it
       extension.gsub!(/\d+-\w+-\w+\z/, '') if Rails.env.test?
 
+      raise UnprocesableEntityError.new("extension not accepted") unless VALID_EXTENSIONS.include?(extension)
       extension
     end
   end

--- a/lib/carto/assets_service.rb
+++ b/lib/carto/assets_service.rb
@@ -27,7 +27,7 @@ module Carto
     end
 
     def fetch_file(resource)
-      temp_file = Tempfile.new("asset_download_#{Time.now.utc.to_i}")
+      temp_file = Tempfile.new(["asset_download_#{Time.now.utc.to_i}", resource_extension(resource)])
 
       begin
         read = IO.copy_stream(open(resource), temp_file, max_size_in_bytes + 1)
@@ -49,6 +49,17 @@ module Carto
 
     def max_size_in_bytes
       1_048_576 # 1 MB
+    end
+
+    def resource_extension(resource)
+      # Resource can be a ActionDispatch::Http::UploadedFile or a URI string
+      filename = resource.respond_to?(:original_filename) ? resource.original_filename : resource
+      extension = File.extname(filename).downcase
+
+      # Filename might include a postfix hash -- Rack::Test::UploadedFile adds it
+      extension.gsub!(/\d+-\w+-\w+\z/, '') if Rails.env.test?
+
+      extension
     end
   end
 end

--- a/lib/carto/assets_service.rb
+++ b/lib/carto/assets_service.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'carto/storage'
+require_dependency 'carto/storage'
 
 module Carto
   class AssetsService

--- a/lib/carto/assets_service.rb
+++ b/lib/carto/assets_service.rb
@@ -57,9 +57,6 @@ module Carto
       filename = resource.respond_to?(:original_filename) ? resource.original_filename : resource
       extension = File.extname(filename).downcase
 
-      # Filename might include a postfix hash -- Rack::Test::UploadedFile adds it
-      extension.gsub!(/\d+-\w+-\w+\z/, '') if Rails.env.test?
-
       raise UnprocesableEntityError.new("extension not accepted") unless VALID_EXTENSIONS.include?(extension)
       extension
     end

--- a/spec/lib/carto/assets_service_spec.rb
+++ b/spec/lib/carto/assets_service_spec.rb
@@ -10,5 +10,26 @@ describe Carto::AssetsService do
         Carto::AssetsService.new.fetch_file(Tempfile.new('manolo'))
       }.to raise_error(Carto::UnprocesableEntityError)
     end
+
+    it 'keeps original extension' do
+      file = Tempfile.new(['test', '.svg'])
+      file.write('wadus')
+      file.rewind
+      uploaded_file = Rack::Test::UploadedFile.new(file)
+
+      temp_file = Carto::AssetsService.new.fetch_file(uploaded_file)
+      temp_file.path.should end_with '.svg'
+    end
+
+    it 'rejects invalid extensions' do
+      file = Tempfile.new(['test', '.exe'])
+      file.write('wadus')
+      file.rewind
+      uploaded_file = Rack::Test::UploadedFile.new(file)
+
+      expect {
+        Carto::AssetsService.new.fetch_file(uploaded_file)
+      }.to raise_error(Carto::UnprocesableEntityError)
+    end
   end
 end

--- a/spec/models/carto/asset_spec.rb
+++ b/spec/models/carto/asset_spec.rb
@@ -36,7 +36,7 @@ describe Carto::Asset do
     it 'should create a valid asset for organization and resource' do
       bypass_storage
       asset = Carto::Asset.for_organization(organization: @organization,
-                                            resource: Tempfile.new('manolo'))
+                                            resource: Tempfile.new(['manolo', '.jpg']))
 
       asset.valid?.should be_true
     end


### PR DESCRIPTION
Fixes #11262 
Keep extensions when saving tempfiles, which makes the mimetypes be correct upon download.

**Acceptance**
Upload a file using the organization assets API. Check that the download link contains the extension and the correct mimetype (check response headers). Check at least with `.svg` as it is the more problematic allowed format.

Example API call:
```
curl -X POST <orgname>.localhost.lan:3000/u/<username>/api/v1/organization/<organization_uuid>/assets?api_key=<api_key_of_user_in_org> -F resource=@path/to/file/you/want/to/upload.svg
```