### PR TITLE
URI encode more problematic characters

### DIFF
--- a/app/models/carto/visualization_export.rb
+++ b/app/models/carto/visualization_export.rb
@@ -44,7 +44,10 @@ module Carto
       file = CartoDB::FileUploadFile.new(filepath)
 
       s3_config = Cartodb.config[:exporter]['s3'] || {}
-      s3_config['content-disposition'] = %{attachment;filename="#{URI::encode(file.original_filename.force_encoding('iso-8859-1'))}";filename*=utf-8''#{URI::encode(file.original_filename)}}
+
+      plain_name = header_encode(file.original_filename.force_encoding('iso-8859-1'))
+      utf_name = header_encode(file.original_filename)
+      s3_config['content-disposition'] = %{attachment;filename=#{plain_name};filename*=utf-8''#{utf_name}}
 
       results = file_upload_helper.upload_file_to_storage(
         file_param: file,
@@ -84,6 +87,10 @@ module Carto
     end
 
     private
+
+    def header_encode(name)
+      URI.encode(name, /[^#{URI::PATTERN::UNRESERVED}]/)
+    end
 
     def default_file_upload_helper
       CartoDB::FileUpload.new(Cartodb.get_config(:exporter, "uploads_path"))

--- a/app/models/carto/visualization_export.rb
+++ b/app/models/carto/visualization_export.rb
@@ -47,7 +47,7 @@ module Carto
 
       plain_name = header_encode(file.original_filename.force_encoding('iso-8859-1'))
       utf_name = header_encode(file.original_filename)
-      s3_config['content-disposition'] = %{attachment;filename=#{plain_name};filename*=utf-8''#{utf_name}}
+      s3_config['content-disposition'] = %{attachment;filename="#{plain_name}";filename*=utf-8''#{utf_name}}
 
       results = file_upload_helper.upload_file_to_storage(
         file_param: file,


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb-management/issues/4756

Encodes more characters. URI::Encode has an unsafe parameter which takes a regex on which characters to encode. By default, it takes al URL safe characters, this changes it to all special characters including things like comma or " which have special meaning in headers (but not in URLs)

**Acceptance**
Rename a map with some special characters and try to export it as .carto. Test at least the following characters: quotes (" and '), space, comma/semicolon (, ;), star (*), spanish characters, chinese characters, emoji.

It's important to test with different browsers. At least Chrome (as it was the one giving issues), but it would be great to cover the major browsers as well.