### PR TITLE
11523 layer without visualization protection

### DIFF
--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -128,7 +128,7 @@ module Carto
     end
 
     def affected_visualizations
-      layers.map(&:visualization).uniq
+      layers.map(&:visualization).uniq.compact
     end
 
     def table

--- a/spec/models/carto/user_table_spec.rb
+++ b/spec/models/carto/user_table_spec.rb
@@ -33,4 +33,29 @@ describe Carto::UserTable do
       user_table.readable_by?(@carto_org_user_2).should be_true
     end
   end
+
+  describe('#affected_visualizations') do
+    before(:each) do
+      # We recreate an inconsistent state where a layer has no visualization
+      @user_table.stubs(:layers).returns([Carto::Layer.new])
+    end
+
+    describe('#fully_dependent_visualizations') do
+      it 'resists layers without visualizations' do
+        expect { @user_table.fully_dependent_visualizations }.to_not raise_error
+      end
+    end
+
+    describe('#accessible_dependent_derived_maps') do
+      it 'resists layers without visualizations' do
+        expect { @user_table.accessible_dependent_derived_maps }.to_not raise_error
+      end
+    end
+
+    describe('#partially_dependent_visualizations') do
+      it 'resists layers without visualizations' do
+        expect { @user_table.partially_dependent_visualizations }.to_not raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #11523 

## Context

We have changed some stuff regarding layer cleanup lately. We must have stirred something up and some layers without visualizations appear here and there.

This PR aims to make some routines in `Carto::UserTable` resistant to this unexpected nilness.

## Acceptance

I can't think how to provoke these layers without maps, and there is an automated suite to check it works. Check instead that all layer operations work:

- [x] Add a layer
- [x] Remove a layer
- [x] Create a map from a dataset and the remove the dataset (you should get warned about the map)
- [x] Delete a map
- [x] Delete a dataset
