### PR TITLE
Fix error handling if dropbox file is not found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,7 +51,7 @@ sudo make install
 
 #### Dropbox API v2 migration
 
-Dropbox API v2 (#8303): [Dropbox deprecated API v1](https://blogs.dropbox.com/developers/2016/06/api-v1-deprecated/)
+Dropbox API v2 (#8303, #12300): [Dropbox deprecated API v1](https://blogs.dropbox.com/developers/2016/06/api-v1-deprecated/)
 so CARTO must migrate. If you are using Dropbox integration, you must:
 * Check which permission does your application has in Dropbox. If it's "Full", just upgrading CARTO is enough.
 * If it's not "Full", you must:

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -204,7 +204,11 @@ module CartoDB
         notify
 
       rescue => exception
-        CartoDB::Logger.error(exception: exception, sync_id: id)
+        if exception.is_a? CartoDB::Datasources::NotFoundDownloadError
+          CartoDB::Logger.debug(exception: exception, sync_id: id)
+        else
+          CartoDB::Logger.error(exception: exception, sync_id: id)
+        end
         log.append_and_store exception.message, truncate = false
         log.append exception.backtrace.join("\n"), truncate = false
 

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -203,46 +203,12 @@ module CartoDB
 
         notify
 
+      rescue CartoDB::Datasources::NotFoundDownloadError => exception
+        CartoDB::Logger.debug(exception: exception, sync_id: id)
+        handle_run_error(log, exception, importer)
       rescue => exception
-        if exception.is_a? CartoDB::Datasources::NotFoundDownloadError
-          CartoDB::Logger.debug(exception: exception, sync_id: id)
-        else
-          CartoDB::Logger.error(exception: exception, sync_id: id)
-        end
-        log.append_and_store exception.message, truncate = false
-        log.append exception.backtrace.join("\n"), truncate = false
-
-        if importer.nil?
-          if exception.is_a?(NotFoundDownloadError)
-            set_general_failure_state_from(exception, 1017, 'File not found, you must import it again')
-          elsif exception.is_a?(CartoDB::Importer2::FileTooBigError)
-            set_general_failure_state_from(exception, exception.error_code,
-                                           CartoDB::IMPORTER_ERROR_CODES[exception.error_code][:title])
-          elsif exception.is_a?(AuthError)
-            set_general_failure_state_from(exception, 1011, 'Unauthorized')
-          else
-            set_general_failure_state_from(exception)
-          end
-        else
-          set_failure_state_from(importer)
-        end
-
-        store
-
-        if exception.is_a?(TokenExpiredOrInvalidError)
-          begin
-            user.oauths.remove(exception.service_name)
-          rescue => ex
-            log.append "Exception removing OAuth: #{ex.message}"
-            log.append ex.backtrace
-          end
-        end
-        notify
-        self
-      ensure
-        CartoDB::PlatformLimits::Importer::UserConcurrentSyncsAmount.new(
-          user: user, redis: { db: $users_metadata }
-        ).decrement!
+        CartoDB::Logger.error(exception: exception, sync_id: id)
+        handle_run_error(log, exception, importer)
       end
 
       def get_runner
@@ -561,6 +527,45 @@ module CartoDB
 
       attr_accessor :log_trace, :service_name, :service_item_id
 
+    end
+
+    private
+
+    def handle_run_error(log, exception, importer)
+      log.append_and_store exception.message, truncate = false
+      log.append exception.backtrace.join("\n"), truncate = false
+
+      if importer.nil?
+        if exception.is_a?(NotFoundDownloadError)
+          set_general_failure_state_from(exception, 1017, 'File not found, you must import it again')
+        elsif exception.is_a?(CartoDB::Importer2::FileTooBigError)
+          set_general_failure_state_from(exception, exception.error_code,
+                                         CartoDB::IMPORTER_ERROR_CODES[exception.error_code][:title])
+        elsif exception.is_a?(AuthError)
+          set_general_failure_state_from(exception, 1011, 'Unauthorized')
+        else
+          set_general_failure_state_from(exception)
+        end
+      else
+        set_failure_state_from(importer)
+      end
+
+      store
+
+      if exception.is_a?(TokenExpiredOrInvalidError)
+        begin
+          user.oauths.remove(exception.service_name)
+        rescue => ex
+          log.append "Exception removing OAuth: #{ex.message}"
+          log.append ex.backtrace
+        end
+      end
+      notify
+      self
+    ensure
+      CartoDB::PlatformLimits::Importer::UserConcurrentSyncsAmount.new(
+        user: user, redis: { db: $users_metadata }
+      ).decrement!
     end
   end
 end

--- a/services/datasources/lib/datasources/url/dropbox.rb
+++ b/services/datasources/lib/datasources/url/dropbox.rb
@@ -226,7 +226,9 @@ module CartoDB
         # @throws AuthError
         # @throws mixed
         def handle_error(original_exception, message)
-          if original_exception.is_a? DropboxApi::Errors::BasicError
+          if original_exception.is_a? DropboxApi::Errors::NotFoundError
+            raise NotFoundDownloadError.new(message, DATASOURCE_NAME)
+          elsif original_exception.is_a? DropboxApi::Errors::BasicError
             error_code = original_exception.http_response.code.to_i
             if error_code == 401 || error_code == 403
               raise TokenExpiredOrInvalidError.new(message, DATASOURCE_NAME)


### PR DESCRIPTION
This closes #12300.

Honestly, I haven't done a test because it's a simple error management improvement, and it should rely on mocking, so I think that it doesn't provide enough value.

_Tests are actually green, they were reversed at Jenkins and I cancelled the wrong one. [Frontend](https://ci.cartodb.net/job/CartoDB-PR-testing-frontend/1682/console), [Backend](https://ci.cartodb.net/job/CartoDB-PR-testing-backend/1693/console)._