### PR TITLE
exporting maps with username table in the sql keeps the schema

### DIFF
--- a/lib/carto/query_rewriter.rb
+++ b/lib/carto/query_rewriter.rb
@@ -2,7 +2,7 @@ module Carto
   module QueryRewriter
     def rewrite_query(query, old_username, new_user, renamed_tables)
       new_query = query
-      new_query = rewrite_query_for_new_user(query, old_username, new_user) if old_username != new_user.username
+      new_query = rewrite_query_for_new_user(query, old_username, new_user) if old_username != new_user.database_schema
       new_query = rewrite_query_for_renamed_tables(new_query, renamed_tables) if renamed_tables.present?
       if test_query(new_user, new_query)
         new_query

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -862,17 +862,17 @@ describe Carto::VisualizationsExportService2 do
         user_table = Carto::UserTable.find(table.id)
         share_table_with_user(table, shared_user)
 
-        query_1 = query(table, owner_user)
+        query1 = query(table, owner_user)
         layer_options = {
           table_name: table.name,
-          query: query_1,
+          query: query1,
           user_name: owner_user.username,
-          query_history: [query_1]
+          query_history: [query1]
         }
         layer = FactoryGirl.create(:carto_layer, options: layer_options)
-        layer.options['query'].should eq query_1
+        layer.options['query'].should eq query1
         layer.options['user_name'].should eq owner_user.username
-        layer.options['query_history'].should eq [query_1]
+        layer.options['query_history'].should eq [query1]
 
         map = FactoryGirl.create(:carto_map, layers: [layer], user: owner_user)
         map, table, table_visualization, visualization = create_full_visualization(owner_user,
@@ -881,7 +881,7 @@ describe Carto::VisualizationsExportService2 do
                                                                                        data_layer: layer)
 
         FactoryGirl.create(:source_analysis, visualization: visualization, user: owner_user,
-                                             source_table: table.name, query: query_1)
+                                             source_table: table.name, query: query1)
         return map, table, table_visualization, visualization
       end
 
@@ -893,14 +893,14 @@ describe Carto::VisualizationsExportService2 do
       let(:export_service) { Carto::VisualizationsExportService2.new }
 
       def check_username_change(visualization, table, source_user, target_user)
-        query_1 = query(table, source_user)
+        query1 = query(table, source_user)
         exported = export_service.export_visualization_json_hash(visualization.id, target_user)
         layers = exported[:visualization][:layers]
         layers.should_not be_nil
         layer = layers[0]
-        layer[:options]['query'].should eq query_1
+        layer[:options]['query'].should eq query1
         layer[:options]['user_name'].should eq source_user.username
-        layer[:options]['query_history'].should eq [query_1]
+        layer[:options]['query_history'].should eq [query1]
 
         built_viz = export_service.build_visualization_from_hash_export(exported)
         imported_viz = Carto::VisualizationsExportPersistenceService.new.save_import(target_user, built_viz)
@@ -954,15 +954,15 @@ describe Carto::VisualizationsExportService2 do
         target_user = @carto_org_user_1
         @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
 
-        query_1 = query(@table, source_user)
+        query1 = query(@table, source_user)
         # Self export
         exported = export_service.export_visualization_json_hash(@visualization.id, source_user)
         layers = exported[:visualization][:layers]
         layers.should_not be_nil
         layer = layers[0]
-        layer[:options]['query'].should eq query_1
+        layer[:options]['query'].should eq query1
         layer[:options]['user_name'].should eq source_user.username
-        layer[:options]['query_history'].should eq [query_1]
+        layer[:options]['query_history'].should eq [query1]
 
         delete_user_data org_user_same_name
         org_user_same_name.destroy

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -857,6 +857,10 @@ describe Carto::VisualizationsExportService2 do
         end
       end
 
+      def setup_visualization_with_layer_query(owner_user, shared_user)
+        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(owner_user, shared_user)
+      end
+
       def shared_table_viz_with_layer_query(owner_user, shared_user)
         table = create_table(privacy: UserTable::PRIVACY_PRIVATE, name: table_name, user_id: owner_user.id)
         user_table = Carto::UserTable.find(table.id)
