### PR TITLE
Fixed problem with Bubbles legend when a new analysis is applied

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,7 +56,8 @@ Development
 * Migrate to use GNIP v2 for twitter search connector (#10051, #11595)
 
 ### Bug fixes
-* Fixed missing metadata option in header when dataset is sync
+* Fixed problem with Bubbles legend when a new analysis is applied (#11666)
+* Fixed missing metadata option in header when dataset is sync (#11458)
 * Fixed problem with dates when filtering time series widget
 * Fixed problem switching between qualitative and quantitative attributes (#10654)
 * Fixed problem found in Surfaces related with map panning and widgets filtering

--- a/lib/assets/core/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var LegendBaseDefModel = require('./legend-base-definition-model');
 var LegendColorHelper = require('../../editor/layers/layer-content-views/legend/form/legend-color-helper');
+var DEFAULT_BUBBLES_COLOR = '#999999';
 
 module.exports = LegendBaseDefModel.extend({
   defaults: _.extend({}, LegendBaseDefModel.prototype.defaults,
@@ -38,8 +39,9 @@ module.exports = LegendBaseDefModel.extend({
   },
 
   _onChangeStyle: function () {
-    if (!this.layerDefinitionModel.get('autoStyle')) {
-      this.set('fillColor', this._inheritStyleColor(this.layerDefinitionModel.styleModel));
+    var styleModel = this.layerDefinitionModel.styleModel;
+    if (!this.layerDefinitionModel.get('autoStyle') && !styleModel.hasNoneStyles()) {
+      this.set('fillColor', this._inheritStyleColor(styleModel));
     }
   },
 
@@ -69,7 +71,7 @@ module.exports = LegendBaseDefModel.extend({
   _inheritStyleColor: function (styleModel) {
     var fill = styleModel.get('fill');
     var stroke = styleModel.get('stroke');
-    var color = fill.color || stroke.color;
-    return LegendColorHelper.getBubbles(color).color.fixed;
+    var color = (fill && fill.color) || (stroke && stroke.color);
+    return (color && LegendColorHelper.getBubbles(color).color.fixed) || DEFAULT_BUBBLES_COLOR;
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
@@ -41,7 +41,7 @@ module.exports = LegendBaseDefModel.extend({
   _onChangeStyle: function () {
     var styleModel = this.layerDefinitionModel.styleModel;
     if (!this.layerDefinitionModel.get('autoStyle') && !styleModel.hasNoneStyles()) {
-      this.set('fillColor', this._inheritStyleColor(styleModel));
+      this.save({ fillColor: this._inheritStyleColor(styleModel) });
     }
   },
 
@@ -72,6 +72,11 @@ module.exports = LegendBaseDefModel.extend({
     var fill = styleModel.get('fill');
     var stroke = styleModel.get('stroke');
     var color = (fill && fill.color) || (stroke && stroke.color);
-    return (color && LegendColorHelper.getBubbles(color).color.fixed) || DEFAULT_BUBBLES_COLOR;
+
+    if (color && (color.fixed || color.range)) {
+      return LegendColorHelper.getBubbles(color).color.fixed;
+    } else {
+      return DEFAULT_BUBBLES_COLOR;
+    }
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/legends/legend-bubble-definition-model.js
@@ -7,16 +7,11 @@ module.exports = LegendBaseDefModel.extend({
   defaults: _.extend({}, LegendBaseDefModel.prototype.defaults,
     {
       type: 'bubble',
-      fillColor: null,
+      fillColor: DEFAULT_BUBBLES_COLOR,
       topLabel: '',
       bottomLabel: ''
     }
   ),
-
-  initialize: function (attrs, opts) {
-    LegendBaseDefModel.prototype.initialize.call(this, attrs, opts);
-    this._initBinds();
-  },
 
   parse: function (r, opts) {
     var attrs = LegendBaseDefModel.prototype.parse.call(this, r);
@@ -31,18 +26,6 @@ module.exports = LegendBaseDefModel.extend({
       }
     }
     return attrs;
-  },
-
-  _initBinds: function () {
-    this.listenTo(this.layerDefinitionModel, 'change:cartocss', this._onChangeStyle.bind(this));
-    this.listenTo(this.layerDefinitionModel.styleModel, 'style:update', this._onChangeStyle.bind(this));
-  },
-
-  _onChangeStyle: function () {
-    var styleModel = this.layerDefinitionModel.styleModel;
-    if (!this.layerDefinitionModel.get('autoStyle') && !styleModel.hasNoneStyles()) {
-      this.save({ fillColor: this._inheritStyleColor(styleModel) });
-    }
   },
 
   toJSON: function () {

--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/legend-manager.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/legend-manager.js
@@ -1,5 +1,7 @@
 var _ = require('underscore');
 var LegendFactory = require('../editor/layers/layer-content-views/legend/legend-factory');
+var LegendColorHelper = require('../editor/layers/layer-content-views/legend/form/legend-color-helper');
+var DEFAULT_BUBBLES_COLOR = '#999999';
 
 var onChange = function (layerDefModel) {
   var styleModel = layerDefModel.styleModel;
@@ -62,7 +64,16 @@ var onChange = function (layerDefModel) {
 
   if (LegendFactory.isEnabledType('size')) {
     if (size && size.attribute !== undefined) {
-      LegendFactory.createLegend(layerDefModel, 'bubble', {title: size.attribute});
+      var attrs = { title: size.attribute };
+
+      if (!isAutoStyleApplied) {
+        // Do not apply the fill color of an autostyle ramp
+        attrs.fillColor = color && (color.fixed || color.range)
+          ? LegendColorHelper.getBubbles(color).color.fixed
+          : DEFAULT_BUBBLES_COLOR;
+      }
+
+      LegendFactory.createLegend(layerDefModel, 'bubble', attrs);
     } else {
       LegendFactory.removeLegend(layerDefModel, 'bubble');
     }

--- a/lib/assets/core/test/spec/cartodb3/data/legends/legend-bubble-definition-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/legends/legend-bubble-definition-model.spec.js
@@ -32,32 +32,4 @@ describe('data/legends/legend-bubble-defintion-model', function () {
     spyOn(this.model, '_inheritStyleColor');
     spyOn(this.model, 'save');
   });
-
-  describe('without autostyle', function () {
-    it('should _inheritStyleColor on custom autostyle', function () {
-      style.trigger('style:update');
-      expect(this.model._inheritStyleColor).toHaveBeenCalled();
-      expect(this.model.save).toHaveBeenCalled();
-    });
-
-    it('should not _inheritStyleColor if autostyle is none type', function () {
-      style.hasNoneStyles = function () {
-        return true;
-      };
-      style.trigger('style:update');
-      expect(this.model._inheritStyleColor).not.toHaveBeenCalled();
-      expect(this.model.save).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('with autostyle', function () {
-    beforeEach(function () {
-      layerDef1.set('autoStyle', 'wadus');
-    });
-
-    it('should not _inheritStyleColor on custom autostyle', function () {
-      style.trigger('style:update');
-      expect(this.model._inheritStyleColor).not.toHaveBeenCalled();
-    });
-  });
 });

--- a/lib/assets/core/test/spec/cartodb3/data/legends/legend-bubble-definition-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/legends/legend-bubble-definition-model.spec.js
@@ -18,6 +18,9 @@ describe('data/legends/legend-bubble-defintion-model', function () {
     });
 
     style = new Backbone.Model();
+    style.hasNoneStyles = function () {
+      return false;
+    };
     layerDef1.styleModel = style;
 
     this.model = new LegendDefinitionModel(null, {
@@ -33,6 +36,14 @@ describe('data/legends/legend-bubble-defintion-model', function () {
     it('should _inheritStyleColor on custom autostyle', function () {
       style.trigger('style:update');
       expect(this.model._inheritStyleColor).toHaveBeenCalled();
+    });
+
+    it('should not _inheritStyleColor if autostyle is none type', function () {
+      style.hasNoneStyles = function () {
+        return true;
+      };
+      style.trigger('style:update');
+      expect(this.model._inheritStyleColor).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/assets/core/test/spec/cartodb3/data/legends/legend-bubble-definition-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/legends/legend-bubble-definition-model.spec.js
@@ -30,12 +30,14 @@ describe('data/legends/legend-bubble-defintion-model', function () {
     });
 
     spyOn(this.model, '_inheritStyleColor');
+    spyOn(this.model, 'save');
   });
 
   describe('without autostyle', function () {
     it('should _inheritStyleColor on custom autostyle', function () {
       style.trigger('style:update');
       expect(this.model._inheritStyleColor).toHaveBeenCalled();
+      expect(this.model.save).toHaveBeenCalled();
     });
 
     it('should not _inheritStyleColor if autostyle is none type', function () {
@@ -44,6 +46,7 @@ describe('data/legends/legend-bubble-defintion-model', function () {
       };
       style.trigger('style:update');
       expect(this.model._inheritStyleColor).not.toHaveBeenCalled();
+      expect(this.model.save).not.toHaveBeenCalled();
     });
   });
 
@@ -52,7 +55,7 @@ describe('data/legends/legend-bubble-defintion-model', function () {
       layerDef1.set('autoStyle', 'wadus');
     });
 
-    it('should _inheritStyleColor on custom autostyle', function () {
+    it('should not _inheritStyleColor on custom autostyle', function () {
       style.trigger('style:update');
       expect(this.model._inheritStyleColor).not.toHaveBeenCalled();
     });

--- a/lib/assets/core/test/spec/cartodb3/deep-insights-integration/legend-manager.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/deep-insights-integration/legend-manager.spec.js
@@ -100,7 +100,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
       });
 
       it('styles color', function () {
@@ -124,7 +124,7 @@ describe('deep-insights-integrations/legend-manager', function () {
         });
 
         expect(LegendFactory.createLegend).toHaveBeenCalledTimes(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
         expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
       });
 
@@ -186,7 +186,7 @@ describe('deep-insights-integrations/legend-manager', function () {
         });
 
         expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'custom_choropleth');
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
       });
 
       it('styles color', function () {
@@ -223,7 +223,7 @@ describe('deep-insights-integrations/legend-manager', function () {
 
         expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'custom_choropleth', jasmine.any(Function));
         expect(LegendFactory.createLegend).toHaveBeenCalledTimes(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
         expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
       });
 
@@ -295,7 +295,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
       });
 
       it('styles color', function () {
@@ -319,7 +319,7 @@ describe('deep-insights-integrations/legend-manager', function () {
         });
 
         expect(LegendFactory.createLegend).toHaveBeenCalledTimes(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
         expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
       });
 
@@ -379,7 +379,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'sudaw'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
       });
 
       it('styles color', function () {
@@ -416,7 +416,7 @@ describe('deep-insights-integrations/legend-manager', function () {
 
         expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'custom_choropleth', jasmine.any(Function));
         expect(LegendFactory.createLegend).toHaveBeenCalledTimes(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
         expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
       });
 
@@ -650,7 +650,7 @@ describe('deep-insights-integrations/legend-manager', function () {
       // only once to create a bubble legend, but no choropleth legend
 
       expect(LegendFactory.createLegend).toHaveBeenCalledTimes(1);
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
+      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
       expect(LegendFactory.createLegend).not.toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
     });
   });


### PR DESCRIPTION
Related: https://github.com/CartoDB/cartodb/issues/11666.

Already described the problem in the ticket ^^^. In order to check it, just follow the steps described there.

- [x] Check that steps described by @javitonino below are working.
- [x] Check that if a style has changed, bubble legend should react to that change (if it implies the fill or stroke color).
- [x] Check that, when a bubble legend is visible, if you apply a widget autostyle, that bubble legend doesn't change the color.