### PR TITLE
Visualization models password methods refactor and test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@ Development
 * Fix error where a sync of a big dataset without geometry would be deleted from dashboard (#12162)
 * `create_dev_user` rake no longer tries to auto-create the database, `cartodb:db:setup` should be run first (#12187).
 * Fix EUMAPI response as per documentation (#12233)
+* Visualization models no longer raise an error checking `password_valid?` (#12270).
 * Fix `BUILDER_ENABLED` parameter in `create_dev_user` rake (#12189)
 * User organization or user key for google maps (#12232)
 * "vector" key in vizjson is skipped in embeds if user has "vector_vs_raster" feature flag enabled.

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -303,7 +303,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def password_valid?(password)
-    has_password? && ( password_digest(password, password_salt) == encrypted_password )
+    has_password? && (password_digest(password, password_salt) == encrypted_password)
   end
 
   def organization?

--- a/app/models/visualization/member.rb
+++ b/app/models/visualization/member.rb
@@ -484,8 +484,7 @@ module CartoDB
       end
 
       def password_valid?(password)
-        raise CartoDB::InvalidMember unless ( privacy == PRIVACY_PROTECTED && has_password? )
-        ( password_digest(password, @password_salt) == @encrypted_password )
+        has_password? && (password_digest(password, @password_salt) == @encrypted_password)
       end
 
       def remove_password

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -1,5 +1,6 @@
 # coding: UTF-8
 require_relative '../../spec_helper'
+require_relative '../visualization_shared_examples'
 require_relative '../../../app/models/visualization/member'
 require 'helpers/unique_names_helper'
 require 'helpers/visualization_destruction_helper'
@@ -25,6 +26,14 @@ describe Carto::Visualization do
     bypass_named_maps
     @user.destroy
     @user2.destroy
+  end
+
+  it_behaves_like 'visualization models' do
+    def build_visualization(attrs = {})
+      v = Carto::Visualization.new(attrs)
+      v.assign_attributes(attrs, without_protection: true)
+      v
+    end
   end
 
   describe '#estimated_row_count and #actual_row_count' do

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -30,7 +30,7 @@ describe Carto::Visualization do
 
   it_behaves_like 'visualization models' do
     def build_visualization(attrs = {})
-      v = Carto::Visualization.new(attrs)
+      v = Carto::Visualization.new
       v.assign_attributes(attrs, without_protection: true)
       v
     end

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require_relative '../../spec_helper'
+require_relative '../visualization_shared_examples'
 require_relative '../../../services/data-repository/backend/sequel'
 require_relative '../../../app/models/visualization/member'
 require_relative '../../../app/models/visualization/collection'
@@ -41,6 +42,12 @@ describe Visualization::Member do
 
     support_tables_mock = Doubles::Visualization::SupportTables.new
     Visualization::Relator.any_instance.stubs(:support_tables).returns(support_tables_mock)
+  end
+
+  it_behaves_like 'visualization models' do
+    def build_visualization(attrs = {})
+      Visualization::Member.new(attrs)
+    end
   end
 
   describe '#initialize' do
@@ -527,41 +534,6 @@ describe Visualization::Member do
       visualization.derived?.should be_false
       visualization.table?.should be_false
       visualization.type_slide?.should be_false
-    end
-  end
-
-  describe '#password' do
-    it 'checks that when using password protected type, encrypted password is generated and stored correctly' do
-      password_value = '123456'
-      password_second_value = '456789'
-
-      visualization = Visualization::Member.new(type: Visualization::Member::TYPE_DERIVED)
-      visualization.privacy = Visualization::Member::PRIVACY_PROTECTED
-
-      visualization.password = password_value
-      visualization.has_password?.should be_true
-      visualization.password_valid?(password_value).should be_true
-
-      # Shouldn't remove the password, and be equal
-      visualization.password = ''
-      visualization.has_password?.should be_true
-      visualization.password_valid?(password_value).should be_true
-      visualization.password = nil
-      visualization.has_password?.should be_true
-      visualization.password_valid?(password_value).should be_true
-
-      # Modify the password
-      visualization.password = password_second_value
-      visualization.has_password?.should be_true
-      visualization.password_valid?(password_second_value).should be_true
-      visualization.password_valid?(password_value).should be_false
-
-      # Test removing the password, should work
-      visualization.remove_password
-      visualization.has_password?.should be_false
-      lambda {
-        visualization.password_valid?(password_value)
-      }.should raise_error CartoDB::InvalidMember
     end
   end
 

--- a/spec/models/visualization_shared_examples.rb
+++ b/spec/models/visualization_shared_examples.rb
@@ -33,5 +33,4 @@ shared_examples_for 'visualization models' do
       visualization.password_valid?(password_value).should be_false
     end
   end
-
 end

--- a/spec/models/visualization_shared_examples.rb
+++ b/spec/models/visualization_shared_examples.rb
@@ -1,0 +1,37 @@
+# requires implementing build_visualization
+shared_examples_for 'visualization models' do
+  describe '#password' do
+    it 'checks that when using password protected type, encrypted password is generated and stored correctly' do
+      password_value = '123456'
+      password_second_value = '456789'
+
+      visualization = build_visualization(type: Visualization::Member::TYPE_DERIVED)
+      visualization.privacy = Visualization::Member::PRIVACY_PROTECTED
+
+      visualization.password = password_value
+      visualization.has_password?.should be_true
+      visualization.password_valid?(password_value).should be_true
+
+      # Shouldn't remove the password, and be equal
+      visualization.password = ''
+      visualization.has_password?.should be_true
+      visualization.password_valid?(password_value).should be_true
+      visualization.password = nil
+      visualization.has_password?.should be_true
+      visualization.password_valid?(password_value).should be_true
+
+      # Modify the password
+      visualization.password = password_second_value
+      visualization.has_password?.should be_true
+      visualization.password_valid?(password_second_value).should be_true
+      visualization.password_valid?(password_value).should be_false
+
+      # Test removing the password, should work
+      # :remove_password doesn't need to be public, so in the new model it's kept private. :send is needed here, then.
+      visualization.send(:remove_password)
+      visualization.has_password?.should be_false
+      visualization.password_valid?(password_value).should be_false
+    end
+  end
+
+end

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1997,6 +1997,26 @@ describe Carto::Api::VisualizationsController do
 
           table.destroy
         end
+
+        it 'sets password protection' do
+          visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id)
+          visualization.password_protected?.should be_false
+
+          payload = {
+            id: visualization.id,
+            password: 'the_pass',
+            privacy: Carto::Visualization::PRIVACY_PROTECTED
+          }
+          put_json api_v1_visualizations_update_url(id: visualization.id), payload do |response|
+            response.status.should be_success
+          end
+
+          visualization.reload
+          visualization.password_protected?.should be_true
+          visualization.password_valid?('the_pass').should be_true
+
+          visualization.destroy
+        end
       end
     end
 


### PR DESCRIPTION
This closes #12270.

The old model has been changed in order to make both behaviors equal. None of them will raise an error.

**Acceptance**
With editor:
- [x] Import a dataset
- [x] Create a map from dashboard
- [x] Create a map from table view
- [x] Set maps privacy to password
- [x] Delete map & datasets