### PR TITLE
11878 observe user creation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: gears/carto_gears_api
   specs:
-    carto_gears_api (0.0.1)
+    carto_gears_api (0.0.3)
       rails (= 3.2.22)
       values (= 1.8.0)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -122,7 +122,7 @@ Development
 * Warn about affected maps on dataset deletion (regression, fixed in #11801)
 * Fix color for "Other" category (#11078)
 * Validate that only one legend per type (color/size) is allowed (#11556)
-* Enable more security HTTP headers (#11727)
+* Enable more security HTTP headers (#11727 and 5e2d4f55ee3c19b3c7fc048977ca5901e28798e3)
 * Clean up import directory when importing from URL (#11599)
 * Custom errors for latitude/longitude out of bounds (#11060, #11048)
 * Fix timeseries widget height (#11077)

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -86,6 +86,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
     ::Resque.enqueue(::Resque::UserDBJobs::CommonData::LoadCommonData, @user.id, common_data_url)
     @user.notify_new_organization_user
     @user.organization.notify_if_seat_limit_reached
+    CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserCreationEvent.new(@user))
     redirect_to CartoDB.url(self, 'organization', {}, current_user), flash: { success: "New user created successfully" }
   rescue Carto::UnprocesableEntityError => e
     CartoDB::Logger.error(exception: e, message: "Validation error")

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -86,7 +86,11 @@ class Admin::OrganizationUsersController < Admin::AdminController
     ::Resque.enqueue(::Resque::UserDBJobs::CommonData::LoadCommonData, @user.id, common_data_url)
     @user.notify_new_organization_user
     @user.organization.notify_if_seat_limit_reached
-    CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserCreationEvent.new(@user))
+    CartoGearsApi::Events::EventManager.instance.notify(
+      CartoGearsApi::Events::UserCreationEvent.new(
+        CartoGearsApi::Events::UserCreationEvent::CREATED_VIA_ORG_ADMIN, @user
+      )
+    )
     redirect_to CartoDB.url(self, 'organization', {}, current_user), flash: { success: "New user created successfully" }
   rescue Carto::UnprocesableEntityError => e
     CartoDB::Logger.error(exception: e, message: "Validation error")

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -3,6 +3,8 @@ require_dependency 'google_plus_api'
 require_dependency 'google_plus_config'
 require_dependency 'carto/controller_helper'
 require_dependency 'dummy_password_generator'
+require_dependency 'carto_gears_api/events/event_manager'
+require_dependency 'carto_gears_api/events/user_events'
 
 class Admin::OrganizationUsersController < Admin::AdminController
   include OrganizationUsersHelper

--- a/app/controllers/google_plus_controller.rb
+++ b/app/controllers/google_plus_controller.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 require_dependency 'google_plus_api'
+require_dependency 'carto_gears_api/events/event_manager'
+require_dependency 'carto_gears_api/events/user_events'
 
 class GooglePlusController < ApplicationController
 

--- a/app/controllers/google_plus_controller.rb
+++ b/app/controllers/google_plus_controller.rb
@@ -7,6 +7,7 @@ class GooglePlusController < ApplicationController
   before_filter :load_button_color
 
   def google_plus
+    headers['X-Frame-Options'] = 'SAMEORIGIN'
     signup_url = Cartodb::Central.sync_data_with_cartodb_central? ? Cartodb::Central.new.google_signup_url : CartoDB.path(self, 'google_plus_signup')
     @config = GooglePlusConfig.new(CartoDB, Cartodb.config, signup_url)
     render 'google_plus'

--- a/app/controllers/google_plus_controller.rb
+++ b/app/controllers/google_plus_controller.rb
@@ -32,6 +32,12 @@ class GooglePlusController < ApplicationController
     common_data_url = CartoDB::Visualization::CommonDataService.build_url(self)
     user.load_common_data(common_data_url)
 
+    CartoGearsApi::Events::EventManager.instance.notify(
+      CartoGearsApi::Events::UserCreationEvent.new(
+        CartoGearsApi::Events::UserCreationEvent::CREATED_VIA_ORG_SIGNUP, user
+      )
+    )
+
     redirect_to CartoDB.path(self, 'dashboard', {trailing_slash: true})
   end
 

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -1,6 +1,8 @@
 require_relative '../../../lib/carto/http/client'
 require_dependency 'carto/uuidhelper'
 require_dependency 'carto/overquota_users_service'
+require_dependency 'carto_gears_api/events/event_manager'
+require_dependency 'carto_gears_api/events/user_events'
 
 class Superadmin::UsersController < Superadmin::SuperadminController
   include Carto::UUIDHelper

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -45,6 +45,11 @@ class Superadmin::UsersController < Superadmin::SuperadminController
       CartoDB::Visualization::CommonDataService.load_common_data(@user, self) if @user.should_load_common_data?
       @user.set_relationships_from_central(params[:user])
     end
+    CartoGearsApi::Events::EventManager.instance.notify(
+      CartoGearsApi::Events::UserCreationEvent.new(
+        CartoGearsApi::Events::UserCreationEvent::CREATED_VIA_SUPERADMIN, @user
+      )
+    )
     respond_with(:superadmin, @user)
   end
 

--- a/app/models/carto/organization.rb
+++ b/app/models/carto/organization.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 require_relative '../../helpers/data_services_metrics_helper'
 require_dependency 'carto/helpers/auth_token_generator'
+require_dependency 'carto/carto_json_serializer'
 
 module Carto
   class Organization < ActiveRecord::Base

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -1,5 +1,7 @@
 # encoding: UTF-8
 require_dependency 'carto/user_authenticator'
+require_dependency 'carto_gears_api/events/event_manager'
+require_dependency 'carto_gears_api/events/user_events'
 
 class Carto::UserCreation < ActiveRecord::Base
   include Carto::UserAuthenticator

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -295,6 +295,7 @@ class Carto::UserCreation < ActiveRecord::Base
     cartodb_user.notify_new_organization_user unless has_valid_invitation?
     cartodb_user.organization.notify_if_disk_quota_limit_reached if cartodb_user.organization
     cartodb_user.organization.notify_if_seat_limit_reached if cartodb_user.organization
+    CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserCreationEvent.new(cartodb_user))
   rescue => e
     handle_failure(e, mark_as_failure = false)
   end

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -4,6 +4,7 @@ require_dependency 'carto/user_authenticator'
 class Carto::UserCreation < ActiveRecord::Base
   include Carto::UserAuthenticator
 
+  # Synced with CartoGearsApi::Events::UserCreationEvent
   CREATED_VIA_SAML = 'saml'.freeze
   CREATED_VIA_LDAP = 'ldap'.freeze
   CREATED_VIA_ORG_SIGNUP = 'org_signup'.freeze
@@ -295,7 +296,9 @@ class Carto::UserCreation < ActiveRecord::Base
     cartodb_user.notify_new_organization_user unless has_valid_invitation?
     cartodb_user.organization.notify_if_disk_quota_limit_reached if cartodb_user.organization
     cartodb_user.organization.notify_if_seat_limit_reached if cartodb_user.organization
-    CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserCreationEvent.new(cartodb_user))
+    CartoGearsApi::Events::EventManager.instance.notify(
+      CartoGearsApi::Events::UserCreationEvent.new(created_via, cartodb_user)
+    )
   rescue => e
     handle_failure(e, mark_as_failure = false)
   end

--- a/gears/carto_gears_api/README.md
+++ b/gears/carto_gears_api/README.md
@@ -91,6 +91,9 @@ Note: YARD support for ERB files is quite limited, and ERBs documentation is sti
 
 ### Extension points
 
+Most extension points require a registration during intialization. A good
+place to put the code it is inside a file in +config/initializers+.
+
 #### Adding links to profile page
 
 See creation at {CartoGearsApi::Pages::SubheaderLink}.
@@ -109,5 +112,17 @@ CartoGearsApi::Pages::Subheader.instance.links_generators << lambda do |context|
           controller: 'my_gear/something')
     ]
   end
+end
+```
+
+#### Events
+
+See a list of events at {CartoGearsApi::Events::BaseEvent} and how to subscribe to them with
+{CartoGearsApi::Events::EventManager}.
+Example:
+
+```ruby
+CartoGearsApi::Events::EventManager.instance.subscribe(CartoGearsApi::Events::UserCreationEvent) do |event|
+  puts "Welcome #{event.user.username}"
 end
 ```

--- a/gears/carto_gears_api/lib/carto_gears_api/events/base_event.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/base_event.rb
@@ -1,5 +1,6 @@
 module CartoGearsApi
   module Events
+    # @abstract All events must subclass this
     class BaseEvent
     end
   end

--- a/gears/carto_gears_api/lib/carto_gears_api/events/base_event.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/base_event.rb
@@ -1,0 +1,6 @@
+module CartoGearsApi
+  module Events
+    class BaseEvent
+    end
+  end
+end

--- a/gears/carto_gears_api/lib/carto_gears_api/events/event_manager.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/event_manager.rb
@@ -18,7 +18,7 @@ module CartoGearsApi
       #   event_manager.subscribe(CartoGearsApi::Events::UserCreationEvent) { |e| puts e.user.username }
       def subscribe(event_type, &block)
         raise ArgumentError.new('block is mandatory') unless block
-        raise ArgumentError.new('event_type must be a subclass of BaseEvent') unless event_type.superclass == BaseEvent
+        raise ArgumentError.new('event_type must be a subclass of BaseEvent') unless event_type < BaseEvent
         listeners_for(event_type).append(block)
         [event_type, block]
       end

--- a/gears/carto_gears_api/lib/carto_gears_api/events/event_manager.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/event_manager.rb
@@ -1,0 +1,43 @@
+require 'singleton'
+
+module CartoGearsApi
+  module Events
+    class EventManager
+      include Singleton
+
+      def initialize
+        @event_listeners = {}
+      end
+
+      # Add a subscriber to an event type
+      # @param [Class] event_type class of the event to subscribe to
+      # @yield [EventType] block to run when the event is triggered. Will receive an object of +event_type+ class
+      def subscribe(event_type, &block)
+        raise ArgumentError.new('block is mandatory') unless block
+        raise ArgumentError.new('event_type must be a subclass of BaseEvent') unless event_type.superclass == BaseEvent
+        listeners_for(event_type).append(block)
+      end
+
+      # @api private
+      def notify(event)
+        listeners_for(event.class).each do |listener|
+          begin
+            listener.call(event)
+          rescue => exception
+            CartoDB::Logger.error(
+              message: 'Error while running Gears event listeners',
+              exception: exception,
+              event: event.class.name
+            )
+          end
+        end
+      end
+
+      private
+
+      def listeners_for(event_type)
+        @event_listeners[event_type] ||= []
+      end
+    end
+  end
+end

--- a/gears/carto_gears_api/lib/carto_gears_api/events/event_manager.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/event_manager.rb
@@ -10,12 +10,23 @@ module CartoGearsApi
       end
 
       # Add a subscriber to an event type
-      # @param [Class] event_type class of the event to subscribe to
+      # @param [Class] event_type class of the event to subscribe to. Subclass of {BaseEvent}
       # @yield [EventType] block to run when the event is triggered. Will receive an object of +event_type+ class
+      # @return a descriptor that can be used to {#unsubscribe} from the event
+      # @example
+      #   event_manager = CartoGearsApi::Events::EventManager.instance.
+      #   event_manager.subscribe(CartoGearsApi::Events::UserCreationEvent) { |e| puts e.user.username }
       def subscribe(event_type, &block)
         raise ArgumentError.new('block is mandatory') unless block
         raise ArgumentError.new('event_type must be a subclass of BaseEvent') unless event_type.superclass == BaseEvent
         listeners_for(event_type).append(block)
+        [event_type, block]
+      end
+
+      # Unsubscribes from an event
+      # @param descriptor A descritor returned from {#subscribe}
+      def unsubscribe(descriptor)
+        listeners_for(descriptor[0]).delete(descriptor[1])
       end
 
       # @api private

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -1,5 +1,6 @@
 require_dependency 'carto_gears_api/events/base_event'
 require_dependency 'carto_gears_api/users/user'
+require_dependency 'carto/user_creation'
 
 module CartoGearsApi
   module Events

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -19,6 +19,8 @@ module CartoGearsApi
       CREATED_VIA_HTTP_AUTENTICATION = Carto::UserCreation::CREATED_VIA_HTTP_AUTENTICATION
       # User created by organization administrator
       CREATED_VIA_ORG_ADMIN = 'org_admin'.freeze
+      # User created by superadmin
+      CREATED_VIA_SUPERADMIN = 'superadmin'.freeze
 
       attr_reader :user, :created_via
 

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -1,6 +1,5 @@
 require_dependency 'carto_gears_api/events/base_event'
 require_dependency 'carto_gears_api/users/user'
-require_dependency 'carto/user_creation'
 
 module CartoGearsApi
   module Events
@@ -9,15 +8,15 @@ module CartoGearsApi
     # @attr_reader [Users::User] user user which was created
     class UserCreationEvent < BaseEvent
       # User created via login in with SAML SSO
-      CREATED_VIA_SAML = Carto::UserCreation::CREATED_VIA_SAML
+      CREATED_VIA_SAML = 'saml'.freeze
       # User created via login with LDAP credentials
-      CREATED_VIA_LDAP = Carto::UserCreation::CREATED_VIA_LDAP
+      CREATED_VIA_LDAP = 'ldap'.freeze
       # User created via signup up to the org
-      CREATED_VIA_ORG_SIGNUP = Carto::UserCreation::CREATED_VIA_ORG_SIGNUP
+      CREATED_VIA_ORG_SIGNUP = 'org_signup'.freeze
       # User created via enterprise user management API (EUMAPI)
-      CREATED_VIA_API = Carto::UserCreation::CREATED_VIA_API
+      CREATED_VIA_API = 'api'.freeze
       # User created via HTTP header authentication
-      CREATED_VIA_HTTP_AUTENTICATION = Carto::UserCreation::CREATED_VIA_HTTP_AUTENTICATION
+      CREATED_VIA_HTTP_AUTENTICATION = 'http_authentication'.freeze
       # User created by organization administrator
       CREATED_VIA_ORG_ADMIN = 'org_admin'.freeze
       # User created by superadmin

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -13,7 +13,7 @@ module CartoGearsApi
       CREATED_VIA_LDAP = Carto::UserCreation::CREATED_VIA_LDAP
       # User created via signup up to the org
       CREATED_VIA_ORG_SIGNUP = Carto::UserCreation::CREATED_VIA_ORG_SIGNUP
-      # User created via API
+      # User created via enterprise user management API (EUMAPI)
       CREATED_VIA_API = Carto::UserCreation::CREATED_VIA_API
       # User created via HTTP header authentication
       CREATED_VIA_HTTP_AUTENTICATION = Carto::UserCreation::CREATED_VIA_HTTP_AUTENTICATION

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -1,0 +1,17 @@
+require_dependency 'carto_gears_api/events/base_event'
+require_dependency 'carto_gears_api/users/user'
+
+module CartoGearsApi
+  module Events
+    # Event triggered when a user is created
+    # @attr_reader [Users::User] user user which was created
+    class UserCreationEvent < BaseEvent
+      attr_reader :user
+
+      # @api private
+      def initialize(user)
+        @user = Users::User.from_model(user)
+      end
+    end
+  end
+end

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -4,12 +4,27 @@ require_dependency 'carto_gears_api/users/user'
 module CartoGearsApi
   module Events
     # Event triggered when a user is created
+    # @attr_reader [String] created_via source of the user creation. One of the +CREATED_VIA_*+ constants
     # @attr_reader [Users::User] user user which was created
     class UserCreationEvent < BaseEvent
-      attr_reader :user
+      # User created via login in with SAML SSO
+      CREATED_VIA_SAML = Carto::UserCreation::CREATED_VIA_SAML
+      # User created via login with LDAP credentials
+      CREATED_VIA_LDAP = Carto::UserCreation::CREATED_VIA_LDAP
+      # User created via signup up to the org
+      CREATED_VIA_ORG_SIGNUP = Carto::UserCreation::CREATED_VIA_ORG_SIGNUP
+      # User created via API
+      CREATED_VIA_API = Carto::UserCreation::CREATED_VIA_API
+      # User created via HTTP header authentication
+      CREATED_VIA_HTTP_AUTENTICATION = Carto::UserCreation::CREATED_VIA_HTTP_AUTENTICATION
+      # User created by organization administrator
+      CREATED_VIA_ORG_ADMIN = 'org_admin'.freeze
+
+      attr_reader :user, :created_via
 
       # @api private
-      def initialize(user)
+      def initialize(created_via, user)
+        @created_via = created_via
         @user = Users::User.from_model(user)
       end
     end

--- a/gears/carto_gears_api/lib/carto_gears_api/version.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/version.rb
@@ -1,3 +1,3 @@
 module CartoGearsApi
-  VERSION = '0.0.1'.freeze
+  VERSION = '0.0.2'.freeze
 end

--- a/gears/carto_gears_api/lib/carto_gears_api/version.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/version.rb
@@ -1,3 +1,3 @@
 module CartoGearsApi
-  VERSION = '0.0.2'.freeze
+  VERSION = '0.0.3'.freeze
 end

--- a/gears/carto_gears_api/spec/carto_gears_api/events/event_manager_spec.rb
+++ b/gears/carto_gears_api/spec/carto_gears_api/events/event_manager_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'carto_gears_api/events/event_manager'
+require 'carto_gears_api/events/base_event'
+
+describe CartoGearsApi::Events::EventManager do
+  class TestEvent < CartoGearsApi::Events::BaseEvent
+  end
+
+  class OtherEvent < CartoGearsApi::Events::BaseEvent
+  end
+
+  class NotAnEvent
+  end
+
+  let(:manager) { CartoGearsApi::Events::EventManager.send(:new) }
+
+  describe '#subscribe' do
+    it 'event type must be a subclass of BaseEvent' do
+      expect { manager.subscribe(NotAnEvent) {} }.to raise_error ArgumentError
+    end
+
+    it 'requires a block' do
+      expect { manager.subscribe(TestEvent) }.to raise_error ArgumentError
+    end
+
+    it 'subscribe with event and block' do
+      expect { manager.subscribe(TestEvent) {} }.not_to raise_error ArgumentError
+    end
+  end
+
+  describe '#notify' do
+    it 'triggers all subscribed events' do
+      handler = mock
+      handler.should_receive(:do).once
+      handler2 = mock
+      handler2.should_receive(:do).once
+
+      manager.subscribe(TestEvent) { handler.do }
+      manager.subscribe(TestEvent) { handler2.do }
+      manager.notify(TestEvent.new)
+    end
+
+    it 'should not trigger subscribers to other events' do
+      handler = mock
+      handler.should_receive(:do).never
+
+      manager.subscribe(TestEvent) { handler.do }
+      manager.notify(OtherEvent.new)
+    end
+
+    it 'should not trigger unsubscribed handlers' do
+      handler = mock
+      handler.should_receive(:do).never
+
+      descriptor = manager.subscribe(TestEvent) { handler.do }
+      manager.unsubscribe(descriptor)
+      manager.notify(TestEvent.new)
+    end
+  end
+end


### PR DESCRIPTION
Closes #11878

There is ugliness in sending the user notifications (from two places, including a controller, no less). I did not like `User.after_create` because it triggers before setting up the database (and also, if org user creation fail, the user is created and then inmediately destroyed). Thus was born the current approach.

**Acceptance**
- [x] Create a gear that subscribes to user creation events (read the docs to check they make sense)
- [ ] Create a user in multiple ways, and make sure it triggers your event listener:
  - [x] Free signup (email/password)
  - [x] Signup into org (email/password)
  - [x] Free signup (Github/Google)
  - [x] Signup into org (Github/Google)
  - [ ] Signup into org (LDAP/SAML)
  - [x] Org user creation (as owner)
  - [x] From superadmin
  - [x] EUMAPI