### PR TITLE
Hide operator list view instead destroy it.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -118,6 +118,7 @@ Development
 * Disable geometry edition button instead of hide in read-only layers (#11543)
 
 ### Bug fixes
+* Fixed operator view edition (#12133)
 * Fixed a problem with shared dataset's title (#12144)
 * Fixed reset autostyle after clicking on more than 1 auto-style buttons without unchecking them (#11795)
 * Fixed styles in numeric fields when editing a feature (#12026)

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/operators/operators-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/operators/operators-list-view.js
@@ -47,7 +47,8 @@ module.exports = CoreView.extend({
       this._toggleVisibility();
 
       if (!isVisible) {
-        this.remove();
+        this._destroyList();
+        this.$('.js-list').html(emptyTemplate());
       } else {
         this.render();
       }

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/operators/operators-list-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/operators/operators-list-view.spec.js
@@ -38,6 +38,17 @@ describe('components/form-components/operators/operators-list-view', function ()
     expect(attrs.attribute).toBe('');
   });
 
+  it('should destroy list if hidden', function () {
+    spyOn(this.view, '_destroyList');
+    spyOn(this.view, 'remove');
+    // To force a change
+    this.view.model.unset('visible');
+    this.view.model.set('visible', false);
+
+    expect(this.view._destroyList).toHaveBeenCalled();
+    expect(this.view.remove).not.toHaveBeenCalled();
+  });
+
   describe('.render', function () {
     it('should render properly', function () {
       expect(this.view.$('.Editor-dropdownCalculations').length).toBe(1);


### PR DESCRIPTION
This PR implements #12133.

In order to test it:
- [x] Check edition is working in style panel.
- [x] Check analyses that use the component:
    - [x] intersect layer
    - [x] centroid
    - [x] group points into polygons
    