### PR TITLE
12148 ldap error handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'addressable',             '2.3.2', require: 'addressable/uri'
 gem 'ejs',                     '~> 1.1.1'
 gem 'execjs',                  '~> 0.4' # Required by ejs
 
-gem 'net-ldap',                '0.11'
+gem 'net-ldap',                '0.16.0'
 gem 'json-schema',             '2.0.0'
 
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    net-ldap (0.11)
+    net-ldap (0.16.0)
     net-telnet (0.1.1)
     nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
@@ -390,7 +390,7 @@ DEPENDENCIES
   memory_profiler
   mocha (= 1.1.0)
   mock_redis
-  net-ldap (= 0.11)
+  net-ldap (= 0.16.0)
   net-telnet
   nokogiri (~> 1.6.6.2)
   oauth (= 0.5.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -240,6 +240,7 @@ Development
 * Rearrange Error tracker script order (#11872)
 * Fix subdomain error not loading tiles.
 * Redirect to last visited page after logging in (#11946)
+* Better error handling in LDAP (#12165)
 * Sanitized HTML from map and layer names.
 * Merged fix subdomain error not loading tiles (CartoDB.js#1607)
 * Create users from org panel with the default quota (#11837)

--- a/app/models/carto/ldap/configuration.rb
+++ b/app/models/carto/ldap/configuration.rb
@@ -85,6 +85,8 @@ class Carto::Ldap::Configuration < ActiveRecord::Base
     return false unless valid_ldap_entry
 
     Carto::Ldap::Entry.new(valid_ldap_entry.first, self)
+  rescue Net::LDAP::Error => e
+    CartoDB::Logger.error(exception: e, message: 'Error authenticating against LDAP', username: username)
   end
 
   # INFO: Resets connection if already made

--- a/app/models/carto/ldap/configuration.rb
+++ b/app/models/carto/ldap/configuration.rb
@@ -66,7 +66,7 @@ class Carto::Ldap::Configuration < ActiveRecord::Base
   # @param String username. No full CN, just the username, e.g. 'administrator1'
   # @param String password
   def authenticate(username, password)
-    ldap_connection = Net::LDAP.new
+    ldap_connection = Net::LDAP.new(connect_timeout: CONNECTION_TIMEOUT)
     ldap_connection.host = self.host
     ldap_connection.port = self.port
     configure_encryption(ldap_connection)
@@ -123,6 +123,8 @@ class Carto::Ldap::Configuration < ActiveRecord::Base
 
   private
 
+  CONNECTION_TIMEOUT = 8
+
   def search_filter(username)
     user_id_filter = "(#{user_id_field}=#{username})"
     if additional_search_filter.present?
@@ -164,7 +166,7 @@ class Carto::Ldap::Configuration < ActiveRecord::Base
   # @param String password Connection password
   # @throws InvalidConfigurationEncryptionError
   def connect(user = self.connection_user, password = self.connection_password)
-    ldap = Net::LDAP.new
+    ldap = Net::LDAP.new(connect_timeout: CONNECTION_TIMEOUT)
     ldap.host = self.host
     ldap.port = self.port
     configure_encryption(ldap)

--- a/spec/models/carto/ldap/configuration_spec.rb
+++ b/spec/models/carto/ldap/configuration_spec.rb
@@ -82,6 +82,11 @@ describe Carto::Ldap::Configuration do
     result.should_not eq false
     result.user_id.should eq other_user_username
 
+    # Test connection error
+    Net::LDAP.any_instance.stubs(:bind_as).raises(Net::LDAP::Error.new)
+    result = ldap_configuration.authenticate(auth_username, auth_password)
+    result.should be_false
+
     ldap_configuration.delete
   end
 


### PR DESCRIPTION
Fixes #12148 

Gracefully handles LDAP connection error, so authentication fallback can proceed. The bad part is that allowing fallback makes the LDAP error go away, so if all authentication method fail, there will be no displayed error.

**Acceptance**
- [x] Configure LDAP with a random host/port (so it doesn't work)
- [x] Try org-login with a correct username, you should login
- [x] Try org-login with an incorrect username, you will get a login error (but no crash)
- [x] Try org-login with an incorrect password, you will get a login error (but no crash)
- [x] Correctly configure LDAP with a valid server
- [x] Try org-login with an LDAP username, you should login
- [x] Try org-login with a CARTO username, you should login
- [x] Try org-login with an invalid username, you should get a login error
- [x] Try org-login with an invalid password, you should get a login error