### PR TITLE
Adds https protocol to WMS Proxy URLs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,7 @@ Development
 * Update tangram-cartocss to use smooth point outline.
 
 ### Bug fixes
+* Adds https protocol to WMS Proxy URLs (#11786)
 * Fixed time widget loader (#11754),
 * Fixed problems related with IE11.
 * Fixed silent problem with jQuery selector (cartodb/deep-insights.js#527)

--- a/lib/assets/core/javascripts/cartodb3/data/wms-service.js
+++ b/lib/assets/core/javascripts/cartodb3/data/wms-service.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 
-var PROXY_URL = '//cartodb-wms.global.ssl.fastly.net/api';
-var PROXY_TILES = '//cartodb-wms.global.ssl.fastly.net/mapproxy';
+var PROXY_URL = 'https://cartodb-wms.global.ssl.fastly.net/api';
+var PROXY_TILES = 'https://cartodb-wms.global.ssl.fastly.net/mapproxy';
 var METHOD_TO_URL = {
   'read': '/check',
   'create': '/add'


### PR DESCRIPTION
This is part of https://github.com/CartoDB/cartodb/issues/11775 and https://github.com/CartoDB/cartodb.js/issues/1595. Basically, WMS layers generated by BUILDER are served via an internal proxy. We were not including the protocol when generating these URLS and Maps API was not rendering these layers correctly in the static images.

@matallo @rochoa 👍 or 👎 ?

cc: @xavijam 