### PR TITLE
Give PERMISSION_READWRITE constant a proper scope

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -119,6 +119,7 @@ Development
 * Updated copies for export image & download map (#12114)
 
 ### Bug fixes
+* Fixed uninitialized constant in Carto::Visualization when a viewer shares a visualization (#12129).
 * Google customers don't need quota checks for hires geocoding (support/#674)
 * Fixed a problem with autostyle when styles has aggregation (#8648)
 * Provide the possibility to add the current source node to the target options list in analysis forms (#12057)

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -549,7 +549,7 @@ class Carto::Visualization < ActiveRecord::Base
   alias :invalidate_cache :invalidate_after_commit
 
   def has_permission?(user, permission_type)
-    return false if user.viewer && permission_type == PERMISSION_READWRITE
+    return false if user.viewer && permission_type == Visualization::Member::PERMISSION_READWRITE
     return is_owner?(user) if permission_id.nil?
     is_owner?(user) || permission.permitted?(user, permission_type)
   end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -549,7 +549,7 @@ class Carto::Visualization < ActiveRecord::Base
   alias :invalidate_cache :invalidate_after_commit
 
   def has_permission?(user, permission_type)
-    return false if user.viewer && permission_type == CartoDB::Permission::ACCESS_READWRITE
+    return false if user.viewer && permission_type == Carto::Permission::ACCESS_READWRITE
     return is_owner?(user) if permission_id.nil?
     is_owner?(user) || permission.permitted?(user, permission_type)
   end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -549,7 +549,7 @@ class Carto::Visualization < ActiveRecord::Base
   alias :invalidate_cache :invalidate_after_commit
 
   def has_permission?(user, permission_type)
-    return false if user.viewer && permission_type == Visualization::Member::PERMISSION_READWRITE
+    return false if user.viewer && permission_type == CartoDB::Permission::ACCESS_READWRITE
     return is_owner?(user) if permission_id.nil?
     is_owner?(user) || permission.permitted?(user, permission_type)
   end


### PR DESCRIPTION
This PR fixes #12129.

`PERMISSION_READWRITE` was missing a proper scope, since it was defined on `app/models/visualization/member.rb`.