### PR TITLE
First batch of ::UserTable usages removal [WIP]

### DIFF
--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -216,8 +216,8 @@ class Api::Json::ImportsController < Api::ApplicationController
 
   def privacy
     if params[:privacy].present?
-      privacy = (UserTable::PRIVACY_VALUES_TO_TEXTS.invert)[params[:privacy].downcase]
-      raise "Unknown value '#{params[:privacy]}' for 'privacy'. Allowed values are: #{[UserTable::PRIVACY_VALUES_TO_TEXTS.values[0..-2].join(', '), UserTable::PRIVACY_VALUES_TO_TEXTS.values[-1]].join(' and ')}" if privacy.nil?
+      privacy = (Carto::UserTable::PRIVACY_VALUES_TO_TEXTS.invert)[params[:privacy].downcase]
+      raise "Unknown value '#{params[:privacy]}' for 'privacy'. Allowed values are: #{[Carto::UserTable::PRIVACY_VALUES_TO_TEXTS.values[0..-2].join(', '), Carto::UserTable::PRIVACY_VALUES_TO_TEXTS.values[-1]].join(' and ')}" if privacy.nil?
       raise "Your account type (#{current_user.account_type.tr('[]','')}) does not allow to create private datasets. Check https://carto.com/pricing for more info." if !current_user.valid_privacy?(privacy)
       privacy
     else

--- a/app/controllers/api/json/visualizations_controller.rb
+++ b/app/controllers/api/json/visualizations_controller.rb
@@ -176,12 +176,9 @@ class Api::Json::VisualizationsController < Api::ApplicationController
   end
 
   def destroy
-    @stats_aggregator.timing('visualizations.destroy') do
 
       begin
-        vis,  = @stats_aggregator.timing('locate') do
-          locator.get(@table_id, CartoDB.extract_subdomain(request))
-        end
+        vis, = locator.get(@table_id, CartoDB.extract_subdomain(request))
 
         return head(404) unless vis
         return head(403) unless vis.is_owner?(current_user)
@@ -205,9 +202,7 @@ class Api::Json::VisualizationsController < Api::ApplicationController
           end
         end
 
-        @stats_aggregator.timing('delete') do
-          vis.delete
-        end
+        Carto::Visualization.find(vis.id).delete
 
         return head 204
       rescue KeyError
@@ -215,7 +210,6 @@ class Api::Json::VisualizationsController < Api::ApplicationController
       rescue Sequel::DatabaseError => e
         render_jsonp({ errors: [e.message] }, 400)
       end
-    end
   end
 
   def notify_watching

--- a/app/controllers/helpers/table_locator.rb
+++ b/app/controllers/helpers/table_locator.rb
@@ -34,7 +34,7 @@ module Helpers
       table = vis.nil? ? nil : vis.table
 
       if UUID_RX.match(id_or_name) && table.nil?
-        table_temp = ::UserTable.where(id: id_or_name).first.try(:service)
+        table_temp = Carto::UserTable.where(id: id_or_name).first.try(:service)
         unless table_temp.nil?
           # Make sure we're allowed to see the table
           vis = CartoDB::Visualization::Collection.new.fetch(

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -139,7 +139,7 @@ class Carto::User < ActiveRecord::Base
   #   +-------------------------+--------+---------+------+
   #
   def valid_privacy?(privacy)
-    self.private_tables_enabled || privacy == UserTable::PRIVACY_PUBLIC
+    self.private_tables_enabled || privacy == Carto::UserTable::PRIVACY_PUBLIC
   end
 
   # @return String public user url, which is also the base url for a given user

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -371,12 +371,12 @@ class DataImport < Sequel::Model
     # We can assume the owner is always who imports the data
     # so no need to change to a Visualization::Collection based load
     # TODO better to use an association for this
-    ::Table.new(user_table: UserTable.where(id: table_id, user_id: user_id).first)
+    ::Table.new(user_table: Carto::UserTable.where(id: table_id, user_id: user_id).first)
   end
 
   def tables
     table_names_array.map do |table_name|
-      UserTable.where(name: table_name, user_id: user_id).first.service
+      Carto::UserTable.where(name: table_name, user_id: user_id).first.service
     end
   end
 
@@ -1074,7 +1074,7 @@ class DataImport < Sequel::Model
                             [{ data_import_id: import_id }, 'copy']
                           end
 
-      user_table = ::UserTable.where(condition).first
+      user_table = Carto::UserTable.where(condition).first
       map = user_table.map if user_table
       if map
         vis = Carto::Visualization.where(map_id: map.id).first

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -219,7 +219,7 @@ class Map < Sequel::Model
     return unless table_id
 
     # Cannot filter by user_id as might be a shared table not owned by us
-    related_table = ::UserTable.filter(id: table_id).first
+    related_table = Carto::UserTable.where(id: table_id).first
     if related_table.map_id != id
       # Manually propagate to visualization (@see Table.after_save) if exists (at table creation won't)
       if related_table.map_id.present?
@@ -229,7 +229,7 @@ class Map < Sequel::Model
         ).each { |entry| entry.store_from_map(map_id: id) }
       end
       # HERE BE DRAGONS! If we try to store using model, callbacks break hell. Manual update required
