### PR TITLE
fixed grammar in delete layer dialog, when an analysis is applied

### DIFF
--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -1379,7 +1379,7 @@
         "widgets": "one widget |||| %{smart_count} widgets",
         "analyses": "one analysis |||| %{smart_count} analyses",
         "layers": "one layer |||| %{smart_count} layers",
-        "affected-items": "Deleting this layer will affect to",
+        "affected-items": "Deleting this layer affects",
         "and": "and",
         "link-to-export": "Before deleting the layer, you can <a href='#' data-event='exportMapAction'>export as .CARTO file</a>"
       },


### PR DESCRIPTION
@xavijam , I found this dialog when deleting a map layer with an analysis applied. That doesn't sound right, so I edited the text. (I'm not sure if if affects other auto-generated dialogs, so please confirm).

![image](https://cloud.githubusercontent.com/assets/13319925/22432472/ff02f8a8-e6e2-11e6-9ffe-f2f5de12218c.png)

