### PR TITLE
12142 saml error reporting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -248,6 +248,7 @@ Development
 * Validate amount of organization seats (#12101)
 * Fixed error dropping tables from ghost table manager on race condition cases (#12012)
 * IE11 fix for dropdowns with scrollview (#12073)
+* Better display and logging of errors when SAML authentication fails (#12151)
 * Fixed problem resetting styles per node after adding a new analysis (#12085)
 * Docs, fixed some minor spelling and grammar errors in the content.
 * Docs, updated "More Info" url from street addresses georeference options to new, related guide.

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -47,7 +47,10 @@ class SessionsController < ApplicationController
   def create
     strategies, username = saml_strategy_username || ldap_strategy_username ||
                            google_strategy_username || credentials_strategy_username
-    return render(action: 'new') unless strategies
+
+    unless strategies
+      return saml_authentication? ? render_403 : render(action: 'new')
+    end
 
     candidate_user = Carto::User.where(username: username).first
 
@@ -220,8 +223,8 @@ class SessionsController < ApplicationController
       if email
         [:saml, username_from_user_by_email(email)]
       else
-        verify_authenticity_token
-        nil
+         # This stops trying other strategies. Important because CSRF is not checked for SAML.
+        [nil, nil]
       end
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -45,7 +45,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    strategies, username = ldap_strategy_username || saml_strategy_username ||
+    strategies, username = saml_strategy_username || ldap_strategy_username ||
                            google_strategy_username || credentials_strategy_username
     return render(action: 'new') unless strategies
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -223,7 +223,7 @@ class SessionsController < ApplicationController
       if email
         [:saml, username_from_user_by_email(email)]
       else
-         # This stops trying other strategies. Important because CSRF is not checked for SAML.
+        # This stops trying other strategies. Important because CSRF is not checked for SAML.
         [nil, nil]
       end
     end

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -17,8 +17,6 @@ module Carto
     end
 
     def get_user_email(saml_response_param)
-      require 'delorean'
-      Delorean.time_travel_to "1 day ago"
       response = get_saml_response(saml_response_param)
       response.is_valid? && email_from_saml_response(response)
     rescue OneLogin::RubySaml::ValidationError

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -18,7 +18,9 @@ module Carto
 
     def get_user_email(saml_response_param)
       response = get_saml_response(saml_response_param)
-      response.is_valid? ? email_from_saml_response(response) : debug_response("Invalid SAML response", response)
+      response.is_valid? && email_from_saml_response(response)
+    rescue OneLogin::RubySaml::ValidationError
+      debug_response("Invalid SAML response", response)
     end
 
     def logout_url_configured?

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -17,6 +17,8 @@ module Carto
     end
 
     def get_user_email(saml_response_param)
+      require 'delorean'
+      Delorean.time_travel_to "1 day ago"
       response = get_saml_response(saml_response_param)
       response.is_valid? && email_from_saml_response(response)
     rescue OneLogin::RubySaml::ValidationError
@@ -84,7 +86,7 @@ module Carto
     def debug_response(message, response)
       CartoDB::Logger.debug(
         message: message,
-        response_settings: response.settings,
+        response_settings: response.settings.to_json,
         response_options: response.options,
         response_errors: response.errors
       )

--- a/spec/lib/carto/saml_service_spec.rb
+++ b/spec/lib/carto/saml_service_spec.rb
@@ -42,7 +42,7 @@ describe Carto::SamlService do
 
     describe '#get_user_email' do
       it 'returns nil if response is invalid' do
-        response_mock.stubs(:is_valid?).returns(false)
+        response_mock.stubs(:is_valid?).raises(OneLogin::RubySaml::ValidationError.new)
 
         service.get_user_email(saml_response_param_mock).should be_nil
       end

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -359,7 +359,7 @@ describe SessionsController do
 
       post create_session_url(user_domain: user_domain, SAMLResponse: 'xx')
 
-      response.status.should == 200
+      response.status.should == 403
     end
 
     describe 'SAML logout' do


### PR DESCRIPTION
Fix #12142 

This makes SAML authentication fails to return a pretty 403 (and log a detailed message) rather than crashing.
Also, reorders SAML to be tried before SAML, see https://github.com/CartoDB/cartodb/pull/12151/commits/890bc17147827ddbe9ce07a976d0eb89fbc09aee