### PR TITLE
11541 expose google maps key

### DIFF
--- a/app/controllers/carto/builder/datasets_controller.rb
+++ b/app/controllers/carto/builder/datasets_controller.rb
@@ -33,6 +33,8 @@ module Carto
           Carto::Api::LayerPresenter.new(l, with_style_properties: true).to_poro(migrate_builder_infowindows: true)
         end
 
+        @google_maps_qs = @canonical_visualization.user.google_maps_query_string
+
         carto_viewer = current_viewer && Carto::User.where(id: current_viewer.id).first
         @dashboard_notifications = carto_viewer ? carto_viewer.notifications_for_category(:dashboard) : {}
       end

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -13,9 +13,9 @@ module Carto
         before_filter :load_vizjson,
                       :load_state, only: [:show, :show_protected]
         before_filter :ensure_viewable, only: [:show]
-        before_filter :ensure_protected_viewable, only: [:show_protected]
-        before_filter :load_auth_tokens, only: [:show, :show_protected]
-        before_filter :load_google_maps_qs, only: [:show, :show_protected]
+        before_filter :ensure_protected_viewable,
+                      :load_auth_tokens,
+                      :load_google_maps_qs, only: [:show, :show_protected]
 
         skip_before_filter :builder_users_only # This is supposed to be public even in beta
 

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -15,7 +15,7 @@ module Carto
         before_filter :ensure_viewable, only: [:show]
         before_filter :ensure_protected_viewable, only: [:show_protected]
         before_filter :load_auth_tokens, only: [:show, :show_protected]
-        before_filter :load_google_maps_key, only: [:show, :show_protected]
+        before_filter :load_google_maps_qs, only: [:show, :show_protected]
 
         skip_before_filter :builder_users_only # This is supposed to be public even in beta
 
@@ -56,8 +56,8 @@ module Carto
                          end
         end
 
-        def load_google_maps_key
-          @google_maps_key = @visualization.user.google_maps_api_key
+        def load_google_maps_qs
+          @google_maps_qs = @visualization.user.google_maps_query_string
         end
 
         def load_vizjson

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -15,6 +15,7 @@ module Carto
         before_filter :ensure_viewable, only: [:show]
         before_filter :ensure_protected_viewable, only: [:show_protected]
         before_filter :load_auth_tokens, only: [:show, :show_protected]
+        before_filter :load_google_maps_key, only: [:show, :show_protected]
 
         skip_before_filter :builder_users_only # This is supposed to be public even in beta
 
@@ -51,6 +52,10 @@ module Carto
                          elsif @visualization.is_privacy_private?
                            current_viewer ? current_viewer.get_auth_tokens : []
                          end
+        end
+
+        def load_google_maps_key
+          @google_maps_key = @visualization.user.google_maps_api_key
         end
 
         def load_vizjson

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -51,6 +51,8 @@ module Carto
                            @visualization.get_auth_tokens
                          elsif @visualization.is_privacy_private?
                            current_viewer ? current_viewer.get_auth_tokens : []
+                         else
+                           []
                          end
         end
 

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -42,6 +42,7 @@ module Carto
         end
         latest_mapcap = @visualization.latest_mapcap
         @mapcaps_data = latest_mapcap ? [Carto::Api::MapcapPresenter.new(latest_mapcap).to_poro] : []
+        @google_maps_qs = @visualization.user.google_maps_query_string
 
         @builder_notifications = notifications(:builder)
         @dashboard_notifications = notifications(:dashboard)

--- a/app/views/carto/builder/datasets/show.html.erb
+++ b/app/views/carto/builder/datasets/show.html.erb
@@ -37,6 +37,8 @@
   var ACTIVE_LOCALE = 'en';
 </script>
 
+<%= render(partial: 'shared/visualizations/google_maps') %>
+
 <%= javascript_include_tag 'vendor_editor3.js' %>
 <%= javascript_include_tag 'common_editor3.js' %>
 <%= javascript_include_tag 'dataset.js' %>

--- a/app/views/carto/builder/datasets/show.html.erb
+++ b/app/views/carto/builder/datasets/show.html.erb
@@ -37,7 +37,9 @@
   var ACTIVE_LOCALE = 'en';
 </script>
 
-<%= render(partial: 'shared/visualizations/google_maps', locals: { google_maps_qs: @google_maps_qs }) %>
+<% if @canonical_visualization.map.provider == 'googlemaps' %>
+  <%= render(partial: 'shared/visualizations/google_maps', locals: { google_maps_qs: @google_maps_qs }) %>
+<% end %>
 
 <%= javascript_include_tag 'vendor_editor3.js' %>
 <%= javascript_include_tag 'common_editor3.js' %>

