### PR TITLE
11343 org setting tab links wrong

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ require_dependency 'carto/http_header_authentication'
 
 class ApplicationController < ActionController::Base
   include ::SslRequirement
+  include UrlHelper
   protect_from_forgery
 
   helper :all

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,10 @@ module ApplicationHelper
     super(CartoDB.extract_subdomain(request))
   end
 
+  def logged_user_url(path, params = {})
+    CartoDB.url(self, path, params, current_user)
+  end
+
   def show_footer?
     (controller_name == 'tables' && action_name != 'show') ||
     (controller_name == 'client_applications') || (controller_name == 'users')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,10 +8,6 @@ module ApplicationHelper
     super(CartoDB.extract_subdomain(request))
   end
 
-  def logged_user_url(path, params = {})
-    CartoDB.url(self, path, params, current_user)
-  end
-
   def show_footer?
     (controller_name == 'tables' && action_name != 'show') ||
     (controller_name == 'client_applications') || (controller_name == 'users')

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,5 +1,5 @@
 module UrlHelper
-  def logged_user_url(path, params = {})
+  def current_user_url(path, params = {})
     CartoDB.url(self, path, params, current_user)
   end
 end

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,5 @@
+module UrlHelper
+  def logged_user_url(path, params = {})
+    CartoDB.url(self, path, params, current_user)
+  end
+end

--- a/app/views/admin/organization_users/edit.html.erb
+++ b/app/views/admin/organization_users/edit.html.erb
@@ -28,7 +28,7 @@
         <div class="Filters-row">
           <ul class="Filters-group CDB-Text CDB-Size-medium">
             <li class="u-flex u-alignCenter">
-              <a href="<%= logged_user_url('organization') %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= current_user_url('organization') %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/admin/organization_users/edit.html.erb
+++ b/app/views/admin/organization_users/edit.html.erb
@@ -28,7 +28,7 @@
         <div class="Filters-row">
           <ul class="Filters-group CDB-Text CDB-Size-medium">
             <li class="u-flex u-alignCenter">
-              <a href="<%= CartoDB.url(self, 'organization', {}, current_user) %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= logged_user_url('organization') %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/admin/organization_users/edit.html.erb
+++ b/app/views/admin/organization_users/edit.html.erb
@@ -28,7 +28,7 @@
         <div class="Filters-row">
           <ul class="Filters-group CDB-Text CDB-Size-medium">
             <li class="u-flex u-alignCenter">
-              <a href="<%= CartoDB.url(self, 'organization') %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= CartoDB.url(self, 'organization', {}, current_user) %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/admin/organization_users/new.html.erb
+++ b/app/views/admin/organization_users/new.html.erb
@@ -25,7 +25,7 @@
         <div class="Filters-row">
           <ul class="Filters-group CDB-Text CDB-Size-medium">
             <li class="u-flex u-alignCenter">
-              <a href="<%= logged_user_url('organization') %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= current_user_url('organization') %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/admin/organization_users/new.html.erb
+++ b/app/views/admin/organization_users/new.html.erb
@@ -25,7 +25,7 @@
         <div class="Filters-row">
           <ul class="Filters-group CDB-Text CDB-Size-medium">
             <li class="u-flex u-alignCenter">
-              <a href="<%= CartoDB.url(self, 'organization', {}, current_user) %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= logged_user_url('organization') %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/admin/organization_users/new.html.erb
+++ b/app/views/admin/organization_users/new.html.erb
@@ -25,7 +25,7 @@
         <div class="Filters-row">
           <ul class="Filters-group CDB-Text CDB-Size-medium">
             <li class="u-flex u-alignCenter">
-              <a href="<%= CartoDB.url(self, 'organization') %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= CartoDB.url(self, 'organization', {}, current_user) %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/admin/shared/_org_subheader.html.erb
+++ b/app/views/admin/shared/_org_subheader.html.erb
@@ -4,22 +4,22 @@
     <div class="Filters-row">
       <ul class="Filters-group CDB-Text CDB-Size-medium">
         <li class="Filters-typeItem">
-          <a href="<%= CartoDB.url(self, 'organization_settings', {}, current_user) %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_settings" %>">
+          <a href="<%= logged_user_url('organization_settings') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_settings" %>">
             Organization profile
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= CartoDB.url(self, 'organization_auth', {}, current_user) %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_auth" %>">
+          <a href="<%= logged_user_url('organization_auth') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_auth" %>">
             Auth settings
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= CartoDB.url(self, 'organization', {}, current_user) %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_show" %>">
+          <a href="<%= logged_user_url('organization') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_show" %>">
             <%= current_user.organization.users.count %>/<%= current_user.organization.total_seats %> users
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= CartoDB.url(self, 'organization_groups', {}, current_user) %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_groups" %>">
+          <a href="<%= logged_user_url('organization_groups') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_groups" %>">
             Groups
           </a>
         </li>

--- a/app/views/admin/shared/_org_subheader.html.erb
+++ b/app/views/admin/shared/_org_subheader.html.erb
@@ -4,22 +4,22 @@
     <div class="Filters-row">
       <ul class="Filters-group CDB-Text CDB-Size-medium">
         <li class="Filters-typeItem">
-          <a href="<%= CartoDB.url(self, 'organization_settings') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_settings" %>">
+          <a href="<%= CartoDB.url(self, 'organization_settings', {}, current_user) %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_settings" %>">
             Organization profile
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= CartoDB.url(self, 'organization_auth') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_auth" %>">
+          <a href="<%= CartoDB.url(self, 'organization_auth', {}, current_user) %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_auth" %>">
             Auth settings
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= CartoDB.url(self, 'organization') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_show" %>">
+          <a href="<%= CartoDB.url(self, 'organization', {}, current_user) %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_show" %>">
             <%= current_user.organization.users.count %>/<%= current_user.organization.total_seats %> users
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= CartoDB.url(self, 'organization_groups') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_groups" %>">
+          <a href="<%= CartoDB.url(self, 'organization_groups', {}, current_user) %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_groups" %>">
             Groups
           </a>
         </li>

