### PR TITLE
Possibility to include the source node in the node/dataset options list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -118,6 +118,7 @@ Development
 * Disable geometry edition button instead of hide in read-only layers (#11543)
 
 ### Bug fixes
+* Provide the possibility to add the current source node to the target options list in analysis forms (#12057)
 * Fixed a problem with shared dataset's title (#12144)
 * Fixed reset autostyle after clicking on more than 1 auto-style buttons without unchecking them (#11795)
 * Fixed styles in numeric fields when editing a feature (#12026)

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
@@ -135,6 +135,7 @@ module.exports = Backbone.Model.extend({
   },
 
   _getSourceOptionsForSource: function (options) {
+    options = options || {};
     var sourceAttrName = null;
     var requiredSimpleGeometryType = '*';
     var ignorePrimarySource = false;

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
@@ -138,6 +138,7 @@ module.exports = Backbone.Model.extend({
     var sourceAttrName = null;
     var requiredSimpleGeometryType = '*';
     var ignorePrimarySource = false;
+    var includeSourceNode = options.includeSourceNode || false;
 
     // options validation and defaults
     if (options.sourceAttrName === void 0) {
@@ -171,7 +172,10 @@ module.exports = Backbone.Model.extend({
       return this._analysisSourceOptionsModel
         .getSelectOptions(requiredSimpleGeometryType)
         .filter(function (d) {
-          return d.val !== sourceId && (options.onlyNodes ? d.type === 'node' : true);
+          return (
+            (includeSourceNode ? true : d.val !== sourceId) &&
+            (options.onlyNodes ? d.type === 'node' : true)
+          );
         });
     }
   }

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/closest-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/closest-form-model.js
@@ -53,7 +53,8 @@ module.exports = BaseAnalysisFormModel.extend({
         type: 'NodeDataset',
         title: _t('editor.layers.analysis-form.find-nearest.target'),
         options: this._getSourceOptionsForSource({
-          sourceAttrName: 'target'
+          sourceAttrName: 'target',
+          includeSourceNode: true
         }),
         dialogMode: 'float',
         validators: ['required'],

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
@@ -286,5 +286,43 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/base-a
 
       expect(this.model._analysisSourceOptionsModel.getSelectOptions).toHaveBeenCalledWith('point');
     });
+
+    it('should return the layer source with the options if includeSourceNode param is provided', function () {
+      var sourceAttrName = 'target';
+      this.model.set(sourceAttrName, 'the source');
+      this.model._layerDefinitionModel.set('source', 1);
+      this.model._analysisSourceOptionsModel.getSelectOptions = function () {};
+      spyOn(this.model._analysisSourceOptionsModel, 'getSelectOptions').and.returnValue([
+        {
+          val: 3,
+          type: 'node'
+        }, {
+          val: 2,
+          type: 'other'
+        }, {
+          val: 1,
+          type: 'node'
+        }
+      ]);
+      spyOn(this.model, '_isPrimarySource').and.returnValue(false);
+      spyOn(this.model, '_isFetchingOptions').and.returnValue(false);
+
+      var result = this.model._getSourceOptionsForSource({
+        sourceAttrName: sourceAttrName,
+        includeSourceNode: true
+      });
+
+      expect(result).toEqual([{
+        val: 3,
+        type: 'node'
+      }, {
+        val: 2,
+        type: 'other'
+      }, {
+        val: 1,
+        type: 'node'
+      }]);
+      expect(this.model._analysisSourceOptionsModel.getSelectOptions).toHaveBeenCalledWith('*');
+    });
   });
 });

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/closest-form-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/closest-form-model.spec.js
@@ -157,7 +157,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/closes
         target: {
           type: 'NodeDataset',
           title: 'editor.layers.analysis-form.find-nearest.target',
-          options: {sourceAttrName: 'target'},
+          options: {sourceAttrName: 'target', includeSourceNode: true},
           dialogMode: 'float',
           validators: ['required'],
           editorAttrs: {


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/12057

In the closest analysis we need to provide the source node as an option in the target list, that's all. By default, we will not provide it (in any other analysis), but it could be added by the `includeSourceNode` parameter.

And about how to test it, we should check we provide that option in that analysis and also check if in the rest of them we don't provide it in the target editor.