### PR TITLE
11280 layer selector name in torque layers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,6 +101,7 @@ Development
 * Hide sync options in builder table view for non-owners (#10986)
 * Fix issues with edition of custom color infowindows (#10985)
 * UI fixes for georeference. Changes of copy and validation warning. (#11426)
+* Show layer name in legends for Torque layers (#11715)
 * Color scheme is now clickable in category ramps (#11413)
 * Fix responsive layout in onboarding steps (#11444)
 * Fix for race condition when importing files and deploying at the same time (#11653)

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -362,10 +362,13 @@ module Carto
 
       def as_torque
         layer_options = @layer.options.deep_symbolize_keys
+        torque_options = layer_options.select { |k| TORQUE_ATTRS.include? k }
+        torque_options[:attribution] = attribution
+        torque_options[:layer_name] = layer_name
 
         torque = {
-          type:       'torque',
-          options:    layer_options.select { |k| TORQUE_ATTRS.include? k }.merge(attribution: attribution)
+          type: 'torque',
+          options: torque_options
         }
 
         torque[:cartocss] = layer_options[:tile_style]

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -276,10 +276,13 @@ describe Carto::Api::VizJSON3Presenter do
         end
       end
 
-      it 'should not include layer_name in options for carto layers' do
-        carto_layer = vizjson[:layers][1]
-        carto_layer.should_not include :layer_name
-        carto_layer[:options][:layer_name].should
+      it 'should include layer_name in options for data layers' do
+        vizjson[:layers].each do |layer|
+          unless layer[:type] == 'tiled'
+            layer.should_not include :layer_name
+            layer[:options][:layer_name].should be
+          end
+        end
       end
 
       it 'should not include Odyssey options' do


### PR DESCRIPTION
Fix #11280 

Vizjson3 for torque layers should include `layer_name` (used in legends).