### PR TITLE
fixed typo line 1654

### DIFF
--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -1651,7 +1651,7 @@
           "street-address-column-help": "Select a column with street addresses",
           "street-address-help": "Use columns or free text to compose your address schema. <a href='https://carto.com/learn/guides/analysis/georeference' target='_blank'>More info.</a>",
           "street-address": "Street Addresses",
-          "advance": "Advance mode",
+          "advance": "Advanced mode",
           "normal": "Normal mode"
         },
         "group-by": "Group by",


### PR DESCRIPTION
Fixed typo in line 1654 for street addresses ui, should be plural "advanced", not "advance mode". (Confirmed by @noguerol in related [Learn issue](https://github.com/CartoDB/learn/pull/352#issuecomment-299979302)

Tagging @xavijam for approval to merge