### PR TITLE
Provide all column types for merge analysis

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
@@ -143,13 +143,13 @@ module.exports = BaseAnalysisFormModel.extend({
       left_source_column: {
         type: 'Select',
         title: this._getLeftSourceLabel(),
-        options: this._leftColumnOptions.filterByType(['string', 'number']),
+        options: this._leftColumnOptions.all(),
         validators: ['required']
       },
       right_source_column: {
         type: 'Select',
         title: this._getRightSourceLabel(),
-        options: this._rightColumnOptions.filterByType(['string', 'number']),
+        options: this._rightColumnOptions.all(),
         validators: ['required']
       },
       source_geometry_selector: {
@@ -163,12 +163,12 @@ module.exports = BaseAnalysisFormModel.extend({
       left_source_columns: {
         type: 'MultiSelect',
         title: this._getLeftSourceLabel(),
-        options: this._leftColumnOptions.filterByType(['string', 'number', 'date'])
+        options: this._leftColumnOptions.all()
       },
       right_source_columns: {
         type: 'MultiSelect',
         title: this._getRightSourceLabel(),
-        options: this._rightColumnOptions.filterByType(['string', 'number', 'date'])
+        options: this._rightColumnOptions.all()
       }
     }));
   },


### PR DESCRIPTION
Ticket: #9501.

Basically, after a checking with @javierarce, we don't know why we decided to filter the columns by type of the dropdowns in this analysis. So, we should check if:

- merge analyses with date columns works.
- merge analysis with boolean columns works.
- merge analysis with geometry columns works.

