### PR TITLE
Use the URI-supported way for finding filenames in URLs

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -345,7 +345,7 @@ module CartoDB
       end
 
       def filename_from_url
-        url_name = self.class.url_filename_regex.match(URI.decode(@translated_url)).to_s
+        url_name = self.class.url_filename_regex.match(@translated_url).to_s
 
         url_name unless url_name.empty?
       end

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -345,7 +345,8 @@ module CartoDB
       end
 
       def filename_from_url
-        url_name = self.class.url_filename_regex.match(@translated_url).to_s
+        unescaped_url = CGI.unescape(@translated_url)
+        url_name = self.class.url_filename_regex.match(unescaped_url).to_s
 
         url_name unless url_name.empty?
       end

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -20,9 +20,6 @@ require_relative '../helpers/quota_check_helpers.rb'
 # interchangeable with CartoDB::Importer2::DatasourceDownloader. A better way to have
 # managed this might have been through inheritance, since Ruby doesn't provide interfaces.
 # The out-facing methods this class must implement for this purpose are:
-# - supported_extensions
-# - supported_extensions_match
-# - url_filename_regex
 # - provides_stream?
 # - http_download?
 # - multi_resource_import_supported?
@@ -38,26 +35,6 @@ module CartoDB
   module Importer2
     class Downloader
       include CartoDB::Importer2::QuotaCheckHelpers, Carto::UrlValidator
