### PR TITLE
Clean up tempfiles upon upload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ group :test do
   gem 'simplecov-json'
   gem 'simplecov-rcov'
   gem 'db-query-matchers',     '0.4.0'
-  gem 'rack-test',             '0.6.2',  require: 'rack/test'
+  gem 'rack-test',             '0.6.3',  require: 'rack/test'
   gem 'factory_girl_rails',    '~> 4.0.0'
   gem 'selenium-webdriver',    '>= 2.5.0'
   gem 'capybara',              '1.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       rack
     rack-ssl (1.3.4)
       rack
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (3.2.22)
       actionmailer (= 3.2.22)
@@ -392,7 +392,7 @@ DEPENDENCIES
   pg (= 0.15.0)
   poltergeist (>= 1.0.0)
   rack
-  rack-test (= 0.6.2)
+  rack-test (= 0.6.3)
   rails (= 3.2.22)
   rails_warden (= 0.5.8)
   raindrops (= 0.15.0)

--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -58,8 +58,10 @@ class Api::Json::ImportsController < Api::ApplicationController
             # In Rack < 1.6 / Rails < 4, tempfiles are not inmediately cleaned (https://github.com/rack/rack/pull/671).
             # Instead they stay around until a GC cycle which can take a while in instances with low traffic.
             # This forces the tempfile to be removed right away, just after we have saved it to our storage.
