### PR TITLE
Deleted maki circle icons.

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets/maki-icons.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets/maki-icons.js
@@ -4,14 +4,6 @@ module.exports = {
   disclaimer: _t('assets.maki-icons.disclaimer'),
   icons: [
     {
-      'name': 'Circle stroked',
-      'icon': 'circle-stroked'
-    },
-    {
-      'name': 'Circle solid',
-      'icon': 'circle'
-    },
-    {
       'name': 'Square stroked',
       'icon': 'square-stroked'
     },

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.spec.js
@@ -2,6 +2,7 @@ var Backbone = require('backbone');
 var ConfigModel = require('../../../../../../../../javascripts/cartodb3/data/config-model');
 var InputColorFileView = require('../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view');
 var utils = require('../../../../../../../../javascripts/cartodb3/helpers/utils');
+var MakiIcons = require('../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/assets/maki-icons');
 
 describe('components/form-components/editors/fill/input-color/input-color-file-view', function () {
   beforeEach(function () {
@@ -33,7 +34,7 @@ describe('components/form-components/editors/fill/input-color/input-color-file-v
 
   it('should render properly', function () {
     expect(this.view.$el.html()).toContain('form-components.editors.fill.image.recently-title');
-    expect(this.view.$el.find('.js-asset').length).toBe(115);
+    expect(this.view.$el.find('.js-asset').length).toBe(MakiIcons.icons.length + 1); // None + icons
     expect(utils.endsWith(this.view.$('img').attr('src'), '?req=markup')).toBe(true);
   });
 


### PR DESCRIPTION
This PR implements #11481.

### How to test
Check those icons are gone once you open the asset picker.