### PR TITLE
12130 speed up org users endpoint

### DIFF
--- a/app/controllers/carto/api/organizations_controller.rb
+++ b/app/controllers/carto/api/organizations_controller.rb
@@ -23,7 +23,7 @@ module Carto
         users = users_query.all
 
         render_jsonp({ users: users.map { |u|
-          Carto::Api::UserPresenter.new(u, current_viewer: current_user).to_poro
+          Carto::Api::UserPresenter.new(u, current_viewer: current_user, fetch_db_size: false).to_poro
         }, total_user_entries: total_user_entries, total_entries: users.count })
       end
     end

--- a/app/controllers/carto/api/user_presenter.rb
+++ b/app/controllers/carto/api/user_presenter.rb
@@ -6,10 +6,11 @@ module Carto
       include AccountTypeHelper
       BUILDER_ACTIVATION_DATE = Date.new(2016, 11, 11).freeze
 
-      def initialize(user, fetch_groups: false, current_viewer: nil)
+      def initialize(user, fetch_groups: false, current_viewer: nil, fetch_db_size: true)
         @user = user
         @fetch_groups = fetch_groups
         @current_viewer = current_viewer
+        @fetch_db_size = fetch_db_size
       end
 
       def to_poro
@@ -23,7 +24,6 @@ module Carto
           avatar_url:       @user.avatar_url,
           base_url:         @user.public_url,
           quota_in_bytes:   @user.quota_in_bytes,
-          db_size_in_bytes: @user.db_size_in_bytes,
           table_count:      @user.table_count,
           viewer:           @user.viewer?,
           org_admin:        @user.organization_admin?,
@@ -34,6 +34,8 @@ module Carto
         if fetch_groups
           poro[:groups] = @user.groups ? @user.groups.map { |g| Carto::Api::GroupPresenter.new(g).to_poro } : []
         end
+
+        poro[:db_size_in_bytes] = @user.db_size_in_bytes if fetch_db_size
 
         poro
       end
@@ -215,7 +217,7 @@ module Carto
 
       private
 
-      attr_reader :current_viewer, :current_user, :fetch_groups
+      attr_reader :current_viewer, :current_user, :fetch_groups, :fetch_db_size
 
       def failed_import_count
         Carto::DataImport.where(user_id: @user.id, state: 'failure').count

--- a/spec/requests/carto/api/organizations_controller_spec.rb
+++ b/spec/requests/carto/api/organizations_controller_spec.rb
@@ -129,6 +129,14 @@ describe Carto::Api::OrganizationsController do
       end
     end
 
+    it 'does not return db size (slow)' do
+      get_json api_v1_organization_users_url(id: @organization.id, api_key: @org_user_1.api_key), @headers do |response|
+        response.status.should == 200
+        response.body[:users].each do |u|
+          u.keys.should_not include 'db_size_in_bytes'
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Fixes #12130 

I tested by manually running the code from the Rails console in production, and indeed, this is ~5x faster (`db_size_in_bytes` accounted for closed to 80% of the execution time). I haven't been able to reproduce locally or in staging.

**Acceptance**
- [x] Nothing breaks, especially, take a look at the user list in the organization settings.
- [x] It's faster. I have not been able to reproduce this in any other org than `team` in production (even orgs with lots of users). So we may need to test it here.