--- a/app/views/carto/builder/datasets/show.html.erb
+++ b/app/views/carto/builder/datasets/show.html.erb
@@ -37,7 +37,7 @@
   var ACTIVE_LOCALE = 'en';
 </script>
 
-<%= render(partial: 'shared/visualizations/google_maps') %>
+<%= render(partial: 'shared/visualizations/google_maps', locals: { google_maps_qs: @google_maps_qs }) %>
 
 <%= javascript_include_tag 'vendor_editor3.js' %>
 <%= javascript_include_tag 'common_editor3.js' %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -29,9 +29,9 @@
     <%= javascript_include_tag 'tangram.min.js' %>
   <% end %>
 
-  <% if @google_maps_api_key %>
+  <% if @google_maps_qs %>
     <!-- include google maps library -->
-    <script type='text/javascript' src="//maps.google.com/maps/api/js?key=<%= @google_maps_api_key %>&v=3.25"></script>
+    <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= @google_maps_qs %>&v=3.25"></script>
   <% end %>
 
   <script>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -29,7 +29,9 @@
     <%= javascript_include_tag 'tangram.min.js' %>
   <% end %>
 
-  <%= render(partial: 'shared/visualizations/google_maps') %>
+  <% if @vizjson[:map_provider] == 'googlemaps' %>
+    <%= render(partial: 'shared/visualizations/google_maps') %>
+  <% end %>
 
   <script>
     var vizJSON = <%= safe_js_object @vizjson.to_hash.to_json %>;

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -29,10 +29,7 @@
     <%= javascript_include_tag 'tangram.min.js' %>
   <% end %>
 
-  <% if @google_maps_qs.present? %>
-    <!-- include google maps library -->
-    <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= @google_maps_qs %>&v=3.25"></script>
-  <% end %>
+  <%= render(partial: 'shared/visualizations/google_maps') %>
 
   <script>
     var vizJSON = <%= safe_js_object @vizjson.to_hash.to_json %>;

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -29,7 +29,7 @@
     <%= javascript_include_tag 'tangram.min.js' %>
   <% end %>
 
-  <% if @google_maps_qs %>
+  <% if @google_maps_qs.present? %>
     <!-- include google maps library -->
     <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= @google_maps_qs %>&v=3.25"></script>
   <% end %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -28,7 +28,7 @@
   <% if params[:vector] %>
     <%= javascript_include_tag 'tangram.min.js' %>
   <% end %>
-  
+
   <% if current_user.google_maps_api_key %>
     <!-- include google maps library -->
     <script type='text/javascript' src="//maps.google.com/maps/api/js?key=<%= current_user.google_maps_api_key %>&v=3.25"></script>
@@ -39,6 +39,9 @@
     var layersData = <%= safe_js_object @layers_data.to_json %>;
     var stateJSON = <%= safe_js_object @state.to_json %>;
     var authTokens = <%= safe_js_object @auth_tokens.to_json %>;
+    <% if @google_maps_key %>
+      var googleMapsKey = <%= safe_js_object @google_maps_key.to_json %>;
+    <% end %>
   </script>
   <%= javascript_include_tag 'vendor_editor3.js' %>
   <%= javascript_include_tag 'common_editor3.js' %>
@@ -47,4 +50,3 @@
   <%= insert_trackjs('builder-embeds') %>
   <%= insert_google_analytics('embeds', true) %>
 <% end %>
-

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -30,7 +30,7 @@
   <% end %>
 
   <% if @vizjson[:map_provider] == 'googlemaps' %>
-    <%= render(partial: 'shared/visualizations/google_maps') %>
+    <%= render(partial: 'shared/visualizations/google_maps', locals: { google_maps_qs: @google_maps_qs }) %>
   <% end %>
 
   <script>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -29,9 +29,9 @@
     <%= javascript_include_tag 'tangram.min.js' %>
   <% end %>
 
-  <% if current_user.google_maps_api_key %>
+  <% if @google_maps_api_key %>
     <!-- include google maps library -->
-    <script type='text/javascript' src="//maps.google.com/maps/api/js?key=<%= current_user.google_maps_api_key %>&v=3.25"></script>
+    <script type='text/javascript' src="//maps.google.com/maps/api/js?key=<%= @google_maps_api_key %>&v=3.25"></script>
   <% end %>
 
   <script>
@@ -39,9 +39,6 @@
     var layersData = <%= safe_js_object @layers_data.to_json %>;
     var stateJSON = <%= safe_js_object @state.to_json %>;
     var authTokens = <%= safe_js_object @auth_tokens.to_json %>;
