### PR TITLE
Render view module in DEV mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@ Development
 * Retrieve google static api url from backend to allow using both client_id and api_key (#12301, #12318)
 * Fix vector problem with lines
 * Fixed "see all formats" url, from the Connect Dataset module, to open in new windown and changed the url.
+* Added a data attribute for Backbone views that points to the module that implements it (Leapfrog #12341)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.1`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/components/stack-layout/stack-layout-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/stack-layout/stack-layout-view.js
@@ -8,6 +8,7 @@ var _ = require('underscore');
  */
 
 module.exports = CoreView.extend({
+  module: 'components:stack-layout:stack-layout-view',
 
   initialize: function (opts) {
     if (!this.collection || !this.collection.size()) {

--- a/lib/assets/core/javascripts/cartodb3/components/tab-pane/tab-pane-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/tab-pane/tab-pane-item-view.js
@@ -5,6 +5,8 @@ var CoreView = require('backbone/core-view');
  */
 
 module.exports = CoreView.extend({
+  module: 'components:tab-pane:tab-pane-item-view',
+
   tagName: 'button',
 
   events: {

--- a/lib/assets/node_modules/backbone/core-view.js
+++ b/lib/assets/node_modules/backbone/core-view.js
@@ -17,7 +17,7 @@ var View = Backbone.View.extend({
     View.viewCount++;
     View.views[this.cid] = this;
     this._created_at = new Date();
-    if (typeof __IN_DEV__ !== 'undefined' && __IN_DEV__ && this.module) {
+    if (typeof __IN_DEV__ !== 'undefined' && __IN_DEV__ && this.module) { // eslint-disable-line
       this.$el.attr('data-module', this.module);
     }
   },

--- a/lib/assets/node_modules/backbone/core-view.js
+++ b/lib/assets/node_modules/backbone/core-view.js
@@ -17,6 +17,9 @@ var View = Backbone.View.extend({
     View.viewCount++;
     View.views[this.cid] = this;
     this._created_at = new Date();
+    if (typeof __IN_DEV__ !== 'undefined' && __IN_DEV__ && this.module) {
+      this.$el.attr('data-module', this.module);
+    }
   },
 
   add_related_model: function (m) {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -67,6 +67,10 @@ module.exports = env => {
         $: 'jquery',
         jQuery: 'jquery',
         ['window.jQuery']: 'jquery'
+      }),
+
+      new webpack.DefinePlugin({
+        __IN_DEV__: JSON.stringify(true)
       })
     ])
     .filter(p => !!p), // undefined is not a valid plugin, so filter undefined values here

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -50,6 +50,10 @@ module.exports = env => {
         ['window.jQuery']: 'jquery'
       }),
 
+      new webpack.DefinePlugin({
+        __IN_DEV__: JSON.stringify(false)
+      }),
+
       // Minify
       new webpack.optimize.UglifyJsPlugin({
         sourceMap: true,


### PR DESCRIPTION
Leapfrog time!! 🐸 

This PR adds to the Builder views a data attribute with the module that implements that particular view. It does it only in development mode, so there is no weight added in production to rendered HTML.

![image](https://user-images.githubusercontent.com/1078228/27276079-386b9522-54da-11e7-9220-0164b0f09b62.png)


**Changes done**
- Modified `CoreView`. If we're in development mode and the view has a property called `module`, it adds a `data-module` attribute with the given description.
- As an example, we've added that `module` property to two views in this PR: `stack-layout-view` and `tab-pane-item-view`.
- Defined `__IN_DEV__` directive in webpack config. It uses the `DefinePlugin` of Webpack. It works somehow like a compiler directive, substituting that directive with the given object.

**Next steps**
If this PR gets accepted, we can add the `module` property to every view in Builder before merging. After that, our Developer Happiness will increase between 2.7x and 3.12x
