### PR TITLE
Using layer-types-and-kinds helper instead of guessing-comparision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -255,6 +255,7 @@ Development
 * Docs, fixed some minor spelling and grammar errors in the content.
 * Docs, updated "More Info" url from street addresses georeference options to new, related guide.
 * Color picker disappears in CartoCSS editor after clicking (#12097).
+* Bug found in dataset view when user had Google basemaps enabled (#12155)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.0`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/dataset.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset.js
@@ -31,6 +31,7 @@ var UserGroupFetcher = require('./data/users-group-fetcher');
 var SQLUtils = require('./helpers/sql-utils');
 var BuilderActivatedNotification = require('./components/onboardings/builder-activated/builder-activated-notification-view');
 var UserNotifications = require('./data/user-notifications');
+var layerTypesAndKinds = require('./data/layer-types-and-kinds');
 
 var userData = window.userData;
 var visData = window.visualizationData;
@@ -59,7 +60,7 @@ var visModel = new VisTableModel(visData, { configModel: configModel });
 var layersCollection = new Backbone.Collection(layersData);
 var layerDataModel = layersCollection.find(function (mdl) {
   var kind = mdl.get('kind');
-  return kind !== 'tiled' && kind !== 'plain';
+  return layerTypesAndKinds.isKindDataLayer(kind);
 });
 
 var layerModel = new LayerDefinitionModel(layerDataModel.toJSON(), {


### PR DESCRIPTION
Related ticket: #12155

We were not taking into account google basemaps and we were building incorrect layer-definition models when user had google basemaps enabled.

## STR
- Take a user with google maps enabled.
- Import a new dataset.
- Go to the dataset view and open the sql panel.
- Open the codemirror "hints" dialog with CTRL + Space.
- If it works 🎉 , if not, :boom:.
- Then, take another user (or the same one) without google key.
- Import a new dataset.
- Check the same as above.

💃 