### PR TITLE
12254 organization metadata export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/requests/admin/users_controller_spec.rb \
 	spec/services/carto/user_table_index_service_spec.rb \
 	spec/services/carto/user_metadata_export_service_spec.rb \
+	spec/services/carto/organization_metadata_export_service_spec.rb \
 	spec/lib/carto/strong_password_validator_spec.rb \
 	spec/lib/initializers/zz_patch_reconnect_spec.rb \
 	spec/lib/cartodb/redis_vizjson_cache_spec.rb \

--- a/app/models/carto/organization.rb
+++ b/app/models/carto/organization.rb
@@ -3,6 +3,7 @@ require_relative '../../helpers/data_services_metrics_helper'
 require_dependency 'carto/helpers/auth_token_generator'
 require_dependency 'carto/carto_json_serializer'
 require_dependency 'common/organization_common'
+require_dependency 'carto/db/insertable_array'
 
 module Carto
   class Organization < ActiveRecord::Base
@@ -21,6 +22,10 @@ module Carto
     has_many :notifications, dependent: :destroy, order: 'created_at DESC'
 
     before_destroy :destroy_groups_with_extension
+
+    # INFO: workaround for array saves not working. There is a bug in `activerecord-postgresql-array 0.0.9`
+    #  We can remove this when the upgrade to Rails 4 allows us to remove that gem
+    before_create :fix_domain_whitelist_for_insert
 
     def self.find_by_database_name(database_name)
       Carto::Organization.
@@ -165,6 +170,10 @@ module Carto
       groups.map { |g| g.destroy_group_with_extension }
 
       reload
