### PR TITLE
Validate user model in EUMAPI update after applying changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -151,6 +151,7 @@ Development
 * Fix for race condition when importing files and deploying at the same time (#11653)
 * Correctly create custom category legend if style has icons (#11592)
 * Fixed error handling if json "errors" field contains one single string (#11752)
+* Check for validation errors in EUMAPI user update endpoint (#11906)
 * Fix problem with perfect-scrollbar in Edge browsers (CartoDB/perfect-scrollbar/#2)
 * Layer onboardings are now aware on sync'd layers and highlighted area is clicked. (#11583)
 * Do not show builder activated notification for new users (#11720)

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -88,15 +88,13 @@ module Carto
         password = params_to_update[:password]
         params_to_update[:password_confirmation] = password
 
-        model_validation_ok = @user.valid?
-        if password.present?
-          model_validation_ok &&= @user.valid_password?(:password, password, password)
-        end
-
         # NOTE: Verify soft limits BEFORE updating the user
-        unless soft_limits_validation(@user, params_to_update) &&
-               @user.set_fields(params_to_update, params_to_update.keys) &&
-               model_validation_ok
+        model_validation_ok = soft_limits_validation(@user, params_to_update)
+        model_validation_ok &&= @user.valid_password?(:password, password, password) if password.present?
+        @user.set_fields(params_to_update, params_to_update.keys)
+        model_validation_ok &&= @user.valid?
+
+        unless model_validation_ok
           render_jsonp(@user.errors.full_messages, 410)
           return
         end

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -469,13 +469,26 @@ describe Carto::Api::OrganizationUsersController do
       user_to_update.email.should_not start_with('fail-')
     end
 
-    it 'should validate before updating in Central' do
+    it 'should validate password before updating in Central' do
       ::User.any_instance.unstub(:update_in_central)
       ::User.any_instance.stubs(:update_in_central).never
       login(@organization.owner)
 
       user_to_update = @organization.non_owner_users[0]
       params = { password: 'a' }
+      put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
+          params
+
+      last_response.status.should == 410
+    end
+
+    it 'should validate before updating in Central' do
+      ::User.any_instance.unstub(:update_in_central)
+      ::User.any_instance.stubs(:update_in_central).never
+      login(@organization.owner)
+
+      user_to_update = @organization.non_owner_users[0]
+      params = { quota_in_bytes: @organization.quota_in_bytes * 2 }
       put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
 


### PR DESCRIPTION
Fixes #11852 

**Acceptance**
- [x] Update an user via EUMAPI. Check that the values are updated in Central and the box
- [x] Update an user via EUMAPI, with invalid parameters (e.g: execssive quota). Check that the values are not updated in Central nor the box