### PR TITLE
Update uglify

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "grunt-contrib-jasmine": "0.9.1",
     "grunt-contrib-jst": "git://github.com/javisantana/grunt-contrib-jst.git#master",
     "grunt-contrib-sass": "0.9.2",
-    "grunt-contrib-uglify": "0.9.x",
+    "grunt-contrib-uglify": "2.0.x",
     "grunt-contrib-watch": "1.0.0",
     "grunt-exorcise": "2.1.0",
     "grunt-mustache": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "open": "0.0.5",
     "semistandard": "7.0.4",
     "source-map-support": "0.4.0",
-    "uglify-js": "2.4.x",
+    "uglify-js": "2.7.x",
     "watchify": "3.7.0"
   },
   "browserify": {


### PR DESCRIPTION
#11465 

This brings back uglify time for vendor_editor 3 from 25 min to 2 min:
http://deploy.int.cartodb.net/user/javitonino/my-views/view/CartoDB+Central/job/Carto%20-%20deploy%20to%20staging%20(carto.com)/1242/

The only concerning thing I could find in the [changelog](https://github.com/gruntjs/grunt-contrib-uglify#release-history) is "screwIE8 is enabled by default." (but we do not support IE8 already, so it should not be a problem)

If this is a concern, grunt-contrib 1.0.2 + uglifyjs 2.6.4 should also work, but I haven't tested those versions.