### PR TITLE
Use presenter for compatibility with both permission models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,7 @@ Development
 * Correctly ask for alternative username when signing up with Google/GitHub into an organization
 * Avoid loading all rake code in resque workers (#11069)
 * Fix analysis notification in running state (#11079)
+* Warn about affected maps on dataset deletion (regression, fixed in #11801)
 * Fix color for "Other" category (#11078)
 * Validate that only one legend per type (color/size) is allowed (#11556)
 * Enable more security HTTP headers (#11727)

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -117,9 +117,7 @@ class Table
     selected_attrs = options[:except].present? ?
       PUBLIC_ATTRIBUTES.select { |k, v| !options[:except].include?(k.to_sym) } : PUBLIC_ATTRIBUTES
 
-    attrs = Hash[selected_attrs.map{ |k, v|
-      [k, (self.send(v) rescue self[v].to_s)]
-    }]
+    attrs = Hash[selected_attrs.map { |k, v| [k, send(v)] }]
 
     if !viewer_user.nil? && !owner.nil? && owner.id != viewer_user.id
       attrs[:name] = "#{owner.sql_safe_database_schema}.#{attrs[:name]}"

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -117,7 +117,9 @@ class Table
     selected_attrs = options[:except].present? ?
       PUBLIC_ATTRIBUTES.select { |k, v| !options[:except].include?(k.to_sym) } : PUBLIC_ATTRIBUTES
 
-    attrs = Hash[selected_attrs.map { |k, v| [k, send(v)] }]
+    attrs = Hash[selected_attrs.map{ |k, v|
+      [k, (self.send(v) rescue self[v].to_s)]
+    }]
 
     if !viewer_user.nil? && !owner.nil? && owner.id != viewer_user.id
       attrs[:name] = "#{owner.sql_safe_database_schema}.#{attrs[:name]}"

--- a/app/models/table/relator.rb
+++ b/app/models/table/relator.rb
@@ -43,9 +43,9 @@ module CartoDB
         updated_at: object.updated_at
       }
       if object[:permission_id].present? && !object.permission.nil?
-        data[:permission] = object.permission.to_poro.select {|key, val|
+        data[:permission] = CartoDB::PermissionPresenter.new(object.permission).to_poro.select do |key, _val|
           [:id, :owner].include?(key)
-        }
+        end
       end
       data
     end


### PR DESCRIPTION
Fixes #11800 

This was introduced in https://github.com/CartoDB/cartodb/pull/11600/files (user table refactor, part 3). In this one, we changed how `::Table.user_table` works, so it could return `Carto::UserTable`. This was judged to be OK, as is only used for presenters.

However, this broke `TableRelator.preview_for` when called like `Carto::UserTable.service.public_values` since this uses the new models and that method is not compatible. Moreover:
- This method was only tested on `table_relator_spec` which makes heavy use of stubs.
- There is a `rescue all` that hides the issue: https://github.com/CartoDB/cartodb/blob/4a5715ad25f88dc15fedc85cd1f8b2649d52f5d0/app/models/table.rb#L121