### PR TITLE
Added jasmine build missing task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -349,6 +349,7 @@ module.exports = function(grunt) {
     grunt.registerTask('dev', 'Typical task for frontend development (watch JS/CSS changes)', [
       'setConfig:env.browserify_watch:true',
       'run_browserify',
+      'build-jasmine-specrunners',
       'connect:server',
       'run_watch:builder_specs=false']);
 


### PR DESCRIPTION
When removing test building from `dev` task, I wiped out also the task of building the jasmine spec runners. It's needed for the old editor specs.

It has come out with a build from scratch.