--- a/app/views/admin/shared/_org_subheader.html.erb
+++ b/app/views/admin/shared/_org_subheader.html.erb
@@ -4,22 +4,22 @@
     <div class="Filters-row">
       <ul class="Filters-group CDB-Text CDB-Size-medium">
         <li class="Filters-typeItem">
-          <a href="<%= logged_user_url('organization_settings') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_settings" %>">
+          <a href="<%= current_user_url('organization_settings') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_settings" %>">
             Organization profile
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= logged_user_url('organization_auth') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_auth" %>">
+          <a href="<%= current_user_url('organization_auth') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_auth" %>">
             Auth settings
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= logged_user_url('organization') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_show" %>">
+          <a href="<%= current_user_url('organization') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_show" %>">
             <%= current_user.organization.users.count %>/<%= current_user.organization.total_seats %> users
           </a>
         </li>
         <li class="Filters-typeItem">
-          <a href="<%= logged_user_url('organization_groups') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_groups" %>">
+          <a href="<%= current_user_url('organization_groups') %>" class="Filters-typeLink <%= 'is-selected' if "#{params[:controller]}_#{params[:action]}" == "admin/organizations_groups" %>">
             Groups
           </a>
         </li>

--- a/app/views/carto/admin/mobile_apps/_show.html.erb
+++ b/app/views/carto/admin/mobile_apps/_show.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="MobileAppsList-itemInfo">
         <div class="MobileAppsList-itemInfoName">
-          <h3 class="MobileAppsList-itemInfoTitle u-ellipsLongText"><%= link_to a.name, CartoDB.url(self, 'mobile_app', id: a.id) %></h3>
+          <h3 class="MobileAppsList-itemInfoTitle u-ellipsLongText"><%= link_to a.name, CartoDB.url(self, 'mobile_app', { id: a.id }, current_user) %></h3>
           <h4 class="MobileAppsList-itemInfoSubtitle u-ellipsLongText"><%= a.description rescue nil %></h4>
         </div>
         <div class="CDB-Size-medium MobileAppsList-details">

--- a/app/views/carto/admin/mobile_apps/_show.html.erb
+++ b/app/views/carto/admin/mobile_apps/_show.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="MobileAppsList-itemInfo">
         <div class="MobileAppsList-itemInfoName">
-          <h3 class="MobileAppsList-itemInfoTitle u-ellipsLongText"><%= link_to a.name, CartoDB.url(self, 'mobile_app', { id: a.id }, current_user) %></h3>
+          <h3 class="MobileAppsList-itemInfoTitle u-ellipsLongText"><%= link_to a.name, logged_user_url('mobile_app', id: a.id) %></h3>
           <h4 class="MobileAppsList-itemInfoSubtitle u-ellipsLongText"><%= a.description rescue nil %></h4>
         </div>
         <div class="CDB-Size-medium MobileAppsList-details">

--- a/app/views/carto/admin/mobile_apps/_show.html.erb
+++ b/app/views/carto/admin/mobile_apps/_show.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="MobileAppsList-itemInfo">
         <div class="MobileAppsList-itemInfoName">
-          <h3 class="MobileAppsList-itemInfoTitle u-ellipsLongText"><%= link_to a.name, logged_user_url('mobile_app', id: a.id) %></h3>
+          <h3 class="MobileAppsList-itemInfoTitle u-ellipsLongText"><%= link_to a.name, current_user_url('mobile_app', id: a.id) %></h3>
           <h4 class="MobileAppsList-itemInfoSubtitle u-ellipsLongText"><%= a.description rescue nil %></h4>
         </div>
         <div class="CDB-Size-medium MobileAppsList-details">

--- a/app/views/carto/admin/mobile_apps/new.html.erb
+++ b/app/views/carto/admin/mobile_apps/new.html.erb
@@ -24,7 +24,7 @@
         <div class="Filters-row">
           <ul class="Filters-group">
             <li class="u-flex u-alignCenter">
-              <a href="<%= CartoDB.url(self, 'mobile_apps') %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= CartoDB.url(self, 'mobile_apps', {}, current_user) %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/carto/admin/mobile_apps/new.html.erb
+++ b/app/views/carto/admin/mobile_apps/new.html.erb
@@ -24,7 +24,7 @@
         <div class="Filters-row">
           <ul class="Filters-group">
             <li class="u-flex u-alignCenter">
-              <a href="<%= logged_user_url('mobile_apps') %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= current_user_url('mobile_apps') %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/carto/admin/mobile_apps/new.html.erb
+++ b/app/views/carto/admin/mobile_apps/new.html.erb
@@ -24,7 +24,7 @@
         <div class="Filters-row">
           <ul class="Filters-group">
             <li class="u-flex u-alignCenter">
-              <a href="<%= CartoDB.url(self, 'mobile_apps', {}, current_user) %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= logged_user_url('mobile_apps') %>" class="u-actionTextColor u-flex u-alignCenter">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>


### PR DESCRIPTION
Fixes a bunch of links, including those in #11343 

**Acceptance**
Test that all the following links work, and have the username in the url (org.carto.com/u/username/...):
- [ ] Tabs inside organizations setting
- [ ] Org user management: link to go back from the new user screen
- [ ] Org user management: link to go back from the edit user screen
- [ ] Mobile apps: link to go back from the new app screen
- [ ] Mobile apps: link to go back from the edit app screen
- [ ] Mobile apps: link to go from the app list to an app details
