### PR TITLE
Select next analysis node when deleting one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -279,6 +279,7 @@ Development
 * Organizations users now get engine_enabled from the organization by default (#12153)
 * Color picker disappears in CartoCSS editor after clicking (#12097).
 * Bug found in dataset view when user had Google basemaps enabled (#12155)
+* Fixed incorrect analysis node being selected after deleting (#11899)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.0`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/core/javascripts/cartodb3/data/user-actions.js
@@ -150,6 +150,7 @@ module.exports = function (params) {
         nodeDefModel = analysisFormModel.createNodeDefinition(this); // delegate creation to the form, but expect it to call userActions.createAnalysisNode when done with its internal stuff
       }
       nodeDefModel.USER_SAVED = true;
+      return nodeDefModel;
     },
 
     /**

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-view.js
@@ -32,6 +32,7 @@ module.exports = CoreView.extend({
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this._selectedNodeId = opts.selectedNodeId;
+    this._infoboxState = this._infoboxState.bind(this);
 
     this._infoboxModel = new InfoboxModel({
       state: ''
@@ -131,13 +132,8 @@ module.exports = CoreView.extend({
   },
 
   _getQueryAndCheckState: function () {
-    var setStateAndRender = function () {
-      this._infoboxState();
-      this.render();
-    }.bind(this);
-
     if (!this._analysisFormsCollection.isEmpty()) {
-      setStateAndRender();
+      this._infoboxState();
       return;
     }
 
@@ -149,7 +145,7 @@ module.exports = CoreView.extend({
         queryGeometryModel: analysisDefinitionNodeModel.queryGeometryModel,
         querySchemaModel: analysisDefinitionNodeModel.querySchemaModel
       },
-      setStateAndRender
+      this._infoboxState
     );
   },
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-list-view.js
@@ -6,7 +6,6 @@ var checkAndBuildOpts = require('../../../../helpers/required-opts');
 var REQUIRED_OPTS = [
   'analysisDefinitionNodesCollection',
   'analysisFormsCollection',
-  'model',
   'layerId'
 ];
 
@@ -17,6 +16,12 @@ module.exports = CoreView.extend({
 
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+
+    if (!opts.model) {
+      throw new Error('model is required');
+    }
+
+    this.model = opts.model;
   },
 
   render: function () {
@@ -33,7 +38,7 @@ module.exports = CoreView.extend({
     var view = new AnalysesWorkflowItemView({
       analysisNode: this._analysisDefinitionNodesCollection.get(formModel.id),
       formModel: formModel,
-      viewModel: this._model,
+      viewModel: this.model,
       layerId: this._layerId
     });
     this.$el.append(view.render().el);

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-list-view.js
@@ -1,6 +1,14 @@
 var CoreView = require('backbone/core-view');
 var AnalysesWorkflowItemView = require('./analyses-workflow-item-view');
 var template = require('./analyses-workflow-list.tpl');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
+
+var REQUIRED_OPTS = [
+  'analysisDefinitionNodesCollection',
+  'analysisFormsCollection',
+  'model',
+  'layerId'
+];
 
 module.exports = CoreView.extend({
 
@@ -8,15 +16,7 @@ module.exports = CoreView.extend({
   tagName: 'ul',
 
   initialize: function (opts) {
-    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
-    if (!opts.analysisFormsCollection) throw new Error('analysisFormsCollection is required');
-    if (!opts.model) throw new Error('model is required');
-    if (!opts.layerId) throw new Error('layerId is required');
-
-    this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
-    this.analysis = opts.analysis;
-    this.analysisFormsCollection = opts.analysisFormsCollection;
-    this._layerId = opts.layerId;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
   },
 
   render: function () {
@@ -25,7 +25,7 @@ module.exports = CoreView.extend({
       layerId: this._layerId
     }));
 
-    this.analysisFormsCollection.each(this._renderWorkflowItem, this);
+    this._analysisFormsCollection.each(this._renderWorkflowItem, this);
     return this;
   },
 
@@ -33,7 +33,7 @@ module.exports = CoreView.extend({
     var view = new AnalysesWorkflowItemView({
       analysisNode: this._analysisDefinitionNodesCollection.get(formModel.id),
       formModel: formModel,
-      viewModel: this.model,
+      viewModel: this._model,
       layerId: this._layerId
     });
     this.$el.append(view.render().el);

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
@@ -20,7 +20,10 @@ module.exports = CoreView.extend({
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
-    this.listenTo(this._analysisDefinitionNodesCollection, 'add', this.render);
+    this.listenTo(this._analysisDefinitionNodesCollection, 'add', function () {
+      // change:source happens when a node is deleted as well, so we can't just listen to it all the time
+      this._layerDefinitionModel.once('change:source', this.render, this);
+    });
   },
 
   render: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
@@ -19,6 +19,8 @@ module.exports = CoreView.extend({
 
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+
+    this.listenTo(this._analysisDefinitionNodesCollection, 'add', this.render);
   },
 
   render: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
@@ -2,6 +2,14 @@ var CoreView = require('backbone/core-view');
 var template = require('./analyses-workflow.tpl');
 var ListView = require('./analyses-workflow-list-view');
 var ScrollView = require('../../../../components/scroll/scroll-view');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
+
+var REQUIRED_OPTS = [
+  'analysisDefinitionNodesCollection',
+  'analysisFormsCollection',
+  'viewModel',
+  'layerDefinitionModel'
+];
 
 module.exports = CoreView.extend({
 
@@ -10,15 +18,7 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
-    if (!opts.analysisFormsCollection) throw new Error('analysisFormsCollection is required');
-    if (!opts.viewModel) throw new Error('viewModel is required');
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-
-    this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
-    this.analysisFormsCollection = opts.analysisFormsCollection;
-    this.viewModel = opts.viewModel;
-    this._layerDefinitionModel = opts.layerDefinitionModel;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
   },
 
   render: function () {
@@ -34,7 +34,7 @@ module.exports = CoreView.extend({
       deleteLabel: !this._nodeDefModel()
         ? _t('editor.layers.layer.cancel-delete-analysis')
         : _t('editor.layers.layer.delete'),
-      selectedNodeId: this.viewModel.get('selectedNodeId'),
+      selectedNodeId: this._viewModel.get('selectedNodeId'),
       layerAnalysisCount: this._layerDefinitionModel.getNumberOfAnalyses()
     });
   },
@@ -46,8 +46,8 @@ module.exports = CoreView.extend({
       createContentView: function () {
         return new ListView({
           analysisDefinitionNodesCollection: self._analysisDefinitionNodesCollection,
-          analysisFormsCollection: self.analysisFormsCollection,
-          model: self.viewModel,
+          analysisFormsCollection: self._analysisFormsCollection,
+          model: self._viewModel,
           layerId: self._layerDefinitionModel.id
         });
       }
@@ -59,7 +59,7 @@ module.exports = CoreView.extend({
 
   _deleteAnalysis: function () {
     if (this._canDeleteSelectedNode()) {
-      this.analysisFormsCollection.deleteNode(this.viewModel.get('selectedNodeId'));
+      this._analysisFormsCollection.deleteNode(this._viewModel.get('selectedNodeId'));
     }
   },
 
@@ -69,7 +69,7 @@ module.exports = CoreView.extend({
   },
 
   _nodeDefModel: function () {
-    var nodeId = this.viewModel.get('selectedNodeId');
+    var nodeId = this._viewModel.get('selectedNodeId');
     return this._layerDefinitionModel.findAnalysisDefinitionNodeModel(nodeId);
   }
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -101,14 +101,19 @@ module.exports = CoreView.extend({
     this.listenTo(this._formModel, 'change', this._onFormModelChanged);
 
     if (this._analysisNode) {
-      this.listenTo(this._analysisNode, 'change:status', function () {
-        this._viewModel.set('isDone', this._isAnalysisDone());
-        var isAnalysisDone = this._isAnalysisDone();
-        if (isAnalysisDone) {
-          this.render();
-        }
-      });
+      this._bindAnalysisNodeStatusChanges();
     }
+  },
+
+  _bindAnalysisNodeStatusChanges: function () {
+    this.listenTo(this._analysisNode, 'change:status', function () {
+      console.log('change:status', 'isDone', this._isAnalysisDone());
+      this._viewModel.set('isDone', this._isAnalysisDone());
+      var isAnalysisDone = this._isAnalysisDone();
+      if (isAnalysisDone) {
+        this.render();
+      }
+    });
   },
 
   _onFormModelChanged: function () {
@@ -322,7 +327,13 @@ module.exports = CoreView.extend({
 
   _saveAnalysis: function () {
     this._infoboxModel.set('state', 'idle');
-    this._userActions.saveAnalysis(this._formModel);
+    var newNode = this._userActions.saveAnalysis(this._formModel);
+
+    if (!this._analysisNode) {
+      this._analysisNode = newNode;
+      this._bindAnalysisNodeStatusChanges();
+    }
+
     this._viewModel.set({ hasChanges: false, isDone: false });
     this.render();
   }

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -107,7 +107,6 @@ module.exports = CoreView.extend({
 
   _bindAnalysisNodeStatusChanges: function () {
     this.listenTo(this._analysisNode, 'change:status', function () {
-      console.log('change:status', 'isDone', this._isAnalysisDone());
       this._viewModel.set('isDone', this._isAnalysisDone());
       var isAnalysisDone = this._isAnalysisDone();
       if (isAnalysisDone) {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-forms-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-forms-collection.js
@@ -57,6 +57,22 @@ module.exports = Backbone.Collection.extend({
     }
   },
 
+  removeUselessModels: function () {
+    var removed = [];
+
+    this.models.forEach(function (model) {
+      var useless = this._layerDefinitionModel.findAnalysisDefinitionNodeModel(model.id) === undefined;
+      if (useless) {
+        removed.push(model);
+      }
+    }, this);
+
+    if (removed.length > 0) {
+      this.remove(removed, { silent: true });
+      this.trigger('destroyedModels');
+    }
+  },
+
   _walkAnalysisChain: function (current, layerDefModel, visitorFn) {
     if (!current.hasPrimarySource()) return;
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
@@ -7,7 +7,6 @@ var analysisSQLErrorTemplate = require('../analyses/analyses-sql-error.tpl');
 var AnalysisFormView = require('../analyses/analysis-form-view');
 var AnalysesWorkflowView = require('../analyses/analyses-workflow-view');
 var AnalysisControlsView = require('../analyses/analysis-controls-view');
-var QuerySanity = require('../../query-sanity-check');
 var actionErrorTemplate = require('../../sql-error-action.tpl');
 var OverlayView = require('../../../components/overlay/overlay-view');
 var AnalysesQuotaInfo = require('./analyses-quota/analyses-quota-info');
@@ -62,8 +61,6 @@ module.exports = CoreView.extend({
     });
 
     this._initBinds();
-
-    QuerySanity.track(this, this.render.bind(this));
   },
 
   render: function () {
@@ -93,11 +90,6 @@ module.exports = CoreView.extend({
     return this;
   },
 
-  clean: function () {
-    CoreView.prototype.clean.apply(this);
-    this._selectedNodeId(null, {silent: true});
-  },
-
   _renderOverlay: function () {
     var view = new OverlayView({
       overlayModel: this._overlayModel
@@ -122,8 +114,8 @@ module.exports = CoreView.extend({
     this._layerDefinitionModel.on('change:source', this._onLayerDefSourceChanged, this);
     this.add_related_model(this._layerDefinitionModel);
 
-    this._analysisFormsCollection.on('add', this._onFormModelAdded, this);
-    this._analysisFormsCollection.on('remove', this._onFormModelRemoved, this);
+    this._analysisFormsCollection.on('destroyedModels', this._renderWithDefaultNodeSelected, this);
+    this._analysisFormsCollection.on('remove', this._renderWithDefaultNodeSelected, this);
     this.add_related_model(this._analysisFormsCollection);
   },
 
@@ -174,11 +166,11 @@ module.exports = CoreView.extend({
   },
 
   _formModel: function () {
-    return this._analysisFormsCollection.get(this._selectedNodeId()) || this._analysisFormsCollection.first();
+    return this._analysisFormsCollection.get(this._getSelectedNodeId()) || this._analysisFormsCollection.first();
   },
 
   _getQuerySchemaModelForEstimation: function () {
-    var node = this._analysisDefinitionNodesCollection.get(this._selectedNodeId());
+    var node = this._analysisDefinitionNodesCollection.get(this._getSelectedNodeId());
     var index;
 
     if (!node) {
@@ -191,36 +183,29 @@ module.exports = CoreView.extend({
     return node.querySchemaModel;
   },
 
-  _selectedNodeId: function (id, options) {
+  _setSelectedNodeId: function (id, options) {
     if (!this._viewModel) {
       return;
     }
 
-    if (id === undefined) {
-      return this._viewModel.get('selectedNodeId');
-    } else {
-      this._viewModel.set('selectedNodeId', id, options);
+    this._viewModel.set('selectedNodeId', id, options);
+  },
+
+  _getSelectedNodeId: function (id, options) {
+    if (!this._viewModel) {
+      return;
     }
+
+    return this._viewModel.get('selectedNodeId');
   },
 
   _onLayerDefSourceChanged: function () {
-    // When reset, the parent view is rendered again, creating a new instance of this one
-    // calling here this._renderWithDefaultNodeSelected(); will cause a race condition
-    // ending up in two instance of this being rendered
-    this._analysisFormsCollection.resetByLayerDefinition();
-  },
-
-  _onFormModelAdded: function () {
-    this._renderWithDefaultNodeSelected();
-  },
-
-  _onFormModelRemoved: function () {
-    this._renderWithDefaultNodeSelected();
+    this._analysisFormsCollection.removeUselessModels();
   },
 
   _renderWithDefaultNodeSelected: function () {
     var selectedNodeId = this._analysisFormsCollection.pluck('id')[0];
-    this._selectedNodeId(selectedNodeId, {silent: true});
+    this._setSelectedNodeId(selectedNodeId, {silent: true});
     this.render();
   }
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
@@ -11,13 +11,7 @@ var AnalysisControlsView = require('../analyses/analysis-controls-view');
 var actionErrorTemplate = require('../../sql-error-action.tpl');
 var OverlayView = require('../../../components/overlay/overlay-view');
 var AnalysesQuotaInfo = require('./analyses-quota/analyses-quota-info');
-
-var STATES = {
-  ready: 'ready',
-  loading: 'loading',
-  fetched: 'fetched',
-  error: 'error'
-};
+var QuerySanity = require('../../query-sanity-check');
 
 var REQUIRED_OPTS = [
   'userActions',
@@ -51,10 +45,6 @@ module.exports = CoreView.extend({
     this._querySchemaModel = this._layerDefinitionModel.getAnalysisDefinitionNodeModel().querySchemaModel;
 
     this._quotaInfo = AnalysesQuotaInfo.get(opts.configModel);
-
-    this.modelView = new Backbone.Model({
-      state: this._getInitialState()
-    });
 
     this._initBinds();
   },
@@ -94,12 +84,8 @@ module.exports = CoreView.extend({
     this.$el.append(view.render().el);
   },
 
-  _getInitialState: function () {
-    return STATES.loading;
-  },
-
   _hasError: function () {
-    return this.modelView.get('state') === STATES.error;
+    return QuerySanity._checkErrors(this._querySchemaModel);
   },
 
   _initBinds: function () {
@@ -145,7 +131,6 @@ module.exports = CoreView.extend({
       analysisNode: analysisNode,
       userActions: this._userActions,
       userModel: this._userModel,
-      statusModel: this.modelView,
       stackLayoutModel: this._stackLayoutModel,
       formModel: formModel,
       quotaInfo: this._quotaInfo,

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
@@ -181,7 +181,7 @@ module.exports = CoreView.extend({
     this._viewModel.set('selectedNodeId', id, options);
   },
 
-  _getSelectedNodeId: function (id, options) {
+  _getSelectedNodeId: function () {
     if (!this._viewModel) {
       return;
     }

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
@@ -104,15 +104,9 @@ module.exports = CoreView.extend({
 
   _initBinds: function () {
     // Init listeners
-    this._viewModel.on('change:selectedNodeId', this.render, this);
-    this.add_related_model(this._viewModel);
-
-    this._layerDefinitionModel.on('change:source', this._onLayerDefSourceChanged, this);
-    this.add_related_model(this._layerDefinitionModel);
-
-    this._analysisFormsCollection.on('destroyedModels', this._renderWithDefaultNodeSelected, this);
-    this._analysisFormsCollection.on('remove', this._renderWithDefaultNodeSelected, this);
-    this.add_related_model(this._analysisFormsCollection);
+    this.listenTo(this._viewModel, 'change:selectedNodeId', this.render);
+    this.listenTo(this._layerDefinitionModel, 'change:source', this._onLayerDefSourceChanged);
+    this.listenTo(this._analysisFormsCollection, 'destroyedModels remove', this._renderWithDefaultNodeSelected);
   },
 
   _renderScrollableListView: function (formModel) {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/layer-content-analyses-view.js
@@ -1,5 +1,6 @@
 var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
 var ScrollView = require('../../../../components/scroll/scroll-view');
 var ViewFactory = require('../../../../components/view-factory');
 var analysisPlaceholderTemplate = require('../analyses/analyses-placeholder.tpl');
@@ -18,6 +19,17 @@ var STATES = {
   error: 'error'
 };
 
+var REQUIRED_OPTS = [
+  'userActions',
+  'analysisFormsCollection',
+  'layerDefinitionModel',
+  'analysisDefinitionNodesCollection',
+  'configModel',
+  'userModel',
+  'stackLayoutModel',
+  'overlayModel'
+];
+
 /**
  * LayerContentAnalysesView:
  *   ├── ScrollView
@@ -33,23 +45,7 @@ module.exports = CoreView.extend({
   },
 
   initialize: function (opts) {
-    if (!opts.userActions) throw new Error('userActions is required');
-    if (!opts.analysisFormsCollection) throw new Error('analysisFormsCollection is required');
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-    if (!opts.analysisDefinitionNodesCollection) throw new Error('analysisDefinitionNodesCollection is required');
-    if (!opts.configModel) throw new Error('configModel is required');
-    if (!opts.userModel) throw new Error('userModel is required');
-    if (!opts.stackLayoutModel) throw new Error('stackLayoutModel is required');
-    if (!opts.overlayModel) throw new Error('overlayModel is required');
-
-    this._userActions = opts.userActions;
-    this._stackLayoutModel = opts.stackLayoutModel;
-    this._userModel = opts.userModel;
-    this._analysisFormsCollection = opts.analysisFormsCollection;
-    this._layerDefinitionModel = opts.layerDefinitionModel;
-    this._analysisDefinitionNodesCollection = opts.analysisDefinitionNodesCollection;
-    this._configModel = opts.configModel;
-    this._overlayModel = opts.overlayModel;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this._viewModel = new Backbone.Model({selectedNodeId: this.options.selectedNodeId});
     this._querySchemaModel = this._layerDefinitionModel.getAnalysisDefinitionNodeModel().querySchemaModel;

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/query-sanity-check.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/query-sanity-check.js
@@ -39,6 +39,10 @@ module.exports = {
   },
 
   _hasErrors: function () {
+    return this._checkErrors(this._querySchemaModel);
+  },
+
+  _checkErrors: function (querySchemaModel) {
     var errors = this.querySchemaModel.get('query_errors');
     return (errors && errors.length > 0);
   }

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/query-sanity-check.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/query-sanity-check.js
@@ -39,11 +39,11 @@ module.exports = {
   },
 
   _hasErrors: function () {
-    return this._checkErrors(this._querySchemaModel);
+    return this._checkErrors(this.querySchemaModel);
   },
 
   _checkErrors: function (querySchemaModel) {
-    var errors = this.querySchemaModel.get('query_errors');
+    var errors = querySchemaModel.get('query_errors');
     return (errors && errors.length > 0);
   }
 };

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-workflow-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-workflow-view.spec.js
@@ -85,6 +85,26 @@ describe('editor/layers/layer-content-view/analyses/analyses-workflow-view', fun
     expect(this.view).toHaveNoLeaks();
   });
 
+  it('should render when analysis node is added', function () {
+    spyOn(this.view, 'render').and.callThrough();
+
+    this.analysisDefinitionNodesCollection.add({
+      id: 'a5',
+      type: 'source',
+      status: 'ready'
+    });
+
+    expect(this.view.render).not.toHaveBeenCalled();
+
+    // A change in the source should trigger the render
+    this.layerDefModel.set({ source: 'a5' });
+    expect(this.view.render).toHaveBeenCalled();
+
+    // But another change in the source without adding a node should not
+    this.layerDefModel.set({ source: 'a4' });
+    expect(this.view.render.calls.count()).toBe(1);
+  });
+
   describe('when click delete-analysis', function () {
     beforeEach(function () {
       this.view.$('.js-delete').click();

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/layer-content-analyses-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/layer-content-analyses-view.spec.js
@@ -122,6 +122,7 @@ describe('editor/layers/layer-content-view/layer-content-analyses-view', functio
       this.layerDefinitionModel.getAnalysisDefinitionNodeModel.and.returnValue(this.a1);
       spyOn(this.a1, 'getPrimarySource').and.returnValue(this.a0);
       this.analysisFormsCollection.add(this.a1.attributes, {at: 0});
+      this.view._renderWithDefaultNodeSelected();
 
       this.layerDefinitionModel.set('source', 'a1');
     });
@@ -164,6 +165,7 @@ describe('editor/layers/layer-content-view/layer-content-analyses-view', functio
         type: 'buffer',
         source: 'a0'
       });
+      this.view._renderWithDefaultNodeSelected();
     });
 
     it('should select new node', function () {

--- a/lib/assets/core/test/spec/cartodb3/helpers/required-opts.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/helpers/required-opts.spec.js
@@ -1,0 +1,28 @@
+var checkAndBuildOpts = require('../../../../javascripts/cartodb3/helpers/required-opts');
+
+describe('required opts', function () {
+  describe('basic usage', function () {
+    it('should throw if any required opt is missing', function () {
+      var REQUIRED_OPTS = [
+        'opt1',
+        'opt2'
+      ];
+
+      expect(function () {
+        checkAndBuildOpts({ opt1: 'foo' }, REQUIRED_OPTS, {});
+      }).toThrow();
+    });
+
+    it('should set all required opts as _opt by default', function () {
+      var REQUIRED_OPTS = [
+        'opt1',
+        'opt2'
+      ];
+      var ops = { opt1: 0, opt2: 1 };
+      var context = {};
+
+      checkAndBuildOpts(ops, REQUIRED_OPTS, context);
+      expect(context).toEqual({ _opt1: 0, _opt2: 1 });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.32",
+  "version": "4.7.32-ded01.1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #11899 

![incorrect-analysis](https://cloud.githubusercontent.com/assets/446970/26628234/8dabb04e-45fd-11e7-83e3-4eebd697357a.gif)

This PR makes it so when you delete an analysis, the next one is selected. It also reduces the number of layer-content-analyses-view render calls.

