### PR TITLE
data layer: edit layer context menu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@ Development
 * Improved formula widget description field. (#11469)
 * Added support for Zeus for faster testing (#11574). Check `CONTRIBUTING.md` for configuration details.
 * Migrate to use GNIP v2 for twitter search connector (#10051, #11595)
+* Improve affordance of layer item (#11359)
 
 ### Bug fixes
 * Fixed problems related with IE11.

--- a/app/assets/stylesheets/editor-3/block-list.css.scss
+++ b/app/assets/stylesheets/editor-3/block-list.css.scss
@@ -26,12 +26,17 @@
 .BlockList-item:hover {
   @include transition(border 200ms ease-in);
   border: 1px solid $cHoverLine;
+
+  .BlockList-titleText {
+    text-decoration: underline;
+  }
 }
 .BlockList-item.BlockList-item--noAction {
   cursor: default;
 
   .BlockList-titleText {
     cursor: default;
+    text-decoration: none;
   }
 }
 .BlockList-item.BlockList-item--noAction:hover {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
@@ -204,7 +204,7 @@ module.exports = CoreView.extend({
   },
 
   _onEditLayer: function (event) {
-    event.stopPropagation();
+    event && event.stopPropagation();
 
     this._stackLayoutModel.nextStep(this.model, 'layer-content', 'style');
   },
@@ -253,6 +253,9 @@ module.exports = CoreView.extend({
     }, {
       label: _t('editor.layers.options.export'),
       val: 'export-data'
+    }, {
+      label: _t('editor.layers.options.edit'),
+      val: 'edit-layer'
     }]);
     if (this._queryGeometryHasGeom()) {
       menuItems.add({
@@ -289,6 +292,9 @@ module.exports = CoreView.extend({
       }
       if (selectedItem === 'export-data') {
         this._exportLayer();
+      }
+      if (selectedItem === 'edit-layer') {
+        this._onEditLayer();
       }
       if (selectedItem === 'center-map') {
         this._centerMap();

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -1437,6 +1437,7 @@
         "export": "Export data",
         "hide": "Hide layer",
         "show": "Show layer",
+        "edit": "Edit layer",
         "center-map": "Center map on layer"
       },
       "drag-n-drop-analysis": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.25",
+  "version": "4.6.26",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
re: https://github.com/CartoDB/cartodb/issues/11359 (for good)

adds the edit layer option in the context menu

![screen shot 2017-03-10 at 14 18 45](https://cloud.githubusercontent.com/assets/36676/23796751/dd2c591c-059c-11e7-8b5d-6a86e7ec19af.png)

and underline the basemap when hover

![screen shot 2017-03-10 at 14 30 06](https://cloud.githubusercontent.com/assets/36676/23797068/5cf39d12-059e-11e7-8044-aa2e1ab496d3.png)

