### PR TITLE
Enables more security headers by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,7 @@ Development
 * Fix analysis notification in running state (#11079)
 * Fix color for "Other" category (#11078)
 * Validate that only one legend per type (color/size) is allowed (#11556)
+* Enable more security HTTP headers (#11727)
 * Clean up import directory when importing from URL (#11599)
 * Custom errors for latitude/longitude out of bounds (#11060, #11048)
 * Fix timeseries widget height (#11077)

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -1,11 +1,5 @@
 class Admin::AdminController < ApplicationController
-  before_filter :x_frame_options_deny
-
   protected
-
-  def x_frame_options_deny
-    response.headers['X-Frame-Options'] = 'DENY'
-  end
 
   def invalidate_browser_cache
     response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -11,9 +11,11 @@ require_dependency 'static_maps_url_helper'
 require_dependency 'static_maps_url_helper'
 require_dependency 'carto/user_db_size_cache'
 require_dependency 'carto/ghost_tables_manager'
+require_dependency 'carto/helpers/frame_options_helper'
 
 class Admin::VisualizationsController < Admin::AdminController
   include CartoDB, VisualizationsControllerHelper
+  include Carto::FrameOptionsHelper
 
   MAX_MORE_VISUALIZATIONS = 3
   DEFAULT_PLACEHOLDER_CHARS = 4
@@ -713,9 +715,5 @@ class Admin::VisualizationsController < Admin::AdminController
     if @visualization && @visualization.version == 3
       redirect_to CartoDB.url(self, 'builder_visualization_public_embed', visualization_id: @visualization.id)
     end
-  end
-
-  def x_frame_options_allow
-    response.headers.delete('X-Frame-Options')
   end
 end

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -23,6 +23,9 @@ class Admin::VisualizationsController < Admin::AdminController
               :embed_protected, :public_map_protected, :embed_forbidden, :track_embed
   ssl_required :index, :show, :protected_public_map, :show_protected_public_map
 
+  before_filter :x_frame_options_allow, only: [:embed_forbidden, :embed_map, :embed_protected,
+                                               :show_organization_embed_map, :show_protected_embed_map,
+                                               :track_embed]
   before_filter :login_required, only: [:index]
   before_filter :table_and_schema_from_params, only: [:show, :public_table, :public_map, :show_protected_public_map,
                                                       :show_protected_embed_map, :embed_map]
@@ -49,10 +52,6 @@ class Admin::VisualizationsController < Admin::AdminController
   skip_before_filter :browser_is_html5_compliant?, only: [:public_map, :embed_map, :track_embed,
                                                           :show_protected_embed_map, :show_protected_public_map]
   skip_before_filter :verify_authenticity_token, only: [:show_protected_public_map, :show_protected_embed_map]
-
-  skip_before_filter :x_frame_options_deny, only: [:embed_forbidden, :embed_map, :embed_protected,
-                                                   :show_organization_embed_map, :show_protected_embed_map,
-                                                   :track_embed]
 
   def index
     @first_time    = !current_user.dashboard_viewed?
@@ -714,5 +713,9 @@ class Admin::VisualizationsController < Admin::AdminController
     if @visualization && @visualization.version == 3
       redirect_to CartoDB.url(self, 'builder_visualization_public_embed', visualization_id: @visualization.id)
     end
+  end
+
+  def x_frame_options_allow
+    response.headers.delete('X-Frame-Options')
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
 
   around_filter :wrap_in_profiler
 
+  before_filter :set_security_headers
   before_filter :http_header_authentication, if: :http_header_authentication?
   before_filter :store_request_host
   before_filter :ensure_user_organization_valid
@@ -364,4 +365,9 @@ class ApplicationController < ActionController::Base
     Carto::HttpHeaderAuthentication.new.valid?(request)
   end
 
+  def set_security_headers
+    headers['X-Frame-Options'] = 'DENY'
+    headers['X-XSS-Protection'] = '1; mode=block'
+    headers['X-Content-Type-Options'] = 'nosniff'
+  end
 end

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -8,7 +8,8 @@ module Carto
 
         ssl_required :show, :show_protected
 
-        before_filter :load_visualization,
+        before_filter :x_frame_options_allow,
+                      :load_visualization,
                       :redirect_to_old_embed_if_v2, only: [:show, :show_protected]
         before_filter :load_vizjson,
                       :load_state, only: [:show, :show_protected]
@@ -39,6 +40,10 @@ module Carto
         end
 
         private
+
+        def x_frame_options_allow
+          response.headers.delete('X-Frame-Options')
+        end
 
         def load_visualization
           @visualization = load_visualization_from_id_or_name(params[:visualization_id])

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -1,10 +1,12 @@
 require_dependency 'carto/api/vizjson3_presenter'
+require_dependency 'carto/helpers/frame_options_helper'
 
 module Carto
   module Builder
     module Public
       class EmbedsController < BuilderController
         include VisualizationsControllerHelper
+        include Carto::FrameOptionsHelper
 
         ssl_required :show, :show_protected
 
@@ -40,10 +42,6 @@ module Carto
         end
 
         private
-
-        def x_frame_options_allow
-          response.headers.delete('X-Frame-Options')
-        end
 
         def load_visualization
           @visualization = load_visualization_from_id_or_name(params[:visualization_id])

--- a/app/controllers/carto/helpers/frame_options_helper.rb
+++ b/app/controllers/carto/helpers/frame_options_helper.rb
@@ -1,0 +1,5 @@
+module Carto::FrameOptionsHelper
+  def x_frame_options_allow
+    response.headers.delete('X-Frame-Options')
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -182,12 +182,6 @@ module CartoDB
     custom_app_views_paths.reverse.each do |custom_views_path|
       config.paths['app/views'].unshift(custom_views_path)
     end
-
-    config.action_dispatch.default_headers = {
-      'X-Frame-Options' => 'DENY',
-      'X-XSS-Protection' => '1; mode=block',
-      'X-Content-Type-Options' => 'nosniff'
-    }
   end
 end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -182,6 +182,12 @@ module CartoDB
     custom_app_views_paths.reverse.each do |custom_views_path|
       config.paths['app/views'].unshift(custom_views_path)
     end
+
+    config.action_dispatch.default_headers = {
+      'X-Frame-Options' => 'DENY',
+      'X-XSS-Protection' => '1; mode=block',
+      'X-Content-Type-Options' => 'nosniff'
+    }
   end
 end
 


### PR DESCRIPTION
I took the chance to enable some security headers. More interesting is the `X-Frame-Options` which was not enabled for APIs (it doesn't matter there) and the new `BuilderController` sub-classes.

The other ones should make the loading of `.js` and `.css` safer, but should not have an effect on normal use of the application as it is. We just need to check that nothing broke (best way is to check browser console in each of the main sections of the application).

**Deploy**
Please notify support. They should be made aware that we may have new issues about embedding CARTO pages inside iframes.

**Acceptance**
- [x] Check that you cannot embed (in an iframe) dashboard and friends. Check the browser console for errors.
- [x] Check that you cannot embed (in an iframe) account pages. Check the browser console for errors.
- [x] Check that you cannot embed (in an iframe) Builder. Check the browser console for errors.
- [x] Check that you can embed (in an iframe) editor and Builder embeds. Check the browser console for errors.