### PR TITLE
Updated dependencies.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,7 @@ Development
 * Update tangram to fix layer geometry conditionals.
 
 ### Bug fixes
+* Autostyling for google basemaps (#11838)
 * Styling falsy categories (#11421)
 * Fixed bug editing geometries from dataset view (#11855)
 * Fixed pagination position in Safari browser

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.73",
+  "version": "4.6.73-ded03-stg",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -86,7 +86,7 @@
                             },
                             "readable-stream": {
                               "version": "2.0.6",
-                              "from": "readable-stream@>=2.0.5 <2.1.0",
+                              "from": "readable-stream@>=2.0.0 <2.1.0",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                               "dependencies": {
                                 "core-util-is": {
@@ -1084,8 +1084,8 @@
     },
     "cartodb-deep-insights.js": {
       "version": "0.0.2",
-      "from": "cartodb/deep-insights.js#11838-no-data-autostyle",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#98f926da1565e1c2f25e9428e7c5d726b72ffa4d",
+      "from": "cartodb/deep-insights.js#master",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#7f79842bcf9a9354f38ff13ac576baabee63bb62",
       "dependencies": {
         "cartodb.js": {
           "version": "4.0.0-alpha.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.62",
+  "version": "4.6.66",
   "dependencies": {
     "backbone": {
       "version": "1.2.3",
@@ -380,9 +380,9 @@
                               }
                             },
                             "sshpk": {
-                              "version": "1.11.0",
+                              "version": "1.13.0",
                               "from": "sshpk@>=1.7.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
+                              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
                               "dependencies": {
                                 "asn1": {
                                   "version": "0.2.3",
@@ -1090,7 +1090,7 @@
         "cartodb.js": {
           "version": "4.0.0-alpha.1",
           "from": "cartodb/cartodb.js#v4",
-          "resolved": "git://github.com/cartodb/cartodb.js.git#543abdd204c37a18243e13f972135fc6cf9b7592",
+          "resolved": "git://github.com/cartodb/cartodb.js.git#b82ed88894c4234c7de7f828f4849f0e5e6b965f",
           "dependencies": {
             "backbone-poller": {
               "version": "1.1.3",
@@ -1171,9 +1171,9 @@
                   }
                 },
                 "tangram-cartocss": {
-                  "version": "0.5.1",
+                  "version": "0.5.2",
                   "from": "cartodb/tangram-carto#master",
-                  "resolved": "git://github.com/cartodb/tangram-carto.git#4a0f2e7a8a800a77e84e4368ca8ef2454a53332b",
+                  "resolved": "git://github.com/cartodb/tangram-carto.git#92ff6fe32743fdee2d296a1512158acef7923d9c",
                   "dependencies": {
                     "babel-runtime": {
                       "version": "6.22.0",
@@ -1424,7 +1424,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#543abdd204c37a18243e13f972135fc6cf9b7592",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#b82ed88894c4234c7de7f828f4849f0e5e6b965f",
       "dependencies": {
         "backbone-poller": {
           "version": "1.1.3",
@@ -1510,9 +1510,9 @@
               }
             },
             "tangram-cartocss": {
-              "version": "0.5.1",
+              "version": "0.5.2",
               "from": "cartodb/tangram-carto#master",
-              "resolved": "git://github.com/cartodb/tangram-carto.git#4a0f2e7a8a800a77e84e4368ca8ef2454a53332b",
+              "resolved": "git://github.com/cartodb/tangram-carto.git#92ff6fe32743fdee2d296a1512158acef7923d9c",
               "dependencies": {
                 "babel-runtime": {
                   "version": "6.22.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "browserify-shim": "3.8.12",
     "camshaft-reference": "<2.0",
     "carto": "cartodb/carto#master",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#11838-no-data-autostyle",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "CartoDB/cartodb.js#v4",
     "cartocolor": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.73",
+  "version": "4.6.73-ded03-stg",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "browserify-shim": "3.8.12",
     "camshaft-reference": "<2.0",
     "carto": "cartodb/carto#master",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#11838-no-data-autostyle",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "CartoDB/cartodb.js#v4",
     "cartocolor": "4.0.0",


### PR DESCRIPTION
This PR implements #11838.

It updates cartodb.js to bring https://github.com/CartoDB/cartodb.js/pull/1623