### PR TITLE
remove db:create and db:migrate from create_dev_user rake task

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -261,6 +261,7 @@ Development
 * Validate amount of organization seats (#12101)
 * Fixed error dropping tables from ghost table manager on race condition cases (#12012)
 * IE11 fix for dropdowns with scrollview (#12073)
+* `create_dev_user` rake no longer tries to auto-create the database, `cartodb:db:setup` should be run first (#12187).
 * Better display and logging of errors when SAML authentication fails (#12151)
 * Fixed problem resetting styles per node after adding a new analysis (#12085)
 * Docs, fixed some minor spelling and grammar errors in the content.

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -48,7 +48,7 @@ DESC
     end
 
     task :create_dev_user =>
-      ["rake:db:create", "rake:db:migrate", "cartodb:db:create_publicuser"] do
+      ["cartodb:db:create_publicuser"] do
       raise "You should provide a valid e-mail"    if ENV['EMAIL'].blank?
       raise "You should provide a valid password"  if ENV['PASSWORD'].blank?
       raise "You should provide a valid subdomain" if ENV['SUBDOMAIN'].blank?


### PR DESCRIPTION
no prior issue created

after discussion, the `create_dev_user` rake task shouldn't have `db:create` nor `db:migrate` responsibility, which appear as independent tasks in the installation README, as well as in the provision task in the VM, furthermore this made the provision tasks because the db already existed

this was surfaced after a change in the sequel gem, which now exit with a more aggressive code than before, which failed silently and exited successfully

/cc @javitonino @juanignaciosl 