### PR TITLE
Number editor to respects min/max validations when using arrow keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Development
 * New loading button styles (#12132)
 
 ### Bug fixes / enhancements
+* Fixed arrow keys exceeding min/max values in number editor (#12212)
 * Fixed aligment problems after cartoassets update (#12234)
 * Fixed layer counter (#12236)
 * Fixed problem when icon upload fails (#11980)

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/number/number.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/number/number.js
@@ -121,7 +121,7 @@ Backbone.Form.editors.Number = Backbone.Form.editors.Base.extend({
 
   _nextValue: function (value, increment) {
     var nextValue = value += increment;
-    
+
     if (nextValue < this.options.min) return this.options.min;
     if (nextValue > this.options.max) return this.options.max;
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/number/number.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/number/number.js
@@ -107,20 +107,25 @@ Backbone.Form.editors.Number = Backbone.Form.editors.Base.extend({
       case ENTER_KEY_CODE:
         return false;
       case UP_ARROW_KEY_CODE:
-        value += increment;
-        if (value <= this.options.max) {
-          $input.val(value);
-        }
+        value = this._nextValue(value, increment);
+        $input.val(value);
         break;
       case BOTTOM_ARROW_KEY_CODE:
-        value -= increment;
-        if (value >= this.options.min) {
-          $input.val(value);
-        }
+        value = this._nextValue(value, increment * -1);
+        $input.val(value);
         break;
       default:
         // Any other case!
     }
+  },
+
+  _nextValue: function (value, increment) {
+    var nextValue = value += increment;
+    
+    if (nextValue < this.options.min) return this.options.min;
+    if (nextValue > this.options.max) return this.options.max;
+
+    return nextValue;
   },
 
   _hasSlider: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/number/number.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/number/number.js
@@ -97,26 +97,26 @@ Backbone.Form.editors.Number = Backbone.Form.editors.Base.extend({
     this.trigger('change', this);
   },
 
-  _onInputKeyDown: function (e) {
-    var value = +this.getValue();
-    var inc = SMALL_INCREMENT;
+  _onInputKeyDown: function (event) {
     var $input = this.$('.js-input');
+    var value = +this.getValue();
+    var increment = event.shiftKey === true ? BIG_INCREMENT : SMALL_INCREMENT;
 
-    if (e.shiftKey === true) {
-      inc = BIG_INCREMENT;
-    }
-
-    switch (e.which) {
+    switch (event.which) {
       case SPACE_KEY_CODE:
       case ENTER_KEY_CODE:
         return false;
       case UP_ARROW_KEY_CODE:
-        value += inc;
-        $input.val(value);
+        value += increment;
+        if (value <= this.options.max) {
+          $input.val(value);
+        }
         break;
       case BOTTOM_ARROW_KEY_CODE:
-        value -= inc;
-        $input.val(value);
+        value -= increment;
+        if (value >= this.options.min) {
+          $input.val(value);
+        }
         break;
       default:
         // Any other case!

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/number.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/number.spec.js
@@ -133,7 +133,6 @@ describe('components/form-components/editors/number', function () {
         });
       });
 
-      
       describe('when pressing the DOWN key', function () {
         it('should decrease the value', function () {
           this.view.setValue(7);

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/number.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/number.spec.js
@@ -1,6 +1,11 @@
 var $ = require('jquery');
 var _ = require('underscore');
 var Backbone = require('backbone');
+// Required for affected specs, because we use backbone-forms through a global namespace
+require('../../../../../../javascripts/cartodb3/components/form-components/editors/number/number.js');
+
+var ARROW_UP_KEY = 38;
+var ARROW_DOWN_KEY = 40;
 
 describe('components/form-components/editors/number', function () {
   var createViewFn = function (options) {
@@ -77,9 +82,7 @@ describe('components/form-components/editors/number', function () {
 
     describe('when input changes', function () {
       beforeEach(function () {
-        this.$input
-          .val(6)
-          .trigger('keyup');
+        this.$input.val(6).trigger('keyup');
       });
 
       it('should trigger change', function () {
@@ -90,58 +93,85 @@ describe('components/form-components/editors/number', function () {
         expect(this.view.$('.js-slider').slider('value')).toBe(6);
       });
 
-      it('should increase the value when pressing the up key', function () {
-        this.view.setValue(7);
+      describe('when pressing the UP key', function () {
+        it('should increase the value', function () {
+          this.view.setValue(7);
 
-        var e = $.Event('keydown');
-        e.keyCode = e.which = 38;
+          var event = $.Event('keydown');
+          event.keyCode = event.which = ARROW_UP_KEY;
 
-        this.$input.trigger(e);
-        this.$input.trigger(e);
-        this.$input.trigger(e);
+          this.$input.trigger(event);
+          this.$input.trigger(event);
+          this.$input.trigger(event);
 
-        expect(this.$input.val()).toBe('10');
+          expect(this.$input.val()).toBe('10');
+        });
+
+        it('should increase the value when pressing shift', function () {
+          this.view.setValue(0);
+
+          var event = $.Event('keydown');
+          event.keyCode = event.which = ARROW_UP_KEY;
+          event.shiftKey = true;
+
+          this.$input.trigger(event);
+
+          expect(this.$input.val()).toBe('10');
+        });
+
+        it('should not increase the value if it exceeds the max allowed', function () {
+          this.view.setValue(10);
+
+          var event = $.Event('keydown');
+          event.keyCode = event.which = ARROW_UP_KEY;
+
+          this.$input.trigger(event);
+          this.$input.trigger(event);
+          this.$input.trigger(event);
+
+          expect(this.$input.val()).toBe('10');
+        });
       });
 
-      it('should increase the value when pressing the up key and shift', function () {
-        this.view.setValue(10);
+      
+      describe('when pressing the DOWN key', function () {
+        it('should decrease the value', function () {
+          this.view.setValue(7);
 
-        var e = $.Event('keydown');
-        e.keyCode = e.which = 38;
-        e.shiftKey = true;
+          var event = $.Event('keydown');
+          event.keyCode = event.which = ARROW_DOWN_KEY;
 
-        this.$input.trigger(e);
-        this.$input.trigger(e);
-        this.$input.trigger(e);
+          this.$input.trigger(event);
+          this.$input.trigger(event);
+          this.$input.trigger(event);
 
-        expect(this.$input.val()).toBe('40');
-      });
+          expect(this.$input.val()).toBe('4');
+        });
 
-      it('should decrease the value when pressing the down key', function () {
-        this.view.setValue(7);
+        it('should decrease the value when pressing shift', function () {
+          this.view.setValue(10);
 
-        var e = $.Event('keydown');
-        e.keyCode = e.which = 40;
+          var event = $.Event('keydown');
+          event.keyCode = event.which = ARROW_DOWN_KEY;
+          event.shiftKey = true;
 
-        this.$input.trigger(e);
-        this.$input.trigger(e);
-        this.$input.trigger(e);
+          this.$input.trigger(event);
 
-        expect(this.$input.val()).toBe('4');
-      });
+          expect(this.$input.val()).toBe('0');
+        });
 
-      it('should decrease the value when pressing the down key and shift', function () {
-        this.view.setValue(70);
+        it('should not decrease the value if it exceeds the max allowed', function () {
+          this.view.setValue(0);
 
-        var e = $.Event('keydown');
-        e.keyCode = e.which = 40;
-        e.shiftKey = true;
+          var event = $.Event('keydown');
+          event.keyCode = event.which = ARROW_DOWN_KEY;
 
-        this.$input.trigger(e);
-        this.$input.trigger(e);
-        this.$input.trigger(e);
+          this.$input.trigger(event);
+          this.$input.trigger(event);
+          this.$input.trigger(event);
 
-        expect(this.$input.val()).toBe('40');
+          expect(this.$input.val()).toBe('0');
+        });
       });
     });
   });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/number.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/number.spec.js
@@ -172,6 +172,29 @@ describe('components/form-components/editors/number', function () {
 
           expect(this.$input.val()).toBe('0');
         });
+
+        it('should work with negative min value', function () {
+          var view = createViewFn({
+            schema: {
+              validators: ['required', {
+                type: 'interval',
+                min: -5,
+                max: 10
+              }]
+            }
+          });
+          var $input = view.$('.js-input');
+          view.setValue(0);
+
+          var event = $.Event('keydown');
+          event.keyCode = event.which = ARROW_DOWN_KEY;
+
+          $input.trigger(event);
+          $input.trigger(event);
+          $input.trigger(event);
+
+          expect($input.val()).toBe('-3');
+        });
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.36",
+  "version": "4.7.36-ded04.1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #12212

![number_editor](https://cloud.githubusercontent.com/assets/905225/26722717/82f3fb62-4791-11e7-869d-34b8e3f64194.gif)

### Acceptance
With the arrow keys:
- [ ] The user can't exceed the max value of the input.
- [ ]  The user can't go below the min value of the input.
- [ ] If the user types an amount bigger than the max permitted and use the arrow keys, the input is set to the maximum value.
- [ ] If the user types an amount smaller than the min permitted and use the arrow keys, the input is set to the min value.