### PR TITLE
User login event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: gears/carto_gears_api
   specs:
-    carto_gears_api (0.0.5)
+    carto_gears_api (0.0.6)
       rails (= 3.2.22)
       values (= 1.8.0)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -67,12 +67,13 @@ Development
   * Sets the default initial size for icons to 20px (#11498)
 * Onboarding for layer edition (#10905)
 * Initial support for Rails engines with CARTO Gears.
+  * Notification API (#11850)
+  * Queue and Email support (#11692).
+  * User login event (#12010).
 * Improved empty bounds map handling (#11711).
 * Updated diagnosis page versions.
 * set_import_limits rake (#11756).
 * Improved formula widget description field. (#11469)
-  * Notification API (#11850)
-  * Queue and Email support (#11692).
 * Improved empty bounds map handling (#11711).
 * Updated diagnosis page versions.
 * Improved formula widget description field (#11469).

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -60,14 +60,6 @@ class SessionsController < ApplicationController
     user = authenticate!(*strategies, scope: username)
     CartoDB::Stats::Authentication.instance.increment_login_counter(user.email)
 
-    CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserLoginEvent.new(user))
-
-    # From the very beginning it's been assumed that after login you go to the dashboard, and
-    # we're using that event as a synonymous to "last logged in date". Now you can skip dashboard
-    # after login (see #11946), so marking that event on authentication is more accurate with the
-    # meaning (although not with the name).
-    user.view_dashboard
-
     redirect_to session[:return_to] || (user.public_url + CartoDB.path(self, 'dashboard', trailing_slash: true))
   end
 

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -502,7 +502,7 @@ class Carto::User < ActiveRecord::Base
   end
 
   def view_dashboard
-    update_attribute(:dashboard_viewed_at, Time.now)
+    update_column(:dashboard_viewed_at, Time.now)
   end
 
   private

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -501,6 +501,10 @@ class Carto::User < ActiveRecord::Base
     !Carto::Ldap::Manager.new.configuration_present?
   end
 
+  def view_dashboard
+    update_attribute(:dashboard_viewed_at, Time.now)
+  end
+
   private
 
   def set_database_host

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -7,6 +7,16 @@ Rails.configuration.middleware.use RailsWarden::Manager do |manager|
   manager.failure_app = SessionsController
 end
 
+Warden::Manager.after_authentication do |user, _auth, _opts|
+  CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserLoginEvent.new(user))
+
+  # From the very beginning it's been assumed that after login you go to the dashboard, and
+  # we're using that event as a synonymous to "last logged in date". Now you can skip dashboard
+  # after login (see #11946), so marking that event on authentication is more accurate with the
+  # meaning (although not with the name).
+  user.view_dashboard
+end
+
 # Setup Session Serialization
 class Warden::SessionSerializer
   def serialize(user)

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,8 +1,14 @@
 require_dependency 'carto/user_authenticator'
+require_dependency 'carto_gears_api/events/user_events'
+require_dependency 'carto_gears_api/events/event_manager'
 
 Rails.configuration.middleware.use RailsWarden::Manager do |manager|
   manager.default_strategies :password, :api_authentication
   manager.failure_app = SessionsController
+end
+
+Warden::Manager.after_authentication do |user, _auth, _opts|
+  CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserLoginEvent.new(user))
 end
 
 # Setup Session Serialization

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -9,6 +9,12 @@ end
 
 Warden::Manager.after_authentication do |user, _auth, _opts|
   CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserLoginEvent.new(user))
+
+  # From the very beginning it's been assumed that after login you go to the dashboard, and
+  # we're using that event as a synonymous to "last logged in date". Now you can skip dashboard
+  # after login (see #11946), so marking that event on authentication is more accurate with the
+  # meaning (although not with the name).
+  user.view_dashboard
 end
 
 # Setup Session Serialization

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -11,7 +11,7 @@ module LoginEventTrigger
   def trigger_login_event(user)
     CartoDB::Logger.debug(message: "Login event",
                           username: user.username,
-                          dashboard_viewed_at: dashboard_viewed_at,
+                          dashboard_viewed_at: user.dashboard_viewed_at,
                           model_class: user.class)
     CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserLoginEvent.new(user))
 

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -7,16 +7,6 @@ Rails.configuration.middleware.use RailsWarden::Manager do |manager|
   manager.failure_app = SessionsController
 end
 
-Warden::Manager.after_authentication do |user, _auth, _opts|
-  CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserLoginEvent.new(user))
-
-  # From the very beginning it's been assumed that after login you go to the dashboard, and
-  # we're using that event as a synonymous to "last logged in date". Now you can skip dashboard
-  # after login (see #11946), so marking that event on authentication is more accurate with the
-  # meaning (although not with the name).
-  user.view_dashboard
-end
-
 # Setup Session Serialization
 class Warden::SessionSerializer
   def serialize(user)

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -11,8 +11,8 @@ module LoginEventTrigger
   def trigger_login_event(user)
     CartoDB::Logger.debug(message: "Login event",
                           username: user.username,
-                          dashboard_viewed_at: user.dashboard_viewed_at,
-                          model_class: user.class)
+                          dashboard_viewed_at: user.dashboard_viewed_at.to_s,
+                          model_class: user.class.name)
     CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserLoginEvent.new(user))
 
     # From the very beginning it's been assumed that after login you go to the dashboard, and

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -9,10 +9,6 @@ end
 
 module LoginEventTrigger
   def trigger_login_event(user)
-    CartoDB::Logger.debug(message: "Login event",
-                          username: user.username,
-                          dashboard_viewed_at: user.dashboard_viewed_at.to_s,
-                          model_class: user.class.name)
     CartoGearsApi::Events::EventManager.instance.notify(CartoGearsApi::Events::UserLoginEvent.new(user))
 
     # From the very beginning it's been assumed that after login you go to the dashboard, and

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -40,11 +40,14 @@ module CartoGearsApi
     # local authentication system.
     class UserLoginEvent < BaseEvent
       def initialize(user)
-        @user = user
+        @first_login = user.dashboard_viewed_at.nil?
+        @user = Users::User.from_model(user)
       end
 
+      attr_reader :user
+
       def first_login?
-        @user.dashboard_viewed_at.nil?
+        @first_login
       end
     end
   end

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -30,5 +30,16 @@ module CartoGearsApi
         @user = Users::User.from_model(user)
       end
     end
+
+    # Event triggered when a user logins
+    class UserLoginEvent < BaseEvent
+      def initialize(user)
+        @user = user
+      end
+
+      def first_login?
+        @user.dashboard_viewed_at.nil?
+      end
+    end
   end
 end

--- a/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/events/user_events.rb
@@ -31,7 +31,13 @@ module CartoGearsApi
       end
     end
 
-    # Event triggered when a user logins
+    # Event triggered when a user performs a login in the box.
+    # This is not triggered if you use an external authentication system
+    # that overrides local authentication.
+    # For example, this won't work in a SaaS with a central authentication system.
+    # Nevertheless, it will always work for organization login.
+    # LDAP, SAML and other authentication systems will work, because they use
+    # local authentication system.
     class UserLoginEvent < BaseEvent
       def initialize(user)
         @user = user

--- a/gears/carto_gears_api/lib/carto_gears_api/version.rb
+++ b/gears/carto_gears_api/lib/carto_gears_api/version.rb
@@ -1,3 +1,3 @@
 module CartoGearsApi
-  VERSION = '0.0.5'.freeze
+  VERSION = '0.0.6'.freeze
 end

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -822,4 +822,19 @@ shared_examples_for "user models" do
       user.google_maps_api_key.should eq 'wadus'
     end
   end
+
+  describe '#view_dashboard' do
+    it 'sets dashboard_viewed_at time' do
+      user = create_user
+      user.dashboard_viewed_at = nil
+      user.save
+
+      user.view_dashboard
+      last = user.dashboard_viewed_at
+      last.should_not be_nil
+
+      user.view_dashboard
+      user.dashboard_viewed_at.should_not eq last
+    end
+  end
 end

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -574,7 +574,6 @@ describe SessionsController do
 
       it 'triggers CartoGearsApi::Events::UserLoginEvent signaling not first login' do
         login(::User.where(id: @user.id).first)
-        logout
 
         CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with do |event|
           event.first_login?.should be_false

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -559,12 +559,21 @@ describe SessionsController do
         post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
       end
 
+      it 'sets dashboard_viewed_at just with login' do
+        @user.update_column(:dashboard_viewed_at, nil)
+        @user.reload
+        @user.dashboard_viewed_at.should be_nil
+
+        post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
+
+        @user.reload
+        @user.dashboard_viewed_at.should_not be_nil
+      end
+
       include Warden::Test::Helpers
 
       it 'triggers CartoGearsApi::Events::UserLoginEvent signaling not first login' do
         login(::User.where(id: @user.id).first)
-        get dashboard_url
-        logout
 
         CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with do |event|
           event.first_login?.should be_false

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -545,6 +545,42 @@ describe SessionsController do
       response.status.should == 302
       response.headers['Location'].should include '/your_apps'
     end
+
+    describe 'events' do
+      # include HttpAuthenticationHelper
+      require 'rack/test'
+      include Rack::Test::Methods
+      include Warden::Test::Helpers
+
+      it 'triggers CartoGearsApi::Events::UserLoginEvent' do
+        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with() do |event|
+          event.class.should eq CartoGearsApi::Events::UserLoginEvent
+        end
+        post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
+      end
+
+      include Warden::Test::Helpers
+
+      it 'triggers CartoGearsApi::Events::UserLoginEvent signaling not first login' do
+        login(::User.where(id: @user.id).first)
+        get dashboard_url
+        logout
+
+        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with() do |event|
+          event.first_login?.should be_false
+        end
+        post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
+      end
+
+      it 'triggers CartoGearsApi::Events::UserLoginEvent signaling first login' do
+        @new_user = FactoryGirl.create(:carto_user)
+        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with()  do |event|
+          event.first_login?.should be_true
+        end
+        post create_session_url(user_domain: @new_user.username, email: @new_user.username, password: @new_user.password)
+        @new_user.destroy
+      end
+    end
   end
 
   describe '#logout' do

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -574,6 +574,7 @@ describe SessionsController do
 
       it 'triggers CartoGearsApi::Events::UserLoginEvent signaling not first login' do
         login(::User.where(id: @user.id).first)
+        logout
 
         CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with do |event|
           event.first_login?.should be_false

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -553,7 +553,7 @@ describe SessionsController do
       include Warden::Test::Helpers
 
       it 'triggers CartoGearsApi::Events::UserLoginEvent' do
-        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with() do |event|
+        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with do |event|
           event.class.should eq CartoGearsApi::Events::UserLoginEvent
         end
         post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
@@ -566,7 +566,7 @@ describe SessionsController do
         get dashboard_url
         logout
 
-        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with() do |event|
+        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with do |event|
           event.first_login?.should be_false
         end
         post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
@@ -574,7 +574,7 @@ describe SessionsController do
 
       it 'triggers CartoGearsApi::Events::UserLoginEvent signaling first login' do
         @new_user = FactoryGirl.create(:carto_user)
-        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with()  do |event|
+        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with do |event|
           event.first_login?.should be_true
         end
         post create_session_url(user_domain: @new_user.username, email: @new_user.username, password: @new_user.password)

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -580,6 +580,15 @@ describe SessionsController do
         post create_session_url(user_domain: @new_user.username, email: @new_user.username, password: @new_user.password)
         @new_user.destroy
       end
+
+      it 'returns a CartoGearsApi::Users::User matching the logged user' do
+        CartoGearsApi::Events::EventManager.any_instance.expects(:notify).once.with do |event|
+          event_user = event.user
+          event_user.class.should eq CartoGearsApi::Users::User
+          event_user.username.should eq @user.username
+        end
+        post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
+      end
     end
   end
 


### PR DESCRIPTION
This closes #12007.

Although the requirement was only the _first_ login, the login event makes sense, and the fact of being the first can be wrapped in a method at the event, so I chose that.

Acceptance.

Nothing is broken...
- [x] Normal signup + logout + login. `dashboard_viewed_at` is updated on login.
- [x] Google signup + logout + login. `dashboard_viewed_at` is updated on login.
- [x] Organization signup + logout + login. `dashboard_viewed_at` is updated on login.
- [x] An API request doesn't update `dashboard_viewed_at`.

From a gear...:

- [x] Deploy test (does not break anything)
- [x] Register to the login event and make sure that you get it.
- [x] With that event, check that `first_login?` only returns `true` after the first login.
- [x] Create an user account via LDAP/SAML/... You should be auto logged-in after creation and the event should be sent.
- [x] Create an org account using email/password. Is the event sent before or after validation the email? (curiosity, we can probably skip this one) -> event sent on email validation
- [x] As an org admin, create an org account. This event should not be triggered. (this is what motivated this event in the first place).

Debug trace should probably be deleted after acceptance, but it shouldn't be harmful.