### PR TITLE
Don't require quota for Google customers in hires-geocoder analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -119,6 +119,7 @@ Development
 * Updated copies for export image & download map (#12114)
 
 ### Bug fixes
+* Google customers don't need quota checks for hires geocoding (support/#674)
 * Fixed a problem with autostyle when styles has aggregation (#8648)
 * Provide the possibility to add the current source node to the target options list in analysis forms (#12057)
 * Update table view on adding or removing a feature (#11978)

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-options.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-options.js
@@ -36,7 +36,11 @@ var ANALYSES_WITH_QUOTA_MAP = {
     api: 'hires_geocoder',
     user: 'geocoding',
     transform: unity,
-    needsQuota: true // we will include gmaps in the future
+    needsQuota: function (quotaInfo) {
+      var info = quotaInfo.getService('hires_geocoder');
+      var provider = info && info.get('provider');
+      return provider !== 'google';
+    }
   },
   'data-observatory-measure': {
     name: _t('editor.layers.analysis-form.quota.analysis-type.data-observatory-measure'),

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-quota/analyses-quota-options.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-quota/analyses-quota-options.spec.js
@@ -46,8 +46,14 @@ describe('editor/layers/layer-content-views/analyses/analyses-quota/analyses-quo
     });
 
     describe('georeference-street-address', function () {
-      it('should return quota', function () {
+      it('should return quota if provider is not google', function () {
         expect(AnalysesQuotaOptions.requiresQuota('georeference-street-address', this.quotaInfo)).toBeTruthy();
+      });
+
+      it('should not return quota if provider is google', function () {
+        var serviceModel = this.quotaInfo.at(1);
+        serviceModel.set('provider', 'google');
+        expect(AnalysesQuotaOptions.requiresQuota('georeference-street-address', this.quotaInfo)).toBeFalsy();
       });
     });
   });
@@ -93,4 +99,3 @@ describe('editor/layers/layer-content-views/analyses/analyses-quota/analyses-quo
     expect(AnalysesQuotaOptions.getUserDataName('data-observatory-measure')).toBe('obs_general');
   });
 });
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.11",
+  "version": "4.7.11-support-674",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/support/issues/674#issuecomment-303028669

## Steps to test it
- Take a user with Google capabilities.
- Create a dataset with several addresses (Plaza de Callao 4, Madrid, Spain; for example).
- Then create a map with that dataset.
- Try to geocode by street address that layer.
- Check that the quota component doesn't appear and it lets you to geocode whatever you need.

cc @nobuti 