### PR TITLE
Hides header back arrow  

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -58,6 +58,7 @@ module.exports = CoreView.extend({
 
     this.$el.append(template({
       columnType: columnType,
+      showBackArrow: this._stackLayoutView.getCurrentPosition() === 0,
       attribute: this.model.get('attribute'),
       quantification: this.model.get('quantification') || 'category'
     }));
@@ -97,6 +98,8 @@ module.exports = CoreView.extend({
     this._stackLayoutView = new StackLayoutView({
       collection: stackViewCollection
     });
+
+    this._stackLayoutView.bind('positionChanged', this.render, this);
   },
 
   _iconStylingEnabled: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -58,7 +58,7 @@ module.exports = CoreView.extend({
 
     this.$el.append(template({
       columnType: columnType,
-      showBackArrow: this._stackLayoutView.getCurrentPosition() === 0,
+      showBackButton: this._stackLayoutView.getCurrentPosition() === 0,
       attribute: this.model.get('attribute'),
       quantification: this.model.get('quantification') || 'category'
     }));

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.tpl
@@ -1,30 +1,32 @@
 <div class="CDB-Box-modalHeader">
-  <ul class="CDB-Box-modalHeaderItem CDB-Box-modalHeaderItem--block CDB-Box-modalHeaderItem--paddingHorizontal">
-    <li class="CDB-ListDecoration-item CDB-ListDecoration-itemPadding--vertical CDB-Text CDB-Size-medium u-secondaryTextColor">
-      <ul class="u-flex u-justifySpace">
-        <li class="u-flex">
-          <% if (showBackArrow) { %>
+  <% if (showBackButton || columnType === 'number') { %>
+    <ul class="CDB-Box-modalHeaderItem CDB-Box-modalHeaderItem--block CDB-Box-modalHeaderItem--paddingHorizontal">
+      <li class="CDB-ListDecoration-item CDB-ListDecoration-itemPadding--vertical CDB-Text CDB-Size-medium u-secondaryTextColor">
+        <ul class="u-flex u-justifySpace">
+          <% if (showBackButton) { %>
+          <li class="u-flex">
             <button class="u-rSpace u-actionTextColor js-back">
               <i class="CDB-IconFont CDB-IconFont-arrowPrev Size-large"></i>
             </button>
+            <span class="label js-label"><%- attribute %></span>
+          </li>
           <% } %>
-          <span class="label js-label"><%- attribute %></span>
-        </li>
-        <% if (columnType === 'number') { %>
-        <li class="u-flex">
-          <%- _t('form-components.editors.fill.quantification.methods.' + quantification) %>
-          <button class="CDB-Shape u-lSpace js-quantification">
-            <div class="CDB-Shape-threePoints is-horizontal is-blue is-small">
-              <div class="CDB-Shape-threePointsItem"></div>
-              <div class="CDB-Shape-threePointsItem"></div>
-              <div class="CDB-Shape-threePointsItem"></div>
-            </div>
-          </button>
-        </li>
-        <% } %>
-      </ul>
-    </li>
-  </ul>
+          <% if (columnType === 'number') { %>
+          <li class="u-flex">
+            <%- _t('form-components.editors.fill.quantification.methods.' + quantification) %>
+            <button class="CDB-Shape u-lSpace js-quantification">
+              <div class="CDB-Shape-threePoints is-horizontal is-blue is-small">
+                <div class="CDB-Shape-threePointsItem"></div>
+                <div class="CDB-Shape-threePointsItem"></div>
+                <div class="CDB-Shape-threePointsItem"></div>
+              </div>
+            </button>
+          </li>
+          <% } %>
+        </ul>
+      </li>
+    </ul>
+  <% } %>
 </div>
 <div class="InputColorCategory-loader js-loader is-hidden">
   <div class="CDB-LoaderIcon is-dark">

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.tpl
@@ -3,9 +3,11 @@
     <li class="CDB-ListDecoration-item CDB-ListDecoration-itemPadding--vertical CDB-Text CDB-Size-medium u-secondaryTextColor">
       <ul class="u-flex u-justifySpace">
         <li class="u-flex">
-          <button class="u-rSpace u-actionTextColor js-back">
-            <i class="CDB-IconFont CDB-IconFont-arrowPrev Size-large"></i>
-          </button>
+          <% if (showBackArrow) { %>
+            <button class="u-rSpace u-actionTextColor js-back">
+              <i class="CDB-IconFont CDB-IconFont-arrowPrev Size-large"></i>
+            </button>
+          <% } %>
           <span class="label js-label"><%- attribute %></span>
         </li>
         <% if (columnType === 'number') { %>

--- a/lib/assets/core/javascripts/cartodb3/components/stack-layout/stack-layout-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/stack-layout/stack-layout-view.js
@@ -28,6 +28,11 @@ module.exports = CoreView.extend({
   _onPositionChange: function (newPos, opts) {
     this._removeOldStackView();
     this._genNewStackView(_.flatten(opts));
+    this.trigger('positionChanged', this);
+  },
+
+  getCurrentPosition: function () {
+    return this.model.get('position');
   },
 
   _removeOldStackView: function () {
@@ -49,5 +54,4 @@ module.exports = CoreView.extend({
     this.$el.html(nextView.render().el);
     this.addView(nextView);
   }
-
 });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
@@ -59,6 +59,14 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
 
     expect(this.view.$('.js-loader').hasClass('is-hidden')).toBeTruthy();
     expect(this.view.$('.js-content').hasClass('is-hidden')).toBeFalsy();
+
+    expect(this.view.$('.js-label').text()).toBe('column1');
+    expect(this.view.$('.js-back').length).toBe(1);
+  });
+
+  it('should hide the title label back arrow', function () {
+    this.view.$('.js-listItem:eq(0)').click();
+    expect(this.view.$('.js-back').length).toBe(1);
   });
 
   it('should show the loader', function () {
@@ -105,6 +113,8 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
 
       expect(this.view.$('.js-listItem:eq(2)').text()).toContain('form-components.editors.fill.input-categories.null');
       expect(this.view.$('.RampItem-bar:eq(2)').css('background-color')).toBe('rgb(221, 28, 119)');
+
+      expect(this.view.$('.js-back').length).toBe(1);
     });
   });
 
@@ -151,6 +161,8 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
 
       expect(this.view.$('.js-loader').hasClass('is-hidden')).toBeTruthy();
       expect(this.view.$('.js-content').hasClass('is-hidden')).toBeFalsy();
+
+      expect(this.view.$('.js-back').length).toBe(1);
     });
 
     afterEach(function () {
@@ -207,6 +219,8 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
 
       expect(this.view.$('.js-listItem:eq(2)').text()).toContain('two');
       expect(this.view.$('.RampItem-bar:eq(2)').css('background-color')).toBe('rgb(56, 166, 165)');
+
+      expect(this.view.$('.js-back').length).toBe(1);
     });
 
     afterEach(function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
@@ -67,6 +67,7 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
   it('should hide the title label back arrow', function () {
     this.view.$('.js-listItem:eq(0)').click();
     expect(this.view.$('.js-back').length).toBe(1);
+    expect(this.view.$('.js-label').text()).not.toBe('column1');
   });
 
   it('should show the loader', function () {


### PR DESCRIPTION
Original issue: #11138 

This ticket removes an arrow from the fill component form when styling by value:

![screen shot 2017-02-17 at 09 54 15](https://cloud.githubusercontent.com/assets/4933/23062068/a2037a3a-f504-11e6-939e-8dad421983b4.png)

With this change we'll prevent users to inadvertently go to the column list instead of going back to the list of categories.