@@ -917,7 +921,7 @@ describe Carto::VisualizationsExportService2 do
       it 'replaces owner name with new user name on import for user_name and query' do
         source_user = @carto_org_user_1
         target_user = @carto_org_user_2
-        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
+        setup_visualization_with_layer_query(source_user, target_user)
         source_user.username.should_not include('-')
         check_username_change(@visualization, @table, source_user, target_user).should eq query(@table, target_user)
       end
@@ -925,7 +929,7 @@ describe Carto::VisualizationsExportService2 do
       it 'replaces owner name (with dash) with new user name on import for user_name and query' do
         source_user = @carto_org_user_with_dash_1
         target_user = @carto_org_user_with_dash_2
-        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
+        setup_visualization_with_layer_query(source_user, target_user)
         source_user.username.should include('-')
         check_username_change(@visualization, @table, source_user, target_user).should eq query(@table, target_user)
       end
@@ -933,7 +937,7 @@ describe Carto::VisualizationsExportService2 do
       it 'replaces owner name (without dash) with new user name (with dash) on import for user_name and query' do
         source_user = @carto_org_user_1
         target_user = @carto_org_user_with_dash_2
-        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
+        setup_visualization_with_layer_query(source_user, target_user)
         source_user.username.should_not include('-')
         target_user.username.should include('-')
         check_username_change(@visualization, @table, source_user, target_user).should eq query(@table, target_user)
@@ -942,7 +946,7 @@ describe Carto::VisualizationsExportService2 do
       it 'removes owner name from user_name and query importing into a non-organization account' do
         source_user = @carto_org_user_with_dash_1
         target_user = @carto_normal_user
-        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
+        setup_visualization_with_layer_query(source_user, target_user)
         source_user.username.should include('-')
         check_username_change(@visualization, @table, source_user, target_user).should eq query(@table)
       end
@@ -991,7 +995,7 @@ describe Carto::VisualizationsExportService2 do
         Carto::Layer.any_instance.stubs(:test_query).returns(false)
         source_user = @carto_org_user_1
         target_user = @carto_org_user_2
-        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
+        setup_visualization_with_layer_query(source_user, target_user)
         check_username_change(@visualization, @table, source_user, target_user).should eq query(@table, source_user)
       end
     end

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -849,22 +849,22 @@ describe Carto::VisualizationsExportService2 do
 
       let(:table_name) { 'a_shared_table' }
 
-      def query(user = nil)
+      def query(table, user = nil)
         if user.present?
-          "SELECT * FROM #{user.sql_safe_database_schema}.#{@table.name}"
+          "SELECT * FROM #{user.sql_safe_database_schema}.#{table.name}"
         else
-          "SELECT * FROM #{@table.name}"
+          "SELECT * FROM #{table.name}"
         end
       end
 
-      def setup_visualization_with_layer_query(owner_user, shared_user)
-        @table = create_table(privacy: UserTable::PRIVACY_PRIVATE, name: table_name, user_id: owner_user.id)
-        user_table = Carto::UserTable.find(@table.id)
-        share_table_with_user(@table, shared_user)
+      def shared_table_viz_with_layer_query(owner_user, shared_user)
+        table = create_table(privacy: UserTable::PRIVACY_PRIVATE, name: table_name, user_id: owner_user.id)
+        user_table = Carto::UserTable.find(table.id)
+        share_table_with_user(table, shared_user)
 
