### PR TITLE
Default configuration changes

### DIFF
--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -548,7 +548,6 @@ development:
     url_purge_command: 'url.purge'
     retries: 5
     timeout: 5
-  enforce_non_empty_layer_css: false
 
 test:
   <<: *defaults

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -286,9 +286,9 @@ defaults: &defaults
     asset_host: "//cartodb-libs.global.ssl.fastly.net/cartodbui"
   avatars:
     gravatar_enabled: true
-    base_url: 'example.com/avatars'
-    kinds: ['stars', 'mountains']
-    colors: ['red', 'blue']
+    base_url: '/assets/unversioned/images/avatars'
+    kinds: ['ghost', 'heart', 'marker', 'mountain', 'pacman', 'planet', 'star']
+    colors: ['green', 'orange', 'red', 'yellow']
   dropbox_api_key: ""
   gdrive:
     api_key: ""

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -535,6 +535,7 @@ defaults: &defaults
     sqlserver:
       enabled: false
       max_rows: 500000
+  enforce_non_empty_layer_css: false
 
 development:
   <<: *defaults


### PR DESCRIPTION
A couple of configuration changes to make life easier:
 - Makes avatars work by default. Test by creating a new user with this configuration.
 - `enforce_non_empty_layer_css: false` in all environments. It is needed for Builder to work (any visualization creation, including dataset imports, will fail if this is not set).