### PR TITLE
Allow to override S3 endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@ Development
 ```
 * Snapshots (backend: #10928) allow to save and share map state.
 * Import API parameter: `collision_strategy`. Support for `skip` #11385.
-* Allow to override S3 endpoint for visualization exports and data imports when using S3 compatible storage services
+* Allow to override S3 endpoint for visualization exports and data imports when using S3 compatible storage services (#11614)
 * Icon styling through in component (#11005)
 * Allow to set opacity for color ramps (#10952)
 * Added Fullstory integration, can be configured in app_config

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ Development
 ```
 * Snapshots (backend: #10928) allow to save and share map state.
 * Import API parameter: `collision_strategy`. Support for `skip` #11385.
+* Allow to override S3 endpoint for visualization exports and data imports when using S3 compatible storage services
 * Icon styling through in component (#11005)
 * Allow to set opacity for color ramps (#10952)
 * Added Fullstory integration, can be configured in app_config

--- a/app/helpers/file_upload.rb
+++ b/app/helpers/file_upload.rb
@@ -103,9 +103,7 @@ module CartoDB
       # S3 storage service is being used
       # WARNING: This attribute may not work in some aws-sdk v1 versions newer
       # than 1.8.5 (http://lists.basho.com/pipermail/riak-users_lists.basho.com/2013-May/011984.html)
-      if !s3_config['s3_endpoint'].blank?
-        s3_config_hash['s3_endpoint'] = s3_config['s3_endpoint']
-      end
+      s3_config_hash['s3_endpoint'] = s3_config['s3_endpoint'] if s3_config['s3_endpoint'].present?
       AWS.config(s3_config_hash)
       s3_bucket = AWS::S3.new.buckets[s3_config['bucket_name']]
 

--- a/app/helpers/file_upload.rb
+++ b/app/helpers/file_upload.rb
@@ -93,12 +93,20 @@ module CartoDB
     end
 
     def upload_file_to_s3(filepath, filename, token, s3_config)
-      AWS.config(
+      s3_config_hash = {
         access_key_id: s3_config['access_key_id'],
         secret_access_key: s3_config['secret_access_key'],
         proxy_uri: (s3_config['proxy_uri'].present? ?  s3_config['proxy_uri'] : nil),
         use_ssl: s3_config['use_ssl']
-      )
+      }
+      # This allows to override the S3 endpoint in case a non AWS compatible
+      # S3 storage service is being used
+      # WARNING: This attribute may not work in some aws-sdk v1 versions newer
+      # than 1.8.5 (http://lists.basho.com/pipermail/riak-users_lists.basho.com/2013-May/011984.html)
+      if !s3_config['s3_endpoint'].blank?
+        s3_config_hash['s3_endpoint'] = s3_config['s3_endpoint']
+      end
+      AWS.config(s3_config_hash)
       s3_bucket = AWS::S3.new.buckets[s3_config['bucket_name']]
 
       path = "#{token}/#{File.basename(filename)}"

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -204,6 +204,7 @@ defaults: &defaults
       bucket_name: ''
       url_ttl: 7200
       async_long_uploads: false
+      s3_endpoint: ''
     uploads_path: 'public/uploads' # including 'uploads' assumes public path. Absolute path example: /tmp/exports/downloads
   importer:
     blacklisted_ip_addr: []
@@ -220,6 +221,7 @@ defaults: &defaults
       async_long_uploads: false
       proxy_uri:
       use_ssl: True
+      s3_endpoint: ''
 
     unp_temporal_folder: '/tmp/imports/'
     # It must end in `/uploads` and be accessible via HTTP, if relative will default to Rails.Root/#{uploads_path}


### PR DESCRIPTION
For visualization exports and data imports it's now possible to override
the S3 endpoint which by default points to AWS URLs. The config
parameter is called s3_endpoint. This is useful when a user, in a
on-premise installation, is working with a S3 compatible storage server
different than AWS one

@CartoDB/builder-backend can you review?