### PR TITLE
Fill number to category bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -119,6 +119,7 @@ Development
 * Fixed overflow on loaders.
 * JOIN Analysis Fails Without Error Message (#11184)
 * Fix problem with perfect-scrollbar in Edge browsers (CartoDB/perfect-scrollbar/#2)
+* Fix problem when number column is used like categories in fill component (#11736) 
 
 4.0.x (2016-12-05)
 ------------------

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-view.js
@@ -94,7 +94,7 @@ module.exports = CoreView.extend({
     this.killEvent(ev);
     var index = $(ev.target).index();
     var color = this._collection.at(index);
-    this._onSelectItem(color);
+    color && this._onSelectItem(color);
   },
 
   _onSelectItem: function (item) {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -37,6 +37,17 @@ module.exports = CoreView.extend({
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
     this._imageEnabled = opts.imageEnabled;
     this.listenTo(this.model, 'change:attribute', this._fetchColumns);
+    this._viewModel = new Backbone.Model({
+      step: 0,
+      status: 'idle'
+    });
+
+    this.listenTo(this._viewModel, 'change:status', this.render);
+
+    // If it comes from a quantification change
+    if (this.model.hasChanged('quantification') && this.model.get('quantification') === 'category') {
+      this._fetchColumns();
+    }
   },
 
   render: function () {
@@ -47,6 +58,7 @@ module.exports = CoreView.extend({
     var columnType = column && column.type;
 
     this.$el.append(template({
+      status: this._viewModel.get('status'),
       columnType: columnType,
       attribute: this.model.get('attribute'),
       quantification: this.model.get('quantification') || 'category'
@@ -59,12 +71,15 @@ module.exports = CoreView.extend({
 
   _generateStackLayoutView: function () {
     var self = this;
+    var currentStep = this._viewModel.get('step');
 
     var stackViewCollection = new Backbone.Collection([{
+      selected: currentStep === 0,
       createStackView: function (stackLayoutModel, opts) {
         return self._createRangeListView(stackLayoutModel, opts).bind(self);
       }
     }, {
+      selected: currentStep === 1,
       createStackView: function (stackLayoutModel, opts) {
         return self._createColorPickerView(stackLayoutModel, opts).bind(self);
       }
@@ -72,6 +87,7 @@ module.exports = CoreView.extend({
 
     if (this._iconStylingEnabled()) {
       stackViewCollection.add({
+        selected: currentStep === 2,
         createStackView: function (stackLayoutModel, opts) {
           return self._createImagePickerView(stackLayoutModel, opts).bind(self);
         }
@@ -105,7 +121,7 @@ module.exports = CoreView.extend({
     }
 
     if (this._query) {
-      this._startLoader();
+      this._setViewStatus('loading');
 
       var sql = new CDB.SQL({
         user: this._configModel.get('user_name'),
@@ -123,8 +139,8 @@ module.exports = CoreView.extend({
         {
           success: this._onQueryDone.bind(this),
           error: function () {
-            // TODO: what happens if fails?
-          }
+            this._setViewStatus('error');
+          }.bind(this)
         }
       );
     } else {
@@ -134,9 +150,8 @@ module.exports = CoreView.extend({
 
   _onQueryDone: function (data) {
     data = data || {};
-    this._stopLoader();
     this._updateRangeAndDomain(data.rows);
-    this.render();
+    this._setViewStatus('idle');
   },
 
   _updateRangeAndDomain: function (rows) {
@@ -171,14 +186,8 @@ module.exports = CoreView.extend({
     });
   },
 
-  _startLoader: function () {
-    this.$('.js-loader').removeClass('is-hidden');
-    this.$('.js-content').addClass('is-hidden');
-  },
-
-  _stopLoader: function () {
-    this.$('.js-loader').addClass('is-hidden');
-    this.$('.js-content').removeClass('is-hidden');
+  _setViewStatus: function (status) {
+    this.model.set('status', status);
   },
 
   _getRange: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.js
@@ -70,27 +70,26 @@ module.exports = CoreView.extend({
   },
 
   _generateStackLayoutView: function () {
-    var self = this;
     var currentStep = this._viewModel.get('step');
 
     var stackViewCollection = new Backbone.Collection([{
       selected: currentStep === 0,
       createStackView: function (stackLayoutModel, opts) {
-        return self._createRangeListView(stackLayoutModel, opts).bind(self);
-      }
+        return this._createRangeListView(stackLayoutModel, opts).bind(this);
+      }.bind(this)
     }, {
       selected: currentStep === 1,
       createStackView: function (stackLayoutModel, opts) {
-        return self._createColorPickerView(stackLayoutModel, opts).bind(self);
-      }
+        return this._createColorPickerView(stackLayoutModel, opts).bind(this);
+      }.bind(this)
     }]);
 
     if (this._iconStylingEnabled()) {
       stackViewCollection.add({
         selected: currentStep === 2,
         createStackView: function (stackLayoutModel, opts) {
-          return self._createImagePickerView(stackLayoutModel, opts).bind(self);
-        }
+          return this._createImagePickerView(stackLayoutModel, opts).bind(this);
+        }.bind(this)
       });
     }
 
@@ -187,7 +186,15 @@ module.exports = CoreView.extend({
   },
 
   _setViewStatus: function (status) {
-    this.model.set('status', status);
+    var attrs = {
+      status: status
+    };
+
+    if (status === 'loading') {
+      attrs.step = 0;
+    }
+
+    this._viewModel.set(attrs);
   },
 
   _getRange: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.tpl
@@ -24,12 +24,17 @@
     </li>
   </ul>
 </div>
-<div class="InputColorCategory-loader js-loader is-hidden">
-  <div class="CDB-LoaderIcon is-dark">
-    <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
-      <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
-    </svg>
-  </div>
-</div>
 
-<div class="InputColorCategory-content js-content"></div>
+<% if (status === 'loading') { %>
+  <div class="InputColorCategory-loader js-loader">
+    <div class="CDB-LoaderIcon is-dark">
+      <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
+        <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
+      </svg>
+    </div>
+  </div>
+<% } else if (status === 'error') { %>
+  <div class="u-flex u-alignCenter u-justifyCenter CDB-Text CDB-Size-medium u-bSpace--m u-tSpace--m u-errorTextColor"><%- _t('form-components.editors.fill.error') %></div>
+<% } else { %>
+  <div class="InputColorCategory-content js-content"></div>
+<% } %>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
@@ -41,11 +41,15 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
-    this.model.bind('change:quantification', function () {
+    this.listenTo(this.model, 'change:quantification', function () {
       if (this.model.get('quantification') !== 'category') {
         this.model.unset('domain');
       }
-    }, this);
+
+      if (this.model.previous('quantification') === 'category') {
+        this.model.unset('range');
+      }
+    });
   },
 
   _initViews: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-value-content-view.js
@@ -42,12 +42,12 @@ module.exports = CoreView.extend({
 
   _initBinds: function () {
     this.listenTo(this.model, 'change:quantification', function () {
-      if (this.model.get('quantification') !== 'category') {
-        this.model.unset('domain');
+      if (this.model.previous('quantification') === 'category') {
+        delete this.model.attributes.range;
       }
 
-      if (this.model.previous('quantification') === 'category') {
-        this.model.unset('range');
+      if (this.model.get('quantification') !== 'category') {
+        this.model.unset('domain');
       }
     });
   },
@@ -181,6 +181,7 @@ module.exports = CoreView.extend({
   _onChangeAttribute: function (columnName, stackLayoutModel) {
     var validCategoryTypes = ['string', 'boolean'];
     var attrsToUnset = ['image', 'fixed', 'quantification', 'opacity'];
+    var wasQuantificationCategory = this.model.get('quantification') === 'category';
 
     this._column = this._getColumn(columnName);
     this._columnType = this._column && this._column.type;
@@ -195,6 +196,12 @@ module.exports = CoreView.extend({
     } else if (this._columnType === 'number') {
       this.model.unset('images', { silent: true });
       this.model.unset('domain', { silent: true });
+
+      // Unset range if previous quantification was category
+      if (wasQuantificationCategory) {
+        this.model.unset('range', { silent: true });
+      }
+
       stackLayoutModel.goToStep(1);
     }
 

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories-list-view.spec.js
@@ -33,7 +33,7 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
     expect(this.view.$el.find('.js-listItem').length).toBe(3);
   });
 
-  it('should allow click on colors', function () {
+  it('should allow click on colors if color is valid', function () {
     spyOn(this.view, 'trigger');
 
     this.view.$('.js-color').eq(1).trigger('click');
@@ -41,5 +41,13 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
       index: 1,
       target: 'color'
     }, this.view);
+  });
+
+  it('should not allow click on colors if there is no colors', function () {
+    spyOn(this.view, 'trigger');
+
+    this.view._collection.reset([]); // No categories, reseted
+    this.view.$('.js-color').eq(1).trigger('click');
+    expect(this.view.trigger).not.toHaveBeenCalled();
   });
 });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/input-categories/input-color-categories.spec.js
@@ -57,8 +57,8 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
     expect(this.view.$('.js-listItem:eq(2)').text()).toContain('Three');
     expect(this.view.$('.RampItem-bar:eq(2)').css('background-color')).toBe('rgb(221, 28, 119)');
 
-    expect(this.view.$('.js-loader').hasClass('is-hidden')).toBeTruthy();
-    expect(this.view.$('.js-content').hasClass('is-hidden')).toBeFalsy();
+    expect(this.view.$('.js-loader').length).toBe(0);
+    expect(this.view.$('.InputColorCategory-content.js-content').length).toBe(1);
 
     expect(this.view.$('.js-label').text()).toBe('column1');
     expect(this.view.$('.js-back').length).toBe(1);
@@ -72,9 +72,11 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
   });
 
   it('should show the loader', function () {
-    spyOn(this.view, '_startLoader');
+    // Not providing any response, we will let the loader be showed forever
+    CDB.SQL.prototype.execute = function (query, vars, params) {};
     this.model.set('attribute', 'column2');
-    expect(this.view._startLoader).toHaveBeenCalled();
+    expect(this.view.$('.js-loader').length).toBe(1);
+    expect(this.view.$('.InputColorCategory-content.js-content').length).toBe(0);
   });
 
   describe('with booleans', function () {
@@ -161,8 +163,8 @@ describe('components/form-components/editors/fill/input-color/input-categories/i
       expect(this.view.$('.js-listItem:eq(10)').text()).toContain('form-components.editors.fill.input-categories.others');
       expect(this.view.$('.RampItem-bar:eq(10)').css('background-color')).toBe('rgb(220, 23, 33)');
 
-      expect(this.view.$('.js-loader').hasClass('is-hidden')).toBeTruthy();
-      expect(this.view.$('.js-content').hasClass('is-hidden')).toBeFalsy();
+      expect(this.view.$('.js-loader').length).toBe(0);
+      expect(this.view.$('.InputColorCategory-content.js-content').length).toBe(1);
 
       expect(this.view.$('.js-back').length).toBe(1);
     });


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/11736.

After the big revision of the fill component done [here](https://github.com/CartoDB/cartodb/pull/11638), we have realized that the possibility to use a number column with categories is not working properly since that change. So this PR tries to fix that problem.

Apart from that, we have improved the states of the `input-color-categories` using a `viewStatus` model, storing the status (loading | idle | error) and the step of the `stackLayoutModel`.

### STTest

- Add a points | lines | polygons layer into a new map.
- Style it by value, first with a number column. It should show the ramps list.
- Choose one and edit any color of it, it should work properly.
- Now go back to columns list and choose a string one.
- Edit the colors, add any icon/image (only if it is a points layer, remember). It should work properly.
- Now let's choose another number column, fill component should select automatically the first ramp color (not the category colors previously selected).
- Change the quantification, selects `category` one.
- Loader first and then colors list should appear (and map should be refreshed of course).
- Change any color of the list.
- Get back again to column list and choose a number type.
- Ramp list should be selected by default, no category colors selected.
- Edit your ramp colors, everything should work properly.
- Go back (the last one) to columns list and select another number column, the previous edited ramp should be selected (not the default one).