### PR TITLE
Remove erroneous org soft limits configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,7 @@ Development
 * Dataservices configuration rake tasks (#11917)
   * `cartodb:services:set_user_quota[username,service,quota]` updated to support the `mapzen_routing` provider
   * `cartodb:services:set_org_quota[orgname,service,quota]` updated to support the `mapzen_routing` provider
-  * `cartodb:services:set_user_soft_limit[username,service,quota]` new task to set configure user soft limits
-  * `cartodb:services:set_org_soft_limit[orgname,service,quota]` new task to set configure organization soft limits
+  * `cartodb:services:set_user_soft_limit[username,service,quota]` new task to set user soft limits
 * Color picker for codemirror component.
 * New dropdown for Data Observatory (#11618)
 * Quota pre-check to analyses that consume quota.

--- a/doc/manual/source/operations/configure_data_services.rst
+++ b/doc/manual/source/operations/configure_data_services.rst
@@ -65,12 +65,11 @@ Set geocoder quota for organization ``org-name`` to 1000 monthly requests::
 Soft limits
 -----------
 
-The limits for a service can be configured to be *soft*, meaning that the user/organization can exceed the limits (possibly incurring in additional charges).
+The service limits for a user can be configured to be *soft*, meaning that the user can exceed the limits (possibly incurring in additional charges).
 So, when soft limits is set to `false` (the default) and the limits are exceeded, service requests will fail,
-while if the soft limits are set to `true` requests will succeed (and the user/org will be charged for the excess).
+while if the soft limits are set to `true` requests will succeed (and the user will be charged for the excess).
 
 * ``cartodb:services:set_user_soft_limit[username,service,soft_limit_status]``
-* ``cartodb:services:set_org_soft_limit[orgname,service,soft_limit_status]``
 
 The possible values for the soft limits status is either ``true`` or ``false``.
 
@@ -89,6 +88,6 @@ Activate soft geocoding limits for user ``user-name``::
 
     rake cartodb:services:set_user_soft_limit['user-name',geocoder,true]
 
-Disable soft geocoding limits for organization ``org-name``::
+Disable soft geocoding limits for user ``user-name``::
 
-    rake cartodb:services:set_org_soft_limit['org-name',geocoder,false]
+    rake cartodb:services:set_user_soft_limit['user-name',geocoder,false]

--- a/lib/tasks/services.rake
+++ b/lib/tasks/services.rake
@@ -131,25 +131,5 @@ namespace :cartodb do
 
       puts "Changed the user soft limit for service #{service} to #{soft_limit}."
     end
-
-    # usage example: (valid values are true or false)
-    #   bundle exec rake cartodb:services:set_org_soft_limit['orgname','geocoding',true]
-    desc 'Assign the soft limit flag for a service to an organization'
-    task :set_org_soft_limit, [:orgname, :service, :soft_limit] => [:environment] do |_task, args|
-      orgname = args[:orgname]
-      service = args[:service]
-      soft_limit = args[:soft_limit] == 'false' ? false : true
-      org = orgname && ::Organization.find(name: orgname)
-
-      assert_valid_arg args, :orgname,    accepted_values: proc { org.present? }
-      assert_valid_arg args, :service,    accepted_values: DS_SERVICES
-      assert_valid_arg args, :soft_limit, accepted_values: ['true', 'false']
-
-      service_quota_key = "soft_#{service}_limit="
-      org.send(service_quota_key, soft_limit)
-      org.save
-
-      puts "Changed the organization soft limit for service #{service} to #{soft_limit}."
-    end
   end
 end


### PR DESCRIPTION
A task configure soft limits for organizations was incorrectly created.
Organizations don't have soft limits.
See #11917