### PR TITLE
Make sure org_admin is set in creation controller

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,8 +112,7 @@ Development
 * Multiple file upload through "upload file" tab (#11952)
 * Change setView by flyto.
 * Update tangram to fix layer geometry conditionals.
-* Allow to have multiple administrators per organization (#12052, #12083)
-* Allow to have multiple administrators per organization (#12052)
+* Allow to have multiple administrators per organization (#12052, #12083, #12069)
 * Added explanation tooltip to the categorize label on the Find Nearest analysis (#12100)
 * Disable geometry edition button instead of hide in read-only layers (#11543)
 * Updated copies for export image & download map (#12114)

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -64,12 +64,13 @@ class Admin::OrganizationUsersController < Admin::AdminController
     @user.set_fields(
       params[:user],
       [
-        :username, :email, :password, :quota_in_bytes, :password_confirmation, :org_admin,
+        :username, :email, :password, :quota_in_bytes, :password_confirmation,
         :twitter_datasource_enabled, :soft_geocoding_limit, :soft_here_isolines_limit,
         :soft_obs_snapshot_limit, :soft_obs_general_limit, :soft_mapzen_routing_limit
       ]
     )
     @user.viewer = params[:user][:viewer] == 'true'
+    @user.org_admin = params[:user][:org_admin] if @organization.owner.has_feature_flag?('organization-admins')
     @user.organization = @organization
     current_user.copy_account_features(@user)
 

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -70,7 +70,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
       ]
     )
     @user.viewer = params[:user][:viewer] == 'true'
-    @user.org_admin = params[:user][:org_admin] if @organization.owner.has_feature_flag?('organization-admins')
+    @user.org_admin = params[:user][:org_admin] unless params[:user][:org_admin].nil?
     @user.organization = @organization
     current_user.copy_account_features(@user)
 

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -64,12 +64,11 @@ class Admin::OrganizationUsersController < Admin::AdminController
     @user.set_fields(
       params[:user],
       [
-        :username, :email, :password, :quota_in_bytes, :password_confirmation,
+        :username, :email, :password, :quota_in_bytes, :password_confirmation, :org_admin,
         :twitter_datasource_enabled, :soft_geocoding_limit, :soft_here_isolines_limit,
         :soft_obs_snapshot_limit, :soft_obs_general_limit, :soft_mapzen_routing_limit
       ]
     )
-    @user.org_admin = params[:user][:org_admin] == 'true'
     @user.viewer = params[:user][:viewer] == 'true'
     @user.organization = @organization
     current_user.copy_account_features(@user)

--- a/spec/requests/admin/organization_users_controller_spec.rb
+++ b/spec/requests/admin/organization_users_controller_spec.rb
@@ -11,14 +11,6 @@ describe Admin::OrganizationUsersController do
     host! "#{@organization.name}.localhost.lan"
   end
 
-  before(:all) do
-    @ff_org_admins = FactoryGirl.create(:feature_flag, name: 'organization-admins', restricted: false)
-  end
-
-  after(:all) do
-    @ff_org_admins.destroy
-  end
-
   let(:username) { 'user-1' }
 
   let(:user_params) do
@@ -28,8 +20,7 @@ describe Admin::OrganizationUsersController do
       password: 'user-1',
       password_confirmation: 'user-1',
       quota_in_bytes: 1000,
-      twitter_datasource_enabled: false,
-      org_admin: false
+      twitter_datasource_enabled: false
     }
   end
 

--- a/spec/requests/admin/organization_users_controller_spec.rb
+++ b/spec/requests/admin/organization_users_controller_spec.rb
@@ -11,6 +11,14 @@ describe Admin::OrganizationUsersController do
     host! "#{@organization.name}.localhost.lan"
   end
 
+  before(:all) do
+    @ff_org_admins = FactoryGirl.create(:feature_flag, name: 'organization-admins', restricted: false)
+  end
+
+  after(:all) do
+    @ff_org_admins.destroy
+  end
+
   let(:username) { 'user-1' }
 
   let(:user_params) do

--- a/spec/requests/admin/organization_users_controller_spec.rb
+++ b/spec/requests/admin/organization_users_controller_spec.rb
@@ -20,7 +20,8 @@ describe Admin::OrganizationUsersController do
       password: 'user-1',
       password_confirmation: 'user-1',
       quota_in_bytes: 1000,
-      twitter_datasource_enabled: false
+      twitter_datasource_enabled: false,
+      org_admin: false
     }
   end
 


### PR DESCRIPTION
Fixes #12159 

**Acceptance**

Verify that the correct value is set after every step.

- [x] Enable `organization-admins` FF for the organization owner
- [x] As the owner, create a new user, set the administrator flag to true. After creation, ensure that this is correctly saved.
- [x] Repeat the previous with the flag set to false.
- [x] Then, edit the previous user. First, enable it. Then disable it. 