### PR TITLE
Engine enabled should be inherited from organization by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -251,6 +251,7 @@ Development
 * Fixed problem resetting styles per node after adding a new analysis (#12085)
 * Docs, fixed some minor spelling and grammar errors in the content.
 * Docs, updated "More Info" url from street addresses georeference options to new, related guide.
+* Organizations users now get engine_enabled from the organization by default (#12153)
 * Color picker disappears in CartoCSS editor after clicking (#12097).
 
 ### NOTICE

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -136,7 +136,7 @@ module Concerns
           :google_maps_key, :google_maps_private_key, :here_isolines_quota, :here_isolines_block_price,
           :soft_here_isolines_limit, :obs_snapshot_quota, :obs_snapshot_block_price, :soft_obs_snapshot_limit,
           :obs_general_quota, :obs_general_block_price, :soft_obs_general_limit,
-          :viewer, :geocoder_provider, :isolines_provider, :routing_provider, :builder_enabled,
+          :viewer, :geocoder_provider, :isolines_provider, :routing_provider, :builder_enabled, :engine_enabled,
           :mapzen_routing_quota, :mapzen_routing_block_price, :soft_mapzen_routing_limit
         )
         case action

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -281,6 +281,7 @@ class User < Sequel::Model
       # Make the default of new organization users nil (inherit from organization) instead of the DB default
       # but only if not explicitly set otherwise
       self.builder_enabled = nil if new? && !changed_columns.include?(:builder_enabled)
+      self.engine_enabled = nil if new? && !changed_columns.include?(:engine_enabled)
     end
 
     if viewer

--- a/spec/requests/admin/organization_users_controller_spec.rb
+++ b/spec/requests/admin/organization_users_controller_spec.rb
@@ -290,6 +290,7 @@ describe Admin::OrganizationUsersController do
         user.quota_in_bytes.should eq user_params[:quota_in_bytes]
         user.twitter_datasource_enabled.should be_nil
         user.builder_enabled.should be_nil
+        user.engine_enabled.should be_nil
 
         user.destroy
       end

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -175,6 +175,7 @@ describe Carto::Api::OrganizationUsersController do
       last_user_created.soft_geocoding_limit.should eq false
       last_user_created.quota_in_bytes.should eq 1024
       last_user_created.builder_enabled.should be_nil
+      last_user_created.engine_enabled.should be_nil
       last_user_created.destroy
     end
 


### PR DESCRIPTION
https://github.com/CartoDB/cartodb-management/issues/4941

Organization users created from the cloud were getting engine enabled by default, ignoring organization settings.

**CR**
Don't forget to CR https://github.com/CartoDB/cartodb-central/pull/1772 as well

**Acceptance**
Deploy this and https://github.com/CartoDB/cartodb-central/pull/1772
- [x] Org user creation (as an owner). Check `engine_enabled` in cloud and central (should be `nil`)
- [x] Org user signup. Check `engine_enabled` in cloud and central (should be `nil`)
- [x] Normal signup. Check `engine_enabled` in cloud and central (should be `false` as in FREE price plan)

**Deploy**
Deploy cartodb and central.
Do not move this task to done until we fix the affected users (see the management ticket)