### PR TITLE
Update users in Gears API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -107,6 +107,7 @@ Development
 * Do not trigger visualization hooks on state update (#11701)
 * Refactor Layer model (#10934)
 * Correctly register table dependencies of torque layers (#11549)
+* Validate number of organization seats in user update (#11839)
 * Fix bugs where legends where being hidden by reordering layers (#11088)
 * Correctly ask for alternative username when signing up with Google/GitHub into an organization
 * Avoid loading all rake code in resque workers (#11069)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -78,26 +78,21 @@ class Organization < Sequel::Model
     end
   end
 
-  def validate_new_user(user, errors)
-    if !whitelisted_email_domains.nil? and !whitelisted_email_domains.empty?
-      email_domain = user.email.split('@')[1]
-      unless whitelisted_email_domains.include?(email_domain) || user.invitation_token.present?
-        errors.add(:email, "Email domain '#{email_domain}' not valid for #{name} organization")
-      end
+  def validate_for_signup(errors, user)
+    validate_seats(user, errors)
+
+    if !valid_disk_quota?(user.quota_in_bytes.to_i)
+      errors.add(:quota_in_bytes, "not enough disk quota")
     end
   end
 
-  def validate_for_signup(errors, user)
+  def validate_seats(user, errors)
     if user.builder? && !valid_builder_seats?([user])
       errors.add(:organization, "not enough seats")
     end
 
     if user.viewer? && remaining_viewer_seats(excluded_users: [user]) <= 0
       errors.add(:organization, "not enough viewer seats")
-    end
-
-    if !valid_disk_quota?(user.quota_in_bytes.to_i)
-      errors.add(:quota_in_bytes, "not enough disk quota")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -152,11 +152,21 @@ class User < Sequel::Model
   def organization_validation
     if new?
       organization.validate_for_signup(errors, self)
-      organization.validate_new_user(self, errors)
-    elsif quota_in_bytes.to_i + organization.assigned_quota - initial_value(:quota_in_bytes) > organization.quota_in_bytes
-      # Organization#assigned_quota includes the OLD quota for this user,
-      # so we have to ammend that in the calculation:
-      errors.add(:quota_in_bytes, "not enough disk quota")
+    else
+      if quota_in_bytes.to_i + organization.assigned_quota - initial_value(:quota_in_bytes) > organization.quota_in_bytes
+        # Organization#assigned_quota includes the OLD quota for this user,
+        # so we have to ammend that in the calculation:
+        errors.add(:quota_in_bytes, "not enough disk quota")
+      end
+
+      organization.validate_seats(self, errors)
+    end
+
+    if organization.whitelisted_email_domains.present?
+      email_domain = email.split('@')[1]
+      unless organization.whitelisted_email_domains.include?(email_domain) || invitation_token.present?
+        errors.add(:email, "Email domain '#{email_domain}' not valid for #{organization.name} organization")
+      end
     end
   end
 

--- a/gears/carto_gears_api/lib/carto_gears_api/errors.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/errors.rb
@@ -1,0 +1,21 @@
+module CartoGearsApi
+  module Errors
+    # Thrown when an object could not be found in the database
+    class RecordNotFound < StandardError
+      def initialize(object)
+        super("Could not find #{object.class.name.split('::').last} with id #{object.id}")
+      end
+    end
+
+    # Thrown when trying to set invalid values for an object
+    class ValidationFailed < StandardError
+      # @return [Hash<String, Array<String>>] A hash with incorrect attributes as keys and array of messages as values
+      attr_reader :errors
+
+      def initialize(errors)
+        super(errors)
+        @errors = errors
+      end
+    end
+  end
+end

--- a/gears/carto_gears_api/lib/carto_gears_api/errors.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/errors.rb
@@ -2,8 +2,8 @@ module CartoGearsApi
   module Errors
     # Thrown when an object could not be found in the database
     class RecordNotFound < StandardError
-      def initialize(object)
-        super("Could not find #{object.class.name.split('::').last} with id #{object.id}")
+      def initialize(object, id)
+        super("Could not find #{object} with id #{id}")
       end
     end
 

--- a/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
@@ -10,9 +10,15 @@ module CartoGearsApi
     # @attr_reader [String] email Email
     # @attr_reader [Integer] quota_in_bytes Disk quota in bytes
     # @attr_reader [Boolean] viewer The user is a viewer (cannot create maps, datasets, etc.)
+    # @attr_reader [Boolean] soft_geocoding_limit User can exceed geocoding limit (billable)
+    # @attr_reader [Boolean] soft_twitter_datasource_limit User can exceed twitter limit (billable)
+    # @attr_reader [Boolean] soft_here_isolines_limit User can exceed HERE geocoder limit (billable)
+    # @attr_reader [Boolean] soft_obs_snapshot_limit User can exceed Data Observatory limit (billable)
+    # @attr_reader [Boolean] soft_obs_general_limit User can exceed Data Observatory limit (billable)
     # @attr_reader [CartoGearsApi::Organizations::Organization] organization Organization
     class User < Value.new(:id, :username, :email, :organization, :feature_flags, :can_change_email, :quota_in_bytes,
-                           :viewer)
+                           :viewer, :soft_geocoding_limit, :soft_twitter_datasource_limit, :soft_here_isolines_limit,
+                           :soft_obs_snapshot_limit, :soft_obs_general_limit)
       extend ActiveModel::Naming
       include ActiveRecord::AttributeMethods::PrimaryKey
 

--- a/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
@@ -10,15 +10,9 @@ module CartoGearsApi
     # @attr_reader [String] email Email
     # @attr_reader [Integer] quota_in_bytes Disk quota in bytes
     # @attr_reader [Boolean] viewer The user is a viewer (cannot create maps, datasets, etc.)
-    # @attr_reader [Boolean] soft_geocoding_limit User can exceed geocoding limit (billable)
-    # @attr_reader [Boolean] soft_twitter_datasource_limit User can exceed twitter limit (billable)
-    # @attr_reader [Boolean] soft_here_isolines_limit User can exceed HERE geocoder limit (billable)
-    # @attr_reader [Boolean] soft_obs_snapshot_limit User can exceed Data Observatory limit (billable)
-    # @attr_reader [Boolean] soft_obs_general_limit User can exceed Data Observatory limit (billable)
     # @attr_reader [CartoGearsApi::Organizations::Organization] organization Organization
     class User < Value.new(:id, :username, :email, :organization, :feature_flags, :can_change_email, :quota_in_bytes,
-                           :viewer, :soft_geocoding_limit, :soft_twitter_datasource_limit, :soft_here_isolines_limit,
-                           :soft_obs_snapshot_limit, :soft_obs_general_limit)
+                           :viewer)
       extend ActiveModel::Naming
       include ActiveRecord::AttributeMethods::PrimaryKey
 

--- a/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
@@ -8,8 +8,11 @@ module CartoGearsApi
     # @attr_reader [String] id User id
     # @attr_reader [String] username User name
     # @attr_reader [String] email Email
+    # @attr_reader [Integer] quota_in_bytes Disk quota in bytes
+    # @attr_reader [Boolean] viewer The user is a viewer (cannot create maps, datasets, etc.)
     # @attr_reader [CartoGearsApi::Organizations::Organization] organization Organization
-    class User < Value.new(:id, :username, :email, :organization, :feature_flags, :can_change_email)
+    class User < Value.new(:id, :username, :email, :organization, :feature_flags, :can_change_email, :quota_in_bytes,
+                           :viewer)
       extend ActiveModel::Naming
       include ActiveRecord::AttributeMethods::PrimaryKey
 

--- a/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
@@ -37,6 +37,13 @@ module CartoGearsApi
 
         user.viewer = false
         user.quota_in_bytes = quota_in_bytes || user.organization.default_quota_in_bytes
+        user.soft_geocoding_limit = user.organization.owner.soft_geocoding_limit
+        user.soft_here_isolines_limit = user.organization.owner.soft_here_isolines_limit
+        user.soft_obs_snapshot_limit = user.organization.owner.soft_obs_snapshot_limit
+        user.soft_obs_general_limit = user.organization.owner.soft_obs_general_limit
+        user.soft_twitter_datasource_limit = user.organization.owner.soft_twitter_datasource_limit
+        user.soft_mapzen_routing_limit = user.organization.owner.soft_mapzen_routing_limit
+
         raise CartoGearsApi::Errors::ValidationFailed.new(user.errors) unless user.save
       end
 

--- a/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
@@ -10,13 +10,15 @@ module CartoGearsApi
       # @param request [ActionDispatch::Request] CARTO request, as received in any controller.
       # @return [User] the user.
       def logged_user(request)
-        user(request.env['warden'].user(CartoDB.extract_subdomain(request)))
+        gears_user(request.env['warden'].user(CartoDB.extract_subdomain(request)))
       end
 
       # Converts an user to a viewer, without editing rights.
       # It also sets all quotas to 0
       #
       # @param user_id [UUID] the user id
+      # @return [User] the updated user
+      #
       # @raise [Errors::RecordNotFound] if the user could not be found in the database
       # @raise [Errors::ValidationFailed] if the validation failed
       def make_viewer(user_id)
@@ -25,12 +27,16 @@ module CartoGearsApi
         user.viewer = true
         raise CartoGearsApi::Errors::ValidationFailed.new(user.errors) unless user.save
         user.update_in_central
+
+        gears_user(user)
       end
 
       # Converts an user to a builder, with full editing rights.
       #
       # @param user_id [UUID] the user id
       # @param quota_in_bytes [Integer] quota for the user. It defaults to the organization default quota
+      # @return [User] the updated user
+      #
       # @raise [Errors::RecordNotFound] if the user could not be found in the database
       # @raise [Errors::ValidationFailed] if the validation failed
       def make_builder(user_id, quota_in_bytes: nil)
@@ -47,16 +53,18 @@ module CartoGearsApi
 
         raise CartoGearsApi::Errors::ValidationFailed.new(user.errors) unless user.save
         user.update_in_central
+
+        gears_user(user)
       end
 
       private
 
-      def user(user)
+      def gears_user(user)
         CartoGearsApi::Users::User.with(
           id: user.id,
           username: user.username,
           email: user.email,
-          organization: user.organization ? organization(user.organization) : nil,
+          organization: user.organization ? gears_organization(user.organization) : nil,
           feature_flags: user.feature_flags,
           can_change_email: user.can_change_email?,
           quota_in_bytes: user.quota_in_bytes,
@@ -64,7 +72,7 @@ module CartoGearsApi
         )
       end
 
-      def organization(organization)
+      def gears_organization(organization)
         CartoGearsApi::Organizations::Organization.with(name: organization.name)
       end
 

--- a/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
@@ -24,6 +24,7 @@ module CartoGearsApi
 
         user.viewer = true
         raise CartoGearsApi::Errors::ValidationFailed.new(user.errors) unless user.save
+        user.update_in_central
       end
 
       # Converts an user to a builder, with full editing rights.
@@ -45,6 +46,7 @@ module CartoGearsApi
         user.soft_mapzen_routing_limit = user.organization.owner.soft_mapzen_routing_limit
 
         raise CartoGearsApi::Errors::ValidationFailed.new(user.errors) unless user.save
+        user.update_in_central
       end
 
       private

--- a/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
@@ -15,7 +15,7 @@ module CartoGearsApi
 
       # Updates the values of a user.
       #
-      # Only the following values can be updated: +quota_in_bytes+, +viewer+
+      # Only the following values can be updated: +quota_in_bytes+, +viewer+, +soft_*_limit+
       # @note Setting +viewer = true+ resets all quotas to 0
       #
       # @param user [User] the user with updated values
@@ -32,6 +32,11 @@ module CartoGearsApi
 
         db_user.viewer = updated_user.viewer
         db_user.quota_in_bytes = updated_user.quota_in_bytes
+        db_user.soft_geocoding_limit = updated_user.soft_geocoding_limit
+        db_user.soft_twitter_datasource_limit = updated_user.soft_twitter_datasource_limit
+        db_user.soft_here_isolines_limit = updated_user.soft_here_isolines_limit
+        db_user.soft_obs_snapshot_limit = updated_user.soft_obs_snapshot_limit
+        db_user.soft_obs_general_limit = updated_user.soft_obs_general_limit
 
         raise CartoGearsApi::Errors::ValidationFailed.new(db_user.errors) unless db_user.save
         user(db_user)
@@ -48,7 +53,12 @@ module CartoGearsApi
           feature_flags: user.feature_flags,
           can_change_email: user.can_change_email?,
           quota_in_bytes: user.quota_in_bytes,
-          viewer: user.viewer
+          viewer: user.viewer,
+          soft_geocoding_limit: user.soft_geocoding_limit,
+          soft_twitter_datasource_limit: user.soft_twitter_datasource_limit,
+          soft_here_isolines_limit: user.soft_here_isolines_limit,
+          soft_obs_snapshot_limit: user.soft_obs_snapshot_limit,
+          soft_obs_general_limit: user.soft_obs_general_limit
         )
       end
 

--- a/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
@@ -60,9 +60,9 @@ module CartoGearsApi
       end
 
       def find_user(user_id)
-        db_user = ::User.find(id: updated_user.id)
-        raise CartoGearsApi::Errors::RecordNotFound.new(updated_user) unless db_user
-        db_user
+        user = ::User.find(id: user_id)
+        raise CartoGearsApi::Errors::RecordNotFound.new('User', user_id) unless user
+        user
       end
     end
   end

--- a/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
@@ -38,6 +38,7 @@ module CartoGearsApi
         db_user.soft_obs_snapshot_limit = updated_user.soft_obs_snapshot_limit
         db_user.soft_obs_general_limit = updated_user.soft_obs_general_limit
 
+        db_user.update_in_central
         raise CartoGearsApi::Errors::ValidationFailed.new(db_user.errors) unless db_user.save
         user(db_user)
       end

--- a/gears/carto_gears_api/spec/carto_gears_api/users_service_spec.rb
+++ b/gears/carto_gears_api/spec/carto_gears_api/users_service_spec.rb
@@ -11,14 +11,20 @@ describe CartoGearsApi::Users::UsersService do
     # within Gears and should not be used as an example.
     it 'returns the logged user based on subdomain and warden' do
       user = CartoGearsApi::Users::User.with(
-                                         id: 'b51e56fb-f3c9-463f-b950-d9be188551e5',
-                                         username: 'wadus_username',
-                                         email: 'wadus@carto.com',
-                                         organization: nil,
-                                         feature_flags: [],
-                                         can_change_email: true,
-                                         quota_in_bytes: 100000,
-                                         viewer: false)
+        id: 'b51e56fb-f3c9-463f-b950-d9be188551e5',
+        username: 'wadus_username',
+        email: 'wadus@carto.com',
+        organization: nil,
+        feature_flags: [],
+        can_change_email: true,
+        quota_in_bytes: 100000,
+        viewer: false,
+        soft_geocoding_limit: false,
+        soft_twitter_datasource_limit: false,
+        soft_here_isolines_limit: false,
+        soft_obs_snapshot_limit: false,
+        soft_obs_general_limit: false
+      )
       warden = double
       warden.should_receive(:user).once.and_return(user)
       request = double

--- a/gears/carto_gears_api/spec/carto_gears_api/users_service_spec.rb
+++ b/gears/carto_gears_api/spec/carto_gears_api/users_service_spec.rb
@@ -16,7 +16,9 @@ describe CartoGearsApi::Users::UsersService do
                                          email: 'wadus@carto.com',
                                          organization: nil,
                                          feature_flags: [],
-                                         can_change_email: true)
+                                         can_change_email: true,
+                                         quota_in_bytes: 100000,
+                                         viewer: false)
       warden = double
       warden.should_receive(:user).once.and_return(user)
       request = double

