### PR TITLE
Using learn guides in all onboarding analyses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@ Development
 * Migrate to use GNIP v2 for twitter search connector (#10051, #11595)
 
 ### Bug fixes
+* Ensured all analysis onboarding screens link to carto.learn guides (#11193)
 * Fixed problem with Bubbles legend when a new analysis is applied (#11666)
 * Fixed missing metadata option in header when dataset is sync (#11458)
 * Fixed problem with dates when filtering time series widget

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/area-of-influence.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/area-of-influence.tpl
@@ -14,5 +14,5 @@
 </p>
 
 <p class="CDB-Text Onboarding-description">
-  <a href="https://carto.com/docs/carto-engine/dataservices-api/isoline-functions/" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.read-more') %></a>
+  <a href="https://carto.com/learn/guides/analysis/areas-of-influence" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
 </p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/centroid.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/centroid.tpl
@@ -28,7 +28,3 @@
 <p class="CDB-Text Onboarding-description">
   <%- _t('analyses-onboarding.centroid.description') %>
 </p>
-
-<p class="CDB-Text Onboarding-description">
-  <a href="https://carto.com/learn/guides/analysis/calculate-clusters-of-points" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
-</p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/centroid.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/centroid.tpl
@@ -28,3 +28,7 @@
 <p class="CDB-Text Onboarding-description">
   <%- _t('analyses-onboarding.centroid.description') %>
 </p>
+
+<p class="CDB-Text Onboarding-description">
+  <a href="https://carto.com/learn/guides/analysis/calculate-clusters-of-points" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
+</p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/connect-with-lines.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/connect-with-lines.tpl
@@ -12,3 +12,7 @@
 <p class="CDB-Text Onboarding-description">
   <%- _t('analyses-onboarding.connect-with-lines.' + type) %>
 </p>
+
+<p class="CDB-Text Onboarding-description">
+  <a href="https://carto.com/learn/guides/analysis/connect-with-lines" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
+</p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/data-observatory-measure.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/data-observatory-measure.tpl
@@ -12,3 +12,7 @@
 <p class="CDB-Text Onboarding-description">
   <%- _t('analyses-onboarding.data-observatory-measure.description') %>
 </p>
+
+<p class="CDB-Text Onboarding-description">
+  <a href="https://carto.com/learn/guides/analysis/detect-outliers-and-clusters" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
+</p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/data-observatory-measure.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/data-observatory-measure.tpl
@@ -14,5 +14,5 @@
 </p>
 
 <p class="CDB-Text Onboarding-description">
-  <a href="https://carto.com/learn/guides/analysis/detect-outliers-and-clusters" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
+  <a href="https://carto.com/learn/guides/analysis/enrich-from-data-observatory" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
 </p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/filter-by-node-column.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/filter-by-node-column.tpl
@@ -1,6 +1,3 @@
 <p class="CDB-Text Onboarding-description">
-  <%- _t('analyses-onboarding.filter-by-node-column.description', {
-    name_of_source_node: source.get('id').toUpperCase(),
-    name_of_filter_source_node: filter_source.get('id').toUpperCase()
-  }) %>
+  <%- _t('analyses-onboarding.filter-by-node-column.description') %>
 </p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/georeference.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/georeference.tpl
@@ -14,5 +14,5 @@
 </p>
 
 <p class="CDB-Text Onboarding-description">
-  <a href="https://carto.com/docs/carto-engine/dataservices-api/geocoding-functions" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.read-more') %></a>
+  <a href="https://carto.com/learn/guides/analysis/georeference" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
 </p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/intersection.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/intersection.tpl
@@ -14,5 +14,5 @@
 </p>
 
 <p class="CDB-Text Onboarding-description">
-  <a href="http://postgis.net/docs/ST_Intersects.html" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.read-more') %></a>
+  <a href="https://carto.com/learn/guides/analysis/intersect-second-layer" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
 </p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/merge.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/merge.tpl
@@ -7,5 +7,5 @@
 </p>
 
 <p class="CDB-Text Onboarding-description">
-  <a href="https://carto.com/academy/courses/sql-postgis/joining-data/" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.read-more') %></a>
+  <a href="https://carto.com/learn/guides/analysis/join-column-from-second-layer" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
 </p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/moran.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/moran.tpl
@@ -26,5 +26,5 @@
 </p>
 
 <p class="CDB-Text Onboarding-description">
-  <a href="https://github.com/CartoDB/crankshaft/blob/develop/doc/02_moran.md" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.read-more') %></a>
+  <a href="https://carto.com/learn/guides/analysis/detect-outliers-and-clusters" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
 </p>

--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/spatial-markov-trend.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/spatial-markov-trend.tpl
@@ -26,5 +26,5 @@
 </p>
 
 <p class="CDB-Text Onboarding-description">
-  <a href="https://github.com/CartoDB/crankshaft/blob/develop/doc/04_markov.md" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.read-more') %></a>
+  <a href="https://carto.com/learn/guides/analysis/predict-trends-and-volatility" class="Onboarding-readMore" target="_blank"><%- _t('analyses-onboarding.learn-more') %></a>
 </p>

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -127,6 +127,7 @@
     "finished": "has finished",
     "style-analysis": "Style this analysis",
     "read-more": "Read more in documentation",
+    "learn-more": "Learn more",
     "never-show-message": "Don't show me this again.",
     "no-new-columns": "No new columns were created.",
     "geometries-updated": "The geometries in your table were updated",

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -138,7 +138,7 @@
     "new-columns-included-based-on-input": "New columns have been included with your original data based on the columns chosen for the input.",
     "sampling": {
       "title": "Subsample of rows",
-      "description": "A sample of your original table was randomly selected to give approximately %{percentage}% of the rows from your input dataset."
+      "description": "A sample of your original table was randomly selected to give approximately a percentage of the rows from your input dataset."
     },
     "merge": {
       "title": "Join columns from 2nd layer",
@@ -166,7 +166,7 @@
     },
     "filter-by-node-column": {
       "title": "Filter by layer",
-      "description": "Filter by layer allows you to filter the data in your layer by propagating the filters in the attached layer. Now if you filter on widgets added to the '%{name_of_filter_source_node}' node, the results in the '%{name_of_source_node}' node would be also filtered."
+      "description": "Filter by layer allows you to filter the data in your layer by propagating the filters in the attached layer. Now if you filter on widgets added to the first node, the results in the second node would be also filtered."
     },
     "spatial-markov-trend": {
       "trend": "The normalized trend for each geometry",
@@ -207,7 +207,7 @@
       "title": "Group points into polygons",
       "the-geom": "This column was updated to polygons encompassing the input points.",
       "category": "This will be the category over which the polygons were calculated",
-      "description": "Group points into polygons used '%{method}' to create new polygons."
+      "description": "Group points into polygons to create new polygons."
     },
     "georeference": {
       "title": "Georeference",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.20",
+  "version": "4.6.20-stg",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.20-stg",
+  "version": "4.6.20",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: #11193.

So I've replaced/added those available guides in each proper analysis onboarding. Except cluster, where the onboarding is not available (should we create it?).

Could you take a look @namessanti or @andy-esch? Is it ok?

cc @javierarce 