### PR TITLE
Memoize visualization names taken by user in order to check name candidates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,7 @@ Development
 * Fix color for "Other" category (#11078)
 * Custom errors for latitude/longitude out of bounds (#11060, #11048)
 * Fix timeseries widget height (#11077)
+* Improve speed of map name availability check, improves map creation and renaming times (#11435)
 * Fix redirection after logout for subdomainless URLs (#11361)
 * Fix scrollbar in carousel (#11061)
 * Restrict login from organization pages to organization users, and redirect to Central otherwise

--- a/app/models/visualization/name_checker.rb
+++ b/app/models/visualization/name_checker.rb
@@ -2,26 +2,23 @@
 require_relative './collection'
 
 module CartoDB
-  module Visualization 
+  module Visualization
     class NameChecker
       def initialize(user)
         @user = user
-      end #initialize
+      end
 
       def available?(candidate)
-        !taken_names_for(user).include?(candidate)
-      end #available?
+        !taken_names_for.include?(candidate)
+      end
 
       private
 
-      def taken_names_for(user)
-        Visualization::Collection.new
-                                 .fetch(user_id: user.id, exclude_shared: true)
-                                 .map(&:name)
-      end #taken_names
+      def taken_names_for
+        @taken_names ||= Carto::Visualization::where(user_id: user.id).select(:name).map(&:name)
+      end
 
       attr_reader :user
     end # NameChecker
   end # Visualization
 end # CartoDB
-


### PR DESCRIPTION
This should improve the situation in #11419 by memoizing temporary results. In map creation, locally, it reduces the time to create a visualization from 2600ms to 60ms, in an account with 300 visualizations (half of that are the data library), 40 of which are unnamed maps.

**Acceptance**
If you have a staging account with many maps, you can take measurements on map creation before and after this patch. Creating several maps named like "Untitled Map XX" (the default) makes the problem more obvious. This also affects visualizations renaming.

- [x] Create map, check that the generated map doesn't conflicts with any others
- [x] Try to rename a map to an existing name -> it should fail
- [x] Try to rename a map to a non-existent name -> it should suceed
- [x] All the previous operations should be quick (a couple of seconds).
- [x] Import a dataset.
- [x] Import the same dataset again.
- [x] Import a .carto
- [x] Import the same .carto again.
- [x] Create a dataset from a query.