### PR TITLE
Cannot update user when organization seats are full

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -111,7 +111,7 @@ Development
 * Do not trigger visualization hooks on state update (#11701)
 * Refactor Layer model (#10934)
 * Correctly register table dependencies of torque layers (#11549)
-* Validate number of organization seats in user update (#11839)
+* Validate number of organization seats in user update (#11839, #11859)
 * Fix bugs where legends where being hidden by reordering layers (#11088)
 * Correctly ask for alternative username when signing up with Google/GitHub into an organization
 * Avoid loading all rake code in resque workers (#11069)

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -171,7 +171,8 @@ class Admin::OrganizationUsersController < Admin::AdminController
     flash.now[:error] = "There was a problem while updating this user. Please, try again and contact us if the problem persists. #{e.user_message}"
     render 'edit'
   rescue Sequel::ValidationFailed => e
-    render 'edit'
+    flash.now[:error] = e.message
+    render 'edit', status: 422
   end
 
   def destroy

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -375,11 +375,11 @@ class Organization < Sequel::Model
   end
 
   def assigned_seats(excluded_users: [])
-    builder_users.count { |u| !excluded_users.include?(u) }
+    builder_users.count { |u| !excluded_users.map(&:id).include?(u.id) }
   end
 
   def assigned_viewer_seats(excluded_users: [])
-    viewer_users.count { |u| !excluded_users.include?(u) }
+    viewer_users.count { |u| !excluded_users.map(&:id).include?(u.id) }
   end
 
   def builder_users

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -186,7 +186,7 @@ describe Organization do
       builder = create_validated_user(organization: organization, viewer: false, quota_in_bytes: 2)
       builder.organization.reload
 
-      builder.set_fields({quota_in_bytes: 1}, [:quota_in_bytes])
+      builder.set_fields({ quota_in_bytes: 1 }, [:quota_in_bytes])
       builder.save(raise_on_failure: true)
       builder.reload
 


### PR DESCRIPTION
This closes #11853.

It also adds flash error message. I think that it wasn't present before because errors would appear next to the fields. Nevertheless, there are errors (those related to the organization, for example), that haven't a field attached, so this is needed. As the UI prevents all fields server-side errors (to the best of my knowledge), it shouldn't actually lead to duplication.