### PR TITLE
11700 user table refactor deletion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -73,7 +73,7 @@ Development
   * Run `cartodb:db:register_table_dependencies` rake to update caches for existing maps
 * Categories legend are now static (#10972)
 * Fixed a bug with vizjson invalidation (#11092). It was introduced in #10934
-* Refactor Layer model (#10934) and UserTable (#11589).
+* Refactor Layer model (#10934) and UserTable (#11589, #11700).
 * Correctly render map previews for maps with google basemaps (#11608)
 * Do not trigger visualization hooks on state update (#11701)
 * Refactor Layer model (#10934)

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -108,6 +108,11 @@ module Carto
       save if persisted?
     end
 
+    # Sequel model compatibility (for TableBlender)
+    def add_map(map)
+      maps << map
+    end
+
     def user_tables_readable_by(user)
       user_tables.select { |ut| ut.readable_by?(user) }
     end

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -110,6 +110,7 @@ module Carto
 
     # Sequel model compatibility (for TableBlender)
     def add_map(map)
+      CartoDB::Logger.debug(message: 'Adding map to Carto::Layer with legacy method')
       maps << map
     end
 

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -111,7 +111,6 @@ module Carto
     # Sequel model compatibility (for TableBlender)
     def add_map(map)
       CartoDB::Logger.debug(message: 'Adding map to Carto::Layer with legacy method')
-      raise "Unexpected Carto::Layer#add_map"
       maps << map
     end
 

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -111,6 +111,7 @@ module Carto
     # Sequel model compatibility (for TableBlender)
     def add_map(map)
       CartoDB::Logger.debug(message: 'Adding map to Carto::Layer with legacy method')
+      raise "Unexpected Carto::Layer#add_map"
       maps << map
     end
 

--- a/app/models/carto/map.rb
+++ b/app/models/carto/map.rb
@@ -11,14 +11,15 @@ class Carto::Map < ActiveRecord::Base
   has_many :layers, class_name: 'Carto::Layer',
                     order: '"order"',
                     through: :layers_maps,
-                    after_add: Proc.new { |map, layer| layer.after_added_to_map(map) }
+                    after_add: Proc.new { |map, layer| layer.after_added_to_map(map) },
+                    dependent: :destroy
 
   has_many :base_layers, class_name: 'Carto::Layer',
                          order: '"order"',
                          through: :layers_maps,
                          source: :layer
 
-  has_one :user_table, class_name: Carto::UserTable, inverse_of: :map
+  has_one :user_table, class_name: Carto::UserTable, inverse_of: :map, dependent: :destroy
 
   belongs_to :user
 

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -55,8 +55,8 @@ module Carto
     # The `destroyed?` check is needed to avoid the hook running twice when deleting a table from the ::Table service
     # as it is triggered directly, and a second time from canonical visualization destruction hooks.
     # TODO: This can be simplified after deleting the old UserTable model
-    before_destroy { service.before_destroy unless destroyed? }
-    after_destroy { service.after_destroy }
+    before_destroy { CartoDB::Logger.debug(message: "Carto::UserTable#before_destroy"); service.before_destroy unless destroyed? }
+    after_destroy { CartoDB::Logger.debug(message: "Carto::UserTable#after_destroy"); service.after_destroy }
 
     def geometry_types
       @geometry_types ||= service.geometry_types

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -55,8 +55,8 @@ module Carto
     # The `destroyed?` check is needed to avoid the hook running twice when deleting a table from the ::Table service
     # as it is triggered directly, and a second time from canonical visualization destruction hooks.
     # TODO: This can be simplified after deleting the old UserTable model
-    before_destroy { raise "Unexpected Carto::UserTable#before_destroy"; CartoDB::Logger.debug(message: "Carto::UserTable#before_destroy"); service.before_destroy unless destroyed? }
-    after_destroy { raise "Unexpected Carto::UserTable#after_destroy"; CartoDB::Logger.debug(message: "Carto::UserTable#after_destroy"); service.after_destroy }
+    before_destroy { CartoDB::Logger.debug(message: "Carto::UserTable#before_destroy"); service.before_destroy unless destroyed? }
+    after_destroy { CartoDB::Logger.debug(message: "Carto::UserTable#after_destroy"); service.after_destroy }
 
     def geometry_types
       @geometry_types ||= service.geometry_types

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -51,6 +51,10 @@ module Carto
     after_create :create_canonical_visualization
     after_create { service.after_create }
     after_save { CartoDB::Logger.debug(message: "Carto::UserTable#after_save"); service.after_save }
+
+    # The `destroyed?` check is needed to avoid the hook running twice when deleting a table from the ::Table service
+    # as it is triggered directly, and a second time from canonical visualization destruction hooks.
+    # TODO: This can be simplified after deleting the old UserTable model
     before_destroy { service.before_destroy unless destroyed? }
     after_destroy { service.after_destroy }
 

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -166,7 +166,7 @@ module Carto
     end
 
     def table_visualization
-      map.visualization
+      map.visualization if map
     end
 
     def update_cdb_tablemetadata

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -51,6 +51,8 @@ module Carto
     after_create :create_canonical_visualization
     after_create { service.after_create }
     after_save { CartoDB::Logger.debug(message: "Carto::UserTable#after_save"); service.after_save }
+    before_destroy { service.before_destroy }
+    after_destroy { service.after_destroy }
 
     def geometry_types
       @geometry_types ||= service.geometry_types
@@ -164,10 +166,7 @@ module Carto
     end
 
     def table_visualization
-      @table_visualization ||= Carto::Visualization.where(
-        map_id: map_id,
-        type:   Carto::Visualization::TYPE_CANONICAL
-      ).first
+      map.visualization
     end
 
     def update_cdb_tablemetadata

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -51,7 +51,7 @@ module Carto
     after_create :create_canonical_visualization
     after_create { service.after_create }
     after_save { CartoDB::Logger.debug(message: "Carto::UserTable#after_save"); service.after_save }
-    before_destroy { service.before_destroy }
+    before_destroy { service.before_destroy unless destroyed? }
     after_destroy { service.after_destroy }
 
     def geometry_types

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -55,8 +55,8 @@ module Carto
     # The `destroyed?` check is needed to avoid the hook running twice when deleting a table from the ::Table service
     # as it is triggered directly, and a second time from canonical visualization destruction hooks.
     # TODO: This can be simplified after deleting the old UserTable model
-    before_destroy { CartoDB::Logger.debug(message: "Carto::UserTable#before_destroy"); service.before_destroy unless destroyed? }
-    after_destroy { CartoDB::Logger.debug(message: "Carto::UserTable#after_destroy"); service.after_destroy }
+    before_destroy { raise "Unexpected Carto::UserTable#before_destroy"; CartoDB::Logger.debug(message: "Carto::UserTable#before_destroy"); service.before_destroy unless destroyed? }
+    after_destroy { raise "Unexpected Carto::UserTable#after_destroy"; CartoDB::Logger.debug(message: "Carto::UserTable#after_destroy"); service.after_destroy }
 
     def geometry_types
       @geometry_types ||= service.geometry_types

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -389,6 +389,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def delete_from_table
+    CartoDB::Logger.debug(message: "Carto::Visualization#delete_from_table");
     destroy if persisted?
   end
 
@@ -550,6 +551,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def unlink_from(user_table)
+    CartoDB::Logger.debug(message: "Carto::Visualization#unlink_from")
     layers_dependent_on(user_table).each do |layer|
       Carto::Analysis.find_by_natural_id(id, layer.source_id).try(:destroy) if layer.source_id
 
@@ -743,6 +745,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def backup_visualization
+    CartoDB::Logger.debug(message: "Carto::Visualization#backup_visualization");
     if user.has_feature_flag?(Carto::VisualizationsExportService::FEATURE_FLAG_NAME) && map
       Carto::VisualizationsExportService.new.export(id)
     end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -588,7 +588,8 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def propagate_name
-    table.reload # Needed to avoid double renames
+    # TODO: Move this to ::Table?
+    return if table.changing_name?
     table.register_table_only = register_table_only
     table.name = name
     table.update(name: name)

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -390,7 +390,6 @@ class Carto::Visualization < ActiveRecord::Base
 
   def delete_from_table
     CartoDB::Logger.debug(message: "Carto::Visualization#delete_from_table");
-    raise "Unexpected Carto::Visualization#delete_from_table"
     destroy if persisted?
   end
 
@@ -553,7 +552,6 @@ class Carto::Visualization < ActiveRecord::Base
 
   def unlink_from(user_table)
     CartoDB::Logger.debug(message: "Carto::Visualization#unlink_from")
-    raise "Unexpected Carto::Visualization#unlink_from"
     layers_dependent_on(user_table).each do |layer|
       Carto::Analysis.find_by_natural_id(id, layer.source_id).try(:destroy) if layer.source_id
 
@@ -748,7 +746,6 @@ class Carto::Visualization < ActiveRecord::Base
 
   def backup_visualization
     CartoDB::Logger.debug(message: "Carto::Visualization#backup_visualization");
-    raise "Unexpected Carto::Visualization#backup_visualization"
     if user.has_feature_flag?(Carto::VisualizationsExportService::FEATURE_FLAG_NAME) && map
       Carto::VisualizationsExportService.new.export(id)
     end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -549,6 +549,15 @@ class Carto::Visualization < ActiveRecord::Base
     user.id == user_id
   end
 
+  def unlink_from(user_table)
+    layers_dependent_on(user_table).each do |layer|
+      Carto::Analysis.find_by_natural_id(id, layer.source_id).try(:destroy) if layer.source_id
+
+      map.remove_layer(layer)
+      layer.destroy
+    end
+  end
+
   private
 
   def remove_password

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -390,6 +390,7 @@ class Carto::Visualization < ActiveRecord::Base
 
   def delete_from_table
     CartoDB::Logger.debug(message: "Carto::Visualization#delete_from_table");
+    raise "Unexpected Carto::Visualization#delete_from_table"
     destroy if persisted?
   end
 
@@ -552,6 +553,7 @@ class Carto::Visualization < ActiveRecord::Base
 
   def unlink_from(user_table)
     CartoDB::Logger.debug(message: "Carto::Visualization#unlink_from")
+    raise "Unexpected Carto::Visualization#unlink_from"
     layers_dependent_on(user_table).each do |layer|
       Carto::Analysis.find_by_natural_id(id, layer.source_id).try(:destroy) if layer.source_id
 
@@ -746,6 +748,7 @@ class Carto::Visualization < ActiveRecord::Base
 
   def backup_visualization
     CartoDB::Logger.debug(message: "Carto::Visualization#backup_visualization");
+    raise "Unexpected Carto::Visualization#backup_visualization"
     if user.has_feature_flag?(Carto::VisualizationsExportService::FEATURE_FLAG_NAME) && map
       Carto::VisualizationsExportService.new.export(id)
     end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -57,21 +57,21 @@ class Carto::Visualization < ActiveRecord::Base
   belongs_to :user, inverse_of: :visualizations, select: Carto::User::DEFAULT_SELECT
   belongs_to :full_user, class_name: Carto::User, foreign_key: :user_id, primary_key: :id, inverse_of: :visualizations, readonly: true
 
-  belongs_to :permission, inverse_of: :visualization
+  belongs_to :permission, inverse_of: :visualization, dependent: :destroy
 
   has_many :likes, foreign_key: :subject
-  has_many :shared_entities, foreign_key: :entity_id, inverse_of: :visualization
+  has_many :shared_entities, foreign_key: :entity_id, inverse_of: :visualization, dependent: :destroy
 
   has_one :external_source
   has_many :unordered_children, class_name: Carto::Visualization, foreign_key: :parent_id
 
-  has_many :overlays, order: '"order"'
+  has_many :overlays, order: '"order"', dependent: :destroy
 
   belongs_to :parent, class_name: Carto::Visualization, primary_key: :parent_id
 
   belongs_to :active_layer, class_name: Carto::Layer
 
-  belongs_to :map, class_name: Carto::Map, inverse_of: :visualization
+  belongs_to :map, class_name: Carto::Map, inverse_of: :visualization, dependent: :destroy
 
   has_many :related_templates, class_name: Carto::Template, foreign_key: :source_visualization_id
 
@@ -96,6 +96,10 @@ class Carto::Visualization < ActiveRecord::Base
   after_save :save_named_map_or_rollback_privacy, :propagate_attribution_change
   after_save :propagate_privacy_and_name_to, if: :table
 
+  before_destroy :backup_visualization
+  after_destroy :invalidate_cache
+  after_destroy :destroy_named_map
+
   # INFO: workaround for array saves not working. There is a bug in `activerecord-postgresql-array` which
   # makes inserting including array fields to save, but updates work. Wo se insert without tags and add them
   # with an update after creation. This is fixed in Rails 4.
@@ -118,10 +122,6 @@ class Carto::Visualization < ActiveRecord::Base
 
   def self.columns
     super.reject { |c| DELETED_COLUMNS.include?(c.name) }
-  end
-
-  def ==(other_visualization)
-    id == other_visualization.id
   end
 
   def size
@@ -386,6 +386,10 @@ class Carto::Visualization < ActiveRecord::Base
 
   def attributions_from_derived_visualizations
     related_canonical_visualizations.map(&:attributions).reject(&:blank?)
+  end
+
+  def delete_from_table
+    destroy if persisted?
   end
 
   def get_named_map
@@ -726,5 +730,22 @@ class Carto::Visualization < ActiveRecord::Base
       self.privacy = privacy_was
       save
     end
+  end
+
+  def backup_visualization
+    if user.has_feature_flag?(Carto::VisualizationsExportService::FEATURE_FLAG_NAME) && map
+      Carto::VisualizationsExportService.new.export(id)
+    end
+  rescue => exception
+    # Don't break deletion flow
+    CartoDB::Logger.error(
+      message: 'Error backing up visualization',
+      exception: exception,
+      visualization_id: id
+    )
+  end
+
+  def destroy_named_map
+    named_maps_api.destroy
   end
 end

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -122,6 +122,7 @@ class Layer < Sequel::Model
     attributes = public_values.select { |k, v| k != 'id' }.merge(override_attributes)
     ::Layer.new(attributes)
   end
+  alias dup copy
 
   def data_layer?
     !base_layer?

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -201,7 +201,7 @@ class Map < Sequel::Model
   end
 
   def dup
-    Map.new(map.to_hash.select { |k, _| k != :id })
+    Map.new(to_hash.select { |k, _| k != :id })
   end
 
   private

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -200,6 +200,10 @@ class Map < Sequel::Model
     }
   end
 
+  def dup
+    Map.new(map.to_hash.select { |k, _| k != :id })
+  end
+
   private
 
   def get_the_last_time_tiles_have_changed_to_render_it_in_vizjsons

--- a/app/models/map/copier.rb
+++ b/app/models/map/copier.rb
@@ -13,7 +13,7 @@ module CartoDB
       end
 
       def new_map_from(map)
-        @new_map ||= ::Map.new(map.to_hash.select { |k, v| k != :id })
+        @new_map ||= map.dup
         # Explicit association assignment to make user itself available, beyond its id, for validations
         if map.user
           @new_map.user ||= map.user
@@ -29,7 +29,7 @@ module CartoDB
 
       def copy_base_layer(origin_map, destination_map)
         origin_map.user_layers.map do |layer|
-          link(destination_map, layer.copy)
+          link(destination_map, layer.dup)
         end
       end
 
@@ -76,7 +76,7 @@ module CartoDB
 
       def data_layer_copies_from(map, user)
         map.data_layers.map do |layer|
-          new_layer = layer.copy
+          new_layer = layer.dup
           new_layer.qualify_for_organization(map.user.username) if user.id != map.user.id
 
           user.builder_enabled? ? reset_layer_styles(layer, new_layer) : new_layer
@@ -84,7 +84,7 @@ module CartoDB
       end
 
       def layer_copies_from(map)
-        map.layers.map(&:copy)
+        map.layers.map(&:dup)
       end
 
       def link(map, layer)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -82,7 +82,7 @@ class Table
 
   # This is here just for testing purposes (being able to test this service against both models)
   def model_class
-    Carto::UserTable
+    ::UserTable
   end
 
   # forwardable does not work well with this one

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -82,7 +82,7 @@ class Table
 
   # This is here just for testing purposes (being able to test this service against both models)
   def model_class
-    ::UserTable
+    Carto::UserTable
   end
 
   # forwardable does not work well with this one

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -492,9 +492,6 @@ class Table
 
   def before_destroy
     @table_visualization                = table_visualization
-    if @table_visualization
-      @table_visualization.user_data = { name: owner.username, api_key: owner.api_key }
-    end
     @fully_dependent_visualizations_cache     = fully_dependent_visualizations.to_a
     @partially_dependent_visualizations_cache = partially_dependent_visualizations.to_a
   end

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1166,6 +1166,10 @@ class Table
     record.nil? ? nil : record[:oid]
   end # get_table_id
 
+  def changing_name?
+    @name_changed_from.present?
+  end
+
   def update_name_changes
     if @name_changed_from.present? && @name_changed_from != name
       reload

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -498,7 +498,7 @@ class Table
 
   def after_destroy
     # Delete visualization BEFORE deleting metadata, or named map won't be destroyed properly
-    @table_visualization.delete(from_table_deletion=true) if @table_visualization
+    @table_visualization.delete_from_table if @table_visualization
     Tag.filter(user_id: user_id, table_id: id).delete
     remove_table_from_stats
 

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -73,8 +73,10 @@ module CartoDB
         if visualization.type == CartoDB::Visualization::Member::TYPE_CANONICAL
           # Each table has a canonical visualization which must have privacy synced
           visualization.privacy = ::UserTable::PRIVACY_VALUES_TO_TEXTS[privacy]
+          visualization.store_using_table(table_privacy_changed)
+        else
+          visualization.invalidate_cache
         end
-        visualization.store_using_table(table_privacy_changed)
       end
 
       self

--- a/app/models/table/relator.rb
+++ b/app/models/table/relator.rb
@@ -7,8 +7,6 @@ module CartoDB
     INTERFACE = %w{
       serialize_fully_dependent_visualizations
       serialize_partially_dependent_visualizations
-      fully_dependent_visualizations
-      partially_dependent_visualizations
       synchronization
       serialize_synchronization
       row_count_and_size
@@ -21,19 +19,11 @@ module CartoDB
     end
 
     def serialize_fully_dependent_visualizations
-      fully_dependent_visualizations.map { |object| preview_for(object) }
+      table.fully_dependent_visualizations.map { |object| preview_for(object) }
     end
 
     def serialize_partially_dependent_visualizations
-      partially_dependent_visualizations.map { |object| preview_for(object) }
-    end
-
-    def fully_dependent_visualizations
-      table.affected_visualizations.select { |v| v.fully_dependent_on?(table) }
-    end
-
-    def partially_dependent_visualizations
-      table.affected_visualizations.select { |v| v.partially_dependent_on?(table) }
+      table.partially_dependent_visualizations.map { |object| preview_for(object) }
     end
 
     def dependent_visualizations

--- a/app/models/table/relator.rb
+++ b/app/models/table/relator.rb
@@ -29,11 +29,11 @@ module CartoDB
     end
 
     def fully_dependent_visualizations
-      affected_visualizations.select { |v| v.fully_dependent_on?(table) }
+      table.affected_visualizations.select { |v| v.fully_dependent_on?(table) }
     end
 
     def partially_dependent_visualizations
-      affected_visualizations.select { |v| v.partially_dependent_on?(table) }
+      table.affected_visualizations.select { |v| v.partially_dependent_on?(table) }
     end
 
     def dependent_visualizations

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -339,6 +339,14 @@ class UserTable < Sequel::Model
     previous_changes[:privacy].first
   end
 
+  def fully_dependent_visualizations
+    affected_visualizations.select { |v| v.fully_dependent_on?(self) }
+  end
+
+  def partially_dependent_visualizations
+    affected_visualizations.select { |v| v.partially_dependent_on?(self) }
+  end
+
   private
 
   def default_privacy_value

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -87,24 +87,6 @@ class UserTable < Sequel::Model
 
   def_delegators :relator, :affected_visualizations
 
-  def_dataset_method(:search) do |query|
-    conditions = <<-EOS
-      to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, '')) @@ plainto_tsquery('english', ?) OR name ILIKE ?
-      EOS
-    where(conditions, query, "%#{query}%")
-  end
-
-  def_dataset_method(:multiple_order) do |criteria|
-    if criteria.nil? || criteria.empty?
-      order(:id)
-    else
-      order_params = criteria.map do |key, order|
-        Sequel.send(order.to_sym, key.to_sym)
-      end
-      order(*order_params)
-    end
-  end
-
   # Ignore mass-asigment on not allowed columns
   self.strict_param_setting = false
 

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -49,6 +49,8 @@ class UserTable < Sequel::Model
     update_updated_at
     values
     affected_visualizations
+    fully_dependent_visualizations
+    partially_dependent_visualizations
     reload
   }
 

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -95,7 +95,6 @@ module CartoDB
         self.id         ||= @repository.next_id
         @name_checker   = name_checker
         @validator      = MinimalValidator::Validator.new
-        @user_data      = nil
         self.permission_change_valid = true   # Changes upon set of different permission_id
         # this flag is passed to the table in case of canonical visualizations. It's used to say to the table to not touch the database and only change the metadata information, useful for ghost tables
         self.register_table_only = false
@@ -309,10 +308,6 @@ module CartoDB
       def unlink_from(table)
         invalidate_cache
         remove_layers_from(table)
-      end
-
-      def user_data=(user_data)
-        @user_data = user_data
       end
 
       def name=(name)

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -252,6 +252,10 @@ module CartoDB
         self
       end
 
+      def delete_from_table
+        delete(true)
+      end
+
       def delete(from_table_deletion = false)
         raise CartoDB::InvalidMember.new(user: "Viewer users can't delete visualizations") if user.viewer
 

--- a/app/models/visualization/table_blender.rb
+++ b/app/models/visualization/table_blender.rb
@@ -15,7 +15,8 @@ module CartoDB
 
         maps            = tables.map(&:map)
         copier          = CartoDB::Map::Copier.new
-        destination_map = copier.new_map_from(maps.first).save
+        destination_map = copier.new_map_from(maps.first)
+        destination_map.save
 
         copier.copy_base_layer(maps.first, destination_map)
 

--- a/spec/factories/carto_visualizations.rb
+++ b/spec/factories/carto_visualizations.rb
@@ -57,12 +57,11 @@ module Carto
 
       # Helper method for `create_full_visualization` results cleanup
       def destroy_full_visualization(map, table, table_visualization, visualization)
-        table_visualization.map.destroy if table_visualization && table_visualization.map
-        table_visualization.destroy if table_visualization
-        table.service.destroy if table && table.service
-        table.destroy if table
-        visualization.destroy if visualization
-        map.destroy if map
+        table_visualization.destroy if table_visualization && Carto::Visualization.exists?(table_visualization.id)
+        table.service.destroy if table && table.service && Carto::UserTable.exists?(table.id)
+        table.destroy if table && Carto::UserTable.exists?(table.id)
+        visualization.destroy if visualization && Carto::Visualization.exists?(visualization.id)
+        map.destroy if map && Carto::Map.exists?(map.id)
       end
 
       def destroy_visualization(visualization_id)

--- a/spec/models/map/copier_spec.rb
+++ b/spec/models/map/copier_spec.rb
@@ -6,11 +6,8 @@ require_relative '../../../app/models/layer'
 describe CartoDB::Map::Copier do
   before do
     @user_id  = UUIDTools::UUID.timestamp_create.to_s
-    @map      = OpenStruct.new(
-                  user_id: @user_id,
-                  to_hash: { user_id: @user_id },
-                  layers:  (1..5).map { Layer.new(kind: 'carto') }
-                )
+    @map      = Map.new(user_id: @user_id)
+    @map.stubs(:layers).returns((1..5).map { Layer.new(kind: 'carto') })
     @copier = CartoDB::Map::Copier.new
   end
 
@@ -23,8 +20,7 @@ describe CartoDB::Map::Copier do
 
     it 'copies all layers from the original map' do
       new_map = @copier.copy(@map)
-      new_map.layers.length.should == @map.layers.length
+      new_map.layers.length.should == 5
     end
   end #copy
 end # CartoDB::Map::Copier
-

--- a/spec/models/table/relator_spec.rb
+++ b/spec/models/table/relator_spec.rb
@@ -43,7 +43,7 @@ describe CartoDB::TableRelator do
     before :each do
       bypass_named_maps
 
-      table = mock('Table')
+      table = Table.new
       table.stubs(:id).returns(2)
       @affected_vis_records = [
         { id: 1, name: '1st', updated_at: Time.now },
@@ -56,6 +56,7 @@ describe CartoDB::TableRelator do
       vis_mock.stubs(:with_sql).returns(records)
       db = { visualizations: vis_mock }
       @table_relator = CartoDB::TableRelator.new(db, table)
+      table.instance_variable_get(:@user_table).stubs(:relator).returns(@table_relator)
     end
 
     describe 'given there are no dependent visualizations' do
@@ -98,7 +99,7 @@ describe CartoDB::TableRelator do
     before :each do
       bypass_named_maps
 
-      table = mock('Table')
+      table = Table.new
       table.stubs(:id).returns(2)
       @affected_vis_records = [
         { id: 1, name: '1st', updated_at: Time.now },
@@ -112,6 +113,7 @@ describe CartoDB::TableRelator do
       vis_mock.stubs(:with_sql).returns(records)
       db = { visualizations: vis_mock }
       @table_relator = CartoDB::TableRelator.new(db, table)
+      table.instance_variable_get(:@user_table).stubs(:relator).returns(@table_relator)
     end
 
     describe 'given there are no dependent visualizations' do

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -2507,6 +2507,6 @@ describe Table do
     end
 
     it_behaves_like 'table service'
-    #it_behaves_like 'table service with legacy model'
+    it_behaves_like 'table service with legacy model'
   end
 end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1774,18 +1774,6 @@ describe Table do
       end
     end
 
-    describe 'UserTable.multiple_order' do
-      it 'returns sorted records' do
-        table_1 = create_table(name: "bogus_table_1", user_id: @user.id)
-        table_2 = create_table(name: "bogus_table_2", user_id: @user.id)
-
-        UserTable.search('bogus').multiple_order(name: 'asc')
-          .to_a.first.name.should == 'bogus_table_1'
-        UserTable.search('bogus').multiple_order(name: 'desc')
-          .to_a.first.name.should == 'bogus_table_2'
-      end
-    end # Table.multiple_order
-
     context "retrieving tables from ids" do
       it "should be able to find a table by name or by identifier" do
         table = new_table :user_id => @user.id
@@ -2304,36 +2292,6 @@ describe Table do
         expect {
           CartoDB::Visualization::Member.new(id: derived.id).fetch
         }.to raise_error KeyError
-      end
-    end
-
-    context "search" do
-      it "should find tables by description" do
-        table = Table.new
-        table.user_id = @user.id
-        table.name = "clubbing_spain_1_copy"
-        table.description = "A world borders shapefile suitable for thematic mapping applications. Contains polygon borders in two resolutions as well as longitude/latitude values and various country codes. Camión"
-        table.save.reload
-
-        ['borders', 'polygons', 'spain', 'countries'].each do |query|
-          tables = UserTable.search(query)
-          tables.should_not be_empty
-          tables.first.id.should == table.id
-        end
-        tables = UserTable.search("wadus")
-        tables.should be_empty
-      end
-
-      it "should find tables by name" do
-        table = Table.new
-        table.user_id = @user.id
-        table.name = "european_countries_1"
-        table.description = "A world borders shapefile suitable for thematic mapping applications. Contains polygon borders in two resolutions as well as longitude/latitude values and various country codes"
-        table.save.reload
-
-        tables = UserTable.search("eur")
-        tables.should_not be_empty
-        tables.first.id.should == table.id
       end
     end
 

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -2281,9 +2281,6 @@ describe Table do
         bypass_named_maps
 
         CartoDB::Varnish.any_instance.stubs(:send_command).returns(true)
-        @doomed_table = create_table(user_id: @user.id)
-        @automatic_geocoding = FactoryGirl.create(:automatic_geocoding, table: @doomed_table)
-        @doomed_table.destroy
         @carto_user = Carto::User.find(@user.id)
       end
 

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -2367,7 +2367,8 @@ describe Table do
         CartoDB::Visualization::Member.stubs(:new).with(has_entry(id: derived.id)).returns(derived)
         CartoDB::Visualization::Member.stubs(:new).with(has_entry(type: 'table')).returns(table.table_visualization)
 
-        derived.expects(:invalidate_cache).at_least_once
+        # Hack to get the correct (Sequel/AR) model
+        CartoDB::Varnish.new.purge(derived.varnish_vizjson_key)
 
         table.privacy = UserTable::PRIVACY_PUBLIC
         table.save

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -314,6 +314,8 @@ describe Visualization::Member do
         Carto::Layer.exists?(canonical_layer.id).should be_true
         Carto::UserTable.exists?(@table.id).should be_true
         Carto::Map.exists?(canonical_map.id).should be_true
+
+        Table.any_instance.unstub(:remove_table_from_user_database)
       end
     end
   end

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -656,7 +656,6 @@ describe Visualization::Member do
           type: Visualization::Member::TYPE_CANONICAL,
           user_id:  user_id
       )
-      visualization.user_data = { actions: { private_maps: false } }
       # Unchanged visualizations could be
       visualization.valid?.should eq true
 

--- a/spec/models/visualization/presenter_spec.rb
+++ b/spec/models/visualization/presenter_spec.rb
@@ -37,7 +37,7 @@ describe Visualization::Member do
           name: 'test',
           type: Visualization::Member::TYPE_CANONICAL
       )
-      visualization.user_data = { actions: { private_maps: true } }
+
       # Careful, do a user mock after touching user_data as it does some checks about user too
       user_mock = mock
       user_mock.stubs(:private_tables_enabled).returns(true)

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -9,7 +9,7 @@ describe Carto::Builder::Public::EmbedsController do
     @user = FactoryGirl.create(:valid_user, private_maps_enabled: true)
     @carto_user = Carto::User.find(@user.id)
     @map = FactoryGirl.create(:map, user_id: @user.id)
-    @visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: @map.id, version: 3)
+    @visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, map_id: @map.id, version: 3)
     # Only mapcapped visualizations are presented by default
     Carto::Mapcap.create!(visualization_id: @visualization.id)
   end
@@ -36,7 +36,7 @@ describe Carto::Builder::Public::EmbedsController do
 
   describe '#show' do
     it 'does not display public visualizations without mapcaps' do
-      unpublished_visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_PUBLIC)
+      unpublished_visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_PUBLIC)
       get builder_visualization_public_embed_url(visualization_id: unpublished_visualization.id)
       response.status.should == 404
 