-    <% if @google_maps_key %>
-      var googleMapsKey = <%= safe_js_object @google_maps_key.to_json %>;
-    <% end %>
   </script>
   <%= javascript_include_tag 'vendor_editor3.js' %>
   <%= javascript_include_tag 'common_editor3.js' %>

--- a/app/views/carto/builder/visualizations/show.html.erb
+++ b/app/views/carto/builder/visualizations/show.html.erb
@@ -18,9 +18,9 @@
   var ACTIVE_LOCALE = 'en';
 </script>
 
-<% if current_user.google_maps_api_key %>
+<% if @google_maps_qs.present? %>
   <!-- include google maps library -->
-  <script type='text/javascript' src="//maps.google.com/maps/api/js?key=<%= current_user.google_maps_api_key %>&v=3.25"></script>
+  <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= @google_maps_qs %>&v=3.25"></script>
 <% end %>
 
 <%= javascript_include_tag 'vendor_editor3.js' %>

--- a/app/views/carto/builder/visualizations/show.html.erb
+++ b/app/views/carto/builder/visualizations/show.html.erb
@@ -18,10 +18,7 @@
   var ACTIVE_LOCALE = 'en';
 </script>
 
-<% if @google_maps_qs.present? %>
-  <!-- include google maps library -->
-  <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= @google_maps_qs %>&v=3.25"></script>
-<% end %>
+<%= render(partial: 'shared/visualizations/google_maps') %>
 
 <%= javascript_include_tag 'vendor_editor3.js' %>
 <%= javascript_include_tag 'common_editor3.js' %>

--- a/app/views/carto/builder/visualizations/show.html.erb
+++ b/app/views/carto/builder/visualizations/show.html.erb
@@ -18,7 +18,7 @@
   var ACTIVE_LOCALE = 'en';
 </script>
 
-<%= render(partial: 'shared/visualizations/google_maps') %>
+<%= render(partial: 'shared/visualizations/google_maps', locals: { google_maps_qs: @google_maps_qs }) %>
 
 <%= javascript_include_tag 'vendor_editor3.js' %>
 <%= javascript_include_tag 'common_editor3.js' %>

--- a/app/views/shared/visualizations/_google_maps.html.erb
+++ b/app/views/shared/visualizations/_google_maps.html.erb
@@ -1,3 +1,3 @@
-<% if @google_maps_qs.present? %>
-  <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= @google_maps_qs %>&v=3.25"></script>
+<% if google_maps_qs.present? %>
+  <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= google_maps_qs %>&v=3.25"></script>
 <% end %>

--- a/app/views/shared/visualizations/_google_maps.html.erb
+++ b/app/views/shared/visualizations/_google_maps.html.erb
@@ -1,4 +1,3 @@
 <% if @google_maps_qs.present? %>
-  <!-- include google maps library -->
   <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= @google_maps_qs %>&v=3.25"></script>
 <% end %>

--- a/app/views/shared/visualizations/_google_maps.html.erb
+++ b/app/views/shared/visualizations/_google_maps.html.erb
@@ -1,3 +1,3 @@
 <% if google_maps_qs.present? %>
-  <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= google_maps_qs %>&v=3.25"></script>
+  <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= google_maps_qs %>&v=3.26"></script>
 <% end %>

--- a/app/views/shared/visualizations/_google_maps.html.erb
+++ b/app/views/shared/visualizations/_google_maps.html.erb
@@ -1,0 +1,4 @@
+<% if @google_maps_qs.present? %>
+  <!-- include google maps library -->
+  <script type='text/javascript' src="//maps.google.com/maps/api/js?<%= @google_maps_qs %>&v=3.25"></script>
+<% end %>

--- a/spec/requests/carto/builder/datasets_controller_spec.rb
+++ b/spec/requests/carto/builder/datasets_controller_spec.rb
@@ -76,6 +76,8 @@ describe Carto::Builder::DatasetsController do
     end
 
     it 'does not include google maps if not configured' do
+      @map.provider = 'googlemaps'
+      @map.save
       @user.google_maps_key = ''
       @user.save
       get builder_dataset_url(id: @visualization.id)
@@ -85,12 +87,25 @@ describe Carto::Builder::DatasetsController do
     end
 
     it 'includes the google maps client id if configured' do
+      @map.provider = 'googlemaps'
+      @map.save
       @user.google_maps_key = 'client=wadus_cid'
       @user.save
       get builder_dataset_url(id: @visualization.id)
 
       response.status.should == 200
       response.body.should include("maps.google.com/maps/api/js?client=wadus_cid")
