### PR TITLE
Fixed problems with custom scroll in generic dropdown

### DIFF
--- a/app/assets/stylesheets/editor-3/custom-list.css.scss
+++ b/app/assets/stylesheets/editor-3/custom-list.css.scss
@@ -112,7 +112,7 @@
   display: block;
   background: none;
 }
-.CustomList-list.ps-container > .ps-scrollbar-y
+.CustomList-list.ps-container > .ps-scrollbar-y,
 .CustomList-list.ps-container > .ps-scrollbar-y-rail {
   width: 4px;
 }

--- a/app/assets/stylesheets/editor-3/custom-list.css.scss
+++ b/app/assets/stylesheets/editor-3/custom-list.css.scss
@@ -33,7 +33,7 @@
 .CustomList-list {
   position: relative;
   width: 100%;
-  max-height: 167px;
+  max-height: 168px;
   overflow: hidden;
 }
 .CustomList-list.is-customized .CustomList-item--add {
@@ -105,18 +105,20 @@
 .CDB-ListDecoration-rampItemBar {
   width: 20px;
 }
-.CustomList-list--visible.ps-container > .ps-scrollbar-y-rail {
+// Custom scroll styles
+.CustomList-list.ps-container > .ps-scrollbar-x-rail,
+.CustomList-list.ps-container > .ps-scrollbar-y-rail {
   @include opacity(0.8);
   display: block;
-  margin-right: 2px;
   background: none;
 }
-.CustomList-list--visible.ps-container>.ps-scrollbar-y-rail>.ps-scrollbar-y {
-  min-height: 16px;
+.CustomList-list.ps-container > .ps-scrollbar-y
+.CustomList-list.ps-container > .ps-scrollbar-y-rail {
+  width: 4px;
 }
-.Editor-panel .CustomList-list--visible .ps-scrollbar-y,
-.Editor-panel .CustomList-list--visible .ps-scrollbar-y-rail,
-.Table-columnMenu .CustomList-list--visible .ps-scrollbar-y,
-.Table-columnMenu .CustomList-list--visible .ps-scrollbar-y-rail {
-  width: 4px !important;
+.CustomList-list.ps-container > .ps-scrollbar-y-rail {
+  margin-right: 2px;
+}
+.CustomList-list.ps-container > .ps-scrollbar-x-rail {
+  margin-bottom: 2px;
 }

--- a/app/assets/stylesheets/editor-3/dropdown.css.scss
+++ b/app/assets/stylesheets/editor-3/dropdown.css.scss
@@ -27,7 +27,7 @@
 
 .Editor-dropdownOperators {
   display: none;
-  max-width: 260px;
+  max-width: 244px;
 
   &.is-visible {
     @include display-flex();

--- a/lib/assets/core/javascripts/cartodb3/components/custom-list/custom-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/custom-list/custom-list-view.js
@@ -54,8 +54,10 @@ module.exports = CoreView.extend({
 
     if (items.size() > 0) {
       items.each(this._renderItem, this);
-      this._applyCustomScroll();
       this._applyArrowBinds();
+      // Perfect-scroll needs to have the element in the DOM in order to
+      // style/positionate the scroll properly, small trick
+      setTimeout(this._applyCustomScroll.bind(this), 0);
     } else if (!allowFreeTextInput || Utils.isBlank(query)) {
       this.$el.append(
         emptyTemplate({
@@ -66,12 +68,6 @@ module.exports = CoreView.extend({
     }
 
     return this;
-  },
-
-  _checkScroll: function () {
-    var $el = this._wrapperContainer();
-    var el = $el.get(0);
-    $el.toggleClass('CustomList-list--visible', el.scrollHeight > el.clientHeight);
   },
 
   _renderItem: function (mdl) {

--- a/lib/assets/core/test/spec/cartodb3/components/custom-list/custom-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/custom-list/custom-list-view.spec.js
@@ -57,6 +57,7 @@ describe('components/custom-list/custom-list-view', function () {
 
   describe('render', function () {
     beforeEach(function () {
+      jasmine.clock().install();
       spyOn(this.view, '_applyCustomScroll');
       spyOn(this.view, '_applyArrowBinds');
       spyOn(this.collection, 'search').and.callThrough();
@@ -80,8 +81,13 @@ describe('components/custom-list/custom-list-view', function () {
     });
 
     it('should apply the custom scroll and the arrows binding', function () {
+      jasmine.clock().tick(100);
       expect(this.view._applyCustomScroll).toHaveBeenCalled();
       expect(this.view._applyArrowBinds).toHaveBeenCalled();
+    });
+
+    afterEach(function () {
+      jasmine.clock().uninstall();
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.00",
+  "version": "4.6.04",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.04",
+  "version": "4.6.05",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related: https://github.com/CartoDB/cartodb/issues/11598.

So, discovered that until the element is not rendered in the DOM, scroll is not calculated correctly and it was not displayed. That was the first problem, solved with a 0 timeout. Then I've realized there was several CSS in the `custom-list` class that were not needed, like the min-height, because the perfect-scrollbar already provide a way to set the min length of the scroll.
Also, `_checkScroll` function was not used and it is not needed, because scroll is only displayed when it is needed.
And finally, bonus thing, operators dropdown was not being displayed correctly, fixed too.

![screen shot 2017-02-22 at 11 55 30](https://cloud.githubusercontent.com/assets/132146/23209825/2a8b60f8-f8fb-11e6-9014-b1383ff72070.png)

**THINGS TO CHECK:**
- [x] Check dropdowns display custom scrolls correctly. For example, map options, table view menu options,... (there are tons in the application).
- [x] Apply an aggregation style (squares, hexabins,...), then change the aggregation operation and check that the element is rendered correctly with a different operation (SUM for example).

cc @nobuti @piensaenpixel 