### PR TITLE
11214 GitHub requires signup confirmation

### DIFF
--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -113,6 +113,7 @@ class Carto::UserCreation < ActiveRecord::Base
   # TODO: Shorcut, search for a better solution to detect requirement
   def requires_validation_email?
     google_sign_in != true &&
+      !github_user_id &&
       !has_valid_invitation? &&
       !Carto::Ldap::Manager.new.configuration_present? &&
       !created_via_api? &&


### PR DESCRIPTION
Fixes #11214 

Acceptance: Signup into an organization with GitHub. You should be automatically logged in, and you should not receive an email telling you to activate your account (you will receive a welcome one, but it shouldn't ask for activation).