### PR TITLE
12113 rails4 first steps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'vizzuality-sequel-rails', '0.3.7', git: 'https://github.com/Vizzuality/sequ
 
 gem 'rails_warden',            '0.5.8' # Auth via the Warden Rack framework
 gem 'ruby-saml',               '1.4.1'
-gem 'oauth',                   '0.4.5'
+gem 'oauth',                   '0.5.1'
 gem 'oauth-plugin',            '0.4.0.pre4'
 
 gem 'redis',                   '3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
     net-telnet (0.1.1)
     nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
-    oauth (0.4.5)
+    oauth (0.5.1)
     oauth-plugin (0.4.0.pre4)
       oauth (>= 0.4.4)
     pg (0.15.0)
@@ -393,7 +393,7 @@ DEPENDENCIES
   net-ldap (= 0.11)
   net-telnet
   nokogiri (~> 1.6.6.2)
-  oauth (= 0.4.5)
+  oauth (= 0.5.1)
   oauth-plugin (= 0.4.0.pre4)
   pg (= 0.15.0)
   poltergeist (>= 1.0.0)
@@ -437,4 +437,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -3,6 +3,7 @@ require 'uuidtools'
 
 require_relative '../models/visualization/support_tables'
 require_dependency 'carto/db/user_schema'
+require_dependency 'visualization/derived_creator'
 
 module CartoDB
   module Connector

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -329,10 +329,9 @@ class ApplicationController < ActionController::Base
       if current_user && env["warden"].authenticated?(current_user.username)
         @current_viewer = current_user if validate_session(current_user)
       else
