### PR TITLE
google_maps_api_key inheritance blank fix #11923

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -108,6 +108,7 @@ Development
 * Fixed missing metadata option in header when dataset is sync (#11458)
 * Fixed problem with dates when filtering time series widget
 * Fixed problem switching between qualitative and quantitative attributes (#10654)
+* Fixed problem with Google Maps API key inheritance from organizations (#11923)
 * Fixed problem found in Surfaces related with map panning and widgets filtering
 * Style with icons
   * Reset icon on map when you remove that custom icon

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -185,11 +185,7 @@ class Carto::User < ActiveRecord::Base
   # returns google maps api key. If the user is in an organization and
   # that organization has api key it's used
   def google_maps_api_key
-    if has_organization?
-      self.organization.google_maps_key || self.google_maps_key
-    else
-      self.google_maps_key
-    end
+    try(:organization).try(:google_maps_key).blank? ? self.google_maps_key : self.organization.google_maps_key
   end
 
   def twitter_datasource_enabled

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -185,7 +185,7 @@ class Carto::User < ActiveRecord::Base
   # returns google maps api key. If the user is in an organization and
   # that organization has api key it's used
   def google_maps_api_key
-    try(:organization).try(:google_maps_key).blank? ? google_maps_key : organization.google_maps_key
+    organization.try(:google_maps_key).blank? ? google_maps_key : organization.google_maps_key
   end
 
   def twitter_datasource_enabled

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -185,7 +185,7 @@ class Carto::User < ActiveRecord::Base
   # returns google maps api key. If the user is in an organization and
   # that organization has api key it's used
   def google_maps_api_key
-    try(:organization).try(:google_maps_key).blank? ? self.google_maps_key : self.organization.google_maps_key
+    try(:organization).try(:google_maps_key).blank? ? google_maps_key : organization.google_maps_key
   end
 
   def twitter_datasource_enabled

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1424,11 +1424,7 @@ class User < Sequel::Model
   # returns google maps api key. If the user is in an organization and
   # that organization has api key it's used
   def google_maps_api_key
-    if has_organization?
-      self.organization.google_maps_key.blank? ? self.google_maps_key : self.organization.google_maps_key
-    else
-      self.google_maps_key
-    end
+    try(:organization).try(:google_maps_key).blank? ? self.google_maps_key : self.organization.google_maps_key
   end
 
   # TODO: this is the correct name for what's stored in the model, refactor changing that name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1424,7 +1424,7 @@ class User < Sequel::Model
   # returns google maps api key. If the user is in an organization and
   # that organization has api key it's used
   def google_maps_api_key
-    try(:organization).try(:google_maps_key).blank? ? google_maps_key : organization.google_maps_key
+    organization.try(:google_maps_key).blank? ? google_maps_key : organization.google_maps_key
   end
 
   # TODO: this is the correct name for what's stored in the model, refactor changing that name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1424,7 +1424,7 @@ class User < Sequel::Model
   # returns google maps api key. If the user is in an organization and
   # that organization has api key it's used
   def google_maps_api_key
-    try(:organization).try(:google_maps_key).blank? ? self.google_maps_key : self.organization.google_maps_key
+    try(:organization).try(:google_maps_key).blank? ? google_maps_key : organization.google_maps_key
   end
 
   # TODO: this is the correct name for what's stored in the model, refactor changing that name

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -794,4 +794,32 @@ shared_examples_for "user models" do
       user.default_basemap['name'].should eq 'GMaps Roadmap'
     end
   end
+
+  describe '#google_maps_api_key' do
+    it 'overrides organization if organization is nil or blank' do
+      user = create_user
+      user.google_maps_api_key.should eq nil
+
+      user.google_maps_key = 'wadus'
+      user.google_maps_api_key.should eq 'wadus'
+
+      user.google_maps_key = nil
+      user.stubs(:organization).returns(mock)
+
+      user.organization.stubs(:google_maps_key).returns(nil)
+      user.google_maps_api_key.should eq nil
+
+      user.organization.stubs(:google_maps_key).returns('org')
+      user.google_maps_api_key.should eq 'org'
+
+      user.google_maps_key = 'wadus'
+      user.google_maps_api_key.should eq 'org'
+
+      user.organization.stubs(:google_maps_key).returns('')
+      user.google_maps_api_key.should eq 'wadus'
+
+      user.organization.stubs(:google_maps_key).returns(nil)
+      user.google_maps_api_key.should eq 'wadus'
+    end
+  end
 end


### PR DESCRIPTION
This fixes #11923.

In addition, I've refactored both, because the `has_organization?` check is indirect.