### PR TITLE
Update the dataservices client extension 0.16.0

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -22,7 +22,7 @@ module CartoDB
       SCHEMA_GEOCODING = 'cdb'.freeze
       SCHEMA_CDB_DATASERVICES_API = 'cdb_dataservices_client'.freeze
       SCHEMA_AGGREGATION_TABLES = 'aggregation'.freeze
-      CDB_DATASERVICES_CLIENT_VERSION = '0.15.0'.freeze
+      CDB_DATASERVICES_CLIENT_VERSION = '0.16.0'.freeze
       ODBC_FDW_VERSION = '0.2.0'.freeze
 
       def initialize(user)


### PR DESCRIPTION
This updates the dataservices api extension to version 0.16.0, which includes rate limits for gecoding.