### PR TITLE
Allow bundling of npm linked modules

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -26,6 +26,13 @@ module.exports = env => {
       filename: `${version}/javascripts/[name].js`,
       path: resolve(__dirname, 'public/assets')
     },
+    resolve: {
+      symlinks: false,
+      modules: [
+        resolve(__dirname, 'node_modules'),
+        resolve(__dirname, 'lib/assets/node_modules')
+      ]
+    },
     devtool: 'cheap-module-eval-source-map',
     plugins: [
       stats(env) ? new BundleAnalyzerPlugin({


### PR DESCRIPTION
### Context
Bundling assets with the new pipeline while having npm linked modules is not working.
This configuration change fixes this problem and allows bundling in both scenarios: with and without links.

Fix provided by @rubenmoya 