### PR TITLE
Return null instead empty string if no date.

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/datetime.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/datetime.js
@@ -46,7 +46,8 @@ Backbone.Form.editors.DateTime = Backbone.Form.editors.Base.extend({
       return momentObj.format('YYYY-MM-DD') + 'T' + momentObj.format('HH:mm:ss') + 'Z';
     }
 
-    return '';
+    // for datetime type, empty '' value raises an error on Postgres
+    return null;
   },
 
   _initViews: function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/datetime.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/datetime.spec.js
@@ -38,6 +38,10 @@ describe('components/form-components/editors/datetime', function () {
       this.view.render();
     });
 
+    it('should return null as value when datetime is not selected', function () {
+      expect(this.view.getValue()).toBe(null);
+    });
+
     it('should render null when datetime is not selected', function () {
       expect(this.view.$('.js-input').length).toBe(1);
       expect(this.view.$('.js-input').html()).toBe('null');


### PR DESCRIPTION
This PR implements #11145.

The problem is when we insert a value, the form grabs all the data from the fields, returning '' for date time fields. In the first scenario, saving directly without adding new attribute values, the initial value is `null`. In order to fix this, we need to return `null` if the value is not a formatted date. Otherwise, Postgres will complain.