-        query_1 = query(owner_user)
+        query_1 = query(table, owner_user)
         layer_options = {
-          table_name: @table.name,
+          table_name: table.name,
           query: query_1,
           user_name: owner_user.username,
           query_history: [query_1]
@@ -875,13 +875,14 @@ describe Carto::VisualizationsExportService2 do
         layer.options['query_history'].should eq [query_1]
 
         map = FactoryGirl.create(:carto_map, layers: [layer], user: owner_user)
-        @map, @table, @table_visualization, @visualization = create_full_visualization(owner_user,
+        map, table, table_visualization, visualization = create_full_visualization(owner_user,
                                                                                        map: map,
                                                                                        table: user_table,
                                                                                        data_layer: layer)
 
-        FactoryGirl.create(:source_analysis, visualization: @visualization, user: owner_user,
-                                             source_table: @table.name, query: query_1)
+        FactoryGirl.create(:source_analysis, visualization: visualization, user: owner_user,
+                                             source_table: table.name, query: query_1)
+        return map, table, table_visualization, visualization
       end
 
       after(:each) do
@@ -891,9 +892,9 @@ describe Carto::VisualizationsExportService2 do
 
       let(:export_service) { Carto::VisualizationsExportService2.new }
 
-      def check_username_replacement(source_user, target_user)
-        query_1 = query(source_user)
-        exported = export_service.export_visualization_json_hash(@visualization.id, target_user)
+      def check_username_change(visualization, table, source_user, target_user)
+        query_1 = query(table, source_user)
+        exported = export_service.export_visualization_json_hash(visualization.id, target_user)
         layers = exported[:visualization][:layers]
         layers.should_not be_nil
         layer = layers[0]
@@ -916,34 +917,34 @@ describe Carto::VisualizationsExportService2 do
       it 'replaces owner name with new user name on import for user_name and query' do
         source_user = @carto_org_user_1
         target_user = @carto_org_user_2
-        setup_visualization_with_layer_query(source_user, target_user)
+        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
         source_user.username.should_not include('-')
-        check_username_replacement(source_user, target_user).should eq query(target_user)
+        check_username_change(@visualization, @table, source_user, target_user).should eq query(@table, target_user)
       end
 
       it 'replaces owner name (with dash) with new user name on import for user_name and query' do
         source_user = @carto_org_user_with_dash_1
         target_user = @carto_org_user_with_dash_2
-        setup_visualization_with_layer_query(source_user, target_user)
+        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
         source_user.username.should include('-')
-        check_username_replacement(source_user, target_user).should eq query(target_user)
+        check_username_change(@visualization, @table, source_user, target_user).should eq query(@table, target_user)
       end
 
       it 'replaces owner name (without dash) with new user name (with dash) on import for user_name and query' do
         source_user = @carto_org_user_1
         target_user = @carto_org_user_with_dash_2
-        setup_visualization_with_layer_query(source_user, target_user)
+        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
         source_user.username.should_not include('-')
         target_user.username.should include('-')
-        check_username_replacement(source_user, target_user).should eq query(target_user)
+        check_username_change(@visualization, @table, source_user, target_user).should eq query(@table, target_user)
       end
 
       it 'removes owner name from user_name and query importing into a non-organization account' do
         source_user = @carto_org_user_with_dash_1
         target_user = @carto_normal_user
-        setup_visualization_with_layer_query(source_user, target_user)
+        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
         source_user.username.should include('-')
-        check_username_replacement(source_user, target_user).should eq query
+        check_username_change(@visualization, @table, source_user, target_user).should eq query(@table)
       end
 
       it 'does not replace owner name with new user name on import when new query fails' do
@@ -952,8 +953,8 @@ describe Carto::VisualizationsExportService2 do
         Carto::Layer.any_instance.stubs(:test_query).returns(false)
         source_user = @carto_org_user_1
         target_user = @carto_org_user_2
-        setup_visualization_with_layer_query(source_user, target_user)
-        check_username_replacement(source_user, target_user).should eq query(source_user)
+        @map, @table, @table_visualization, @visualization = shared_table_viz_with_layer_query(source_user, target_user)
+        check_username_change(@visualization, @table, source_user, target_user).should eq query(@table, source_user)
       end
     end
 


### PR DESCRIPTION
This closes #11400 

About the CR, you might want to read independent commits instead of the full PR:
- I first had to refactor the tests to be able to use an intermediate user, helper methods relied too much in state.
- The second commit is the actual change.

Minimum acceptance:
- [ ] Create a map within an organization, including a query that contains the username in the table schema (`select * from username.table_name`). Export the map and delete that user. Create a user outside any organization, but with the same username. Import the map. It should work.
- [ ] Import within an organization account (with a different username).