### PR TITLE
When removing a selected custom icon, remove it from the CartoCSS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,8 @@ Development
   * Removed Pin, and Simple icons (#11479)
 
 ### Bug fixes
+* Style with icons
+  * Reset icon on map when you remove that custom icon
 * Start using layers<->user_table cache in all places (#11303)
   * Run `cartodb:db:register_table_dependencies` rake to update caches for existing maps
 * Categories legend are now static (#10972)

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
@@ -72,6 +72,7 @@ module.exports = CoreView.extend({
 
     this._stateModel = new Backbone.Model({
       status: 'show',
+      setButton: this.model.get('image') !== undefined,
       uploads: 0
     });
 
@@ -88,6 +89,7 @@ module.exports = CoreView.extend({
   _initBinds: function () {
     this.listenTo(this._selectedAsset, 'change:url', this._onChangeSelectedAsset);
     this.listenTo(this._stateModel, 'change:status', this.render);
+    this.listenTo(this._stateModel, 'change:setButton', this._onChangeSetButton);
     this.listenTo(this._assetsTabPaneView.collection, 'change', this._onChangeSelectedTab);
   },
 
@@ -175,18 +177,21 @@ module.exports = CoreView.extend({
     switch (this._assetsTabPaneView.getSelectedTabPaneName()) {
       case 'maki-icons':
         this._setDisclaimer(MakiIcons.disclaimer);
+        this._toggleSetButton();
         break;
       case 'upload-file':
-        this._selectedAsset.set({
-          url: '',
-          kind: ''
-        });
         this._hideDisclaimer();
+        this._stateModel.set('setButton', false);
         break;
       default:
         this._hideDisclaimer();
+        this._toggleSetButton();
         break;
     }
+  },
+
+  _toggleSetButton: function () {
+    this._stateModel.set('setButton', this._selectedAsset.get('url') !== undefined);
   },
 
   _createYourUploadsView: function () {
@@ -241,8 +246,17 @@ module.exports = CoreView.extend({
     this._assetsTabPaneView.setSelectedTabPaneByName('your-uploads');
   },
 
+  _onChangeSetButton: function () {
+    this.$('.js-add').toggleClass('is-disabled', !this._stateModel.get('setButton'));
+  },
+
   _onChangeSelectedAsset: function () {
-    this.$('.js-add').toggleClass('is-disabled', !this._selectedAsset.get('url'));
+    if (!this._selectedAsset.get('url')) {
+      this.model.unset('image');
+      this.model.unset('kind');
+    }
+
+    this._stateModel.set('setButton', !!this._selectedAsset.get('url'));
   },
 
   _initUpload: function (e) {
@@ -328,7 +342,7 @@ module.exports = CoreView.extend({
   _onSetImage: function (e) {
     this.killEvent(e);
 
-    if (!this._selectedAsset.get('url')) {
+    if (!this._stateModel.get('setButton')) {
       return;
     }
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
@@ -72,7 +72,7 @@ module.exports = CoreView.extend({
 
     this._stateModel = new Backbone.Model({
       status: 'show',
-      modal_enabled: this.model.get('image') !== undefined,
+      modalEnabled: this.model.get('image') !== undefined,
       uploads: 0
     });
 
@@ -89,7 +89,7 @@ module.exports = CoreView.extend({
   _initBinds: function () {
     this.listenTo(this._selectedAsset, 'change:url', this._onChangeSelectedAsset);
     this.listenTo(this._stateModel, 'change:status', this.render);
-    this.listenTo(this._stateModel, 'change:modal_enabled', this._onChangeSetButton);
+    this.listenTo(this._stateModel, 'change:modalEnabled', this._onChangeSetButton);
     this.listenTo(this._assetsTabPaneView.collection, 'change', this._onChangeSelectedTab);
   },
 
@@ -181,7 +181,7 @@ module.exports = CoreView.extend({
         break;
       case 'upload-file':
         this._hideDisclaimer();
-        this._stateModel.set('modal_enabled', false);
+        this._stateModel.set('modalEnabled', false);
         break;
       default:
         this._hideDisclaimer();
@@ -191,7 +191,7 @@ module.exports = CoreView.extend({
   },
 
   _toggleSetButton: function () {
-    this._stateModel.set('modal_enabled', this._selectedAsset.get('url') !== undefined);
+    this._stateModel.set('modalEnabled', this._selectedAsset.get('url') !== undefined);
   },
 
   _createYourUploadsView: function () {
@@ -247,7 +247,7 @@ module.exports = CoreView.extend({
   },
 
   _onChangeSetButton: function () {
-    this.$('.js-add').toggleClass('is-disabled', !this._stateModel.get('modal_enabled'));
+    this.$('.js-add').toggleClass('is-disabled', !this._stateModel.get('modalEnabled'));
   },
 
   _onChangeSelectedAsset: function () {
@@ -256,7 +256,7 @@ module.exports = CoreView.extend({
       this.model.unset('kind');
     }
 
-    this._stateModel.set('modal_enabled', !!this._selectedAsset.get('url'));
+    this._stateModel.set('modalEnabled', !!this._selectedAsset.get('url'));
   },
 
   _initUpload: function (e) {
@@ -342,7 +342,7 @@ module.exports = CoreView.extend({
   _onSetImage: function (e) {
     this.killEvent(e);
 
-    if (!this._stateModel.get('modal_enabled')) {
+    if (!this._stateModel.get('modalEnabled')) {
       return;
     }
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
@@ -72,7 +72,7 @@ module.exports = CoreView.extend({
 
     this._stateModel = new Backbone.Model({
       status: 'show',
-      setButton: this.model.get('image') !== undefined,
+      modal_enabled: this.model.get('image') !== undefined,
       uploads: 0
     });
 
@@ -89,7 +89,7 @@ module.exports = CoreView.extend({
   _initBinds: function () {
     this.listenTo(this._selectedAsset, 'change:url', this._onChangeSelectedAsset);
     this.listenTo(this._stateModel, 'change:status', this.render);
-    this.listenTo(this._stateModel, 'change:setButton', this._onChangeSetButton);
+    this.listenTo(this._stateModel, 'change:modal_enabled', this._onChangeSetButton);
     this.listenTo(this._assetsTabPaneView.collection, 'change', this._onChangeSelectedTab);
   },
 
@@ -181,7 +181,7 @@ module.exports = CoreView.extend({
         break;
       case 'upload-file':
         this._hideDisclaimer();
-        this._stateModel.set('setButton', false);
+        this._stateModel.set('modal_enabled', false);
         break;
       default:
         this._hideDisclaimer();
@@ -191,7 +191,7 @@ module.exports = CoreView.extend({
   },
 
   _toggleSetButton: function () {
-    this._stateModel.set('setButton', this._selectedAsset.get('url') !== undefined);
+    this._stateModel.set('modal_enabled', this._selectedAsset.get('url') !== undefined);
   },
 
   _createYourUploadsView: function () {
@@ -247,7 +247,7 @@ module.exports = CoreView.extend({
   },
 
   _onChangeSetButton: function () {
-    this.$('.js-add').toggleClass('is-disabled', !this._stateModel.get('setButton'));
+    this.$('.js-add').toggleClass('is-disabled', !this._stateModel.get('modal_enabled'));
   },
 
   _onChangeSelectedAsset: function () {
@@ -256,7 +256,7 @@ module.exports = CoreView.extend({
       this.model.unset('kind');
     }
 
-    this._stateModel.set('setButton', !!this._selectedAsset.get('url'));
+    this._stateModel.set('modal_enabled', !!this._selectedAsset.get('url'));
   },
 
   _initUpload: function (e) {
@@ -342,7 +342,7 @@ module.exports = CoreView.extend({
   _onSetImage: function (e) {
     this.killEvent(e);
 
-    if (!this._stateModel.get('setButton')) {
+    if (!this._stateModel.get('modal_enabled')) {
       return;
     }
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.js
@@ -199,6 +199,8 @@ module.exports = CoreView.extend({
     if (response.status === 200) {
       this._removeSelectedAssetsFromView();
       this._stateModel.unset('status');
+      this._selectedAsset.unset('kind');
+      this._selectedAsset.unset('url');
     } else {
       this._stateModel.set({
         error_message: response.statusText,

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
@@ -64,20 +64,20 @@ describe('components/form-components/editors/fill/input-color/assets-view', func
     });
 
     it('should toggle the set button state', function () {
-      this.view._stateModel.set('modal_enabled', true);
+      this.view._stateModel.set('modalEnabled', true);
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeFalsy();
-      this.view._stateModel.set('modal_enabled', false);
+      this.view._stateModel.set('modalEnabled', false);
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeTruthy();
     });
 
     it('should toggle the set button state when there\'s no image selected', function () {
       this.view._selectedAsset.set('url', 'batman.png');
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeFalsy();
-      expect(this.view._stateModel.get('modal_enabled')).toBeTruthy();
+      expect(this.view._stateModel.get('modalEnabled')).toBeTruthy();
 
       this.view._selectedAsset.set('url', '');
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeTruthy();
-      expect(this.view._stateModel.get('modal_enabled')).toBeFalsy();
+      expect(this.view._stateModel.get('modalEnabled')).toBeFalsy();
     });
 
     it('should render disclaimer', function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
@@ -64,17 +64,20 @@ describe('components/form-components/editors/fill/input-color/assets-view', func
     });
 
     it('should toggle the set button state', function () {
-      this.view._stateModel.set('setButton', true);
+      this.view._stateModel.set('modal_enabled', true);
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeFalsy();
-      this.view._stateModel.set('setButton', false);
+      this.view._stateModel.set('modal_enabled', false);
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeTruthy();
     });
 
     it('should toggle the set button state when there\'s no image selected', function () {
       this.view._selectedAsset.set('url', 'batman.png');
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeFalsy();
+      expect(this.view._stateModel.get('modal_enabled')).toBeTruthy();
+
       this.view._selectedAsset.set('url', '');
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeTruthy();
+      expect(this.view._stateModel.get('modal_enabled')).toBeFalsy();
     });
 
     it('should render disclaimer', function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
@@ -63,7 +63,14 @@ describe('components/form-components/editors/fill/input-color/assets-view', func
       expect(this.view.$('.js-add').length).toBe(1);
     });
 
-    it('should toggle the upload button state', function () {
+    it('should toggle the set button state', function () {
+      this.view._stateModel.set('setButton', true);
+      expect(this.view.$('.js-add').hasClass('is-disabled')).toBeFalsy();
+      this.view._stateModel.set('setButton', false);
+      expect(this.view.$('.js-add').hasClass('is-disabled')).toBeTruthy();
+    });
+
+    it('should toggle the set button state when there\'s no image selected', function () {
       this.view._selectedAsset.set('url', 'batman.png');
       expect(this.view.$('.js-add').hasClass('is-disabled')).toBeFalsy();
       this.view._selectedAsset.set('url', '');

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.spec.js
@@ -100,6 +100,8 @@ describe('components/form-components/editors/fill/input-color/assets-picker/user
 
     this.view.$('.js-remove').click();
     expect(this._assetsCollection.size()).toBe(1);
+    expect(this._selectAllAsset.get('url')).toBe(undefined);
+    expect(this._selectAllAsset.get('kind')).toBe(undefined);
   });
 
   afterEach(function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.spec.js
@@ -43,12 +43,6 @@ describe('components/form-components/editors/fill/input-color/assets-picker/user
       selectedAsset: this.selectedAsset
     });
 
-    var self = this;
-
-    AssetModel.prototype.destroy = function () {
-      self.view._onDestroyFinished({ status: 200 });
-    };
-
     this.view.render();
   });
 
@@ -106,18 +100,22 @@ describe('components/form-components/editors/fill/input-color/assets-picker/user
     expect(this.view.$('.is-selected').length).toBe(0);
   });
 
-  it('should remove selected assets', function () {
+  it('should remove the selected assets', function () {
     this._assetsCollection.at(0).set('state', 'selected');
     this._assetsCollection.at(1).set('state', 'selected');
     this._assetsCollection.at(2).set('state', '');
 
     this.view.$('.js-remove').click();
     expect(this._assetsCollection.size()).toBe(1);
-    expect(this.selectedAsset.get('url')).toBe(undefined);
-    expect(this.selectedAsset.get('kind')).toBe(undefined);
   });
 
   it('should unset the selected asset', function () {
+    var self = this;
+
+    AssetModel.prototype.destroy = function () {
+      self.view._onDestroyFinished({ status: 200 });
+    };
+
     this._assetsCollection.at(0).set('state', 'selected');
     this._assetsCollection.at(1).set('state', '');
     this._assetsCollection.at(2).set('state', '');

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.spec.js
@@ -4,6 +4,7 @@ var UserAssetsListView = require('../../../../../../../../../javascripts/cartodb
 var AssetsCollection = require('../../../../../../../../../javascripts/cartodb3/data/assets-collection');
 var ConfigModel = require('../../../../../../../../../javascripts/cartodb3/data/config-model');
 var UserModel = require('../../../../../../../../../javascripts/cartodb3/data/user-model');
+var AssetModel = require('../../../../../../../../../javascripts/cartodb3/data/asset-model');
 
 describe('components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view', function () {
   beforeEach(function () {
@@ -18,13 +19,19 @@ describe('components/form-components/editors/fill/input-color/assets-picker/user
       configModel: configModel
     });
 
-    this._assetsCollection = new AssetsCollection([{
-      item: 1, state: ''
-    }, {
-      item: 2, state: ''
-    }, {
-      item: 3, state: ''
-    }], {
+    var asset1 = new AssetModel({
+      item: 1, state: '', public_url: 'one.jpg'
+    });
+
+    var asset2 = new AssetModel({
+      item: 2, state: '', public_url: 'two.png'
+    });
+
+    var asset3 = new AssetModel({
+      item: 3, state: '', public_url: 'three.gif'
+    });
+
+    this._assetsCollection = new AssetsCollection([asset1, asset2, asset3], {
       configModel: configModel,
       userModel: userModel
     });
@@ -35,6 +42,12 @@ describe('components/form-components/editors/fill/input-color/assets-picker/user
       assetsCollection: this._assetsCollection,
       selectedAsset: this.selectedAsset
     });
+
+    var self = this;
+
+    AssetModel.prototype.destroy = function () {
+      self.view._onDestroyFinished({ status: 200 });
+    };
 
     this.view.render();
   });
@@ -100,8 +113,21 @@ describe('components/form-components/editors/fill/input-color/assets-picker/user
 
     this.view.$('.js-remove').click();
     expect(this._assetsCollection.size()).toBe(1);
-    expect(this._selectAllAsset.get('url')).toBe(undefined);
-    expect(this._selectAllAsset.get('kind')).toBe(undefined);
+    expect(this.selectedAsset.get('url')).toBe(undefined);
+    expect(this.selectedAsset.get('kind')).toBe(undefined);
+  });
+
+  it('should unset the selected asset', function () {
+    this._assetsCollection.at(0).set('state', 'selected');
+    this._assetsCollection.at(1).set('state', '');
+    this._assetsCollection.at(2).set('state', '');
+
+    expect(this.selectedAsset.get('url')).toBe('one.jpg');
+    expect(this.selectedAsset.get('kind')).toBe('custom-marker');
+
+    this.view.$('.js-remove').click();
+    expect(this.selectedAsset.get('url')).toBe(undefined);
+    expect(this.selectedAsset.get('kind')).toBe(undefined);
   });
 
   afterEach(function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.143",
+  "version": "4.5.143-staging-11510",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.143-staging-11510",
+  "version": "4.5.143",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Original issue: https://github.com/CartoDB/cartodb/issues/11510

This PR also refactor the code to enable/disable the set button in the modal window to use the `stateModel`.

#### Acceptance

See the `Steps to Reproduce` section from [the original issue](https://github.com/CartoDB/cartodb/issues/11510).