### PR TITLE
Do not add google maps basemaps to named map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,7 @@ Development
   * Run `cartodb:db:register_table_dependencies` rake to update caches for existing maps
 * Categories legend are now static (#10972)
 * Fixed a bug with vizjson invalidation (#11092). It was introduced in #10934
+* Correctly render map previews for maps with google basemaps (#11608)
 * Refactor Layer model (#10934)
 * Correctly register table dependencies of torque layers (#11549)
 * Fix bugs where legends where being hidden by reordering layers (#11088)

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -103,6 +103,8 @@ module Carto
             if layer_options['type'] == 'Plain'
               layers.push(type: 'plain', options: options_for_plain_basemap_layers(layer_options))
             elsif !layer.gmapsbase?
+              # Tiler doesn't support rendering Google basemaps in static images. We skip them to avoid errors in
+              # dashboard previews, this way at least we get the data on a transparent background.
               layers.push(type: 'http', options: options_for_http_basemap_layers(layer_options))
             end
           end

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -102,7 +102,7 @@ module Carto
 
             if layer_options['type'] == 'Plain'
               layers.push(type: 'plain', options: options_for_plain_basemap_layers(layer_options))
-            else
+            elsif !layer.gmapsbase?
               layers.push(type: 'http', options: options_for_http_basemap_layers(layer_options))
             end
           end

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -437,6 +437,23 @@ module Carto
               @background_layer_hash[:type].should eq 'http'
             end
           end
+
+          describe 'when google maps' do
+            before(:all) do
+              @gmaps_layer = @visualization.layers.first
+
+              @gmaps_layer.options[:type] = 'gmapsbase'
+
+              @gmaps_layer.save
+              @visualization.reload
+
+              @named_map_hash = Carto::NamedMaps::Template.new(@visualization).to_hash
+            end
+
+            it 'should not be included' do
+              @named_map_hash[:layergroup][:layers].none? { |l| l[:type] == 'gmapsbase' }.should be_true
+            end
+          end
         end
       end
 


### PR DESCRIPTION
#11605

The tiler doesn't support rendering google maps base layers in the preview. This removes google maps layers from the named map in order to be able to render something, even if the basemap is not correct.

**Acceptance**
- [x] Create a map with google basemaps. See that the preview in the dashboard list is displayed (except the basemap itself)
- [x] With the same map, ensure the embed works
- [x] Repeat the previous two test with another basemap (Positron for example)
- [x] Repeat the previous two test with a color background