### PR TITLE
Disabling geometry buttons for read-only layers

### DIFF
--- a/app/assets/stylesheets/editor-3/context-switcher.css.scss
+++ b/app/assets/stylesheets/editor-3/context-switcher.css.scss
@@ -48,11 +48,13 @@
     border-right: 0;
   }
 }
-.Editor-contextSwitcherItem.is-disabled {
-  opacity: 0.24;
+.Editor-contextSwitcher.is-disabled {
+  .Editor-contextSwitcherItem {
+    opacity: 0.24;
 
-  .Editor-contextSwitcherButton {
-    cursor: default;
+    .Editor-contextSwitcherButton {
+      cursor: default;
+    }
   }
 }
 .Editor-contextSwitcherButton.is-selected .Editor-contextSwitcherMedia {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/change-view-buttons.tpl
@@ -32,10 +32,10 @@
   </li>
 </ul>
 
-<% if (!isReadOnly) { %>
   <div class="EditOverlay js-editOverlay is-hidden"><p class="EditOverlay-inner CDB-Text CDB-Size-medium u-whiteTextColor js-editOverlay-text"></p></div>
 
   <ul class="u-flex u-alignRight Editor-contextSwitcher Editor-contextSwitcher--geom js-mapTableView js-newGeometryView
+  <% if (isReadOnly || !isVisible) { %>is-disabled<% } %>
   <% if (context === 'table') { %>in-table<% } %>
   <% if (isThereOtherWidgets && context === 'map') { %>is-moved<% } %>
   <% if (isThereTimeSeries && context === 'map') { %>
@@ -46,7 +46,7 @@
   <% } %>
   ">
     <% if (queryGeometryModel === 'point' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
+      <li class="Editor-contextSwitcherItem js-newGeometryItem">
         <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='point'>
           <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <defs>
@@ -80,7 +80,7 @@
       </li>
     <% } %>
     <% if (queryGeometryModel === 'line' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
+      <li class="Editor-contextSwitcherItem js-newGeometryItem">
         <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='line'>
           <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <defs>
@@ -108,7 +108,7 @@
       </li>
     <% } %>
     <% if (queryGeometryModel === 'polygon' || !queryGeometryModel) { %>
-      <li class="Editor-contextSwitcherItem js-newGeometryItem <% if (!isVisible) { %>is-disabled<% } %>">
+      <li class="Editor-contextSwitcherItem js-newGeometryItem">
         <div class="Editor-contextSwitcherButton js-newGeometry" data-feature-type='polygon'>
           <svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
             <defs>
@@ -143,4 +143,3 @@
       </li>
     <% } %>
   </ul>
-<% } %>

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -382,7 +382,7 @@ module.exports = CoreView.extend({
     var $target = $(ev.target).closest('.js-newGeometry');
     var featureType = $target.data('feature-type');
 
-    if ($target.closest('.js-newGeometryItem').hasClass('is-disabled')) return false;
+    if ($target.closest('.js-newGeometryView').hasClass('is-disabled')) return false;
 
     var editOverlayText = _t('editor.edit-feature.overlay-text', { featureType: _t('editor.edit-feature.features.' + featureType) });
 

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
@@ -150,6 +150,7 @@ describe('editor/layers/layer-content-view/lcv', function () {
     beforeEach(function () {
       analysisDefNodeModel = this.view._getAnalysisDefinitionNodeModel();
       spyOn(analysisDefNodeModel, 'isReadOnly');
+      this.view._layerDefinitionModel.set('visible', true);
       this.view._renderContextButtons();
     });
 
@@ -158,7 +159,7 @@ describe('editor/layers/layer-content-view/lcv', function () {
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherButton.js-showMap').length).toBe(1);
     });
 
-    it('should show all geometry buttons not disabled when read only', function () {
+    it('should show all geometry buttons not disabled when not read only', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(false);
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom.is-disabled').length).toBe(0);

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
@@ -150,7 +150,6 @@ describe('editor/layers/layer-content-view/lcv', function () {
     beforeEach(function () {
       analysisDefNodeModel = this.view._getAnalysisDefinitionNodeModel();
       spyOn(analysisDefNodeModel, 'isReadOnly');
-      this.view._layerDefinitionModel.set('visible', true);
       this.view._renderContextButtons();
     });
 
@@ -161,12 +160,14 @@ describe('editor/layers/layer-content-view/lcv', function () {
 
     it('should show all geometry buttons not disabled when not read only', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(false);
+      this.view._layerDefinitionModel.set('visible', true);
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom.is-disabled').length).toBe(0);
     });
 
     it('should show & mark geo buttons as disabled when read only', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(true);
+      this.view._layerDefinitionModel.set('visible', true);
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom.is-disabled').length).toBe(1);
     });

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view.spec.js
@@ -158,14 +158,16 @@ describe('editor/layers/layer-content-view/lcv', function () {
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherButton.js-showMap').length).toBe(1);
     });
 
-    it('should not display edit geometry buttons when node is read only', function () {
+    it('should show all geometry buttons not disabled when read only', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(false);
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom.is-disabled').length).toBe(0);
     });
 
-    it('should not display edit geometry buttons when node is read only', function () {
+    it('should show & mark geo buttons as disabled when read only', function () {
       analysisDefNodeModel.isReadOnly.and.returnValue(true);
       expect($(dashboardCanvasEl).find('.Editor-contextSwitcherItem.js-newGeometryItem').length).toBe(3);
+      expect($(dashboardCanvasEl).find('.Editor-contextSwitcher--geom.is-disabled').length).toBe(1);
     });
   });
 


### PR DESCRIPTION
This PR makes new geometry buttons look disabled (instead of hiding them) for read-only layers.

I've moved the is-disabled to the parent view, which requires a small change in styles & a slight change in the click handler as well.

This is how it looks like (like isVisible false)

![image](https://cloud.githubusercontent.com/assets/446970/25406333/9d0aa5b2-2a06-11e7-9352-7363c42d87a2.png)

I've updated the tests blindly because the cartodb3 tests don't run locally for me. It looks like the previous ones are broken (it expected .length 3 in both cases, which makes sense now, not before), so I don't know if my changes are correct or not.

We could add more coverage by testing the behaviour with isVisible as well, which produces the same result.