-      related_table.this.update(map_id: id)
+      related_table.update_column(:map_id, id)
     end
   end
 

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -218,7 +218,7 @@ class Table
           user_id = owner.id
         end
       end
-      ::UserTable.where(user_id: user_id, name: table_name).first
+      Carto::UserTable.where(user_id: user_id, name: table_name).first
     }
   end
 
@@ -1059,7 +1059,7 @@ class Table
 
   # Simplify certain privacy values for the vizjson
   def privacy_text_for_vizjson
-    privacy == UserTable::PRIVACY_LINK ? 'PUBLIC' : @user_table.privacy_text
+    privacy == Carto::UserTable::PRIVACY_LINK ? 'PUBLIC' : @user_table.privacy_text
   end
 
   def relator

--- a/app/models/table/privacy_manager.rb
+++ b/app/models/table/privacy_manager.rb
@@ -58,9 +58,9 @@ module CartoDB
 
     def set_from_table_privacy(table_privacy)
       case table_privacy
-      when ::UserTable::PRIVACY_PUBLIC
+      when Carto::UserTable::PRIVACY_PUBLIC
         set_public
-      when ::UserTable::PRIVACY_LINK
+      when Carto::UserTable::PRIVACY_LINK
         set_public_with_link_only
       else
         set_private
@@ -72,7 +72,7 @@ module CartoDB
       visualizations.each do |visualization|
         if visualization.type == CartoDB::Visualization::Member::TYPE_CANONICAL
           # Each table has a canonical visualization which must have privacy synced
-          visualization.privacy = ::UserTable::PRIVACY_VALUES_TO_TEXTS[privacy]
+          visualization.privacy = Carto::UserTable::PRIVACY_VALUES_TO_TEXTS[privacy]
           visualization.store_using_table(table_privacy_changed)
         else
           visualization.invalidate_cache
@@ -83,7 +83,7 @@ module CartoDB
     end
 
     def set_public
-      self.privacy = ::UserTable::PRIVACY_PUBLIC
+      self.privacy = Carto::UserTable::PRIVACY_PUBLIC
       set_database_permissions(grant_query)
       overviews_service = Carto::OverviewsService.new(owner.in_database)
       overviews_service.overview_tables(fully_qualified_table_name(table.name)).each do |overview_table|
@@ -93,7 +93,7 @@ module CartoDB
     end
 
     def set_private
-      self.privacy = ::UserTable::PRIVACY_PRIVATE
+      self.privacy = Carto::UserTable::PRIVACY_PRIVATE
       set_database_permissions(revoke_query)
       overviews_service = Carto::OverviewsService.new(owner.in_database)
       overviews_service.overview_tables(fully_qualified_table_name(table.name)).each do |overview_table|
@@ -103,7 +103,7 @@ module CartoDB
     end
 
     def set_public_with_link_only
-      self.privacy = ::UserTable::PRIVACY_LINK
+      self.privacy = Carto::UserTable::PRIVACY_LINK
       set_database_permissions(grant_query)
       overviews_service = Carto::OverviewsService.new(owner.in_database)
       overviews_service.overview_tables(fully_qualified_table_name(table.name)).each do |overview_table|

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -357,7 +357,7 @@ class UserTable < Sequel::Model
       attributions: esv.try(:attributions),
       source:       esv.try(:source),
       tags:         (tags.split(',') if tags),
