### PR TITLE
Fix analysis quota view leak

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/tab-pane/tab-pane-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/tab-pane/tab-pane-view.js
@@ -23,6 +23,9 @@ module.exports = CoreView.extend({
   },
 
   render: function () {
+    this.clearSubViews();
+    this.$el.empty();
+
     this.$el.html(this.template(this.options));
 
     this._renderCollection();
@@ -75,14 +78,14 @@ module.exports = CoreView.extend({
   _renderTabPaneItemView: function (model) {
     var tabPaneItemView = new TabPaneItem(_.extend({ model: model }, this._tabPaneItemOptions));
     this.addView(tabPaneItemView);
-    this.$('.js-menu').append(tabPaneItemView.render().$el);
+    this.$('.js-menu').append(tabPaneItemView.render().el);
   },
 
   _renderTabPaneContentView: function (model) {
     var tabPaneContentView = model.get(this._createContentKey).call(model);
     if (tabPaneContentView) {
       this.addView(tabPaneContentView);
-      this.$('.js-content').append(tabPaneContentView.render().$el);
+      this.$('.js-content').append(tabPaneContentView.render().el);
     }
     return tabPaneContentView;
   },

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -246,11 +246,10 @@ module.exports = CoreView.extend({
 
     this._layerTabPaneView = createTextLabelsTabPane(tabPaneTabs, tabPaneOptions);
     this._bindEvents();
-    this._layerTabPaneView.render();
-    this._layerTabPaneView.$el.addClass('js-editorPanelContent');
-    this.$el.append(this._layerTabPaneView.$el);
+    this.$el.append(this._layerTabPaneView.render().el);
     this.addView(this._layerTabPaneView);
 
+    this._layerTabPaneView.$el.addClass('js-editorPanelContent');
     this._renderContextButtons();
 
     return this;

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-view.js
@@ -59,6 +59,7 @@ module.exports = CoreView.extend({
   render: function () {
     this._launchOnboarding();
     this.clearSubViews();
+    this.$el.empty();
 
     var self = this;
     var infoboxSstates = [

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -84,7 +84,6 @@ module.exports = CoreView.extend({
     }
 
     this.addView(view);
-
     this.$el.append(view.render().el);
     return this;
   },

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-quota-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-quota-view.js
@@ -25,7 +25,6 @@ module.exports = CoreView.extend({
       infoboxCollection: this._infoboxCollection
     });
     this.addView(view);
-
     this.$el.append(view.render().el);
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
@@ -190,17 +190,23 @@ module.exports = CoreView.extend({
     return node.querySchemaModel;
   },
 
-  _selectedNodeId: function () {
-    if (arguments.length === 0) {
+  _selectedNodeId: function (id, options) {
+    if (!this._viewModel) {
+      return;
+    }
+
+    if (id === undefined) {
       return this._viewModel.get('selectedNodeId');
     } else {
-      this._viewModel.set('selectedNodeId', arguments[0], arguments[1]);
+      this._viewModel.set('selectedNodeId', id, options);
     }
   },
 
   _onLayerDefSourceChanged: function () {
+    // When reset, the parent view is rendered again, creating a new instance of this one
+    // calling here this._renderWithDefaultNodeSelected(); will cause a race condition
+    // ending up in two instance of this being rendered
     this._analysisFormsCollection.resetByLayerDefinition();
-    this._renderWithDefaultNodeSelected();
   },
 
   _onFormModelAdded: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
@@ -68,6 +68,7 @@ module.exports = CoreView.extend({
 
   render: function () {
     this.clearSubViews();
+    this.$el.empty();
 
     if (this._hasError()) {
       this.$el.html(
@@ -83,7 +84,6 @@ module.exports = CoreView.extend({
       if (this._analysisFormsCollection.isEmpty()) {
         this.$el.html(analysisPlaceholderTemplate());
       } else {
-        this.$el.empty();
         var formModel = this._formModel();
         this._renderScrollableListView(formModel);
         this._renderControlsView(formModel);
@@ -94,9 +94,8 @@ module.exports = CoreView.extend({
   },
 
   clean: function () {
-    CoreView.prototype.clean.apply(this, arguments);
+    CoreView.prototype.clean.apply(this);
     this._selectedNodeId(null, {silent: true});
-    this.viewModel = null;
   },
 
   _renderOverlay: function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.91",
+  "version": "4.6.92",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes a leak related to the quota analysis view. In some scenarios, we found the analysis-control-view is not properly removed when the parent view was removed. This could cause an inconsistent state of this view when the analysis finishes or fails. Basically, it gets stuck in the fetching state.

### Context

In analyses-view.js we have [a bind](https://github.com/CartoDB/cartodb/blob/master/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-view.js#L129) for when the analysis form collection is reset or an analysis is removed. When an analysis is done, [the source changes](https://github.com/CartoDB/cartodb/blob/master/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js#L123), so we [reset the analysis form collection](https://github.com/CartoDB/cartodb/blob/master/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js#L203) with the new data. This follows [a complete render of the parent view](https://github.com/CartoDB/cartodb/blob/master/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-view.js#L132-L153). But the thread in the actual view is not finished, so when it get back to [this point](https://github.com/CartoDB/cartodb/blob/master/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js#L204) the former view is rendered again, this time in memory because it was removed from the DOM when the parent view was re-rendered, but still listening and rendering subviews.
