### PR TITLE
11461 register torque layer dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,7 @@ Development
 * Categories legend are now static (#10972)
 * Fixed a bug with vizjson invalidation (#11092). It was introduced in #10934
 * Refactor Layer model (#10934)
+* Correctly register table dependencies of torque layers (#11549)
 * Fix bugs where legends where being hidden by reordering layers (#11088)
 * Correctly ask for alternative username when signing up with Google/GitHub into an organization
 * Avoid loading all rake code in resque workers (#11069)

--- a/app/controllers/carto/api/visualization_vizjson_adapter.rb
+++ b/app/controllers/carto/api/visualization_vizjson_adapter.rb
@@ -8,7 +8,7 @@ module Carto
       include Carto::HtmlSafe
 
       delegate [:id, :map, :qualified_name, :likes, :description, :retrieve_named_map?, :password_protected?, :overlays,
-                :prev_id, :next_id, :transition_options, :has_password?, :parent_id, :get_auth_tokens, :user, 
+                :prev_id, :next_id, :transition_options, :has_password?, :parent_id, :get_auth_tokens, :user,
                 :related_canonical_visualizations
                ] => :visualization
 
@@ -60,7 +60,7 @@ module Carto
         when :base
           map.user_layers
         when :cartodb
-          map.data_layers
+          map.carto_layers
         when :others
           map.other_layers
         else

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -124,7 +124,7 @@ module Carto
       def layers_vizjson(forced_privacy_version)
         ordered_layers = (
           [basemap_layer] +
-          @visualization.data_layers +
+          @visualization.carto_layers +
           @visualization.other_layers +
           non_basemap_base_layers).compact
 

--- a/app/models/carto/map.rb
+++ b/app/models/carto/map.rb
@@ -49,10 +49,6 @@ class Carto::Map < ActiveRecord::Base
     layers.select(&:user_layer?)
   end
 
-  def carto_and_torque_layers
-    layers.select { |layer| layer.carto? || layer.torque? }
-  end
-
   def torque_layers
     layers.select(&:torque?)
   end
@@ -155,7 +151,7 @@ class Carto::Map < ActiveRecord::Base
   end
 
   def can_add_layer?(user)
-    return false if user.max_layers && user.max_layers <= carto_and_torque_layers.count
+    return false if user.max_layers && user.max_layers <= data_layers.count
 
     visualization.writable_by?(user)
   end

--- a/app/models/carto/map.rb
+++ b/app/models/carto/map.rb
@@ -38,7 +38,7 @@ class Carto::Map < ActiveRecord::Base
   after_commit :force_notify_map_change
 
   def data_layers
-    layers.select(&:carto?)
+    layers.select(&:data_layer?)
   end
 
   def carto_layers

--- a/app/models/carto/map.rb
+++ b/app/models/carto/map.rb
@@ -41,6 +41,10 @@ class Carto::Map < ActiveRecord::Base
     layers.select(&:carto?)
   end
 
+  def carto_layers
+    layers.select(&:carto?)
+  end
+
   def user_layers
     layers.select(&:user_layer?)
   end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -238,6 +238,10 @@ class Carto::Visualization < ActiveRecord::Base
     map ? map.data_layers : []
   end
 
+  def carto_layers
+    map ? map.carto_layers : []
+  end
+
   def user_layers
     map ? map.user_layers : []
   end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -7,17 +7,17 @@ require_dependency 'carto/helpers/auth_token_generator'
 
 module Carto::VisualizationDependencies
   def fully_dependent_on?(user_table)
-    derived? && layers_dependent_on(user_table).count == carto_and_torque_layers.count
+    derived? && layers_dependent_on(user_table).count == data_layers.count
   end
 
   def partially_dependent_on?(user_table)
-    derived? && layers_dependent_on(user_table).count.between?(1, carto_and_torque_layers.count - 1)
+    derived? && layers_dependent_on(user_table).count.between?(1, data_layers.count - 1)
   end
 
   private
 
   def layers_dependent_on(user_table)
-    carto_and_torque_layers.select { |l| l.depends_on?(user_table) }
+    data_layers.select { |l| l.depends_on?(user_table) }
   end
 end
 
@@ -246,10 +246,6 @@ class Carto::Visualization < ActiveRecord::Base
     map ? map.user_layers : []
   end
 
-  def carto_and_torque_layers
-    map ? map.carto_and_torque_layers : []
-  end
-
   def torque_layers
     map ? map.torque_layers : []
   end
@@ -418,7 +414,7 @@ class Carto::Visualization < ActiveRecord::Base
   def add_source_analyses
     return unless analyses.empty?
 
-    carto_and_torque_layers.each_with_index do |layer, index|
+    data_layers.each_with_index do |layer, index|
       analysis = Carto::Analysis.source_analysis_for_layer(layer, index)
 
       if analysis.save
@@ -547,7 +543,7 @@ class Carto::Visualization < ActiveRecord::Base
   def get_related_tables
     return [] unless map
 
-    map.carto_and_torque_layers.flat_map(&:user_tables).uniq
+    map.data_layers.flat_map(&:user_tables).uniq
   end
 
   def get_related_canonical_visualizations

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -27,7 +27,7 @@ class Map < Sequel::Model
   many_to_many :data_layers,
                clone: :layers,
                right_key: :layer_id,
-               conditions: { kind: "carto" }
+               conditions: "kind in ('carto', 'torque')"
 
   many_to_many :user_layers,
                clone: :layers,

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -19,6 +19,11 @@ class Map < Sequel::Model
                clone: :layers,
                right_key: :layer_id
 
+  many_to_many :carto_layers,
+               clone: :layers,
+               right_key: :layer_id,
+               conditions: { kind: "carto" }
+
   many_to_many :data_layers,
                clone: :layers,
                right_key: :layer_id,

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -34,11 +34,6 @@ class Map < Sequel::Model
                right_key: :layer_id,
                conditions: "kind in ('tiled', 'background', 'gmapsbase', 'wms')"
 
-  many_to_many :carto_and_torque_layers,
-               clone: :layers,
-               right_key: :layer_id,
-               conditions: "kind in ('carto', 'torque')"
-
   many_to_many :torque_layers,
                clone: :layers,
                right_key: :layer_id,
@@ -155,7 +150,7 @@ class Map < Sequel::Model
   end
 
   def can_add_layer(user)
-    return false if self.user.max_layers && self.user.max_layers <= carto_and_torque_layers.count
+    return false if self.user.max_layers && self.user.max_layers <= data_layers.count
     return false if self.user.viewer
 
     current_vis = visualizations.first

--- a/app/models/map/copier.rb
+++ b/app/models/map/copier.rb
@@ -75,7 +75,7 @@ module CartoDB
       attr_reader :map
 
       def data_layer_copies_from(map, user)
-        map.carto_and_torque_layers.map do |layer|
+        map.data_layers.map do |layer|
           new_layer = layer.copy
           new_layer.qualify_for_organization(map.user.username) if user.id != map.user.id
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -893,7 +893,7 @@ module CartoDB
 
         # This includes both the canonical and derived visualizations
         table.affected_visualizations.each do |affected_visualization|
-          affected_visualization.layers(:carto_and_torque).each do |layer|
+          affected_visualization.layers(:data).each do |layer|
             if layer.options['table_name'] == table.name
               layer.options['attribution']  = self.attributions
               layer.save

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -11,13 +11,13 @@ module CartoDB
       LAYER_SCOPES = {
         base:             :user_layers,
         cartodb:          :carto_layers,
-        carto_and_torque: :carto_and_torque_layers,
+        data:             :data_layers,
         others:           :other_layers,
         named_map:        :named_maps_layers
       }.freeze
 
       INTERFACE = %w{ overlays user table related_templates related_tables related_canonical_visualizations
-                      layers stats mapviews total_mapviews carto_and_torque_layers synchronization is_synced? permission
+                      layers stats mapviews total_mapviews data_layers synchronization is_synced? permission
                       parent children support_tables prev_list_item next_list_item likes likes_count reload_likes
                       estimated_row_count actual_row_count }.freeze
 
@@ -96,7 +96,7 @@ module CartoDB
       end
 
       def related_tables
-        @related_tables ||= layers(:carto_and_torque).flat_map { |layer| layer.user_tables.map(&:service) }.uniq(&:id)
+        @related_tables ||= layers(:data).flat_map { |layer| layer.user_tables.map(&:service) }.uniq(&:id)
       end
 
       def related_canonical_visualizations
@@ -130,8 +130,8 @@ module CartoDB
         @total_mapviews ||= Visualization::Stats.new(self, user).total_mapviews
       end
 
-      def carto_and_torque_layers
-        layers(:carto_and_torque)
+      def data_layers
+        layers(:data)
       end
 
       def permission

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -10,7 +10,7 @@ module CartoDB
     class Relator
       LAYER_SCOPES = {
         base:             :user_layers,
-        cartodb:          :data_layers,
+        cartodb:          :carto_layers,
         carto_and_torque: :carto_and_torque_layers,
         others:           :other_layers,
         named_map:        :named_maps_layers

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -258,7 +258,7 @@ module Carto
       def preview_layers
         preview_layers = {}
 
-        @visualization.carto_and_torque_layers.each do |layer|
+        @visualization.data_layers.each do |layer|
           preview_layers[:"#{layer.id}"] = layer.options[:visible] || false
         end
 

--- a/lib/explore_api.rb
+++ b/lib/explore_api.rb
@@ -11,12 +11,12 @@ class ExploreAPI
   def get_visualization_tables(visualization)
     # We are using layers instead of related tables because with related tables we are connecting
     # to the users databases and we are reaching the connections limit
-    table_names = visualization.layers(:carto_and_torque).map { |layer| extract_table_name(layer) }.uniq
+    table_names = visualization.layers(:data).map { |layer| extract_table_name(layer) }.uniq
     %[{#{table_names.compact.join(',')}}]
   end
 
   def get_map_layers(visualization)
-    visualization.layers(:carto_and_torque)
+    visualization.layers(:data)
   end
 
   def get_geometry_data(visualization)

--- a/spec/lib/explore_api_spec.rb
+++ b/spec/lib/explore_api_spec.rb
@@ -16,7 +16,7 @@ describe 'ExploreAPI' do
     visualization = FactoryGirl.build(:table_visualization, user_id: user.id, map_id: map.id)
     layer_1 = create_layer('table_1', 'user_name_1', 1)
     visualization.stubs(:map).returns(map)
-    visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1])
+    visualization.stubs(:layers).with(:data).returns([layer_1])
     tables = @explore_api.get_visualization_tables(visualization)
     tables.should eq '{\"user_name_1\".table_1}'
   end
@@ -28,7 +28,7 @@ describe 'ExploreAPI' do
     layer_1 = create_layer('table_1', 'user_name_1', 1)
     layer_2 = create_layer('table_2', 'user_name_2', 2)
     visualization.stubs(:map).returns(map)
-    visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1, layer_2])
+    visualization.stubs(:layers).with(:data).returns([layer_1, layer_2])
     tables = @explore_api.get_visualization_tables(visualization)
     tables.should eq '{\"user_name_1\".table_1,\"user_name_2\".table_2}'
   end
@@ -40,7 +40,7 @@ describe 'ExploreAPI' do
     layer_1 = create_layer('table_1', 'user_name_1', 1)
     layer_2 = create_layer('table_1', 'user_name_1', 2)
     visualization.stubs(:map).returns(map)
-    visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1, layer_2])
+    visualization.stubs(:layers).with(:data).returns([layer_1, layer_2])
     tables = @explore_api.get_visualization_tables(visualization)
     tables.should eq '{\"user_name_1\".table_1}'
   end
@@ -52,7 +52,7 @@ describe 'ExploreAPI' do
     layer_1 = create_layer('table_1', '', 1)
     layer_2 = create_layer('', 'user_name_2', 1)
     visualization.stubs(:map).returns(map)
-    visualization.stubs(:layers).with(:carto_and_torque).returns([layer_1, layer_2])
+    visualization.stubs(:layers).with(:data).returns([layer_1, layer_2])
     tables = @explore_api.get_visualization_tables(visualization)
     tables.should eq '{}'
   end

--- a/spec/models/carto/map_spec.rb
+++ b/spec/models/carto/map_spec.rb
@@ -40,8 +40,8 @@ describe Carto::Map do
     base_layers_count = map.base_layers.count
     base_layers_count.should eq 9
 
-    data_layers_count = map.data_layers.count
-    data_layers_count.should eq 5
+    carto_layers_count = map.carto_layers.count
+    carto_layers_count.should eq 5
 
     user_layers_count = map.user_layers.count
     user_layers_count.should eq 3
@@ -59,7 +59,7 @@ describe Carto::Map do
 
     layers_count.should eq map_new.layers.count
     base_layers_count.should eq map_new.base_layers.count
-    data_layers_count.should eq map_new.data_layers.count
+    carto_layers_count.should eq map_new.carto_layers.count
     user_layers_count.should eq map_new.user_layers.count
     carto_and_torque_layers_count.should eq map_new.data_layers.count
     torque_layers_count.should eq map_new.torque_layers.count

--- a/spec/models/carto/map_spec.rb
+++ b/spec/models/carto/map_spec.rb
@@ -46,7 +46,7 @@ describe Carto::Map do
     user_layers_count = map.user_layers.count
     user_layers_count.should eq 3
 
-    carto_and_torque_layers_count = map.carto_and_torque_layers.count
+    carto_and_torque_layers_count = map.data_layers.count
     carto_and_torque_layers_count.should eq 6
 
     torque_layers_count = map.torque_layers.count
@@ -61,7 +61,7 @@ describe Carto::Map do
     base_layers_count.should eq map_new.base_layers.count
     data_layers_count.should eq map_new.data_layers.count
     user_layers_count.should eq map_new.user_layers.count
-    carto_and_torque_layers_count.should eq map_new.carto_and_torque_layers.count
+    carto_and_torque_layers_count.should eq map_new.data_layers.count
     torque_layers_count.should eq map_new.torque_layers.count
     other_layers_count.should eq map_new.other_layers.count
 
@@ -69,7 +69,7 @@ describe Carto::Map do
     map.base_layers.map(&:id).should eq map_new.base_layers.map(&:id)
     map.data_layers.map(&:id).should eq map_new.data_layers.map(&:id)
     map.user_layers.map(&:id).should eq map_new.user_layers.map(&:id)
-    map.carto_and_torque_layers.map(&:id).should eq map_new.carto_and_torque_layers.map(&:id)
+    map.data_layers.map(&:id).should eq map_new.data_layers.map(&:id)
     map.torque_layers.map(&:id).should eq map_new.torque_layers.map(&:id)
     map.other_layers.map(&:id).should eq map_new.other_layers.map(&:id)
 

--- a/spec/models/carto/map_spec.rb
+++ b/spec/models/carto/map_spec.rb
@@ -4,6 +4,7 @@ require_relative '../../spec_helper'
 describe Carto::Map do
   before(:all) do
     @user = create_user
+    @carto_user = Carto::User.find(@user.id)
   end
 
   before(:each) do
@@ -73,6 +74,30 @@ describe Carto::Map do
     map.other_layers.map(&:id).should eq map_new.other_layers.map(&:id)
 
     map.destroy
+  end
+
+  describe '#update_dataset_dependencies' do
+    before(:all) do
+      @carto_layer = FactoryGirl.create(:carto_layer, kind: 'carto')
+      @torque_layer = FactoryGirl.create(:carto_layer, kind: 'torque')
+      @map = Carto::Map.create(user: @carto_user, layers: [@carto_layer, @torque_layer])
+    end
+
+    after(:all) do
+      @torque_layer.destroy
+      @carto_layer.destroy
+      @map.destroy
+    end
+
+    it 'updates dependencies of carto layers' do
+      @map.layers.select(&:carto?).first.expects(:register_table_dependencies).once
+      @map.update_dataset_dependencies
+    end
+
+    it 'updates dependencies of carto layers' do
+      @map.layers.select(&:torque?).first.expects(:register_table_dependencies).once
+      @map.update_dataset_dependencies
+    end
   end
 
 end

--- a/spec/models/layer_shared_examples.rb
+++ b/spec/models/layer_shared_examples.rb
@@ -300,5 +300,18 @@ shared_examples_for 'Layer model' do
       @layer.save
       LayerNodeStyle.where(layer_id: @layer.id).count.should eq 0
     end
+
+    it 'saves styles for torque layers' do
+      @layer.kind = 'torque'
+      @layer.options['source'] = 'a0'
+      @layer.save
+      lns = LayerNodeStyle.where(layer_id: @layer.id).first
+      lns.should be
+      lns.tooltip.should eq @layer.tooltip || {}
+      lns.infowindow.should eq @layer.infowindow || {}
+      lns.options['tile_style'].should eq @layer.options['tile_style']
+      lns.options['sql_wrap'].should eq @layer.options['sql_wrap']
+      lns.options['style_properties'].should eq @layer.options['style_properties']
+    end
   end
 end

--- a/spec/models/visualization/table_blender_spec.rb
+++ b/spec/models/visualization/table_blender_spec.rb
@@ -15,7 +15,7 @@ describe TableBlender do
     map.stubs(:to_hash).returns({})
     map.stubs(:user).returns(user)
     map.stubs(:user_layers).returns([])
-    map.stubs(:carto_and_torque_layers).returns([])
+    map.stubs(:data_layers).returns([])
     map
   end
 

--- a/spec/requests/carto/api/analyses_controller_spec.rb
+++ b/spec/requests/carto/api/analyses_controller_spec.rb
@@ -391,6 +391,16 @@ describe Carto::Api::AnalysesController do
       end
     end
 
+    it '#show returns tile styles for torque layers' do
+      Carto::Layer.any_instance.stubs(:kind).returns('torque')
+      get_json viz_analysis_url(@user, @visualization, @styled_analysis.id) do |response|
+        response.status.should eq 200
+        Carto::AnalysisNode.new(response[:body][:analysis_definition].deep_symbolize_keys).descendants.each do |node|
+          node.options[:style_history][@layer_id.to_sym][:options][:tile_style].should eq 'wadus'
+        end
+      end
+    end
+
     it '#update invalidates the affected node' do
       @styled_analysis.analysis_node.params[:dummy] = 'yes'
       new_payload = {

--- a/spec/services/carto/visualizations_export_service_spec.rb
+++ b/spec/services/carto/visualizations_export_service_spec.rb
@@ -101,7 +101,7 @@ describe Carto::VisualizationsExportService do
     base_layer = visualization.layers(:base).first
     visualization_clone = visualization.dup
 
-    original_data_layer_names = visualization.layers(:carto_and_torque).map { |layer| layer.options["table_name"] }
+    original_data_layer_names = visualization.layers(:data).map { |layer| layer.options["table_name"] }
 
     # As duplicating the vis only works fine with parent object, store also the vizjson for comparisons
     vizjson_options = {
@@ -133,7 +133,7 @@ describe Carto::VisualizationsExportService do
                                                       .to_json
     restored_vizjson = ::JSON.parse(restored_vizjson)
 
-    restored_data_layer_names = visualization.layers(:carto_and_torque).map { |layer| layer.options["table_name"] }
+    restored_data_layer_names = visualization.layers(:data).map { |layer| layer.options["table_name"] }
 
     # Base attributes checks
     restored_visualization.name.should eq visualization_clone.name
@@ -171,7 +171,7 @@ describe Carto::VisualizationsExportService do
     # Layer checks
     (restored_visualization.layers(:base).count > 0).should eq true
     restored_visualization.layers(:base).first["options"].should eq base_layer["options"]
-    restored_visualization.layers(:carto_and_torque).count.should eq 2
+    restored_visualization.layers(:data).count.should eq 2
     (restored_data_layer_names - original_data_layer_names).should eq []
   end
 


### PR DESCRIPTION
Fixes #11461

Makes the following important changes:
- Adds `Map.carto_layers` to return layers with kind carto
- `Map.data_layers` now returns carto and torque layers
- Removed `Map.carto_and_torque_layers`

This makes the interface at map level more similar to the one at layer level. There is an overview table at the ticket. There are more changes that could be made (`Map.base_layers` is a good candidate, since it returns all layers), but this only focuses in the one producing the actual issue.

This fixes the following:
- No update table dependencies on torque layers
- No auto-indexing on torque layers (when publishing a map)
- No layer node style on torque layers presenter (little effect, since the frontend switches torque layers to normal after applying an analysis)
- No updated_at date in torque layers
- Incorrect calculation of max layers per map (not counting torque layers)

**Acceptance** (suggestions, this one is hard to evaluate)
- [x] STR of the ticket
- [x] Create an animated torque layer over a dataset with > 10k rows. A timeline widget should be automatically added. Check Rollbar, you should see an autoindex trigger.
- ~~In a map with a Torque layer, try adding a new Torque layer (APII/console, we don't want to test frontend blocking). You shouldn't be able to.~~ Not needed. There's no public API for this.
- [x] Export a .carto from a map with labels on top, a normal layer and a torque layer. Import it. It should keep layers and order.
- [x] Repeat with a map using a basemap without labels.