-      privacy:      UserTable::PRIVACY_VALUES_TO_TEXTS[default_privacy_value],
+      privacy:      Carto::UserTable::PRIVACY_VALUES_TO_TEXTS[default_privacy_value],
       user_id:      user.id,
       kind:         kind
     )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -180,7 +180,7 @@ class User < Sequel::Model
   #   +-------------------------+--------+---------+------+
   #
   def valid_privacy?(privacy)
-    self.private_tables_enabled || privacy == UserTable::PRIVACY_PUBLIC
+    self.private_tables_enabled || privacy == Carto::UserTable::PRIVACY_PUBLIC
   end
 
   def valid_password?(key, value, confirmation_value)
@@ -646,7 +646,7 @@ class User < Sequel::Model
   end #map_tags
 
   def tables
-    ::UserTable.filter(:user_id => self.id).order(:id).reverse
+    Carto::UserTable.where(user_id: self.id).order(:id).reverse
   end
 
   def tables_including_shared

--- a/app/models/visualization/relator.rb
+++ b/app/models/visualization/relator.rb
@@ -80,7 +80,7 @@ module CartoDB
 
       def table
         return nil if map.nil?
-        @table ||= ::UserTable.from_map_id(map.id).try(:service)
+        @table ||= Carto::UserTable.where(map_id: map.id).first.try(:service)
       end
 
       def estimated_row_count

--- a/app/models/visualization/table_blender.rb
+++ b/app/models/visualization/table_blender.rb
@@ -13,6 +13,8 @@ module CartoDB
       def blend
         raise "Viewer users can't blend tables" if user.viewer
 
+        carto_user = Carto::User.find(user.id)
+
         maps            = tables.map(&:map)
         copier          = CartoDB::Map::Copier.new
         destination_map = copier.new_map_from(maps.first)
@@ -20,9 +22,9 @@ module CartoDB
 
         copier.copy_base_layer(maps.first, destination_map)
 
-        maps.each { |map| copier.copy_data_layers(map, destination_map, user) }
+        maps.each { |map| copier.copy_data_layers(map, destination_map, carto_user) }
 
-        destination_map.user = user
+        destination_map.user = carto_user
         destination_map.save
         destination_map
       end

--- a/lib/cartodb/stats/platform.rb
+++ b/lib/cartodb/stats/platform.rb
@@ -14,7 +14,7 @@ module CartoDB
 
       # Total datasets
       def datasets
-        return UserTable.count
+        return Carto::UserTable.count
       end
 
       # Total seats among orgs

--- a/lib/explore_api.rb
+++ b/lib/explore_api.rb
@@ -110,7 +110,7 @@ class ExploreAPI
   def tables_geometry_types(user_id, tables)
     geometry_types = {}
     tables.each do |table|
-      user_table = UserTable.where(user_id: user_id, name: table).first
+      user_table = Carto::UserTable.where(user_id: user_id, name: table).first
       geometry_types[table] = user_table.service.geometry_types
     end
     geometry_types

--- a/services/importer/lib/importer/overviews.rb
+++ b/services/importer/lib/importer/overviews.rb
@@ -40,7 +40,7 @@ module CartoDB
       end
 
       def get_table(table_name)
-        UserTable.find_by_identifier(@user.id, table_name).service
+        Carto::UserTable.where(user_id: @user.id, name: table_name).first.service
       end
 
       def can_create_overviews?

--- a/spec/models/layer_shared_examples.rb
+++ b/spec/models/layer_shared_examples.rb
@@ -236,7 +236,7 @@ shared_examples_for 'Layer model' do
       layers = @table.table_visualization.data_layers
       layers.length.should == 1
       layers.first.uses_private_tables?.should be_true
-      @table.privacy = UserTable::PRIVACY_PUBLIC
+      @table.privacy = Carto::UserTable::PRIVACY_PUBLIC
       @table.save
       @user.reload
 


### PR DESCRIPTION
`[^Carto]::UserTable[^Presenter]` now only matches a couple of
relations and INTERFACE delegation.

This closes #11912.