-            file = params[:filename]
-            file.tempfile.close! if file
+            [:filename, :file].each do |param_name|
+              file = params[param_name]
+              file.tempfile.close! if file
+            end
 
             # Not queued import is set by skipping pending state and setting directly as already enqueued
             options.merge({

--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -58,7 +58,7 @@ class Api::Json::ImportsController < Api::ApplicationController
             # In Rack < 1.6 / Rails < 4, tempfiles are not inmediately cleaned (https://github.com/rack/rack/pull/671).
             # Instead they stay around until a GC cycle which can take a while in instances with low traffic.
             # This forces the tempfile to be removed right away, just after we have saved it to our storage.
-            params[:filename].tempfile.close! if params[:filename].respond_to?(:tempfile)
+            params[:filename].tempfile.close!
 
             # Not queued import is set by skipping pending state and setting directly as already enqueued
             options.merge({

--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -58,7 +58,7 @@ class Api::Json::ImportsController < Api::ApplicationController
             # In Rack < 1.6 / Rails < 4, tempfiles are not inmediately cleaned (https://github.com/rack/rack/pull/671).
             # Instead they stay around until a GC cycle which can take a while in instances with low traffic.
             # This forces the tempfile to be removed right away, just after we have saved it to our storage.
-            params[:filename].tempfile.close!
+            params[:filename].tempfile.close! if params[:filename].respond_to?(:tempfile)
 
             # Not queued import is set by skipping pending state and setting directly as already enqueued
             options.merge({

--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -54,6 +54,12 @@ class Api::Json::ImportsController < Api::ApplicationController
               file_param: params[:file],
               request_body: request.body,
               s3_config: Cartodb.config[:importer]['s3'])
+
+            # In Rack < 1.6 / Rails < 4, tempfiles are not inmediately cleaned (https://github.com/rack/rack/pull/671).
+            # Instead they stay around until a GC cycle which can take a while in instances with low traffic.
+            # This forces the tempfile to be removed right away, just after we have saved it to our storage.
+            params[:filename].tempfile.close!
+
             # Not queued import is set by skipping pending state and setting directly as already enqueued
             options.merge({
                               data_source: results[:file_uri].presence,

--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -58,7 +58,8 @@ class Api::Json::ImportsController < Api::ApplicationController
             # In Rack < 1.6 / Rails < 4, tempfiles are not inmediately cleaned (https://github.com/rack/rack/pull/671).
             # Instead they stay around until a GC cycle which can take a while in instances with low traffic.
             # This forces the tempfile to be removed right away, just after we have saved it to our storage.
-            params[:filename].tempfile.close!
+            file = params[:filename]
+            file.tempfile.close! if file
 
             # Not queued import is set by skipping pending state and setting directly as already enqueued
             options.merge({

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -34,6 +34,20 @@ describe "Imports API" do
     table.map.data_layers.first.options["table_name"].should == "column_number_to_boolean"
   end
 
+  it 'performs asynchronous imports (file parameter, used in API docs)' do
+    f = upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
+    post api_v1_imports_create_url(params.merge(table_name: "wadus")), file: f
+
+    response.code.should be == '200'
+    response_json = JSON.parse(response.body)
+
+    last_import = DataImport[response_json['item_queue_id']]
+    last_import.state.should be == 'complete'
+    table = UserTable[last_import.table_id]
+    table.name.should == "column_number_to_boolean"
+    table.map.data_layers.first.options["table_name"].should == "column_number_to_boolean"
+  end
+
   it 'performs asynchronous url imports' do
     CartoDB::Importer2::Downloader.any_instance.stubs(:validate_url!).returns(true)
     serve_file Rails.root.join('db/fake_data/clubbing.csv') do |url|

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -52,8 +52,7 @@ describe "Imports API" do
     @table = FactoryGirl.create(:table, :user_id => @user.id)
 
     f = upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
-    post api_v1_imports_create_url(
-           params.merge(table_id: @table.id, append: true)),
+    post api_v1_imports_create_url(params.merge(table_id: @table.id, append: true)),
          f.read.force_encoding('UTF-8'),
          filename: f
 

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -22,11 +22,7 @@ describe "Imports API" do
 
   it 'performs asynchronous imports' do
     f = upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
-    post api_v1_imports_create_url(
-      params.merge(:filename  => 'column_number_to_boolean.csv',
-                   :table_name => "wadus")),
-      f.read.force_encoding('UTF-8')
-
+    post api_v1_imports_create_url(params.merge(:table_name => "wadus")), filename: f
 
     response.code.should be == '200'
     response_json = JSON.parse(response.body)
@@ -57,9 +53,9 @@ describe "Imports API" do
 
     f = upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
     post api_v1_imports_create_url(
-      params.merge(:filename   => 'column_number_to_boolean.csv',
-                   :table_id   => @table.id,
-                   :append     => true)), f.read.force_encoding('UTF-8')
+      params.merge(:table_id   => @table.id,
+                   :append     => true)), f.read.force_encoding('UTF-8'),
+      filename: f
 
 
     response.code.should be == '200'

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -22,7 +22,7 @@ describe "Imports API" do
 
   it 'performs asynchronous imports' do
     f = upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
-    post api_v1_imports_create_url(params.merge(:table_name => "wadus")), filename: f
+    post api_v1_imports_create_url(params.merge(table_name: "wadus")), filename: f
 
     response.code.should be == '200'
     response_json = JSON.parse(response.body)
@@ -53,10 +53,9 @@ describe "Imports API" do
 
     f = upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
     post api_v1_imports_create_url(
-      params.merge(:table_id   => @table.id,
-                   :append     => true)), f.read.force_encoding('UTF-8'),
-      filename: f
-
+           params.merge(table_id: @table.id, append: true)),
+         f.read.force_encoding('UTF-8'),
+         filename: f
 
     response.code.should be == '200'
     response_json = JSON.parse(response.body)

--- a/spec/requests/carto/api/imports_controller_spec.rb
+++ b/spec/requests/carto/api/imports_controller_spec.rb
@@ -65,8 +65,8 @@ describe Carto::Api::ImportsController do
   end
 
   it 'gets the detail of an import' do
-    post api_v1_imports_create_url(api_key: @user.api_key, table_name: 'wadus', filename: File.basename('wadus.csv')),
-         upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
+    post api_v1_imports_create_url(api_key: @user.api_key, table_name: 'wadus'),
+         filename: upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
 
     item_queue_id = JSON.parse(response.body)['item_queue_id']
 
@@ -76,12 +76,12 @@ describe Carto::Api::ImportsController do
 
     import = JSON.parse(response.body)
     import['state'].should be == 'complete'
-    import['display_name'].should be == 'wadus.csv'
+    import['display_name'].should be == 'column_number_to_boolean.csv'
   end
 
   it 'gets the detail of an import stuck unpacking' do
-    post api_v1_imports_create_url(api_key: @user.api_key, table_name: 'wadus', filename: File.basename('wadus.csv')),
-         upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
+    post api_v1_imports_create_url(api_key: @user.api_key, table_name: 'wadus'),
+         filename: upload_file('db/fake_data/column_number_to_boolean.csv', 'text/csv')
 
     response_json = JSON.parse(response.body)
     last_import = DataImport[response_json['item_queue_id']]
@@ -139,8 +139,8 @@ describe Carto::Api::ImportsController do
   end
 
   it 'creates a table from a sql query' do
-    post api_v1_imports_create_url,
-         params.merge(filename: upload_file('spec/support/data/_penguins_below_80.zip', 'application/octet-stream'))
+    post api_v1_imports_create_url(params.merge(table_name: 'wadus_2')),
+         filename: upload_file('spec/support/data/_penguins_below_80.zip', 'application/octet-stream')
 
     response.code.should be == '200'
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -25,7 +25,7 @@ module HelperMethods
   end
 
   def upload_file(file_path, mime_type)
-    Rack::Test::UploadedFile.new(Rails.root.join(file_path), mime_type)
+    fixture_file_upload(Rails.root.join(file_path), mime_type)
   end
 
   def http_json_headers


### PR DESCRIPTION
Fix for #11509 

When uploading files, Rack creates a temporary file which is automatically deleted later. The problem here is a limitation in [Rack < 1.6](https://github.com/rack/rack/pull/671) where the file is not deleted when the requests ends, but rather when the garbage collector runs. This can be a problem, specially in instances with low traffic, since the GC will not run very often.

The solution I came up with is to simple remove the file as soon as we are done with it. I only added it to the imports controller since it is the problematic ones (assets are much smaller). I tried implementing the same solution as in the Rack PR, but our version doesn't have the same middleware API as the one in the patch, and I wanted to avoid conflicts in the future (updating Rails).

**Acceptance**
- [x] Remove any `RackMultipart*` file you may have in your `/tmp` directory. Upload a dataset. Check the `/tmp` directory, there should not be any leftover `RackMultipart*` files.
- [ ] Repeat the previous one using the imports API.