### PR TITLE
Fix this._tooltipTitle is not a function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ Development
 * Fix `BUILDER_ENABLED` parameter in `create_dev_user` rake (#12189)
 * User organization or user key for google maps (#12232)
 * "vector" key in vizjson is skipped in embeds if user has "vector_vs_raster" feature flag enabled.
+* Fixed 'not a function' bug related to a tooltip (#12279)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.1`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
@@ -203,11 +203,7 @@ module.exports = CoreView.extend({
     var tooltip = new TipsyTooltipView({
       el: this.$('.js-add'),
       title: function () {
-        if (_.isFunction(this._tooltipTitle)) {
-          return this._tooltipTitle();
-        } else {
-          return '';
-        }
+        return this._tooltipTitle;
       }.bind(this)
     });
     this.addView(tooltip);
@@ -342,7 +338,7 @@ module.exports = CoreView.extend({
 
     switch (this._mapTabPaneView.getSelectedTabPaneName()) {
       case 'widgets':
-        this._tooltipTitle = String;
+        this._tooltipTitle = '';
         if (this._widgetDefinitionsCollection.size()) {
           this._showAddButton();
         }
@@ -357,11 +353,10 @@ module.exports = CoreView.extend({
         }
         if (count === max) {
           this._disableAddButton();
-          this._tooltipTitle = this._getMaxLayerTitle;
+          this._tooltipTitle = this._getMaxLayerTitle();
         } else {
           this._enableAddButton();
-          // This will be called without arguments => empty string => no tooltip
-          this._tooltipTitle = String;
+          this._tooltipTitle = '';
         }
         break;
       case 'elements':

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
@@ -203,7 +203,11 @@ module.exports = CoreView.extend({
     var tooltip = new TipsyTooltipView({
       el: this.$('.js-add'),
       title: function () {
-        return this._tooltipTitle();
+        if (_.isFunction(this._tooltipTitle)) {
+          return this._tooltipTitle();
+        } else {
+          return '';
+        }
       }.bind(this)
     });
     this.addView(tooltip);

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
@@ -342,6 +342,7 @@ module.exports = CoreView.extend({
 
     switch (this._mapTabPaneView.getSelectedTabPaneName()) {
       case 'widgets':
+        this._tooltipTitle = String;
         if (this._widgetDefinitionsCollection.size()) {
           this._showAddButton();
         }


### PR DESCRIPTION
Fix #12279 

Minor oversight when it was developed, did not take widgets into account 🙇 

I fixed tooltip showing on widget tab & guarded in case it's not set.