### PR TITLE
Refactor dashboard sync dataset modal to use new styles

### DIFF
--- a/app/assets/stylesheets/common/modals-elements.scss
+++ b/app/assets/stylesheets/common/modals-elements.scss
@@ -1,0 +1,115 @@
+@import 'cdb-variables/colors';
+@import 'cdb-variables/sizes';
+@import 'cdb-utilities/mixins';
+
+.Modal-listActions {
+  margin-top: $baseSize * 4;
+}
+
+.Modal-listActionsitem,
+.Modal-icon {
+  margin-right: $baseSize * 2;
+}
+
+.Modal-listActionsitem:last-child {
+  margin-right: 0;
+}
+
+.Modal-icon {
+  margin-top: 6px;
+  line-height: 34px; /* align-items: baseline doesnt work correctly in ff */
+}
+
+.Modal-listTextItem {
+  margin-top: 32px;
+}
+
+.Modal-listTextHighlight {
+  display: inline-block;
+  padding: 4px 5px;
+  border-radius: 2px;
+  background: $cThirdBackground;
+}
+
+.Modal-listTextHighlight.is-code {
+  font: 500 12px 'Monaco', 'Monospace';
+}
+
+.Modal-listForm {
+  margin-left: 24px;
+}
+
+.Modal-listFormItem {
+  margin-right: 32px;
+}
+.Modal-listFormItem.is-disabled {
+  color: $cHintText;
+}
+
+
+.Modal-listFormItem:last-child {
+  margin-right: 0;
+}
+
+.Modal-addItem {
+  width: 40px;
+  height: 40px;
+  border: 1px solid $cMainLine;
+  border-radius: $halfBaseSize;
+}
+
+.Modal-titleBasemap {
+  margin: $baseSize * 3 0;
+}
+
+
+/* animation analysis */
+.Analysis-animation {
+  @include display-flex();
+  @include align-items(center);
+  @include justify-content(center);
+  width: 304px;
+  height: 96px;
+  border-top-left-radius: $halfBaseSize;
+  border-top-right-radius: $halfBaseSize;
+  background: $cMainText;
+  overflow: hidden;
+}
+.Analysis-animation.is-rounded {
+  border-radius: $halfBaseSize;
+}
+.ModalBlockList-item.is-disabled .Analysis-animation {
+  background-color: transparent;
+  pointer-events: none;
+  filter: grayscale(100);
+  opacity: 0.6;
+}
+.ModalBlockList-item.is-disabled .u-actionTextColor {
+  display: none;
+}
+
+.Analysis-info {
+  padding: 16px;
+}
+
+.SubmenuModal {
+  margin-bottom: $baseSize * 4;
+  padding-bottom: $baseSize * 3;
+}
+.SubmenuModal-item::after {
+  width: 3px;
+  height: 6px;
+  margin-left: 12px;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iM3B4IiBoZWlnaHQ9IjZweCIgdmlld0JveD0iMCAwIDMgNiIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4gICAgICAgIDx0aXRsZT5MaW5lIENvcHkgOTwvdGl0bGU+ICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiAgICA8ZGVmcz48L2RlZnM+ICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHN0cm9rZS1saW5lY2FwPSJzcXVhcmUiPiAgICAgICAgPHBvbHlsaW5lIGlkPSJMaW5lLUNvcHktOSIgc3Ryb2tlPSIjQ0JDRUQwIiBzdHJva2Utd2lkdGg9IjEuMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMS43NTAwMDAsIDMuMDAwMDAwKSByb3RhdGUoLTkwLjAwMDAwMCkgdHJhbnNsYXRlKC0xLjc1MDAwMCwgLTMuMDAwMDAwKSAiIHBvaW50cz0iLTAuMjQ5OTk5OTk2IDIuMjUgMS43NTAwMDAwMSAzLjI1IDMuNzUgMi4yNSI+PC9wb2x5bGluZT4gICAgPC9nPjwvc3ZnPg==);
+  content: '';
+}
+.SubmenuModal-item:last-child::after {
+  display: none;
+}
+
+.Analysis-moreInfo {
+  width: 624px;
+}
+.Analysis-moreInfoTitle {
+  margin: 32px 0 20px;
+}

--- a/app/assets/stylesheets/common/modals-elements.scss
+++ b/app/assets/stylesheets/common/modals-elements.scss
@@ -1,3 +1,6 @@
+// This is a copy of the Builder style file /app/assets/stylesheets/editor-3/_modals-elements.scss
+// Copied as is to avoid referencing the file from outside Builder codebase
+
 @import 'cdb-variables/colors';
 @import 'cdb-variables/sizes';
 @import 'cdb-utilities/mixins';

