### PR TITLE
codemirror: mustache template

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/code-mirror/mode/mustache.js
+++ b/lib/assets/core/javascripts/cartodb3/components/code-mirror/mode/mustache.js
@@ -3,56 +3,22 @@ module.exports = function (CodeMirror) {
     return {
       token: function (stream, state) {
         var ch;
-
         if (stream.match('{{')) {
-          ch = stream.peek();
-          if (ch == null || ch != null && ch.match(/[{]{1,}/)) {
-            stream.next();
-            return 'mustache-error';
-          } else if (ch != null && ch.match(/[a-zA-Z_]+/)) {
-            return null;
+          while ((ch = stream.next()) != null) {
+            if (ch === '}' && stream.next() === '}') {
+              stream.eat('}');
+              return 'mustache-text';
+            }
           }
         }
-
-        if (stream.match('}}')) {
-          ch = stream.peek();
-          if (ch != null && ch.match(/[}]{1,}/)) {
-            stream.next();
-            return 'mustache-error';
-          } else if (ch == null) {
-            return null;
-          }
-        }
-
-        if (stream.match('}')) {
-          ch = stream.peek();
-          if (ch == null || ch != null && ch.match(/[}]{1,}/)) {
-            stream.next();
-            return 'mustache-error';
-          }
-        }
-
-        if (stream.match('{')) {
-          ch = stream.peek();
-          if (ch == null || ch != null && ch.match(/[{]{1,}/)) {
-            stream.next();
-            return 'mustache-error';
-          }
-        }
-
-        // Delimiter character
-        if (stream.match(/[a-zA-Z_]+/, true)) {
-          return 'mustache-text';
-        }
-
-        // jump to the next item, needed OR CRASH
-        stream.next();
+        while (stream.next() !== null && !stream.match('{{', false)) {}
+        return null;
       }
     };
   });
 
   (function () {
-    var sqlKeywords = '{{  }}';
+    var sqlKeywords = '{{ }}';
 
     function set (str) {
       var obj = {};


### PR DESCRIPTION
 made changes in the codemirror parser to comply with this request in https://github.com/CartoDB/cartodb/pull/11939#issuecomment-292559200

> Change the text color to difference the text inside {{}} and the text outside. Maybe we can use the white for the text outside like a “{“

it's much less sophisticated now, so I'm not sure about it, what's your opinion @nobuti ?

![screen shot 2017-04-11 at 18 04 41](https://cloud.githubusercontent.com/assets/36676/24918789/dc5924bc-1ee1-11e7-8f5c-9fae474811d9.png)

/cc @urbanphes 