### PR TITLE
11850 gears notification api

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@ Development
   * Sets the default initial size for icons to 20px (#11498)
 * Onboarding for layer edition (#10905)
 * Initial support for Rails engines with CARTO Gears.
+  * Notification API (#11850)
 * Improved empty bounds map handling (#11711).
 * Updated diagnosis page versions.
 * Improved formula widget description field. (#11469)

--- a/app/models/carto/notification.rb
+++ b/app/models/carto/notification.rb
@@ -7,6 +7,7 @@ module Carto
   class Notification < ActiveRecord::Base
     MAX_BODY_LENGTH = 140
 
+    # Update CartoGearsAPI::Notifications::Notification when adding constants here
     ICON_WARNING = 'warning'.freeze
     ICON_SUCCESS = 'success'.freeze
     ICONS = [ICON_SUCCESS, ICON_WARNING].freeze

--- a/app/models/carto/notification.rb
+++ b/app/models/carto/notification.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require_dependency 'carto/notifications_markdown_renderer'
+require_dependency 'carto_gears_api/organizations/organization'
 
 module Carto
   class Notification < ActiveRecord::Base

--- a/app/models/carto/notification.rb
+++ b/app/models/carto/notification.rb
@@ -8,11 +8,12 @@ module Carto
 
     ICON_WARNING = 'warning'.freeze
     ICON_SUCCESS = 'success'.freeze
+    ICONS = [ICON_SUCCESS, ICON_WARNING].freeze
 
     belongs_to :organization, inverse_of: :notifications
     has_many :received_notifications, inverse_of: :notification
 
-    validates :icon, presence: true, inclusion: { in: [ICON_WARNING, ICON_SUCCESS] }
+    validates :icon, presence: true, inclusion: { in: ICONS }
     validates :recipients, inclusion: { in: [nil, 'builders', 'viewers', 'all'] }
     validates :recipients, presence: true, if: :organization
     validates :body, presence: true

--- a/app/models/carto/notification.rb
+++ b/app/models/carto/notification.rb
@@ -6,11 +6,13 @@ module Carto
   class Notification < ActiveRecord::Base
     MAX_BODY_LENGTH = 140
 
+    ICON_WARNING = 'warning'.freeze
+    ICON_SUCCESS = 'success'.freeze
+
     belongs_to :organization, inverse_of: :notifications
     has_many :received_notifications, inverse_of: :notification
 
-    # TODO: `icon` should be a restricted list of values
-    validates :icon, presence: true
+    validates :icon, presence: true, inclusion: { in: [ICON_WARNING, ICON_SUCCESS] }
     validates :recipients, inclusion: { in: [nil, 'builders', 'viewers', 'all'] }
     validates :recipients, presence: true, if: :organization
     validates :body, presence: true

--- a/app/models/carto/notification.rb
+++ b/app/models/carto/notification.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require_dependency 'carto/notifications_markdown_renderer'
-require_dependency 'carto_gears_api/organizations/organization'
 
 module Carto
   class Notification < ActiveRecord::Base

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -8,7 +8,7 @@ module CartoGearsApi
     # @attr_reader [String] icon name of the icon shown next to the notification
     # @attr_reader [String] body text of the notification, markdown formatted
     # @attr_reader [Organization] organization organization if this is an org-notification, +nil+ otherwise
-    # @attr_reader [String] recipients +builders+, +viewers+, +all+ if this is an org-notification, nil otherwise
+    # @attr_reader [String] recipients +builders+, +viewers+ or +all+ if this is an org-notification, nil otherwise
     # @attr_reader [DateTime] created_at date this notification was created at
     class Notification < Value.new(:id, :icon, :body, :organization, :recipients, :created_at)
 

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -11,7 +11,9 @@ module CartoGearsApi
     # @attr_reader [String] recipients +builders+, +viewers+ or +all+ if this is an org-notification, nil otherwise
     # @attr_reader [DateTime] created_at date this notification was created at
     class Notification < Value.new(:id, :icon, :body, :organization, :recipients, :created_at)
-      # List of possible icon values
+      ICON_WARNING = Carto::Notification::ICON_WARNING
+      ICON_SUCCESS = Carto::Notification::ICON_SUCCESS
+      # List of possible icons
       ICONS = Carto::Notification::ICONS
 
       # @api private

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -14,8 +14,6 @@ module CartoGearsApi
     class Notification < Value.new(:id, :icon, :body, :organization, :recipients, :created_at)
       ICON_WARNING = Carto::Notification::ICON_WARNING
       ICON_SUCCESS = Carto::Notification::ICON_SUCCESS
-      # List of possible icons
-      ICONS = Carto::Notification::ICONS
 
       # @api private
       def self.from_model(notification)

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -11,6 +11,18 @@ module CartoGearsApi
     # @attr_reader [String] recipients +builders+, +viewers+, +all+ if this is an org-notification, nil otherwise
     # @attr_reader [DateTime] created_at date this notification was created at
     class Notification < Value.new(:id, :icon, :body, :organization, :recipients, :created_at)
+
+      # @api private
+      def self.from_model(notification)
+        CartoGearsApi::Notifications::Notification.with(
+          id: notification.id,
+          body: notification.body,
+          icon: notification.icon,
+          organization: notification.organization,
+          recipients: notification.recipients,
+          created_at: notification.created_at
+        )
+      end
     end
   end
 end

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -18,7 +18,7 @@ module CartoGearsApi
           id: notification.id,
           body: notification.body,
           icon: notification.icon,
-          organization: notification.organization,
+          organization: CartoGearsApi::Organizations::Organization.from_model(notification.organization),
           recipients: notification.recipients,
           created_at: notification.created_at
         )

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -1,4 +1,5 @@
 require 'values'
+require_dependency 'carto_gears_api/organizations/organization'
 
 module CartoGearsApi
   module Notifications

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -1,0 +1,16 @@
+require 'values'
+
+module CartoGearsApi
+  module Notifications
+    # Notification information.
+    #
+    # @attr_reader [String] id notification id
+    # @attr_reader [String] icon name of the icon shown next to the notification
+    # @attr_reader [String] body text of the notification, markdown formatted
+    # @attr_reader [Organization] organization organization if this is an org-notification, +nil+ otherwise
+    # @attr_reader [String] recipients +builders+, +viewers+, +all+ if this is an org-notification, nil otherwise
+    # @attr_reader [DateTime] created_at date this notification was created at
+    class Notification < Value.new(:id, :icon, :body, :organization, :recipients, :created_at)
+    end
+  end
+end

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -11,6 +11,8 @@ module CartoGearsApi
     # @attr_reader [String] recipients +builders+, +viewers+ or +all+ if this is an org-notification, nil otherwise
     # @attr_reader [DateTime] created_at date this notification was created at
     class Notification < Value.new(:id, :icon, :body, :organization, :recipients, :created_at)
+      # List of possible icon values
+      ICONS = Carto::Notification::ICONS
 
       # @api private
       def self.from_model(notification)

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notification.rb
@@ -20,7 +20,7 @@ module CartoGearsApi
           id: notification.id,
           body: notification.body,
           icon: notification.icon,
-          organization: CartoGearsApi::Organizations::Organization.from_model(notification.organization),
+          organization: notification.organization && Organizations::Organization.from_model(notification.organization),
           recipients: notification.recipients,
           created_at: notification.created_at
         )

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
@@ -1,0 +1,49 @@
+require_dependency 'carto_gears_api/notifications/notification'
+require_dependency 'carto_gears_api/errors'
+
+module CartoGearsApi
+  module Notifications
+    class NotificationsService
+      # Creates a new notification. Does not send it to any user.
+      # @see send_notification
+      #
+      # @param [String] body markdown body of the notification
+      # @param [String] icon name of the icon (defaults to success)
+      # @return [Notification] the created notification
+      # @raise ValidationFailed if there were some invalid parameters
+      def create_notification(body:, icon: Carto::Notification::ICON_SUCCESS)
+        gears_notification(Carto::Notification.create!(body: body, icon: icon))
+      rescue ActiveRecord::RecordInvalid => e
+        raise Errors::ValidationFailed.new(e.record.errors.messages)
+      end
+
+      # Send a notification to a user
+      #
+      # @param [String] notification_id
+      # @param [String] user_id
+      # @raise RecordNotFound if the user or notification does not exist in the database
+      def send_notification(notification_id, user_id)
+        notification = Carto::Notification.where(id: notification_id).first
+        raise Errors::RecordNotFound.new('Notification', notification_id) unless notification
+        user = Carto::User.where(id: user_id).first
+        raise Errors::RecordNotFound.new('User', user_id) unless user
+
+        user.received_notifications.create!(notification: notification, received_at: DateTime.now)
+        nil
+      end
+
+      private
+
+      def gears_notification(notification)
+        Notification.with(
+          id: notification.id,
+          body: notification.body,
+          icon: notification.icon,
+          organization: notification.organization,
+          recipients: notification.recipients,
+          created_at: notification.created_at
+        )
+      end
+    end
+  end
+end

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
@@ -12,7 +12,7 @@ module CartoGearsApi
       # @return [Notification] the created notification
       # @raise ValidationFailed if there were some invalid parameters
       def create_notification(body:, icon: Carto::Notification::ICON_SUCCESS)
-        gears_notification(Carto::Notification.create!(body: body, icon: icon))
+        CartoGearsApi::Notifications::Notification.from_model(Carto::Notification.create!(body: body, icon: icon))
       rescue ActiveRecord::RecordInvalid => e
         raise Errors::ValidationFailed.new(e.record.errors.messages)
       end
@@ -30,19 +30,6 @@ module CartoGearsApi
 
         user.received_notifications.create!(notification: notification, received_at: DateTime.now)
         nil
-      end
-
-      private
-
-      def gears_notification(notification)
-        Notification.with(
-          id: notification.id,
-          body: notification.body,
-          icon: notification.icon,
-          organization: notification.organization,
-          recipients: notification.recipients,
-          created_at: notification.created_at
-        )
       end
     end
   end

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
@@ -8,10 +8,10 @@ module CartoGearsApi
       # @see send_notification
       #
       # @param [String] body markdown body of the notification
-      # @param [String] icon name of the icon (defaults to +success+)
+      # @param [String] icon name of the icon (defaults to a generic notification icon)
       # @return [Notification] the created notification
       # @raise [Errors::ValidationFailed] if there were some invalid parameters
-      def create_notification(body:, icon: Carto::Notification::ICON_SUCCESS)
+      def create_notification(body:, icon: Notification::ICONS[0])
         CartoGearsApi::Notifications::Notification.from_model(Carto::Notification.create!(body: body, icon: icon))
       rescue ActiveRecord::RecordInvalid => e
         raise Errors::ValidationFailed.new(e.record.errors.messages)

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
@@ -11,7 +11,7 @@ module CartoGearsApi
       # @param [String] icon name of the icon (defaults to a generic notification icon)
       # @return [Notification] the created notification
       # @raise [Errors::ValidationFailed] if there were some invalid parameters
-      def create_notification(body:, icon: Notification::ICONS[0])
+      def create_notification(body:, icon: Notification::ICON_SUCCESS)
         CartoGearsApi::Notifications::Notification.from_model(Carto::Notification.create!(body: body, icon: icon))
       rescue ActiveRecord::RecordInvalid => e
         raise Errors::ValidationFailed.new(e.record.errors.messages)

--- a/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/notifications/notifications_service.rb
@@ -8,9 +8,9 @@ module CartoGearsApi
       # @see send_notification
       #
       # @param [String] body markdown body of the notification
-      # @param [String] icon name of the icon (defaults to success)
+      # @param [String] icon name of the icon (defaults to +success+)
       # @return [Notification] the created notification
-      # @raise ValidationFailed if there were some invalid parameters
+      # @raise [Errors::ValidationFailed] if there were some invalid parameters
       def create_notification(body:, icon: Carto::Notification::ICON_SUCCESS)
         CartoGearsApi::Notifications::Notification.from_model(Carto::Notification.create!(body: body, icon: icon))
       rescue ActiveRecord::RecordInvalid => e
@@ -21,7 +21,7 @@ module CartoGearsApi
       #
       # @param [String] notification_id
       # @param [String] user_id
-      # @raise RecordNotFound if the user or notification does not exist in the database
+      # @raise [Errors::RecordNotFound] if the user or notification does not exist in the database
       def send_notification(notification_id, user_id)
         notification = Carto::Notification.where(id: notification_id).first
         raise Errors::RecordNotFound.new('Notification', notification_id) unless notification

--- a/gears/carto_gears_api/lib/carto_gears_api/organizations/organization.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/organizations/organization.rb
@@ -6,6 +6,13 @@ module CartoGearsApi
     #
     # @attr_reader [String] name Organization name.
     class Organization < Value.new(:name)
+
+      # @api private
+      def self.from_model(organization)
+        CartoGearsApi::Organizations::Organization.with(
+          name: organization.name
+        )
+      end
     end
   end
 end

--- a/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
@@ -39,6 +39,20 @@ module CartoGearsApi
       def can_change_email?
         @can_change_email
       end
+
+      # @api private
+      def self.from_model(user)
+        CartoGearsApi::Users::User.with(
+          id: user.id,
+          username: user.username,
+          email: user.email,
+          organization: user.organization && CartoGearsApi::Organizations::Organization.from_model(user.organization),
+          feature_flags: user.feature_flags,
+          can_change_email: user.can_change_email?,
+          quota_in_bytes: user.quota_in_bytes,
+          viewer: user.viewer
+        )
+      end
     end
   end
 end

--- a/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/user.rb
@@ -1,5 +1,6 @@
 require 'values'
 require 'active_record'
+require_dependency 'carto_gears_api/organizations/organization'
 
 module CartoGearsApi
   module Users

--- a/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
@@ -10,7 +10,7 @@ module CartoGearsApi
       # @param request [ActionDispatch::Request] CARTO request, as received in any controller.
       # @return [User] the user.
       def logged_user(request)
-        gears_user(request.env['warden'].user(CartoDB.extract_subdomain(request)))
+        CartoGearsApi::Users::User.from_model(request.env['warden'].user(CartoDB.extract_subdomain(request)))
       end
 
       # Converts an user to a viewer, without editing rights.
@@ -28,7 +28,7 @@ module CartoGearsApi
         raise CartoGearsApi::Errors::ValidationFailed.new(user.errors) unless user.save
         user.update_in_central
 
-        gears_user(user)
+        CartoGearsApi::Users::User.from_model(user)
       end
 
       # Converts an user to a builder, with full editing rights.
@@ -54,27 +54,10 @@ module CartoGearsApi
         raise CartoGearsApi::Errors::ValidationFailed.new(user.errors) unless user.save
         user.update_in_central
 
-        gears_user(user)
+        CartoGearsApi::Users::User.from_model(user)
       end
 
       private
-
-      def gears_user(user)
-        CartoGearsApi::Users::User.with(
-          id: user.id,
-          username: user.username,
-          email: user.email,
-          organization: user.organization ? gears_organization(user.organization) : nil,
-          feature_flags: user.feature_flags,
-          can_change_email: user.can_change_email?,
-          quota_in_bytes: user.quota_in_bytes,
-          viewer: user.viewer
-        )
-      end
-
-      def gears_organization(organization)
-        CartoGearsApi::Organizations::Organization.with(name: organization.name)
-      end
 
       def find_user(user_id)
         user = ::User.find(id: user_id)

--- a/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/users/users_service.rb
@@ -1,5 +1,4 @@
 require_dependency 'carto_gears_api/users/user'
-require_dependency 'carto_gears_api/organizations/organization'
 require_dependency 'carto_gears_api/errors'
 
 module CartoGearsApi

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :notification, class: Carto::Notification do
     body 'Hey there!'
-    icon 'error'
+    icon Carto::Notification::ICON_WARNING
   end
 end

--- a/spec/models/carto/notification_spec.rb
+++ b/spec/models/carto/notification_spec.rb
@@ -16,12 +16,15 @@ module Carto
 
     describe '#validation' do
       it 'passes for valid notification' do
-        n = Notification.new(icon: 'ok', body: 'Hello, friend!')
+        n = Notification.new(icon: Notification::ICON_SUCCESS, body: 'Hello, friend!')
         expect(n).to be_valid
       end
 
       it 'passes for valid organization notification' do
-        n = Notification.new(icon: 'ok', body: 'Hello, friend!', organization: @organization, recipients: 'builders')
+        n = Notification.new(icon: Notification::ICON_SUCCESS,
+                             body: 'Hello, friend!',
+                             organization: @organization,
+                             recipients: 'builders')
         expect(n).to be_valid
       end
 
@@ -95,20 +98,25 @@ module Carto
 
     it 'should be deleted when the organization is destroyed' do
       org = FactoryGirl.create(:organization)
-      n = Notification.create!(organization_id: org.id, icon: 'ok', recipients: 'all', body: 'Hey!')
+      n = Notification.create!(organization_id: org.id,
+                               icon: Notification::ICON_SUCCESS,
+                               recipients: 'all',
+                               body: 'Hey!')
       org.destroy
       expect(Notification.exists?(n.id)).to be_false
     end
 
     describe '#after_create' do
       it 'for non-org notifications should not send the notification to users' do
-        n = Notification.create(icon: 'ok', body: 'Hello, friend!')
+        n = Notification.create(icon: Notification::ICON_SUCCESS, body: 'Hello, friend!')
         expect(n.received_notifications).to be_empty
       end
 
       describe 'for org notifications' do
         before(:each) do
-          @notification = Notification.new(icon: 'ok', body: 'Hello, friend!', organization: @organization)
+          @notification = Notification.new(icon: Notification::ICON_SUCCESS,
+                                           body: 'Hello, friend!',
+                                           organization: @organization)
         end
 
         after(:each) do

--- a/spec/requests/carto/api/organization_notifications_controller_spec.rb
+++ b/spec/requests/carto/api/organization_notifications_controller_spec.rb
@@ -34,7 +34,7 @@ module Carto
       let(:valid_payload) do
         {
           organization_id: @organization.id,
-          icon: 'success',
+          icon: Carto::Notification::ICON_SUCCESS,
           recipients: 'builders',
           body: 'wadus'
         }
@@ -81,7 +81,8 @@ module Carto
     describe '#destroy' do
       before(:each) do
         @organization.notifications.each(&:destroy)
-        @notification = @organization.notifications.create!(body: 'a', recipients: 'builders', icon: 'error')
+        @notification = @organization.notifications.create!(body: 'a', recipients: 'builders',
+                                                            icon: Carto::Notification::ICON_WARNING)
       end
 
       def destroy_notification_request(org_id, user, notification_id)


### PR DESCRIPTION
Closes #11850 

This has a commit from #11779 (for notification model constants). Should be a clean merge.

- Adds two methods to manage notifications `create_notification` and `send_notification` in the Gears API.
- Moves instantiation of Value objects to a helper in the model `self.from_model`, marked as private API. This can be reverted (isolated commit). Rationale was that we were duplicating logic to instantiate an organization value in multiple places (user, notification). I changed all the models for consistency.