### PR TITLE
Don't provide the_geom or the_geom_webmercator as columns to keep in a join analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,7 @@ Development
 * Color scheme is now clickable in category ramps (#11413)
 * Fix responsive layout in onboarding steps (#11444)
 * Correctly create custom category legend if style has icons (#11592)
+* JOIN Analysis Fails Without Error Message (#11184)
 
 4.0.x (2016-12-05)
 ------------------

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
@@ -167,13 +167,13 @@ module.exports = BaseAnalysisFormModel.extend({
       left_source_columns: {
         type: 'MultiSelect',
         title: this._getLeftSourceLabel(),
-        options: this._leftColumnOptions.all(),
+        options: this._leftColumnOptions.filterByType(['string', 'number', 'date']), // this._leftColumnOptions.all()
         dialogMode: 'float'
       },
       right_source_columns: {
         type: 'MultiSelect',
         title: this._getRightSourceLabel(),
-        options: this._rightColumnOptions.all(),
+        options: this._rightColumnOptions.filterByType(['string', 'number', 'date']), // this._rightColumnOptions.all(),
         dialogMode: 'float'
       }
     }));

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
@@ -167,13 +167,13 @@ module.exports = BaseAnalysisFormModel.extend({
       left_source_columns: {
         type: 'MultiSelect',
         title: this._getLeftSourceLabel(),
-        options: this._leftColumnOptions.filterByType(['string', 'number', 'date']), // this._leftColumnOptions.all()
+        options: this._leftColumnOptions.filterByType(['string', 'number', 'date', 'boolean']),
         dialogMode: 'float'
       },
       right_source_columns: {
         type: 'MultiSelect',
         title: this._getRightSourceLabel(),
-        options: this._rightColumnOptions.filterByType(['string', 'number', 'date']), // this._rightColumnOptions.all(),
+        options: this._rightColumnOptions.filterByType(['string', 'number', 'date', 'boolean']),
         dialogMode: 'float'
       }
     }));


### PR DESCRIPTION
Related ticket: #11184.

Basically that, we should not provide any geometry column in the last step of the merge/join analysis.

<img width="499" alt="screen shot 2017-03-01 at 11 18 24" src="https://cloud.githubusercontent.com/assets/132146/23455760/112af666-fe71-11e6-8d27-c57b61d914e6.png">

- [ ] Check that in a join analysis in the last step (columns to keep) we don't provide geometry columns.