### PR TITLE
Move TrackJS in order to obtain better results when any error is thrown at the beginning

### DIFF
--- a/app/views/admin/visualizations/embed_map.html.erb
+++ b/app/views/admin/visualizations/embed_map.html.erb
@@ -49,7 +49,7 @@
 <% end %>
 
 <%= content_for(:js) do %>
-  <%= render :partial => 'admin/visualizations/public/embed_map_inline_js' %>
   <%= insert_trackjs('embeds') %>
+  <%= render :partial => 'admin/visualizations/public/embed_map_inline_js' %>
   <%= insert_google_analytics('embeds', true) %>
 <% end %>

--- a/app/views/admin/visualizations/embed_map_error.html.erb
+++ b/app/views/admin/visualizations/embed_map_error.html.erb
@@ -30,7 +30,6 @@
       </div>
     </div>
 
-    <%= insert_trackjs('embeds') %>
     <%= insert_google_analytics('embeds', true) %>
     <%= insert_hubspot() %>
   </body>

--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -311,6 +311,8 @@
 
 
 <%= content_for(:js) do %>
+  <%= insert_trackjs('embeds') %>
+
   <% if @visualization.map.provider == 'googlemaps' %>
     <script type="text/javascript"
         src="//maps.googleapis.com/maps/api/js?sensor=false&v=3.12&<%= @google_maps_query_string %>">
@@ -423,7 +425,7 @@
 
   </script>
 
-  <%= insert_trackjs('embeds') %>
+  
   <%= insert_google_analytics('embeds', true, [{ title: "Public Pages", value: "Other", num: 3 }]) -%>
   <%= insert_hubspot() -%>
 <% end %>

--- a/app/views/carto/builder/datasets/show.html.erb
+++ b/app/views/carto/builder/datasets/show.html.erb
@@ -26,6 +26,8 @@
   </div>
 </div>
 
+<%= insert_trackjs('builder') %>
+
 <script>
   var frontendConfig = <%= safe_js_object frontend_config %>;
   var visualizationData = <%= safe_js_object @canonical_visualization_data.to_json %>;

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -25,6 +25,8 @@
 <% end %>
 
 <%= content_for(:js) do %>
+  <%= insert_trackjs('builder-embeds') %>
+
   <% if params[:vector] %>
     <%= javascript_include_tag 'tangram.min.js' %>
   <% end %>
@@ -43,6 +45,5 @@
   <%= javascript_include_tag 'common_editor3.js' %>
   <%= javascript_include_tag 'public_editor3.js' %>
 
-  <%= insert_trackjs('builder-embeds') %>
   <%= insert_google_analytics('embeds', true) %>
 <% end %>

--- a/app/views/carto/builder/visualizations/show.html.erb
+++ b/app/views/carto/builder/visualizations/show.html.erb
@@ -3,6 +3,7 @@
 </div>
 
 <%= insert_trackjs('builder') %>
+
 <script>
   var frontendConfig = <%= safe_js_object frontend_config %>;
   var visualizationData = <%= safe_js_object @visualization_data.to_json %>;

--- a/app/views/carto/builder/visualizations/show.html.erb
+++ b/app/views/carto/builder/visualizations/show.html.erb
@@ -2,6 +2,7 @@
   <div id="dashboard"></div>
 </div>
 
+<%= insert_trackjs('builder') %>
 <script>
   var frontendConfig = <%= safe_js_object frontend_config %>;
   var visualizationData = <%= safe_js_object @visualization_data.to_json %>;
@@ -23,5 +24,4 @@
 <%= javascript_include_tag 'vendor_editor3.js' %>
 <%= javascript_include_tag 'common_editor3.js' %>
 <%= javascript_include_tag 'editor3.js' %>
-<%= insert_trackjs('builder') %>
 <%= insert_fullstory %>

--- a/app/views/layouts/application_table_public.html.erb
+++ b/app/views/layouts/application_table_public.html.erb
@@ -39,8 +39,8 @@
   </head>
   <body class="public">
     <%= yield :content %>
