### PR TITLE
Wait server response to add the model.

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integrations.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integrations.js
@@ -698,7 +698,7 @@ F.prototype._manageTimeSeriesForTorque = function (m) {
   })[0];
 
   var currentTimeseries = this._getTimeseriesDefinition();
-  var persistWidget = !!(currentTimeseries && currentTimeseries.get('title') !== 'time_date__t');
+  var persistWidget = !!currentTimeseries && currentTimeseries.get('title') !== 'time_date__t';
   var newLayer = this._getLayer(m);
 
   if (type !== 'animation' && previousType === 'animation' && this._lastType !== type) {
@@ -761,7 +761,7 @@ F.prototype._createTimeseries = function (newLayer, animatedChanged, persist) {
         widget_style: WidgetDefinitionModel.getDefaultWidgetStyle('time-series')
       }
     };
-    this._widgetDefinitionsCollection.create(baseAttrs);
+    this._widgetDefinitionsCollection.create(baseAttrs, {wait: true});
   }
 };
 

--- a/lib/assets/core/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -227,6 +227,114 @@ describe('deep-insights-integrations/dii', function () {
     document.body.removeChild(el);
   });
 
+  describe('time series', function () {
+    var xhrSpy = jasmine.createSpyObj('xhr', ['abort', 'always', 'fail']);
+
+    var cartocss = 'Map {-torque-frame-count: 256;-torque-animation-duration: 30;-torque-time-attribute: cartodb_id";-torque-aggregation-function: "count(1)";-torque-resolution: 4;-torque-data-aggregation: linear;} #layer {}, #layer[frame-offset=1] {marker-width: 9; marker-fill-opacity: 0.45;} #layer[frame-offset=2] {marker-width: 11; marker-fill-opacity: 0.225;}';
+
+    var animatedChanged1 = {attribute: 'cartodb_id', duration: 24, overlap: false, resolution: 4, steps: 256, trails: 2};
+    var animatedChanged2 = {attribute: 'cartodb_id', duration: 24, overlap: false, resolution: 4, steps: 256, trails: 3};
+
+    beforeEach(function () {
+      spyOn(Backbone.Model.prototype, 'sync').and.returnValue(xhrSpy);
+
+      this.layerDefModel = new LayerDefinitionModel({
+        id: 'wadus',
+        kind: 'torque',
+        options: {
+          sql: 'SELECT * FROM fooo',
+          table_name: 'fooo',
+          cartocss: cartocss,
+          // source: 'd0',
+          style_properties: {
+            type: 'animation',
+            properties: {
+              animated: {
+                attribute: 'cartodb_id',
+                duration: 30,
+                overlap: false,
+                resolution: 4,
+                steps: 256,
+                trails: 2
+              }
+            }
+          }
+        }
+      }, { parse: true, configModel: 'c' });
+
+      this.layerDefinitionsCollection.add(this.layerDefModel);
+
+      this.d0 = this.analysisDefinitionNodesCollection.add({
+        id: 'd0',
+        type: 'source',
+        params: {
+          query: 'SELECT * FROM fooo'
+        }
+      });
+
+      var nodeMod = this.analysis._analysisCollection.at(0);
+      spyOn(nodeMod, 'isDone');
+    });
+
+    it('should create time-series widget on layer changes', function () {
+      var l = this.integrations.visMap().layers.get(this.layerDefModel.id);
+      spyOn(this.integrations, '_createTimeseries').and.callThrough();
+
+      expect(l).toBeDefined();
+      this.layerDefModel.styleModel.set({animated: animatedChanged1});
+      this.layerDefModel.set({alias: 'wadus'});
+
+      expect(this.integrations._createTimeseries).toHaveBeenCalled();
+    });
+
+    it('should create only one time-series widget', function () {
+      spyOn(this.integrations, '_createTimeseries').and.callThrough();
+      this.layerDefModel.styleModel.set({animated: animatedChanged1});
+      this.layerDefModel.set({alias: 'wadus'});
+
+      expect(this.integrations._createTimeseries).toHaveBeenCalled();
+
+      Backbone.Model.prototype.sync.calls.argsFor(0)[2].error({
+        error: 'abort'
+      });
+
+      this.layerDefModel.styleModel.set({animated: animatedChanged2});
+      this.layerDefModel.set({alias: 'wadus wadus'});
+
+      expect(this.integrations._createTimeseries).toHaveBeenCalled();
+
+      Backbone.Model.prototype.sync.calls.argsFor(0)[2].success({
+        id: '1',
+        layer_id: 'wadus',
+        options: {
+          column: 'cartodb_id',
+          bins: 256,
+          animated: true,
+          sync_on_data_change: true,
+          sync_on_bbox_change: true
+        },
+        order: 0,
+        source: {
+          id: 'a0'
+        },
+        style: {
+          widget_style: {
+            definition: {
+              color: {
+                fixed: '#F2CC8F',
+                opacity: 1
+              }
+            }
+          }
+        },
+        title: 'time_date__t',
+        type: 'time-series'
+      });
+
+      expect(this.widgetDefinitionsCollection.length).toBe(1);
+    });
+  });
+
   describe('_resetStylesIfNoneApplied', function () {
     beforeEach(function () {
       this.layerDefModel = new LayerDefinitionModel({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.121",
+  "version": "4.5.121-11339",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR implements #11339.

Not waiting caused a race condition and two creation requests were made. The first one was aborted by the sync abort thing, but the model was already added to the collection. Then the style
definition model changed, causing the widgets to persist.

So two time-series were created when this race condition met.