### PR TITLE
Setting autostyle always true in public views

### DIFF
--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -55,7 +55,6 @@ module Carto
 
         def load_vizjson
           @vizjson = generate_named_map_vizjson3(visualization_for_presentation, params)
-          @auto_style = @visualization.user.has_feature_flag?('auto-style')
         end
 
         def load_state

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -30,7 +30,6 @@
     var layersData = <%= safe_js_object @layers_data.to_json %>;
     var stateJSON = <%= safe_js_object @state.to_json %>;
     var authTokens = <%= safe_js_object @auth_tokens.to_json %>;
-    var autoStyle = <%= safe_js_object @auto_style.to_json %>;
   </script>
   <%= javascript_include_tag 'vendor_editor3.js' %>
   <%= javascript_include_tag 'common_editor3.js' %>

--- a/lib/assets/core/javascripts/cartodb3/public_editor.js
+++ b/lib/assets/core/javascripts/cartodb3/public_editor.js
@@ -13,7 +13,7 @@ var dashboardOpts = {
   share_urls: true,
   authToken: window.authTokens,
   layerSelectorEnabled: true,
-  autoStyle: window.autoStyle
+  autoStyle: true
 };
 var stateJSON = window.stateJSON;
 var layersData = window.layersData;


### PR DESCRIPTION
Related to #11392

This PR sets autostyle to true in public views.

### Acceptance

1. Delete the `auto-style` FF of your user.
2. Set a map with autostyle widgets. That is, select a map with category and histogram widgets.
3. In private and public views, autostyle icons should show up in both widgets.

### Deploy
Remember to purge caches