### PR TITLE
Reorder user deletion so we delete from box and then Central

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,7 @@ Development
 * Fix layer loading at embeds (#11554)
 * Restrict login from organization pages to organization users, and redirect to Central otherwise
 * Correctly refresh map after adding/editing map geometries (#11064)
+* Fix inconsistent state after user deletion failed (#11606)
 * Return embed private instead of 404 in visualization embeds where the visualization doesn't exist (#11056)
 * Fix error loading builder in visualizations without permissions (#10996)
 * Correctly update legend styles (with custom titles) (#10889, #10904)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -118,8 +118,8 @@ class Admin::UsersController < Admin::AdminController
       raise PASSWORD_DOES_NOT_MATCH_MESSAGE
     end
 
-    @user.delete_in_central
     @user.destroy
+    @user.delete_in_central
 
     redirect_to logout_url
   rescue CartoDB::CentralCommunicationFailure => e

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -101,8 +101,8 @@ module Carto
           return
         end
 
-        @user.update_in_central
         @user.save
+        @user.update_in_central
 
         presentation = Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer)
                                                 .to_poro_without_id
@@ -121,8 +121,8 @@ module Carto
           render_jsonp "Can't delete @user. #{'Has shared entities' if @user.has_shared_entities?}", 410
         end
 
-        @user.delete_in_central
         @user.destroy
+        @user.delete_in_central
 
         render_jsonp 'User deleted', 200
       rescue CartoDB::CentralCommunicationFailure => e

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -128,6 +128,8 @@ module Carto
       rescue CartoDB::CentralCommunicationFailure => e
         CartoDB::Logger.error(exception: e, message: 'Central error deleting user from EUMAPI', user: @user)
         render_jsonp "User couldn't be deleted", 500
+      rescue => e
+        render_jsonp "User couldn't be deleted: #{e.message}", 500
       end
 
       private

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -101,8 +101,8 @@ module Carto
           return
         end
 
-        @user.save
         @user.update_in_central
+        @user.save
 
         presentation = Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer)
                                                 .to_poro_without_id

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -555,9 +555,9 @@ describe Carto::Api::OrganizationUsersController do
         last_response.status.should eq 200
       end
 
-      it 'should not delete users that failed to delete from Central' do
-        ::User.any_instance.stubs(:destroy).never
-        mock_delete_request(500)
+      it 'should not delete users from Central that failed to delete in the box' do
+        ::User.any_instance.stubs(:delete_in_central).never
+        ::User.any_instance.stubs(:destroy).raises("BOOM")
         login(@organization.owner)
 
         delete api_v2_organization_users_delete_url(id_or_name: @organization.name,


### PR DESCRIPTION
From #11407 

Also needs PR in Central: https://github.com/CartoDB/cartodb-central/pull/1692 (to correct return codes from users API)

Change the order of box and Central deletion, so the box is deleted first. This way we keep track of the user until it is actually deleted instead of leaving the user in an inconsistent state (where things like password change don't work). This is the same change that was done in https://github.com/CartoDB/cartodb/commit/3679134e6503bc4be4192660752f0b64e7d95910, ported to the API endpoints.

**Acceptance**
- [x] Create an org user. Create a table with SQL API. Delete the user with EUMAPI. You should get an error regarding database objects. User should be still present in box and central.
- [x] Try to change the password for the previous user. It should work.
- [x] Delete the db table. Try to delete the user again. It should succeed.
- [x] Create and delete a FREE user (from signup / his account).
- [x] Create and delete a FREE user (from superadmin).
- [x] Create and delete a org user (from organization settings).
- [x] Create an organization with two users (owner and normal one). Delete de full organization from superadmin.