+    end
+
+    def fix_domain_whitelist_for_insert
+      self.whitelisted_email_domains = Carto::InsertableArray.new(whitelisted_email_domains)
     end
   end
 end

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -1,0 +1,150 @@
+require 'json'
+
+# Version History
+# 1.0.0: export organization metadata
+module Carto
+  module OrganizationMetadataExportServiceConfiguration
+    CURRENT_VERSION = '1.0.0'.freeze
+    EXPORTED_ORGANIZATION_ATTRIBUTES = [
+      :id, :seats, :quota_in_bytes, :created_at, :updated_at, :name, :avatar_url, :owner_id, :website, :description,
+      :display_name, :discus_shortname, :twitter_organizationname, :geocoding_quota, :map_view_quota, :auth_token,
+      :geocoding_block_price, :map_view_block_price, :twitter_datasource_enabled, :twitter_datasource_block_price,
+      :twitter_datasource_block_size, :twitter_datasource_quota, :google_maps_key, :google_maps_private_key, :color,
+      :default_quota_in_bytes, :whitelisted_email_domains, :admin_email, :auth_organizationname_password_enabled,
+      :auth_google_enabled, :location, :here_isolines_quota, :here_isolines_block_price, :strong_passwords_enabled,
+      :obs_snapshot_quota, :obs_snapshot_block_price, :obs_general_quota, :obs_general_block_price,
+      :salesforce_datasource_enabled, :viewer_seats, :geocoder_provider, :isolines_provider, :routing_provider,
+      :auth_github_enabled, :engine_enabled, :mapzen_routing_quota, :mapzen_routing_block_price, :builder_enabled,
+      :auth_saml_configuration, :no_map_logo
+    ].freeze
+
+    def compatible_version?(version)
+      version.to_i == CURRENT_VERSION.split('.')[0].to_i
+    end
+  end
+
+  module OrganizationMetadataExportServiceImporter
+    include OrganizationMetadataExportServiceConfiguration
+    include LayerImporter
+
+    def build_organization_from_json_export(exported_json_string)
+      build_organization_from_hash_export(JSON.parse(exported_json_string).deep_symbolize_keys)
+    end
+
+    def build_organization_from_hash_export(exported_hash)
+      raise 'Wrong export version' unless compatible_version?(exported_hash[:version])
+
+      build_organization_from_hash(exported_hash[:organization])
+    end
+
+    def save_imported_organization(organization)
+      organization.save!
+      ::Organization[organization.id].after_save
+    end
+
+    private
+
+    def build_organization_from_hash(exported_organization)
+      organization = Organization.new(exported_organization.slice(*EXPORTED_ORGANIZATION_ATTRIBUTES))
+
+      organization.assets = exported_organization[:assets].map { |asset| build_asset_from_hash(asset.symbolize_keys) }
+
+      # Must be the last one to avoid attribute assignments to try to run SQL
+      organization.id = exported_organization[:id]
+      organization
+    end
+
+    def build_asset_from_hash(exported_asset)
+      Asset.new(
+        public_url: exported_asset[:public_url],
+        kind: exported_asset[:kind],
+        storage_info: exported_asset[:storage_info]
+      )
+    end
+  end
+
+  module OrganizationMetadataExportServiceExporter
+    include OrganizationMetadataExportServiceConfiguration
+    include LayerExporter
+
+    def export_organization_json_string(organization_id)
+      export_organization_json_hash(organization_id).to_json
+    end
+
+    def export_organization_json_hash(organization_id)
+      {
+        version: CURRENT_VERSION,
+        organization: export(Organization.find(organization_id))
+      }
+    end
+
+    private
+
+    def export(organization)
+      organization_hash = EXPORTED_ORGANIZATION_ATTRIBUTES.map { |att| [att, organization.attributes[att.to_s]] }.to_h
+
+      organization_hash[:assets] = organization.assets.map { |a| export_asset(a) }
+
+      organization_hash
+    end
+
+    def export_asset(asset)
+      {
+        public_url: asset.public_url,
+        kind: asset.kind,
+        storage_info: asset.storage_info
+      }
+    end
+  end
+
+  # Both String and Hash versions are provided because `deep_symbolize_keys` won't symbolize through arrays
+  # and having separated methods make handling and testing much easier.
+  class OrganizationMetadataExportService
+    include OrganizationMetadataExportServiceImporter
+    include OrganizationMetadataExportServiceExporter
+
+    def export_organization_to_directory(organization_id, path)
+      organization = Carto::Organization.find(organization_id)
+      root_dir = Pathname.new(path)
+
+      # Export organization
+      organization_json = export_organization_json_string(organization_id)
+      root_dir.join("organization_#{organization_id}.json").open('w') { |file| file.write(organization_json) }
+
+      # Export users
+      organization.users.each do |user|
+        user_path = root_dir.join("user_#{user.id}")
+        Dir.mkdir(user_path)
+        Carto::UserMetadataExportService.new.export_user_to_directory(user.id, user_path)
+      end
+    end
+
+    def import_organization_from_directory(path)
+      # Import organization
+      organization_file = Dir["#{path}/organization_*.json"].first
+      organization = build_organization_from_json_export(File.read(organization_file))
+      save_imported_organization(organization)
+
+      user_list = Dir["#{path}/user_*"]
+
+      # In order to get permissions right, we first import all users, then all datasets and finally, all maps
+      organization.users = user_list.map do |user_path|
+        Carto::UserMetadataExportService.new.import_user_from_directory(user_path, import_visualizations: false)
+      end
+
+      organization.users.each do |user|
+        Carto::UserMetadataExportService.new.import_user_visualizations_from_directory(
+          user, Carto::Visualization::TYPE_CANONICAL, "#{path}/user_#{user.id}"
+        )
+      end
+
+      organization.users.each do |user|
+        Carto::UserMetadataExportService.new.import_user_visualizations_from_directory(
+          user, Carto::Visualization::TYPE_DERIVED, "#{path}/user_#{user.id}"
+        )
+      end
+
+      organization
+    end
+  end
+end

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -119,7 +119,7 @@ module Carto
       end
     end
 
-    def import_organization_from_directory(path)
+    def import_organization_and_users_from_directory(path)
       # Import organization
       organization_file = Dir["#{path}/organization_*.json"].first
       organization = build_organization_from_json_export(File.read(organization_file))
@@ -132,6 +132,10 @@ module Carto
         Carto::UserMetadataExportService.new.import_user_from_directory(user_path, import_visualizations: false)
       end
 
