### PR TITLE
11381 delete analysis on dataset deletion

### DIFF
--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -199,6 +199,10 @@ class Layer < Sequel::Model
     register_table_dependencies
   end
 
+  def source_id
+    options && options.symbolize_keys[:source]
+  end
+
   private
 
   def rename_in(target, anchor, substitution)
@@ -232,10 +236,6 @@ class Layer < Sequel::Model
 
   def query
     options.symbolize_keys[:query]
-  end
-
-  def source_id
-    options && options.symbolize_keys[:source]
   end
 
   def update_layer_node_style

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -933,10 +933,14 @@ module CartoDB
       end
 
       def remove_layers_from(table)
-        related_layers_from(table).each { |layer|
+        related_layers_from(table).each do |layer|
+          # Using delete to avoid hooks, as they generate a conflict between ORMs and are
+          # not needed in this case since they are already triggered by deleting the layer
+          Carto::Analysis.find_by_natural_id(id, layer.source_id).try(:delete) if layer.source_id
+
           map.remove_layer(layer)
           layer.destroy
-        }
+        end
         self.active_layer_id = layers(:cartodb).first.nil? ? nil : layers(:cartodb).first.id
         store
       end

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -218,6 +218,76 @@ describe Visualization::Member do
       member.expects(:invalidate_cache)
       member.delete
     end
+
+    describe 'dataset' do
+      include Carto::Factories::Visualizations
+
+      before(:all) do
+        @user = FactoryGirl.create(:carto_user)
+        @other_table = FactoryGirl.create(:carto_user_table)
+      end
+
+      before(:each) do
+        @map, @table, @table_visualization, @visualization = create_full_visualization(@user)
+        @visualization.data_layers.first.user_tables << @table
+      end
+
+      after(:each) do
+        destroy_full_visualization(@map, @table, @table_visualization, @visualization)
+      end
+
+      after(:all) do
+        @user.destroy
+      end
+
+      it 'destroys maps if they are dependent' do
+        table_visualization = CartoDB::Visualization::Member.new(id: @table_visualization.id).fetch
+        table_visualization.delete
+
+        Carto::Visualization.exists?(@visualization.id).should be_false
+      end
+
+      it 'unlinks only dependent data layers' do
+        layer_to_be_deleted = @visualization.data_layers.first
+        layer = FactoryGirl.build(:carto_layer, kind: 'carto', maps: [@map])
+        layer.options[:query] = "SELECT * FROM #{@other_table.name}"
+        layer.save
+        layer.user_tables << @other_table
+
+        table_visualization = CartoDB::Visualization::Member.new(id: @table_visualization.id).fetch
+        table_visualization.delete
+
+        Carto::Visualization.exists?(@visualization.id).should be_true
+        Carto::Layer.exists?(layer_to_be_deleted.id).should be_false
+        Carto::Layer.exists?(layer.id).should be_true
+      end
+
+      it 'deletes related analysis' do
+        layer_to_be_deleted = @visualization.data_layers.first
+        layer_to_be_deleted.options[:source] = 'a0'
+        layer_to_be_deleted.save
+        layer_to_be_deleted.user_tables << @table
+
+        layer = FactoryGirl.build(:carto_layer, kind: 'carto', maps: [@map])
+        layer.options[:source] = 'b0'
+        layer.save
+        layer.user_tables << @other_table
+
+        # We are doing dependencies manually because the physical table does not exist
+        Carto::Map.any_instance.stubs(:update_dataset_dependencies)
+        analysis_to_be_deleted = @visualization.analyses.create(user: @user, analysis_definition: { id: 'a0' })
+        analysis_to_keep = @visualization.analyses.create(user: @user, analysis_definition: { id: 'b0' })
+
+        table_visualization = CartoDB::Visualization::Member.new(id: @table_visualization.id).fetch
+        table_visualization.delete
+
+        Carto::Visualization.exists?(@visualization.id).should be_true
+        Carto::Layer.exists?(layer_to_be_deleted.id).should be_false
+        Carto::Layer.exists?(layer.id).should be_true
+        Carto::Analysis.exists?(analysis_to_be_deleted.id).should be_false
+        Carto::Analysis.exists?(analysis_to_keep.id).should be_true
+      end
+    end
   end
 
   describe '#unlink_from' do


### PR DESCRIPTION
Fixes #11381 

This simply deletes analyses that should be deleted after deleting a dataset. It also adds general tests to dataset deletion (I couldn't find any in the whole test suite).

**Acceptance**
This changes how deleting a dataset affects related maps. The expected behaviour is that deleting a dataset deletes all related layers and analyses. It will not try to remove only part of the chain of analysis, if a layer has a reference to the dataset some how, it will be completely deleted.

- [x] Create a map with multiple layers and analyses (publish it). Delete one of the source datasets. All related layers should be deleted, all related analyses should be deleted (check `analysesData` from the JS console in Builder).
- [x] Check embed for the previous map. It should be broken (as the data does not exist). Republish it, it should start working again (but without the deleted layers).
- [ ] Repeat the previous steps, but make all layers related somehow to the deleted dataset (could be directly, could be though analysis). The entire map should be deleted (as we cannot have a map with no layers)
- [ ] ~Create a map with two layers: `A`, `B`, based on two different datasets, `a` and `b`. Add a join column analysis on `A`, joining `B` sampling. Now delete dataset `b`. The warning modal about the map should appear. The full map should be deleted afterwards.~
- [ ] ~Repeat previous steps, but this time delete dataset `a`. The warning modal about the map should appear. Only layer `A` should be deleted.~
- [ ] General: make sure that deleting a dataset does not delete anything (layer or analysis) that it shouldn't.

**Note**: If you use JOIN analysis, this will break. We are going to handle that in a different ticket.

I suggest dragging analysis to create new layers in order to test this, as it is an easy way to create multiple layers related to the same data.