### PR TITLE
12197 geocoder rake saves to redis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -265,6 +265,7 @@ Development
 * `create_dev_user` rake no longer tries to auto-create the database, `cartodb:db:setup` should be run first (#12187).
 * Better display and logging of errors when SAML authentication fails (#12151)
 * Fixed problem resetting styles per node after adding a new analysis (#12085)
+* Ensure Google services activation rake writes the api keys to Redis (#12209)
 * Docs, fixed some minor spelling and grammar errors in the content.
 * Fix `BUILDER_ENABLED` parameter in `create_dev_user` rake (#12189)
 * Docs, updated "More Info" url from street addresses georeference options to new, related guide.

--- a/lib/tasks/google_services.rake
+++ b/lib/tasks/google_services.rake
@@ -4,7 +4,7 @@ namespace :cartodb do
   namespace :services do
     namespace :external do
       namespace :google do
-        def add_feature_flag_if_not_exists(name, restricted=true)
+        def add_feature_flag_if_not_exists(name, restricted = true)
           ff = Carto::FeatureFlag.where(name: name).first
 
           if ff.nil?
@@ -12,8 +12,8 @@ namespace :cartodb do
 
             ff.id = Carto::FeatureFlag.order(:id).last.id + 1
             ff.restricted = restricted
-          else
-            ff.restricted = restricted if ff.restricted != restricted
+          elsif ff.restricted != restricted
+            ff.restricted = restricted
           end
 
           ff.save
@@ -52,7 +52,7 @@ namespace :cartodb do
         end
 
         desc 'Enable Google Services for a given user'
-        task :enable_for_user, [:google_maps_key, :google_maps_private_key, :username] => [:environment] do |task, args|
+        task :enable_for_user, [:google_maps_key, :google_maps_private_key, :username] => [:environment] do |_, args|
           add_feature_flag_if_not_exists('google_maps')
 
           user = ::User.where(username: args[:username]).first
@@ -70,7 +70,7 @@ namespace :cartodb do
 
         desc 'Enable Google Services for an organization'
         task :enable_for_organization,
-             [:google_maps_key, :google_maps_private_key, :org_name] => [:environment] do |task, args|
+             [:google_maps_key, :google_maps_private_key, :org_name] => [:environment] do |_, args|
           add_feature_flag_if_not_exists('google_maps')
 
           organization = ::Organization.where(name: args[:org_name]).first
@@ -94,7 +94,7 @@ namespace :cartodb do
         end
 
         desc 'Enable Google Services for all users'
-        task :enable_for_all, [:google_maps_key, :google_maps_private_key] => [:environment] do |task, args|
+        task :enable_for_all, [:google_maps_key, :google_maps_private_key] => [:environment] do |_, args|
           add_feature_flag_if_not_exists('google_maps')
 
           ::Organization.all.each do |organization|
@@ -128,7 +128,7 @@ namespace :cartodb do
         end
 
         desc 'Disable Google Services for a given user'
-        task :disable_for_user, [:username] => [:environment] do |task, args|
+        task :disable_for_user, [:username] => [:environment] do |_, args|
           user = ::User.where(username: args[:username]).first
 
           raise "No user with username '#{args[:username]}'" if user.nil?
@@ -144,7 +144,7 @@ namespace :cartodb do
         end
 
         desc 'Disable Google Services for an organization'
-        task :disable_for_organization, [:org_name] => [:environment] do |task, args|
+        task :disable_for_organization, [:org_name] => [:environment] do |_, args|
           organization = ::Organization.where(name: args[:org_name]).first
 
           raise "No organization with name '#{args[:org_name]}'" if organization.nil?
@@ -163,7 +163,7 @@ namespace :cartodb do
         end
 
         desc 'Disable Google Services for all users'
-        task :disable_for_all => [:environment] do |task|
+        task disable_for_all: [:environment] do |_|
           remove_feature_flag_if_exists('google_maps')
 
           ::Organization.all.each do |organization|

--- a/lib/tasks/google_services.rake
+++ b/lib/tasks/google_services.rake
@@ -55,7 +55,7 @@ namespace :cartodb do
         task :enable_for_user, [:google_maps_key, :google_maps_private_key, :username] => [:environment] do |task, args|
           add_feature_flag_if_not_exists('google_maps')
 
-          user = Carto::User.where(username: args[:username]).first
+          user = ::User.where(username: args[:username]).first
           raise "No user with username '#{args[:username]}'" if user.nil?
 
           puts "Enabling 'google_maps' feature flag for user '#{user.username}'"
@@ -73,7 +73,7 @@ namespace :cartodb do
              [:google_maps_key, :google_maps_private_key, :org_name] => [:environment] do |task, args|
           add_feature_flag_if_not_exists('google_maps')
 
-          organization = Carto::Organization.where(name: args[:org_name]).first
+          organization = ::Organization.where(name: args[:org_name]).first
 
           raise "No organization with name '#{args[:org_name]}'" if organization.nil?
 
@@ -97,7 +97,7 @@ namespace :cartodb do
         task :enable_for_all, [:google_maps_key, :google_maps_private_key] => [:environment] do |task, args|
           add_feature_flag_if_not_exists('google_maps')
 
-          Carto::Organization.all.each do |organization|
+          ::Organization.all.each do |organization|
             puts "Enabling 'google_maps' feature flag for users in '#{organization.name}'"
             organization.users.each do |user|
               puts "\tenabling 'google_maps' feature flag for user '#{user.username}'"
@@ -115,7 +115,7 @@ namespace :cartodb do
           end
 
           # For users not in organizations
-          Carto::User.where(organization_id: nil).each do |user|
+          ::User.where(organization_id: nil).each do |user|
             puts "Enabling 'google_maps' feature flag for user '#{user.username}'"
             add_feature_flag_to_user('google_maps', user)
 
@@ -129,7 +129,7 @@ namespace :cartodb do
 
         desc 'Disable Google Services for a given user'
         task :disable_for_user, [:username] => [:environment] do |task, args|
-          user = Carto::User.where(username: args[:username]).first
+          user = ::User.where(username: args[:username]).first
 
           raise "No user with username '#{args[:username]}'" if user.nil?
 
@@ -145,7 +145,7 @@ namespace :cartodb do
 
         desc 'Disable Google Services for an organization'
         task :disable_for_organization, [:org_name] => [:environment] do |task, args|
-          organization = Carto::Organization.where(name: args[:org_name]).first
+          organization = ::Organization.where(name: args[:org_name]).first
 
           raise "No organization with name '#{args[:org_name]}'" if organization.nil?
 
@@ -166,7 +166,7 @@ namespace :cartodb do
         task :disable_for_all => [:environment] do |task|
           remove_feature_flag_if_exists('google_maps')
 
-          Carto::Organization.all.each do |organization|
+          ::Organization.all.each do |organization|
             puts "Disabling google services for organization '#{organization.name}'..."
 
             organization.google_maps_key = nil
@@ -176,7 +176,7 @@ namespace :cartodb do
           end
 
           # For users not in organizations
-          Carto::User.where(organization_id: nil).each do |user|
+          ::User.where(organization_id: nil).each do |user|
             puts "Disabling google services for non-organization user '#{user.username}'..."
 
             user.google_maps_key = nil


### PR DESCRIPTION
Fixes #12197 

I also reviewed all usages of `Carto::Organization` and `Carto::User` in all clouds, but I found no other affected rakes (all other uses are just getting a count of users, a list of ids or something similar, that does not save using the model).