--- a/gears/carto_gears_api/spec/carto_gears_api/users_service_spec.rb
+++ b/gears/carto_gears_api/spec/carto_gears_api/users_service_spec.rb
@@ -18,12 +18,7 @@ describe CartoGearsApi::Users::UsersService do
         feature_flags: [],
         can_change_email: true,
         quota_in_bytes: 100000,
-        viewer: false,
-        soft_geocoding_limit: false,
-        soft_twitter_datasource_limit: false,
-        soft_here_isolines_limit: false,
-        soft_obs_snapshot_limit: false,
-        soft_obs_general_limit: false
+        viewer: false
       )
       warden = double
       warden.should_receive(:user).once.and_return(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -81,8 +81,8 @@ describe User do
   end
 
   it "should not allow a username in use by an organization" do
-    create_org('testusername', 10.megabytes, 1)
-    @user.username = 'testusername'
+    org = create_org('testusername', 10.megabytes, 1)
+    @user.username = org.name
     @user.valid?.should be_false
     @user.username = 'wadus'
     @user.valid?.should be_true


### PR DESCRIPTION
Closes #11835 

Aside from the new API, I fix the validations on the user model so they apply to updates as well. Before this, the viewer/builder seats validations was only enforced by backend on user creation, not update. It was blocked in UI, but not in API's / backend.

Acceptance:
- [x] User signup works.
- [x] Create an organization with 3 builder seats and 1 viewer seats. Create one builder and one viewer in the owner interface. It should work.
- [x] Try to create a new viewer. It shouldn't work.
- [ ] Try to convert a user from builder to viewer. It shouldn't work.
- [x] For that organization, set a whitelist email domain.
- [x] Try to signup within that organization with a non-whitelisted domain. It should fail.
- [x] Try to signup with a whitelisted domain. It should work.
- [x] Try to signup again. Page should say that you can't (because there are no builder seats available).