### PR TITLE
11324 migration of simple style with property set

### DIFF
--- a/app/controllers/carto/api/layer_presenter.rb
+++ b/app/controllers/carto/api/layer_presenter.rb
@@ -475,7 +475,8 @@ module Carto
                       when 'density'
                         spp['aggregation']['value']
                       else
-                        raise "Unsupported source type: #{@source_type}"
+                        # Ignore some malformed wizards that have a property set even when the type does not support it
+                        return
                       end
 
         destination['attribute'] = wpp['property']

--- a/spec/requests/carto/api/layer_presenter_spec.rb
+++ b/spec/requests/carto/api/layer_presenter_spec.rb
@@ -229,16 +229,21 @@ describe Carto::Api::LayerPresenter do
             }
           end
 
-          before(:each) do
+          it 'sets fill size from marker-width' do
             layer = build_layer_with_wizard_properties(polygon_wizard_properties)
             options = presenter_with_style_properties(layer).to_poro['options']
-            @properties = options['style_properties']['properties']
-            @fill_color = @properties['fill']['color']
-            @fill_size = @properties['fill']['size']
+            properties = options['style_properties']['properties']
+            fill_size = properties['fill']['size']
+            fill_size['fixed'].should eq marker_width
           end
 
-          it 'sets fill size from marker-width' do
-            @fill_size['fixed'].should eq marker_width
+          it 'ignores property' do
+            polygon_wizard_properties['properties']['property'] = 'wadus_property'
+            layer = build_layer_with_wizard_properties(polygon_wizard_properties)
+            options = presenter_with_style_properties(layer).to_poro['options']
+
+            properties = options['style_properties']['properties']
+            JSON.dump(properties).should_not include 'wadus_property'
           end
         end
 
@@ -273,10 +278,17 @@ describe Carto::Api::LayerPresenter do
 
       describe 'cluster' do
         let(:query_wrapper) { "with meta ... <%= sql %> ..." }
+        let(:cluster_options) do
+          {
+            "query_wrapper" => query_wrapper,
+            "wizard_properties" => {
+              "type" => "cluster",
+              "properties" => { "method" => "3 Buckets", "marker-fill" => "#FD8D3C" }
+            }
+          }
+        end
         before(:each) do
-          properties = { "type" => "cluster", "properties" => { "method" => "3 Buckets", "marker-fill" => "#FD8D3C" } }
-          options = { 'query_wrapper' => query_wrapper, 'wizard_properties' => properties }
-          layer = FactoryGirl.build(:carto_layer, options: options)
+          layer = FactoryGirl.build(:carto_layer, options: cluster_options)
           @options = presenter_with_style_properties(layer).to_poro['options']
           @properties = @options['style_properties']['properties']
         end
@@ -288,6 +300,14 @@ describe Carto::Api::LayerPresenter do
 
         it 'sets query_wrapper at sql_wrap' do
           @options['sql_wrap'].should eq query_wrapper
+        end
+
+        it 'ignores property' do
+          cluster_options['wizard_properties']['properties']['property'] = 'wadus_property'
+          layer = FactoryGirl.build(:carto_layer, options: cluster_options)
+          options = presenter_with_style_properties(layer).to_poro['options']
+          properties = options['style_properties']['properties']
+          JSON.dump(properties).should_not include 'wadus_property'
         end
       end
 


### PR DESCRIPTION
Fixes #11324 

There are some old wizard properties of type polygon which have a `property` set, even though they shouldn't. This caused the migrator to crash. This avoids the crash and does not try to set the property in those cases.

**Acceptance**
- [ ] Create an editor map, apply a polygon wizard, and manually edit the wizard properties of the layer to add a `property` field, using a column name as the value (see the ticket for an example).
- [ ] Then switch to builder and open the map. The style should be migrated without crashing.