-
-      def self.supported_extensions
-        @supported_extensions ||= CartoDB::Importer2::Unp::SUPPORTED_FORMATS
-                                  .concat(CartoDB::Importer2::Unp::COMPRESSED_EXTENSIONS)
-                                  .sort_by(&:length).reverse
-      end
-
-      def self.supported_extensions_match
-        @supported_extensions_match ||= supported_extensions.map { |ext|
-          ext = ext.gsub('.', '\\.')
-          [/#{ext}$/i, /#{ext}(?=\.)/i, /#{ext}(?=\?)/i, /#{ext}(?=&)/i]
-        }.flatten
-      end
-
-      def self.url_filename_regex
-        return @url_filename_regex if @url_filename_regex
-
-        se_match_regex = Regexp.union(supported_extensions_match)
-        @url_filename_regex = Regexp.new("[[:word:]-]+#{se_match_regex}+", Regexp::IGNORECASE)
-      end
 
       def provides_stream?
         false

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -20,6 +20,9 @@ require_relative '../helpers/quota_check_helpers.rb'
 # interchangeable with CartoDB::Importer2::DatasourceDownloader. A better way to have
 # managed this might have been through inheritance, since Ruby doesn't provide interfaces.
 # The out-facing methods this class must implement for this purpose are:
+# - supported_extensions
+# - supported_extensions_match
+# - url_filename_regex
 # - provides_stream?
 # - http_download?
 # - multi_resource_import_supported?
@@ -35,6 +38,26 @@ module CartoDB
   module Importer2
     class Downloader
       include CartoDB::Importer2::QuotaCheckHelpers, Carto::UrlValidator
+
+      def self.supported_extensions
+        @supported_extensions ||= CartoDB::Importer2::Unp::SUPPORTED_FORMATS
+                                  .concat(CartoDB::Importer2::Unp::COMPRESSED_EXTENSIONS)
+                                  .sort_by(&:length).reverse
+      end
+
+      def self.supported_extensions_match
+        @supported_extensions_match ||= supported_extensions.map { |ext|
+          ext = ext.gsub('.', '\\.')
+          [/#{ext}$/i, /#{ext}(?=\.)/i, /#{ext}(?=\?)/i, /#{ext}(?=&)/i]
+        }.flatten
+      end
+
+      def self.url_filename_regex
+        return @url_filename_regex if @url_filename_regex
+
+        se_match_regex = Regexp.union(supported_extensions_match)
+        @url_filename_regex = Regexp.new("[[:word:]-]+#{se_match_regex}+", Regexp::IGNORECASE)
+      end
 
       def provides_stream?
         false

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -347,7 +347,17 @@ module CartoDB
       def filename_from_url
         filename = CGI.unescape(File.basename(URI(@translated_url).path))
 
-        filename if filename.present?
+        extension = File.extname(filename)
+        if extension.present? && self.class.supported_extensions.include?(extension)
+          filename
+        else
+          regex_match = self.class
+                            .url_filename_regex
+                            .match(@translated_url)
+                            .to_s
+
+          return regex_match if regex_match.present?
+        end
       end
 
       CONTENT_TYPES_MAPPING = [

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -351,12 +351,13 @@ module CartoDB
         if extension.present? && self.class.supported_extensions.include?(extension)
           filename
         else
+          # For non-conventional URLs (i.e: filename in params)
           regex_match = self.class
                             .url_filename_regex
                             .match(@translated_url)
                             .to_s
 
-          return regex_match if regex_match.present?
+          regex_match if regex_match.present?
         end
       end
 

--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -345,10 +345,9 @@ module CartoDB
       end
 
       def filename_from_url
-        unescaped_url = CGI.unescape(@translated_url)
-        url_name = self.class.url_filename_regex.match(unescaped_url).to_s
+        filename = CGI.unescape(File.basename(URI(@translated_url).path))
 
-        url_name unless url_name.empty?
+        filename if filename.present?
       end
 
       CONTENT_TYPES_MAPPING = [

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -338,7 +338,7 @@ describe Downloader do
     end
 
     it 'gets the file name from the URL if no Content-Disposition header and custom params schema is used' do
-      hard_url = "https://manolo.escobar.es/zip_file.csv.zip?param=1.zip&otherinfo"
+      hard_url = "https://manolo.escobar.es/param&myfilenameparam&zip_file.csv.zip&otherinfo"
 
       downloader = Downloader.new(@user.id, hard_url)
       downloader.send(:set_headers, Hash.new)

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -338,7 +338,7 @@ describe Downloader do
     end
 
     it 'gets the file name from the URL if no Content-Disposition header and custom params schema is used' do
-      hard_url = "https://manolo.escobar.es/param&myfilenameparam&zip_file.csv.zip&otherinfo"
+      hard_url = "https://manolo.escobar.es/zip_file.csv.zip?param=1.zip&otherinfo"
 
       downloader = Downloader.new(@user.id, hard_url)
       downloader.send(:set_headers, Hash.new)


### PR DESCRIPTION
See #11334

## Context

There are 4 strategies to decide the filename of a downloaded file in the importer. In order of preference:

1. A custom name provided for the outside
2. Looking at headers
3. Looking into the URL 
4. Picking a random name

Step 3. uses a regex that will only match `.carto` if the URL is encoded. The new code decoded the URL since it helped with some other matches, but it seems that those used to work with other strategies. `.carto` files are usually uploaded and rely solely on URL detection, so I guess it's best to go to old behaviour (match against encoded URL) and think in some optimisation for the future.

This solution uses the `URI` way and if the extension is not recognised defaults to old method.

## Acceptance

- [x] Export as SHP (try to re-import it as .zip, .tgz, .tar.gz)
- [x] Export as CSV (try to re-import it)
- [x] Export as KML (try to re-import it)
- [x] Export as GeoJSON (try to re-import it)
- [x] Try to export a private table
- [x] Import OSM (Go to https://www.openstreetmap.org/ and import an export)
- [x] Connect a sync Dataset (if you can't, change your user limits)
- [x] Force a sync (you need to wait for 15 min)
- [x] Disconnect sync dataset in the options menu
- [x] Export a map (.carto)
- [x] Import a map (.carto)
- [x] Connect dataset from URL
- [x] Connect dataset from dropbox
- [x] Connect dataset from GDrive
- [ ] Import from one click
- [x] Common data import
- [x] Create table from SQL

cc @CartoDB/builder-backend 