### PR TITLE
Skip cache invalidation on remote table cleanup task

### DIFF
--- a/lib/tasks/remote_tables_maintenance.rake
+++ b/lib/tasks/remote_tables_maintenance.rake
@@ -131,8 +131,8 @@ namespace :cartodb do
               next
             end
 
-            v.external_source.destroy
-            v.destroy
+            v.external_source.delete
+            v.delete
           rescue => e
             puts "  Error deleting visualization #{v.id}: #{e.message}"
           end


### PR DESCRIPTION
@juanignaciosl 

Tested in my production account. From 2:25 to 3s.