### PR TITLE
Overlay issues in legends view.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -121,6 +121,7 @@ Development
 * New style for add analysis button (#11902)
 
 ### Bug fixes
+* Fixed overlay for legends view (#11825)
 * Fixed UI when editing merge analysis (#10850)
 * Fixed uninitialized constant in Carto::Visualization when a viewer shares a visualization (#12129).
 * Google customers don't need quota checks for hires geocoding (support/#674)

--- a/lib/assets/core/javascripts/cartodb3/editor/components/overlay/overlay-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/components/overlay/overlay-view.js
@@ -18,6 +18,5 @@ module.exports = CoreView.extend({
 
   _initBinds: function () {
     this.listenTo(this.overlayModel, 'change:visible', this.render);
-    this.add_related_model(this.overlayModel);
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legends-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legends-view.js
@@ -86,7 +86,7 @@ module.exports = CoreView.extend({
       overlayModel: this._overlayModel
     });
     this.addView(view);
-    this.$('.js-content').append(view.render().el);
+    this.$el.append(view.render().el);
   },
 
   _initModels: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legends-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legends-view.js
@@ -86,7 +86,7 @@ module.exports = CoreView.extend({
       overlayModel: this._overlayModel
     });
     this.addView(view);
-    this.$('.js-type .js-content').first().append(view.render().el);
+    this.$('.js-type > .js-content').first().append(view.render().el);
   },
 
   _initModels: function () {
@@ -114,7 +114,6 @@ module.exports = CoreView.extend({
     this.listenTo(this._queryRowsCollection.statusModel, 'change:status', this._onStatusChanged);
     this.listenTo(this._editorModel, 'change:edition', this._changeStyle);
     this.listenTo(this._queryGeometryModel, 'change:status', this._onGeometryChanged);
-    this.listenTo(this._editorModel, 'change:edition', this._changeStyle);
   },
 
   _onVisibilityChanged: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legends-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legends-view.js
@@ -86,7 +86,7 @@ module.exports = CoreView.extend({
       overlayModel: this._overlayModel
     });
     this.addView(view);
-    this.$el.append(view.render().el);
+    this.$('.js-type .js-content').first().append(view.render().el);
   },
 
   _initModels: function () {
@@ -108,12 +108,17 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
+    this.listenTo(this._layerDefinitionModel, 'change:visible', this._onVisibilityChanged);
     this.listenTo(this._querySchemaModel, 'change:status', this._onStatusChanged);
     this.listenTo(this._queryGeometryModel, 'change:status', this._onStatusChanged);
     this.listenTo(this._queryRowsCollection.statusModel, 'change:status', this._onStatusChanged);
     this.listenTo(this._editorModel, 'change:edition', this._changeStyle);
     this.listenTo(this._queryGeometryModel, 'change:status', this._onGeometryChanged);
     this.listenTo(this._editorModel, 'change:edition', this._changeStyle);
+  },
+
+  _onVisibilityChanged: function () {
+    this._overlayModel.set({visible: this._isLayerHidden()});
   },
 
   _fetchAllQueryObjectsIfNecessary: function () {
@@ -211,7 +216,7 @@ module.exports = CoreView.extend({
       label: _t('editor.legend.menu-tab-pane-labels.color'),
       createContentView: function () {
         return new LegendColorView({
-          className: 'Editor-content',
+          className: 'Editor-content js-type',
           mapDefinitionModel: self._mapDefinitionModel,
           editorModel: self._editorModel,
           userActions: self._userActions,
@@ -229,7 +234,7 @@ module.exports = CoreView.extend({
       label: _t('editor.legend.menu-tab-pane-labels.size'),
       createContentView: function () {
         return new LegendSizeView({
-          className: 'Editor-content',
+          className: 'Editor-content js-type',
           mapDefinitionModel: self._mapDefinitionModel,
           editorModel: self._editorModel,
           userActions: self._userActions,

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/legend/legends-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/legend/legends-view.spec.js
@@ -205,10 +205,13 @@ describe('editor/layers/layer-content-view/legend/legends-view', function () {
       expect(this.view.$('.CDB-Size-huge').text()).toContain('editor.layers.georeference.manually-add');
       expect(this.view.$('.CDB-Button-Text').text()).toBe('editor.layers.georeference.georeference-button');
     });
+  });
 
-    it('should not have any leaks', function () {
-      expect(this.view).toHaveNoLeaks();
-    });
+  it('should show/hide overlay properly', function () {
+    this.layerDefinitionModel.set('visible', false);
+    expect(this.view._overlayModel.get('visible')).toBe(true);
+    this.layerDefinitionModel.set('visible', true);
+    expect(this.view._overlayModel.get('visible')).toBe(false);
   });
 
   it('should bind events properly', function () {


### PR DESCRIPTION
This PR fixes #11825. I've fixed in DO branch but it makes sense to pull it out. Also, once fixed, I've discovered other issues related it, so in order to test it:

- [x] Check the original issue is fixed.
- [x] The overlay is placed properly in the dom tree, for instance, the infoboxes are below it.
- [x] Make the layer not visible. Get the legend panel and make the layer visible again. The overlay should hide.