### PR TITLE
forms: make Text default type in schema

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
@@ -49,7 +49,7 @@ module.exports = Backbone.Model.extend({
       return fieldType === columnType;
     });
 
-    return supportedColumnType || 'string'
+    return supportedColumnType || 'string';
   },
 
   _generateSchema: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.js
@@ -44,6 +44,14 @@ module.exports = Backbone.Model.extend({
     return rows && rows.length ? 'Suggest' : 'Text';
   },
 
+  _getSupportedColumnType: function (columnType) {
+    var supportedColumnType = _.find(_.keys(FIELDTYPE_TO_FORMTYPE), function (fieldType) {
+      return fieldType === columnType;
+    });
+
+    return supportedColumnType || 'string'
+  },
+
   _generateSchema: function () {
     var self = this;
 
@@ -51,7 +59,7 @@ module.exports = Backbone.Model.extend({
 
     this._columnsCollection.each(function (mdl) {
       var columnName = mdl.get('name');
-      var columnType = mdl.get('type');
+      var columnType = this._getSupportedColumnType(mdl.get('type'));
 
       if (!_.contains(BLACKLISTED_COLUMNS, columnName)) {
         // default field type

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/edit-feature-content-views/edit-feature-attributes-form-model.spec.js
@@ -70,6 +70,9 @@ describe('editor/layers/edit-feature-content-views/edit-feature-attributes-form-
       }, {
         name: 'updated_at',
         type: 'date'
+      }, {
+        name: 'coordonnees',
+        type: 'number[]'
       }
     ], {
       querySchemaModel: this.querySchemaModel,
@@ -85,7 +88,8 @@ describe('editor/layers/edit-feature-content-views/edit-feature-attributes-form-
       created_at: '2016-10-21T11:27:39+00:00',
       the_geom: '{"type":"Point","coordinates":[0,0]}',
       the_geom_webmercator: '{"type":"Point","coordinates":[0,0]}',
-      updated_at: '2016-10-21T11:27:39+00:00'
+      updated_at: '2016-10-21T11:27:39+00:00',
+      coordonnees: '48.1100259201,-1.6780371631'
     });
 
     this.formModel = new EditFeatureAttributesFormModel(this.featureModel.toJSON(), {
@@ -96,7 +100,7 @@ describe('editor/layers/edit-feature-content-views/edit-feature-attributes-form-
     });
   });
 
-  it('should generate schema from columns collection and omit reserved columns', function () {
+  it('should generate schema from columns collection, omit reserved columns, and assign default Text type', function () {
     expect(this.formModel.schema).toEqual({
       'cartodb_id': {
         'type': 'Number',
@@ -133,6 +137,9 @@ describe('editor/layers/edit-feature-content-views/edit-feature-attributes-form-
       },
       'date': {
         'type': 'DateTime'
+      },
+      'coordonnees': {
+        'type': 'Text'
       }
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.112",
+  "version": "4.5.113",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.113",
+  "version": "4.5.112",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
re: https://github.com/CartoDB/cartodb/issues/11328

**to reproduce in acceptance**

- import a dataset with culumn type `number[]`

https://data.rennesmetropole.fr/explore/dataset/topologie-des-stations-le-velo-star0/download?format=geojson&timezone=Europe/Berlin&use_labels_for_header=true

- go to edit feature
- column should appear as Text