+    end
+
+    it 'does not include google maps if the map does not need it' do
+      @map.provider = 'leaflet'
+      @map.save
+      @user.google_maps_key = 'client=wadus_cid'
+      @user.save
+      get builder_dataset_url(id: @visualization.id)
+
+      response.status.should == 200
+      response.body.should_not include("maps.google.com/maps/api/js")
     end
   end
 end

--- a/spec/requests/carto/builder/datasets_controller_spec.rb
+++ b/spec/requests/carto/builder/datasets_controller_spec.rb
@@ -74,5 +74,23 @@ describe Carto::Builder::DatasetsController do
 
       response.status.should == 404
     end
+
+    it 'does not include google maps if not configured' do
+      @user.google_maps_key = ''
+      @user.save
+      get builder_dataset_url(id: @visualization.id)
+
+      response.status.should == 200
+      response.body.should_not include("maps.google.com/maps/api/js")
+    end
+
+    it 'includes the google maps client id if configured' do
+      @user.google_maps_key = 'client=wadus_cid'
+      @user.save
+      get builder_dataset_url(id: @visualization.id)
+
+      response.status.should == 200
+      response.body.should include("maps.google.com/maps/api/js?client=wadus_cid")
+    end
   end
 end

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -88,7 +88,7 @@ describe Carto::Builder::Public::EmbedsController do
       get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
 
       response.status.should == 200
-      response.body.should include("var authTokens = JSON.parse('null');")
+      response.body.should include("var authTokens = JSON.parse('[]');")
     end
 
     it 'does not embed password protected viz' do

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -91,6 +91,24 @@ describe Carto::Builder::Public::EmbedsController do
       response.body.should include("var authTokens = JSON.parse('[]');")
     end
 
+    it 'does not include google maps if not configured' do
+      @user.google_maps_key = ''
+      @user.save
+      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
+
+      response.status.should == 200
+      response.body.should_not include("maps.google.com/maps/api/js")
+    end
+
+    it 'includes the google maps client id if configured' do
+      @user.google_maps_key = 'client=wadus_cid'
+      @user.save
+      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
+
+      response.status.should == 200
+      response.body.should include("maps.google.com/maps/api/js?client=wadus_cid")
+    end
+
     it 'does not embed password protected viz' do
       @visualization.privacy = Carto::Visualization::PRIVACY_PROTECTED
       @visualization.save
@@ -210,6 +228,16 @@ describe Carto::Builder::Public::EmbedsController do
         auth_tokens = @org_user_1.get_auth_tokens
         auth_tokens.count.should eq 2
         auth_tokens.each { |token| response.body.should include token }
+      end
+
+      it 'includes the organizations google maps client id if configured' do
+        @organization.google_maps_key = 'client=wadus_org_cid'
+        @organization.save
+        login_as(@org_user_1)
+        get builder_visualization_public_embed_url(visualization_id: @org_visualization.id, vector: true)
+
+        response.status.should == 200
+        response.body.should include("maps.google.com/maps/api/js?client=wadus_org_cid")
       end
     end
   end

--- a/spec/requests/carto/builder/visualizations_controller_spec.rb
+++ b/spec/requests/carto/builder/visualizations_controller_spec.rb
@@ -188,5 +188,23 @@ describe Carto::Builder::VisualizationsController do
       response.status.should == 200
       response.body.should include(analysis.natural_id)
     end
+
+    it 'does not include google maps if not configured' do
+      @user1.google_maps_key = ''
+      @user1.save
+      get builder_visualization_url(id: @visualization.id)
+
+      response.status.should == 200
+      response.body.should_not include("maps.google.com/maps/api/js")
+    end
+
+    it 'includes the google maps client id if configured' do
+      @user1.google_maps_key = 'client=wadus_cid'
+      @user1.save
+      get builder_visualization_url(id: @visualization.id)
+
+      response.status.should == 200
+      response.body.should include("maps.google.com/maps/api/js?client=wadus_cid")
+    end
   end
 end


### PR DESCRIPTION
Fixes #11541 

Adds google maps JS to all Builder views that require it.

Bonus track, changes the auth tokens when none are loaded to empty array instead of null, so it is consistent (private org maps used to return `[]` if the user didn't have permission, and public maps did return `null`).

**Acceptance**

For possible regressions with the auth tokens change (unlikely).
- [x] Create a password protected map. Check that the embed works (from a private window).
- [x] Create a private map, share it inside the org. Check that the embed works (from a private window, logged in as a different user than the owner).

The part about adding google maps tokens will be checked as part of the bigger branch (@alonsogarciapablo can you confirm this is true?)