### PR TITLE
bounds_from nil explicit handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@ Development
   * Select an icon previously uploaded by the organization admin (#11462)
   * Sets the default initial size for icons to 20px (#11498)
 * Onboarding for layer edition (#10905)
+* Improved empty bounds map handling (#11711).
 * Updated diagnosis page versions.
 * Improved formula widget description field. (#11469)
 * Added support for Zeus for faster testing (#11574). Check `CONTRIBUTING.md` for configuration details.

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -114,6 +114,8 @@ module Carto
       end
 
       def bounds_from(map)
+        return nil unless map.view_bounds_sw && map.view_bounds_ne
+
         ::JSON.parse("[#{map.view_bounds_sw}, #{map.view_bounds_ne}]")
       rescue => e
         CartoDB::Logger.debug(

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -113,6 +113,22 @@ describe Carto::Api::VizJSON3Presenter do
     end
   end
 
+  describe '#to_vizjson (without caching)' do
+    include_context 'full visualization'
+
+    it 'returns map bounds' do
+      presenter = Carto::Api::VizJSON3Presenter.new(@visualization, nil)
+      presenter.to_vizjson[:bounds].should eq [[-85.0511, -179], [85.0511, 179]]
+    end
+
+    it 'returns nil map bounds if map bounds are not set' do
+      @visualization.map.view_bounds_sw = nil
+      @visualization.map.view_bounds_ne = nil
+
+      Carto::Api::VizJSON3Presenter.new(@visualization, nil).to_vizjson[:bounds].should be_nil
+    end
+  end
+
   describe '#to_named_map_vizjson' do
     include_context 'full visualization'
 


### PR DESCRIPTION
This closes #11711.

Acceptance:
- [x] Move (pan) a map. Publish. Check that embed is updated.
- [x] Zoom a map. Publish. Check that embed is updated.
- [x] Force nil bounds and open the map. No error must appear neither in JS console nor in Rollbar.