### PR TITLE
It is not necessary to trigger fetchs for reset-style-per-node when node itself launches one when it is ready/finished

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -227,6 +227,7 @@ Development
 * Check if analysis node is on top before fetching query data (#11874)
 * Fixed error dropping tables from ghost table manager on race condition cases (#12012)
 * IE11 fix for dropdowns with scrollview (#12073)
+* Fixed problem resetting styles per node after adding a new analysis (#12085)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.0`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/helpers/reset-style-per-node.js
+++ b/lib/assets/core/javascripts/cartodb3/helpers/reset-style-per-node.js
@@ -83,8 +83,13 @@ module.exports = function (nodeDefModel, layerDefModel, forceStyleUpdate, resetQ
 
     saveDefaultStylesIfStillRelevant();
 
-    queryGeometryModel.bind(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
-    querySchemaModel.bind(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
+    if (!queryGeometryModel.isFetched()) {
+      queryGeometryModel.bind(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
+    }
+
+    if (!querySchemaModel.isFetched()) {
+      querySchemaModel.bind(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
+    }
   };
 
   if (resetQueryReady) {

--- a/lib/assets/core/javascripts/cartodb3/helpers/reset-style-per-node.js
+++ b/lib/assets/core/javascripts/cartodb3/helpers/reset-style-per-node.js
@@ -83,20 +83,8 @@ module.exports = function (nodeDefModel, layerDefModel, forceStyleUpdate, resetQ
 
     saveDefaultStylesIfStillRelevant();
 
-    if (!queryGeometryModel.isFetched()) {
-      queryGeometryModel.bind(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
-    }
-
-    if (!querySchemaModel.isFetched()) {
-      querySchemaModel.bind(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
-    }
-
-    if (queryGeometryModel.shouldFetch()) {
-      queryGeometryModel.fetch();
-    }
-    if (querySchemaModel.shouldFetch()) {
-      querySchemaModel.fetch();
-    }
+    queryGeometryModel.bind(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
+    querySchemaModel.bind(CHANGE_STATUS, saveDefaultStylesIfStillRelevant);
   };
 
   if (resetQueryReady) {

--- a/lib/assets/core/test/spec/cartodb3/helpers/reset-style-per-node.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/helpers/reset-style-per-node.spec.js
@@ -125,12 +125,14 @@ describe('helpers/reset-style-per-node', function () {
     });
 
     describe('fetch models', function () {
-      it('should fetch geometry model if it is not fetching or it is available', function () {
-        expect(nodeDefModel.queryGeometryModel.fetch).toHaveBeenCalled();
+      // It is not needed anymore due to we "force" a fetch for all query objects when
+      // the analysis node is ready (CartoDB/cartodb/pull/11989)
+      it('should not fetch geometry model if it is not fetching or it is available', function () {
+        expect(nodeDefModel.queryGeometryModel.fetch).not.toHaveBeenCalled();
       });
 
-      it('should fetch schema model if it is not fetching or it is available', function () {
-        expect(nodeDefModel.queryGeometryModel.fetch).toHaveBeenCalled();
+      it('should not fetch schema model if it is not fetching or it is available', function () {
+        expect(nodeDefModel.queryGeometryModel.fetch).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/12085

When we introduced https://github.com/CartoDB/cartodb/pull/11989, we didn't realize we f***** up reset-styles thing. Because it was resetting the status of the query objects from the deep-insights-integration node changes (https://github.com/CartoDB/cartodb/blob/master/lib/assets/core/javascripts/cartodb3/deep-insights-integrations.js#L347-L375).

In the future, we will remove this and we will apply the specific style for each type of analysis (cc @saleiva @makella).

In order to test this, I'd check that when a new analysis is added, reset styles works properly. Visit styles panel and check that the simple one is selected when the analysis is finished.