### PR TITLE
Don't provide a way to rename a dataset shared with you

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -117,6 +117,7 @@ Development
 * Added explanation tooltip to the categorize label on the Find Nearest analysis (#12100)
 
 ### Bug fixes
+* Fixed a problem with shared dataset's title (#12144)
 * Fixed reset autostyle after clicking on more than 1 auto-style buttons without unchecking them (#11795)
 * Fixed styles in numeric fields when editing a feature (#12026)
 * Fixed disabling button while export image is running (#12029)

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-header/dataset-header-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-header/dataset-header-view.js
@@ -99,7 +99,7 @@ module.exports = CoreView.extend({
     var shareWith;
     var isOwner = this._tableModel.isOwner(this._userModel);
 
-    if (this._isEditable()) {
+    if (this._isDatasetOwner() && !this._tableModel.isSync()) {
       this._inlineEditor = new InlineEditorView({
         template: templateInlineEditor,
         renderOptions: {
@@ -358,6 +358,10 @@ module.exports = CoreView.extend({
 
   _isEditable: function () {
     return !this._analysisDefinitionNodeModel.isReadOnly();
+  },
+
+  _isDatasetOwner: function () {
+    return this._tableModel.isOwner(this._userModel);
   }
 
 });

--- a/lib/assets/core/test/spec/cartodb3/dataset/dataset-header-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/dataset/dataset-header-view.spec.js
@@ -130,7 +130,17 @@ describe('dataset/dataset-header-view', function () {
       expect(this.view.$('.SyncInfo-state').length).toBe(1);
     });
 
-    it('should not render the inline editor or the sync info view or the share info view if owner is different', function () {
+    it('should not render the inline editor if owner is different', function () {
+      spyOn(this.view._userModel, 'isInsideOrg').and.returnValue(true);
+      this.view._tableModel.isOwner.and.returnValue(false);
+      this.tableModel.isSync.and.returnValue(false);
+      this.view.render();
+      expect(_.size(this.view._subviews)).toBe(0);
+      expect(this.view.$('.Inline-editor').length).toBe(0);
+      expect(this.view.$('.SyncInfo-state').length).toBe(0);
+    });
+
+    it('should not render the sync info if owner is different', function () {
       spyOn(this.view._userModel, 'isInsideOrg').and.returnValue(true);
       this.view._tableModel.isOwner.and.returnValue(false);
       this.tableModel.isSync.and.returnValue(true);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.02",
+  "version": "4.7.02.stag1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: #12144 

If a user A shares a dataset with read&write permissions with a user B, dataset view should NOT provide a way to rename the dataset. It is true user B can edit the data, but not the name or the sync options.