### PR TITLE
12229 org admin eumapi create response

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -273,6 +273,7 @@ Development
 * Fixed problem resetting styles per node after adding a new analysis (#12085)
 * Ensure Google services activation rake writes the api keys to Redis (#12209)
 * Docs, fixed some minor spelling and grammar errors in the content.
+* Fix EUMAPI response as per documentation (#12233)
 * Fix `BUILDER_ENABLED` parameter in `create_dev_user` rake (#12189)
 * Docs, updated "More Info" url from street addresses georeference options to new, related guide.
 * Organizations users now get engine_enabled from the organization by default (#12153)

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -16,7 +16,7 @@ module Carto
 
       def index
         presentations = @organization.users.each do |user|
-          Carto::Api::UserPresenter.new(user, current_viewer: current_viewer).to_poro_without_id
+          Carto::Api::UserPresenter.new(user, current_viewer: current_viewer).to_eumapi_poro
         end
 
         render_jsonp presentations, 200
@@ -24,7 +24,7 @@ module Carto
 
       def show
         presentation = Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer)
-                                                .to_poro_without_id
+                                                .to_eumapi_poro
 
         render_jsonp presentation, 200
       end
@@ -77,7 +77,7 @@ module Carto
 
         presentation = Carto::Api::UserPresenter.new(account_creator.user,
                                                      current_viewer: current_viewer)
-                                                .to_poro_without_id
+                                                .to_eumapi_poro
 
         render_jsonp presentation, 200
       rescue => e
@@ -110,7 +110,7 @@ module Carto
         @user.save
 
         presentation = Carto::Api::UserPresenter.new(@user, current_viewer: current_viewer)
-                                                .to_poro_without_id
+                                                .to_eumapi_poro
 
         render_jsonp presentation, 200
       rescue CartoDB::CentralCommunicationFailure => e

--- a/app/controllers/carto/api/user_presenter.rb
+++ b/app/controllers/carto/api/user_presenter.rb
@@ -28,8 +28,7 @@ module Carto
           viewer:           @user.viewer?,
           org_admin:        @user.organization_admin?,
           public_visualization_count: @user.public_visualization_count,
-          all_visualization_count: @user.all_visualization_count,
-          soft_geocoding_limit: @user.soft_geocoding_limit
+          all_visualization_count: @user.all_visualization_count
         }
 
         if fetch_groups
@@ -41,10 +40,11 @@ module Carto
         poro
       end
 
-      def to_poro_without_id
+      def to_eumapi_poro
         presentation = to_poro
 
         presentation.delete(:id)
+        presentation[:soft_geocoding_limit] = @user.soft_geocoding_limit
 
         presentation
       end

--- a/app/controllers/carto/api/user_presenter.rb
+++ b/app/controllers/carto/api/user_presenter.rb
@@ -28,7 +28,8 @@ module Carto
           viewer:           @user.viewer?,
           org_admin:        @user.organization_admin?,
           public_visualization_count: @user.public_visualization_count,
-          all_visualization_count: @user.all_visualization_count
+          all_visualization_count: @user.all_visualization_count,
+          soft_geocoding_limit: @user.soft_geocoding_limit
         }
 
         if fetch_groups

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,6 +234,7 @@ class User < Sequel::Model
     self.obs_snapshot_quota ||= DEFAULT_OBS_SNAPSHOT_QUOTA
     self.obs_general_quota ||= DEFAULT_OBS_GENERAL_QUOTA
     self.mapzen_routing_quota ||= DEFAULT_MAPZEN_ROUTING_QUOTA
+    self.soft_geocoding_limit = false if soft_geocoding_limit.nil?
     self.viewer = false if viewer.nil?
     self.org_admin = false if org_admin.nil?
     true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,6 +234,9 @@ class User < Sequel::Model
     self.obs_snapshot_quota ||= DEFAULT_OBS_SNAPSHOT_QUOTA
     self.obs_general_quota ||= DEFAULT_OBS_GENERAL_QUOTA
     self.mapzen_routing_quota ||= DEFAULT_MAPZEN_ROUTING_QUOTA
+    self.viewer = false if viewer.nil?
+    self.org_admin = false if org_admin.nil?
+    true
   end
 
   def before_create


### PR DESCRIPTION
Fix #12229 

Fixes EUMAPI response so they matched expectations (as documented). Notable changes:
- Add `soft_geocoding_limit` to user presenter. This is used in EUMAPI docs for PUT responses. We should add it to the documented POST response (it's not there).
- The docs indicate that `avatar_url` is returned on creation. This is not possible right now without DB migration, due to how the queue works (`avatar_url` is not a field of `user_creations`). There is no easy solution for this, and it's minor, so I think we can ignore it.