### PR TITLE
Fixed two problems found in Builder for IE11 browsers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,7 @@ Development
 * Migrate to use GNIP v2 for twitter search connector (#10051, #11595)
 
 ### Bug fixes
+* Fixed problems related with IE11.
 * Fixed silent problem with jQuery selector (cartodb/deep-insights.js#527)
 * Form editors remains open if a modal is open even triggering document click or ESC (#11686)
 * Fixed font style for the "You have run out of quota" module (#11690)

--- a/lib/assets/core/javascripts/cartodb3/components/modals/add-analysis/analysis-option-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/add-analysis/analysis-option-view.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var $ = require('jquery');
 var CoreView = require('backbone/core-view');
 var template = require('./analysis-option.tpl');
 var Analyses = require('../../../data/analyses');
@@ -66,7 +67,7 @@ module.exports = CoreView.extend({
   },
 
   _onClick: function (e) {
-    if (e && e.target && e.target.getAttribute('class') && e.target.getAttribute('class').match('js-more')) {
+    if (e && e.target && $(e.target).hasClass('js-more')) {
       this.trigger('onClickInfo', this);
     }
 

--- a/lib/assets/core/javascripts/cartodb3/components/modals/add-widgets/tablestats.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/add-widgets/tablestats.js
@@ -277,7 +277,7 @@ ColumnGraph.prototype = {
     var min = bounds[0];
     var max = bounds[bounds.length - 1];
     var width = (max - min) / bins;
-    var histogram = new Array(bins).fill(0);
+    var histogram = new Array(bins + 1).join('0').split('').map(parseFloat);
     function scaleBin (value) {
       if (max === min) return min;
       return Math.floor((bins - 1) * (value - min) / (max - min));

--- a/lib/assets/core/javascripts/cartodb3/components/modals/add-widgets/tablestats.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/add-widgets/tablestats.js
@@ -316,7 +316,7 @@ ColumnGraph.prototype = {
       return [];
     }
 
-    var histogram = new Array(bins).fill(0);
+    var histogram = new Array(bins + 1).join('0').split('').map(parseFloat);
     function scale (value) {
       if (max === min) return min;
       return (bins - 1) * (value - min) / (max - min);


### PR DESCRIPTION
1. .fill method for Array objects is not available in IE11.
2. `getAttribute` was not working properly in IE11.

@nobuti 