### PR TITLE
Fixing problem with datasets without geometry at the beginning of the data

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/data/query-geometry-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/query-geometry-model.js
@@ -11,7 +11,7 @@ var template = _.template("" +
 "     WHEN 'st_multipoint' THEN 'point' " +
 "     WHEN 'st_point' THEN 'point' " +
 "     ELSE '' " +
-"  END AS the_geom FROM (<%= sql %>) __wrapped"
+"  END AS the_geom FROM (<%= sql %>) __wrapped WHERE <%= geom_column %> IS NOT NULL"
 /* eslint-enable */
 );
 


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb-management/issues/4830.

So, when a dataset where first (50-100) rows don't provide any geometry, we set it as a dataset without geometry, although it had rows with geometry info at the end of the dataset.
We used to take the first sample of the dataset in order to check the geometry, always the first sample, so it is not a good solution when dataset is like above described.

After talking with @rochoa, he thinks the change will work properly and we will get rid of the problem, so let's check the following things in order to be sure everything will be ok:

- Import a big dataset where first 50-100 rows don't contain any geometry info, it should guess the geometry.
- Import an empty dataset, it should not fail and guess that there is no geometry.
- Import a dataset (or apply a query) where there is no `the_geom` column (it is dropped) and `the_geom_webmercator` is present. Geometry should be guessed thanks to `the_geom_webmercator` column.
- Do the same as previous point but having first 50 rows without any geometry info in the `the_geom_webmercator` column.