### PR TITLE
Fixes for the get geometries queries

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/data/data-observatory/boundaries-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/data/data-observatory/boundaries-collection.js
@@ -1,13 +1,16 @@
 var BaseCollection = require('./data-observatory-base-collection');
 var BaseModel = require('../../components/custom-list/custom-list-item-model');
 
-var BOUNDARIES_QUERY_PLAIN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, NULL) denoms WHERE valid_numer IS TRUE ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data';
+var FILTER_CLIPPED_GEOMS_IF_EXISTS = 'WHERE CASE WHEN (SELECT true as cond FROM _data WHERE geom_tags ?\'boundary_type/tags.cartographic_boundary\' group by cond) THEN geom_tags ? \'boundary_type/tags.cartographic_boundary\' ELSE true END;';
 
-var BOUNDARIES_QUERY_NORMALIZE = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, NULL) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data';
+var BOUNDARIES_QUERY_PLAIN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, NULL) denoms WHERE valid_numer IS TRUE ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data ' + FILTER_CLIPPED_GEOMS_IF_EXISTS;
 
-var BOUNDARIES_QUERY_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR valid_denom IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data';
+var BOUNDARIES_QUERY_NORMALIZE = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, NULL) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data ' + FILTER_CLIPPED_GEOMS_IF_EXISTS;
 
-var BOUNDARIES_QUERY_NORMALIZE_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data';
+var BOUNDARIES_QUERY_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR valid_denom IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data ' + FILTER_CLIPPED_GEOMS_IF_EXISTS;
+
+var BOUNDARIES_QUERY_NORMALIZE_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data ' + FILTER_CLIPPED_GEOMS_IF_EXISTS;
+
 
 module.exports = BaseCollection.extend({
   model: function (attrs, opts) {

--- a/lib/assets/core/javascripts/cartodb3/data/data-observatory/boundaries-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/data/data-observatory/boundaries-collection.js
@@ -11,7 +11,6 @@ var BOUNDARIES_QUERY_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGe
 
 var BOUNDARIES_QUERY_NORMALIZE_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data ' + FILTER_CLIPPED_GEOMS_IF_EXISTS;
 
-
 module.exports = BaseCollection.extend({
   model: function (attrs, opts) {
     // label and val to custom list compatibility

--- a/lib/assets/core/javascripts/cartodb3/data/data-observatory/boundaries-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/data/data-observatory/boundaries-collection.js
@@ -5,7 +5,7 @@ var BOUNDARIES_QUERY_PLAIN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeome
 
 var BOUNDARIES_QUERY_NORMALIZE = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, NULL) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data LIMIT 15';
 
-var BOUNDARIES_QUERY_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND valid_denom IS TRUE ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data LIMIT 15';
+var BOUNDARIES_QUERY_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR valid_denom IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data LIMIT 15';
 
 var BOUNDARIES_QUERY_NORMALIZE_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data LIMIT 15';
 

--- a/lib/assets/core/javascripts/cartodb3/data/data-observatory/boundaries-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/data/data-observatory/boundaries-collection.js
@@ -1,13 +1,13 @@
 var BaseCollection = require('./data-observatory-base-collection');
 var BaseModel = require('../../components/custom-list/custom-list-item-model');
 
-var BOUNDARIES_QUERY_PLAIN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, NULL) denoms WHERE valid_numer IS TRUE ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data LIMIT 15';
+var BOUNDARIES_QUERY_PLAIN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, NULL) denoms WHERE valid_numer IS TRUE ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data';
 
-var BOUNDARIES_QUERY_NORMALIZE = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, NULL) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data LIMIT 15';
+var BOUNDARIES_QUERY_NORMALIZE = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, NULL) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data';
 
-var BOUNDARIES_QUERY_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR valid_denom IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data LIMIT 15';
+var BOUNDARIES_QUERY_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, NULL, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR valid_denom IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data';
 
-var BOUNDARIES_QUERY_NORMALIZE_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data LIMIT 15';
+var BOUNDARIES_QUERY_NORMALIZE_TIMESPAN = 'WITH _data as (SELECT * FROM OBS_GetAvailableGeometries((SELECT ST_SetSRID(ST_Extent(the_geom), 4326) FROM ({{{ query }}}) q), NULL, {{{ measurement }}}, {{{ denom_id }}}, {{{ timespan }}}) denoms WHERE valid_numer IS TRUE AND (valid_denom IS TRUE OR {{{ denom_id }}} IS NULL) ORDER BY numgeoms DESC) SELECT DISTINCT on (geom_id) * FROM _data';
 
 module.exports = BaseCollection.extend({
   model: function (attrs, opts) {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-nested-measure-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-nested-measure-model.js
@@ -254,6 +254,9 @@ module.exports = Backbone.Model.extend({
 
   _getColumnNameOptions: function () {
     var normalize = this.get('normalize') || null;
+    if (normalize !== null) {
+      normalize = (DENOMINATORS_BLACKLIST.indexOf(normalize) >= 0) ? null : normalize;
+    }
     var normalization = this.get('normalization');
 
     var defaults = {


### PR DESCRIPTION
Fixes Cartodb/observatory-extension#293

- Now we show the boundaries in any case, even when we select the timespan
- If possible we show only the clipped geometries if not we show all the geometries
- Fixes the bug where we can have the same measure with different parameters in some cases