### PR TITLE
Showing metadata option when dataset is sync

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,7 @@ Development
 * Migrate to use GNIP v2 for twitter search connector (#10051, #11595)
 
 ### Bug fixes
+* Fixed missing metadata option in header when dataset is sync
 * Fixed problem switching between qualitative and quantitative attributes (#10654)
 * Fixed problem found in Surfaces related with map panning and widgets filtering
 * Style with icons

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-content/dataset-content-options.tpl
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-content/dataset-content-options.tpl
@@ -5,7 +5,7 @@
       <li>
         <button class="CDB-Text CDB-Size-small is-semibold u-actionTextColor u-upperCase js-addRow">
           <div class="u-flex u-alignCenter">
-            <svg width="16px" height="7px" viewBox="0 0 16 7" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <svg width="16px" height="18px" viewBox="0 0 16 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
               <defs>
                 <path d="M4,3 L4,0 L3,0 L3,3 L0,3 L0,4 L3,4 L3,7 L4,7 L4,4 L7,4 L7,3 L4,3 Z" id="path-1"></path>
                 <mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="7" height="7" fill="white">
@@ -27,7 +27,7 @@
       <li class="u-lSpace--xl">
         <button class="CDB-Text CDB-Size-small is-semibold u-actionTextColor u-upperCase js-addColumn">
           <div class="u-flex u-alignCenter">
-            <svg width="16px" height="7px" viewBox="0 4 16 7" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <svg width="16px" height="18px" viewBox="0 4 16 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
               <g id="Add-Column" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(0.000000, 4.000000)">
                 <path d="M4,3 L4,0 L3,0 L3,3 L0,3 L0,4 L3,4 L3,7 L4,7 L4,4 L7,4 L7,3 L4,3 Z" id="Combined-Shape" fill="#1181FB"></path>
                 <path d="M9,0 L12,0 L12,7 L9,7 L9,0 Z M10,1 L11,1 L11,6 L10,6 L10,1 Z" id="Combined-Shape" fill="#1181FB"></path>
@@ -44,7 +44,7 @@
     <li class="u-lSpace--xl">
       <button class="CDB-Text CDB-Size-small is-semibold u-actionTextColor u-upperCase is-disabled js-export">
         <div class="u-flex u-alignCenter">
-          <svg width="11px" height="10px" viewBox="-1 2 11 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <svg width="11px" height="18px" viewBox="-1 2 11 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <g id="Esport" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(0.000000, 3.000000)" stroke-linecap="square">
               <path d="M4.5,0.5 L4.5,6.5" id="Line" stroke="#1181FB"></path>
               <path d="M4.5,7.5 L8.5,3.5" id="Line" stroke="#1181FB"></path>

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-header/create-context-menu.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-header/create-context-menu.js
@@ -4,7 +4,7 @@ var CustomListCollection = require('../../components/custom-list/custom-list-col
 var REQUIRED_OPTS = [
   'ev',
   'isTableOwner',
-  'isLocked',
+  'isSync',
   'isCustomQuery',
   'triggerElementID'
 ];
@@ -27,7 +27,7 @@ module.exports = function (opts) {
   ];
 
   if (this._isTableOwner) {
-    if (!this._isLocked) {
+    if (!this._isSync) {
       menuItems.push({
         label: _t('dataset.rename.option'),
         val: 'rename',
@@ -35,18 +35,16 @@ module.exports = function (opts) {
           this.trigger('rename', this);
         }
       });
+    }
 
-      menuItems.push({
+    menuItems = menuItems.concat([
+      {
         label: _t('dataset.metadata.option'),
         val: 'metadata',
         action: function () {
           this.trigger('metadata', this);
         }
-      });
-    }
-
-    menuItems = menuItems.concat([
-      {
+      }, {
         label: _t('dataset.lock.option'),
         val: 'lock',
         action: function () {

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-header/dataset-header-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-header/dataset-header-view.js
@@ -19,6 +19,7 @@ var SQLUtils = require('../../helpers/sql-utils');
 var templateConfirmation = require('./rename-confirmation-modal.tpl');
 var createContextMenu = require('./create-context-menu');
 var tableDuplicationOperation = require('../operations/table-duplication-operation');
+var checkAndBuildOpts = require('../../helpers/required-opts');
 var TITLE_SUFFIX = ' | CARTO';
 
 var PRIVACY_MAP = {
@@ -26,6 +27,18 @@ var PRIVACY_MAP = {
   link: 'orange',
   private: 'red'
 };
+
+var REQUIRED_OPTS = [
+  'configModel',
+  'layerDefinitionModel',
+  'modals',
+  'querySchemaModel',
+  'router',
+  'syncModel',
+  'tableModel',
+  'userModel',
+  'visModel'
+];
 
 module.exports = CoreView.extend({
 
@@ -37,25 +50,7 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    if (!opts.router) throw new Error('router is required');
-    if (!opts.tableModel) throw new Error('tableModel is required');
-    if (!opts.modals) throw new Error('modals is required');
-    if (!opts.visModel) throw new Error('visModel is required');
-    if (!opts.syncModel) throw new Error('syncModel is required');
-    if (!opts.userModel) throw new Error('userModel is required');
-    if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
-    if (!opts.configModel) throw new Error('configModel is required');
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-
-    this._tableModel = opts.tableModel;
-    this._configModel = opts.configModel;
-    this._userModel = opts.userModel;
-    this._modals = opts.modals;
-    this._querySchemaModel = opts.querySchemaModel;
-    this._syncModel = opts.syncModel;
-    this._visModel = opts.visModel;
-    this._layerDefinitionModel = opts.layerDefinitionModel;
-    this._router = opts.router;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     var privacyOptions = CreatePrivacyOptions(this._visModel, this._userModel);
     this._privacyCollection = new PrivacyCollection(privacyOptions);
@@ -68,7 +63,8 @@ module.exports = CoreView.extend({
     this.clearSubViews();
     var privacy = this._visModel.get('privacy');
     var isOwner = this._tableModel.isOwner(this._userModel);
-    var hasWriteAccess = this._tableModel._permissionModel.isOwner(this._userModel) || this._tableModel._permissionModel.hasWriteAccess(this._userModel);
+    var permissionModel = this._tableModel._permissionModel;
+    var hasWriteAccess = permissionModel.isOwner(this._userModel) || permissionModel.hasWriteAccess(this._userModel);
 
     this.$el.html(
       template({
@@ -156,7 +152,7 @@ module.exports = CoreView.extend({
 
   _showContextMenu: function (ev) {
     var isTableOwner = this._tableModel.isOwner(this._userModel);
-    var isLocked = this._syncModel.isSync();
+    var isSync = this._syncModel.isSync();
     var triggerElementID = 'context-menu-trigger-' + this._tableModel.cid;
     this.$('.js-options').attr('id', triggerElementID);
 
@@ -171,7 +167,7 @@ module.exports = CoreView.extend({
       ev: ev,
       isTableOwner: isTableOwner,
       isCustomQuery: this._isCustomQueryApplied(),
-      isLocked: isLocked,
+      isSync: isSync,
       triggerElementID: triggerElementID
     });
     this._menuView.bind('rename', function () {
@@ -254,7 +250,7 @@ module.exports = CoreView.extend({
           }, {
             wait: true,
             success: function () {
-              window.location = self._configModel.get('base_url') + '/dashboard';
+              window.location = self._configModel.get('base_url') + '/dashboard/datasets';
             },
             error: function () {
               opts.error && opts.error();

--- a/lib/assets/core/test/spec/cartodb3/dataset/create-context-menu.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/dataset/create-context-menu.spec.js
@@ -5,7 +5,7 @@ describe('dataset/create-context-menu', function () {
     var view = createContextMenu({
       ev: {},
       isTableOwner: true,
-      isLocked: false,
+      isSync: false,
       isCustomQuery: false,
       triggerElementID: '--'
     });
@@ -25,7 +25,7 @@ describe('dataset/create-context-menu', function () {
     var view = createContextMenu({
       ev: {},
       isTableOwner: false,
-      isLocked: false,
+      isSync: false,
       isCustomQuery: false,
       triggerElementID: '--'
     });
@@ -41,20 +41,20 @@ describe('dataset/create-context-menu', function () {
     view.clean();
   });
 
-  it('should not provide rename option if is locked', function () {
+  it('should not provide rename option if is synced', function () {
     var view = createContextMenu({
       ev: {},
       isTableOwner: true,
-      isLocked: true,
+      isSync: true,
       isCustomQuery: false,
       triggerElementID: '--'
     });
     view.render();
 
-    expect(view.$('.js-listItem').length).toBe(3);
+    expect(view.$('.js-listItem').length).toBe(4);
     expect(view.$('.js-listItem[data-val="delete"]').length).toBe(1);
     expect(view.$('.js-listItem[data-val="rename"]').length).toBe(0);
-    expect(view.$('.js-listItem[data-val="metadata"]').length).toBe(0);
+    expect(view.$('.js-listItem[data-val="metadata"]').length).toBe(1);
     expect(view.$('.js-listItem[data-val="lock"]').length).toBe(1);
     expect(view.$('.js-listItem[data-val="duplicate"]').length).toBe(1);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.06",
+  "version": "4.6.06-stg",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related: #11458 

- Added "metadata" option when dataset is sync.
- Start using required-opts helper in `dataset-header-view`.
- Fixed problem with dataset options alignment.
![screen shot 2017-02-24 at 15 06 38](https://cloud.githubusercontent.com/assets/132146/23306373/a0f1f956-faa3-11e6-9c64-a97fb7bae7a4.png)

**How to test it?**
- [x] Check dataset options with different types of dataset (different owner, synced or not, etc...).
- [x] Check dataset options appear correctly aligned (centered).

---
Part of Friday's leapfrog.