### PR TITLE
Revamp ramps when attribute_types changes.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@ Development
   * Sets the default initial size for icons to 20px (#11498)
 
 ### Bug fixes
+* Fixed problem switching between qualitative and quantitative attributes (#10654)
 * Fixed problem found in Surfaces related with map panning and widgets filtering
 * Style with icons
   * Reset icon on map when you remove that custom icon

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
@@ -132,9 +132,9 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
-    this.model.bind('change:bins', this._onChangeBins, this);
+    this.listenTo(this.model, 'change:bins', this._onChangeBins);
     this.listenTo(this.model, 'change:attribute_type', this._updateRampOnAttributeChange);
-    this.collection.bind('change:selected', this._onSelectItem, this);
+    this.listenTo(this.collection, 'change:selected', this._onSelectItem);
   },
 
   _updateRampOnAttributeChange: function (m, type) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
@@ -51,14 +51,20 @@ module.exports = CoreView.extend({
 
     if (customRamp) {
       this.$('.js-customList').addClass('is-customized');
-    }
+    } else {
+      var selectedRamp = this.collection.getSelectedItem();
 
-    this._selectRamp(this.collection.getSelectedItem());
+      if (!selectedRamp) {
+        selectedRamp = this.collection.first();
+      }
+
+      this._selectRamp(selectedRamp);
+    }
 
     return this;
   },
 
-  _setupCollection: function () {
+  _getRamps: function () {
     var attributeType = this.model.get('attribute_type');
     // select only suitable ramps for the data type
     // number -> ramps
@@ -105,6 +111,11 @@ module.exports = CoreView.extend({
       };
     }, this);
 
+    return ramps;
+  },
+
+  _setupCollection: function () {
+    var ramps = this._getRamps();
     this.collection = new CustomListCollection(_.compact(ramps), { silent: false });
     this.add_related_model(this.collection);
 
@@ -122,7 +133,21 @@ module.exports = CoreView.extend({
 
   _initBinds: function () {
     this.model.bind('change:bins', this._onChangeBins, this);
+    this.listenTo(this.model, 'change:attribute_type', this._updateRampOnAttributeChange);
     this.collection.bind('change:selected', this._onSelectItem, this);
+  },
+
+  _updateRampOnAttributeChange: function (m, type) {
+    var ramps = this._getRamps();
+    // Update the ramps when the attribute changes
+    this.collection.reset(_.compact(ramps), {silent: true});
+    // and delete the custom ramp
+    this._customRamp.set('range', false);
+
+    // apply the first ramp
+    var first = this.collection.first();
+    first && first.set('selected', true);
+    this.render();
   },
 
   _initViews: function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.spec.js
@@ -58,6 +58,17 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
       expect(this.view.$('.js-listItem.is-inverted').length).toBe(1);
     });
 
+    it('should update ramps on attribute type changes and select the first one', function () {
+      spyOn(this.view, 'render').and.callThrough();
+
+      this.model.set('attribute_type', 'string');
+
+      expect(this.view.render).toHaveBeenCalled();
+      expect(this.view.$('.js-listItem:eq(0)').data('val')).toContain(this.view.collection.at(0).get('val').join(','));
+      expect(this.view.$('.js-listItem:eq(0)').hasClass('is-selected')).toBe(true);
+      expect(this.view.$('.js-customize').text()).toBe('form-components.editors.fill.customize');
+    });
+
     afterEach(function () {
       this.view.remove();
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.5.151",
+  "version": "4.5.152",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR implements #10654.

### How to test

- [ ] Change between string and number attributes. The ramps should be revamped and the selected one should be the first.
- [ ] On change, no custom ramp should be present.