+      organization
+    end
+
+    def import_organization_visualizations_from_directory(organization, path)
       organization.users.each do |user|
         Carto::UserMetadataExportService.new.import_user_visualizations_from_directory(
           user, Carto::Visualization::TYPE_CANONICAL, "#{path}/user_#{user.id}"

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -7,10 +7,10 @@ module Carto
     CURRENT_VERSION = '1.0.0'.freeze
     EXPORTED_ORGANIZATION_ATTRIBUTES = [
       :id, :seats, :quota_in_bytes, :created_at, :updated_at, :name, :avatar_url, :owner_id, :website, :description,
-      :display_name, :discus_shortname, :twitter_organizationname, :geocoding_quota, :map_view_quota, :auth_token,
+      :display_name, :discus_shortname, :twitter_username, :geocoding_quota, :map_view_quota, :auth_token,
       :geocoding_block_price, :map_view_block_price, :twitter_datasource_enabled, :twitter_datasource_block_price,
       :twitter_datasource_block_size, :twitter_datasource_quota, :google_maps_key, :google_maps_private_key, :color,
-      :default_quota_in_bytes, :whitelisted_email_domains, :admin_email, :auth_organizationname_password_enabled,
+      :default_quota_in_bytes, :whitelisted_email_domains, :admin_email, :auth_username_password_enabled,
       :auth_google_enabled, :location, :here_isolines_quota, :here_isolines_block_price, :strong_passwords_enabled,
       :obs_snapshot_quota, :obs_snapshot_block_price, :obs_general_quota, :obs_general_block_price,
       :salesforce_datasource_enabled, :viewer_seats, :geocoder_provider, :isolines_provider, :routing_provider,

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -146,19 +146,19 @@ module Carto
       export_user_visualizations_to_directory(user, Carto::Visualization::TYPE_DERIVED, path)
     end
 
-    def import_user_from_directory(path)
+    def import_user_from_directory(path, import_visualizations: true)
       # Import user
       user_file = Dir["#{path}/user_*.json"].first
       user = build_user_from_json_export(File.read(user_file))
       save_imported_user(user)
 
-      import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_CANONICAL, path)
-      import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_DERIVED, path)
+      if import_visualizations
+        import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_CANONICAL, path)
+        import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_DERIVED, path)
+      end
 
       user
     end
-
-    private
 
     def import_user_visualizations_from_directory(user, type, path)
       Dir["#{path}/#{type}_*#{Carto::VisualizationExporter::EXPORT_EXTENSION}"].each do |filename|

