### PR TITLE
GME users get all basemaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,7 @@ Development
 * Migrate to use GNIP v2 for twitter search connector (#10051, #11595)
 * Notifications API (WIP) (#11734)
 * Update tangram with smooth point outline.
+* GME users can change to any basemap #11785.
 * Improve affordance of layer item (#11359)
 * Update tangram-cartocss to use smooth point outline.
 

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -232,10 +232,10 @@ class Carto::User < ActiveRecord::Base
   # return the default basemap based on the default setting. If default attribute is not set, first basemaps is returned
   # it only takes into account basemaps enabled for that user
   def default_basemap
-    default = if google_maps_enabled? && basemaps['GMaps']
+    default = if google_maps_enabled? && basemaps['GMaps'].present?
                 ['GMaps', basemaps['GMaps']]
               else
-                basemaps.find { |group, group_basemaps | group_basemaps.find { |b, attr| attr['default'] } }
+                basemaps.find { |_, group_basemaps| group_basemaps.find { |_, attr| attr['default'] } }
               end
     default ||= basemaps.first
     # return only the attributes

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -226,13 +226,8 @@ class Carto::User < ActiveRecord::Base
   # this may have change in the future but in any case this method provides a way to abstract what
   # basemaps are active for the user
   def basemaps
-    basemaps = Cartodb.config[:basemaps]
-    if basemaps
-      basemaps.select { |group|
-        g = group == 'GMaps'
-        google_maps_enabled? ? g : !g
-      }
-    end
+    basemaps = Cartodb.config[:basemaps] || []
+    basemaps.select { |group| group != 'GMaps' || google_maps_enabled? }
   end
 
   def google_maps_enabled?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1474,13 +1474,8 @@ class User < Sequel::Model
   # this may have change in the future but in any case this method provides a way to abstract what
   # basemaps are active for the user
   def basemaps
-    basemaps = Cartodb.config[:basemaps]
-    if basemaps
-      basemaps.select { |group|
-        g = group == 'GMaps'
-        google_maps_enabled? ? g : !g
-      }
-    end
+    basemaps = Cartodb.config[:basemaps] || []
+    basemaps.select { |group| group != 'GMaps' || google_maps_enabled? }
   end
 
   def google_maps_enabled?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1468,21 +1468,9 @@ class User < Sequel::Model
     Rack::Utils.parse_nested_query(google_maps_query_string)['client'] if google_maps_query_string
   end
 
-  # returnd a list of basemaps enabled for the user
-  # when google map key is set it gets the basemaps inside the group "GMaps"
-  # if not it get everything else but GMaps in any case GMaps and other groups can work together
-  # this may have change in the future but in any case this method provides a way to abstract what
-  # basemaps are active for the user
+  # returns a list of basemaps enabled for the user
   def basemaps
-    sorted_basemaps = (Cartodb.config[:basemaps] || [])
-                        .select { |group| group != 'GMaps' || google_maps_enabled? }
-                        .sort { |a, b|
-      if a[0] == 'GMaps' then
-        -1
-      else
-        b[0] == 'GMaps' ? 1 : 0
-      end }
-    Hash[sorted_basemaps]
+    (Cartodb.config[:basemaps] || []).select { |group| group != 'GMaps' || google_maps_enabled? }
   end
 
   def google_maps_enabled?
@@ -1492,16 +1480,14 @@ class User < Sequel::Model
   # return the default basemap based on the default setting. If default attribute is not set, first basemaps is returned
   # it only takes into account basemaps enabled for that user
   def default_basemap
-    default = basemaps.find { |group, group_basemaps |
-      group_basemaps.find { |b, attr| attr['default'] }
-    }
-    if default.nil?
-      default = basemaps.first[1]
-    else
-      default = default[1]
-    end
+    default = if google_maps_enabled? && basemaps['GMaps']
+                ['GMaps', basemaps['GMaps']]
+              else
+                basemaps.find { |group, group_basemaps | group_basemaps.find { |b, attr| attr['default'] } }
+              end
+    default ||= basemaps.first
     # return only the attributes
-    default.first[1]
+    default[1].first[1]
   end
 
   def copy_account_features(to)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1474,8 +1474,15 @@ class User < Sequel::Model
   # this may have change in the future but in any case this method provides a way to abstract what
   # basemaps are active for the user
   def basemaps
-    basemaps = Cartodb.config[:basemaps] || []
-    basemaps.select { |group| group != 'GMaps' || google_maps_enabled? }
+    sorted_basemaps = (Cartodb.config[:basemaps] || [])
+                        .select { |group| group != 'GMaps' || google_maps_enabled? }
+                        .sort { |a, b|
+      if a[0] == 'GMaps' then
+        -1
+      else
+        b[0] == 'GMaps' ? 1 : 0
+      end }
+    Hash[sorted_basemaps]
   end
 
   def google_maps_enabled?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1480,10 +1480,10 @@ class User < Sequel::Model
   # return the default basemap based on the default setting. If default attribute is not set, first basemaps is returned
   # it only takes into account basemaps enabled for that user
   def default_basemap
-    default = if google_maps_enabled? && basemaps['GMaps']
+    default = if google_maps_enabled? && basemaps['GMaps'].present?
                 ['GMaps', basemaps['GMaps']]
               else
-                basemaps.find { |group, group_basemaps | group_basemaps.find { |b, attr| attr['default'] } }
+                basemaps.find { |_, group_basemaps| group_basemaps.find { |_, attr| attr['default'] } }
               end
     default ||= basemaps.first
     # return only the attributes

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -772,13 +772,28 @@ shared_examples_for "user models" do
   end
 
   describe '#basemaps' do
-    it 'shows all basemaps for google maps users' do
+    it 'shows all basemaps for Google Maps users' do
       user = create_user
-      user.basemaps.keys.sort.should eq ["CARTO", "Stamen"]
+      basemaps = user.basemaps
+      basemaps.keys.sort.should eq ['CARTO', 'Stamen']
+      basemaps.keys.first.should eq 'CARTO'
       user.google_maps_key = 'client=whatever'
       user.google_maps_private_key = 'wadus'
       user.save
-      user.basemaps.keys.sort.should eq ["CARTO", "GMaps", "Stamen"]
+      basemaps = user.basemaps
+      basemaps.keys.sort.should eq ['CARTO', 'GMaps', 'Stamen']
+      basemaps.keys.first.should eq 'GMaps'
+    end
+  end
+
+  describe '#default_basemap' do
+    it 'defaults to Google for Google Maps users, Positron for others' do
+      user = create_user
+      user.default_basemap['name'].should eq 'Positron'
+      user.google_maps_key = 'client=whatever'
+      user.google_maps_private_key = 'wadus'
+      user.save
+      user.default_basemap['name'].should eq 'GMaps Roadmap'
     end
   end
 end

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -770,4 +770,15 @@ shared_examples_for "user models" do
       @user1.batch_queries_statement_timeout.should eq 42
     end
   end
+
+  describe '#basemaps' do
+    it 'shows all basemaps for google maps users' do
+      user = create_user
+      user.basemaps.keys.sort.should eq ["CARTO", "Stamen"]
+      user.google_maps_key = 'client=whatever'
+      user.google_maps_private_key = 'wadus'
+      user.save
+      user.basemaps.keys.sort.should eq ["CARTO", "GMaps", "Stamen"]
+    end
+  end
 end

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -776,13 +776,11 @@ shared_examples_for "user models" do
       user = create_user
       basemaps = user.basemaps
       basemaps.keys.sort.should eq ['CARTO', 'Stamen']
-      basemaps.keys.first.should eq 'CARTO'
       user.google_maps_key = 'client=whatever'
       user.google_maps_private_key = 'wadus'
       user.save
       basemaps = user.basemaps
       basemaps.keys.sort.should eq ['CARTO', 'GMaps', 'Stamen']
-      basemaps.keys.first.should eq 'GMaps'
     end
   end
 


### PR DESCRIPTION
This closes #11785.

Acceptance:
- [x] Login with a free, normal user. Add a new map. Google basemaps shouldn't be offered. Positron is the default.
- [x] Add a Google Maps query string and Google Maps private key. Add a new map. You should be able to choose between CARTO, Stamen and Google basemaps. Google Roadmap is the default.