### PR TITLE
11909 viewer creation should not load common data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -155,6 +155,7 @@ Development
 * Fixed error handling if json "errors" field contains one single string (#11752)
 * Check for validation errors in EUMAPI user update endpoint (#11906)
 * Fix problem with perfect-scrollbar in Edge browsers (CartoDB/perfect-scrollbar/#2)
+* Skip loading common data for viewers created via EUMAPI (#11909)
 * Layer onboardings are now aware on sync'd layers and highlighted area is clicked. (#11583)
 * Do not show builder activated notification for new users (#11720)
 * Fixed overflow on loaders.

--- a/NEWS.md
+++ b/NEWS.md
@@ -155,7 +155,7 @@ Development
 * Fixed error handling if json "errors" field contains one single string (#11752)
 * Check for validation errors in EUMAPI user update endpoint (#11906)
 * Fix problem with perfect-scrollbar in Edge browsers (CartoDB/perfect-scrollbar/#2)
-* Skip loading common data for viewers created via EUMAPI (#11909)
+* Skip loading common data for viewer users created via EUMAPI (#11909)
 * Layer onboardings are now aware on sync'd layers and highlighted area is clicked. (#11583)
 * Do not show builder activated notification for new users (#11720)
 * Fixed overflow on loaders.

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -82,9 +82,12 @@ class Carto::UserCreation < ActiveRecord::Base
           :validating_user => :saving_user,
           :saving_user => :promoting_user
 
-      transition :promoting_user => :creating_user_in_central, :creating_user_in_central => :load_common_data, :load_common_data => :success, :if => :sync_data_with_cartodb_central?
-
-      transition :promoting_user => :load_common_data, :load_common_data => :success, :unless => :sync_data_with_cartodb_central?
+      transition :promoting_user => :creating_user_in_central, if: :sync_data_with_cartodb_central?
+      transition :promoting_user => :load_common_data, if: lambda { !sync_data_with_cartodb_central? && !viewer? }
+      transition :promoting_user => :success, if: lambda { !sync_data_with_cartodb_central? && viewer? }
+            transition :creating_user_in_central => :load_common_data, unless: :viewer?
+      transition :creating_user_in_central => :success, if: :viewer?
+      transition :load_common_data => :success
     end
 
     event :fail_user_creation do

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -87,11 +87,11 @@ class Carto::UserCreation < ActiveRecord::Base
       #   creating_user_in_central is skipped if central is not configured
       #   load_common_data is skipped for viewers
       transition promoting_user: :creating_user_in_central, if: :sync_data_with_cartodb_central?
-      transition promoting_user: :load_common_data, if: ->(uc) { !uc.sync_data_with_cartodb_central? && !uc.viewer? }
-      transition promoting_user: :success, if: ->(uc) { !uc.sync_data_with_cartodb_central? && uc.viewer? }
+      transition promoting_user: :load_common_data, unless: :viewer?
+      transition promoting_user: :success
 
       transition creating_user_in_central: :load_common_data, unless: :viewer?
-      transition creating_user_in_central: :success, if: :viewer?
+      transition creating_user_in_central: :success
 
       transition load_common_data: :success
     end
@@ -161,11 +161,6 @@ class Carto::UserCreation < ActiveRecord::Base
   def has_valid_invitation?
     return false unless invitation_token
     !valid_invitation.nil?
-  end
-
-  # INFO: state_machine needs guard methods to be public instance methods
-  def sync_data_with_cartodb_central?
-    Cartodb::Central.sync_data_with_cartodb_central?
   end
 
   private
@@ -350,4 +345,8 @@ class Carto::UserCreation < ActiveRecord::Base
     self.save
   end
 
+  # INFO: state_machine needs guard methods to be instance methods
+  def sync_data_with_cartodb_central?
+    Cartodb::Central.sync_data_with_cartodb_central?
+  end
 end

--- a/spec/models/carto/user_creation_spec.rb
+++ b/spec/models/carto/user_creation_spec.rb
@@ -385,7 +385,7 @@ describe Carto::UserCreation do
 
     def creation_steps(user_creation)
       states = [user_creation.state]
-      while !user_creation.finished?
+      until user_creation.finished?
         user_creation.next_creation_step
         states << user_creation.state
       end

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -179,6 +179,7 @@ describe Carto::Api::OrganizationUsersController do
     end
 
     it 'can create viewers' do
+      Carto::UserCreation.any_instance.expects(:load_common_data).never
       login(@organization.owner)
       username = 'viewer-user'
       params = user_params(username, viewer: true)


### PR DESCRIPTION
Closes #11909 

**Acceptance**
- [x] Create a builder user via EUMAPI/superadmin. Ensure that the common data is loaded during creation. Ensure that it's registered in central
- [x] Create a viewer user via EUMAPI/superadmin. Ensure that the common data is not loaded during creation (you can check Rollbar for errors). Ensure that it's registered in central
- [x] Disable central (restart resque), and create a user via EUMAPI. It should work (no errors).