--- a/lib/carto/db/insertable_array.rb
+++ b/lib/carto/db/insertable_array.rb
@@ -1,0 +1,9 @@
+# This is a hack for a bug in activerecord-postgres-array 0.0.9
+# We can remove this when the upgrade to Rails 4 allows us to remove that gem
+class Carto::InsertableArray < Array
+  # Omit quotes is set as `new_record?`, so quotes should be omitted for inserts. This is incorrect, we override it
+  # to never escape quotes. This quick hack would be a problem if we used nested postgres arrays.
+  def to_postgres_array(omit_quotes = false)
+    super(false)
+  end
+end

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -1,0 +1,193 @@
+require 'spec_helper_min'
+require 'factories/carto_visualizations'
+
+describe Carto::OrganizationMetadataExportService do
+  include NamedMapsHelper
+  include Carto::Factories::Visualizations
+  include TableSharing
+
+  def create_organization_with_dependencies
+    @sequel_organization = FactoryGirl.create(:organization_with_users)
+    @organization = Carto::Organization.find(@sequel_organization.id)
+    @owner = @organization.owner
+    @non_owner = @organization.users.reject(&:organization_owner?).first
+
+    @map, @table, @table_visualization, @visualization = create_full_visualization(@non_owner)
+    share_visualization_with_user(@table_visualization, @owner)
+
+    @asset = FactoryGirl.create(:carto_asset, organization: @organization)
+
+    @organization.reload
+  end
+
+  def destroy_organization
+    Organization[@organization.id].destroy_cascade
+  end
+
+  let(:service) { Carto::OrganizationMetadataExportService.new }
+
+  describe '#organization export' do
+    before(:all) do
+      create_organization_with_dependencies
+    end
+
+    after(:all) do
+      destroy_organization
+    end
+
+    it 'exports' do
+      export = service.export_organization_json_hash(@organization.id)
+
+      expect_export_matches_organization(export[:organization], @organization)
+    end
+
+    it 'includes all user model attributes' do
+      export = service.export_organization_json_hash(@organization.id)
+
+      expect(export[:organization].keys).to include(*@organization.attributes.symbolize_keys.keys)
+    end
+  end
+
+  describe '#organization import' do
+    it 'imports' do
+      organization = service.build_organization_from_hash_export(full_export)
+
+      expect_export_matches_organization(full_export[:organization], organization)
+    end
+  end
+
+  describe '#organization export + import' do
+    it 'export + import' do
+      create_organization_with_dependencies
+      export = service.export_organization_json_hash(@organization.id)
+      expect_export_matches_organization(export[:organization], @organization)
+      source_organization = @organization.attributes
+      destroy_organization
+
+      imported_organization = service.build_organization_from_hash_export(export)
+      service.save_imported_organization(imported_organization)
+      imported_organization.reload
+
+      expect_export_matches_organization(export[:organization], imported_organization)
+      compare_excluding_dates(imported_organization.attributes, source_organization)
+    end
+  end
+
+  describe '#full export + import (organization, users and visualizations)' do
+    it 'export + import organization, users and visualizations' do
+      Dir.mktmpdir do |path|
+        create_user_with_basemaps_assets_visualizations
+        service.export_user_to_directory(@user.id, path)
+        source_user = @user.attributes
+
+        source_visualizations = @user.visualizations.map(&:attributes)
+        destroy_user
+
+        imported_user = service.import_user_from_directory(path)
+
+        compare_excluding_dates(imported_user.attributes, source_user)
+        expect(imported_user.visualizations.count).to eq source_visualizations.count
+        imported_user.visualizations.zip(source_visualizations).each do |v1, v2|
+          compare_excluding_dates_and_ids(v1.attributes, v2)
+        end
+      end
+    end
+  end
+
+  EXCLUDED_DATE_FIELDS = ['created_at', 'updated_at'].freeze
+  EXCLUDED_ID_FIELDS = ['map_id', 'permission_id', 'active_layer_id', 'tags'].freeze
+
+  def compare_excluding_dates_and_ids(v1, v2)
+    filtered1 = v1.reject { |k, _| EXCLUDED_ID_FIELDS.include?(k) }
+    filtered2 = v2.reject { |k, _| EXCLUDED_ID_FIELDS.include?(k) }
+    compare_excluding_dates(filtered1, filtered2)
+  end
+
+  def compare_excluding_dates(u1, u2)
+    filtered1 = u1.reject { |k, _| EXCLUDED_DATE_FIELDS.include?(k) }
+    filtered2 = u2.reject { |k, _| EXCLUDED_DATE_FIELDS.include?(k) }
+    expect(filtered1).to eq filtered2
+  end
+
+  def expect_export_matches_organization(export, organization)
+    Carto::OrganizationMetadataExportService::EXPORTED_ORGANIZATION_ATTRIBUTES.each do |att|
+      expect(export[att]).to eq organization.attributes[att.to_s]
+    end
+
+    expect(export[:assets].count).to eq organization.assets.size
+    export[:assets].zip(organization.assets).each { |exported_asset, asset| expect_export_matches_asset(exported_asset, asset) }
+  end
+
+  def expect_export_matches_asset(exported_asset, asset)
+    expect(exported_asset[:public_url]).to eq asset.public_url
+    expect(exported_asset[:kind]).to eq asset.kind
+    expect(exported_asset[:storage_info]).to eq asset.storage_info
+  end
+
+  let(:full_export) do
+    {
+      version: "1.0.0",
+      organization: {
+        id: "189d642c-c7da-40aa-bffd-517aa0eb7999",
+        seats: 100,
+        quota_in_bytes: 99999999997,
+        created_at: DateTime.now,
+        updated_at: DateTime.now,
+        name: "worg",
+        avatar_url: nil,
+        owner_id: "06b974db-de0d-49b7-ae9b-76c63af8c122",
+        website: "",
+        description: "",
+        display_name: "",
+        discus_shortname: "",
+        twitter_organizationname: nil,
+        geocoding_quota: 0,
+        map_view_quota: nil,
+        auth_token: "pgYcd8XnAn46HlczpvQcIw",
+        geocoding_block_price: nil,
+        map_view_block_price: nil,
+        twitter_datasource_enabled: true,
+        twitter_datasource_block_price: 100,
+        twitter_datasource_block_size: 1000,
+        twitter_datasource_quota: 1,
+        google_maps_key: "key=AIzaSyBYumNYEyM18D9te7PeArJ_pinDIPyYVts",
+        google_maps_private_key: nil,
+        color: "#FF9900",
+        default_quota_in_bytes: 209715200,
+        whitelisted_email_domains: ["carto.com", "worg.com"],
+        admin_email: "worg1@worg.com",
+        auth_username_password_enabled: nil,
+        auth_google_enabled: true,
+        location: nil,
+        here_isolines_quota: 0,
+        here_isolines_block_price: nil,
+        strong_passwords_enabled: false,
+        obs_snapshot_quota: 0,
+        obs_snapshot_block_price: nil,
+        obs_general_quota: 999999999,
+        obs_general_block_price: nil,
+        salesforce_datasource_enabled: false,
+        viewer_seats: 100,
+        geocoder_provider: "heremaps",
+        isolines_provider: "heremaps",
+        routing_provider: "mapzen",
+        auth_github_enabled: true,
+        engine_enabled: true,
+        mapzen_routing_quota: nil,
+        mapzen_routing_block_price: nil,
+        builder_enabled: true,
+        auth_saml_configuration: {},
+        no_map_logo: false,
+        assets: [{
+          public_url: "http://localhost.lan:3000/uploads/organization_assets/189d642c-c7da-40aa-bffd-517aa0eb7999/asset_download_148430456220170113-20961-67b7r0",
+          kind: "organization_asset",
+          storage_info: {
+            type: "local",
+            location: "organization_assets",
+            identifier: "public/uploads/organization_assets/189d642c-c7da-40aa-bffd-517aa0eb7999/asset_download_148430456220170113-20961-67b7r0"
+          }
+        }]
+      }
+    }
+  end
+end


