### PR TITLE
Fixed problems found with input-fill

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker-template.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker-template.tpl
@@ -1,0 +1,14 @@
+<div class="colorpicker dropdown-menu">
+  <div class="colorpicker-saturation">
+    <i><b></b></i>
+  </div>
+  <div class="colorpicker-hue">
+    <i class="ColorPicker-ball"></i>
+  </div>
+  <div class="colorpicker-alpha js-alpha">
+    <i class="ColorPicker-ball"></i>
+  </div>
+  <div class="ColorPicker-colorWrapper">
+    <div class="ColorPicker-color colorpicker-color js-color"></div>
+  </div>
+</div>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/color-picker/color-picker.js
@@ -3,6 +3,7 @@ var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 require('bootstrap-colorpicker');
 var template = require('./template.tpl');
+var colorPickerTemplate = require('./color-picker-template.tpl');
 var Utils = require('../../../../../helpers/utils');
 
 module.exports = CoreView.extend({
@@ -13,7 +14,7 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    var opacity = opts.opacity !== undefined && opts.opacity !== null ? opts.opacity : 1;
+    var opacity = opts.opacity != null ? opts.opacity : 1;
 
     this.model = new Backbone.Model({
       hex: opts.value,
@@ -43,12 +44,7 @@ module.exports = CoreView.extend({
       horizontal: true,
       inline: true,
       customClass: 'ColorPicker',
-      template: '<div class="colorpicker dropdown-menu">' +
-        '<div class="colorpicker-saturation"><i><b></b></i></div>' +
-          '<div class="colorpicker-hue"><i class="ColorPicker-ball"></i></div>' +
-            '<div class="colorpicker-alpha js-alpha"><i class="ColorPicker-ball"></i></div>' +
-              '<div class="ColorPicker-colorWrapper"><div class="ColorPicker-color colorpicker-color js-color"></div></div>' +
-                  '</div>',
+      template: colorPickerTemplate(),
       slidersHorz: {
         saturation: {
           maxLeft: 206,

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/column-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/column-list-view.js
@@ -23,23 +23,20 @@ module.exports = CoreView.extend({
     this._itemTemplate = opts.itemTemplate;
 
     this.collection = new CustomListCollection(this._columns);
-
-    this._initBinds();
-
-    this._listView = new CustomListView({
-      collection: this.collection,
-      showSearch: this._showSearch,
-      typeLabel: this._typeLabel,
-      itemTemplate: this._itemTemplate
-    });
+    this.listenTo(this.collection, 'change:selected', this._onSelectItem);
   },
 
   render: function () {
-    this.$el.append(template({
-      headerTitle: this.options.headerTitle
-    }));
+    this.clearSubViews();
+    this.$el.empty();
 
-    this.$('.js-content').append(this._listView.render().$el);
+    this.$el.append(
+      template({
+        headerTitle: this.options.headerTitle
+      })
+    );
+
+    this._initViews();
 
     return this;
   },
@@ -49,8 +46,15 @@ module.exports = CoreView.extend({
     this.trigger('back', this);
   },
 
-  _initBinds: function () {
-    this.collection.bind('change:selected', this._onSelectItem, this);
+  _initViews: function () {
+    this._listView = new CustomListView({
+      collection: this.collection,
+      showSearch: this._showSearch,
+      typeLabel: this._typeLabel,
+      itemTemplate: this._itemTemplate
+    });
+    this.$('.js-content').append(this._listView.render().$el);
+    this.addView(this._listView);
   },
 
   _onSelectItem: function (item) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/asset-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/asset-item-view.js
@@ -13,10 +13,6 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    this._initBinds();
-  },
-
-  _initBinds: function () {
     this.listenTo(this.model, 'change:state', this._changeState);
   },
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
@@ -76,15 +76,11 @@ module.exports = CoreView.extend({
       url: this.model.get('image')
     });
 
-    this.add_related_model(this._selectedAsset);
-
     this._stateModel = new Backbone.Model({
       status: 'loading',
       modalEnabled: false,
       uploads: 0
     });
-
-    this.add_related_model(this._stateModel);
 
     this._assetCollections = [];
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/input-asset-picker-header.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/input-asset-picker-header.js
@@ -33,6 +33,10 @@ module.exports = CoreView.extend({
     return this;
   },
 
+  _initBinds: function () {
+    this.listenTo(this.model, 'change:image', this.render);
+  },
+
   _getRampItem: function () {
     var ramp = this.model.get('ramp');
 
@@ -57,10 +61,6 @@ module.exports = CoreView.extend({
     });
     this.addView(this.iconView);
     this.$('.js-image-container').append(this.iconView.render().el);
-  },
-
-  _initBinds: function () {
-    this.model.bind('change:image', this.render, this);
   },
 
   _onClickBack: function (ev) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/input-asset-picker-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/input-asset-picker-view.js
@@ -4,17 +4,17 @@ var CoreView = require('backbone/core-view');
 var template = require('./input-asset-picker-view.tpl');
 var InputAssetPickerHeader = require('./input-asset-picker-header');
 var InputAssetPickerView = require('../input-color-file-view');
+var checkAndBuildOpts = require('../../../../../../helpers/required-opts');
+var REQUIRED_OPTS = [
+  'configModel',
+  'modals',
+  'ramp',
+  'userModel'
+];
 
 module.exports = CoreView.extend({
   initialize: function (opts) {
-    if (!opts || !opts.ramp) throw new Error('ramp param is required');
-    if (!opts.configModel) throw new Error('configModel param is required');
-    if (!opts.userModel) throw new Error('userModel param is required');
-    if (!opts.modals) throw new Error('modals param is required');
-
-    this._userModel = opts.userModel;
-    this._configModel = opts.configModel;
-    this._modals = opts.modals;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
     this._imageEnabled = opts.imageEnabled;
 
     this.model = new Backbone.Model({
@@ -27,11 +27,6 @@ module.exports = CoreView.extend({
     this.clearSubViews();
     this.$el.html(template());
     this._initViews();
-    this._initBinds();
-
-    this.$('.js-header').append(this._headerView.render().el);
-    this.$('.js-content').append(this._assetPicker.render().el);
-
     return this;
   },
 
@@ -40,6 +35,9 @@ module.exports = CoreView.extend({
       model: this.model,
       imageEnabled: this._imageEnabled
     });
+    this._headerView.bind('goToColorPicker', this._onGoToColorPicker, this);
+    this._headerView.bind('back', this._onClickBack, this);
+    this.$('.js-header').append(this._headerView.render().el);
     this.addView(this._headerView);
 
     this._assetPicker = new InputAssetPickerView({
@@ -49,14 +47,9 @@ module.exports = CoreView.extend({
       modals: this._modals,
       imageEnabled: this._imageEnabled
     });
-    this.addView(this._assetPicker);
-  },
-
-  _initBinds: function () {
-    this._headerView.bind('goToColorPicker', this._onGoToColorPicker, this);
-    this._headerView.bind('back', this._onClickBack, this);
-
     this._assetPicker.bind('change', _.debounce(this._onChangeImage, 50), this);
+    this.$('.js-content').append(this._assetPicker.render().el);
+    this.addView(this._assetPicker);
   },
 
   _getRampItem: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/static-asset-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/static-asset-item-view.js
@@ -10,11 +10,7 @@ module.exports = CoreView.extend({
   },
 
   initialize: function () {
-    this._initBinds();
-  },
-
-  _initBinds: function () {
-    this.model.bind('change:state', this._changeState, this);
+    this.listenTo(this.model, 'change:state', this._changeState);
   },
 
   render: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/upload-assets-tab.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/upload-assets-tab.js
@@ -31,7 +31,7 @@ module.exports = CoreView.extend({
       uploads: 0
     });
 
-    this.add_related_model(this._stateModel);
+    this.listenTo(this._stateModel, 'change:status', this.render);
 
     this._assetCollection = new AssetsCollection(
       null, {
@@ -39,8 +39,6 @@ module.exports = CoreView.extend({
         userModel: this._userModel
       }
     );
-
-    this._initBinds();
   },
 
   render: function () {
@@ -106,11 +104,6 @@ module.exports = CoreView.extend({
     if (this.dropzone) {
       this.dropzone.destroy();
     }
-  },
-
-  _initBinds: function () {
-    this._stateModel.on('change:status', this.render, this);
-    this.add_related_model(this._stateModel);
   },
 
   _hasError: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.js
@@ -30,7 +30,8 @@ module.exports = CoreView.extend({
       this._organizationAssetCollection = opts.organizationAssetCollection;
     }
 
-    this._initModels();
+    this._stateModel = new Backbone.Model();
+
     this._initBinds();
   },
 
@@ -87,11 +88,6 @@ module.exports = CoreView.extend({
 
     this.addView(addAssetButton);
     this.$('.js-assets').append(addAssetButton.render().$el);
-  },
-
-  _initModels: function () {
-    this._stateModel = new Backbone.Model();
-    this.add_related_model(this._stateModel);
   },
 
   _initBinds: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-tab.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-tab.js
@@ -27,9 +27,8 @@ module.exports = CoreView.extend({
 
   render: function () {
     this.clearSubViews();
-
+    this.$el.empty();
     this._renderAssets();
-
     return this;
   },
 
@@ -56,5 +55,4 @@ module.exports = CoreView.extend({
     this.addView(view);
     this.$el.append(view.render().el);
   }
-
 });

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view.js
@@ -6,8 +6,8 @@ var CustomListItemView = require('../../../../../../custom-list/custom-list-item
 module.exports = CustomListItemView.extend({
 
   render: function () {
-    this.$el.empty();
     this.clearSubViews();
+    this.$el.empty();
 
     var name = this.model.getName() == null ? 'null' : this.model.getName();
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-view.js
@@ -85,9 +85,9 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
-    this.model.on('change:range', this.render, this);
-    this.model.on('change:domain', this.render, this);
-    this._collection.bind('change:selected', this._onSelectItem, this);
+    this.listenTo(this.model, 'change:range', this.render);
+    this.listenTo(this.model, 'change:domain', this.render);
+    this.listenTo(this._collection, 'change:selected', this._onSelectItem);
   },
 
   _onClickColor: function (ev) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -84,7 +84,6 @@ module.exports = CoreView.extend({
     }
 
     this._stackLayoutView = new StackLayoutView({ collection: stackViewCollection });
-    this._stackLayoutView.bind('positionChanged', this.render, this);
     this.addView(this._stackLayoutView);
   },
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -9,10 +9,16 @@ var CategoriesListView = require('./input-color-categories-list-view');
 var rampList = require('cartocolor');
 var AssetPickerView = require('../assets-picker/input-asset-picker-view');
 var MAX_VALUES = 10;
-// max values + "others" color
-var DEFAULT_COLORS = _.clone(rampList.Prism[MAX_VALUES + 1]);
-
+var DEFAULT_COLORS = _.clone(rampList.Prism[MAX_VALUES + 1]); // max values + "others" color
 var queryTemplate = _.template('SELECT <%= column %>, count(<%= column %>) FROM (<%= sql %>) _table_sql GROUP BY <%= column %> ORDER BY count DESC, <%= column %> ASC LIMIT <%= max_values %>');
+var checkAndBuildOpts = require('../../../../../../helpers/required-opts');
+var REQUIRED_OPTS = [
+  'columns',
+  'configModel',
+  'modals',
+  'query',
+  'userModel'
+];
 
 function _quote (c) {
   if (c && c !== true) {
@@ -28,30 +34,16 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    if (!opts.columns) throw new Error('columns param is required');
-    if (!opts.configModel) throw new Error('configModel param is required');
-    if (!opts.userModel) throw new Error('userModel param is required');
-    if (!opts.query) throw new Error('query param is required');
-    if (!opts.modals) throw new Error('modals param is required');
-
-    this._columns = opts.columns;
-    this._configModel = opts.configModel;
-    this._userModel = opts.userModel;
-    this._query = opts.query;
-    this._modals = opts.modals;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
     this._imageEnabled = opts.imageEnabled;
-
     this._initBinds();
-    this._initViews();
-
-    if (!this.model.get('domain') || !this.model.get('range') || !this.model.get('images')) {
-      this._fetchColumns();
-    }
   },
 
   render: function () {
     this.clearSubViews();
     this.$el.empty();
+
+    this._generateStackLayoutView();
 
     var column = this._getColumn();
     var columnType = column && column.type;
@@ -71,10 +63,10 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
-    this.model.bind('change:attribute', this._fetchColumns, this);
+    this.model.on('change:attribute', this._fetchColumns, this);
   },
 
-  _initViews: function () {
+  _generateStackLayoutView: function () {
     var self = this;
 
     var stackViewCollection = new Backbone.Collection([{
@@ -95,11 +87,9 @@ module.exports = CoreView.extend({
       });
     }
 
-    this._stackLayoutView = new StackLayoutView({
-      collection: stackViewCollection
-    });
-
+    this._stackLayoutView = new StackLayoutView({ collection: stackViewCollection });
     this._stackLayoutView.bind('positionChanged', this.render, this);
+    this.addView(this._stackLayoutView);
   },
 
   _iconStylingEnabled: function () {
@@ -149,7 +139,6 @@ module.exports = CoreView.extend({
     data = data || {};
     this._stopLoader();
     this._updateRangeAndDomain(data.rows);
-    this._initViews();
     this.render();
   },
 
@@ -171,18 +160,18 @@ module.exports = CoreView.extend({
       return (i < MAX_VALUES) ? DEFAULT_COLORS[i] : DEFAULT_COLORS[MAX_VALUES + 1];
     });
 
+    if (this._iconStylingEnabled()) {
+      var images = _.map(categoryNames, function () {
+        return '';
+      });
+
+      this.model.attributes.images = images;
+    }
+
     this.model.set({
       range: range,
       domain: domain
     });
-
-    if (this._iconStylingEnabled()) {
-      var images = _.map(categoryNames, function (name, i) {
-        return '';
-      });
-
-      this.model.set('images', images);
-    }
   },
 
   _startLoader: function () {
@@ -313,10 +302,6 @@ module.exports = CoreView.extend({
   _onClickBack: function (e) {
     this.killEvent(e);
     this.trigger('back', this);
-  },
-
-  remove: function () {
-    CoreView.prototype.remove.apply(this);
   }
 }, {
   MAX_VALUES: MAX_VALUES

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -43,21 +43,16 @@ module.exports = CoreView.extend({
     this.clearSubViews();
     this.$el.empty();
 
-    this._generateStackLayoutView();
-
     var column = this._getColumn();
     var columnType = column && column.type;
 
     this.$el.append(template({
       columnType: columnType,
-      showBackButton: this._stackLayoutView.getCurrentPosition() === 0,
       attribute: this.model.get('attribute'),
       quantification: this.model.get('quantification') || 'category'
     }));
 
-    if (this._stackLayoutView) {
-      this.$('.js-content').append(this._stackLayoutView.render().$el);
-    }
+    this._generateStackLayoutView();
 
     return this;
   },
@@ -84,7 +79,14 @@ module.exports = CoreView.extend({
     }
 
     this._stackLayoutView = new StackLayoutView({ collection: stackViewCollection });
+    this._stackLayoutView.bind('positionChanged', this._onStackLayoutPositionChange, this);
+
     this.addView(this._stackLayoutView);
+    this.$('.js-content').append(this._stackLayoutView.render().$el);
+  },
+
+  _onStackLayoutPositionChange: function () {
+    this.$('.js-prevStep').toggle(this._stackLayoutView.getCurrentPosition() === 0);
   },
 
   _iconStylingEnabled: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -36,7 +36,7 @@ module.exports = CoreView.extend({
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
     this._imageEnabled = opts.imageEnabled;
-    this._initBinds();
+    this.listenTo(this.model, 'change:attribute', this._fetchColumns);
   },
 
   render: function () {
@@ -60,10 +60,6 @@ module.exports = CoreView.extend({
     }
 
     return this;
-  },
-
-  _initBinds: function () {
-    this.model.on('change:attribute', this._fetchColumns, this);
   },
 
   _generateStackLayoutView: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.tpl
@@ -1,17 +1,14 @@
-<div class="CDB-Box-modalHeader">
-  <% if (showBackButton || columnType === 'number') { %>
-    <ul class="CDB-Box-modalHeaderItem CDB-Box-modalHeaderItem--block CDB-Box-modalHeaderItem--paddingHorizontal">
-      <li class="CDB-ListDecoration-item CDB-ListDecoration-itemPadding--vertical CDB-Text CDB-Size-medium u-secondaryTextColor">
-        <ul class="u-flex u-justifySpace">
-          <% if (showBackButton) { %>
-          <li class="u-flex">
-            <button class="u-rSpace u-actionTextColor js-back">
-              <i class="CDB-IconFont CDB-IconFont-arrowPrev Size-large"></i>
-            </button>
-            <span class="label js-label"><%- attribute %></span>
-          </li>
-          <% } %>
-          <% if (columnType === 'number') { %>
+<div class="CDB-Box-modalHeader js-prevStep">
+  <ul class="CDB-Box-modalHeaderItem CDB-Box-modalHeaderItem--block CDB-Box-modalHeaderItem--paddingHorizontal">
+    <li class="CDB-ListDecoration-item CDB-ListDecoration-itemPadding--vertical CDB-Text CDB-Size-medium u-secondaryTextColor">
+      <ul class="u-flex u-justifySpace">
+        <li class="u-flex">
+          <button class="u-rSpace u-actionTextColor js-back">
+            <i class="CDB-IconFont CDB-IconFont-arrowPrev Size-large"></i>
+          </button>
+          <span class="label js-label"><%- attribute %></span>
+        </li>
+        <% if (columnType === 'number') { %>
           <li class="u-flex">
             <%- _t('form-components.editors.fill.quantification.methods.' + quantification) %>
             <button class="CDB-Shape u-lSpace js-quantification">
@@ -22,11 +19,10 @@
               </div>
             </button>
           </li>
-          <% } %>
-        </ul>
-      </li>
-    </ul>
-  <% } %>
+        <% } %>
+      </ul>
+    </li>
+  </ul>
 </div>
 <div class="InputColorCategory-loader js-loader is-hidden">
   <div class="CDB-LoaderIcon is-dark">

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-dialog-content.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-dialog-content.js
@@ -38,8 +38,17 @@ module.exports = CoreView.extend({
     this._modals = opts.modals;
     this._query = opts.query;
 
-    this._setupTabPanes();
+    this._initBinds();
+  },
 
+  render: function () {
+    this.clearSubViews();
+    this.$el.empty();
+    this._initViews();
+    return this;
+  },
+
+  _initBinds: function () {
     this.model.on('change:fixed', function () {
       if (!this.model.get('fixed') || this.model.get('range')) {
         this.model.unset('image', { silent: true });
@@ -47,14 +56,7 @@ module.exports = CoreView.extend({
     }, this);
   },
 
-  render: function () {
-    if (this._tabPaneView) {
-      this.$el.append(this._tabPaneView.render().$el);
-    }
-    return this;
-  },
-
-  _setupTabPanes: function () {
+  _initViews: function () {
     var self = this;
 
     var fixedPane = {
@@ -105,18 +107,19 @@ module.exports = CoreView.extend({
     }
 
     this._tabPaneView = createTextLabelsTabPane(this._tabPaneTabs, tabPaneOptions);
-    this.addView(this._tabPaneView);
     this._tabPaneView.collection.bind('change:selected', this._onChangeTabPaneViewTab, this);
+    this.$el.append(this._tabPaneView.render().$el);
+    this.addView(this._tabPaneView);
   },
 
   _onChangeTabPaneViewTab: function () {
     var selectedTabPaneName = this._tabPaneView.getSelectedTabPaneName();
+    var attrsToUnsetIfFixed = ['domain', 'bins', 'attribute', 'quantification'];
 
     if (selectedTabPaneName === 'fixed') {
-      this.model.unset('domain', { silent: true });
-      this.model.unset('bins', { silent: true });
-      this.model.unset('attribute', { silent: true });
-      this.model.unset('quantification', { silent: true });
+      _.each(attrsToUnsetIfFixed, function (attr) {
+        this.model.unset(attr, { silent: true });
+      }, this);
 
       if (!this.model.get('fixed')) {
         if (this.model.get('range')) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.js
@@ -25,23 +25,19 @@ module.exports = CoreView.extend({
     this._modals = opts.modals;
 
     this._initCarouselCollection();
-    this._renderAssets();
-
     this._initBinds();
   },
 
   render: function () {
     this.clearSubViews();
     this.$el.html(template());
-
     this._renderAssets();
-
     return this;
   },
 
   _initBinds: function () {
-    this._carouselCollection.on('change:selected', this._onSelectAsset, this);
-    this._carouselCollection.on('reset', this.render, this);
+    this.listenTo(this._carouselCollection, 'change:selected', this._onSelectAsset);
+    this.listenTo(this._carouselCollection, 'reset', this.render);
   },
 
   _resetCarouselCollection: function (url) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-fixed-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-fixed-content-view.js
@@ -31,13 +31,15 @@ module.exports = CoreView.extend({
     this._configModel = opts.configModel;
     this._modals = opts.modals;
     this._query = opts.query;
+  },
+
+  render: function () {
+    this.clearSubViews();
 
     if (this._imageEnabled) {
       this._setupTabPanes();
     }
-  },
 
-  render: function () {
     if (this._tabPaneView) {
       this.$el.append(this._tabPaneView.render().$el);
     } else {
@@ -102,8 +104,8 @@ module.exports = CoreView.extend({
     if (this.model.get('image') && this._tabPaneTabs.length > 1) {
       this._tabPaneTabs[1].selected = true;
     }
-    this.model.bind('change:image', this._updateImageTabPane, this);
-    this.model.bind('change:fixed', this._updateTextTabPane, this);
+    this.listenTo(this.model, 'change:image', this._updateImageTabPane);
+    this.listenTo(this.model, 'change:fixed', this._updateTextTabPane);
 
     this._tabPaneView = createMixedLabelsTabPane(this._tabPaneTabs, tabPaneOptions);
     this.addView(this._tabPaneView);

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-header.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-header.js
@@ -13,7 +13,7 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    this._initBinds();
+    this.listenTo(this.model, 'change', this.render);
   },
 
   render: function (model, options) {
@@ -78,10 +78,6 @@ module.exports = CoreView.extend({
     });
     this.addView(this.iconView);
     this.$('.js-image-container').append(this.iconView.render().el);
-  },
-
-  _initBinds: function () {
-    this.model.bind('change', this.render, this);
   },
 
   _onClickColor: function (ev) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-view.js
@@ -4,6 +4,12 @@ var CoreView = require('backbone/core-view');
 var ColorPicker = require('../../color-picker/color-picker');
 var template = require('./input-color-picker-view.tpl');
 var InputColorPickerHeader = require('./input-color-picker-header');
+var checkAndBuildOpts = require('../../../../../../helpers/required-opts');
+
+var REQUIRED_OPTS = [
+  'ramp',
+  'opacity'
+];
 
 module.exports = CoreView.extend({
   events: {
@@ -11,8 +17,7 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    if (!opts || !opts.ramp) throw new Error('ramp param is required');
-    if (!opts.opacity) throw new Error('opacity is required');
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this.model = new Backbone.Model({
       index: this.options.index,
@@ -20,21 +25,30 @@ module.exports = CoreView.extend({
       opacity: opts.opacity
     });
 
-    this.model.bind('change:index', this._onChangeIndex, this);
-    this.model.bind('change:opacity', this._onOpacityChanged, this);
+    this._initBinds();
   },
 
   render: function () {
     this.clearSubViews();
-    this.$el.empty();
+    this.$el.html(template());
+    this._initViews();
+    return this;
+  },
 
+  _initBinds: function () {
+    this.listenTo(this.model, 'change:index', this._onChangeIndex);
+    this.listenTo(this.model, 'change:opacity', this._onOpacityChanged);
+  },
+
+  _initViews: function () {
     this._headerView = new InputColorPickerHeader({
       model: this.model,
       imageEnabled: this.options.imageEnabled
     });
-    this._headerView.bind('goToAssetPicker', this._onGoToAssetPicker, this);
 
     this.addView(this._headerView);
+    this._headerView.bind('goToAssetPicker', this._onGoToAssetPicker, this);
+    this.$('.js-header').append(this._headerView.render().$el);
 
     this._colorPicker = new ColorPicker({
       value: this._getColor(),
@@ -43,15 +57,8 @@ module.exports = CoreView.extend({
     });
 
     this.addView(this._colorPicker);
-
     this._colorPicker.bind('change', this._onChangeValue, this);
-
-    this.$el.append(template());
-
-    this.$('.js-header').append(this._headerView.render().$el);
     this.$('.js-content').append(this._colorPicker.render().$el);
-
-    return this;
   },
 
   _setColor: function (color) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
@@ -1,4 +1,3 @@
-
 var _ = require('underscore');
 var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
@@ -8,45 +7,45 @@ var quantificationMethodItemTemplate = require('./quantification-method-item.tpl
 var InputColorRamps = require('./input-ramps/input-color-ramps');
 var InputColorCategories = require('./input-categories/input-color-categories');
 var DefaultFillSettings = require('../default-fill-settings.json');
+var checkAndBuildOpts = require('../../../../../helpers/required-opts');
 
 var EXCLUDED_COLUMNS = ['the_geom', 'the_geom_webmercator'];
+var REQUIRED_OPTS = [
+  'columns',
+  'configModel',
+  'modals',
+  'query',
+  'userModel'
+];
 
 module.exports = CoreView.extend({
   initialize: function (opts) {
-    if (!opts.columns) throw new Error('columns param is required');
-    if (!opts.configModel) throw new Error('configModel param is required');
-    if (!opts.userModel) throw new Error('userModel param is required');
-    if (!opts.modals) throw new Error('modals param is required');
-    if (!opts.query) throw new Error('query param is required');
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this._settings = DefaultFillSettings.color;
 
-    this._columns = opts.columns;
-    this._configModel = opts.configModel;
-    this._userModel = opts.userModel;
-    this._query = opts.query;
     this._categorizeColumns = opts.categorizeColumns;
     this._imageEnabled = opts.imageEnabled;
-    this._modals = opts.modals;
 
     this._column = this._getColumn();
     this._columnType = this._column && this._column.type;
 
-    this._initViews();
-
-    this.model.bind('change:quantification', function () {
-      if (this.model.get('quantification') !== 'category') {
-        this.model.unset('domain');
-      }
-    }, this);
+    this._initBinds();
   },
 
   render: function () {
     this.clearSubViews();
     this.$el.empty();
-
-    this.$el.append(this._stackLayoutView.render().$el);
+    this._initViews();
     return this;
+  },
+
+  _initBinds: function () {
+    this.model.bind('change:quantification', function () {
+      if (this.model.get('quantification') !== 'category') {
+        this.model.unset('domain');
+      }
+    }, this);
   },
 
   _initViews: function () {
@@ -85,6 +84,9 @@ module.exports = CoreView.extend({
         this._stackLayoutView.model.set('position', 1);
       }
     }
+
+    this.$el.append(this._stackLayoutView.render().$el);
+    this.addView(this._stackLayoutView);
   },
 
   _createInputColorCategories: function (stackLayoutModel, opts) {
@@ -173,15 +175,15 @@ module.exports = CoreView.extend({
   },
 
   _onChangeAttribute: function (columnName, stackLayoutModel) {
-    this.model.unset('image', { silent: true });
-    this.model.unset('fixed', { silent: true });
-    this.model.unset('quantification', { silent: true });
-    this.model.unset('opacity', { silent: true });
-
     var validCategoryTypes = ['string', 'boolean'];
+    var attrsToUnset = ['image', 'fixed', 'quantification', 'opacity'];
 
     this._column = this._getColumn(columnName);
     this._columnType = this._column && this._column.type;
+
+    _.each(attrsToUnset, function (attr) {
+      this.model.unset(attr, { silent: true });
+    }, this);
 
     if (_.contains(validCategoryTypes, this._columnType) || this._categorizeColumns) {
       this.model.unset('bins', { silent: true });
@@ -192,7 +194,9 @@ module.exports = CoreView.extend({
       stackLayoutModel.goToStep(1);
     }
 
-    this.model.set('attribute', columnName);
-    this.model.set('attribute_type', this._columnType);
+    this.model.set({
+      attribute: columnName,
+      attribute_type: this._columnType
+    });
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.js
@@ -14,15 +14,12 @@ module.exports = CoreView.extend({
 
     this._setupModel();
     this._initBinds();
-    this._initViews();
   },
 
   render: function () {
     this.clearSubViews();
     this.$el.empty();
-
-    this.$el.append(this._stackLayoutView.render().$el);
-
+    this._initViews();
     return this;
   },
 
@@ -47,9 +44,9 @@ module.exports = CoreView.extend({
   _initBinds: function () {
     var range = this.model.get('range');
 
-    this.model.bind('change:bins', this._updateRange, this);
-    this.model.bind('change:attribute', this.render, this);
-    this.model.bind('change:quantification', this._onChangeQuantification, this);
+    this.listenTo(this.model, 'change:bins', this._updateRange);
+    this.listenTo(this.model, 'change:attribute', this.render);
+    this.listenTo(this.model, 'change:quantification', this._onChangeQuantification);
 
     this.model.unset('fixed');
 
@@ -99,6 +96,9 @@ module.exports = CoreView.extend({
     this._stackLayoutView = new StackLayoutView({
       collection: stackViewCollection
     });
+
+    this.$el.append(this._stackLayoutView.render().$el);
+    this.addView(this._stackLayoutView);
   },
 
   _updateRange: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-content-view.js
@@ -10,16 +10,10 @@ module.exports = CoreView.extend({
     'click .js-back': '_onClickBack'
   },
 
-  initialize: function (opts) {
-    this._initViews();
-  },
-
   render: function () {
     this.clearSubViews();
     this.$el.empty();
-
-    this.$el.append(this._stackLayoutView.render().$el);
-
+    this._initViews();
     return this;
   },
 
@@ -39,6 +33,9 @@ module.exports = CoreView.extend({
     this._stackLayoutView = new StackLayoutView({
       collection: stackViewCollection
     });
+
+    this.$el.append(this._stackLayoutView.render().$el);
+    this.addView(this._stackLayoutView);
   },
 
   _createColorPickerView: function (stackLayoutModel, opts) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-item-view.js
@@ -15,12 +15,12 @@ module.exports = CoreView.extend({
 
   initialize: function (opts) {
     this.options = _.extend({}, this.options, opts);
-    this.model.on('change', this.render, this);
+    this.listenTo(this.model, 'change', this.render);
   },
 
   render: function () {
-    this.$el.empty();
     this.clearSubViews();
+    this.$el.empty();
 
     this.$el.append(
       this.options.template(

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.js
@@ -28,12 +28,11 @@ module.exports = CoreView.extend({
 
     this._initModels();
     this._initBinds();
-    this._initViews();
   },
 
   render: function () {
-    this.$el.empty();
     this.clearSubViews();
+    this.$el.empty();
 
     this.$el.append(template({
       bins: this.model.get('bins'),
@@ -41,7 +40,7 @@ module.exports = CoreView.extend({
       quantification: this.model.get('quantification')
     }));
 
-    this.$('.js-content').append(this._listView.render().$el);
+    this._initViews();
 
     var customRamp = this._customRamp.get('range');
 
@@ -62,6 +61,35 @@ module.exports = CoreView.extend({
     }
 
     return this;
+  },
+
+  _initModels: function () {
+    this._customRamp = new cdb.core.Model();
+    this._setupCollection();
+  },
+
+  _initBinds: function () {
+    this.listenTo(this.model, 'change:bins', this._onChangeBins);
+    this.listenTo(this.model, 'change:attribute_type', this._updateRampOnAttributeChange);
+    this.listenTo(this.collection, 'change:selected', this._onSelectItem);
+  },
+
+  _initViews: function () {
+    this._listView = new CustomListView({
+      collection: this.collection,
+      showSearch: this._showSearch,
+      typeLabel: this._typeLabel,
+      itemTemplate: rampItemTemplate,
+      itemView: rampItemView
+    });
+
+    this._listView.bind('invert', this._invertRamp, this);
+    this._listView.bind('customize', function (ramp) {
+      this.trigger('customize', ramp, this);
+    }, this);
+
+    this.$('.js-content').append(this._listView.render().el);
+    this.addView(this._listView);
   },
 
   _getRamps: function () {
@@ -117,24 +145,9 @@ module.exports = CoreView.extend({
   _setupCollection: function () {
     var ramps = this._getRamps();
     this.collection = new CustomListCollection(_.compact(ramps), { silent: false });
-    this.add_related_model(this.collection);
-
     if (!this.collection.getSelectedItem()) {
       this._customRamp.set('range', this.model.get('range'));
     }
-  },
-
-  _initModels: function () {
-    this._customRamp = new cdb.core.Model();
-    this.add_related_model(this._customRamp);
-
-    this._setupCollection();
-  },
-
-  _initBinds: function () {
-    this.listenTo(this.model, 'change:bins', this._onChangeBins);
-    this.listenTo(this.model, 'change:attribute_type', this._updateRampOnAttributeChange);
-    this.listenTo(this.collection, 'change:selected', this._onSelectItem);
   },
 
   _updateRampOnAttributeChange: function (m, type) {
@@ -148,21 +161,6 @@ module.exports = CoreView.extend({
     var first = this.collection.first();
     first && first.set('selected', true);
     this.render();
-  },
-
-  _initViews: function () {
-    this._listView = new CustomListView({
-      collection: this.collection,
-      showSearch: this._showSearch,
-      typeLabel: this._typeLabel,
-      itemTemplate: rampItemTemplate,
-      itemView: rampItemView
-    });
-
-    this._listView.bind('invert', this._invertRamp, this);
-    this._listView.bind('customize', function (ramp) {
-      this.trigger('customize', ramp, this);
-    }, this);
   },
 
   _invertRamp: function (item) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
@@ -11,6 +11,7 @@ module.exports = CoreView.extend({
 
   render: function () {
     this.clearSubViews();
+    this._removeForm();
     this.$el.empty();
 
     this.$el.append(template({
@@ -103,6 +104,10 @@ module.exports = CoreView.extend({
     this.$('.js-content').append(this._formView.render().$el);
   },
 
+  _removeForm: function () {
+    this._formView && this._formView.remove();
+  },
+
   _onClickBack: function (e) {
     this.killEvent(e);
     this.trigger('back', this);
@@ -120,7 +125,7 @@ module.exports = CoreView.extend({
 
   clean: function () {
     // Backbone.Form removes the view with the following method
-    this._formView.remove();
+    this._removeForm();
     CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.js
@@ -20,7 +20,7 @@ module.exports = CoreView.extend({
       quantification: this.model.get('quantification')
     }));
 
-    this._generateForms();
+    this._initForm();
 
     return this;
   },
@@ -37,7 +37,7 @@ module.exports = CoreView.extend({
     ];
   },
 
-  _generateForms: function () {
+  _initForm: function () {
     var self = this;
 
     if (this._formView) {
@@ -105,6 +105,7 @@ module.exports = CoreView.extend({
   },
 
   _removeForm: function () {
+    // Backbone.Form removes the view with the following method
     this._formView && this._formView.remove();
   },
 
@@ -124,7 +125,6 @@ module.exports = CoreView.extend({
   },
 
   clean: function () {
-    // Backbone.Form removes the view with the following method
     this._removeForm();
     CoreView.prototype.clean.call(this);
   }

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-dialog-content.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-dialog-content.js
@@ -14,12 +14,13 @@ module.exports = CoreView.extend({
     if (!opts.columns) throw new Error('columns param is required');
     this._columns = opts.columns;
 
-    this._initViews();
-    this._initBindings();
+    this.listenTo(this.model, 'change:attribute', this._updateRangeValue);
   },
 
   render: function () {
-    this.$el.append(this._tabPaneView.render().$el);
+    this.clearSubViews();
+    this.$el.empty();
+    this._initViews();
     return this;
   },
 
@@ -75,12 +76,9 @@ module.exports = CoreView.extend({
     }
 
     this._tabPaneView = createTextLabelsTabPane(this._tabPaneTabs, tabPaneOptions);
+    this.listenTo(this._tabPaneView.collection, 'change:selected', this._onChangeTabPaneViewTab);
     this.addView(this._tabPaneView);
-  },
-
-  _initBindings: function () {
-    this._tabPaneView.collection.bind('change:selected', this._onChangeTabPaneViewTab, this);
-    this.model.bind('change:attribute', this._updateRangeValue, this);
+    this.$el.append(this._tabPaneView.render().$el);
   },
 
   _onChangeTabPaneViewTab: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-fixed-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-fixed-content-view.js
@@ -2,19 +2,15 @@ var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 
 module.exports = CoreView.extend({
-  initialize: function (opts) {
-    this._initViews();
-  },
-
   render: function () {
     this.clearSubViews();
+    this._removeForm();
     this.$el.empty();
-
-    this.$el.append(this._formView.render().$el);
+    this._initForm();
     return this;
   },
 
-  _initViews: function () {
+  _initForm: function () {
     this._formModel = new Backbone.Model({
       value: this.model.get('fixed')
     });
@@ -43,11 +39,17 @@ module.exports = CoreView.extend({
     this._formView.bind('change', function () {
       this.commit();
     });
+
+    this.$el.append(this._formView.render().$el);
+  },
+
+  _removeForm: function () {
+    // Backbone.Form removes the view with the following method
+    this._formView && this._formView.remove();
   },
 
   clean: function () {
-    // Backbone.Form removes the view with the following method
-    this._formView.remove();
+    this._removeForm();
     CoreView.prototype.clean.call(this);
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.js
@@ -27,14 +27,12 @@ module.exports = CoreView.extend({
     this._settings = DefaultFillSettings.number;
 
     this._setupModel();
-    this._initViews();
   },
 
   render: function () {
     this.clearSubViews();
     this.$el.empty();
-
-    this.$el.append(this._stackLayoutView.render().$el);
+    this._initViews();
     return this;
   },
 
@@ -90,6 +88,8 @@ module.exports = CoreView.extend({
     }
 
     this._stackLayoutView.model.set('position', position);
+    this.$el.append(this._stackLayoutView.render().$el);
+    this.addView(this._stackLayoutView);
   },
 
   _createInputRampContentView: function (stackLayoutModel, opts) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-number/input-number.js
@@ -52,15 +52,13 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
-    var self = this;
-
     this.model.set('createContentView', function () {
-      return self._createContentView();
-    }).bind(this);
+      return this._createContentView();
+    }.bind(this));
 
-    this.model.on('change:selected', this._onToggleSelected, this);
-    this.model.on('change:fixed', this._onChangeValue, this);
-    this.model.on('change:range', this._onChangeValue, this);
+    this.listenTo(this.model, 'change:selected', this._onToggleSelected);
+    this.listenTo(this.model, 'change:fixed', this._onChangeValue);
+    this.listenTo(this.model, 'change:range', this._onChangeValue);
   },
 
   _getValue: function () {

--- a/lib/assets/core/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/layer-definition-model.js
@@ -60,6 +60,9 @@ module.exports = Backbone.Model.extend({
       }
     }
     if (r.options.table_name) {
+      // Set autostyle as false if it doesn't contain any id
+      attrs.autoStyle = attrs.autoStyle || false;
+
       if (!this.styleModel) {
         this.styleModel = new StyleDefinitionModel(r.options.style_properties, {
           parse: true

--- a/lib/assets/core/test/jasmine/cartodb3/data/layer-definition-model.spec.js
+++ b/lib/assets/core/test/jasmine/cartodb3/data/layer-definition-model.spec.js
@@ -45,6 +45,10 @@ describe('cartodb3/data/layer-definition-model', function () {
     });
   });
 
+  it('should set autoStyle as false if it is not defined', function () {
+    expect(this.model.get('autoStyle')).toBe(false);
+  });
+
   it('should transform some attrs to be compatible with cartodb.js', function () {
     expect(this.model.get('cartocss')).toEqual('asdasd');
     expect(this.model.get('tile_style')).toBeUndefined();

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/color-picker/color-picker.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/color-picker/color-picker.spec.js
@@ -20,6 +20,10 @@ describe('components/form-components/editors/fill/color-picker/color-picker', fu
       expect(this.view.$('.js-a').val()).toBe('0.5');
     });
 
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
+    });
+
     afterEach(function () {
       this.view.remove();
     });
@@ -81,6 +85,10 @@ describe('components/form-components/editors/fill/color-picker/color-picker', fu
 
       expect(this.view.model.get('hex')).toBe('#A6CEE3');
       expect(this.view.$('.js-b').hasClass('has-error')).toBeTruthy();
+    });
+
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
     });
 
     afterEach(function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
@@ -309,6 +309,10 @@ describe('components/form-components/editors/fill/input-color/assets-view', func
     });
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     createCalls = [];
     this.view.clean();

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/input-asset-picker-header.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/input-asset-picker-header.spec.js
@@ -59,6 +59,10 @@ describe('components/form-components/editors/fill/input-color/assets-picker/inpu
     });
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.clean();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/input-asset-picker-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/input-asset-picker-view.spec.js
@@ -90,6 +90,10 @@ describe('components/form-components/editors/fill/input-color/assets-picker/inpu
     });
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.clean();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/static-asset-item-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/static-asset-item-view.spec.js
@@ -40,5 +40,9 @@ describe('components/form-components/editors/fill/input-color/asset-picker/stati
     });
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   // render function is already tested in assets-list-view.spec.js render
 });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/upload-assets-tab.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/upload-assets-tab.spec.js
@@ -67,6 +67,10 @@ describe('components/form-components/editors/fill/input-color/assets-picker/upoa
     });
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.clean();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/assets-picker/user-assets-list-view.spec.js
@@ -179,6 +179,10 @@ describe('components/form-components/editors/fill/input-color/assets-picker/user
     expect(this.selectedAsset.get('kind')).toBe(undefined);
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.clean();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/categories-list/categories-list-item-view.spec.js
@@ -50,6 +50,10 @@ describe('components/form-components/editors/fill/input-color/input-categories/c
     });
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.remove();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
@@ -66,8 +66,9 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
 
   it('should hide the title label back arrow', function () {
     this.view.$('.js-listItem:eq(0)').click();
-    expect(this.view.$('.js-back').length).toBe(1);
+    expect(this.view.$('.js-prevStep').attr('style')).toBe('display: none;');
     expect(this.view.$('.js-label').text()).not.toBe('column1');
+    expect(this.view.$('.js-back').length).toBe(2);
   });
 
   it('should show the loader', function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
@@ -66,7 +66,7 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
 
   it('should hide the title label back arrow', function () {
     this.view.$('.js-listItem:eq(0)').click();
-    expect(this.view.$('.js-prevStep').attr('style')).toBe('display: none;');
+    expect(this.view.$('.js-prevStep').attr('style')).toContain('display: none;');
     expect(this.view.$('.js-label').text()).not.toBe('column1');
     expect(this.view.$('.js-back').length).toBe(2);
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
@@ -270,6 +270,10 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
     });
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.remove();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-dialog-content.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-dialog-content.spec.js
@@ -38,6 +38,10 @@ describe('components/form-components/editors/fill/input-color/input-color-dialog
     expect(this.view.$el.html()).toContain('form-components.editors.fill.input-color.value');
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.remove();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.spec.js
@@ -38,6 +38,10 @@ describe('components/form-components/editors/fill/input-color/input-color-file-v
     expect(utils.endsWith(this.view.$('img').attr('src'), '?req=markup')).toBe(true);
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.remove();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-fixed-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-fixed-content-view.spec.js
@@ -59,6 +59,10 @@ describe('components/form-components/editors/fill/input-color/input-color-fixed-
       expect(this.view.$('.Editor-boxModalHeader').html()).toContain('<div class="Tab-paneLabelImageContainer js-image-container">');
     });
 
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
+    });
+
     afterEach(function () {
       this.view.remove();
     });
@@ -80,6 +84,10 @@ describe('components/form-components/editors/fill/input-color/input-color-fixed-
       expect(_.size(this.view._subviews)).toBe(0);
       expect(this.view.$el.find('.CDB-NavMenu-item').length).toBe(0);
       expect(this.view._tabPaneView).not.toBeDefined();
+    });
+
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
     });
 
     afterEach(function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-picker-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-picker-view.spec.js
@@ -4,10 +4,10 @@ describe('components/form-components/editors/fill/input-color/input-color-picker
   describe('initialization', function () {
     it('should throw Error if no ramp provided', function () {
       var wrapper = function () {
-        new InputColorPickerView(); // eslint-disable-line no-new
+        new InputColorPickerView({}); // eslint-disable-line no-new
       };
 
-      expect(wrapper).toThrowError('ramp param is required');
+      expect(wrapper).toThrowError('ramp is required');
     });
 
     it('should throw Error if no opacity provided', function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-picker-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-picker-view.spec.js
@@ -1,6 +1,10 @@
 var InputColorPickerView = require('../../../../../../../../javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-view');
 
 describe('components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-view', function () {
+  beforeEach(function () {
+    this.view = new InputColorPickerView({ ramp: [ 303 ], opacity: 0.81 });
+  });
+
   describe('initialization', function () {
     it('should throw Error if no ramp provided', function () {
       var wrapper = function () {
@@ -45,5 +49,9 @@ describe('components/form-components/editors/fill/input-color/input-color-picker
 
       expect(opacity).toBe(0.5);
     });
+  });
+
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
   });
 });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-header.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-color-picker/input-color-picker-header.spec.js
@@ -145,4 +145,8 @@ describe('components/form-components/editors/fill/input-color/input-color-picker
       expect(this.view.$('.js-slider').slider('value')).toBe(this.view._inverseSliderValue(0.68));
     });
   });
+
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
 });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-color-ramps.spec.js
@@ -56,6 +56,10 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
       expect(this.model.get('fixed')).toBe(undefined);
     });
 
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
+    });
+
     afterEach(function () {
       this.view.remove();
     });
@@ -95,6 +99,10 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
     it('should set a default ramp list', function () {
       expect(this.model.get('bins')).toBe('5');
       expect(this.model.get('range').length).toBe(5);
+    });
+
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
     });
 
     afterEach(function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-content-view.spec.js
@@ -33,5 +33,10 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
 
       expect(view.model.get('opacity')).toEqual(0.84);
     });
+
+    it('should not have leaks', function () {
+      var view = createView(0.43);
+      expect(view).toHaveNoLeaks();
+    });
   });
 });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-ramps/input-ramp-list-view.spec.js
@@ -69,6 +69,10 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
       expect(this.view.$('.js-customize').text()).toBe('form-components.editors.fill.customize');
     });
 
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
+    });
+
     afterEach(function () {
       this.view.remove();
     });
@@ -121,6 +125,10 @@ describe('components/form-components/editors/fill/input-color/input-ramps/input-
       expect(this.view.$('.js-customRamp .ColorBar').length).toBe(3);
       this.view.$('.js-clear').click();
       expect(this.view.$('.js-customRamp .ColorBar').length).toBe(0);
+    });
+
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
     });
 
     afterEach(function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-number.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-number.spec.js
@@ -79,6 +79,10 @@ describe('components/form-components/editors/fill/input-number', function () {
     });
   });
 
+  it('should not have leaks', function () {
+    expect(this.view).toHaveNoLeaks();
+  });
+
   afterEach(function () {
     this.view.remove();
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-number/input-number-content-view.spec.js
@@ -32,6 +32,10 @@ describe('components/form-components/editors/fill/input-number/input-number-cont
       expect(range).toEqual([4, 22]);
     });
 
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
+    });
+
     afterEach(function () {
       this.view.remove();
     });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-number/input-number-value-content-view.spec.js
@@ -50,6 +50,10 @@ describe('components/form-components/editors/fill/input-number/input-number-valu
       expect(this.view.$('.js-listItem').length).toBe(6);
     });
 
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
+    });
+
     afterEach(function () {
       this.view.remove();
     });
@@ -92,6 +96,10 @@ describe('components/form-components/editors/fill/input-number/input-number-valu
       expect(this.view.$el.html()).toContain('5 form-components.editors.fill.input-ramp.buckets');
       expect(this.view.$el.html()).toContain('Max');
       expect(this.view.$el.html()).toContain('Min');
+    });
+
+    it('should not have leaks', function () {
+      expect(this.view).toHaveNoLeaks();
     });
 
     afterEach(function () {

--- a/lib/assets/core/test/spec/cartodb3/deep-insights-integrations.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/deep-insights-integrations.spec.js
@@ -649,6 +649,7 @@ describe('deep-insights-integrations/dii', function () {
           cartocss: 'CARTO_CSS',
           table_name: 'bar',
           table_name_alias: 'My BAR',
+          autoStyle: false,
           order: 1,
           source: 'b0',
           type: 'torque',


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/11648

Lately I've been suffering several weird things with the fill component. For example, the category list rendering null strings instead of the top 10 values for that column, slow performance between tabs, ...

**The main problem was the way we have been rendering several views and not adding them as subviews to be cleaned when the main view is removed (`view.addView(subview)`). That caused several ghost views and unexpected behaviours.**

Fixed that, I've reviewed the whole component looking for that pattern, and I've applied the Boy Scout law (:tm:), trying to change several things like:

(1) Add those created subviews to the main view (the most important thing of this PR) using `addView` method.
(2) Start using `listenTo` instead of on/bind due to the fact that it avoids the use of `add_related_model` (for "storing" listeners to external models or collections).
(3) Created template instead of using inline HTML.
(4) Generate components (`_initViews`) when the view is rendered, not in the initialize (and of course applying (1) ).
(5) Following the Boy Scout (:tm:), I've been using the `checkAndBuildOpts` (_ya puestos..._).
(6) And a bonus track, as @nobuti pointed, there was a problem with the style-content-view, where it was rendered once a change in the styles was done. It was caused by a not initialization of the `autoStyle` layer definition attribute.


**THINGS TO TEST (:scream):**
- [x] Test deeply the fill component (several times) in the style form:
  - Changing size.
  - Changing size by value.
  - Change fixed color.
  - Apply icons.
  - Change color by value.
  - Change ramps.
  - Change category colors and images.
  - …
- [x] Check that after changing any value of the style (ramp to categories, stroke color,...), the dropdown is not closed (compare behaviour with a production account).
- [x] Check the fill component in the custom legends form.
- [x] Check the fill component in the widget form (change fill color and custom ramp).
- [x] Check the fill component in any other context not already mentioned ^^^.