-        authenticated_usernames = request.session.select {|k, v|
+        authenticated_usernames = request.session.to_hash.select {|k, v|
           k.start_with?("warden.user") && !k.end_with?(".session")
-        }
-                                                    .values
+        }.values
         # See if there's a session of the viewed subdomain corresponding user
         current_user_present = authenticated_usernames.select { |username|
           CartoDB.extract_subdomain(request) == username

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -329,7 +329,7 @@ class ApplicationController < ActionController::Base
       if current_user && env["warden"].authenticated?(current_user.username)
         @current_viewer = current_user if validate_session(current_user)
       else
-        authenticated_usernames = request.session.to_hash.select {|k, v|
+        authenticated_usernames = request.session.to_hash.select { |k, _|
           k.start_with?("warden.user") && !k.end_with?(".session")
         }.values
         # See if there's a session of the viewed subdomain corresponding user

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -63,11 +63,12 @@ module LoginHelper
 
     if env['warden']
       env['warden'].logout
-      request.session.to_hash.select { |k, v|
+      warden_sessions = request.session.to_hash.select do |k, _|
         k.start_with?("warden.user") && !k.end_with?(".session")
-      }.each { |k, v|
+      end
+      warden_sessions.each do |_, value|
         env['warden'].logout(value) if warden_proxy.authenticated?(value)
-      }
+      end
     end
   end
 

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -63,7 +63,7 @@ module LoginHelper
 
     if env['warden']
       env['warden'].logout
-      request.session.select { |k, v|
+      request.session.to_hash.select { |k, v|
         k.start_with?("warden.user") && !k.end_with?(".session")
       }.each { |k, v|
         env['warden'].logout(value) if warden_proxy.authenticated?(value)

--- a/app/models/carto/legend.rb
+++ b/app/models/carto/legend.rb
@@ -10,9 +10,9 @@ module Carto
 
     belongs_to :layer, class_name: Carto::Layer
 
-    VALID_LEGEND_TYPES = %(category bubble choropleth custom custom_choropleth).freeze
+    VALID_LEGEND_TYPES = %w(category bubble choropleth custom custom_choropleth).freeze
     LEGEND_TYPES_PER_ATTRIBUTE = {
-      color: %(category choropleth custom custom_choropleth),
+      color: %w(category choropleth custom custom_choropleth),
       size: %(bubble)
     }.freeze
 

--- a/app/services/carto/visualizations_export_persistence_service.rb
+++ b/app/services/carto/visualizations_export_persistence_service.rb
@@ -107,8 +107,7 @@ module Carto
           layers.push(layer)
         end
       end
-      visualization.map.layers_maps.clear
-      layers.each { |l| visualization.map.layers << l }
+      visualization.map.layers = layers
     end
   end
 end

--- a/app/services/carto/visualizations_export_persistence_service.rb
+++ b/app/services/carto/visualizations_export_persistence_service.rb
@@ -107,7 +107,8 @@ module Carto
           layers.push(layer)
         end
       end
-      visualization.map.layers = layers
+      visualization.map.layers_maps.clear
+      layers.each { |l| visualization.map.layers << l }
     end
   end
 end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -294,7 +294,7 @@ Warden::Manager.after_set_user except: :fetch do |user, auth, opts|
   warden_proxy = auth.env['warden']
   # On testing there is no warden global so we cannot run this logic
   if warden_proxy
-    auth.env['rack.session'].select { |key, value|
+    auth.env['rack.session'].to_hash.select { |key, value|
       key.start_with?("warden.user") && !key.end_with?(".session")
     }.each { |key, value|
       unless value == user.username

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -294,13 +294,14 @@ Warden::Manager.after_set_user except: :fetch do |user, auth, opts|
   warden_proxy = auth.env['warden']
   # On testing there is no warden global so we cannot run this logic
   if warden_proxy
-    auth.env['rack.session'].to_hash.select { |key, value|
+    warden_sessions = auth.env['rack.session'].to_hash.select do |key, _|
       key.start_with?("warden.user") && !key.end_with?(".session")
-    }.each { |key, value|
+    end
+    warden_sessions.each do |_, value|
       unless value == user.username
         warden_proxy.logout(value) if warden_proxy.authenticated?(value)
       end
-    }
+    end
   end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -333,7 +333,7 @@ CartoDB::Application.routes.draw do
     resources :mobile_apps, path: '(/user/:user_domain)(/u/:user_domain)/your_apps/mobile', except: [:edit]
   end
 
-  scope module: 'carto/api', format: :json do
+  scope module: 'carto/api', defaults: { format: :json } do
     # Visualizations
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz'                                => 'visualizations#index',           as: :api_v1_visualizations_index
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id'                            => 'visualizations#show',            as: :api_v1_visualizations_show,            constraints: { id: /[^\/]+/ }
@@ -471,7 +471,7 @@ CartoDB::Application.routes.draw do
     put '(/user/:user_domain)(/u/:user_domain)/api/v1/perm/:id' => 'permissions#update', as: :api_v1_permissions_update
   end
 
-  scope :module => 'api/json', :format => :json do
+  scope :module => 'api/json', defaults: { format: :json } do
 
     # V1
     # --
@@ -546,7 +546,7 @@ CartoDB::Application.routes.draw do
     end
   end
 
-  scope :module => 'superadmin', :format => :json do
+  scope :module => 'superadmin', defaults: { format: :json } do
     get '/superadmin/get_databases_info' => 'platform#databases_info'
     get '/superadmin/stats/total_users' => 'platform#total_users'
     get '/superadmin/stats/total_pay_users' => 'platform#total_pay_users'
@@ -561,7 +561,7 @@ CartoDB::Application.routes.draw do
 
   UUID_REGEXP = /([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})/
 
-  scope module: 'carto/api', path: '(/user/:user_domain)(/u/:user_domain)/api/', format: :json do
+  scope module: 'carto/api', path: '(/user/:user_domain)(/u/:user_domain)/api/', defaults: { format: :json } do
     scope 'v3/' do
       scope 'maps/:map_id/layers/:map_layer_id', constraints: { map_id: /[^\/]+/, map_layer_id: /[^\/]+/ } do
         resources :widgets, only: [:show, :create, :update, :destroy], constraints: { id: /[^\/]+/ }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,8 +10,8 @@
 
 CartoDB::Application.routes.draw do
   # Double use: for user public dashboard AND org dashboard
-  get   '/[(user/:user_domain)(u/:user_domain)]'                 => 'admin/pages#public'
-  root :to => 'admin/pages#index'
+  get '/[(user/:user_domain)(u/:user_domain)]' => 'admin/pages#public'
+  root to: 'admin/pages#index'
 
   get   '/signup'           => 'signup#signup',     as: :signup
   post  '/signup'           => 'signup#create',  as: :signup_organization_user
@@ -470,7 +470,7 @@ CartoDB::Application.routes.draw do
     put '(/user/:user_domain)(/u/:user_domain)/api/v1/perm/:id' => 'permissions#update', as: :api_v1_permissions_update
   end
 
-  scope :module => 'api/json', defaults: { format: :json } do
+  scope module: 'api/json', defaults: { format: :json } do
 
     # V1
     # --
@@ -545,7 +545,7 @@ CartoDB::Application.routes.draw do
     end
   end
 
-  scope :module => 'superadmin', defaults: { format: :json } do
+  scope module: 'superadmin', defaults: { format: :json } do
     get '/superadmin/get_databases_info' => 'platform#databases_info'
     get '/superadmin/stats/total_users' => 'platform#total_users'
     get '/superadmin/stats/total_pay_users' => 'platform#total_pay_users'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@
 
 CartoDB::Application.routes.draw do
   # Double use: for user public dashboard AND org dashboard
-  get   '/[(user/:user_domain)(u/:user_domain)]'                 => 'admin/pages#public', as: :root
+  get   '/[(user/:user_domain)(u/:user_domain)]'                 => 'admin/pages#public'
   root :to => 'admin/pages#index'
 
   get   '/signup'           => 'signup#signup',     as: :signup
@@ -24,10 +24,10 @@ CartoDB::Application.routes.draw do
 
   get   '(/user/:user_domain)/login' => 'sessions#new',     as: :login
   get   '(/user/:user_domain)(/u/:user_domain)/logout'          => 'sessions#destroy', as: :logout
-  match '(/user/:user_domain)(/u/:user_domain)/sessions/create' => 'sessions#create',  as: :create_session
+  match '(/user/:user_domain)(/u/:user_domain)/sessions/create' => 'sessions#create',  as: :create_session, via: [:get, :post]
 
-  match '(/user/:user_domain)(/u/:user_domain)/status'          => 'home#app_status'
-  match '(/user/:user_domain)(/u/:user_domain)/diagnosis'       => 'home#app_diagnosis'
+  get '(/user/:user_domain)(/u/:user_domain)/status'          => 'home#app_status'
+  get '(/user/:user_domain)(/u/:user_domain)/diagnosis'       => 'home#app_diagnosis'
 
   # Explore
   get   '(/user/:user_domain)(/u/:user_domain)/explore'         => 'explore#index',     as: :explore_index
@@ -38,13 +38,13 @@ CartoDB::Application.routes.draw do
   get   '(/user/:user_domain)(/u/:user_domain)/data-library'           => 'data_library#index',     as: :data_library_index
 
   # OAuth
-  match '(/user/:user_domain)(/u/:user_domain)/oauth/authorize'      => 'oauth#authorize',     as: :authorize
-  match '(/user/:user_domain)(/u/:user_domain)/oauth/request_token'  => 'oauth#request_token', as: :request_token
-  match '(/user/:user_domain)(/u/:user_domain)/oauth/access_token'   => 'oauth#access_token',  as: :access_token
+  match '(/user/:user_domain)(/u/:user_domain)/oauth/authorize'      => 'oauth#authorize',     as: :authorize, via: [:get, :post]
+  match '(/user/:user_domain)(/u/:user_domain)/oauth/request_token'  => 'oauth#request_token', as: :request_token, via: [:get, :post]
+  match '(/user/:user_domain)(/u/:user_domain)/oauth/access_token'   => 'oauth#access_token',  as: :access_token, via: [:get, :post]
   get   '(/user/:user_domain)(/u/:user_domain)/oauth/identity'       => 'sessions#show',       as: :oauth_show_sessions
 
   # This is what an external SAML endpoint should redirect to after successful auth.
-  match '(/user/:user_domain)(/u/:user_domain)/saml/finalize' => 'sessions#create'
+  post '(/user/:user_domain)(/u/:user_domain)/saml/finalize' => 'sessions#create'
 
   get '/google_plus' => 'google_plus#google_plus', as: :google_plus
   post '/google/signup' => 'google_plus#google_signup', as: :google_plus_signup
@@ -65,7 +65,7 @@ CartoDB::Application.routes.draw do
     end
 
     namespace :editor do
-      match '(*path)', to: redirect { |params, request|
+      get '(*path)', to: redirect { |params, request|
         CartoDB.base_url_from_request(request) + '/builder/' + params[:path].to_s
       }
     end
@@ -105,7 +105,7 @@ CartoDB::Application.routes.draw do
     get    '(/user/:user_domain)(/u/:user_domain)/profile' => 'users#profile',        as: :profile_user
     put    '(/user/:user_domain)(/u/:user_domain)/profile' => 'users#profile_update', as: :profile_update_user
     get    '(/user/:user_domain)(/u/:user_domain)/account' => 'users#account',        as: :account_user
-    delete '(/user/:user_domain)(/u/:user_domain)/account' => 'users#delete',        as: :account_user
+    delete '(/user/:user_domain)(/u/:user_domain)/account' => 'users#delete',        as: :account_delete_user
     put    '(/user/:user_domain)(/u/:user_domain)/account' => 'users#account_update', as: :account_update_user
     delete '(/user/:user_domain)(/u/:user_domain)/account/:id' => 'users#delete', as: :delete_user
 
@@ -323,9 +323,9 @@ CartoDB::Application.routes.draw do
     get '(/user/:user_domain)(/u/:user_domain)/viz/:id/protected_public_map'  => 'visualizations#show_protected_public_map', constraints: { id: /[^\/]+/ }, defaults: { dont_rewrite: true }
     post '(/user/:user_domain)(/u/:user_domain)/viz/:id/protected_public_map' => 'visualizations#show_protected_public_map', as: :protected_public_map, constraints: { id: /[^\/]+/ }, defaults: { dont_rewrite: true }
 
-    match '(/user/:user_domain)(/u/:user_domain)/your_apps'                    => 'client_applications#api_key',            as: :api_key_credentials
+    get '(/user/:user_domain)(/u/:user_domain)/your_apps'                      => 'client_applications#api_key',            as: :api_key_credentials
     post '(/user/:user_domain)(/u/:user_domain)/your_apps/api_key/regenerate'  => 'client_applications#regenerate_api_key', as: :regenerate_api_key
-    match '(/user/:user_domain)(/u/:user_domain)/your_apps/oauth'              => 'client_applications#oauth',              as: :oauth_credentials
+    get '(/user/:user_domain)(/u/:user_domain)/your_apps/oauth'                => 'client_applications#oauth',              as: :oauth_credentials
     delete '(/user/:user_domain)(/u/:user_domain)/your_apps/oauth/regenerate'  => 'client_applications#regenerate_oauth',   as: :regenerate_oauth
   end
 
@@ -339,8 +339,7 @@ CartoDB::Application.routes.draw do
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id'                            => 'visualizations#show',            as: :api_v1_visualizations_show,            constraints: { id: /[^\/]+/ }
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/likes'                      => 'visualizations#likes_count',     as: :api_v1_visualizations_likes_count,     constraints: { id: /[^\/]+/ }
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/likes/detailed'             => 'visualizations#likes_list',      as: :api_v1_visualizations_likes_list,      constraints: { id: /[^\/]+/ }
-    get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/like'                       => 'visualizations#is_liked',        as: :api_v1_visualizations_is_liked,        constraints: { id: /[^\/]+/ }
-    match '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/like' => 'visualizations#is_liked', as: :api_v1_visualizations_is_liked, constraints: {method: 'OPTIONS'}
+    match '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/like'                     => 'visualizations#is_liked',        as: :api_v1_visualizations_is_liked,        constraints: { id: /[^\/]+/ }, via: [:get, :options]
     get '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id/related_templates'          => 'templates#related_templates_by_visualization', as: :api_v1_visualizations_related_templates, constraints: { id: /[^\/]+/ }
 
     delete '(/user/:user_domain)(/u/:user_domain)/api/v1/viz/:id'                         => 'visualizations#destroy',         as: :api_v1_visualizations_destroy,         constraints: { id: /[^\/]+/ }
@@ -568,7 +567,7 @@ CartoDB::Application.routes.draw do
       end
 
       scope '/viz/:id', constraints: { id: /[^\/]+/ } do
-        match 'viz' => 'visualizations#vizjson3', as: :api_v3_visualizations_vizjson
+        get 'viz' => 'visualizations#vizjson3', as: :api_v3_visualizations_vizjson
       end
 
       resource :metrics, only: [:create]

--- a/services/user-mover/spec/user_mover_spec.rb
+++ b/services/user-mover/spec/user_mover_spec.rb
@@ -77,8 +77,9 @@ describe CartoDB::DataMover::ExportJob do
     it_behaves_like "a migrated user"
 
     it "matches old and new user except database_name and database_host" do
-      expect(first_user.as_json.reject { |x| [:updated_at, :database_name, :database_host, :organization_id, :database_schema].include? x.to_sym })
-        .to eq(subject.as_json.reject { |x| [:updated_at, :database_name, :database_host, :organization_id, :database_schema].include? x.to_sym })
+      IGNORED_KEYS = [:updated_at, :database_name, :database_host, :organization_id, :database_schema].freeze
+      expect(first_user.as_json.reject { |x| IGNORED_KEYS.include? x.to_sym })
+        .to eq(subject.as_json.reject { |x| IGNORED_KEYS.include? x.to_sym })
       expect(subject.database_name).to eq(@org.owner.database_name)
       expect(subject.database_schema).to eq(subject.username)
       expect(subject.database_host).to eq('127.0.0.2')

--- a/services/user-mover/spec/user_mover_spec.rb
+++ b/services/user-mover/spec/user_mover_spec.rb
@@ -46,8 +46,8 @@ describe CartoDB::DataMover::ExportJob do
 
     it_behaves_like "a migrated user"
     it "matches old and new user" do
-      expect((first_user.as_json.reject { |x| x == :updated_at || x == :database_host }))
-        .to eq((subject.as_json.reject { |x| x == :updated_at || x == :database_host }))
+      expect((first_user.as_json.reject { |x| [:updated_at, :database_host].include?(x.to_sym) }))
+        .to eq((subject.as_json.reject { |x| [:updated_at, :database_host].include?(x.to_sym) }))
     end
   end
 
@@ -77,8 +77,8 @@ describe CartoDB::DataMover::ExportJob do
     it_behaves_like "a migrated user"
 
     it "matches old and new user except database_name and database_host" do
-      expect(first_user.as_json.reject { |x| [:updated_at, :database_name, :database_host, :organization_id, :database_schema].include? x })
-        .to eq(subject.as_json.reject { |x| [:updated_at, :database_name, :database_host, :organization_id, :database_schema].include? x })
+      expect(first_user.as_json.reject { |x| [:updated_at, :database_name, :database_host, :organization_id, :database_schema].include? x.to_sym })
+        .to eq(subject.as_json.reject { |x| [:updated_at, :database_name, :database_host, :organization_id, :database_schema].include? x.to_sym })
       expect(subject.database_name).to eq(@org.owner.database_name)
       expect(subject.database_schema).to eq(subject.username)
       expect(subject.database_host).to eq('127.0.0.2')

--- a/spec/models/carto/legend_spec.rb
+++ b/spec/models/carto/legend_spec.rb
@@ -50,7 +50,7 @@ module Carto
       end
 
       it 'only accepts known types' do
-        Legend::VALID_LEGEND_TYPES.split.each do |type|
+        Legend::VALID_LEGEND_TYPES.each do |type|
           @legend.type = type
           @legend.valid?
           @legend.errors[:type].should be_empty

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -599,7 +599,7 @@ shared_examples_for "user models" do
     it 'is false for users within a SAML organization' do
       organization = FactoryGirl.create(:saml_organization)
       organization.auth_saml_enabled?.should == true
-      @user.organization = organization
+      @user.organization = @user.is_a?(Carto::User) ? Carto::Organization.find(organization.id) : organization
       @user.needs_password_confirmation?.should == false
 
       @user.organization = nil

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -17,7 +17,7 @@ describe SessionsController do
       google_plus_config.stubs(:domain).returns { user_domain }
       GooglePlusConfig.stubs(instance: google_plus_config)
 
-      @user = FactoryGirl.create(:carto_user, username: 'google_user')
+      @user = FactoryGirl.create(:carto_user, username: 'google-user')
     end
 
     after(:all) do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -29,7 +29,7 @@ module HelperMethods
   end
 
   def http_json_headers
-    { "CONTENT_TYPE" => "application/json", :format => "json" }
+    { "CONTENT_TYPE" => "application/json", :format => "json", 'Accept' => 'application/json' }
   end
 
   def get_json(path, params = {}, headers = http_json_headers)
@@ -44,7 +44,7 @@ module HelperMethods
   end
 
   def put_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT_TYPE" => "application/json")
+    headers = headers.merge("CONTENT-TYPE" => "application/json", 'Accept' => 'application/json')
     put path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = the_response.body.blank? ? {} : ::JSON.parse(the_response.body)
@@ -56,7 +56,7 @@ module HelperMethods
   end
 
   def post_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT_TYPE" => "application/json")
+    headers = headers.merge("CONTENT-TYPE" => "application/json", 'Accept' => 'application/json')
     post path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = the_response.body.blank? ? {} : ::JSON.parse(the_response.body)
@@ -68,7 +68,7 @@ module HelperMethods
   end
 
   def delete_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT_TYPE" => "application/json")
+    headers = headers.merge("CONTENT-TYPE" => "application/json", 'Accept' => 'application/json')
     delete path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = (the_response.body.blank? || the_response.body.to_s.length < 2) ? {} : ::JSON.parse(the_response.body)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -44,7 +44,7 @@ module HelperMethods
   end
 
   def put_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT-TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
+    headers = headers.merge("CONTENT_TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
     put path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = the_response.body.blank? ? {} : ::JSON.parse(the_response.body)
@@ -56,7 +56,7 @@ module HelperMethods
   end
 
   def post_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT-TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
+    headers = headers.merge("CONTENT_TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
     post path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = the_response.body.blank? ? {} : ::JSON.parse(the_response.body)
@@ -68,7 +68,7 @@ module HelperMethods
   end
 
   def delete_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT-TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
+    headers = headers.merge("CONTENT_TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
     delete path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = (the_response.body.blank? || the_response.body.to_s.length < 2) ? {} : ::JSON.parse(the_response.body)

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -29,7 +29,7 @@ module HelperMethods
   end
 
   def http_json_headers
-    { "CONTENT_TYPE" => "application/json", :format => "json", 'Accept' => 'application/json' }
+    { "CONTENT_TYPE" => "application/json", :format => "json", 'HTTP_ACCEPT' => 'application/json' }
   end
 
   def get_json(path, params = {}, headers = http_json_headers)
@@ -44,7 +44,7 @@ module HelperMethods
   end
 
   def put_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT-TYPE" => "application/json", 'Accept' => 'application/json')
+    headers = headers.merge("CONTENT-TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
     put path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = the_response.body.blank? ? {} : ::JSON.parse(the_response.body)
@@ -56,7 +56,7 @@ module HelperMethods
   end
 
   def post_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT-TYPE" => "application/json", 'Accept' => 'application/json')
+    headers = headers.merge("CONTENT-TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
     post path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = the_response.body.blank? ? {} : ::JSON.parse(the_response.body)
@@ -68,7 +68,7 @@ module HelperMethods
   end
 
   def delete_json(path, params = {}, headers = http_json_headers)
-    headers = headers.merge("CONTENT-TYPE" => "application/json", 'Accept' => 'application/json')
+    headers = headers.merge("CONTENT-TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
     delete path, JSON.dump(params), headers
     the_response = response || get_last_response
     response_parsed = (the_response.body.blank? || the_response.body.to_s.length < 2) ? {} : ::JSON.parse(the_response.body)


### PR DESCRIPTION
#12113

A random bag of fixes needed for Rails 4 that can be applied independently.

Highlights:
- Routes:
  - Main one was using `match` without specifying verbs.
  - `format: :json` is now written as `defaults: { format: :json }`
- Modified `verb_json` test helpers to pass HTTP Header `Accept: application/json`. Before, this was being done with `format: json`, which is not supposed to work (but it did because Rails 3 merged `params` and `headers`)
- Updated oauth gem [changelog](https://github.com/oauth-xx/oauth-ruby/blob/master/HISTORY)
- Session objects are slightly different in Rails 4. Added `to_hash` to make compatible

**Acceptance**
- [x] Login / logout
- [x] Modified routes
- [ ] Oauth
- [x] Legend edition