### PR TITLE
When quota API is not available, it should not required the quota infobox

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -121,6 +121,7 @@ Development
 * Fixed overflow on loaders.
 * JOIN Analysis Fails Without Error Message (#11184)
 * Fix problem with perfect-scrollbar in Edge browsers (CartoDB/perfect-scrollbar/#2)
+* Fix problem creating analyses without Data Services API (#11745)
 
 4.0.x (2016-12-05)
 ------------------

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -65,21 +65,26 @@ module.exports = CoreView.extend({
     this.clearSubViews();
     var type = this._formModel.get('type');
     var fetchingState = this._viewModel.get('userFetchModelState');
-    var requiresQuota;
+    // If no dataservice, requiresQuota returns false because the model doesn't exist and it's converted to boolean
+    var requiresQuota = AnalysesQuotaOptions.requiresQuota(type, this._quotaInfo);
     var html;
 
     if (this._isAnalysisDone() && !this._hasChanges()) {
       html = this._html();
     } else {
-      if (fetchingState === 'fetching' || fetchingState === 'error') {
-        html = this._createQuotaView();
-      } else if (fetchingState === 'fetched') {
-        // If no dataservice, requiresQuota returns false because the model doesn't exist and it's converted to boolean
-        requiresQuota = AnalysesQuotaOptions.requiresQuota(type, this._quotaInfo);
-        if (this._canSave() && requiresQuota) {
+      // If the analysis doesn't require quota, let's not wait or check the fetching state
+      if (!requiresQuota) {
+        html = this._html();
+      } else {
+        // If analysis requires quota info, we should wait for the quota info
+        if (fetchingState === 'fetching' || fetchingState === 'error') {
           html = this._createQuotaView();
-        } else {
-          html = this._html();
+        } else if (fetchingState === 'fetched') {
+          if (this._canSave() && requiresQuota) {
+            html = this._createQuotaView();
+          } else {
+            html = this._html();
+          }
         }
       }
     }

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -65,7 +65,6 @@ module.exports = CoreView.extend({
     this.clearSubViews();
     var type = this._formModel.get('type');
     var fetchingState = this._viewModel.get('userFetchModelState');
-    var apiReady = this._quotaInfo.isReady();
     var requiresQuota;
     var html;
 
@@ -77,7 +76,7 @@ module.exports = CoreView.extend({
       } else if (fetchingState === 'fetched') {
         // If no dataservice, requiresQuota returns false because the model doesn't exist and it's converted to boolean
         requiresQuota = AnalysesQuotaOptions.requiresQuota(type, this._quotaInfo);
-        if (this._canSave() && (requiresQuota || !apiReady)) {
+        if (this._canSave() && requiresQuota) {
           html = this._createQuotaView();
         } else {
           html = this._html();

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
@@ -5,6 +5,7 @@ var UserModel = require('../../../../../../../javascripts/cartodb3/data/user-mod
 var BaseAnalysisFormModel = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model');
 var AnalysisControlsView = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view');
 var analyses = require('../../../../../../../javascripts/cartodb3/data/analyses');
+var AnalysesQuotaOptions = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-options');
 var AnalysesQuotaInfo = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-info');
 var AnalysesQuotaEnough = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-enough');
 var AnalysesQuotaEstimation = require('../../../../../../../javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-estimation-input');
@@ -159,6 +160,30 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
 
     it('should have create label since it is not persisted yet', function () {
       expect(this.view.$('.js-save').html()).toContain('create');
+    });
+
+    it('should not render quota info in any case', function () {
+      spyOn(this.view, '_createQuotaView');
+      spyOn(this.view, '_html');
+      spyOn(AnalysesQuotaOptions, 'requiresQuota').and.returnValue(false);
+
+      spyOn(this.view, '_isAnalysisDone').and.returnValue(false);
+      spyOn(this.view, '_hasChanges').and.returnValue(true);
+      this.view.render();
+      expect(this.view._createQuotaView).not.toHaveBeenCalled();
+      expect(this.view._html).toHaveBeenCalled();
+
+      this.view._html.calls.reset();
+      this.view._viewModel.attributes.userFetchModelState = 'error';
+      this.view.render();
+      expect(this.view._createQuotaView).not.toHaveBeenCalled();
+      expect(this.view._html.calls.count()).toEqual(1);
+
+      this.view._html.calls.reset();
+      this.view._viewModel.attributes.userFetchModelState = 'fetching';
+      this.view.render();
+      expect(this.view._createQuotaView).not.toHaveBeenCalled();
+      expect(this.view._html.calls.count()).toEqual(1);
     });
 
     describe('when form is valid', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.27",
+  "version": "4.6.27-11745",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/11745.

It should only add the quota info if the form is valid and the analysis (to be added) requires the quota. It is likely I'm wrong, what do you think @nobuti?