### PR TITLE
Adding carto logo image in the copy grunt task

### DIFF
--- a/lib/build/tasks/copy.js
+++ b/lib/build/tasks/copy.js
@@ -78,7 +78,7 @@ exports.task = function (grunt) {
         // Some images should be placed in a unversioned folder
         expand: true,
         cwd: 'app/assets/images/',
-        src: ['avatars/**/*', 'alphamarker.png', 'google-maps-basemap-icons/*'],
+        src: ['avatars/*.png', 'alphamarker.png', 'google-maps-basemap-icons/*.jpg', 'carto.png'],
         dest: '<%= root_assets_dir %>/unversioned/images/'
       }, {
         // CARTO.js images


### PR DESCRIPTION
We have that for uploading the files to s3 but not in local 😱 . So the "image export" in local should fail.