### PR TITLE
11543 - Disabled edit geometry buttons in read-only and not visible layers

### DIFF
--- a/app/assets/stylesheets/editor-3/context-switcher.css.scss
+++ b/app/assets/stylesheets/editor-3/context-switcher.css.scss
@@ -15,6 +15,9 @@
   overflow: hidden;
   z-index: 4;
 }
+.Editor-contextSwitcher.is-disabled {
+  background: rgba($cBlue, 0.5);
+}
 .Editor-contextSwitcher.is-moved {
   right: 392px;
 }
@@ -48,8 +51,8 @@
     border-right: 0;
   }
 }
-.Editor-contextSwitcherItem.is-disabled {
-  opacity: 0.24;
+.is-disabled .Editor-contextSwitcherItem {
+  opacity: 0.5;
 
   .Editor-contextSwitcherButton {
     cursor: default;
@@ -111,6 +114,3 @@
     bottom: 358px;
   }
 }
-
-
-

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
@@ -32,115 +32,114 @@
   </li>
 </ul>
 
-<% if (!isReadOnly) { %>
-  <div class="EditOverlay js-editOverlay is-hidden"><p class="EditOverlay-inner CDB-Text CDB-Size-medium u-whiteTextColor js-editOverlay-text"></p></div>
+<div class="EditOverlay js-editOverlay is-hidden"><p class="EditOverlay-inner CDB-Text CDB-Size-medium u-whiteTextColor js-editOverlay-text"></p></div>
 
-  <ul class="u-flex u-alignRight Editor-contextSwitcher Editor-contextSwitcher--geom js-mapTableView js-newGeometryView
-  <% if (context === 'table') { %>in-table<% } %>
-  <% if (isThereOtherWidgets && context === 'map') { %>is-moved<% } %>
-  <% if (isThereTimeSeries && context === 'map') { %>
-    has-timeSeries
-    <% if (isThereAnimatedTimeSeries) { %>
-      has-timeSeries--animated
-    <% } %>
+<ul class="u-flex u-alignRight Editor-contextSwitcher Editor-contextSwitcher--geom js-mapTableView js-newGeometryView
+<% if (!isVisible || isReadOnly) { %>is-disabled<% } %>
+<% if (context === 'table') { %>in-table<% } %>
+<% if (isThereOtherWidgets && context === 'map') { %>is-moved<% } %>
+<% if (isThereTimeSeries && context === 'map') { %>
+  has-timeSeries
+  <% if (isThereAnimatedTimeSeries) { %>
+    has-timeSeries--animated
   <% } %>
-  ">
-    <% if (queryGeometryModel === 'point' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
-        <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='point'>
-          <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-            <defs>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="e"/>
-            </defs>
-            <g fill="none" fill-rule="evenodd">
-              <path fill="#FFF" d="M4 3h3v1H4v3H3V4H0V3h3V0h1"/>
-              <g transform="rotate(180 2.5 6)">
-                <mask id="b" fill="#fff">
-                  <use xlink:href="#a"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#b)" stroke="#FFF" stroke-width="2"/>
-              </g>
-              <g transform="rotate(180 6 6)">
-                <mask id="d" fill="#fff">
-                  <use xlink:href="#c"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#d)" stroke="#FFF" stroke-width="2"/>
-              </g>
-              <g transform="rotate(180 6 2.5)">
-                <mask id="f" fill="#fff">
-                  <use xlink:href="#e"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#f)" stroke="#FFF" stroke-width="2"/>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </li>
-    <% } %>
-    <% if (queryGeometryModel === 'line' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
-        <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='line'>
-          <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-            <defs>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
-            </defs>
-            <g fill="none" fill-rule="evenodd">
-              <path fill="#FFF" d="M11.5 5l-.707-.707-6.354 6.853.705.708"/>
-              <g transform="translate(11 2)">
-                <mask id="b" fill="#fff">
-                  <use xlink:href="#a"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#b)" stroke="#FFF" stroke-width="2"/>
-              </g>
-              <g transform="translate(2 11)">
-                <mask id="d" fill="#fff">
-                  <use xlink:href="#c"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#d)" stroke="#FFF" stroke-width="2"/>
-              </g>
-              <path fill="#FFF" d="M3 4H0V3h3V0h1v3h3v1H4v3H3"/>
-            </g>
-          </svg>
-        </div>
-      </li>
-    <% } %>
-    <% if (queryGeometryModel === 'polygon' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
-        <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='polygon'>
-          <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-            <defs>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
-              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="e"/>
-            </defs>
-            <g fill="none" fill-rule="evenodd">
-              <path d="M13 11.5V5h-1v7h1m-.5-7.5l-.707-.707-7.647 7.353-.353.354.707.707.354-.353M4 3h3v1H4v3H3V4H0V3h3V0h1" fill="#FFF"/>
-              <path fill="#FFF" d="M4.5 13H12v-1H4v1"/>
-              <g transform="rotate(180 7 7)">
-                <mask id="b" fill="#fff">
-                  <use xlink:href="#a"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#b)"/>
-              </g>
-              <g transform="rotate(180 7 2.5)">
-                <mask id="d" fill="#fff">
-                  <use xlink:href="#c"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#d)"/>
-              </g>
-              <g transform="rotate(180 2.5 7)">
-                <mask id="f" fill="#fff">
-                  <use xlink:href="#e"/>
-                </mask>
-                <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#f)"/>
-              </g>
-            </g>
-          </svg>
-        </div>
-      </li>
-    <% } %>
-  </ul>
 <% } %>
+" <% if (!isVisible || isReadOnly) { %>data-tooltip="<%- _t('editor.edit-feature.geometry-disabled') %>"<% } %>>
+  <% if (queryGeometryModel === 'point' || !queryGeometryModel) { %>
+    <li class="Editor-contextSwitcherItem js-newGeometryItem">
+      <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='point'>
+        <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="e"/>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <path fill="#FFF" d="M4 3h3v1H4v3H3V4H0V3h3V0h1"/>
+            <g transform="rotate(180 2.5 6)">
+              <mask id="b" fill="#fff">
+                <use xlink:href="#a"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#b)" stroke="#FFF" stroke-width="2"/>
+            </g>
+            <g transform="rotate(180 6 6)">
+              <mask id="d" fill="#fff">
+                <use xlink:href="#c"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#d)" stroke="#FFF" stroke-width="2"/>
+            </g>
+            <g transform="rotate(180 6 2.5)">
+              <mask id="f" fill="#fff">
+                <use xlink:href="#e"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#f)" stroke="#FFF" stroke-width="2"/>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </li>
+  <% } %>
+  <% if (queryGeometryModel === 'line' || !queryGeometryModel) { %>
+    <li class="Editor-contextSwitcherItem js-newGeometryItem">
+      <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='line'>
+        <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <path fill="#FFF" d="M11.5 5l-.707-.707-6.354 6.853.705.708"/>
+            <g transform="translate(11 2)">
+              <mask id="b" fill="#fff">
+                <use xlink:href="#a"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#b)" stroke="#FFF" stroke-width="2"/>
+            </g>
+            <g transform="translate(2 11)">
+              <mask id="d" fill="#fff">
+                <use xlink:href="#c"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" mask="url(#d)" stroke="#FFF" stroke-width="2"/>
+            </g>
+            <path fill="#FFF" d="M3 4H0V3h3V0h1v3h3v1H4v3H3"/>
+          </g>
+        </svg>
+      </div>
+    </li>
+  <% } %>
+  <% if (queryGeometryModel === 'polygon' || !queryGeometryModel) { %>
+    <li class="Editor-contextSwitcherItem js-newGeometryItem">
+      <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='polygon'>
+        <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <defs>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="a"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="c"/>
+            <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" id="e"/>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <path d="M13 11.5V5h-1v7h1m-.5-7.5l-.707-.707-7.647 7.353-.353.354.707.707.354-.353M4 3h3v1H4v3H3V4H0V3h3V0h1" fill="#FFF"/>
+            <path fill="#FFF" d="M4.5 13H12v-1H4v1"/>
+            <g transform="rotate(180 7 7)">
+              <mask id="b" fill="#fff">
+                <use xlink:href="#a"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#b)"/>
+            </g>
+            <g transform="rotate(180 7 2.5)">
+              <mask id="d" fill="#fff">
+                <use xlink:href="#c"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#d)"/>
+            </g>
+            <g transform="rotate(180 2.5 7)">
+              <mask id="f" fill="#fff">
+                <use xlink:href="#e"/>
+              </mask>
+              <path d="M0 2h3v1H0V2zm0-2h3v1H0V0zm2 1h1v1H2V1zM0 1h1v1H0V1z" stroke="#FFF" stroke-width="2" mask="url(#f)"/>
+            </g>
+          </g>
+        </svg>
+      </div>
+    </li>
+  <% } %>
+</ul>

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -18,6 +18,7 @@ var LegendsView = require('./layer-content-views/legend/legends-view');
 var FeatureDefinitionModel = require('../../data/feature-definition-model');
 var AnalysesService = require('./layer-content-views/analyses/analyses-service');
 var checkAndBuildOpts = require('../../helpers/required-opts');
+var TipsyTooltipView = require('../../components/tipsy-tooltip-view');
 
 var REQUIRED_OPTS = [
   'userActions',
@@ -322,6 +323,7 @@ module.exports = CoreView.extend({
 
     var analysisDefinitionNodeModel = this._getAnalysisDefinitionNodeModel();
     var isReadOnly = analysisDefinitionNodeModel.isReadOnly();
+    var isVisible = this._layerDefinitionModel.get('visible');
     var queryGeometryModel = this._getQueryGeometryModel();
 
     $('.CDB-Dashboard-canvas').append(
@@ -332,13 +334,23 @@ module.exports = CoreView.extend({
         isThereAnimatedTimeSeries: this._widgetDefinitionsCollection.isThereTimeSeries({ animated: true }),
         queryGeometryModel: queryGeometryModel.get('simple_geom'),
         isSourceType: analysisDefinitionNodeModel.isSourceType(),
-        isVisible: this._layerDefinitionModel.get('visible'),
+        isVisible: isVisible,
         isReadOnly: isReadOnly
       })
     );
     $('.js-showMap').bind('click', this._onMapClick.bind(this));
     $('.js-showTable').bind('click', this._onTableClick.bind(this));
     $('.js-newGeometry').bind('click', this._onClickNewGeometry.bind(this));
+
+    if (isReadOnly || !isVisible) {
+      var tooltip = new TipsyTooltipView({
+        el: $('.js-newGeometryView'),
+        title: function () {
+          return $(this).data('tooltip');
+        }
+      });
+      this.addView(tooltip);
+    }
   },
 
   _destroyContextButtons: function () {
@@ -382,7 +394,7 @@ module.exports = CoreView.extend({
     var $target = $(ev.target).closest('.js-newGeometry');
     var featureType = $target.data('feature-type');
 
-    if ($target.closest('.js-newGeometryItem').hasClass('is-disabled')) return false;
+    if ($target.closest('.js-newGeometryView').hasClass('is-disabled')) return false;
 
     var editOverlayText = _t('editor.edit-feature.overlay-text', { featureType: _t('editor.edit-feature.features.' + featureType) });
 

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -2223,6 +2223,7 @@
       "cancel": "Cancel",
       "geometry": "Geometry",
       "geometry-edit": "You can also edit it on the map",
+      "geometry-disabled": "Not available for hidden or read only layers",
       "out-of-bounds-lng": "Longitude is out of bounds [-180, 180]",
       "out-of-bounds-lat": "Latitude is out of bounds [-90, 90]",
       "valid-lng": "Must be a valid longitude",

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
@@ -133,7 +133,7 @@ describe('editor/layers/layer-content-view/lcv', function () {
   });
 
   it('should render correctly', function () {
-    expect(_.size(this.view._subviews)).toBe(2);
+    expect(_.size(this.view._subviews)).toBe(3);
     expect(this.view.$('.Editor-HeaderInfo-titleText').text()).toContain('foo');
     expect(this.view.$('.CDB-NavMenu .CDB-NavMenu-item').length).toBe(5);
     // Onboarding

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
@@ -147,8 +147,10 @@ describe('editor/layers/layer-content-view/lcv', function () {
 
   describe('._renderContextButtons', function () {
     var analysisDefNodeModel;
+    var layerDefinitionModel;
     beforeEach(function () {
       analysisDefNodeModel = this.view._getAnalysisDefinitionNodeModel();
+      layerDefinitionModel = this.view._layerDefinitionModel;
       spyOn(analysisDefNodeModel, 'isReadOnly');
       this.view._renderContextButtons();
     });
@@ -158,14 +160,38 @@ describe('editor/layers/layer-content-view/lcv', function () {
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherButton.js-showMap').length).toBe(1);
     });
 
-    it('should not display edit geometry buttons when node is read only', function () {
+    it('should enable edit geometry buttons when node is visible and not read only', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(false);
-      expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
+      layerDefinitionModel.set('visible', true);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom.is-disabled').length).toBe(0);
     });
 
-    it('should not display edit geometry buttons when node is read only', function () {
+    it('should disable edit geometry buttons when node is read only', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(true);
-      expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
+      layerDefinitionModel.set('visible', true);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom.is-disabled').length).toBe(1);
+    });
+
+    it('should disable edit geometry buttons when node is not visible', function () {
+      layerDefinitionModel.set('visible', false);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom.is-disabled').length).toBe(1);
+    });
+
+    it('should not show tooltip when node is visible and not read only', function () {
+      analysisDefNodeModel.isReadOnly.and.returnValue(false);
+      layerDefinitionModel.set('visible', true);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom[data-tooltip]').length).toBe(0);
+    });
+
+    it('should show tooltip when node is read only', function () {
+      analysisDefNodeModel.isReadOnly.and.returnValue(true);
+      layerDefinitionModel.set('visible', true);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom[data-tooltip]').length).toBe(1);
+    });
+
+    it('should show tooltip when node is not visible', function () {
+      layerDefinitionModel.set('visible', false);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom[data-tooltip]').length).toBe(1);
     });
   });
 


### PR DESCRIPTION
This pull request solves the following issue CartoDB/cartodb#11543.

The main goal was to show edit geometry buttons always but disabled for read-only and not visible layers, as you can see in the following GIF.

![edit-geometry-disabled](https://cloud.githubusercontent.com/assets/1225594/24906876/ef32c0e8-1eb9-11e7-80f2-8a935a213de8.gif)

Also, I've added a tooltip to the buttons so the user understands why this functionality can't be used in the current layer.

Every edit geometry buttons are disabled in this case, so instead of disabling each one individually, I've disabled all at once by disabling their container. This way I've been able to change the opacity of the buttons' background and reduce the instances where we evaluate if the current layer is read-only or not visible.

In the future, if each button can be disabled individually they should be individual buttons, each one with their background and space around. In that case, each button should evaluate the conditions to be or not be disabled, but for now, the current solutions works for its purpose.

I've added the corresponding tests to check that buttons are disabled and the tooltip is visible only when the layer is read-only or not visible.