### PR TITLE
Update cartodb-ui to 4.6.20

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.12",
+  "version": "4.6.20",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -10,7 +10,7 @@
     "backbone-forms": {
       "version": "0.14.0",
       "from": "backbone-forms@0.14.0",
-      "resolved": "http://registry.npmjs.org/backbone-forms/-/backbone-forms-0.14.0.tgz"
+      "resolved": "https://registry.npmjs.org/backbone-forms/-/backbone-forms-0.14.0.tgz"
     },
     "backbone-model-file-upload": {
       "version": "1.0.0",
@@ -442,9 +442,9 @@
                               }
                             },
                             "sshpk": {
-                              "version": "1.10.2",
+                              "version": "1.11.0",
                               "from": "sshpk@>=1.7.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
                               "dependencies": {
                                 "asn1": {
                                   "version": "0.2.3",
@@ -576,7 +576,7 @@
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "escape-string-regexp@>=1.0.3 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                                 },
                                 "has-ansi": {
@@ -1101,7 +1101,7 @@
     "camshaft-reference": {
       "version": "0.29.0",
       "from": "camshaft-reference@<2.0.0",
-      "resolved": "http://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.29.0.tgz"
+      "resolved": "https://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.29.0.tgz"
     },
     "carto": {
       "version": "0.15.1-cdb1",
@@ -1152,7 +1152,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#7725805682711725962494dc5dcfd6b5d938a5d5",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#64a5203d0816e4919ffe6a860608685e8be30d7a",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1556,7 +1556,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#7725805682711725962494dc5dcfd6b5d938a5d5",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#64a5203d0816e4919ffe6a860608685e8be30d7a",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1980,7 +1980,7 @@
     "queue-async": {
       "version": "1.2.1",
       "from": "queue-async@1.2.1",
-      "resolved": "http://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz"
     },
     "tangram": {
       "version": "0.11.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.19",
+  "version": "4.6.20",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update cartodb-ui to 4.6.20 in order to grab cartodb.js@v4 updates, as
per the procedure described here:

https://github.com/CartoDB/cartodb.js/pull/1569#issuecomment-283940933

Deployment procedure for this issue:

https://github.com/CartoDB/tangram-carto/issues/28