### PR TITLE
Remove icon model from userAssetsCollection if upload fails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -123,6 +123,7 @@ Development
 * Show infowindow when user reaches max layer limit (#12167)
 
 ### Bug fixes
+* Fixed problem when icon upload fails (#11980)
 * Boolean fields are visible in the filter by column value analysis (#11546)
 * Fixed legend's color mismatch with empty values (#11632)
 * Fixed overlay for legends view (#11825)

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/assets-picker/assets-view.js
@@ -405,6 +405,7 @@ module.exports = CoreView.extend({
   },
 
   _onAssetUploadError: function (model, response) {
+    this._userAssetCollection.remove(model);
     this._resetFileSelection();
     this._setError(response);
   },

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
@@ -223,7 +223,7 @@ describe('components/form-components/editors/fill/input-color/assets-view', func
   });
 
   describe('._onAssetUploadError', function () {
-    beforeEach(function() {
+    beforeEach(function () {
       mockCreate.call(this, 'error');
       spyOn(this.view, '_getSelectedFiles').and.returnValue(files);
       spyOn(this.view, '_resetFileSelection');

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/fill/input-color/asset-picker/assets-view.spec.js
@@ -47,13 +47,13 @@ describe('components/form-components/editors/fill/input-color/assets-view', func
         callbacks: callbacks
       };
 
-      this.add(options);
+      var model = this.add(options);
 
       createCalls.push(createCall);
 
       if (callback) {
         if (callback === 'error') {
-          callbacks[callback].call(this, new Backbone.Model(), {
+          callbacks[callback].call(this, model, {
             responseText: '{"error": ["hi, I am an error"]}'
           });
         } else if (callback === 'success') {
@@ -223,17 +223,24 @@ describe('components/form-components/editors/fill/input-color/assets-view', func
   });
 
   describe('._onAssetUploadError', function () {
-    it('should reset selection and show the proper error message', function () {
+    beforeEach(function() {
       mockCreate.call(this, 'error');
-
       spyOn(this.view, '_getSelectedFiles').and.returnValue(files);
       spyOn(this.view, '_resetFileSelection');
-
       this.view.$('.js-fileInput').trigger('change');
+    });
 
+    it('should reset selection', function () {
       expect(this.view._resetFileSelection).toHaveBeenCalled();
+    });
+
+    it('should show the proper error message', function () {
       expect(this.view._stateModel.get('error_message')).toBe('hi, I am an error');
       expect(this.view._stateModel.get('status')).toBe('error');
+    });
+
+    it('should remove the model from _userAssetCollection', function () {
+      expect(this.view._userAssetCollection.length).toBe(0);
     });
   });
 


### PR DESCRIPTION
Fixes #11980

![image_upload](https://cloud.githubusercontent.com/assets/905225/26627885/4b87057a-45fc-11e7-9905-24e66ac21477.gif)

### Acceptance
- [ ] When the upload fails, the icon is not in "Your uploads" tab.