-    <%= yield :js %>
     <%= insert_trackjs('embeds') %>
+    <%= yield :js %>
     <%= insert_google_analytics('embeds', true) %>
     <%= insert_hubspot() %>
   </body>

--- a/app/views/layouts/data_library.html.erb
+++ b/app/views/layouts/data_library.html.erb
@@ -39,10 +39,9 @@
       var dataset_base_url = '<%= @dataset_base_url %>';
     </script>
 
+    <%= insert_trackjs() %>
     <%= javascript_include_tag 'cdb.js', 'templates', 'data_library_deps', 'data_library' %>
     <%= yield :js %>
-
-    <%= insert_trackjs() %>
     <%= insert_google_analytics('primary', true) %>
     <%= insert_hubspot() %>
   </body>

--- a/app/views/layouts/explore.html.erb
+++ b/app/views/layouts/explore.html.erb
@@ -40,10 +40,9 @@
       var avatar_url= '<%= @avatar_url %>';
     </script>
 
+    <%= insert_trackjs() %>
     <%= javascript_include_tag 'cdb.js', 'templates', 'explore_deps', 'explore' %>
     <%= yield :js %>
-
-    <%= insert_trackjs() %>
     <%= insert_google_analytics('primary', true) %>
     <%= insert_hubspot() -%>
   </body>

--- a/app/views/layouts/front_layout.html.erb
+++ b/app/views/layouts/front_layout.html.erb
@@ -13,8 +13,8 @@
   </head>
   <body class="sessions">
     <%= yield %>
-    <%= yield :js %>
     <%= insert_trackjs() %>
+    <%= yield :js %>
     <%= insert_google_analytics('primary', true) %>
   </body>
 </html>

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -13,8 +13,8 @@
 </head>
 <body class="frontend">
   <%= yield %>
+  <%= insert_trackjs() %>
   <%= yield :js %>
   <%= insert_google_analytics('primary', true) %>
-  <%= insert_trackjs() %>
 </body>
 </html>

--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -40,6 +40,7 @@
     <%= yield %>
 
     <%= render 'admin/shared/footer', { light: true } %>
+    <%= insert_trackjs('embeds') %>
     <script type="text/javascript">
       var config = <%= safe_js_object frontend_config_public({https_apis: request.protocol == 'https://' }) %>;
       var account_host = '<%= CartoDB.account_host %>';
@@ -65,7 +66,6 @@
     <% end %>
     <%= javascript_include_tag 'cdb.js', 'templates', 'public_dashboard_deps', 'public_dashboard' %>
     <%= yield :js %>
-    <%= insert_trackjs('embeds') %>
     <%= insert_google_analytics('embeds', true) %>
     <%= insert_hubspot() %>
   </body>

--- a/app/views/layouts/public_user_feed.html.erb
+++ b/app/views/layouts/public_user_feed.html.erb
@@ -32,6 +32,8 @@
     <%= yield %>
 
     <%= render 'admin/shared/footer', { light: true } %>
+
+    <%= insert_trackjs('embeds') %>
     <script type="text/javascript">
       var config = <%= safe_js_object frontend_config_public({https_apis: request.protocol == 'https://' }) %>;
       var account_host = '<%= CartoDB.account_host %>';
@@ -56,8 +58,6 @@
 
     <%= javascript_include_tag 'cdb.js', 'templates', 'user_feed_deps', 'user_feed' %>
     <%= yield :js %>
-
-    <%= insert_trackjs('embeds') %>
     <%= insert_google_analytics('embeds', true) %>
     <%= insert_hubspot() %>
   </body>


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/11872.

Basically that. Where TrackJS is required, we are moving it to the top of the `<script>` files in order to follow their suggestions (http://docs.trackjs.com/tracker/installation).

Due to the fact that we don't load TrackJS in staging, we should review carefully we haven't broken anything important.

cc @CartoDB/frontend 