### PR TITLE
11335 delete layer ternaries

### DIFF
--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -59,13 +59,13 @@ module Carto
     serialize :infowindow, CartoJsonSerializer
     serialize :tooltip, CartoJsonSerializer
 
-    has_many :layers_maps
+    has_many :layers_maps, dependent: :destroy
     has_many :maps, through: :layers_maps, after_add: :set_default_order
 
-    has_many :layers_user
+    has_many :layers_user, dependent: :destroy
     has_many :users, through: :layers_user, after_add: :set_default_order
 
-    has_many :layers_user_table
+    has_many :layers_user_table, dependent: :destroy
     has_many :user_tables, through: :layers_user_table, class_name: Carto::UserTable
 
     has_many :widgets, class_name: Carto::Widget, order: '"order"'


### PR DESCRIPTION
Fixes #11335 on Rails side.

I would have liked to do this from the DB (foreign keys), but I ran into some blockers (lack of indices), so I'm launching this for now to unblock #11303. I split the DB issues to https://github.com/CartoDB/cartodb-management/issues/4817

~~I would suggest doing acceptance for both at once (combined branch: `10939-11335-merged`), since they are related and the tests for them have a large overlap.~~