--- a/app/assets/stylesheets/common/modals-elements.scss
+++ b/app/assets/stylesheets/common/modals-elements.scss
@@ -65,6 +65,10 @@
   margin: $baseSize * 3 0;
 }
 
+.Modal-intervalLabel {
+  font-size: 10px;
+}
+
 
 /* animation analysis */
 .Analysis-animation {

--- a/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/interval_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/interval_template.jst.ejs
@@ -1,4 +1,4 @@
-<div class="u-iBlock CDB-Text CDB-Size-medium RadioButton js-interval<%- interval === 0 ? ' u-alertTextColor' : '' %>">
+<div class="u-iBlock CDB-Text CDB-Size-medium RadioButton js-interval">
   <input
     id="<%- id %>"
     type="radio"
@@ -7,6 +7,6 @@
     <% if (checked) { %> checked <% } %>
   />
   <span class="u-iBlock CDB-Radio-face"></span>
-  <label for="<%- id %>" class="u-iBlock u-lSpace"><%- name %></label>
+  <label for="<%- id %>" class="Modal-intervalLabel u-iBlock u-lSpace u-upperCase"><%- name %></label>
 </div>
 

--- a/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/interval_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/interval_view.js
@@ -7,7 +7,7 @@ module.exports = cdb.core.View.extend({
 
   tagName: "li",
 
-  className: "DatasetSelected-syncOptionsItem",
+  className: "Modal-listFormItem",
 
   events: {
     "click": "_onClick"

--- a/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset.jst.ejs
@@ -1,20 +1,45 @@
-<div class="Dialog-header u-inner">
-  <div class="Dialog-headerIcon Dialog-headerIcon--neutral">
-    <i class="CDB-IconFont CDB-IconFont-alarm"></i>
+<div class="u-flex u-justifyCenter">
+  <div class="Modal-inner Modal-inner--full u-flex u-justifyCenter">
+    <div class="Modal-icon">
+      <svg width="24px" height="20px" viewBox="0 8 24 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <g id="Icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(0.000000, 8.000000)">
+              <path d="M19.591513,9.26858726 C19.7142261,9.39218837 19.8745043,9.45462604 20.0347826,9.45462604 C20.1950609,9.45462604 20.3553391,9.39218837 20.4780522,9.26858726 C20.7222261,9.0201108 20.7222261,8.61617729 20.4780522,8.36770083 C20.1988174,8.08354571 19.908313,7.81468144 19.6065391,7.56365651 C19.5652174,7.52925208 19.5201391,7.4999446 19.4775652,7.46554017 C17.3914435,5.76952909 14.824487,4.84060942 12.1147826,4.84060942 L12.1122783,4.84060942 L12.1097739,4.84060942 C8.95053913,4.84060942 5.98038261,6.0931856 3.74775652,8.36770083 C3.50358261,8.61617729 3.50358261,9.0201108 3.74775652,9.26858726 C3.87046957,9.3934626 4.03074783,9.45462604 4.19102609,9.45462604 C4.35130435,9.45462604 4.51158261,9.39218837 4.63304348,9.26858726 C6.63151304,7.23490305 9.28737391,6.11484765 12.1122783,6.11484765 C14.9371826,6.11484765 17.5930435,7.23490305 19.591513,9.26858726 L19.591513,9.26858726 Z" id="Shape" fill="#2E3C43"></path>
+              <path d="M22.7607652,5.95695291 C22.8834783,6.08182825 23.0437565,6.14299169 23.2040348,6.14299169 C23.364313,6.14299169 23.5245913,6.08055402 23.6473043,5.95695291 C23.8914783,5.70847645 23.8914783,5.30454294 23.6473043,5.05606648 C17.2862609,-1.41706371 6.93704348,-1.41451524 0.578504348,5.05606648 C0.334330435,5.30454294 0.334330435,5.70847645 0.578504348,5.95695291 C0.822678261,6.20542936 1.21961739,6.20542936 1.4637913,5.95695291 C7.33398261,-0.0179501385 16.8905739,-0.0166759003 22.7607652,5.95695291 L22.7607652,5.95695291 Z" id="Shape" fill="#2E3C43"></path>
+              <path d="M9.58789565,9.966759 C8.61495652,10.3273684 7.69586087,10.8854848 6.91575652,11.6793352 C6.67158261,11.9278116 6.67158261,12.3317452 6.91575652,12.5802216 C7.03846957,12.705097 7.19874783,12.7662604 7.35902609,12.7662604 C7.51930435,12.7662604 7.67958261,12.7038227 7.80229565,12.5802216 C10.1789217,10.1642659 14.046887,10.1642659 16.4247652,12.5802216 C16.5474783,12.705097 16.7077565,12.7662604 16.8680348,12.7662604 C17.028313,12.7662604 17.1885913,12.7038227 17.3113043,12.5802216 C17.5554783,12.3317452 17.5554783,11.9278116 17.3113043,11.6793352 C15.2239304,9.55645429 12.1924174,8.99961219 9.58789565,9.966759 L9.58789565,9.966759 Z" id="Shape" fill="#2E3C43"></path>
+              <path d="M12.1122783,14.1359557 C10.5307826,14.1359557 9.2448,15.4445983 9.2448,17.052687 C9.2448,18.6620499 10.5307826,19.9706925 12.1122783,19.9706925 C13.6925217,19.9706925 14.9785043,18.6620499 14.9785043,17.052687 C14.9785043,15.4458726 13.6925217,14.1359557 12.1122783,14.1359557 L12.1122783,14.1359557 Z M12.1122783,18.6977285 C11.2219826,18.6977285 10.4969739,17.9599446 10.4969739,17.0539612 C10.4969739,16.1479778 11.2219826,15.4114681 12.1122783,15.4114681 C13.0025739,15.4114681 13.7263304,16.1479778 13.7263304,17.0539612 C13.7263304,17.9599446 13.0025739,18.6977285 12.1122783,18.6977285 L12.1122783,18.6977285 Z" id="Shape" fill="#2E3C43"></path>
+          </g>
+      </svg>
+    </div>
+    <div>
+      <h2 class="CDB-Text CDB-Size-huge is-light u-bSpace--m">
+        Sync dataset options
+     </h2>
+      <p class="CDB-Text CDB-Size-medium u-altTextColor">
+        Your dataset is in sync with a <%- service %> file: <br/><%- url %>
+      </p>
+      <div class="Modal-listTextItem u-flex u-alignCenter">
+        <h3 class="CDB-Text CDB-Size-small is-semibold u-upperCase">Sync my data</h3>
+        <ul class="Modal-listForm u-flex u-alignCenter CDB-Text CDB-Size-small js-intervals">
+        </ul>
+      </div>
+      <ul class="Modal-listActions u-flex u-alignCenter">
+        <li class="Modal-listActionsitem">
+          <button class="CDB-Button CDB-Button--secondary CDB-Button--big js-cancel">
+            <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-medium u-upperCase">
+              Cancel
+            </span>
+          </button>
+        </li>
+        <li class="Modal-listActionsitem">
+          <button class="CDB-Button CDB-Button--primary CDB-Button--big js-confirm ok">
+            <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-medium u-upperCase">
+              Save
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
   </div>
-  <h4 class="CDB-Text CDB-Size-large u-mainTextColor u-bSpace--m u-tSpace-xl">Sync dataset options</h4>
-  <p class="CDB-Text CDB-Size-medium u-altTextColor u-ellipsis Dialog-headerText--centered Dialog-headerText--small" title="<%- url %>">
-    Your dataset is in sync with a <%- service %> file: <br/><%- url %>
-  </p>
-</div>
-<div class="CDB-Fieldset CDB-Text CDB-Size-medium Dialog-body Dialog-body--small">
-  <p class="CDB-Legend CDB-Text is-semibold CDB-Size-medium u-rSpace--m">Sync my data</p>
-  <ul class="CDB-Size-medium CDB-Text CDB-Fieldset-block DatasetSelected-syncOptionsList DatasetSelected-syncOptionsList--syncView js-intervals">
-  </ul>
 </div>
 
-<div class="Dialog-footer Dialog-footer--small Dialog-footer Dialog-footer--simple u-inner">
-  <button class="CDB-Button CDB-Button--primary ok">
-    <span class="CDB-Button-Text CDB-Text u-upperCase is-semibold CDB-Size-small">Save settings</span>
-  </button>
-</div>
+

--- a/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/sync_dataset/sync_dataset_view.js
@@ -18,6 +18,11 @@ module.exports = BaseDialog.extend({
     { name: 'Never', time: 0, type: 'never', if_external_source: true }
   ],
 
+  events: {
+    'click .js-cancel': '_cancel',
+    'click .js-confirm': '_ok'
+  },
+
   initialize: function() {
     if (!this.options.table) {
       throw new TypeError('table is required');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.46-12145",
+  "version": "4.7.46-12145b",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.46",
+  "version": "4.7.46-12145",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.7.46-12145b",
+  "version": "4.7.46-12145c",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
PR for reopened https://github.com/CartoDB/cartodb/issues/12145

So this is how it looks now

![screen shot 2017-06-08 at 16 29 48](https://user-images.githubusercontent.com/446970/26933744-b80a0bf4-4c67-11e7-9d03-a8373cb8599f.png)

I saw two ways of doing this, either we:

- Moved the modals-elements.scss to common, and updated the css_files.js so it builds correctly
- We duplicated the modals-elements.scss in common for now

Went with the second one since eventually all the common stuff will disappear, and we'll have to migrate all dashboard code I guess 🤔 