### PR TITLE
Stellar zeus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,7 @@ Notes:
 - If you want to pass ENV variables, pass them to the `zeus start` process (master), not to the slaves.
 - When testing, you can run `TURBO=1 zeus start` to enable some extra optimizations for the testing environment
   (less database cleaning).
+- If your console breaks after running zeus, add something like `zeus() { /usr/bin/zeus "$@"; stty sane; }` to `.bashrc`.
 
 ### Stellar
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,3 +156,40 @@ After that, there are several rules you should follow when a new pull request is
   - Change UI assets version, present in [package.json](package.json) file. Minor if it is a bugfixing or a small feature, major when it is a big change.
 - Our linter machine, [Hound](https://houndci.com/), should not trigger any warnings about your changes.
 - All tests should pass, both for JS and Ruby.
+
+## Development environment accessories
+
+The development environment can be quite slow to start up, but we have some workarounds that help speed it up:
+- Using Zeus to avoid the load times of the Rails environment by keeping it into memory. It provides a very fast
+  execution of rails commands.
+- Using Stellar (database snapshotting tool) in order to quickly reload the test database. This is also useful
+  while testing code, in order to quickly rollback to a previous DB state.
+
+### Zeus
+
+1. Install zeus globally with `gem install zeus`. This is recommended but not needed. You can also use `bundle exec zeus`, which is a bit slower.
+2. Start the zeus server. `zeus start`. This will start preloading the environments.
+3. Run your rails commands prefixed by zeus. For example: `zeus c` for console, `zeus rspec xxx` for testing. Run `zeus commands` for a full list (or check `zeus.json`).
+
+Notes:
+- If you want to pass ENV variables, pass them to the `zeus start` process (master), not to the slaves.
+- When testing, you can run `TURBO=1 zeus start` to enable some extra optimizations for the testing environment
+  (less database cleaning).
+
+### Stellar
+
+1. Install stellar. Check your distribution packages, or install with pip: `pip install stellar`
+2. Create a configuration file by running `stellar init` and following the steps. The connection string is: `postgresql://postgres@localhost/carto_db_test`. The project name doesn't matter.
+3. Create a clean testing database `make prepare-test-db`
+4. Create a snapshot: `stellar snapshot`
+
+Then to use it for testing, you can pass `STELLAR=stellar` (you can pass the executable path) as an ENV variable and the
+testing environment will use it to clean up the database (instead of manually truncating tables).
+
+#### For development
+Stellar can also be useful for development, to quickly restore the database to its original configuration. Just create
+a different configuration (by going to a different directory, stellar always reads `stellar.yaml` in the current path)
+for the development environment.
+
+Then, you can use `stellar snapshot` and `stellar restore` to take and restore snapshot quickly. Also check
+`stellar list` to list current db snapshots and `stellar gc` to remove old ones.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,14 +168,17 @@ The development environment can be quite slow to start up, but we have some work
 ### Zeus
 
 1. Install zeus globally with `gem install zeus`. This is recommended but not needed. You can also use `bundle exec zeus`, which is a bit slower.
-2. Start the zeus server. `zeus start`. This will start preloading the environments.
-3. Run your rails commands prefixed by zeus. For example: `zeus c` for console, `zeus rspec xxx` for testing. Run `zeus commands` for a full list (or check `zeus.json`).
+2. Start the zeus server. `zeus start`. This will start preloading the environments. and display a colorful status.
+3. In a different console, run your rails commands prefixed by zeus. For example: `zeus c` for console,
+   `zeus rspec xxx` for testing. Run `zeus commands` for a full list (or check `zeus.json`).
 
 Notes:
 - If you want to pass ENV variables, pass them to the `zeus start` process (master), not to the slaves.
 - When testing, you can run `TURBO=1 zeus start` to enable some extra optimizations for the testing environment
   (less database cleaning).
 - If your console breaks after running zeus, add something like `zeus() { /usr/bin/zeus "$@"; stty sane; }` to `.bashrc`.
+- If using Vagrant and getting errors, check out [zeus docs](https://github.com/burke/zeus/wiki/Using-with-vagrant).
+  Basically, you have to run with `ZEUSSOCK=/tmp/zeus.sock` as an environment variable.
 
 ### Stellar
 

--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,7 @@ group :development, :test do
   gem 'rb-readline'
   gem 'byebug'
   gem 'rack'
+  gem 'zeus'
 
   # Server
   gem 'thin',                           require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
       treetop (~> 1.4.8)
     memory_profiler (0.9.6)
     metaclass (0.0.4)
+    method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)
     mocha (1.1.0)
@@ -349,6 +350,8 @@ GEM
     websocket (1.2.2)
     xpath (0.1.4)
       nokogiri (~> 1.3)
+    zeus (0.15.13)
+      method_source (>= 0.6.7)
 
 PLATFORMS
   ruby
@@ -429,6 +432,7 @@ DEPENDENCIES
   virtus (= 1.0.5)
   vizzuality-sequel-rails (= 0.3.7)!
   webrick (= 1.3.1)
+  zeus
 
 BUNDLED WITH
-   1.11.2
+   1.14.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@ Development
   * Sets the default initial size for icons to 20px (#11498)
 * Onboarding for layer edition (#10905)
 * Improved formula widget description field. (#11469)
+* Added support for Zeus for faster testing (#11574). Check `CONTRIBUTING.md` for configuration details.
 * Migrate to use GNIP v2 for twitter search connector (#10051, #11595)
 
 ### Bug fixes

--- a/spec/helpers/spec_helper_helpers.rb
+++ b/spec/helpers/spec_helper_helpers.rb
@@ -6,13 +6,18 @@ module SpecHelperHelpers
   end
 
   def clean_metadata_database
-    protected_tables = [:schema_migrations, :spatial_ref_sys]
-    Rails::Sequel.connection.tables.each do |t|
-      if !protected_tables.include?(t)
-        begin
-          Rails::Sequel.connection.run("TRUNCATE TABLE \"#{t}\" CASCADE")
-        rescue Sequel::DatabaseError => e
-          raise e unless e.message =~ /PG::Error: ERROR:  relation ".*" does not exist/
+    if ENV['STELLAR'].present?
+      Rails::Sequel.connection.disconnect
+      system "#{ENV['STELLAR']} restore"
+    else
+      protected_tables = [:schema_migrations, :spatial_ref_sys]
+      Rails::Sequel.connection.tables.each do |t|
+        if !protected_tables.include?(t)
+          begin
+            Rails::Sequel.connection.run("TRUNCATE TABLE \"#{t}\" CASCADE")
+          rescue Sequel::DatabaseError => e
+            raise e unless e.message =~ /PG::Error: ERROR:  relation ".*" does not exist/
+          end
         end
       end
     end

--- a/zeus.json
+++ b/zeus.json
@@ -1,0 +1,30 @@
+{
+  "command": "ruby -rbundler/setup -r./zeus_plan -eZeus.go",
+
+  "plan": {
+    "boot": {
+      "default_bundle": {
+        "development_environment": {
+          "prerake": {
+            "rake": [],
+            "carto_resque": ["resque"]
+          },
+          "runner": ["r"],
+          "console": ["c"],
+          "server": ["s"],
+          "generate": ["g"],
+          "destroy": ["d"],
+          "dbconsole": ["dbm"],
+          "carto_user_dbconsole": ["dbd"]
+        },
+        "test_environment": {
+          "carto_test": {
+            "test_helper": {
+              "test": ["rspec", "testrb"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeus_plan.rb
+++ b/zeus_plan.rb
@@ -1,0 +1,53 @@
+require 'zeus/rails'
+
+require_relative 'spec/support/redis'
+require_relative 'spec/helpers/spec_helper_helpers'
+
+class CustomPlan < Zeus::Rails
+  include SpecHelperHelpers
+
+  def carto_test
+    # Disable before suite hooks
+    ENV['PARALLEL'] = 'true'
+
+    # Clean up at least sometimes
+    drop_leaked_test_user_databases
+
+    # Start redis server
+    CartoDB::RedisTest.up
+
+    if ENV['TURBO']
+      clean_redis_databases
+      clean_metadata_database
+    else
+      RSpec.configure do |config|
+        config.before(:all) do
+          # Clean redis
+          clean_redis_databases
+          clean_metadata_database
+        end
+      end
+    end
+  end
+
+  def test
+    ENV['CHECK_SPEC'] = Process.pid.to_s if ENV['TURBO']
+    Rails::Sequel.connection.disconnect
+
+    super
+  end
+
+  def carto_user_dbconsole
+    u = Carto::User.find_by_username(ARGV[0])
+    exec "psql -U postgres #{u.database_name}"
+  end
+
+  def carto_resque
+    ENV['VVERBOSE'] = 'true'
+    ENV['QUEUE'] = 'imports,exports,users,user_dbs,geocodings,synchronizations,tracker,user_migrations'
+    ARGV.replace(['resque:work'])
+    Rake.application.run
+  end
+end
+
+Zeus.plan = CustomPlan.new


### PR DESCRIPTION
Closes #11645 

**Acceptance** not required (it's a development tool), but could be nice to try to set it up locally and test that it works outside my system.

From https://github.com/CartoDB/leapfrog/issues/39

Why do I care about this? Do you care about saving ~10 seconds every time you run a test?
```
time bundle exec rspec spec/models/carto/legend_spec.rb
19.958s
time zeus rspec spec/models/carto/legend_spec.rb
9.409s
```
Great while developing tests.

### Zeus
[Zeus](https://github.com/burke/zeus) is a server (written in Go) that keeps a Rails environment preloaded, so commands can be run faster. What this means is that we got almost immediate loading of the application, so commands like `rails console` start in a few milliseconds. This PR includes a configuration file for CARTO specifics.

How to use it:
1. Install zeus. `gem install zeus`. You should not add this to the Gemfile.
2. Start the zeus server. `zeus start`. This will start preloading the environments.
3. Run your rails commands prefixed by zeus. For example: `zeus c` for console, `zeus rspec xxx` for testing. It also works for the server (`s`) or the queues (`resque`).

Note that we didn't use `bundle` anywhere, that's internally handled by the config file.

Look at the JSON file for a list of commands, or request one. I also included `zeus dbd username` and `zeus dbm` to open psql with the correct parameters for the user database or metadata databse, because "why not?".

As an extra, specific for testing, you can start the server (yes, the server, is antiintuitive) with `TURBO=1 zeus start`. This enables some aggressive optimizations for testing (basically, stops cleaning the database between _spec files) which saves you a couple of extra seconds.

In my machine, this thing saves about 4 seconds per run.

### Stellar
[Stellar](https://github.com/fastmonkeys/stellar) is a system for easily managing database snapshot. In out context, I use this to restore a snapshot of the testing database instead of relying on truncating every table in the database as we do currently. In my system, this saves 8s (from 10 -> 2 seconds) per spec.

How to use it:
1. Install stellar
2. Create a configuration file by running `stellar init` and following the steps. The connection string is: `postgresql://postgres@localhost/carto_db_test`. The project name doesn't matter.
3. Create a clean testing database `make prepare-test-db`
4. Create a snapshot: `stellar snapshot`

And that's it. The spec helper will automatically detect stellar and will start using it over the truncation method. Combine with zeus and `TURBO=1` for an awesome testing experience.