### PR TITLE
Fixing problem about saving metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,7 @@ Development
 * Update tangram to fix layer geometry conditionals.
 
 ### Bug fixes
+* Fixed problem with the textarea editor (cartodb/support#656)
 * Autostyling for google basemaps (#11838)
 
 * Save collapse state for layer list (#11927)

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/textarea.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/textarea.js
@@ -2,13 +2,11 @@ var Backbone = require('backbone');
 
 Backbone.Form.editors.TextArea = Backbone.Form.editors.Text.extend({
   tagName: 'textarea',
-
   className: 'CDB-Textarea',
 
   initialize: function (opts) {
-    Backbone.Form.editors.Base.prototype._setOptions.call(this, opts); // Options
-
-    this.value = this.model.get(this.options.keyAttr);
+    Backbone.Form.editors.Base.prototype._setOptions.call(this, opts);
+    Backbone.Form.editors.Base.prototype.initialize.call(this, opts);
   },
 
   render: function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/textarea.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/textarea.spec.js
@@ -27,7 +27,7 @@ describe('components/form-components/editors/textarea', function () {
 
   it('set key variable', function () {
     this.createView();
-    expect(this.view.key).toBe('stree_address_column');
+    expect(this.view.key).toBe('street_address_column');
   });
 
   it('should render properly', function () {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/textarea.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/textarea.spec.js
@@ -25,9 +25,13 @@ describe('components/form-components/editors/textarea', function () {
     this.createView = createViewFn.bind(this);
   });
 
+  it('set key variable', function () {
+    this.createView();
+    expect(this.view.key).toBe('stree_address_column');
+  });
+
   it('should render properly', function () {
     this.createView();
-
     expect(this.view.$el.prop('tagName').toLowerCase()).toBe('textarea');
   });
 


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/support/issues/656

We didn't set the "internal" properties for the TextArea editor component, and in the commit function it was required:

```js
…
  commit: function(options) {
    var error = this.validate();
    if (error) return error;

    this.listenTo(this.model, 'invalid', function(model, e) {
      error = e;
    });
    this.model.set(this.key, this.getValue(), options);

    if (error) return error;
  },
…
```

That was the reason why description was not updated after editing it in the metadata modal 💃 .

## STTest
- Check **map** description is stored after being edited in metadata dialog.
- Check **dataset** description is stored after being edited in metadata dialog.