### PR TITLE
GDAL version for Python dependency

### DIFF
--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -3,6 +3,6 @@ argparse==1.2.1
 brewery==0.6
 redis==2.4.9
 python-varnish==0.1.2
-gdal==1.10.0
+gdal==2.1.0
 csvkit==0.9.0
 openpyxl==2.1.3


### PR DESCRIPTION
@rafatower @luisbosque in my latest local installation I needed a newer GDAL version for installation and importing to work. According to the [installation guide](http://cartodb.readthedocs.io/en/latest/install.html#gis-dependencies) 2.1 seems to be the right version. Should this be merged?

cc @gfiorav 