### PR TITLE
Fixing problem related with image-picker

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@ Development
 ### Bug fixes
 * Style with icons
   * Reset icon on map when you remove that custom icon
+  * Made icon's clicking area larger
 * Start using layers<->user_table cache in all places (#11303)
   * Run `cartodb:db:register_table_dependencies` rake to update caches for existing maps
 * Categories legend are now static (#10972)

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view.js
@@ -1,8 +1,10 @@
 var _ = require('underscore');
+var $ = require('jquery');
 var ImageLoaderView = require('../../../../../../img-loader-view');
 var CustomListItemView = require('../../../../../../custom-list/custom-list-item-view');
 
 module.exports = CustomListItemView.extend({
+
   render: function () {
     this.$el.empty();
     this.clearSubViews();
@@ -42,5 +44,17 @@ module.exports = CustomListItemView.extend({
     });
     this.addView(this.iconView);
     this.$('.js-image-container').append(this.iconView.render().el);
+  },
+
+  _onClick: function (ev) {
+    this.killEvent(ev);
+    var $target = $(ev.target);
+    var isIconClicked = $target.closest('.js-image-container').length > 0;
+    var isImgClicked = $target.closest('.js-assetPicker').length > 0;
+
+    this.model.set({
+      selectedClass: isImgClicked || isIconClicked ? ['js-assetPicker'] : [],
+      selected: true
+    });
   }
 });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view.spec.js
@@ -1,0 +1,56 @@
+var CustomListItemModel = require('../../../../../../../../../../javascripts/cartodb3/components/custom-list/custom-list-item-model');
+var CategoriesListItemView = require('../../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view');
+var inputColorCategoriesListItemTemplate = require('../../../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-item.tpl');
+
+describe('components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view', function () {
+  beforeEach(function () {
+    this.model = new CustomListItemModel({
+      label: 'hello',
+      val: '#FFF',
+      image: 'https://s3.amazonaws.com/com.cartodb.users-assets.production/maki-icons/star-stroked-18.svg'
+    });
+
+    this.view = new CategoriesListItemView(({
+      model: this.model,
+      typeLabel: 'column',
+      template: inputColorCategoriesListItemTemplate,
+      imageEnabled: true
+    }));
+
+    spyOn(this.view, '_loadImages');
+
+    this.view.render();
+  });
+
+  it('should render properly', function () {
+    expect(this.view.$('.CDB-Text').length).toBe(1);
+    expect(this.view.$('.CDB-Text').attr('title')).toBe('hello');
+    expect(this.view.$('.js-colorPicker').attr('style')).toBe('background-color: #FFF;');
+    expect(this.view.$('.js-image-container').length).toBe(1);
+  });
+
+  describe('_onClick', function () {
+    it('should set js-assetPicker class in model when image is clicked', function () {
+      this.view.$('.js-image-container').click();
+      expect(this.model.get('selectedClass')).toEqual(['js-assetPicker']);
+    });
+
+    it('should set js-assetPicker class in model when IMG label is clicked', function () {
+      this.model.unset('image');
+      this.view.render();
+      this.view.$('.js-assetPicker').click();
+      expect(this.model.get('selectedClass')).toEqual(['js-assetPicker']);
+    });
+
+    it('should not set js-assetPicker class in model when rest of the item is clicked', function () {
+      this.model.unset('image');
+      this.view.render();
+      this.view.$el.click();
+      expect(this.model.get('selectedClass')).toEqual([]);
+    });
+  });
+
+  afterEach(function () {
+    this.view.remove();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.144-staging-11499",
+  "version": "4.5.144",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.144",
+  "version": "4.5.144-staging-11499",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/11499.

**Things to test**
- Enable `icon-styling` flag for the user you want to test.
- Create a map with a layer of points.
- Then go to the style tab.
- Style by a category.
- [x] Then, if you click over the IMG label should send you to the image-picker panel.
- Select an image, and the preview should appear.
- [x] If you click over the previous image selected, it should redirect you to the image-picker panel (too).
- Go back or select a new image.
- [x] Once you are in the categories list again, select wherever you want except the "color" or the image. It should open the color panel.
