### PR TITLE
Show title & error on analysis workflow tooltip

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,7 @@ Development
 * Fix onboarding in layers (#12192)
 * Show infowindow when user reaches max layer limit (#12167)
 * Format quota infowindow numbers (#11743)
+* Improved analysis error tooltip (#12250)
 
 ### Bug fixes
 * Google customers don't need quota checks for hires geocoding (support/#674)

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -5,6 +5,7 @@ var layerColors = require('../../../../data/layer-colors');
 var AnalysisTooltip = require('../../analysis-views/analyses-tooltip-error');
 var TipsyTooltipView = require('../../../../components/tipsy-tooltip-view');
 var Analyses = require('../../../../data/analyses');
+var NotificationErrorMessageHandler = require('../../notification-error-message-handler');
 
 module.exports = CoreView.extend({
 
@@ -25,14 +26,6 @@ module.exports = CoreView.extend({
 
     this._analysisNode.on('change:status', this.render, this);
     this.add_related_model(this._analysisNode);
-
-    this._analysisTooltip = new AnalysisTooltip({
-      analysisNode: this._analysisNode,
-      element: this.$el,
-      triggerSelector: '.Editor-ListAnalysis-itemError'
-    });
-
-    this.addView(this._analysisTooltip);
   },
 
   render: function () {
@@ -41,6 +34,14 @@ module.exports = CoreView.extend({
     var isSelected = this._analysisNode.id === this._viewModel.get('selectedNodeId');
     var letter = nodeIds.letter(this._analysisNode.id);
     var bgColor = layerColors.getColorForLetter(letter);
+    var analysisTitle = Analyses.title(this._analysisNode.get('type') || '');
+    var tooltipTitle = analysisTitle;
+    var hasFailed = status === 'failed';
+
+    if (hasFailed) {
+      var message = NotificationErrorMessageHandler.extractErrorFromAnalysisNode(this.analysisNode);
+      tooltipTitle = analysisTitle + ': ' + message;
+    }
 
     this.$el.html(
       template({
@@ -62,9 +63,10 @@ module.exports = CoreView.extend({
 
     var tooltip = new TipsyTooltipView({
       el: this.$el,
+      className: hasFailed ? 'is-error' : '',
       title: function () {
-        return Analyses.title(this._analysisNode.get('type') || '');
-      }.bind(this)
+        return tooltipTitle;
+      }
     });
     this.addView(tooltip);
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -38,8 +38,10 @@ module.exports = CoreView.extend({
     var hasFailed = status === 'failed';
 
     if (hasFailed) {
-      var message = NotificationErrorMessageHandler.extractErrorFromAnalysisNode(this.analysisNode);
-      tooltipTitle = analysisTitle + ': ' + message;
+      var message = NotificationErrorMessageHandler.extractErrorFromAnalysisNode(this.analysisNode).message;
+      if (message) {
+        tooltipTitle = analysisTitle + ': ' + message;
+      }
     }
 
     this.$el.html(

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -9,6 +9,7 @@ var NotificationErrorMessageHandler = require('../../notification-error-message-
 var tooltipPresenter = function (analysis, hasFailed) {
   var body = [Analyses.title(analysis.get('type') || '')];
   var error;
+  var errorMessage;
 
   if (hasFailed) {
     error = analysis.get('error');
@@ -17,7 +18,7 @@ var tooltipPresenter = function (analysis, hasFailed) {
   }
 
   return body.join(': ');
-}
+};
 
 module.exports = CoreView.extend({
 
@@ -46,7 +47,6 @@ module.exports = CoreView.extend({
     var isSelected = this._analysisNode.id === this._viewModel.get('selectedNodeId');
     var letter = nodeIds.letter(this._analysisNode.id);
     var bgColor = layerColors.getColorForLetter(letter);
-    var analysisTitle = Analyses.title(this._analysisNode.get('type') || '');
     var hasFailed = status === 'failed';
     var tooltipMessage = tooltipPresenter(this._analysisNode, hasFailed);
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -36,14 +36,14 @@ module.exports = CoreView.extend({
     var analysisTitle = Analyses.title(this._analysisNode.get('type') || '');
     var tooltipTitle = analysisTitle;
     var hasFailed = status === 'failed';
-
-    if (hasFailed) {
-      var message = NotificationErrorMessageHandler.extractErrorFromAnalysisNode(this.analysisNode).message;
-      if (message) {
-        tooltipTitle = analysisTitle + ': ' + message;
-      }
+    var error = this._analysisNode.get('error');
+    var errorMessage = (error && error.message) ? NotificationErrorMessageHandler.extractError(error.message) : null;
+  
+    if (hasFailed && errorMessage) {
+      tooltipTitle = analysisTitle + ': ' + errorMessage.message;
     }
-
+    
+    this.clearSubViews();
     this.$el.html(
       template({
         isNew: this._isNew,

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -2,7 +2,6 @@ var CoreView = require('backbone/core-view');
 var template = require('./analyses-workflow-item.tpl');
 var nodeIds = require('../../../../value-objects/analysis-node-ids');
 var layerColors = require('../../../../data/layer-colors');
-var AnalysisTooltip = require('../../analysis-views/analyses-tooltip-error');
 var TipsyTooltipView = require('../../../../components/tipsy-tooltip-view');
 var Analyses = require('../../../../data/analyses');
 var NotificationErrorMessageHandler = require('../../notification-error-message-handler');

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -50,7 +50,7 @@ module.exports = CoreView.extend({
         bgColor: bgColor,
         isSelected: isSelected,
         nodeId: this._analysisNode.id,
-        hasError: status === 'failed'
+        hasError: hasFailed
       })
     );
 
@@ -59,7 +59,7 @@ module.exports = CoreView.extend({
       border: isSelected ? '1px solid ' + bgColor : ''
     });
     this.$el.toggleClass('is-selected', isSelected);
-    this.$el.toggleClass('has-error', status === 'failed');
+    this.$el.toggleClass('has-error', hasFailed);
 
     var tooltip = new TipsyTooltipView({
       el: this.$el,

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-workflow-item-view.js
@@ -6,6 +6,19 @@ var TipsyTooltipView = require('../../../../components/tipsy-tooltip-view');
 var Analyses = require('../../../../data/analyses');
 var NotificationErrorMessageHandler = require('../../notification-error-message-handler');
 
+var tooltipPresenter = function (analysis, hasFailed) {
+  var body = [Analyses.title(analysis.get('type') || '')];
+  var error;
+
+  if (hasFailed) {
+    error = analysis.get('error');
+    errorMessage = error && error.message && NotificationErrorMessageHandler.extractError(error.message).message;
+    errorMessage && body.push(errorMessage);
+  }
+
+  return body.join(': ');
+}
+
 module.exports = CoreView.extend({
 
   tagName: 'li',
@@ -34,15 +47,9 @@ module.exports = CoreView.extend({
     var letter = nodeIds.letter(this._analysisNode.id);
     var bgColor = layerColors.getColorForLetter(letter);
     var analysisTitle = Analyses.title(this._analysisNode.get('type') || '');
-    var tooltipTitle = analysisTitle;
     var hasFailed = status === 'failed';
-    var error = this._analysisNode.get('error');
-    var errorMessage = (error && error.message) ? NotificationErrorMessageHandler.extractError(error.message) : null;
-  
-    if (hasFailed && errorMessage) {
-      tooltipTitle = analysisTitle + ': ' + errorMessage.message;
-    }
-    
+    var tooltipMessage = tooltipPresenter(this._analysisNode, hasFailed);
+
     this.clearSubViews();
     this.$el.html(
       template({
@@ -66,7 +73,7 @@ module.exports = CoreView.extend({
       el: this.$el,
       className: hasFailed ? 'is-error' : '',
       title: function () {
-        return tooltipTitle;
+        return tooltipMessage;
       }
     });
     this.addView(tooltip);


### PR DESCRIPTION
Fix #12250 

If there's an error, it shows the tooltip in red and combines the Analysis name & the error message.


![tooltip_2](https://cloud.githubusercontent.com/assets/905225/26717023/15d433fe-477c-11e7-9870-4ebc8c3f379a.gif)
