### PR TITLE
Upgrade cartodb extension to 0.19.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -197,6 +197,13 @@ Development
 * Fixed way to listen Deep-insights.js map or widgets changes (#11894)
 * Using latest cartodb.js and deep-insights.js to tackle map zooming problem (support#605)
 
+### NOTICE
+This release upgrades the CartoDB PostgreSQL extension to `0.19.0`. Run the following to have it available:
+```shell
+cd $(git rev-parse --show-toplevel)/lib/sql
+sudo make install
+```
+
 4.0.x (2016-12-05)
 ------------------
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,8 +10,8 @@ class HomeController < ApplicationController
   OS_VERSION = "Description:\tUbuntu 12.04"
   PG_VERSION = 'PostgreSQL 9.5'.freeze
   POSTGIS_VERSION = '2.2'.freeze
-  CDB_VALID_VERSION = '0.18'.freeze
-  CDB_LATEST_VERSION = '0.18.5'.freeze
+  CDB_VALID_VERSION = '0.19'.freeze
+  CDB_LATEST_VERSION = '0.19.0'.freeze
   REDIS_VERSION = '3'.freeze
   RUBY_BIN_VERSION = 'ruby 2.2.3'.freeze
   NODE_VERSION = 'v0.10'.freeze

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -525,7 +525,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.18.5'
+          cdb_extension_target_version = '0.19.0'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|


### PR DESCRIPTION
Use version 0.19.0 of the SQL extension, which includes a new function `CDB_EstimateRowCount`.
