### PR TITLE
3109 fix for file uploads

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,7 @@ Development
 * UI fixes for georeference. Changes of copy and validation warning. (#11426)
 * Color scheme is now clickable in category ramps (#11413)
 * Fix responsive layout in onboarding steps (#11444)
+* Fix for race condition when importing files and deploying at the same time (#11653)
 * Correctly create custom category legend if style has icons (#11592)
 
 4.0.x (2016-12-05)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -40,15 +40,13 @@ namespace :cartodb do
         data_import_item.state = DataImport::STATE_PENDING
         data_import_item.save
 
-        filepath = data_import_item.data_source
-        filename = data_import_item.data_source.slice(data_import_item.data_source.rindex('/') + 1,
-                                                      data_import_item.data_source.length)
+        filepath = File.realpath data_import_item.data_source
+        filename = File.basename data_import_item.data_source
 
-        uploads_path = file_upload_helper.get_uploads_path
+        uploads_path = File.realpath file_upload_helper.get_uploads_path
 
-        token = data_import_item.data_source.slice(/#{uploads_path}\/(.)+\//)
-                                            .sub("#{uploads_path}/", '')
-                                            .sub('/', '')
+        # Files are temp stored in "/%{uploads_path}/token/basename.ext"
+        token = File.basename File.dirname filepath
 
         file_uri = file_upload_helper.upload_file_to_s3(filepath, filename, token, Cartodb.config[:importer]['s3'])
         begin

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -31,7 +31,7 @@ namespace :cartodb do
     file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
 
     unless data_import_item.nil?
-      # be 100% safe en rescue blocks when trying to log the failed id
+      # be 100% safe in rescue blocks when trying to log the failed id
       data_import_item_id = data_import_item.id rescue nil
 
       begin


### PR DESCRIPTION
From the commit message:

Fix race condition that may happen when deploying new code and enqueuing
files for upload to S3 at the same time. Refer to this code here:

https://github.com/CartoDB/cartodb/blob/e57f09f3b6fb18f0eef32499d4137178c4cd166f/lib/tasks/import.rake#L43-L51

and check the annotated version below. What happens is:

```ruby

filepath = data_import_item.data_source # => "/home/ubuntu/www/production.cartodb.com/releases/20170221104214/public/uploads/1a45870296e683c05b3b/permits_2013.csv"
filename = data_import_item.data_source.slice(data_import_item.data_source.rindex('/') + 1,
                                              data_import_item.data_source.length) # => "permits_2013.csv"

uploads_path = file_upload_helper.get_uploads_path # => "/home/ubuntu/www/production.cartodb.com/releases/20170221145321/public/uploads"

token = data_import_item.data_source.slice(/#{uploads_path}\/(.)+\//) # => nil
                                    .sub("#{uploads_path}/", '') # => NoMethodError: undefined method `sub' for nil:NilClass
                                    .sub('/', '')
```

So, essentially we have a race condition. In pseudo-code:
1. Version X of the rails code stores an uploaded file in dir Y/public/uploads
1. A deployment takes place, replacing X with Y. Pending requests are dealt by version X. New requests are dealt by version Y.
1. The async cron job in charge of uploading the file to S3 is run, searching for the file in dir Y/public/uploads => Exception

This commit fixes it by using `File.realpath` (to get the "real path"
when using symlinks) and by using `File.basename` and `File.dirname`
instead of parsing the paths through a regexp.