### PR TITLE
Disable geometry edition for layers with aggregated styles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@ Development
 * User organization or user key for google maps (#12232)
 * "vector" key in vizjson is skipped in embeds if user has "vector_vs_raster" feature flag enabled.
 * Fixed 'not a function' bug related to a tooltip (#12279)
+* Disable edit geometry for Layers with aggregated styles (#11714)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.1`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/data/layer-definition-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/layer-definition-model.js
@@ -246,6 +246,10 @@ module.exports = Backbone.Model.extend({
     return this.getNumberOfAnalyses() > 0;
   },
 
+  hasAggregatedStyles: function () {
+    return this.styleModel && this.styleModel.isAggregatedType();
+  },
+
   getNumberOfAnalyses: function () {
     var analysisNode = this.getAnalysisDefinitionNodeModel();
     var count = 0;

--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/edit-feature-overlay.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/edit-feature-overlay.js
@@ -43,7 +43,7 @@ var EditFeatureOverlay = CoreView.extend({
   render: function () {
     this.clearSubViews();
 
-    var isEditable = this._isEditable();
+    var isEditable = this._isEditable() && !this._isAggregated();
 
     this.$el.html(templateEditGeometry({
       isEditable: isEditable,
@@ -80,6 +80,8 @@ var EditFeatureOverlay = CoreView.extend({
       disabledLayerType = _t('editor.edit-feature.custom-sql');
     } else if (this._isReadOnly()) {
       disabledLayerType = _t('editor.edit-feature.sync');
+    } else if (this._isAggregated()) {
+      disabledLayerType = _t('editor.edit-feature.aggregated');
     }
 
     return _t('editor.edit-feature.disabled', { disabledLayerType: disabledLayerType });
@@ -99,6 +101,10 @@ var EditFeatureOverlay = CoreView.extend({
 
   _isReadOnly: function () {
     return this._featureDefinition && this._featureDefinition.isReadOnly();
+  },
+
+  _isAggregated: function () {
+    return this._featureDefinition && this._featureDefinition.getLayerDefinition().hasAggregatedStyles();
   },
 
   hide: function (event) {

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -2297,6 +2297,7 @@
       "edit": "Edit %{featureType}",
       "analysis": "layers with analysis nodes",
       "custom-sql": "layers with custom SQL applied",
+      "aggregated": "layers with aggregated styles",
       "sync": "read only layers",
       "disabled": "Feature editing is disabled in %{disabledLayerType}. To edit the data, export this layer and import it as a new layer."
     }

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -2299,7 +2299,7 @@
       "custom-sql": "layers with custom SQL applied",
       "aggregated": "layers with aggregated styles",
       "sync": "read only layers",
-      "disabled": "Feature editing is disabled in %{disabledLayerType}. To edit the data, export this layer and import it as a new layer."
+      "disabled": "Feature editing is disabled for %{disabledLayerType}. To edit data, export this layer and import it as a new layer."
     }
   },
   "notifications": {

--- a/lib/assets/core/test/spec/cartodb3/locale/en.json.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/locale/en.json.spec.js
@@ -4,7 +4,7 @@ describe('en.json', function () {
   describe('edit-feature', function () {
     it('assert that the texts are the expected ones', function () {
       var texts = en.editor['edit-feature'];
-      expect(texts.disabled).toEqual('Feature editing is disabled in %{disabledLayerType}. To edit the data, export this layer and import it as a new layer.');
+      expect(texts.disabled).toEqual('Feature editing is disabled for %{disabledLayerType}. To edit data, export this layer and import it as a new layer.');
     });
   });
 });


### PR DESCRIPTION
Fix #11714 

Edit geometry button is now disabled for layers with aggregated styles. Copy is mine, so @brittanymicek would appreciate some input 🙇 

![screen shot 2017-06-07 at 17 39 11](https://user-images.githubusercontent.com/446970/26887440-5085b42a-4ba8-11e7-87b6-5f5134fc1780.png)




