### PR TITLE
11437 dependent visualization calculation

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -185,19 +185,19 @@ class Admin::VisualizationsController < Admin::AdminController
     @disqus_shortname       = @visualization.user.disqus_shortname.presence || 'cartodb'
     @public_tables_count    = @visualization.user.public_table_count
 
-    @non_dependent_visualizations = @table.non_dependent_visualizations.select{
+    @partially_dependent_visualizations = @table.partially_dependent_visualizations.select{
         |vis| vis.privacy == Visualization::Member::PRIVACY_PUBLIC
     }
 
-    @dependent_visualizations = @table.dependent_visualizations.select{
+    @fully_dependent_visualizations = @table.fully_dependent_visualizations.select{
         |vis| vis.privacy == Visualization::Member::PRIVACY_PUBLIC
     }
 
-    @total_visualizations  = @non_dependent_visualizations + @dependent_visualizations
+    @total_visualizations  = @partially_dependent_visualizations + @fully_dependent_visualizations
 
-    @total_nonpublic_total_vis_count = @table.non_dependent_visualizations.select{
+    @total_nonpublic_total_vis_count = @table.partially_dependent_visualizations.select{
         |vis| vis.privacy != Visualization::Member::PRIVACY_PUBLIC
-    }.count + @table.dependent_visualizations.select{
+    }.count + @table.fully_dependent_visualizations.select{
         |vis| vis.privacy != Visualization::Member::PRIVACY_PUBLIC
     }.count
 

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -185,20 +185,20 @@ class Admin::VisualizationsController < Admin::AdminController
     @disqus_shortname       = @visualization.user.disqus_shortname.presence || 'cartodb'
     @public_tables_count    = @visualization.user.public_table_count
 
-    @partially_dependent_visualizations = @table.partially_dependent_visualizations.select{
-        |vis| vis.privacy == Visualization::Member::PRIVACY_PUBLIC
-    }
+    @partially_dependent_visualizations = @table.partially_dependent_visualizations.select do |vis|
+      vis.privacy == Visualization::Member::PRIVACY_PUBLIC
+    end
 
-    @fully_dependent_visualizations = @table.fully_dependent_visualizations.select{
-        |vis| vis.privacy == Visualization::Member::PRIVACY_PUBLIC
-    }
+    @fully_dependent_visualizations = @table.fully_dependent_visualizations.select do |vis|
+      vis.privacy == Visualization::Member::PRIVACY_PUBLIC
+    end
 
-    @total_visualizations  = @partially_dependent_visualizations + @fully_dependent_visualizations
+    @total_visualizations = @partially_dependent_visualizations + @fully_dependent_visualizations
 
-    @total_nonpublic_total_vis_count = @table.partially_dependent_visualizations.select{
-        |vis| vis.privacy != Visualization::Member::PRIVACY_PUBLIC
-    }.count + @table.fully_dependent_visualizations.select{
-        |vis| vis.privacy != Visualization::Member::PRIVACY_PUBLIC
+    @total_nonpublic_total_vis_count = @table.partially_dependent_visualizations.select { |vis|
+      vis.privacy != Visualization::Member::PRIVACY_PUBLIC
+    }.count + @table.fully_dependent_visualizations.select { |vis|
+      vis.privacy != Visualization::Member::PRIVACY_PUBLIC
     }.count
 
     # Public export API SQL url

--- a/app/controllers/api/json/visualizations_controller.rb
+++ b/app/controllers/api/json/visualizations_controller.rb
@@ -195,7 +195,7 @@ class Api::Json::VisualizationsController < Api::ApplicationController
         end
 
         unless vis.table.nil?
-          vis.table.dependent_visualizations.each do |dependent_vis|
+          vis.table.fully_dependent_visualizations.each do |dependent_vis|
             properties = { user_id: current_viewer_id, visualization_id: dependent_vis.id }
             if dependent_vis.derived?
               Carto::Tracking::Events::DeletedMap.new(current_viewer_id, properties).report

--- a/app/controllers/carto/admin/user_table_public_map_adapter.rb
+++ b/app/controllers/carto/admin/user_table_public_map_adapter.rb
@@ -4,7 +4,7 @@ module Carto
     class UserTablePublicMapAdapter
       extend Forwardable
 
-      delegate [ :non_dependent_visualizations, :dependent_visualizations, :name, :id ] => :user_table
+      delegate [ :partially_dependent_visualizations, :fully_dependent_visualizations, :name, :id ] => :user_table
 
       attr_reader :user_table
 

--- a/app/controllers/carto/admin/user_table_public_map_adapter.rb
+++ b/app/controllers/carto/admin/user_table_public_map_adapter.rb
@@ -4,7 +4,7 @@ module Carto
     class UserTablePublicMapAdapter
       extend Forwardable
 
-      delegate [ :partially_dependent_visualizations, :fully_dependent_visualizations, :name, :id ] => :user_table
+      delegate [:partially_dependent_visualizations, :fully_dependent_visualizations, :name, :id] => :user_table
 
       attr_reader :user_table
 

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -284,6 +284,10 @@ module Carto
       register_table_dependencies
     end
 
+    def depends_on?(user_table)
+      user_tables.include?(user_table)
+    end
+
     private
 
     def rename_in(target, anchor, substitution)

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -128,18 +128,7 @@ module Carto
     end
 
     def affected_visualizations
-      @affected_visualizations ||= affected_visualization_ids.map { |id| Carto::Visualization.find(id) }
-    end
-
-    # TODO: use associations?
-    def affected_visualization_ids
-      ActiveRecord::Base.connection.execute(%Q{
-        SELECT  distinct visualizations.id
-        FROM    layers_user_tables, layers_maps, visualizations
-        WHERE   layers_user_tables.user_table_id = '#{table.id}'
-        AND     layers_user_tables.layer_id = layers_maps.layer_id
-        AND     layers_maps.map_id = visualizations.map_id
-      }).map { |row| row['id'] }
+      layers.map(&:visualization).uniq
     end
 
     def table

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -64,7 +64,7 @@ module Carto
       visualization.synchronization if visualization
     end
 
-    def dependent_visualizations
+    def fully_dependent_visualizations
       affected_visualizations.select { |v| v.fully_dependent_on?(self) }
     end
 
@@ -72,7 +72,7 @@ module Carto
       affected_visualizations.select { |v| (v.has_read_permission?(user) && v.derived?) ? v : nil }
     end
 
-    def non_dependent_visualizations
+    def partially_dependent_visualizations
       affected_visualizations.select { |v| v.partially_dependent_on?(self) }
     end
 

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -65,7 +65,7 @@ module Carto
     end
 
     def dependent_visualizations
-      affected_visualizations.select(&:dependent?)
+      affected_visualizations.select { |v| v.fully_dependent_on?(self) }
     end
 
     def accessible_dependent_derived_maps
@@ -73,7 +73,7 @@ module Carto
     end
 
     def non_dependent_visualizations
-      affected_visualizations.select(&:non_dependent?)
+      affected_visualizations.select { |v| v.partially_dependent_on?(self) }
     end
 
     def name_for_user(other_user)

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -218,7 +218,9 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def partially_dependent_on?(user_table)
-    derived? && layers_dependent_on(user_table).instance_eval { any? && !all? }
+    return false unless derived?
+    layer_dependencies = layers_dependent_on(user_table)
+    layer_dependencies.any? && !layer_dependencies.all?
   end
 
   def layers_dependent_on(user_table)

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -214,17 +214,15 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def fully_dependent_on?(user_table)
-    derived? && layers_dependent_on(user_table).all?
+    derived? && layers_dependent_on(user_table).count == carto_and_torque_layers.count
   end
 
   def partially_dependent_on?(user_table)
-    return false unless derived?
-    layer_dependencies = layers_dependent_on(user_table)
-    layer_dependencies.any? && !layer_dependencies.all?
+    derived? && layers_dependent_on(user_table).count.between?(1, carto_and_torque_layers.count - 1)
   end
 
   def layers_dependent_on(user_table)
-    carto_and_torque_layers.map { |l| l.depends_on?(user_table) }
+    carto_and_torque_layers.select { |l| l.depends_on?(user_table) }
   end
 
   def layers

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -213,18 +213,16 @@ class Carto::Visualization < ActiveRecord::Base
     type == TYPE_DERIVED
   end
 
-  # TODO: Check if for type slide should return true also
-  def dependent?
-    derived? && single_data_layer?
+  def fully_dependent_on?(user_table)
+    derived? && layers_dependent_on(user_table).all?
   end
 
-  # TODO: Check if for type slide should return true also
-  def non_dependent?
-    derived? && !single_data_layer?
+  def partially_dependent_on?(user_table)
+    derived? && layers_dependent_on(user_table).instance_eval { any? && !all? }
   end
 
-  def single_data_layer?
-    data_layers.count == 1 || related_tables.count == 1
+  def layers_dependent_on(user_table)
+    carto_and_torque_layers.map { |l| l.user_tables.include?(user_table) }
   end
 
   def layers

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -224,7 +224,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def layers_dependent_on(user_table)
-    carto_and_torque_layers.map { |l| l.user_tables.include?(user_table) }
+    carto_and_torque_layers.map { |l| l.depends_on?(user_table) }
   end
 
   def layers

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -203,6 +203,10 @@ class Layer < Sequel::Model
     options && options.symbolize_keys[:source]
   end
 
+  def depends_on?(table)
+    user_tables.map(&:id).include?(table.id)
+  end
+
   private
 
   def rename_in(target, anchor, substitution)

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -483,10 +483,10 @@ module CartoDB
     #  - if the table is used in the only one visualization layer, the vis is removed
     # TODO: send a notification to the visualizations owner
     def check_related_visualizations(table)
-      dependent_visualizations = table.dependent_visualizations.to_a
-      non_dependent_visualizations = table.non_dependent_visualizations.to_a
+      fully_dependent_visualizations = table.fully_dependent_visualizations.to_a
+      partially_dependent_visualizations = table.partially_dependent_visualizations.to_a
       table_visualization = table.table_visualization
-      non_dependent_visualizations.each do |visualization|
+      partially_dependent_visualizations.each do |visualization|
         # check permissions, if the owner does not have permissions
         # to see the table the layers using this table are removed
         perm = visualization.permission
@@ -495,7 +495,7 @@ module CartoDB
         end
       end
 
-      dependent_visualizations.each do |visualization|
+      fully_dependent_visualizations.each do |visualization|
         # check permissions, if the owner does not have permissions
         # to see the table the visualization is removed
         perm = visualization.permission

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -56,8 +56,8 @@ class Table
       :description                  => :description,
       :geometry_types               => :geometry_types,
       :table_visualization          => :table_visualization,
-      :dependent_visualizations     => :serialize_dependent_visualizations,
-      :non_dependent_visualizations => :serialize_non_dependent_visualizations,
+      :dependent_visualizations     => :serialize_fully_dependent_visualizations,
+      :non_dependent_visualizations => :serialize_partially_dependent_visualizations,
       :synchronization              => :serialize_synchronization
   }
 
@@ -567,8 +567,8 @@ class Table
     if @table_visualization
       @table_visualization.user_data = { name: owner.username, api_key: owner.api_key }
     end
-    @dependent_visualizations_cache     = dependent_visualizations.to_a
-    @non_dependent_visualizations_cache = non_dependent_visualizations.to_a
+    @fully_dependent_visualizations_cache     = fully_dependent_visualizations.to_a
+    @partially_dependent_visualizations_cache = partially_dependent_visualizations.to_a
   end
 
   def after_destroy
@@ -578,8 +578,8 @@ class Table
     remove_table_from_stats
 
     cache.del geometry_types_key
-    @dependent_visualizations_cache.each(&:delete)
-    @non_dependent_visualizations_cache.each do |visualization|
+    @fully_dependent_visualizations_cache.each(&:delete)
+    @partially_dependent_visualizations_cache.each do |visualization|
       visualization.unlink_from(self)
     end
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -45,21 +45,21 @@ class Table
   # @see config/initializers/carto_db.rb -> RESERVED_COLUMN_NAMES
   RESERVED_COLUMN_NAMES = %w(oid tableoid xmin cmin xmax cmax ctid ogc_fid).freeze
   PUBLIC_ATTRIBUTES = {
-      :id                           => :id,
-      :name                         => :name,
-      :privacy                      => :privacy_text,
-      :schema                       => :schema,
-      :updated_at                   => :updated_at,
-      :rows_counted                 => :rows_estimated,
-      :table_size                   => :table_size,
-      :map_id                       => :map_id,
-      :description                  => :description,
-      :geometry_types               => :geometry_types,
-      :table_visualization          => :table_visualization,
-      :dependent_visualizations     => :serialize_fully_dependent_visualizations,
-      :non_dependent_visualizations => :serialize_partially_dependent_visualizations,
-      :synchronization              => :serialize_synchronization
-  }
+    id:                           :id,
+    name:                         :name,
+    privacy:                      :privacy_text,
+    schema:                       :schema,
+    updated_at:                   :updated_at,
+    rows_counted:                 :rows_estimated,
+    table_size:                   :table_size,
+    map_id:                       :map_id,
+    description:                  :description,
+    geometry_types:               :geometry_types,
+    table_visualization:          :table_visualization,
+    dependent_visualizations:     :serialize_fully_dependent_visualizations,
+    non_dependent_visualizations: :serialize_partially_dependent_visualizations,
+    synchronization:              :serialize_synchronization
+  }.freeze
 
   DEFAULT_THE_GEOM_TYPE = 'geometry'
 

--- a/app/models/table/relator.rb
+++ b/app/models/table/relator.rb
@@ -44,11 +44,11 @@ module CartoDB
     end
 
     def dependent_visualizations
-      affected_visualizations.select(&:dependent?)
+      affected_visualizations.select { |v| v.fully_dependent_on?(table) }
     end
 
     def non_dependent_visualizations
-      affected_visualizations.select(&:non_dependent?)
+      affected_visualizations.select { |v| v.partially_dependent_on?(table) }
     end
 
     def affected_visualizations
@@ -118,4 +118,3 @@ module CartoDB
 
   end
 end
-

--- a/app/models/table/relator.rb
+++ b/app/models/table/relator.rb
@@ -6,10 +6,10 @@ module CartoDB
   class TableRelator
     INTERFACE = %w{
       table_visualization
-      serialize_dependent_visualizations
-      serialize_non_dependent_visualizations
-      dependent_visualizations
-      non_dependent_visualizations
+      serialize_fully_dependent_visualizations
+      serialize_partially_dependent_visualizations
+      fully_dependent_visualizations
+      partially_dependent_visualizations
       affected_visualizations
       synchronization
       serialize_synchronization
@@ -35,19 +35,19 @@ module CartoDB
       @table_visualization = table_visualization
     end
 
-    def serialize_dependent_visualizations
-      dependent_visualizations.map { |object| preview_for(object) }
+    def serialize_fully_dependent_visualizations
+      fully_dependent_visualizations.map { |object| preview_for(object) }
     end
 
-    def serialize_non_dependent_visualizations
-      non_dependent_visualizations.map { |object| preview_for(object) }
+    def serialize_partially_dependent_visualizations
+      partially_dependent_visualizations.map { |object| preview_for(object) }
     end
 
-    def dependent_visualizations
+    def fully_dependent_visualizations
       affected_visualizations.select { |v| v.fully_dependent_on?(table) }
     end
 
-    def non_dependent_visualizations
+    def partially_dependent_visualizations
       affected_visualizations.select { |v| v.partially_dependent_on?(table) }
     end
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -23,6 +23,7 @@ module CartoDB
       extend Forwardable
       include Virtus.model
       include CacheHelper
+      include Carto::VisualizationDependencies
 
       PRIVACY_PUBLIC       = 'public'        # published and listable in public user profile
       PRIVACY_PRIVATE      = 'private'       # not published (viz.json and embed_map should return 404)
@@ -479,14 +480,6 @@ module CartoDB
 
       def type_slide?
         type == TYPE_SLIDE
-      end
-
-      def fully_dependent_on?(user_table)
-        derived? && layers_dependent_on(user_table).count == carto_and_torque_layers.count
-      end
-
-      def partially_dependent_on?(user_table)
-        derived? && layers_dependent_on(user_table).count.between?(1, carto_and_torque_layers.count - 1)
       end
 
       def invalidate_cache

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -12,6 +12,7 @@ require_relative '../table/privacy_manager'
 require_relative '../../../services/minimal-validation/validator'
 require_relative '../../helpers/embed_redis_cache'
 require_dependency 'cartodb/redis_vizjson_cache'
+require_dependency 'carto/visualization'
 
 # Every table has always at least one visualization (the "canonical visualization"), of type 'table',
 # which shares the same privacy options as the table and gets synced.

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -481,12 +481,12 @@ module CartoDB
         type == TYPE_SLIDE
       end
 
-      def dependent?
-        derived? && single_data_layer?
+      def fully_dependent_on?(table)
+        derived? && layers_dependent_on(table).all?
       end
 
-      def non_dependent?
-        derived? && !single_data_layer?
+      def partially_dependent_on?(table)
+        derived? && layers_dependent_on(table).instance_eval { any? && !all? }
       end
 
       def invalidate_cache

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -481,12 +481,12 @@ module CartoDB
         type == TYPE_SLIDE
       end
 
-      def fully_dependent_on?(table)
-        derived? && layers_dependent_on(table).all?
+      def fully_dependent_on?(user_table)
+        derived? && layers_dependent_on(user_table).count == carto_and_torque_layers.count
       end
 
-      def partially_dependent_on?(table)
-        derived? && layers_dependent_on(table).instance_eval { any? && !all? }
+      def partially_dependent_on?(user_table)
+        derived? && layers_dependent_on(user_table).count.between?(1, carto_and_torque_layers.count - 1)
       end
 
       def invalidate_cache

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -17,7 +17,7 @@ module CartoDB
       }.freeze
 
       INTERFACE = %w{ overlays user table related_templates related_tables related_canonical_visualizations
-                      layers stats mapviews total_mapviews layers_dependent_on synchronization is_synced? permission
+                      layers stats mapviews total_mapviews carto_and_torque_layers synchronization is_synced? permission
                       parent children support_tables prev_list_item next_list_item likes likes_count reload_likes
                       estimated_row_count actual_row_count }.freeze
 

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -17,7 +17,7 @@ module CartoDB
       }.freeze
 
       INTERFACE = %w{ overlays user table related_templates related_tables related_canonical_visualizations
-                      layers stats mapviews total_mapviews single_data_layer? synchronization is_synced? permission
+                      layers stats mapviews total_mapviews layers_dependent_on synchronization is_synced? permission
                       parent children support_tables prev_list_item next_list_item likes likes_count reload_likes
                       estimated_row_count actual_row_count }.freeze
 
@@ -130,8 +130,8 @@ module CartoDB
         @total_mapviews ||= Visualization::Stats.new(self, user).total_mapviews
       end
 
-      def single_data_layer?
-        layers(:cartodb).to_a.length == 1 || related_tables.length == 1
+      def layers_dependent_on(table)
+        layers(:carto_and_torque).map { |l| l.user_tables.map(&:id).include?(table.id) }
       end
 
       def permission

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -130,8 +130,8 @@ module CartoDB
         @total_mapviews ||= Visualization::Stats.new(self, user).total_mapviews
       end
 
-      def layers_dependent_on(table)
-        layers(:carto_and_torque).map { |l| l.depends_on?(table) }
+      def carto_and_torque_layers
+        layers(:carto_and_torque)
       end
 
       def permission

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -131,7 +131,7 @@ module CartoDB
       end
 
       def layers_dependent_on(table)
-        layers(:carto_and_torque).map { |l| l.user_tables.map(&:id).include?(table.id) }
+        layers(:carto_and_torque).map { |l| l.depends_on?(table) }
       end
 
       def permission

--- a/spec/models/carto/user_table_spec.rb
+++ b/spec/models/carto/user_table_spec.rb
@@ -1,12 +1,17 @@
 # coding: UTF-8
 require_relative '../../spec_helper_min'
+require 'models/user_table_shared_examples'
 
 describe Carto::UserTable do
   before(:all) do
     bypass_named_maps
 
     @user = FactoryGirl.create(:carto_user)
+    @carto_user = @user
     @user_table = Carto::UserTable.create(user: @user, name: 'user_table')
+
+    # The dependent visualization models are in the UserTable class for the AR model
+    @dependent_test_object = @user_table
   end
 
   after(:all) do
@@ -14,24 +19,7 @@ describe Carto::UserTable do
     @user.destroy
   end
 
-  describe '#estimated_row_count and #actual_row_count' do
-    it 'should query Table estimated an actual row count methods' do
-      ::Table.any_instance.stubs(:estimated_row_count).returns(999)
-      ::Table.any_instance.stubs(:actual_row_count).returns(1000)
-
-      @user_table.estimated_row_count.should == 999
-      @user_table.actual_row_count.should == 1000
-    end
-  end
-
-  it 'should sync table_id with physical table oid' do
-    @user_table.table_id = nil
-    @user_table.save
-
-    @user_table.table_id.should be_nil
-
-    @user_table.sync_table_id.should eq @user_table.service.get_table_id
-  end
+  it_behaves_like 'user table models'
 
   describe '#readable_by?' do
     include_context 'organization with users helper'

--- a/spec/models/table/relator_spec.rb
+++ b/spec/models/table/relator_spec.rb
@@ -39,7 +39,7 @@ describe CartoDB::TableRelator do
     end
   end
 
-  describe '.serialize_dependent_visualizations' do
+  describe '.serialize_fully_dependent_visualizations' do
     before :each do
       bypass_named_maps
 
@@ -60,7 +60,7 @@ describe CartoDB::TableRelator do
 
     describe 'given there are no dependent visualizations' do
       before :each do
-        @dependents = @table_relator.serialize_dependent_visualizations
+        @dependents = @table_relator.serialize_fully_dependent_visualizations
       end
 
       it 'should return an empty list' do
@@ -75,7 +75,7 @@ describe CartoDB::TableRelator do
         CartoDB::Visualization::Member.any_instance
                                       .stubs(:fully_dependent_on?)
                                       .returns(true, false, true)
-        @dependents = @table_relator.serialize_dependent_visualizations
+        @dependents = @table_relator.serialize_fully_dependent_visualizations
       end
 
       it 'should return a list with dependent visualizations' do
@@ -94,7 +94,7 @@ describe CartoDB::TableRelator do
     end
   end
 
-  describe '.serialize_non_dependent_visualizations' do
+  describe '.serialize_partially_dependent_visualizations' do
     before :each do
       bypass_named_maps
 
@@ -118,7 +118,7 @@ describe CartoDB::TableRelator do
       before :each do
         bypass_named_maps
 
-        @non_dependents = @table_relator.serialize_non_dependent_visualizations
+        @non_dependents = @table_relator.serialize_partially_dependent_visualizations
       end
 
       it 'should return an empty list' do
@@ -133,7 +133,7 @@ describe CartoDB::TableRelator do
         CartoDB::Visualization::Member.any_instance
                                       .stubs(:partially_dependent_on?)
                                       .returns(true, false, false)
-        @non_dependents = @table_relator.serialize_non_dependent_visualizations
+        @non_dependents = @table_relator.serialize_partially_dependent_visualizations
       end
 
       it 'should return a list with dependent visualizations' do

--- a/spec/models/table/relator_spec.rb
+++ b/spec/models/table/relator_spec.rb
@@ -72,7 +72,7 @@ describe CartoDB::TableRelator do
       before :each do
         bypass_named_maps
 
-        CartoDB::Visualization::Member.any_instance.stubs(:dependent?).returns(true, false, true)
+        CartoDB::Visualization::Member.any_instance.stubs(:fully_dependent?).returns(true, false, true)
         @dependents = @table_relator.serialize_dependent_visualizations
       end
 
@@ -128,7 +128,7 @@ describe CartoDB::TableRelator do
       before :each do
         bypass_named_maps
 
-        CartoDB::Visualization::Member.any_instance.stubs(:non_dependent?).returns(true, false, false)
+        CartoDB::Visualization::Member.any_instance.stubs(:partially_dependent?).returns(true, false, false)
         @non_dependents = @table_relator.serialize_non_dependent_visualizations
       end
 

--- a/spec/models/user_table_shared_examples.rb
+++ b/spec/models/user_table_shared_examples.rb
@@ -29,6 +29,7 @@ shared_examples_for 'user table models' do
 
     before(:each) do
       @second_layer.update_attribute(:kind, 'carto')
+      @user_table.reload
     end
 
     after(:all) do

--- a/spec/models/user_table_shared_examples.rb
+++ b/spec/models/user_table_shared_examples.rb
@@ -1,0 +1,88 @@
+shared_examples_for 'user table models' do
+  describe '#estimated_row_count and #actual_row_count' do
+    it 'should query Table estimated an actual row count methods' do
+      ::Table.any_instance.stubs(:estimated_row_count).returns(999)
+      ::Table.any_instance.stubs(:actual_row_count).returns(1000)
+
+      @user_table.estimated_row_count.should == 999
+      @user_table.actual_row_count.should == 1000
+    end
+  end
+
+  it 'should sync table_id with physical table oid' do
+    @user_table.table_id = nil
+    @user_table.save
+
+    @user_table.table_id.should be_nil
+
+    @user_table.sync_table_id.should eq @user_table.service.get_table_id
+  end
+
+  describe 'dependent visualizations' do
+    include Carto::Factories::Visualizations
+
+    before(:all) do
+      @map, @other_table, @table_visualization, @visualization = create_full_visualization(@carto_user)
+      @first_layer = @visualization.data_layers.first
+      @second_layer = FactoryGirl.create(:carto_layer, kind: 'carto', maps: [@map])
+    end
+
+    before(:each) do
+      @second_layer.update_attribute(:kind, 'carto')
+    end
+
+    after(:all) do
+      @second_layer.destroy
+      destroy_full_visualization(@map, @other_table, @table_visualization, @visualization)
+    end
+
+    it 'no layers depending on the table -> not dependent' do
+      @first_layer.user_table_ids = []
+      @second_layer.user_table_ids = []
+
+      @dependent_test_object.dependent_visualizations.any?.should be_false
+      @dependent_test_object.non_dependent_visualizations.any?.should be_false
+    end
+
+    it 'one layer depending on the table -> fully dependent' do
+      @first_layer.user_table_ids = [@user_table.id]
+      @second_layer.user_table_ids = []
+      @second_layer.update_attribute(:kind, 'tiled')
+
+      @dependent_test_object.dependent_visualizations.any?.should be_true
+      @dependent_test_object.non_dependent_visualizations.any?.should be_false
+    end
+
+    it 'two layers depending on the table -> fully dependent' do
+      @first_layer.user_table_ids = [@user_table.id]
+      @second_layer.user_table_ids = [@user_table.id]
+
+      @dependent_test_object.dependent_visualizations.any?.should be_true
+      @dependent_test_object.non_dependent_visualizations.any?.should be_false
+    end
+
+    it 'two layers depending on different tables -> partially dependent' do
+      @first_layer.user_table_ids = [@user_table.id]
+      @second_layer.user_table_ids = [@other_table.id]
+
+      @dependent_test_object.dependent_visualizations.any?.should be_false
+      @dependent_test_object.non_dependent_visualizations.any?.should be_true
+    end
+
+    it 'two layers depending on multiple tables (both include this one) -> fully dependent' do
+      @first_layer.user_table_ids = [@user_table.id]
+      @second_layer.user_table_ids = [@user_table.id, @other_table.id]
+
+      @dependent_test_object.dependent_visualizations.any?.should be_true
+      @dependent_test_object.non_dependent_visualizations.any?.should be_false
+    end
+
+    it 'two layers depending on multiple tables (this table is only used in one layer) -> partially dependent' do
+      @first_layer.user_table_ids = [@user_table.id, @other_table.id]
+      @second_layer.user_table_ids = [@other_table.id]
+
+      @dependent_test_object.dependent_visualizations.any?.should be_false
+      @dependent_test_object.non_dependent_visualizations.any?.should be_true
+    end
+  end
+end

--- a/spec/models/user_table_shared_examples.rb
+++ b/spec/models/user_table_shared_examples.rb
@@ -41,8 +41,8 @@ shared_examples_for 'user table models' do
       @first_layer.user_table_ids = []
       @second_layer.user_table_ids = []
 
-      @dependent_test_object.dependent_visualizations.any?.should be_false
-      @dependent_test_object.non_dependent_visualizations.any?.should be_false
+      @dependent_test_object.fully_dependent_visualizations.any?.should be_false
+      @dependent_test_object.partially_dependent_visualizations.any?.should be_false
     end
 
     it 'one layer depending on the table -> fully dependent' do
@@ -50,40 +50,40 @@ shared_examples_for 'user table models' do
       @second_layer.user_table_ids = []
       @second_layer.update_attribute(:kind, 'tiled')
 
-      @dependent_test_object.dependent_visualizations.any?.should be_true
-      @dependent_test_object.non_dependent_visualizations.any?.should be_false
+      @dependent_test_object.fully_dependent_visualizations.any?.should be_true
+      @dependent_test_object.partially_dependent_visualizations.any?.should be_false
     end
 
     it 'two layers depending on the table -> fully dependent' do
       @first_layer.user_table_ids = [@user_table.id]
       @second_layer.user_table_ids = [@user_table.id]
 
-      @dependent_test_object.dependent_visualizations.any?.should be_true
-      @dependent_test_object.non_dependent_visualizations.any?.should be_false
+      @dependent_test_object.fully_dependent_visualizations.any?.should be_true
+      @dependent_test_object.partially_dependent_visualizations.any?.should be_false
     end
 
     it 'two layers depending on different tables -> partially dependent' do
       @first_layer.user_table_ids = [@user_table.id]
       @second_layer.user_table_ids = [@other_table.id]
 
-      @dependent_test_object.dependent_visualizations.any?.should be_false
-      @dependent_test_object.non_dependent_visualizations.any?.should be_true
+      @dependent_test_object.fully_dependent_visualizations.any?.should be_false
+      @dependent_test_object.partially_dependent_visualizations.any?.should be_true
     end
 
     it 'two layers depending on multiple tables (both include this one) -> fully dependent' do
       @first_layer.user_table_ids = [@user_table.id]
       @second_layer.user_table_ids = [@user_table.id, @other_table.id]
 
-      @dependent_test_object.dependent_visualizations.any?.should be_true
-      @dependent_test_object.non_dependent_visualizations.any?.should be_false
+      @dependent_test_object.fully_dependent_visualizations.any?.should be_true
+      @dependent_test_object.partially_dependent_visualizations.any?.should be_false
     end
 
     it 'two layers depending on multiple tables (this table is only used in one layer) -> partially dependent' do
       @first_layer.user_table_ids = [@user_table.id, @other_table.id]
       @second_layer.user_table_ids = [@other_table.id]
 
-      @dependent_test_object.dependent_visualizations.any?.should be_false
-      @dependent_test_object.non_dependent_visualizations.any?.should be_true
+      @dependent_test_object.fully_dependent_visualizations.any?.should be_false
+      @dependent_test_object.partially_dependent_visualizations.any?.should be_true
     end
   end
 end

--- a/spec/models/user_table_shared_examples.rb
+++ b/spec/models/user_table_shared_examples.rb
@@ -24,11 +24,11 @@ shared_examples_for 'user table models' do
     before(:all) do
       @map, @other_table, @table_visualization, @visualization = create_full_visualization(@carto_user)
       @first_layer = @visualization.data_layers.first
-      @second_layer = FactoryGirl.create(:carto_layer, kind: 'carto', maps: [@map])
+      @second_layer = FactoryGirl.create(:carto_layer, kind: 'torque', maps: [@map])
     end
 
     before(:each) do
-      @second_layer.update_attribute(:kind, 'carto')
+      @second_layer.update_attribute(:kind, 'torque')
       @user_table.reload
     end
 

--- a/spec/models/user_table_spec.rb
+++ b/spec/models/user_table_spec.rb
@@ -1,17 +1,22 @@
 # coding: UTF-8
 require_relative '../spec_helper'
+require 'models/user_table_shared_examples'
 
 describe UserTable do
   before(:all) do
     bypass_named_maps
 
     @user = create_user(email: 'admin@cartotest.com', username: 'admin', password: '123456')
+    @carto_user = Carto::User.find(@user.id)
 
     @user_table = ::UserTable.new
 
     @user_table.user_id = @user.id
     @user_table.name = 'user_table'
     @user_table.save
+
+    # The dependent visualization models are in the Table class for the Sequel model
+    @dependent_test_object = @user_table.service
   end
 
   after(:all) do
@@ -19,24 +24,7 @@ describe UserTable do
     @user.destroy
   end
 
-  describe '#estimated_row_count and #actual_row_count' do
-    it 'should query Table estimated an actual row count methods' do
-      ::Table.any_instance.stubs(:estimated_row_count).returns(999)
-      ::Table.any_instance.stubs(:actual_row_count).returns(1000)
-
-      @user_table.estimated_row_count.should == 999
-      @user_table.actual_row_count.should == 1000
-    end
-  end
-
-  it 'should sync table_id with physical table oid' do
-    @user_table.table_id = nil
-    @user_table.save
-
-    @user_table.table_id.should be_nil
-
-    @user_table.sync_table_id.should eq @user_table.service.get_table_id
-  end
+  it_behaves_like 'user table models'
 
   context 'viewer users' do
     after(:each) do

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -247,6 +247,19 @@ describe Visualization::Member do
         Carto::Visualization.exists?(@visualization.id).should be_false
       end
 
+      it 'destroys maps with join analyses if they are dependent' do
+        # First layer uses tables @table, Second layer uses tables @table and @other_table. Map is dependent on @table
+        layer = FactoryGirl.build(:carto_layer, kind: 'carto', maps: [@map])
+        layer.options[:query] = "SELECT * FROM #{@other_table.name}"
+        layer.save
+        layer.user_tables << @table << @other_table
+
+        table_visualization = CartoDB::Visualization::Member.new(id: @table_visualization.id).fetch
+        table_visualization.delete
+
+        Carto::Visualization.exists?(@visualization.id).should be_false
+      end
+
       it 'unlinks only dependent data layers' do
         layer_to_be_deleted = @visualization.data_layers.first
         layer = FactoryGirl.build(:carto_layer, kind: 'carto', maps: [@map])


### PR DESCRIPTION
Fix for #11437

This rewrites a good chunk of the code to check dependencies between user tables and visualizations. The old code assumed that a layer could only depend on a single user table, which is terribly false with join/merge analyses (it was also false before for custom join queries).

The new logic is that a visualization depends on a user table, if all of its layers depend on it. It can also be "partially dependent" (or non_dependent) if some of its layers do (this is used for deletign only some layers when deleting a dataset).

**Acceptance**
- [x] STR for this ticket
- [x] Create a map with two layers: A, B, based on two different datasets, a and b. Add a join column analysis on A, joining B sampling. Now delete dataset b. The warning modal about the map should appear. The full map should be deleted afterwards.
- [x] Repeat previous steps, but this time delete dataset a. The warning modal about the map should appear. Only layer A should be deleted.