### PR TITLE
Fixing bad argument passing for data observatory metadata

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/data-observatory-metadata.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/data-observatory-metadata.js
@@ -3,7 +3,11 @@ var Backbone = require('backbone');
 var cdb = require('cartodb.js');
 
 function getQueryForGeometryType (geometryType) {
-  return 'select * from obs_legacybuildermetadata(\'' + (geometryType === 'polygon' ? 'sum' : '') + '\')';
+  if (geometryType === 'polygon') {
+    return "select * from obs_legacybuildermetadata('sum')";
+  } else {
+    return 'select * from obs_legacybuildermetadata()';
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.112",
+  "version": "4.5.113",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes #11318 

Lecacybuildermatada function should receive no argument when is not a polygon geometry type