### PR TITLE
Removed auto-style flag logic

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor.js
+++ b/lib/assets/core/javascripts/cartodb3/editor.js
@@ -271,7 +271,7 @@ var mapCreation = function () {
     state: stateJSON,
     interactiveFeatures: true,
     layerSelectorEnabled: false,
-    autoStyle: userModel.featureEnabled('auto-style')
+    autoStyle: true
   }, function (error, dashboard) {
     if (error) {
       console.error('Dashboard has some errors:', error);

--- a/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-base-schema-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-base-schema-model.js
@@ -5,9 +5,6 @@ var WidgetDefinitionModel = require('../../../../data/widget-definition-model');
 module.exports = Backbone.Model.extend({
 
   initialize: function (attrs, options) {
-    // Feature flag for autoStyle, it should be cleaned once the flag is deleted.
-    this._autoStyleEnable = options.userModel && options.userModel.featureEnabled('auto-style');
-
     var o = [
       {
         val: true,
@@ -85,9 +82,7 @@ module.exports = Backbone.Model.extend({
       });
     }
 
-    if (this._autoStyleEnable) {
-      this.schema = _.extend(this.schema, styleAttrs);
-    }
+    this.schema = _.extend(this.schema, styleAttrs);
   },
 
   parse: function (r) {
@@ -108,7 +103,7 @@ module.exports = Backbone.Model.extend({
       this.attributes
     );
 
-    if (this._autoStyleEnable && attrs.auto_style_definition !== '' && _.isEmpty(attrs.auto_style_definition)) {
+    if (attrs.auto_style_definition !== '' && _.isEmpty(attrs.auto_style_definition)) {
       attrs.auto_style_definition = WidgetDefinitionModel.getDefaultAutoStyle(widgetDefinitionModel.get('type'), widgetDefinitionModel.get('column'));
     }
 

--- a/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-category-schema-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-category-schema-model.js
@@ -35,7 +35,7 @@ module.exports = WidgetsFormBaseSchema.extend({
 
     return {
       data: fields.join(','),
-      style: this._autoStyleEnable ? ['sync_on_bbox_change', 'widget_style_definition', 'auto_style_definition'] : ['sync_on_bbox_change']
+      style: ['sync_on_bbox_change', 'widget_style_definition', 'auto_style_definition']
     };
   },
 

--- a/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-histogram-schema-model.js
@@ -20,7 +20,7 @@ module.exports = WidgetsFormBaseSchema.extend({
   getFields: function () {
     return {
       data: ['column', 'bins'],
-      style: this._autoStyleEnable ? ['sync_on_bbox_change', 'widget_style_definition', 'auto_style_definition'] : ['sync_on_bbox_change']
+      style: ['sync_on_bbox_change', 'widget_style_definition', 'auto_style_definition']
     };
   },
 


### PR DESCRIPTION
Related ticket: #11392 

Auto-style should be enabled by default for everybody, it doesn't matter if the user has enabled the feature flag or not. So, for testing:

- If user has the `auto-style` feature flag enabled, auto style behaviour should be **enabled**, and the widget form should show the color options.
- If user doesn't have the `auto-style` feature flag enabled, auto style behaviour should be **enabled** too, and the widget form should show the color options.