### PR TITLE
Respect geometry_types when data from table visualization is parsed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -135,6 +135,7 @@ Development
 * Fixed overflow on loaders.
 * JOIN Analysis Fails Without Error Message (#11184)
 * Fix problem with perfect-scrollbar in Edge browsers (CartoDB/perfect-scrollbar/#2)
+* Correctly autostyle layers based on geometry when adding layers from modal (#11813)
 * Fix problem creating analyses without Data Services API (#11745)
 * Fix problem when number column is used like categories in fill component (#11736)
 

--- a/lib/assets/core/javascripts/cartodb3/data/table-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/table-model.js
@@ -38,7 +38,13 @@ module.exports = Backbone.Model.extend({
     // attribute, because it returns the canonical visualization data. So we have to take
     // the data from there.
     if (r.table_visualization && !_.isEmpty(r.table_visualization)) {
-      r = r.table_visualization;
+      r = _.extend(
+        {},
+        r.table_visualization,
+        {
+          geometry_types: r.geometry_types
+        }
+      );
     }
 
     if (r.synchronization) {

--- a/lib/assets/core/test/spec/cartodb3/data/table-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/table-model.spec.js
@@ -56,22 +56,27 @@ describe('data/table-model', function () {
   });
 
   describe('.parse', function () {
-    it('should take table_visualization attributes from response if they exist', function () {
+    it('should take table_visualization attributes from response if they exist, not removing or overwritting geometry_types', function () {
       var parseAttrs = this.model.parse({
         id: 'bad',
+        geometry_types: ['ST_POLYGON'],
         table_visualization: {
-          id: 'good'
+          id: 'good',
+          geometry_types: ['pepito']
         }
       });
 
       expect(parseAttrs.id).toBe('good');
+      expect(parseAttrs.geometry_types).toEqual(['ST_POLYGON']);
 
       parseAttrs = this.model.parse({
         id: 'new_good',
+        geometry_types: ['ST_POINT'],
         table_visualization: {}
       });
 
       expect(parseAttrs.id).toBe('new_good');
+      expect(parseAttrs.geometry_types).toEqual(['ST_POINT']);
     });
 
     describe('synchronization', function () {


### PR DESCRIPTION
Related ticket: #11799 

Basically, when table model is fetched, we take data from `table_visualization` attribute but we got rid of `geometry_types` and it made failed this part of code where we decide which styles should be included for the new added layer.

## STT
- Create a map with any layer.
- **Import** a layer of polygons/lines.
- Check that the style tab is reflecting the same colors than in the map.