### PR TITLE
Use new loading buttons styles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,7 @@ Development
 * Allow to have multiple administrators per organization (#12052)
 * Added explanation tooltip to the categorize label on the Find Nearest analysis (#12100)
 * Disable geometry edition button instead of hide in read-only layers (#11543)
+* New loading button styles (#12132)
 
 ### Bug fixes
 * Fixed a problem with shared dataset's title (#12144)

--- a/lib/assets/core/javascripts/cartodb3/components/modals/publish/publish-button.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/publish/publish-button.tpl
@@ -1,22 +1,17 @@
-<button class="Publish-modalButton CDB-Button CDB-Button--primary CDB-Button--small u-rSpace js-button <% if (isDisabled) {%>is-disabled<% } %>">
+<button class="Publish-modalButton CDB-Button CDB-Button--loading CDB-Button--primary CDB-Button--small u-rSpace js-button
+  <% if (isDisabled) {%> is-disabled<% } %>
+  <% if (isLoading) {%> is-loading<% } %>
+">
   <div class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-flex">
-    <% if (isLoading) { %>
-      <div class="CDB-LoaderIcon CDB-LoaderIcon--small u-iBlock">
-        <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
-          <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
-        </svg>
-      </div>
-      <% if (isPublished) { %>
-      <%- _t('components.modals.publish.updating-btn') %>
-      <% } else { %>
-      <%- _t('components.modals.publish.publishing-btn') %>
-      <% } %>
+    <% if (isPublished) { %>
+    <%- _t('components.modals.publish.update-btn') %>
     <% } else { %>
-      <% if (isPublished) { %>
-      <%- _t('components.modals.publish.update-btn') %>
-      <% } else { %>
-      <%- _t('components.modals.publish.publish-btn') %>
-      <% } %>
+    <%- _t('components.modals.publish.publish-btn') %>
     <% } %>
+  </div>
+  <div class="CDB-Button-loader CDB-LoaderIcon is-white">
+    <svg class="CDB-LoaderIcon-spinner" viewbox="0 0 50 50">
+      <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"/>
+    </svg>
   </div>
 </button> <%- publishedOn %>

--- a/lib/assets/core/javascripts/cartodb3/components/modals/publish/publish-button.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/publish/publish-button.tpl
@@ -2,14 +2,14 @@
   <% if (isDisabled) {%> is-disabled<% } %>
   <% if (isLoading) {%> is-loading<% } %>
 ">
-  <div class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-flex">
+  <div class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">
     <% if (isPublished) { %>
     <%- _t('components.modals.publish.update-btn') %>
     <% } else { %>
     <%- _t('components.modals.publish.publish-btn') %>
     <% } %>
   </div>
-  <div class="CDB-Button-loader CDB-LoaderIcon is-white">
+  <div class="CDB-Button-loader CDB-LoaderIcon CDB-LoaderIcon--small is-white">
     <svg class="CDB-LoaderIcon-spinner" viewbox="0 0 50 50">
       <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"/>
     </svg>

--- a/lib/assets/core/javascripts/cartodb3/components/undo-redo/undo-redo-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/undo-redo/undo-redo-view.js
@@ -21,6 +21,7 @@ module.exports = CoreView.extend({
     this._trackModel = opts.trackModel;
     this._editorModel = opts.editorModel;
     this._clearModel = opts.clearModel;
+    this._applyStatusModel = opts.applyStatusModel;
 
     this._initBinds();
   },
@@ -36,7 +37,8 @@ module.exports = CoreView.extend({
         canUndo: this._trackModel.canUndo(),
         canRedo: this._trackModel.canRedo(),
         canApply: this.options.applyButton && this._editorModel.isEditing(),
-        canClear: canClear
+        canClear: canClear,
+        isLoading: this._applyStatusModel && this._applyStatusModel.get('loading')
       })
     );
     this._checkButtonsStyle();
@@ -53,6 +55,10 @@ module.exports = CoreView.extend({
     if (this._clearModel) {
       this._clearModel.bind('change', this.render, this);
       this.add_related_model(this._clearModel);
+    }
+
+    if (this._applyStatusModel) {
+      this._applyStatusModel.bind('change:loading', this._applyStatusChanged, this);
     }
   },
 
@@ -87,5 +93,9 @@ module.exports = CoreView.extend({
 
   _getIcons: function () {
     return this.$('.js-theme');
+  },
+
+  _applyStatusChanged: function () {
+    this.render();
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/components/undo-redo/undo-redo-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/undo-redo/undo-redo-view.js
@@ -59,6 +59,7 @@ module.exports = CoreView.extend({
 
     if (this._applyStatusModel) {
       this._applyStatusModel.bind('change:loading', this._applyStatusChanged, this);
+      this.add_related_model(this._applyStatusModel);
     }
   },
 

--- a/lib/assets/core/javascripts/cartodb3/components/undo-redo/undo-redo.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/undo-redo/undo-redo.tpl
@@ -11,8 +11,15 @@
   </button>
   <% } %>
   <% if (canApply) { %>
-  <button class="u-lSpace--xl CDB-Button CDB-Button--primary js-apply">
+  <button class="u-lSpace--xl CDB-Button CDB-Button--loading CDB-Button--primary js-apply
+    <% if (isLoading) {%> is-loading is-disabled<% } %>
+  ">
     <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small"><%- _t('components.undo-redo.apply') %></span>
+    <div class="CDB-Button-loader CDB-LoaderIcon is-white">
+      <svg class="CDB-LoaderIcon-spinner" viewbox="0 0 50 50">
+        <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"/>
+      </svg>
+    </div>
   </button>
   <% } %>
 </div>

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-actions-edition-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-actions-edition-view.js
@@ -1,3 +1,4 @@
+var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 var template = require('./dataset-actions.tpl');
 var UndoButtons = require('../../components/undo-redo/undo-redo-view');
@@ -9,6 +10,7 @@ var REQUIRED_OPTS = [
   'trackModel',
   'editorModel',
   'queryGeometryModel',
+  'querySchemaModel',
   'onApply',
   'onClear',
   'clearSQLModel'
@@ -25,7 +27,14 @@ module.exports = CoreView.extend({
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
+    this._applyButtonStatusModel = new Backbone.Model({
+      loading: false
+    });
+
     this._queryGeometryModel.bind('change:status', this.render, this);
+    this._querySchemaModel.bind('change:status', function () {
+      this._applyButtonStatusModel.set('loading', this._querySchemaModel.isFetching());
+    }, this);
     this.add_related_model(this._queryGeometryModel);
   },
 
@@ -47,6 +56,7 @@ module.exports = CoreView.extend({
       trackModel: this._trackModel,
       editorModel: this._editorModel,
       clearModel: this._clearSQLModel,
+      applyStatusModel: this._applyButtonStatusModel,
       applyButton: true,
       clearButton: true,
       onApplyClick: this._onApply.bind(this),

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-actions-edition-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-actions-edition-view.js
@@ -28,7 +28,7 @@ module.exports = CoreView.extend({
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this._applyButtonStatusModel = new Backbone.Model({
-      loading: false
+      loading: this._querySchemaModel.isFetching()
     });
 
     this._queryGeometryModel.bind('change:status', this.render, this);

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-options-view.js
@@ -153,6 +153,7 @@ module.exports = DatasetBaseView.extend({
           trackModel: self._sqlModel,
           editorModel: self._editorModel,
           queryGeometryModel: self._queryGeometryModel,
+          querySchemaModel: self._querySchemaModel,
           onApply: self._parseSQL,
           previewAction: self._previewMap.bind(self),
           onClear: self._clearSQL.bind(self)

--- a/lib/assets/core/javascripts/cartodb3/editor/export-image-pane/footer/footer.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/export-image-pane/footer/footer.tpl
@@ -1,17 +1,14 @@
-<button class="CDB-Button CDB-Button--primary js-ok track-ImageExport track-export
+<button class="CDB-Button CDB-Button--loading CDB-Button--primary js-ok track-ImageExport track-export
   <% if (isLoading || isDisabled) { %> is-disabled <% } %>
+  <% if (isLoading) { %> is-loading <% } %>
   "
   <% if (isDisabled) { %> disabled <% } %>>
   <div class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-flex">
-    <% if (isLoading) { %>
-    <div class="CDB-LoaderIcon CDB-LoaderIcon--small u-iBlock">
-      <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
-        <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
-      </svg>
-    </div>
-     <%- _t('editor.maps.export-image.generating') %>
-    <% } else { %>
-     <%- _t('editor.maps.export-image.export') %>
-    <% } %>
+    <%- _t('editor.maps.export-image.export') %>
+  </div>
+  <div class="CDB-Button-loader CDB-LoaderIcon is-white">
+    <svg class="CDB-LoaderIcon-spinner" viewbox="0 0 50 50">
+      <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"/>
+    </svg>
   </div>
 </button>

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-button-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-button-view.js
@@ -18,5 +18,7 @@ module.exports = CoreView.extend({
 
   _initBinds: function () {
     this.listenTo(this.model, 'change:isDisabled', this.render);
+    // listenTo drops events if view is removed from DOM
+    this.model.on('change:isDone', this.render, this);
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -34,6 +34,8 @@ module.exports = CoreView.extend({
     'click .js-save': '_onSaveClicked'
   },
 
+  _buttonView: null,
+
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
     this._analysisNode = opts.analysisNode;
@@ -44,6 +46,7 @@ module.exports = CoreView.extend({
     this._viewModel = new Backbone.Model({
       isNewAnalysis: !opts.analysisNode,
       hasChanges: !opts.analysisNode,
+      isDone: true,
       type: this._formModel.get('type')
     });
 
@@ -99,6 +102,7 @@ module.exports = CoreView.extend({
 
     if (this._analysisNode) {
       this.listenTo(this._analysisNode, 'change:status', function () {
+        this._viewModel.set('isDone', this._isAnalysisDone());
         var isAnalysisDone = this._isAnalysisDone();
         if (isAnalysisDone) {
           this.render();
@@ -155,10 +159,14 @@ module.exports = CoreView.extend({
       isDisabled: !this._canSave()
     });
 
-    return new AnalysisButtonView({
-      template: template,
-      model: this._viewModel
-    });
+    if (this._buttonView === null) {
+      this._buttonView = new AnalysisButtonView({
+        template: template,
+        model: this._viewModel
+      });
+    }
+
+    return this._buttonView;
   },
 
   _buildQuotaViewInfo: function () {
@@ -315,7 +323,7 @@ module.exports = CoreView.extend({
   _saveAnalysis: function () {
     this._infoboxModel.set('state', 'idle');
     this._userActions.saveAnalysis(this._formModel);
-    this._viewModel.set('hasChanges', false);
+    this._viewModel.set({ hasChanges: false, isDone: false });
     this.render();
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls.tpl
@@ -1,5 +1,11 @@
-<button class="CDB-Button CDB-Button--primary js-save <% if (isDisabled) { %>is-disabled<% } %>">
-  <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">
-    <%- label %>
-  </span>
+<button class="CDB-Button CDB-Button--loading CDB-Button--primary js-save
+<% if (isDisabled) { %> is-disabled<% } %>
+<% if (!isDone) { %> is-loading<% } %>
+">
+  <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase"><%- label %></span>
+   <div class="CDB-Button-loader CDB-LoaderIcon is-white">
+     <svg class="CDB-LoaderIcon-spinner" viewbox="0 0 50 50">
+       <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"/>
+     </svg>
+   </div>
 </button>

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
@@ -163,6 +163,7 @@ module.exports = CoreView.extend({
       analysisNode: analysisNode,
       userActions: this._userActions,
       userModel: this._userModel,
+      statusModel: this.modelView,
       stackLayoutModel: this._stackLayoutModel,
       formModel: formModel,
       quotaInfo: this._quotaInfo,

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/data/data-view.js
@@ -58,6 +58,10 @@ module.exports = DatasetBaseView.extend({
       visible: this._isLayerHidden()
     });
 
+    this._applyButtonStatusModel = new Backbone.Model({
+      loading: false
+    });
+
     this._tableStats = new TableStats({
       configModel: this._configModel,
       userModel: this._userModel
@@ -154,6 +158,10 @@ module.exports = DatasetBaseView.extend({
     }.bind(this));
 
     this.listenTo(this._layerDefinitionModel, 'change:visible', this._infoboxState);
+
+    this._querySchemaModel.bind('change:status', function () {
+      this._applyButtonStatusModel.set('loading', this._querySchemaModel.isFetching());
+    }, this);
   },
 
   _runQuery: function (query, callback) {
@@ -275,6 +283,7 @@ module.exports = DatasetBaseView.extend({
             trackModel: self._sqlModel,
             editorModel: self._editorModel,
             clearModel: self._clearSQLModel,
+            applyStatusModel: self._applyButtonStatusModel,
             applyButton: true,
             clearButton: true,
             onApplyClick: self._parseSQL,

--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-view.js
@@ -60,6 +60,10 @@ module.exports = CoreView.extend({
       visible: this._isLayerHidden()
     });
 
+    this._applyButtonStatusModel = new Backbone.Model({
+      loading: false
+    });
+
     this._appendMapsAPIError();
 
     CartoCSSNotifications.track(this);
@@ -147,7 +151,7 @@ module.exports = CoreView.extend({
     this._editorModel.set('disabled', hasErrors);
   },
 
-  _saveCartoCSS: function () {
+  _saveCartoCSS: function (cb) {
     var content = this._codemirrorModel.get('content');
     var parser = new ParserCSS(content);
     var errors = parser.errors();
@@ -156,6 +160,7 @@ module.exports = CoreView.extend({
       return false;
     }
 
+    this._applyButtonStatusModel.set('loading', true);
     this._codemirrorModel.set('errors', parser.parseError(errors));
 
     if (errors.length === 0) {
@@ -167,9 +172,9 @@ module.exports = CoreView.extend({
       this._layerDefinitionModel.save({
         cartocss_custom: true,
         cartocss: content
+      }, {
+        complete: cb
       });
-
-      CartoCSSNotifications.showSuccessNotification();
 
       MetricsTracker.track('Applied Cartocss', {
         layer_id: this._layerDefinitionModel.get('id'),
@@ -177,7 +182,13 @@ module.exports = CoreView.extend({
       });
     } else {
       this._editorModel.get('edition') === false && CartoCSSNotifications.showErrorNotification(parser.parseError(errors));
+      this._applyButtonStatusModel.set('loading', false);
     }
+  },
+
+  _onSaveComplete: function () {
+    CartoCSSNotifications.showSuccessNotification();
+    this._applyButtonStatusModel.set('loading', false);
   },
 
   _cancelClearStyles: function () {
@@ -301,15 +312,16 @@ module.exports = CoreView.extend({
           styleModel: self._styleModel,
           editorModel: self._editorModel,
           codemirrorModel: self._codemirrorModel,
-          onApplyEvent: self._saveCartoCSS.bind(self)
+          onApplyEvent: self._saveCartoCSS.bind(self, self._onSaveComplete.bind(self))
         });
       },
       createActionView: function () {
         return new UndoButtons({
           trackModel: self._cartocssModel,
           editorModel: self._editorModel,
+          applyStatusModel: self._applyButtonStatusModel,
           applyButton: true,
-          onApplyClick: self._saveCartoCSS.bind(self)
+          onApplyClick: self._saveCartoCSS.bind(self, self._onSaveComplete.bind(self))
         });
       }
     }];

--- a/lib/assets/core/test/spec/cartodb3/editor/components/undo-redo/undo-redo-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/components/undo-redo/undo-redo-view.spec.js
@@ -54,6 +54,33 @@ describe('components/undo-redo/undo-redo-view', function () {
     expect(view.$('button').length).toBe(4);
   });
 
+  it('should show the apply button as not loading by default', function () {
+    expect(this.view.$el.find('.js-apply.is-loading').length).toBe(0);
+    expect(this.view.$el.find('.js-apply.is-disabled').length).toBe(0);
+  });
+
+  it('should show the apply button as loading if applyStatusModel changes', function () {
+    var view = new UndoRedo({
+      applyButton: true,
+      applyStatusModel: new Backbone.Model({
+        loading: false
+      }),
+      editorModel: new EditorModel({
+        edition: true
+      }),
+      trackModel: new StyleModel()
+    });
+    view.render();
+
+    expect(view.$el.find('.js-apply.is-loading').length).toBe(0);
+    expect(view.$el.find('.js-apply.is-disabled').length).toBe(0);
+
+    view._applyStatusModel.set('loading', true);
+
+    expect(view.$el.find('.js-apply.is-loading').length).toBe(1);
+    expect(view.$el.find('.js-apply.is-disabled').length).toBe(1);
+  });
+
   afterEach(function () {
     this.view.clean();
   });

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/data/data-view.spec.js
@@ -169,6 +169,20 @@ describe('editor/layers/layers-content-view/data/data-view', function () {
       this.sqlModel.redo();
       expect(this.view._codemirrorModel.set).toHaveBeenCalled();
     });
+
+    it('should sync the query status with the apply button status', function () {
+      this.view._querySchemaModel.set('status', 'fetching');
+      expect(this.view._applyButtonStatusModel.get('loading')).toBe(true);
+
+      this.view._querySchemaModel.set('status', 'fetched');
+      expect(this.view._applyButtonStatusModel.get('loading')).toBe(false);
+
+      this.view._querySchemaModel.set('status', 'unavailable');
+      expect(this.view._applyButtonStatusModel.get('loading')).toBe(false);
+
+      this.view._querySchemaModel.set('status', 'unfetched');
+      expect(this.view._applyButtonStatusModel.get('loading')).toBe(false);
+    });
   });
 
   it('should apply default query and refresh map and dataset view when query alters data', function () {

--- a/lib/assets/core/test/spec/cartodb3/editor/style/style-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/style/style-view.spec.js
@@ -279,13 +279,21 @@ describe('editor/style/style-view', function () {
     spyOn(this.layerDefinitionModel, 'save');
     this.view._codemirrorModel.set('content', content);
 
-    this.view._saveCartoCSS();
+    this.view._saveCartoCSS(this.view._onSaveComplete);
     expect(this.view._cartocssModel.get('content')).toBe(content);
     expect(this.layerDefinitionModel.get('autoStyle')).toBeFalsy();
     expect(this.layerDefinitionModel.save).toHaveBeenCalledWith({
       cartocss_custom: true,
       cartocss: content
-    });
+    }, { complete: this.view._onSaveComplete });
+  });
+
+  it('should set loading to false when save is complete', function () {
+    this.view._applyButtonStatusModel.set('loading', true);
+
+    this.view._onSaveComplete();
+
+    expect(this.view._applyButtonStatusModel.get('loading')).toBe(false);
   });
 
   it('should not save cartocss if content is empty', function () {
@@ -296,6 +304,14 @@ describe('editor/style/style-view', function () {
     expect(this.layerDefinitionModel.get('cartocss_custom')).toBeFalsy();
     expect(this.layerDefinitionModel.get('cartocss')).not.toBe(content);
     expect(this.layerDefinitionModel.save).not.toHaveBeenCalled();
+  });
+
+  it('should set loading to false when cartoCSS validation fails', function () {
+    spyOn(this.layerDefinitionModel, 'save');
+    this.view._codemirrorModel.set('content', '#layer {');
+    this.view._saveCartoCSS();
+    expect(this.layerDefinitionModel.save).not.toHaveBeenCalled();
+    expect(this.view._applyButtonStatusModel.get('loading')).toBe(false);
   });
 
   describe('._launchOnboarding', function () {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2777,11 +2777,7 @@
     "tangram-cartocss": {
       "version": "0.5.3",
       "from": "cartodb/tangram-carto#master",
-<<<<<<< HEAD
       "resolved": "git://github.com/cartodb/tangram-carto.git#04b45c7e47adf3ebdeb63a50e11652e67a22a453",
-=======
-      "resolved": "git://github.com/cartodb/tangram-carto.git#3f3c485233faa70f1c17575986fa407ed631f8b4",
->>>>>>> eb78ecad20e83c019da2472da83c38b2e27f92f4
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.6.88-12018g",
+  "version": "4.7.4",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -115,10 +115,789 @@
       "from": "aws4@>=1.2.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
     },
+    "babel-code-frame": {
+      "version": "6.22.0",
+      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "dependencies": {
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        }
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.24.1",
+      "from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "from": "babel-helper-explode-assignable-expression@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.24.1",
+      "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "from": "babel-helper-remap-async-to-generator@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "from": "babel-messages@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "from": "babel-plugin-syntax-trailing-function-commas@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-async-to-generator@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-block-scoping@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-classes@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-computed-properties@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-destructuring@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-for-of@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-modules-amd@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-modules-umd@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-object-super@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.23.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-exponentiation-operator@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-regenerator@>=6.22.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz"
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.4.0",
+      "from": "babel-preset-env@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.4.0.tgz"
+    },
     "babel-runtime": {
       "version": "6.18.0",
       "from": "babel-runtime@6.18.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
+    },
+    "babel-template": {
+      "version": "6.24.1",
+      "from": "babel-template@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.24.1",
+      "from": "babel-traverse@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "debug": {
+          "version": "2.6.7",
+          "from": "debug@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.24.1",
+      "from": "babel-types@>=6.24.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.17.1",
+      "from": "babylon@>=6.11.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.1.tgz"
     },
     "backbone": {
       "version": "1.2.3",
@@ -282,6 +1061,11 @@
       "from": "browserify-zlib@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
+    "browserslist": {
+      "version": "1.7.7",
+      "from": "browserslist@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz"
+    },
     "buffer": {
       "version": "4.9.1",
       "from": "buffer@>=4.1.0 <5.0.0",
@@ -316,6 +1100,11 @@
       "version": "0.32.0",
       "from": "camshaft-reference@0.32.0",
       "resolved": "https://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.32.0.tgz"
+    },
+    "caniuse-db": {
+      "version": "1.0.30000670",
+      "from": "caniuse-db@>=1.0.30000639 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000670.tgz"
     },
     "carto": {
       "version": "0.15.1-cdb3",
@@ -443,14 +1232,14 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
     },
     "create-hash": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "from": "create-hash@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz"
     },
     "create-hmac": {
-      "version": "1.1.4",
+      "version": "1.1.6",
       "from": "create-hmac@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz"
     },
     "crypt": {
       "version": "0.0.2",
@@ -574,6 +1363,11 @@
       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "optional": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.11",
+      "from": "electron-to-chromium@>=1.2.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.11.tgz"
     },
     "elliptic": {
       "version": "6.4.0",
@@ -835,6 +1629,11 @@
         }
       }
     },
+    "globals": {
+      "version": "9.17.0",
+      "from": "globals@>=9.0.0 <10.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
+    },
     "globo": {
       "version": "1.0.2",
       "from": "globo@>=1.0.0 <1.1.0",
@@ -970,6 +1769,11 @@
       "from": "has-require@>=1.1.0 <1.2.0",
       "resolved": "https://registry.npmjs.org/has-require/-/has-require-1.1.0.tgz"
     },
+    "hash-base": {
+      "version": "2.0.2",
+      "from": "hash-base@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
+    },
     "hash.js": {
       "version": "1.0.3",
       "from": "hash.js@>=1.0.0 <2.0.0",
@@ -1057,6 +1861,11 @@
         }
       }
     },
+    "invariant": {
+      "version": "2.2.2",
+      "from": "invariant@>=2.2.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+    },
     "is-buffer": {
       "version": "1.1.5",
       "from": "is-buffer@>=1.1.0 <2.0.0",
@@ -1123,6 +1932,11 @@
       "from": "js-base64@>=2.1.9 <3.0.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
     },
+    "js-tokens": {
+      "version": "3.0.1",
+      "from": "js-tokens@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+    },
     "js-yaml": {
       "version": "2.0.5",
       "from": "js-yaml@>=2.0.5 <2.1.0",
@@ -1133,6 +1947,11 @@
       "from": "jsbn@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "optional": true
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "from": "jsesc@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1261,6 +2080,11 @@
       "from": "lodash.memoize@>=3.0.3 <3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
     },
+    "loose-envify": {
+      "version": "1.3.1",
+      "from": "loose-envify@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+    },
     "lru-cache": {
       "version": "2.7.3",
       "from": "lru-cache@>=2.0.0 <3.0.0",
@@ -1337,9 +2161,9 @@
       "resolved": "https://registry.npmjs.org/mothership/-/mothership-0.2.0.tgz"
     },
     "ms": {
-      "version": "0.7.1",
-      "from": "ms@0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+      "version": "2.0.0",
+      "from": "ms@2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
     },
     "mustache": {
       "version": "1.1.0",
@@ -1437,9 +2261,9 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-1.3.7.tgz"
     },
     "pbkdf2": {
-      "version": "3.0.9",
+      "version": "3.0.12",
       "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz"
     },
     "pend": {
       "version": "1.2.0",
@@ -1494,6 +2318,11 @@
       "version": "3.3.0",
       "from": "postcss-value-parser@3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+    },
+    "private": {
+      "version": "0.1.7",
+      "from": "private@>=0.1.6 <0.2.0",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
     },
     "process": {
       "version": "0.11.10",
@@ -1577,10 +2406,35 @@
       "from": "readable-stream@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
     },
+    "regenerate": {
+      "version": "1.3.2",
+      "from": "regenerate@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+    },
     "regenerator-runtime": {
       "version": "0.9.6",
       "from": "regenerator-runtime@>=0.9.5 <0.10.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz"
+    },
+    "regenerator-transform": {
+      "version": "0.9.11",
+      "from": "regenerator-transform@0.9.11",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz"
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "from": "regexpu-core@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "from": "regjsgen@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
     },
     "rename-function-calls": {
       "version": "0.1.1",
@@ -1637,9 +2491,14 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
     },
     "ripemd160": {
-      "version": "1.0.1",
-      "from": "ripemd160@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+      "version": "2.0.1",
+      "from": "ripemd160@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz"
+    },
+    "safe-buffer": {
+      "version": "5.0.1",
+      "from": "safe-buffer@>=5.0.1 <6.0.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
     },
     "select": {
       "version": "1.1.2",
@@ -1653,7 +2512,7 @@
     },
     "sha.js": {
       "version": "2.4.8",
-      "from": "sha.js@>=2.3.6 <3.0.0",
+      "from": "sha.js@>=2.4.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
     },
     "shallow-copy": {
@@ -1916,14 +2775,14 @@
       }
     },
     "tangram-cartocss": {
-      "version": "0.5.2",
+      "version": "0.5.3",
       "from": "cartodb/tangram-carto#master",
-      "resolved": "git://github.com/cartodb/tangram-carto.git#92ff6fe32743fdee2d296a1512158acef7923d9c",
+      "resolved": "git://github.com/cartodb/tangram-carto.git#c244332f529565e01fd6b1531d70f60633fd1bb1",
       "dependencies": {
         "babel-runtime": {
-          "version": "6.22.0",
-          "from": "babel-runtime@6.22.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz"
+          "version": "6.23.0",
+          "from": "babel-runtime@6.23.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         },
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -1938,9 +2797,9 @@
       "resolved": "https://registry.npmjs.org/tangram-reference/-/tangram-reference-1.0.17.tgz"
     },
     "tangram.cartodb": {
-      "version": "0.3.1",
+      "version": "0.4.1",
       "from": "cartodb/tangram.cartodb#master",
-      "resolved": "git://github.com/cartodb/tangram.cartodb.git#538136b79f0f401ba806d75fe2f9df534bb99017"
+      "resolved": "git://github.com/cartodb/tangram.cartodb.git#cdb7801827926519d391f10bb26c682bec784606"
     },
     "temporary": {
       "version": "0.0.8",
@@ -1999,6 +2858,11 @@
       "from": "to-arraybuffer@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
     },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+    },
     "topojson-client": {
       "version": "2.1.0",
       "from": "tangrams/topojson-client#read-only",
@@ -2055,6 +2919,11 @@
           "version": "3.1.2",
           "from": "es6-promise@3.1.2",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.1.2.tgz"
+        },
+        "ms": {
+          "version": "0.7.1",
+          "from": "ms@0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -851,9 +851,9 @@
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         },
         "debug": {
-          "version": "2.6.7",
+          "version": "2.6.8",
           "from": "debug@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz"
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
         },
         "lodash": {
           "version": "4.17.4",
@@ -2777,7 +2777,7 @@
     "tangram-cartocss": {
       "version": "0.5.3",
       "from": "cartodb/tangram-carto#master",
-      "resolved": "git://github.com/cartodb/tangram-carto.git#c244332f529565e01fd6b1531d70f60633fd1bb1",
+      "resolved": "git://github.com/cartodb/tangram-carto.git#04b45c7e47adf3ebdeb63a50e11652e67a22a453",
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",
@@ -2799,7 +2799,7 @@
     "tangram.cartodb": {
       "version": "0.4.1",
       "from": "cartodb/tangram.cartodb#master",
-      "resolved": "git://github.com/cartodb/tangram.cartodb.git#cdb7801827926519d391f10bb26c682bec784606"
+      "resolved": "git://github.com/cartodb/tangram.cartodb.git#dbd91c9fa8cafc8eefd1563af12250aa6a0574f6"
     },
     "temporary": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.13",
+  "version": "4.7.13.ded02.1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Uses the new loading buttons in Builder as requested in #12132.

Example:
![loading_button](https://cloud.githubusercontent.com/assets/905225/26238114/f9085b74-3c77-11e7-98f3-fe242bc7fd49.gif)

Places where it has to be updated:
- [x] Run analysis.
- [x] Update the map.
- [x] Publish
- [x] Apply CSS.
- [x] Export as an image.
- [x] Apply SQL.

### How to test
Check the list above. In addition to this, check if we should update the analysis quota view as well.