### PR TITLE
Rebind events.

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/notifier/notifier-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/notifier/notifier-view.js
@@ -22,8 +22,16 @@ module.exports = CoreView.extend({
     return this;
   },
 
+  rebindEvents: function () {
+    // Just in case
+    this.stopListening(this.collection);
+    this.stopListening(this._editorModel);
+    this._initBinds();
+    return this;
+  },
+
   _initBinds: function () {
-    this.listenTo(this.collection, 'add reset remove change:status', this.render);
+    this.listenTo(this.collection, 'reset update change:status', this.render);
     this.add_related_model(this.collection);
 
     this.listenTo(this._editorModel, 'change:edition', this._changeStyle);

--- a/lib/assets/core/javascripts/cartodb3/components/notifier/notifier.js
+++ b/lib/assets/core/javascripts/cartodb3/components/notifier/notifier.js
@@ -21,7 +21,6 @@ var manager = (function () {
       collection: collection,
       editorModel: editorModel
     });
-    notifierView.render();
   }
 
   return {
@@ -35,7 +34,7 @@ var manager = (function () {
 
     getView: function () {
       if (!initialized) init();
-      return notifierView;
+      return notifierView.rebindEvents();
     },
 
     getCollection: function () {

--- a/lib/assets/core/test/spec/cartodb3/components/notifier/notifier-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/notifier/notifier-view.spec.js
@@ -2,6 +2,7 @@ var Backbone = require('backbone');
 var Notifier = require('../../../../../javascripts/cartodb3/components/notifier/notifier.js');
 var ConfigModel = require('../../../../../javascripts/cartodb3/data/config-model');
 var VisDefinitionModel = require('../../../../../javascripts/cartodb3/data/vis-definition-model');
+var CoreView = require('backbone/core-view');
 
 describe('components/notifier/notifier-view', function () {
   var view;
@@ -55,6 +56,21 @@ describe('components/notifier/notifier-view', function () {
     expect(view.$('.Notifier-inner').length).toBe(1);
     expect(view.$('.Notifier-icon').length).toBe(0);
     expect(view.$('#foo').length).toBe(1);
+  });
+
+  it('should rebind events properly', function () {
+    var holder = new CoreView();
+    var notifierView = Notifier.getView();
+    spyOn(notifierView, 'rebindEvents');
+
+    holder.$el.append(notifierView.render().el);
+    holder.addView(notifierView);
+
+    // clearSubViews calls to clear listeners
+    holder.clearSubViews();
+
+    Notifier.getView();
+    expect(view.rebindEvents).toHaveBeenCalled();
   });
 
   it('should add subview properly', function () {


### PR DESCRIPTION
This PR implements #11244.

Notifier view is a singleton view. This means, the view is created once, then added and removed.
When removed, because of the internal management of our views, we destroy the bindings. This happens when we change to the options view. The notifier parent's view, editor-map-view, is deleted, so it performs a clearSubViews, deleting the bindings. In order to fix this, every time we append the notifier view, we need to make sure bindings are working properly.

In order to test this, make sure notifications are working properly when back from the options panel. It's in this scenario where the re-binding should get back to listen to every event again.
