### PR TITLE
Disable security header that causes issues with vizjson jsonp

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -368,6 +368,5 @@ class ApplicationController < ActionController::Base
   def set_security_headers
     headers['X-Frame-Options'] = 'DENY'
     headers['X-XSS-Protection'] = '1; mode=block'
-    headers['X-Content-Type-Options'] = 'nosniff'
   end
 end


### PR DESCRIPTION
Tested locally, 🔥 fix straight to production.