### PR TITLE
Updating dependencies for making vector maps work

### DIFF
--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -51,7 +51,7 @@
   <script>
     (function () {
       <% if Cartodb.get_config(:graphite_public, 'host') %>
-        if (location.protocol.indexOf('https') === -1) {
+        if (location.protocol.indexOf('https') === 0) {
           statsc.connect('http://<%= Cartodb.get_config(:graphite_public, 'host') %>:<%= Cartodb.get_config(:graphite_public, 'port') %>/');
           cartodb.core.Profiler.backend(function () {
             statsc.send.apply(statsc, arguments);

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -27,6 +27,10 @@
 <%= content_for(:js) do %>
   <%= insert_trackjs('builder-embeds') %>
 
+  <% if @visualization.user.has_feature_flag?('vector_vs_raster') %>
+    <%= javascript_include_tag 'tangram.min.js' %>
+  <% end %>
+
   <% if @vizjson[:map_provider] == 'googlemaps' %>
     <%= render(partial: 'shared/visualizations/google_maps', locals: { google_maps_qs: @google_maps_qs }) %>
   <% end %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -27,7 +27,6 @@
 <%= content_for(:js) do %>
   <%= insert_trackjs('builder-embeds') %>
 
-  <!-- Make available if FF auto or vector -->
   <%= javascript_include_tag 'tangram.min.js' %>
 
   <% if @vizjson[:map_provider] == 'googlemaps' %>
@@ -43,21 +42,6 @@
   <%= javascript_include_tag 'common.js' %>
   <%= javascript_include_tag 'builder_embed_vendor.js' %>
   <%= javascript_include_tag 'builder_embed.js' %>
-
-  <script>
-    (function () {
-      <% if Cartodb.config[:graphite_public] %>
-        if (location.protocol.indexOf('https') === -1) {
-          jQuery.getScript('<%= javascript_path "statsc.js" %>', function(ready) {
-            statsc.connect('http://<%= Cartodb.config[:graphite_public]['host'] %>:<%= Cartodb.config[:graphite_public]['port'] %>/');
-            cartodb.core.Profiler.backend(function () {
-              statsc.send.apply(statsc, arguments);
-            });
-          });
-        }
-      <% end %>
-    }());
-  </script>
 
   <%= insert_google_analytics('embeds', true) %>
 <% end %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -27,10 +27,6 @@
 <%= content_for(:js) do %>
   <%= insert_trackjs('builder-embeds') %>
 
-  <% if @visualization.user.has_feature_flag?('vector_vs_raster') %>
-    <%= javascript_include_tag 'tangram.min.js' %>
-  <% end %>
-
   <% if @vizjson[:map_provider] == 'googlemaps' %>
     <%= render(partial: 'shared/visualizations/google_maps', locals: { google_maps_qs: @google_maps_qs }) %>
   <% end %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -45,14 +45,14 @@
   <%= javascript_include_tag 'builder_embed_vendor.js' %>
   <%= javascript_include_tag 'builder_embed.js' %>
 
-  <% if Cartodb.config[:graphite_public] %>
+  <% if Cartodb.get_config(:graphite_public, 'host') %>
     <%= javascript_include_tag "statsc.js" %>
   <% end %>
   <script>
     (function () {
-      <% if Cartodb.config[:graphite_public] %>
+      <% if Cartodb.get_config(:graphite_public, 'host') %>
         if (location.protocol.indexOf('https') === -1) {
-          statsc.connect('http://<%= Cartodb.config[:graphite_public]['host'] %>:<%= Cartodb.config[:graphite_public]['port'] %>/');
+          statsc.connect('http://<%= Cartodb.get_config(:graphite_public, 'host') %>:<%= Cartodb.get_config(:graphite_public, 'port') %>/');
           cartodb.core.Profiler.backend(function () {
             statsc.send.apply(statsc, arguments);
           });

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -27,7 +27,9 @@
 <%= content_for(:js) do %>
   <%= insert_trackjs('builder-embeds') %>
 
-  <%= javascript_include_tag 'tangram.min.js' %>
+  <% if @visualization.user.has_feature_flag?('vector_vs_raster') %>
+    <%= javascript_include_tag 'tangram.min.js' %>
+  <% end %>
 
   <% if @vizjson[:map_provider] == 'googlemaps' %>
     <%= render(partial: 'shared/visualizations/google_maps', locals: { google_maps_qs: @google_maps_qs }) %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -45,5 +45,21 @@
   <%= javascript_include_tag 'builder_embed_vendor.js' %>
   <%= javascript_include_tag 'builder_embed.js' %>
 
+  <% if Cartodb.config[:graphite_public] %>
+    <%= javascript_include_tag "statsc.js" %>
+  <% end %>
+  <script>
+    (function () {
+      <% if Cartodb.config[:graphite_public] %>
+        if (location.protocol.indexOf('https') === -1) {
+          statsc.connect('http://<%= Cartodb.config[:graphite_public]['host'] %>:<%= Cartodb.config[:graphite_public]['port'] %>/');
+          cartodb.core.Profiler.backend(function () {
+            statsc.send.apply(statsc, arguments);
+          });
+        }
+      <% end %>
+    }());
+  </script>
+
   <%= insert_google_analytics('embeds', true) %>
 <% end %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -51,7 +51,7 @@
   <script>
     (function () {
       <% if Cartodb.get_config(:graphite_public, 'host') %>
-        if (location.protocol.indexOf('https') === 0) {
+        if (location.protocol.indexOf('https') === -1) {
           statsc.connect('http://<%= Cartodb.get_config(:graphite_public, 'host') %>:<%= Cartodb.get_config(:graphite_public, 'port') %>/');
           cartodb.core.Profiler.backend(function () {
             statsc.send.apply(statsc, arguments);

--- a/app/views/layouts/application_public_visualization_layout.html.erb
+++ b/app/views/layouts/application_public_visualization_layout.html.erb
@@ -32,10 +32,6 @@
     <meta name="twitter:image" content="<%= yield :twitter_card %>">
 
     <%= yield :css %>
-
-    <!--[if lt IE 9]>
-      <%= javascript_include_tag 'modernizr' %>
-    <![endif]-->
   </head>
   <body class="<%= yield :body_class %>">
     <%= yield :content %>

--- a/app/views/layouts/application_table_public.html.erb
+++ b/app/views/layouts/application_table_public.html.erb
@@ -32,10 +32,6 @@
     <meta name="twitter:image" content="<%= yield :twitter_card %>">
 
     <%= yield :css %>
-
-    <!--[if lt IE 9]>
-      <%= javascript_include_tag 'modernizr' %>
-    <![endif]-->
   </head>
   <body class="public">
     <%= yield :content %>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.0",
+  "version": "4.8.3",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -671,9 +671,9 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
-      "version": "2.1.4",
+      "version": "2.1.5",
       "from": "browserslist@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.1.5.tgz"
     },
     "buffer": {
       "version": "4.9.1",
@@ -717,7 +717,7 @@
     },
     "caniuse-lite": {
       "version": "1.0.30000684",
-      "from": "caniuse-lite@>=1.0.30000670 <2.0.0",
+      "from": "caniuse-lite@>=1.0.30000684 <2.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000684.tgz"
     },
     "carto": {
@@ -733,7 +733,7 @@
     "cartodb-deep-insights.js": {
       "version": "0.0.2",
       "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#8d0601c6554b813503349b2aa593242a834cc2f0"
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#d072c1631ebc76584b64ef1d170b00ad3aa817e0"
     },
     "cartodb-pecan": {
       "version": "0.2.0",
@@ -743,7 +743,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#a17f1d35ae040dc769e3b7bdc77f5b59aa4255bd"
+      "resolved": "git://github.com/cartodb/cartodb.js.git#90bdb18389da056b300e421baf7af79e3120d71c"
     },
     "caseless": {
       "version": "0.11.0",
@@ -1034,7 +1034,7 @@
     },
     "electron-to-chromium": {
       "version": "1.3.14",
-      "from": "electron-to-chromium@>=1.3.11 <2.0.0",
+      "from": "electron-to-chromium@>=1.3.14 <2.0.0",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz"
     },
     "elliptic": {
@@ -1302,7 +1302,7 @@
     },
     "fsevents": {
       "version": "1.1.2",
-      "from": "fsevents@>=1.0.0 <2.0.0",
+      "from": "fsevents@*",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
       "optional": true
     },
@@ -2972,9 +2972,9 @@
       }
     },
     "tangram-cartocss": {
-      "version": "0.5.4",
+      "version": "0.5.5",
       "from": "cartodb/tangram-carto#master",
-      "resolved": "git://github.com/cartodb/tangram-carto.git#bdf4814bab04096cf0ffa6b9ce3b19c46649a2b7"
+      "resolved": "git://github.com/cartodb/tangram-carto.git#98fb17381ec4102a5c7dc428514d1337ed4abd66"
     },
     "tangram-reference": {
       "version": "1.0.18",
@@ -2982,19 +2982,39 @@
       "resolved": "https://registry.npmjs.org/tangram-reference/-/tangram-reference-1.0.18.tgz"
     },
     "tangram.cartodb": {
-      "version": "0.4.3",
+      "version": "0.4.4",
       "from": "cartodb/tangram.cartodb#master",
-      "resolved": "git://github.com/cartodb/tangram.cartodb.git#295263464066009e305f3e2aece6f4bb2c777cfe",
+      "resolved": "git://github.com/cartodb/tangram.cartodb.git#0c256d09594ace3014ad7d86e3741024336b76be",
       "dependencies": {
+        "argparse": {
+          "version": "1.0.9",
+          "from": "argparse@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
+        },
         "babel-runtime": {
           "version": "6.18.0",
           "from": "babel-runtime@6.18.0",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz"
         },
+        "esprima": {
+          "version": "2.7.3",
+          "from": "esprima@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+        },
+        "js-yaml": {
+          "version": "3.5.3",
+          "from": "tangrams/js-yaml#read-only",
+          "resolved": "git://github.com/tangrams/js-yaml.git#1637976c6f593bed33ed088aedb6d01390a947c0"
+        },
         "regenerator-runtime": {
           "version": "0.9.6",
           "from": "regenerator-runtime@>=0.9.5 <0.10.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz"
+        },
+        "tangram": {
+          "version": "0.12.5",
+          "from": "tangrams/tangram#master",
+          "resolved": "git://github.com/tangrams/tangram.git#70a7bd7cb3103cbbd9528ea68750dfb4c98b678b"
         }
       }
     },
@@ -3157,9 +3177,9 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uglify-js": {
-      "version": "2.8.28",
+      "version": "2.8.29",
       "from": "uglify-js@>=2.8.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "dependencies": {
         "yargs": {
           "version": "3.10.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.8",
+  "version": "4.8.9",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -3076,9 +3076,9 @@
       "resolved": "https://registry.npmjs.org/tangram-reference/-/tangram-reference-1.0.18.tgz"
     },
     "tangram.cartodb": {
-      "version": "0.4.4",
+      "version": "0.4.5",
       "from": "cartodb/tangram.cartodb#master",
-      "resolved": "git://github.com/cartodb/tangram.cartodb.git#097180df4c22a5d52a39a8331af63a1ef06efda9",
+      "resolved": "git://github.com/cartodb/tangram.cartodb.git#136c3894b9490bd3e89f4fe56f4576b3af7ac0d4",
       "dependencies": {
         "argparse": {
           "version": "1.0.9",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.5",
+  "version": "4.8.7",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -3078,7 +3078,7 @@
     "tangram.cartodb": {
       "version": "0.4.4",
       "from": "cartodb/tangram.cartodb#master",
-      "resolved": "git://github.com/cartodb/tangram.cartodb.git#0c256d09594ace3014ad7d86e3741024336b76be",
+      "resolved": "git://github.com/cartodb/tangram.cartodb.git#097180df4c22a5d52a39a8331af63a1ef06efda9",
       "dependencies": {
         "argparse": {
           "version": "1.0.9",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.7",
+  "version": "4.8.8",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.6-12319",
+  "version": "4.8.7-12319",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.9-12319",
+  "version": "4.8.9",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.5",
+  "version": "4.8.6-12319",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.7-12319",
+  "version": "4.8.8-12319",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.8-12319",
+  "version": "4.8.9-12319",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/12319.

Several things here:

- Updated dependencies.
- Don't load tangram when user doesn't have the feature flag enabled (any @CartoDB/builder-backend can validate that change?).
- Removed not used code in builder embed (modernizr??).

Deployed in ded03.

