### PR TITLE
show overlay/infobox in analysis panel when hiding a layer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Development
 * New loading button styles (#12132)
 
 ### Bug fixes / enhancements
+* Fixed error where analysis overlay/infobox wasn't shown when hiding a layer (#11767)
 * Fixed arrow keys exceeding min/max values in number editor (#12212)
 * Better handling and reporting of "table with no map associated" error in map privacy changes (#12137).
 * Improve formula widget form (#12242)

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-view.js
@@ -127,6 +127,7 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
+    this.listenTo(this._layerDefinitionModel, 'change:visible', this._infoboxState);
     // Only when there is no nodes we should check if node can be georeferenced
     this.listenTo(this._analysisFormsCollection, 'reset remove', this._getQueryAndCheckState);
   },

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-view.spec.js
@@ -74,6 +74,7 @@ describe('editor/layers/layer-content-views/analyses/analyses-view', function ()
     var userActions = jasmine.createSpyObj('userActions', ['saveLayer']);
 
     spyOn(AnalysesView.prototype, '_getQueryAndCheckState').and.callThrough();
+    spyOn(AnalysesView.prototype, '_infoboxState').and.callThrough();
 
     var analysisFormsCollection = new Backbone.Collection();
     analysisFormsCollection.isEmpty = function () {
@@ -159,6 +160,14 @@ describe('editor/layers/layer-content-views/analyses/analyses-view', function ()
 
       this.view._analysisFormsCollection.remove(this.view._analysisFormsCollection.at(0));
       expect(AnalysesView.prototype._getQueryAndCheckState.calls.count()).toBe(1);
+    });
+
+    it('should set infobox when layer visibility changes', function () {
+      this.view._layerDefinitionModel.set('visible', false);
+
+      expect(AnalysesView.prototype._infoboxState).toHaveBeenCalled();
+      expect(this.view._infoboxModel.get('state')).toBe('layer-hidden');
+      expect(this.view._overlayModel.get('visible')).toBe(true);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.37",
+  "version": "4.7.37-ded07",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #11767 

![analysis_overlay](https://cloud.githubusercontent.com/assets/905225/26779115/751e530c-49e4-11e7-8abf-53deeb549551.gif)

