### PR TITLE
Add explicit locking to layer->user_tables relation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,7 @@ Development
 * Fix color for "Other" category (#11078)
 * Custom errors for latitude/longitude out of bounds (#11060, #11048)
 * Fix timeseries widget height (#11077)
+* Fix a DB deadlock while simultaneously updating and deleting layers (#11568)
 * Improve speed of map name availability check, improves map creation and renaming times (#11435)
 * Fix redirection after logout for subdomainless URLs (#11361)
 * Fix scrollbar in carousel (#11061)

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -298,7 +298,7 @@ module Carto
     # before the model. This can cause deadlocks with simultaneous request to update and delete the model.
     # This request a explicit lock to PostgreSQL so the tables are always accessed in the same order. #11443
     def lock_user_tables
-      user_tables.lock.all
+      user_tables.lock.all if persisted?
     end
 
     def rename_in(target, anchor, substitution)

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -80,6 +80,7 @@ module Carto
 
     before_destroy :ensure_not_viewer
     before_destroy :invalidate_maps
+    before_save :lock_user_tables
     after_save :invalidate_maps, :update_layer_node_style
     after_save :register_table_dependencies, if: :data_layer?
 
@@ -292,6 +293,13 @@ module Carto
     end
 
     private
+
+    # The table dependencies will only be updated after the layer. However, when deleting them, they need to be deleted
+    # before the model. This can cause deadlocks with simultaneous request to update and delete the model.
+    # This request a explicit lock to PostgreSQL so the tables are always accessed in the same order. #11443
+    def lock_user_tables
+      user_tables.lock.all
+    end
 
     def rename_in(target, anchor, substitution)
       return if target.blank?


### PR DESCRIPTION
Fix for #11443 

There is a dedlock describe in this comment: https://github.com/CartoDB/cartodb/issues/11443#issuecomment-280626409. The important part:
1. Update controller updates the layer
2. Delete controller removes layers_user_tables
3. Update controller tries to add/remove layers_user_tables. Starts waiting for a lock
4. Delete controller tries to remove the layer. Starts waiting for a lock. Deadlock is inmediately detected and this request is killed (500).
5. Update completes successfully.

The problem is that the tables (`layers` and `layers_user_tables`) are locked in different orders in two operations. This change forces the `layers_user_table` to always be locked first, so deadlocks cannot occur, at the price of delaying the second operation until the first one finishes.