### PR TITLE
Providing proper basemaps to users, no GMaps when user doesn't have GMaps enabled

### DIFF
--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -36,7 +36,7 @@ module Carto
         @vizjson = generate_anonymous_map_vizjson3(@visualization, params)
         @state = @visualization.state.json
         @analyses_data = @visualization.analyses.map { |a| Carto::Api::AnalysisPresenter.new(a).to_poro }
-        @basemaps = Cartodb.config[:basemaps].present? && Cartodb.config[:basemaps]
+        @basemaps = current_viewer.basemaps
         @overlays_data = @visualization.overlays.map do |overlay|
           Carto::Api::OverlayPresenter.new(overlay).to_poro
         end


### PR DESCRIPTION
Related: https://github.com/CartoDB/cartodb/issues/11627.

It will filter current user basemaps. So if the user doesn't have GMaps enabled, Gmaps basemaps will not appear.

cc @alonsogarciapablo 