@@ -45,7 +45,7 @@ describe Carto::Builder::Public::EmbedsController do
     end
 
     it 'does not display link visualizations without mapcaps' do
-      unpublished_visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_LINK)
+      unpublished_visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_LINK)
       get builder_visualization_public_embed_url(visualization_id: unpublished_visualization.id)
       response.status.should == 404
 
@@ -54,7 +54,7 @@ describe Carto::Builder::Public::EmbedsController do
     end
 
     it 'does not display visualizations without mapcaps' do
-      unpublished_visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: @map.id, version: 3)
+      unpublished_visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, map_id: @map.id, version: 3)
       get builder_visualization_public_embed_url(visualization_id: unpublished_visualization.id)
       response.status.should == 404
 
@@ -301,7 +301,7 @@ describe Carto::Builder::Public::EmbedsController do
   describe '#show_protected' do
     it 'does not display visualizations without mapcaps' do
       stub_passwords(TEST_PASSWORD)
-      unpublished_visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_PROTECTED)
+      unpublished_visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_PROTECTED)
       unpublished_visualization.published?.should be_false
 
 
@@ -316,7 +316,7 @@ describe Carto::Builder::Public::EmbedsController do
 
     it 'does display published visualizations' do
       stub_passwords(TEST_PASSWORD)
