### PR TITLE
Add test for Table.public_values, privacy text for vizjson

### DIFF
--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -185,8 +185,7 @@ module Carto
       super(value.split(',').map(&:strip).reject(&:blank?).uniq.join(','))
     end
 
-    # TODO: remove if error https://rollbar.com/vizzuality/CartoDB/items/21868/occurrences/22255989732/ disappears
-    # Simplify certain privacy values for the vizjson
+    # TODO: This is related to an incompatibility between visualizations models, `get_related_tables`, See #11705
     def privacy_text_for_vizjson
       privacy == PRIVACY_LINK ? 'PUBLIC' : privacy_text
     end

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -2207,6 +2207,22 @@ describe Table do
         [0, 1].should include(table.estimated_row_count)
       end
     end
+
+    describe '#public_values' do
+      it 'should work with a canonical visualizations that has two related tables' do
+        # Note: with Builder, this should not happen (canonical visualizations cannot be modified), for compatibility
+        # with older, migrated, canonical visualizations
+        main_table = create_table(user_id: @user.id)
+        aux_table = create_table(user_id: @user.id)
+
+        canonical_layer = main_table.layers.first
+        canonical_layer.options["query"] = "SELECT * FROM #{main_table.name} JOIN #{aux_table.name} ON true"
+        canonical_layer.save
+
+        main_table.public_values[:table_visualization][:related_tables].count.should eq 1
+        main_table.public_values[:table_visualization][:related_tables][0][:name].should eq aux_table.name
+      end
+    end
   end
 
   shared_examples_for 'table service with legacy model' do


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/11705

Add a test. More details can be found in the ticket. I decided to not change the previous fix as we are going to be refactoring this pretty soon. Instead, I left a TODO to check for this, and the added test should keep us safe through the refactor (I double-checked that it fails if removing `privacy_text_for_vizjson` from `Carto::UserTable`, with the same trace as Rollbar).