### PR TITLE
Cleanup after downloader refactor hotfix

### DIFF
--- a/services/importer/lib/importer/downloader.rb
+++ b/services/importer/lib/importer/downloader.rb
@@ -71,7 +71,7 @@ module CartoDB
         false
       end
 
-      attr_reader :source_file, :etag, :last_modified, :http_response_code, :datasource
+      attr_reader :source_file, :http_response_code, :datasource
 
       def initialize(user_id, url, http_options = {}, options = {})
         raise UploadError unless user_id && url

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -243,6 +243,20 @@ describe Downloader do
       lambda { downloader.run }.should raise_error PartialDownloadError
     end
 
+    describe '#etag' do
+      it "reads etag from download" do
+        etag = 'whatever'
+        stub_download(
+            url:      @file_url,
+            filepath: @file_filepath,
+            headers:  { "ETag" => etag }
+        )
+
+        downloader = Downloader.new(@user.id, @file_url)
+        downloader.etag.should eq etag
+      end
+    end
+
     describe('#quota_checks') do
       before(:all) do
         @old_max_import_file_size = @user.max_import_file_size

--- a/services/importer/spec/unit/downloader_spec.rb
+++ b/services/importer/spec/unit/downloader_spec.rb
@@ -247,9 +247,9 @@ describe Downloader do
       it "reads etag from download" do
         etag = 'whatever'
         stub_download(
-            url:      @file_url,
-            filepath: @file_filepath,
-            headers:  { "ETag" => etag }
+          url:      @file_url,
+          filepath: @file_filepath,
+          headers:  { "ETag" => etag }
         )
 
         downloader = Downloader.new(@user.id, @file_url)


### PR DESCRIPTION
This closes #11313 .

Acceptance: test sync and sync update, from URLs and 3rd party services. Keep an eye on Rollbar, you should not see errors regarding the import (if in doubt, ask)