### PR TITLE
fixed minor typo in ui dialogs

### DIFF
--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -562,7 +562,7 @@
       },
       "maps-metadata": {
         "modal-title": "Map metadata",
-        "modal-desc": "Edit the attributtes of your map",
+        "modal-desc": "Edit the attributes of your map",
         "back-btn": "GO BACK",
         "save-btn": "Save",
         "cancel-btn": "Cancel",
@@ -588,7 +588,7 @@
       },
       "dataset-metadata": {
         "modal-title": "Dataset metadata",
-        "modal-desc": "Edit the attributtes of your dataset",
+        "modal-desc": "Edit the attributes of your dataset",
         "back-btn": "GO BACK",
         "save-btn": "Save",
         "cancel-btn": "Cancel",


### PR DESCRIPTION
@xavijam, caught this today when helping a customer through Community. Fixed tiny, minor spelling error from the metadata options.