### PR TITLE
Owner can delete organizations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ Development
   * `cartodb:services:set_org_quota[orgname,service,quota]` updated to support the `mapzen_routing` provider
   * `cartodb:services:set_user_soft_limit[username,service,quota]` new task to set user soft limits
 * Color picker for codemirror component.
-* Delete organization account (#12049).
+* Owner can delete organization account (not at SaaS, #12049).
 * New dropdown for Data Observatory (#11618)
 * Quota pre-check to analyses that consume quota.
 * Marking 'Do not show me again' in Layer Onboarding affects every tab. (#11586)

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Development
   * `cartodb:services:set_org_quota[orgname,service,quota]` updated to support the `mapzen_routing` provider
   * `cartodb:services:set_user_soft_limit[username,service,quota]` new task to set user soft limits
 * Color picker for codemirror component.
+* Delete organization account (#12049).
 * New dropdown for Data Observatory (#11618)
 * Quota pre-check to analyses that consume quota.
 * Marking 'Do not show me again' in Layer Onboarding affects every tab. (#11586)

--- a/app/assets/stylesheets/common/account_forms.css.scss
+++ b/app/assets/stylesheets/common/account_forms.css.scss
@@ -702,7 +702,7 @@ $sLabel-width: 140px;
   font-style: italic;
 }
 
-.FormAccount-button--deleteAccount {
+.FormAccount-button--deleteAccount, .FormAccount-button--deleteOrganization {
   color: rgba(247, 24, 0, 1);
   cursor: pointer;
 

--- a/app/assets/stylesheets/common/account_forms.css.scss
+++ b/app/assets/stylesheets/common/account_forms.css.scss
@@ -702,7 +702,8 @@ $sLabel-width: 140px;
   font-style: italic;
 }
 
-.FormAccount-button--deleteAccount, .FormAccount-button--deleteOrganization {
+.FormAccount-button--deleteAccount,
+.FormAccount-button--deleteOrganization {
   color: rgba(247, 24, 0, 1);
   cursor: pointer;
 

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -26,7 +26,7 @@ class Admin::OrganizationsController < Admin::AdminController
     end
   end
 
-  def delete
+  def destroy
     deletion_password_confirmation = params[:deletion_password_confirmation]
     if current_user.needs_password_confirmation? && !current_user.validate_old_password(deletion_password_confirmation)
       flash.now[:error] = "Password doesn't match"

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -7,13 +7,15 @@ class Admin::OrganizationsController < Admin::AdminController
   include OrganizationNotificationsHelper
 
   ssl_required :show, :settings, :settings_update, :regenerate_all_api_keys, :groups, :auth, :auth_update,
-               :notifications, :new_notification, :destroy_notification
+               :notifications, :new_notification, :destroy_notification, :delete
   before_filter :login_required, :load_organization_and_members, :load_ldap_configuration
-  before_filter :owners_only, only: [:settings, :settings_update, :regenerate_all_api_keys, :auth, :auth_update]
+  before_filter :owners_only, only: [:settings, :settings_update, :regenerate_all_api_keys, :auth, :auth_update,
+                                     :delete]
   before_filter :enforce_engine_enabled, only: :regenerate_all_api_keys
   before_filter :load_carto_organization, only: [:notifications, :new_notification]
   before_filter :load_notification, only: [:destroy_notification]
-  before_filter :load_organization_notifications, only: [:settings, :auth, :show, :groups, :notifications, :new_notification]
+  before_filter :load_organization_notifications, only: [:settings, :auth, :show, :groups, :notifications,
+                                                         :new_notification]
   helper_method :show_billing
 
   layout 'application'
@@ -22,6 +24,21 @@ class Admin::OrganizationsController < Admin::AdminController
     respond_to do |format|
       format.html { render 'show' }
     end
+  end
+
+  def delete
+    deletion_password_confirmation = params[:deletion_password_confirmation]
+    if current_user.needs_password_confirmation? && !current_user.validate_old_password(deletion_password_confirmation)
+      flash.now[:error] = "Password doesn't match"
+      render 'show', status: 400
+    else
+      @organization.destroy_cascade(delete_in_central: true)
+      redirect_to logout_url
+    end
+  rescue => e
+    CartoDB::Logger.error(message: "Error deleting organization", exception: e, organization: @organization)
+    flash.now[:error] = "Error deleting organization: #{e.message}"
+    render 'show', status: 500
   end
 
   def settings

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -7,10 +7,10 @@ class Admin::OrganizationsController < Admin::AdminController
   include OrganizationNotificationsHelper
 
   ssl_required :show, :settings, :settings_update, :regenerate_all_api_keys, :groups, :auth, :auth_update,
-               :notifications, :new_notification, :destroy_notification, :delete
+               :notifications, :new_notification, :destroy_notification, :destroy
   before_filter :login_required, :load_organization_and_members, :load_ldap_configuration
   before_filter :owners_only, only: [:settings, :settings_update, :regenerate_all_api_keys, :auth, :auth_update,
-                                     :delete]
+                                     :destroy]
   before_filter :enforce_engine_enabled, only: :regenerate_all_api_keys
   before_filter :load_carto_organization, only: [:notifications, :new_notification]
   before_filter :load_notification, only: [:destroy_notification]

--- a/app/controllers/superadmin/organizations_controller.rb
+++ b/app/controllers/superadmin/organizations_controller.rb
@@ -43,7 +43,7 @@ class Superadmin::OrganizationsController < Superadmin::SuperadminController
   end
 
   def destroy
-    @organization.destroy_cascade
+    @organization.destroy_cascade(delete_in_central: false)
     respond_with(:superadmin, @organization)
   rescue => e
     CartoDB::Logger.error(exception: e, message: 'Error deleting organization', organization: @organization)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -191,4 +191,8 @@ module ApplicationHelper
   def model_errors(model)
     model.errors.full_messages.map(&:capitalize).join(', ') if model.errors.present?
   end
+
+  def saas?
+    Cartodb.config[:cartodb_com_hosted] == false
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,9 @@
 # coding: utf-8
 require_dependency 'cartodb_config_utils'
+require_dependency 'carto/configuration'
 
 module ApplicationHelper
+  include Carto::Configuration
   include CartoDB::ConfigUtils
   include SafeJsObject
   include TrackjsHelper
@@ -190,9 +192,5 @@ module ApplicationHelper
 
   def model_errors(model)
     model.errors.full_messages.map(&:capitalize).join(', ') if model.errors.present?
-  end
-
-  def saas?
-    Cartodb.config[:cartodb_com_hosted] == false
   end
 end

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -56,7 +56,7 @@ module Concerns
             raise "Can't destroy the organization owner"
           end
         end
-      elsif self.is_a?(Organization)
+      elsif is_a?(Organization)
         # See Organization#destroy_cascade
         raise "Delete organizations is not allowed" if saas?
         cartodb_central_client.delete_organization(name)

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -53,6 +53,8 @@ module Concerns
             raise "Can't destroy the organization owner"
           end
         end
+      elsif self.is_a?(Organization)
+        cartodb_central_client.delete_organization(name)
       end
       return true
     end

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -1,5 +1,8 @@
+require_dependency 'carto/configuration'
+
 module Concerns
   module CartodbCentralSynchronizable
+    include Carto::Configuration
 
     # This validation can't be added to the model because if a user creation begins at Central we can't know if user is the same or existing
     def validate_credentials_not_taken_in_central
@@ -54,6 +57,8 @@ module Concerns
           end
         end
       elsif self.is_a?(Organization)
+        # See Organization#destroy_cascade
+        raise "Delete organizations is not allowed" if saas?
         cartodb_central_client.delete_organization(name)
       end
       return true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -151,9 +151,12 @@ class Organization < Sequel::Model
   # INFO: replacement for destroy because destroying owner triggers
   # organization destroy
   def destroy_cascade(delete_in_central: false)
+    # This remains commented because we consider that enabling this for users at SaaS is unnecessary and risky.
+    # Nevertheless, code remains, _just in case_. More info at https://github.com/CartoDB/cartodb/issues/12049
+    # Central branch: 1764-Allow_updating_inactive_users
     # Central asks for usage information before deleting, so organization must be first deleted there
     # Corollary: you need multithreading for organization to work if you run Central
-    self.delete_in_central if delete_in_central
+    # self.delete_in_central if delete_in_central
 
     destroy_groups
     destroy_non_owner_users

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -169,6 +169,7 @@ class Organization < Sequel::Model
 
   def destroy_non_owner_users
     non_owner_users.each do |user|
+      user.ensure_nonviewer
       user.shared_entities.map(&:entity).each(&:delete)
       user.destroy_cascade
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -396,7 +396,7 @@ class User < Sequel::Model
         end
       end
 
-      unless can_delete
+      unless can_delete || @force_destroy
         raise CartoDB::BaseCartoDBError.new('Cannot delete user, has shared entities')
       end
 
@@ -1577,6 +1577,11 @@ class User < Sequel::Model
 
   def new_visualizations_version
     builder_enabled? ? 3 : 2
+  end
+
+  def destroy_cascade
+    @force_destroy = true
+    destroy
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -375,13 +375,17 @@ class User < Sequel::Model
     shared_entities.any?
   end
 
-  def before_destroy
+  def ensure_nonviewer
     # A viewer can't destroy data, this allows the cleanup. Down to dataset level
     # to skip model hooks.
     if viewer
       this.update(viewer: false)
       self.viewer = false
     end
+  end
+
+  def before_destroy
+    ensure_nonviewer
 
     @org_id_for_org_wipe = nil
     error_happened = false

--- a/app/views/admin/organizations/_organization_settings.html.erb
+++ b/app/views/admin/organizations/_organization_settings.html.erb
@@ -10,6 +10,7 @@
     <script type="text/javascript">
         var username = "<%= current_user.username %>";
         var config = <%= safe_js_object frontend_config %>;
+        var authenticity_token = "<%= form_authenticity_token %>";
         var user_data = <%= safe_js_object current_user.data.to_json.html_safe %>;
         <% if @avatar_valid_extensions %>
           var avatar_valid_extensions = <%= raw @avatar_valid_extensions %>;

--- a/app/views/admin/organizations/settings.html.erb
+++ b/app/views/admin/organizations/settings.html.erb
@@ -201,6 +201,23 @@
           </button>
       </div>
     <% end %>
+
+    <% if current_user.organization_owner? && current_user.has_feature_flag?('organization-admins')  %>
+        <div class="FormAccount-title">
+          <p class="FormAccount-titleText">Delete organization</p>
+        </div>
+
+        <span class="FormAccount-separator"></span>
+
+        <div class="FormAccount-row FormAccount-row--wideMarginBottom">
+          <div class="FormAccount-rowLabel">
+            <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">Are you sure?</label>
+          </div>
+          <div class="FormAccount-rowData">
+            <span class="FormAccount-button--deleteOrganization CDB-Size-medium js-deleteOrganization">Delete organization, including all users and data</span>
+          </div>
+        </div>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/admin/organizations/settings.html.erb
+++ b/app/views/admin/organizations/settings.html.erb
@@ -202,7 +202,7 @@
       </div>
     <% end %>
 
-    <% if current_user.organization_owner? && current_user.has_feature_flag?('organization-admins')  %>
+    <% if !saas? && current_user.organization_owner? && current_user.has_feature_flag?('organization-admins')  %>
         <div class="FormAccount-title">
           <p class="FormAccount-titleText">Delete organization</p>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ CartoDB::Application.routes.draw do
 
     # Organization dashboard page
     get    '(/user/:user_domain)(/u/:user_domain)/organization'                 => 'organizations#show',            as: :organization
+    delete '(/user/:user_domain)(/u/:user_domain)/organization'                 => 'organizations#delete',          as: :organization_delete
     get    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings',        as: :organization_settings
     put    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings_update', as: :organization_settings_update
     post '(/user/:user_domain)(/u/:user_domain)/organization/regenerate_api_keys'       => 'organizations#regenerate_all_api_keys', as: :regenerate_organization_users_api_key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,7 @@ CartoDB::Application.routes.draw do
 
     # Organization dashboard page
     get    '(/user/:user_domain)(/u/:user_domain)/organization'                 => 'organizations#show',            as: :organization
-    delete '(/user/:user_domain)(/u/:user_domain)/organization'                 => 'organizations#delete',          as: :organization_delete
+    delete '(/user/:user_domain)(/u/:user_domain)/organization'                 => 'organizations#destroy',          as: :organization_destroy
     get    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings',        as: :organization_settings
     put    '(/user/:user_domain)(/u/:user_domain)/organization/settings'        => 'organizations#settings_update', as: :organization_settings_update
     post '(/user/:user_domain)(/u/:user_domain)/organization/regenerate_api_keys'       => 'organizations#regenerate_all_api_keys', as: :regenerate_organization_users_api_key

--- a/lib/assets/core/javascripts/cartodb/organization/entry.js
+++ b/lib/assets/core/javascripts/cartodb/organization/entry.js
@@ -6,7 +6,8 @@ var HeaderViewModel = require('./header_view_model');
 var LocalStorage = require('../common/local_storage');
 var OrganizationUserForm = require('./organization_user_form');
 var OrganizationUserQuota = require('./organization_user_quota');
-var DeleteAccount = require('./delete_org_user_view');
+var DeleteOrganizationUser = require('./delete_org_user_view');
+var DeleteOrganization = require('../common/delete_organization_view');
 var AvatarSelector = require('../common/avatar_selector_view');
 var ColorPickerView = require('./color_picker_view');
 var OrganizationUsersView = require('./organization_users/organization_users_view');
@@ -203,10 +204,24 @@ $(function () {
         if (ev) {
           ev.preventDefault();
         }
-        new DeleteAccount({
+        new DeleteOrganizationUser({
           organizationUser: organizationUser,
           authenticityToken: window.authenticity_token,
-          clean_on_hide: true
+          clean_on_hide: false
+        }).appendToBody();
+      });
+    }
+
+    // Organization deletion
+    if (this.$('.js-deleteOrganization').length > 0 && window.authenticity_token) {
+      this.$('.js-deleteOrganization').click(function (ev) {
+        if (ev) {
+          ev.preventDefault();
+        }
+        new DeleteOrganization({
+          authenticityToken: window.authenticity_token,
+          clean_on_hide: true,
+          user: currentUser
         }).appendToBody();
       });
     }

--- a/lib/assets/javascripts/cartodb/common/delete_account_view.js
+++ b/lib/assets/javascripts/cartodb/common/delete_account_view.js
@@ -22,13 +22,14 @@ module.exports = BaseDialog.extend({
   initialize: function() {
     this.elder('initialize');
     this.template = cdb.templates.getTemplate('common/views/delete_account');
+    this._userModel = this.options.user;
   },
 
   render_content: function() {
     return this.template({
       formAction: cdb.config.prefixUrl() + '/account',
       authenticityToken: this.options.authenticityToken,
-      passwordNeeded: this.options.user.attributes.needs_password_confirmation === true
+      passwordNeeded: !!this._userModel.get('needs_password_confirmation')
     });
   }
 

--- a/lib/assets/javascripts/cartodb/common/delete_organization_view.js
+++ b/lib/assets/javascripts/cartodb/common/delete_organization_view.js
@@ -20,13 +20,14 @@ module.exports = BaseDialog.extend({
   initialize: function () {
     this.elder('initialize');
     this.template = cdb.templates.getTemplate('common/views/delete_organization');
+    this.passwordNeeded = this.options.user.attributes.needs_password_confirmation === true
   },
 
   render_content: function () {
     return this.template({
       formAction: cdb.config.prefixUrl() + '/organization',
       authenticityToken: this.options.authenticityToken,
-      passwordNeeded: this.options.user.attributes.needs_password_confirmation === true
+      passwordNeeded: this.passwordNeeded
     });
   }
 });

--- a/lib/assets/javascripts/cartodb/common/delete_organization_view.js
+++ b/lib/assets/javascripts/cartodb/common/delete_organization_view.js
@@ -1,4 +1,3 @@
-var $ = require('jquery-cdb-v3');
 var cdb = require('cartodb.js-v3');
 var BaseDialog = require('./views/base_dialog/view');
 
@@ -7,29 +6,27 @@ var BaseDialog = require('./views/base_dialog/view');
  *
  */
 
-module.exports = BaseDialog.extend({
+module.exports = BaseDialog.extend ({
+  options: {
+    authenticityToken: ''
+  },
 
-    options: {
-        authenticityToken: ''
-    },
+  events: BaseDialog.extendEvents ({
+    'submit .js-form': 'close'
+  }),
 
-    events: BaseDialog.extendEvents({
-        'submit .js-form': 'close'
-    }),
+  className: 'Dialog is-opening',
 
-    className: 'Dialog is-opening',
+  initialize: function () {
+    this.elder('initialize');
+    this.template = cdb.templates.getTemplate('common/views/delete_organization');
+  },
 
-    initialize: function() {
-        this.elder('initialize');
-        this.template = cdb.templates.getTemplate('common/views/delete_organization');
-    },
-
-    render_content: function() {
-        return this.template({
-            formAction: cdb.config.prefixUrl() + '/organization',
-            authenticityToken: this.options.authenticityToken,
-            passwordNeeded: this.options.user.attributes.needs_password_confirmation === true
-        });
-    }
-
-})
+  render_content: function () {
+    return this.template({
+      formAction: cdb.config.prefixUrl() + '/organization',
+      authenticityToken: this.options.authenticityToken,
+      passwordNeeded: this.options.user.attributes.needs_password_confirmation === true
+    });
+  }
+});

--- a/lib/assets/javascripts/cartodb/common/delete_organization_view.js
+++ b/lib/assets/javascripts/cartodb/common/delete_organization_view.js
@@ -20,14 +20,14 @@ module.exports = BaseDialog.extend({
   initialize: function () {
     this.elder('initialize');
     this.template = cdb.templates.getTemplate('common/views/delete_organization');
-    this.passwordNeeded = this.options.user.attributes.needs_password_confirmation === true
+    this._userModel = this.options.user;
   },
 
   render_content: function () {
     return this.template({
       formAction: cdb.config.prefixUrl() + '/organization',
       authenticityToken: this.options.authenticityToken,
-      passwordNeeded: this.passwordNeeded
+      passwordNeeded: !!this._userModel.get('needs_password_confirmation')
     });
   }
 });

--- a/lib/assets/javascripts/cartodb/common/delete_organization_view.js
+++ b/lib/assets/javascripts/cartodb/common/delete_organization_view.js
@@ -6,12 +6,12 @@ var BaseDialog = require('./views/base_dialog/view');
  *
  */
 
-module.exports = BaseDialog.extend ({
+module.exports = BaseDialog.extend({
   options: {
     authenticityToken: ''
   },
 
-  events: BaseDialog.extendEvents ({
+  events: BaseDialog.extendEvents({
     'submit .js-form': 'close'
   }),
 

--- a/lib/assets/javascripts/cartodb/common/delete_organization_view.js
+++ b/lib/assets/javascripts/cartodb/common/delete_organization_view.js
@@ -1,0 +1,35 @@
+var $ = require('jquery-cdb-v3');
+var cdb = require('cartodb.js-v3');
+var BaseDialog = require('./views/base_dialog/view');
+
+/**
+ *  When an organization owner wants to delete the full organization
+ *
+ */
+
+module.exports = BaseDialog.extend({
+
+    options: {
+        authenticityToken: ''
+    },
+
+    events: BaseDialog.extendEvents({
+        'submit .js-form': 'close'
+    }),
+
+    className: 'Dialog is-opening',
+
+    initialize: function() {
+        this.elder('initialize');
+        this.template = cdb.templates.getTemplate('common/views/delete_organization');
+    },
+
+    render_content: function() {
+        return this.template({
+            formAction: cdb.config.prefixUrl() + '/organization',
+            authenticityToken: this.options.authenticityToken,
+            passwordNeeded: this.options.user.attributes.needs_password_confirmation === true
+        });
+    }
+
+})

--- a/lib/assets/javascripts/cartodb/common/views/delete_organization.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/delete_organization.jst.ejs
@@ -1,0 +1,41 @@
+<form accept-charset="UTF-8" action="<%- formAction %>" method="post" class="js-form">
+    <input name="utf8" type="hidden" value="&#x2713;" />
+    <input name="authenticity_token" type="hidden" value="<%- authenticityToken %>" />
+    <input name="_method" type="hidden" value="delete" />
+
+    <div class="CDB-Text Dialog-header u-inner">
+        <div class="Dialog-headerIcon Dialog-headerIcon--negative">
+            <i class="CDB-IconFont CDB-IconFont-defaultUser"></i>
+        </div>
+        <p class="Dialog-headerTitle">You are about to delete the full organization.</p>
+        <p class="Dialog-headerText">
+            Remember, once you delete the organization there is no going back.<br/>
+            All users, along with their maps, data and work (including yours) will be lost. Are you sure you want to proceed?<br/>
+            <% if (passwordNeeded) { %>
+            In any case, you need to type your password.
+            <% } %>
+        </p>
+    </div>
+
+    <% if (passwordNeeded) { %>
+    <div class="CDB-Text Dialog-body">
+        <div class="Form-row Form-row--centered has-label">
+            <div class="Form-rowLabel">
+                <label class="Form-label">Your password</label>
+            </div>
+            <div class="Form-rowData">
+                <input type="password" name="deletion_password_confirmation" class="CDB-InputText CDB-Text Form-input Form-input--long" value=""/>
+            </div>
+        </div>
+    </div>
+    <% } %>
+
+    <div class="Dialog-footer u-inner">
+        <button type="button" class="CDB-Button CDB-Button--secondary cancel">
+            <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Cancel</span>
+        </button>
+        <button type="submit" class="CDB-Button CDB-Button--error js-ok">
+            <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Yes, delete the organization</span>
+        </button>
+    </div>
+</form>

--- a/lib/assets/javascripts/cartodb/common/views/delete_organization.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/delete_organization.jst.ejs
@@ -7,12 +7,12 @@
         <div class="Dialog-headerIcon Dialog-headerIcon--negative">
             <i class="CDB-IconFont CDB-IconFont-defaultUser"></i>
         </div>
-        <p class="Dialog-headerTitle">You are about to delete the full organization.</p>
+        <p class="Dialog-headerTitle">You are about to delete your organization.</p>
         <p class="Dialog-headerText">
-            Remember, once you delete the organization there is no going back.<br/>
-            All users, along with their maps, data and work (including yours) will be lost. Are you sure you want to proceed?<br/>
+            You will remove this organization and all its users (including this account)<br/>
+            and it will not be possible to recover its information (including tables and data) after this deletion.<br/>
             <% if (passwordNeeded) { %>
-            In any case, you need to type your password.
+                If you want to proceed, type your password:<br/>
             <% } %>
         </p>
     </div>

--- a/lib/carto/configuration.rb
+++ b/lib/carto/configuration.rb
@@ -53,6 +53,10 @@ module Carto
       (config && config['custom_paths'] && config['custom_paths']['views']) || Array.new
     end
 
+    def saas?
+      Cartodb.config[:cartodb_com_hosted] == false
+    end
+
     private
 
     def config_files_root

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -117,7 +117,7 @@ module Cartodb
     end # update_organization
 
     def delete_organization(organization_name)
-      return send_request("api/organizations/#{ organization_name }", nil, :delete, [204, 404])
+      send_request("api/organizations/#{organization_name}", nil, :delete, [204, 404])
     end # delete_organization
 
     ############################################################################

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -117,7 +117,7 @@ module Cartodb
     end # update_organization
 
     def delete_organization(organization_name)
-      return send_request("api/organizations/#{ organization_name }", nil, :delete, [204])
+      return send_request("api/organizations/#{ organization_name }", nil, :delete, [204, 404])
     end # delete_organization
 
     ############################################################################

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.14",
+  "version": "4.7.15",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.02",
+  "version": "4.7.03",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.13",
+  "version": "4.7.14",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.12",
+  "version": "4.7.13",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -93,6 +93,11 @@ describe Organization do
       @organization.destroy
       Carto::Asset.exists?(asset.id).should be_false
     end
+
+    it 'calls :delete_in_central if delete_in_central parameter is true' do
+      @organization.expects(:delete_in_central).once
+      @organization.destroy_cascade(delete_in_central: true)
+    end
   end
 
   describe '#add_user_to_org' do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -95,6 +95,8 @@ describe Organization do
     end
 
     it 'calls :delete_in_central if delete_in_central parameter is true' do
+      pending "Don't implemented. See Organization#destroy_cascade"
+
       @organization.expects(:delete_in_central).once
       @organization.destroy_cascade(delete_in_central: true)
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -105,8 +105,8 @@ describe Organization do
       ::User.where(id: user1.id).first.should be nil
       ::User.where(id: user2.id).first.should be nil
       ::User.where(id: owner.id).first.should be nil
-      Carto::UserTable.exists?(table1.id)
-      Carto::UserTable.exists?(table2.id)
+      Carto::UserTable.exists?(table1.id).should be_false
+      Carto::UserTable.exists?(table2.id).should be_false
     end
 
     it 'destroys its groups through the extension' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1460,14 +1460,15 @@ describe User do
         include TableSharing
 
         it 'blocks deletion even with shared entities' do
-          table = create_random_table(@org_user_1)
-          share_table_with_user(table, @org_user_1)
+          @not_to_be_deleted = TestUserFactory.new.create_test_user(unique_name('user'), @organization)
+          table = create_random_table(@not_to_be_deleted)
+          share_table_with_user(table, @org_user_owner)
 
           expect do
-            @org_user_1.destroy
+            @not_to_be_deleted.destroy
           end.to raise_error(/Cannot delete user, has shared entities/)
 
-          ::User[@org_user_1.id].should be
+          ::User[@not_to_be_deleted.id].should be
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1455,6 +1455,35 @@ describe User do
         db = @org_user_owner.in_database
         db["SELECT COUNT(*) FROM cdb_analysis_catalog WHERE username='#{@org_user_2.username}'"].first[:count].should eq 0
       end
+
+      describe 'User#destroy' do
+        include TableSharing
+
+        it 'blocks deletion even with shared entities' do
+          table = create_random_table(@org_user_1)
+          share_table_with_user(table, @org_user_1)
+
+          expect do
+            @org_user_1.destroy
+          end.to raise_error(/Cannot delete user, has shared entities/)
+
+          ::User[@org_user_1.id].should be
+        end
+      end
+    end
+  end
+
+  describe 'User#destroy_cascade' do
+    include_context 'organization with users helper'
+    include TableSharing
+
+    it 'allows deletion even with shared entities' do
+      table = create_random_table(@org_user_1)
+      share_table_with_user(table, @org_user_1)
+
+      @org_user_1.destroy_cascade
+
+      ::User[@org_user_1.id].should_not be
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1459,7 +1459,7 @@ describe User do
       describe 'User#destroy' do
         include TableSharing
 
-        it 'blocks deletion even with shared entities' do
+        it 'blocks deletion with shared entities' do
           @not_to_be_deleted = TestUserFactory.new.create_test_user(unique_name('user'), @organization)
           table = create_random_table(@not_to_be_deleted)
           share_table_with_user(table, @org_user_owner)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1464,9 +1464,7 @@ describe User do
           table = create_random_table(@not_to_be_deleted)
           share_table_with_user(table, @org_user_owner)
 
-          expect do
-            @not_to_be_deleted.destroy
-          end.to raise_error(/Cannot delete user, has shared entities/)
+          expect { @not_to_be_deleted.destroy }.to raise_error(/Cannot delete user, has shared entities/)
 
           ::User[@not_to_be_deleted.id].should be
         end

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -66,7 +66,7 @@ describe Admin::OrganizationsController do
       helper = TestUserFactory.new
       @delete_org_owner = helper.create_owner(@delete_org)
 
-      @delete_org_user_1 = @helper.create_test_user(unique_name('user'), @delete_org)
+      @delete_org_user1 = @helper.create_test_user(unique_name('user'), @delete_org)
     end
 
     after(:all) do
@@ -79,8 +79,8 @@ describe Admin::OrganizationsController do
     end
 
     it 'cannot be accessed by non owner users' do
-      login_as(@delete_org_user_1, scope: @delete_org_user_1.username)
-      delete organization_delete_url(user_domain: @delete_org_user_1.username)
+      login_as(@delete_org_user1, scope: @delete_org_user1.username)
+      delete organization_delete_url(user_domain: @delete_org_user1.username)
       response.status.should eq 404
     end
 

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -80,7 +80,7 @@ describe Admin::OrganizationsController do
 
     it 'cannot be accessed by non owner users' do
       login_as(@delete_org_user1, scope: @delete_org_user1.username)
-      delete organization_delete_url(user_domain: @delete_org_user1.username)
+      delete organization_destroy_url(user_domain: @delete_org_user1.username)
       response.status.should eq 404
     end
 
@@ -90,20 +90,20 @@ describe Admin::OrganizationsController do
       end
 
       it 'returns 400 if no password confirmation is provided' do
-        delete organization_delete_url(user_domain: @delete_org_owner.username)
+        delete organization_destroy_url(user_domain: @delete_org_owner.username)
         response.status.should eq 400
         response.body.should include("Password doesn't match")
       end
 
       it 'returns 400 if password confirmation is wrong' do
         payload = { deletion_password_confirmation: @delete_org_owner.password + 'wadus' }
-        delete organization_delete_url(user_domain: @delete_org_owner.username), payload
+        delete organization_destroy_url(user_domain: @delete_org_owner.username), payload
         response.status.should eq 400
       end
 
       it 'deletes organization and redirects if passwords match' do
         payload = { deletion_password_confirmation: @delete_org_owner.password }
-        delete organization_delete_url(user_domain: @delete_org_owner.username), payload
+        delete organization_destroy_url(user_domain: @delete_org_owner.username), payload
         response.status.should eq 302
         Carto::Organization.exists?(@delete_org.id).should be_false
       end

--- a/spec/requests/admin/organizations_controller_spec.rb
+++ b/spec/requests/admin/organizations_controller_spec.rb
@@ -58,6 +58,58 @@ describe Admin::OrganizationsController do
     end
   end
 
+  describe '#delete' do
+    before(:all) do
+      @delete_org = test_organization
+      @delete_org.save
+
+      helper = TestUserFactory.new
+      @delete_org_owner = helper.create_owner(@delete_org)
+
+      @delete_org_user_1 = @helper.create_test_user(unique_name('user'), @delete_org)
+    end
+
+    after(:all) do
+      @delete_org.destroy_cascade if Carto::Organization.exists?(@delete_org.id)
+    end
+
+    before(:each) do
+      host! "#{@delete_org.name}.localhost.lan"
+      Organization.any_instance.stubs(:update_in_central).returns(true)
+    end
+
+    it 'cannot be accessed by non owner users' do
+      login_as(@delete_org_user_1, scope: @delete_org_user_1.username)
+      delete organization_delete_url(user_domain: @delete_org_user_1.username)
+      response.status.should eq 404
+    end
+
+    describe 'as owner' do
+      before(:each) do
+        login_as(@delete_org_owner, scope: @delete_org_owner.username)
+      end
+
+      it 'returns 400 if no password confirmation is provided' do
+        delete organization_delete_url(user_domain: @delete_org_owner.username)
+        response.status.should eq 400
+        response.body.should include("Password doesn't match")
+      end
+
+      it 'returns 400 if password confirmation is wrong' do
+        payload = { deletion_password_confirmation: @delete_org_owner.password + 'wadus' }
+        delete organization_delete_url(user_domain: @delete_org_owner.username), payload
+        response.status.should eq 400
+      end
+
+      it 'deletes organization and redirects if passwords match' do
+        payload = { deletion_password_confirmation: @delete_org_owner.password }
+        delete organization_delete_url(user_domain: @delete_org_owner.username), payload
+        response.status.should eq 302
+        Carto::Organization.exists?(@delete_org.id).should be_false
+      end
+    end
+  end
+
   describe '#auth' do
     let(:payload) do
       {


### PR DESCRIPTION
This closes #12049.

Acceptance:

- [x] In staging, with default configuration, this shouldn't appear (not even with organization-admins flag).
- [x] Delete an account works as usual: it doesn't ask for the password for Google signups, it does for normal users.

In order to test it, you must set `cartodb_com_hosted` to `true` (either in staging or in local). This is only meant for onpremise.

- [x] Admins don't see that option.
- [x] Create an organization with two users (one should be a viewer, both should have datasets imported) and share one dataset with another. Delete the org with the new option. Check that after deletion, user database and all metadata (visualizations and so on) are deleted.