### PR DESCRIPTION
Closes #12253 

Pretty straightforward. The only major issue is the bug we have with insertion of records with array fields (like Visualization.tags and, in this case, the domain whitelist). The same patch we used for Visualization doesn't work here. I ended up with something that is pretty clean (just overrides a method that the gem monkey-patches into array) and avoids forking the gem. This is fixed in Rails 4 (this gem is built-in and works properly).

This is what I used for acceptance locally. To run between staging servers, just skip destroying the organization, move the temporary path between servers and follow the code snippet in https://github.com/CartoDB/cartodb-central/issues/1782 for DNS changes.

```
# Load dependencies
load 'services/user-mover/export_user.rb'
load 'services/user-mover/import_user.rb'
require 'carto/organization_metadata_export_service'
service = Carto::OrganizationMetadataExportService.new

# Parameters
org = Carto::Organization.find_by_name('worg')
path = '/tmp/a'

# Export
Dir.mkdir(path + '/data')
Dir.mkdir(path + '/meta')
ume_job = CartoDB::DataMover::ExportJob.new(organization_name: org.name, schema_mode: true, split_user_schemas: true, path: path + '/data/')
service.export_organization_to_directory(org.id, path + '/meta')

# Destroy organization
::Organization[org.id].destroy_cascade

# Import (org & users, psql db, visualizations)
imported_organization = service.import_organization_and_users_from_directory("#{path}/meta")
CartoDB::DataMover::ImportJob.new(file: Dir["#{path}/data/org*json"].first, data: true, metadata: false, host: '127.0.0.1', rollback: false, mode: :import, set_banner: false).run!
service.import_organization_visualizations_from_directory(imported_organization, "#{path}/meta")

imported_organization.users.each { |u| u.update_attribute(:last_common_data_update_date, nil) }
```


Acceptance notes:
- user1 can insert a row in a user2 table if and only if user2 shared it with him.
- check schemas of imported tables.