### PR TITLE
Load gemspecs from CartoGearsApi directory

### DIFF
--- a/lib/carto/carto_gears_support.rb
+++ b/lib/carto/carto_gears_support.rb
@@ -43,7 +43,11 @@ module Carto
     end
 
     def gemspec
-      Gem::Specification::load(File::join(path, "#{name}.gemspec"))
+      pwd = Dir.pwd
+      Dir.chdir(path)
+      Gem::Specification::load("#{name}.gemspec")
+    ensure
+      Dir.chdir(pwd)
     end
 
     def full_path


### PR DESCRIPTION
Fixes #12069

**Acceptance**
- [x] Nothing breaks
- [x] It goes fast in Vagrant (or you can check by adding a breakpoint in the Gears gemspec, to check that it does not scan everything)
- [x] Private gears work