### PR TITLE
Adding z-index to file-input button

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -115,6 +115,7 @@ Development
 * Added explanation tooltip to the categorize label on the Find Nearest analysis (#12100)
 
 ### Bug fixes
+* Solved problem with file input in connect dataset dialog (cartodb/support#690)
 * Fixed problem with feature flag in analyses (cartodb/support#691)
 * Removed link to markdown support in organization notifications
 * Fix image export in Safari and IE (#12066)

--- a/app/assets/stylesheets/common/form-content.css.scss
+++ b/app/assets/stylesheets/common/form-content.css.scss
@@ -443,6 +443,7 @@ $sLabel-width: 140px;
   -moz-transform: translate(26px, 0) scale(1);
   direction: ltr;
   cursor: pointer;
+  z-index: 3;
 }
 .Form-fileLabel {
   width: 130px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.97",
+  "version": "4.6.98",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/support/issues/690.

Silly change, and certainly, I have no idea why it was not already there.