-      published_visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_PROTECTED)
+      published_visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_PROTECTED)
       Carto::Mapcap.create!(visualization_id: published_visualization.id)
       published_visualization.published?.should be_true
 

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -5,6 +5,7 @@ describe Carto::Builder::Public::EmbedsController do
   include Warden::Test::Helpers, Carto::Factories::Visualizations, HelperMethods
 
   before(:all) do
+    bypass_named_maps
     @user = FactoryGirl.create(:valid_user, private_maps_enabled: true)
     @carto_user = Carto::User.find(@user.id)
     @map = FactoryGirl.create(:map, user_id: @user.id)
@@ -14,6 +15,7 @@ describe Carto::Builder::Public::EmbedsController do
   end
 
   before(:each) do
+    bypass_named_maps
     Carto::Visualization.any_instance.stubs(:organization?).returns(false)
     Carto::Visualization.any_instance.stubs(:get_auth_tokens).returns(['trusty_token'])
   end
@@ -38,6 +40,7 @@ describe Carto::Builder::Public::EmbedsController do
       get builder_visualization_public_embed_url(visualization_id: unpublished_visualization.id)
       response.status.should == 404
 
+      unpublished_visualization.map = nil
       unpublished_visualization.destroy
     end
 
@@ -46,6 +49,7 @@ describe Carto::Builder::Public::EmbedsController do
       get builder_visualization_public_embed_url(visualization_id: unpublished_visualization.id)
       response.status.should == 404
 
