### PR TITLE
Adding userModel parameter for analysis check-if-enabled

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/modals/add-analysis/analysis-options.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/add-analysis/analysis-options.js
@@ -45,7 +45,7 @@ module.exports = function (Analyses, userModel, configModel) {
             return type !== 'source' && !_.contains(implementedAnalyses, type);
           })
           .map(function (type) {
-            if (!Analyses.isAnalysisValidByType(type, configModel)) {
+            if (!Analyses.isAnalysisValidByType(type, configModel, userModel)) {
               return false;
             }
 

--- a/lib/assets/core/javascripts/cartodb3/data/analyses.js
+++ b/lib/assets/core/javascripts/cartodb3/data/analyses.js
@@ -358,10 +358,10 @@ var definitionByType = function (m) {
   };
 };
 
-var isAnalysisValidByType = function (type, configModel) {
+var isAnalysisValidByType = function (type, configModel, userModel) {
   var analysis = MAP[type];
   var dsReady = DataServicesApiCheck.get().isReady();
-  return analysis && analysis.checkIfEnabled ? analysis.checkIfEnabled(configModel) && dsReady : true;
+  return analysis && analysis.checkIfEnabled ? analysis.checkIfEnabled(configModel, userModel) && dsReady : true;
 };
 
 module.exports = {
@@ -373,10 +373,10 @@ module.exports = {
       : UnknownTypeFormModel;
   },
 
-  getAnalysesByModalCategory: function (category, configModel) {
+  getAnalysesByModalCategory: function (category, configModel, userModel) {
     return _.reduce(MAP, function (memo, item, analysisType) {
       if (item.modalCategory === category) {
-        if (isAnalysisValidByType(analysisType, configModel)) {
+        if (isAnalysisValidByType(analysisType, configModel, userModel)) {
           var obj = {
             nodeAttrs: {
               type: analysisType

--- a/lib/assets/core/test/spec/cartodb3/data/analyses.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/analyses.spec.js
@@ -36,6 +36,8 @@ describe('cartodb3/data/analyses', function () {
           data_observatory: true
         }
       });
+
+      this.userModel = new Backbone.Model();
     });
 
     describe('data observatory', function () {
@@ -51,14 +53,14 @@ describe('cartodb3/data/analyses', function () {
 
       it('dataservices api existing', function () {
         DataServicesApiCheck.get(this.configModel)._ready = 'ready';
-        var analysisModels = analyses.getAnalysesByModalCategory('create_clean', this.configModel);
+        var analysisModels = analyses.getAnalysesByModalCategory('create_clean', this.configModel, this.userModel);
         expect(analysisModels.length).toBe(4);
         expect(findDataObservatory(analysisModels).length).toBe(1);
       });
 
       it('dataservices api not existing', function () {
         DataServicesApiCheck.get(this.configModel)._ready = 'notready';
-        var analysisModels = analyses.getAnalysesByModalCategory('create_clean', this.configModel);
+        var analysisModels = analyses.getAnalysesByModalCategory('create_clean', this.configModel, this.userModel);
         expect(analysisModels.length).toBe(3);
         expect(findDataObservatory(analysisModels).length).toBe(0);
       });


### PR DESCRIPTION
Related ticket: #12025 

Basically that ^^^. We will have the chance to check if an analysis is enabled by any userModel attribute from now on. Example, we can use it in `analyses.js` like:

```js
…
  'routing-to-single-point': {
    title: _t('analyses.routing.short-title'),
    FormModel: FallbackFormModel,
    checkIfEnabled: function (configModel, userModel) {
      return userModel.featureEnabled('routing-analysis');
    }
  },
…
```