### PR TITLE
Truncate synchronization logs to last 8k characters

### DIFF
--- a/app/services/carto/visualizations_export_service_2.rb
+++ b/app/services/carto/visualizations_export_service_2.rb
@@ -19,6 +19,7 @@ require 'carto/export/layer_exporter'
 module Carto
   module VisualizationsExportService2Configuration
     CURRENT_VERSION = '2.1.0'.freeze
+    MAX_LOG_SIZE = 8192
 
     def compatible_version?(version)
       version.to_i == CURRENT_VERSION.split('.')[0].to_i
@@ -333,7 +334,7 @@ module Carto
 
       {
         type: log.type,
-        entries: log.entries
+        entries: log.entries.length > MAX_LOG_SIZE ? log.entries.slice(-MAX_LOG_SIZE..-1) : log.entries
       }
     end
 

--- a/app/services/carto/visualizations_export_service_2.rb
+++ b/app/services/carto/visualizations_export_service_2.rb
@@ -334,7 +334,7 @@ module Carto
 
       {
         type: log.type,
-        entries: log.entries.length > MAX_LOG_SIZE ? log.entries.slice(-MAX_LOG_SIZE..-1) : log.entries
+        entries: log.entries && log.entries.length > MAX_LOG_SIZE ? log.entries.slice(-MAX_LOG_SIZE..-1) : log.entries
       }
     end
 

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -847,6 +847,14 @@ describe Carto::VisualizationsExportService2 do
 
         destroy_full_visualization(map, table, table_visualization, visualization)
       end
+
+      it 'truncates long sync logs' do
+        FactoryGirl.create(:carto_synchronization, visualization: @table_visualization)
+        @table_visualization.reload
+        @table_visualization.synchronization.log.update_attribute(:entries, 'X' * 15000)
+        export = Carto::VisualizationsExportService2.new.export_visualization_json_hash(@table_visualization.id, @user)
+        expect(export[:visualization][:synchronization][:log][:entries].length).to be < 10000
+      end
     end
 
     describe 'exporting + importing visualizations with shared tables' do


### PR DESCRIPTION
Fixes #12343 