+      unpublished_visualization.map = nil
       unpublished_visualization.destroy
     end
 
@@ -54,6 +58,7 @@ describe Carto::Builder::Public::EmbedsController do
       get builder_visualization_public_embed_url(visualization_id: unpublished_visualization.id)
       response.status.should == 404
 
+      unpublished_visualization.map = nil
       unpublished_visualization.destroy
     end
 
@@ -305,6 +310,7 @@ describe Carto::Builder::Public::EmbedsController do
       response.body.include?('Invalid password').should be false
       response.status.should == 404
 
+      unpublished_visualization.map = nil
       unpublished_visualization.destroy
     end
 
@@ -319,6 +325,7 @@ describe Carto::Builder::Public::EmbedsController do
 
       response.status.should == 200
 
+      published_visualization.map = nil
       published_visualization.destroy
     end
 


### PR DESCRIPTION
**REMEMBER TO REMOVE RAISES (revert last commit) BEFORE DEPLOY**

#11700 

With this, all tests in `table_spec.rb` pass. Next step would be to change the `model_class` to `Carto::UserTable` and see what breaks. I made a [quick experiment](https://ci.cartodb.net/job/CartoDB-PR-testing-backend/79/console) to facilitate writing the next issue.

Implemented in this PR:
- Table deletion hooks, including visualization model deletion (and friends)
- Table blender compatibility with both models (this one changes production code that is being actively used, but should be safe)
- Junk deletion. Notably `UserTable.search` which is not being used in production code (now searches go through VQB).
- The typical bunch of test fixes. I have not reorganized `table_spec.rb` again, so we can see changes more clearly.

**Acceptance**
- [x] Ghost tables. Rename a table via SQL API, refresh the dashboard. Ghost tables should fix it.
- [x] Ghost tables. Create a table via SQL API (and cartodbfy) it, refresh the dashboard. Ghost tables should create metadata.
- [x] Ghost tables. Drop a table via SQL API, refresh the dashboard. Ghost tables should delete metadata.
- [x] Table blender. Create a map from one dataset (in dashboard). Check privacy of created map.
- [x] Table blender. Create a map from multiple dataset (in dashboard). Check privacy of created map.
- [x] Table blender. Create a map from dataset (from dataset view). Check privacy of created map.
- [x] Delete a map.
- [x] Delete a dataset (with maps depending on it, partially and fully).
- [x] Set a new custom basemap. Delete the map. Create a new map. The previous custom basemap should be one of the options for custom basemaps.
- [x] Publish a public map. Open the embed and the vizjson. Change privacy to private and republish. Reload the embed and vizjson. Both should throw an error.
- [x] Create a map, open the vizjson. Delete the map and refresh the vizjson. It should throw an error.