### PR TITLE
Selects the first timespan available after measurement selection

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/data/data-observatory/timespan-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/data/data-observatory/timespan-collection.js
@@ -21,5 +21,12 @@ module.exports = BaseCollection.extend({
     } else {
       return TIMESPAN_QUERY_WITHOUT_NORMALIZE;
     }
+  },
+
+  selectFirstAsDefault: function () {
+    var first = this.first();
+    if (first) {
+      this.setSelected(first.getValue());
+    }
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-nested-measure-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-nested-measure-model.js
@@ -187,7 +187,7 @@ module.exports = Backbone.Model.extend({
     var timespan = this.get('timespan');
     var selected = this.timespan.setSelected(timespan);
     if (!selected) {
-      this.set({ timespan: null }, { silent: true });
+      this.timespan.selectFirstAsDefault();
       this._setSchema();
     }
 
@@ -385,5 +385,4 @@ module.exports = Backbone.Model.extend({
     this.schema = schema;
     this.trigger('updateSchema', this.schema);
   }
-
 });

--- a/lib/assets/core/test/spec/cartodb3/data/data-observatory/timespan-collection.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/data-observatory/timespan-collection.spec.js
@@ -1,0 +1,105 @@
+var Backbone = require('backbone');
+var cdb = require('cartodb.js');
+var TimeSpanCollection = require('../../../../../javascripts/cartodb3/data/data-observatory/timespan-collection');
+var AnalysisDefinitionNodeModel = require('../../../../../javascripts/cartodb3/data/analysis-definition-node-model');
+
+describe('data/data-observatory/timespan-collection', function () {
+  var sqlExecuteBackup = cdb.SQL.prototype.execute;
+
+  beforeEach(function () {
+    var configModel = new Backbone.Model({
+      base_url: '/u/foo',
+      user_name: 'foo',
+      sql_api_template: 'foo',
+      api_key: 'foo'
+    });
+
+    this.nodeDefModel = new AnalysisDefinitionNodeModel({
+      id: 'a1',
+      type: 'data-observatory-multiple-measures',
+      final_column: 'foo',
+      source: 'a0'
+    }, {
+      configModel: configModel,
+      collection: new Backbone.Collection()
+    });
+
+    this.querySchemaModel = new Backbone.Model({
+      query: 'select * from wadus'
+    });
+
+    this.nodeDefModel.querySchemaModel = this.querySchemaModel;
+
+    cdb.SQL.prototype.execute = function (query, vars, params) {
+      params && params.success({
+        rows: [
+          {
+            timespan_id: '2010',
+            timespan_name: '2010'
+          },
+          {
+            timespan_id: '2015',
+            timespan_name: '2015'
+          },
+          {
+            timespan_id: '2017',
+            timespan_name: '2017'
+          }
+        ]
+      });
+    };
+
+    this.collection = new TimeSpanCollection([], {
+      configModel: configModel,
+      nodeDefModel: this.nodeDefModel
+    });
+
+    this.successCallback = jasmine.createSpy('successCallback');
+    this.errorCallback = jasmine.createSpy('errorCallback');
+  });
+
+  afterEach(function () {
+    cdb.SQL.prototype.execute = sqlExecuteBackup;
+  });
+
+  it('initial state', function () {
+    expect(this.collection.getState()).toBe('unfetched');
+  });
+
+  it('fetch', function () {
+    this.collection.fetch({
+      success: this.successCallback,
+      error: this.errorCallback
+    });
+
+    expect(this.successCallback).toHaveBeenCalled();
+    expect(this.collection.length).toBe(3);
+    expect(this.collection.getState()).toBe('fetched');
+  });
+
+  it('first timespan as default', function () {
+    this.collection.fetch({
+      success: this.successCallback,
+      error: this.errorCallback
+    });
+
+    this.collection.selectFirstAsDefault();
+    expect(this.collection.getSelectedItem().getValue()).toBe('2010');
+  });
+
+  it('should not select the first item if empty', function () {
+    cdb.SQL.prototype.execute = function (query, vars, params) {
+      params && params.success({
+        rows: []
+      });
+    };
+
+    this.collection.fetch({
+      success: this.successCallback,
+      error: this.errorCallback
+    });
+
+    this.collection.selectFirstAsDefault();
+    expect(this.collection.getSelectedItem()).toBeUndefined();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.11-stg26",
+  "version": "4.8.11-stg27",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/12349.

### Acceptance

- Take a user from RUI staging servers.
- Enable new DO analysis with the feature flag `data-observatory-multiple-measures`.
- Add a new DO analysis.
- Select a measurement.
- Check after requests that the timespan dropdown selects automatically the first available option.

cc @nobuti 