### PR TITLE
Warn organization owner if signup is enabled but not valid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ WORKING_SPECS_2 = \
 WORKING_SPECS_4 = \
 	services/wms/spec/unit/wms_spec.rb \
 	services/sql-api/spec/sql_api_spec.rb \
+	spec/requests/admin/organizations_controller_spec.rb \
 	spec/requests/admin/visualizations_spec.rb \
 	spec/requests/api/json/visualizations_controller_spec.rb \
 	spec/requests/carto/api/visualizations_controller_spec.rb \

--- a/app/assets/stylesheets/common/flash-message.css.scss
+++ b/app/assets/stylesheets/common/flash-message.css.scss
@@ -12,8 +12,10 @@
 .FlashMessage > .u-inner {
   @include display-flex();
   @include justify-content(center, justify);
-  @include align-items(center);
+  @include flex-direction(column);
+  @include align-items(left);
   height: 80px;
+  line-height: $sLineHeight-larger;
 }
 .FlashMessage.FlashMessage--inDialogWithFiltersNavListing {
   position: fixed;
@@ -30,12 +32,19 @@
 .FlashMessage--error {
   background: #FFDBDB;
 }
+.FlashMessage--warning {
+  background: #FFFFD9;
+}
 .FlashMessage--main {
   background: #F0F7FC;
 }
 .FlashMessage-info {
   color: $cTypography-headers;
   font-size: $sFontSize-large;
+}
+.FlashMessage-detail {
+  color: $cTypography-secondary;
+  font-size: $sFontSize-normal;
 }
 .FlashMessage-info--larger {
   max-width: 720px;

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -109,8 +109,11 @@ class Admin::OrganizationsController < Admin::AdminController
     @organization = current_user.organization
     raise RecordNotFound unless @organization.present? && current_user.organization_owner?
 
-    unless @organization.validate_disk_quota
-      flash.now[:warning] = "Your organization has run out of quota"
+    warning = []
+    warning << "Your organization has run out of quota" unless @organization.validate_disk_quota
+    warning << "Your organization has run out of seats" unless @organization.validate_builder_seats
+    unless warning.empty?
+      flash.now[:warning] = warning.join('. ')
       flash.now[:detail] = "Users won't be able to sign up to your organization. <a href='mailto:contact@carto.com'>Contact us</a> to increase your quota."
     end
 

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -109,6 +109,11 @@ class Admin::OrganizationsController < Admin::AdminController
     @organization = current_user.organization
     raise RecordNotFound unless @organization.present? && current_user.organization_owner?
 
+    unless @organization.validate_disk_quota
+      flash.now[:warning] = "Your organization has run out of quota"
+      flash.now[:detail] = "Users won't be able to sign up to your organization. <a href='mailto:contact@carto.com'>Contact us</a> to increase your quota."
+    end
+
     # INFO: Special scenario of handcrafted URL to go to organization-based signup page
     @organization_signup_url =
       "#{CartoDB.protocol}://#{@organization.name}.#{CartoDB.account_host}#{CartoDB.path(self, 'signup_organization_user')}"

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -118,8 +118,8 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def display_signup_warnings
     warning = []
-    warning << "Your organization has run out of quota" unless @organization.validate_disk_quota
-    warning << "Your organization has run out of seats" unless @organization.validate_builder_seats
+    warning << "Your organization has run out of quota" unless @organization.valid_disk_quota?
+    warning << "Your organization has run out of seats" unless @organization.valid_builder_seats?
     unless warning.empty?
       flash.now[:warning] = "#{warning.join('. ')}."
       flash.now[:warning_detail] = "Users won't be able to sign up to your organization. <a href='mailto:contact@carto.com'>Contact us</a> to increase your quota."

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -109,6 +109,14 @@ class Admin::OrganizationsController < Admin::AdminController
     @organization = current_user.organization
     raise RecordNotFound unless @organization.present? && current_user.organization_owner?
 
+    display_signup_warnings if @organization.signup_page_enabled
+
+    # INFO: Special scenario of handcrafted URL to go to organization-based signup page
+    @organization_signup_url =
+      "#{CartoDB.protocol}://#{@organization.name}.#{CartoDB.account_host}#{CartoDB.path(self, 'signup_organization_user')}"
+  end
+
+  def display_signup_warnings
     warning = []
     warning << "Your organization has run out of quota" unless @organization.validate_disk_quota
     warning << "Your organization has run out of seats" unless @organization.validate_builder_seats
@@ -116,10 +124,6 @@ class Admin::OrganizationsController < Admin::AdminController
       flash.now[:warning] = warning.join('. ')
       flash.now[:detail] = "Users won't be able to sign up to your organization. <a href='mailto:contact@carto.com'>Contact us</a> to increase your quota."
     end
-
-    # INFO: Special scenario of handcrafted URL to go to organization-based signup page
-    @organization_signup_url =
-      "#{CartoDB.protocol}://#{@organization.name}.#{CartoDB.account_host}#{CartoDB.path(self, 'signup_organization_user')}"
   end
 
   def show_billing

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -121,8 +121,8 @@ class Admin::OrganizationsController < Admin::AdminController
     warning << "Your organization has run out of quota" unless @organization.validate_disk_quota
     warning << "Your organization has run out of seats" unless @organization.validate_builder_seats
     unless warning.empty?
-      flash.now[:warning] = warning.join('. ')
-      flash.now[:detail] = "Users won't be able to sign up to your organization. <a href='mailto:contact@carto.com'>Contact us</a> to increase your quota."
+      flash.now[:warning] = "#{warning.join('. ')}."
+      flash.now[:warning_detail] = "Users won't be able to sign up to your organization. <a href='mailto:contact@carto.com'>Contact us</a> to increase your quota."
     end
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -96,9 +96,13 @@ class Organization < Sequel::Model
       errors.add(:organization, "not enough viewer seats")
     end
 
-    if unassigned_quota <= 0 || unassigned_quota < user.quota_in_bytes.to_i
+    if !validate_disk_quota(user.quota_in_bytes.to_i)
       errors.add(:quota_in_bytes, "not enough disk quota")
     end
+  end
+
+  def validate_disk_quota(quota = default_quota_in_bytes)
+    unassigned_quota >= quota
   end
 
   def before_validation

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -88,7 +88,7 @@ class Organization < Sequel::Model
   end
 
   def validate_for_signup(errors, user)
-    if user.builder? && !validate_builder_seats([user])
+    if user.builder? && !valid_builder_seats?([user])
       errors.add(:organization, "not enough seats")
     end
 
@@ -96,16 +96,16 @@ class Organization < Sequel::Model
       errors.add(:organization, "not enough viewer seats")
     end
 
-    if !validate_disk_quota(user.quota_in_bytes.to_i)
+    if !valid_disk_quota?(user.quota_in_bytes.to_i)
       errors.add(:quota_in_bytes, "not enough disk quota")
     end
   end
 
-  def validate_disk_quota(quota = default_quota_in_bytes)
+  def valid_disk_quota?(quota = default_quota_in_bytes)
     unassigned_quota >= quota
   end
 
-  def validate_builder_seats(users = [])
+  def valid_builder_seats?(users = [])
     remaining_seats(excluded_users: users) > 0
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -88,7 +88,7 @@ class Organization < Sequel::Model
   end
 
   def validate_for_signup(errors, user)
-    if user.builder? && remaining_seats(excluded_users: [user]) <= 0
+    if user.builder? && !validate_builder_seats([user])
       errors.add(:organization, "not enough seats")
     end
 
@@ -103,6 +103,10 @@ class Organization < Sequel::Model
 
   def validate_disk_quota(quota = default_quota_in_bytes)
     unassigned_quota >= quota
+  end
+
+  def validate_builder_seats(users = [])
+    remaining_seats(excluded_users: users) > 0
   end
 
   def before_validation

--- a/app/views/admin/organizations/groups.html.erb
+++ b/app/views/admin/organizations/groups.html.erb
@@ -13,6 +13,8 @@
   <%= stylesheet_link_tag 'organization.css', :media => 'all' %>
 <% end %>
 
+<%= render :partial => 'shared/flash_message' %>
+
 <div class="FormAccount-Section u-inner">
   <%= render partial: 'admin/shared/pages_subheader' %>
 

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,32 +1,13 @@
 <% error_message = local_assigns[:error_message] %>
-<% if cookies[:flash] || flash[:success] || flash[:warning] || error_message || flash[:error] %>
-  <%
-      flash_container_class = if flash[:success]
-                                'FlashMessage--success'
-                              elsif flash[:warning]
-                                'FlashMessage--warning'
-                              elsif error_message || flash[:error]
-                                'FlashMessage--error'
-                              end
-  %>
-  <div class="CDB-Text FlashMessage <%= flash_container_class %>">
-    <div class="u-inner">
-      <%
-        flash_class =  if flash[:success]
-                         'success'
-                       elsif flash[:warning]
-                         'warning'
-                       elsif error_message || flash[:error]
-                         'error'
-                       end
-      %>
-      <p class="FlashMessage-info <%= flash_class %>">
-        <%= raw cookies[:flash] || flash[:success]  || flash[:warning] || [error_message, flash[:error]].compact.join(', ') %>
-      </p>
-
-      <% if flash[:detail] %>
-          <p class="FlashMessage-detail <%= flash_class %>"><%= raw flash[:detail] %></p>
-      <% end %>
-    </div>
-  </div>
+<% if flash[:success] %>
+    <%= render(partial: 'shared/flash_single_message', locals: { message_class: 'success', message: flash[:success], detail: flash[:success_detail] }) %>
+<% end %>
+<% if error_message || flash[:error] %>
+    <%= render(partial: 'shared/flash_single_message', locals: { message_class: 'error', message: error_message || flash[:error], detail: flash[:error_detail] }) %>
+<% end %>
+<% if flash[:warning] %>
+    <%= render(partial: 'shared/flash_single_message', locals: { message_class: 'warning', message: flash[:warning], detail: flash[:warning_detail] }) %>
+<% end %>
+<% if cookies[:flash] %>
+    <%= render(partial: 'shared/flash_single_message', locals: { message: cookies[:flash] }) %>
 <% end %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,10 +1,32 @@
 <% error_message = local_assigns[:error_message] %>
-<% if cookies[:flash] || flash[:success] || error_message || flash[:error] %>
-  <div class="CDB-Text FlashMessage <%= 'FlashMessage--success' if flash[:success] %><%= 'FlashMessage--error' if error_message || flash[:error] %>">
+<% if cookies[:flash] || flash[:success] || flash[:warning] || error_message || flash[:error] %>
+  <%
+      flash_container_class = if flash[:success]
+                                'FlashMessage--success'
+                              elsif flash[:warning]
+                                'FlashMessage--warning'
+                              elsif error_message || flash[:error]
+                                'FlashMessage--error'
+                              end
+  %>
+  <div class="CDB-Text FlashMessage <%= flash_container_class %>">
     <div class="u-inner">
-      <p class="FlashMessage-info <%= 'success' if flash[:success] %><%= 'error' if error_message || flash[:error] %>">
-        <%= raw cookies[:flash] || flash[:success] || [error_message, flash[:error]].compact.join(', ') %>
+      <%
+        flash_class =  if flash[:success]
+                         'success'
+                       elsif flash[:warning]
+                         'warning'
+                       elsif error_message || flash[:error]
+                         'error'
+                       end
+      %>
+      <p class="FlashMessage-info <%= flash_class %>">
+        <%= raw cookies[:flash] || flash[:success]  || flash[:warning] || [error_message, flash[:error]].compact.join(', ') %>
       </p>
+
+      <% if flash[:detail] %>
+          <p class="FlashMessage-detail <%= flash_class %>"><%= raw flash[:detail] %></p>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_flash_single_message.html.erb
+++ b/app/views/shared/_flash_single_message.html.erb
@@ -1,0 +1,16 @@
+<%
+  flash_class = local_assigns[:message_class]
+  flash_container_class = "FlashMessage--#{flash_class}"
+  flash_message = local_assigns[:message]
+  flash_detail = local_assigns[:detail]
+%>
+<div class="CDB-Text FlashMessage <%= flash_container_class %>">
+  <div class="u-inner">
+    <p class="FlashMessage-info <%= flash_class %>">
+      <%= raw flash_message %>
+    </p>
+    <% if flash_detail %>
+        <p class="FlashMessage-detail <%= flash_class %>"><%= raw flash_detail %></p>
+    <% end %>
+  </div>
+</div>

--- a/lib/build/tasks/watch.js
+++ b/lib/build/tasks/watch.js
@@ -88,6 +88,7 @@ exports.task = function () {
     css: {
       files: [
         'app/assets/stylesheets/editor-3/**/*.css.scss',
+        // 'app/assets/stylesheets/common/**/*.css.scss',
         'app/assets/client/stylesheets/**/*.css.scss'
       ],
       tasks: ['css'],

--- a/lib/build/tasks/watch.js
+++ b/lib/build/tasks/watch.js
@@ -88,6 +88,7 @@ exports.task = function () {
     css: {
       files: [
         'app/assets/stylesheets/editor-3/**/*.css.scss',
+        // Uncomment next line to watch Dashboard and Editor SCSS files
         // 'app/assets/stylesheets/common/**/*.css.scss',
         'app/assets/client/stylesheets/**/*.css.scss'
       ],

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -5,6 +5,9 @@ describe Admin::OrganizationsController do
   include Warden::Test::Helpers
   include_context 'organization with users helper'
 
+  let(:out_of_quota_message) { "Your organization has run out of quota" }
+  let(:out_of_seats_message) { "Your organization has run out of seats" }
+
   describe '#auth' do
     before(:each) do
       host! "#{@organization.name}.localhost.lan"
@@ -27,8 +30,8 @@ describe Admin::OrganizationsController do
         get organization_auth_url(user_domain: @org_user_owner.username)
 
         response.status.should eq 200
-        response.body.should_not include("Your organization has run out of quota")
-        response.body.should_not include("Your organization has run out of seats")
+        response.body.should_not include(out_of_quota_message)
+        response.body.should_not include(out_of_seats_message)
       end
 
       it 'displays out of quota message if there is no remaining quota' do
@@ -44,7 +47,7 @@ describe Admin::OrganizationsController do
         get organization_auth_url(user_domain: @org_user_owner.username)
 
         response.status.should eq 200
-        response.body.should include("Your organization has run out of quota")
+        response.body.should include(out_of_quota_message)
 
         @organization.quota_in_bytes = old_quota_in_bytes
         @organization.save
@@ -62,7 +65,7 @@ describe Admin::OrganizationsController do
         get organization_auth_url(user_domain: @org_user_owner.username)
 
         response.status.should eq 200
-        response.body.should include("Your organization has run out of seats")
+        response.body.should include(out_of_seats_message)
 
         @organization.seats = old_seats
         @organization.save
@@ -93,8 +96,8 @@ describe Admin::OrganizationsController do
         get organization_auth_url(user_domain: @org_user_owner.username)
 
         response.status.should eq 200
-        response.body.should_not include("Your organization has run out of quota")
-        response.body.should_not include("Your organization has run out of seats")
+        response.body.should_not include(out_of_quota_message)
+        response.body.should_not include(out_of_seats_message)
 
         @organization.quota_in_bytes = old_quota_in_bytes
         @organization.seats = old_seats

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../../spec_helper_min'
+require_relative '../../factories/organizations_contexts'
+
+describe Admin::OrganizationsController do
+  include Warden::Test::Helpers
+  include_context 'organization with users helper'
+
+  describe '#auth' do
+    before(:each) do
+      host! "#{@organization.name}.localhost.lan"
+      login_as(@org_user_owner, scope: @org_user_owner.username)
+    end
+
+    it 'does not display out of quota message if there is remaining quota' do
+      @organization.unassigned_quota.should > @organization.default_quota_in_bytes
+
+      get organization_auth_url(user_domain: @org_user_owner.username)
+
+      response.status.should eq 200
+      response.body.should_not include("Your organization has run out of quota")
+    end
+
+    it 'displays out of quota message if there is no remaining quota' do
+      old_remaining_quota = @organization.unassigned_quota
+      new_quota = (@organization.quota_in_bytes - old_remaining_quota) + (@organization.default_quota_in_bytes / 2)
+      @organization.reload
+      @org_user_owner.reload
+      @organization.quota_in_bytes = new_quota
+      @organization.save
+
+      get organization_auth_url(user_domain: @org_user_owner.username)
+
+      response.status.should eq 200
+      response.body.should include("Your organization has run out of quota")
+    end
+  end
+end

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -11,51 +11,95 @@ describe Admin::OrganizationsController do
       login_as(@org_user_owner, scope: @org_user_owner.username)
     end
 
-    it 'does not display out warning messages if organization signup would work' do
-      @organization.unassigned_quota.should > @organization.default_quota_in_bytes
+    describe 'signup enabled' do
+      before(:all) do
+        @organization.whitelisted_email_domains = ['carto.com']
+        @organization.save
+      end
 
-      get organization_auth_url(user_domain: @org_user_owner.username)
+      before(:each) do
+        @organization.signup_page_enabled.should eq true
+      end
 
-      response.status.should eq 200
-      response.body.should_not include("Your organization has run out of quota")
-      response.body.should_not include("Your organization has run out of seats")
+      it 'does not display out warning messages if organization signup would work' do
+        @organization.unassigned_quota.should > @organization.default_quota_in_bytes
+
+        get organization_auth_url(user_domain: @org_user_owner.username)
+
+        response.status.should eq 200
+        response.body.should_not include("Your organization has run out of quota")
+        response.body.should_not include("Your organization has run out of seats")
+      end
+
+      it 'displays out of quota message if there is no remaining quota' do
+        old_quota_in_bytes = @organization.quota_in_bytes
+
+        old_remaining_quota = @organization.unassigned_quota
+        new_quota = (@organization.quota_in_bytes - old_remaining_quota) + (@organization.default_quota_in_bytes / 2)
+        @organization.reload
+        @org_user_owner.reload
+        @organization.quota_in_bytes = new_quota
+        @organization.save
+
+        get organization_auth_url(user_domain: @org_user_owner.username)
+
+        response.status.should eq 200
+        response.body.should include("Your organization has run out of quota")
+
+        @organization.quota_in_bytes = old_quota_in_bytes
+        @organization.save
+      end
+
+      it 'displays out of seats message if there are no seats left' do
+        old_seats = @organization.seats
+
+        new_seats = @organization.seats - @organization.remaining_seats
+        @organization.reload
+        @org_user_owner.reload
+        @organization.seats = new_seats
+        @organization.save
+
+        get organization_auth_url(user_domain: @org_user_owner.username)
+
+        response.status.should eq 200
+        response.body.should include("Your organization has run out of seats")
+
+        @organization.seats = old_seats
+        @organization.save
+      end
     end
 
-    it 'displays out of quota message if there is no remaining quota' do
-      old_quota_in_bytes = @organization.quota_in_bytes
+    describe 'signup disabled' do
+      before(:all) do
+        @organization.whitelisted_email_domains = []
+        @organization.save
+      end
 
-      old_remaining_quota = @organization.unassigned_quota
-      new_quota = (@organization.quota_in_bytes - old_remaining_quota) + (@organization.default_quota_in_bytes / 2)
-      @organization.reload
-      @org_user_owner.reload
-      @organization.quota_in_bytes = new_quota
-      @organization.save
+      before(:each) do
+        @organization.signup_page_enabled.should eq false
+      end
 
-      get organization_auth_url(user_domain: @org_user_owner.username)
+      it 'does not display out warning messages even without quota and seats' do
+        old_quota_in_bytes = @organization.quota_in_bytes
+        old_seats = @organization.seats
 
-      response.status.should eq 200
-      response.body.should include("Your organization has run out of quota")
+        @organization.reload
+        @org_user_owner.reload
 
-      @organization.quota_in_bytes = old_quota_in_bytes
-      @organization.save
-    end
+        @organization.seats = @organization.assigned_seats
+        @organization.quota_in_bytes = @organization.assigned_quota + 1
+        @organization.save
 
-    it 'displays out of seats message if there are no seats left' do
-      old_seats = @organization.seats
+        get organization_auth_url(user_domain: @org_user_owner.username)
 
-      new_seats = @organization.seats - @organization.remaining_seats
-      @organization.reload
-      @org_user_owner.reload
-      @organization.seats = new_seats
-      @organization.save
+        response.status.should eq 200
+        response.body.should_not include("Your organization has run out of quota")
+        response.body.should_not include("Your organization has run out of seats")
 
-      get organization_auth_url(user_domain: @org_user_owner.username)
-
-      response.status.should eq 200
-      response.body.should include("Your organization has run out of seats")
-
-      @organization.seats = old_seats
-      @organization.save
+        @organization.quota_in_bytes = old_quota_in_bytes
+        @organization.seats = old_seats
+        @organization.save
+      end
     end
   end
 end


### PR DESCRIPTION
This closes #9778.

It involves flash messages (user general error messages) improvements, as this validation is a warning (first time needed) and it might display both a success and a warning.

Some screenshots:

![captura de pantalla 2017-01-25 a las 18 07 15](https://cloud.githubusercontent.com/assets/932968/22300885/44dec9e6-e329-11e6-8e52-610eff2cf0cd.png)
![captura de pantalla 2017-01-25 a las 18 07 27](https://cloud.githubusercontent.com/assets/932968/22300897/462159f4-e329-11e6-88c4-ee20116937a3.png)
![captura de pantalla 2017-01-25 a las 18 07 50](https://cloud.githubusercontent.com/assets/932968/22300899/47486340-e329-11e6-9100-853e02643a63.png)
![captura de pantalla 2017-01-25 a las 18 08 04](https://cloud.githubusercontent.com/assets/932968/22300902/4867545c-e329-11e6-885a-23b4cb8fa2d4.png)




Acceptance minimum:
- [ ] Organization with authentication, whitelisted domains and available quota and seats should display no message.
- [ ] Without remaining seats it should display message.
- [ ] Without remaining quota it should display both messages.
- [ ] Without authentication it should hide the messages.
- [ ] Successful organization signup with valid configuration.
- [ ] Organization signup error without remaining quota.
- [ ] Organization signup error without remaining seats.
- [ ] Organization groups page flash message.

Acceptance regression:
- [ ] Find other flash messages (banner notifications) through the application and ensure they display correctly. For example, when an update to user parameters fails (e.g: invalid email)