### PR TITLE
On214 correct logout url

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,7 @@ Development
 * Fix color for "Other" category (#11078)
 * Custom errors for latitude/longitude out of bounds (#11060, #11048)
 * Fix timeseries widget height (#11077)
+* Fix redirection after logout for subdomainless URLs (#11361)
 * Fix scrollbar in carousel (#11061)
 * Restrict login from organization pages to organization users, and redirect to Central otherwise
 * Correctly refresh map after adding/editing map geometries (#11064)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -300,7 +300,7 @@ class SessionsController < ApplicationController
 
   def default_logout_url
     # User could've been just deleted
-    username = CartoDB.subdomain_from_request(request)
+    username = CartoDB.extract_subdomain(request)
     if username && (Carto::User.exists?(username: username) || Carto::Organization.exists?(name: username))
       CartoDB.url(self, 'public_visualizations_home')
     elsif Cartodb::Central.sync_data_with_cartodb_central?

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -557,7 +557,7 @@ describe SessionsController do
       end
     end
 
-    describe 'subddomainless' do
+    describe 'subdomainless' do
       it_behaves_like 'logout endpoint'
 
       before(:each) do

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -531,6 +531,41 @@ describe SessionsController do
     end
   end
 
+  describe '#logout' do
+    before(:all) do
+      @user = FactoryGirl.create(:carto_user)
+    end
+
+    after(:all) do
+      @user.destroy
+    end
+
+    shared_examples_for 'logout endpoint' do
+      it 'redirects to user dashboard' do
+        post create_session_url(email: @user.username, password: @user.password)
+        get CartoDB.base_url(@user.username) + logout_path
+        response.status.should eq 302
+        response.location.should include @user.username
+      end
+    end
+
+    describe 'domainful' do
+      it_behaves_like 'logout endpoint'
+
+      before(:each) do
+        stub_domainful(@user.username)
+      end
+    end
+
+    describe 'subddomainless' do
+      it_behaves_like 'logout endpoint'
+
+      before(:each) do
+        stub_subdomainless
+      end
+    end
+  end
+
   private
 
   def bypass_named_maps


### PR DESCRIPTION
Fixes https://github.com/CartoDB/onpremises/issues/214

The old code extracted the username from the domain, the new code also takes into account subdomainless mode.

**Acceptance**
Test logout for the 4 combinations of org user / normal user and subdonmainless / domainful. All of them should redirect to the user dashboard.