### PR TITLE
Add more information to shp_spec (randomly failing)

### DIFF
--- a/services/importer/spec/acceptance/shp_spec.rb
+++ b/services/importer/spec/acceptance/shp_spec.rb
@@ -53,6 +53,7 @@ describe 'SHP regression tests' do
                                user: @user
                              })
     runner.run
+    puts runner.log
 
     geometry_type_for(runner, @user).should eq "MULTIPOLYGON"
     job = runner.send(:job)


### PR DESCRIPTION
Quick experiment to see if we can get more debug information on the randomly failing `shp_spec` (printing the importer log). It seems to be increasingly problematic 😕

Please CR @juanignaciosl 