### PR TITLE
Update CartoDB to CARTO when renaming map

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/map-operations/rename-map.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/map-operations/rename-map.js
@@ -23,7 +23,7 @@ module.exports = function (opts) {
     wait: true,
     success: function (mdl, e) {
       successCallback && successCallback(newName);
-      document.title = newName + ' | CartoDB';
+      document.title = newName + ' | CARTO';
       notification.set({
         status: 'success',
         info: _t('editor.maps.rename.success', {name: newName}),


### PR DESCRIPTION
I found a place where CartoDB was still active and changed it in the source code. It should be CARTO now when the map name is edited in Builder.