### PR TITLE
Do not throw error when revocation fails due to already invalid token

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ Development
 * Boolean fields are visible in the filter by column value analysis (#11546)
 * Fixed legend's color mismatch with empty values (#11632)
 * Fixed overlay for legends view (#11825)
+* Fix error when revoking a Dropbox token that was revoked from Dropbox side (#12359)
 * Fixed UI when editing merge analysis (#10850)
 * Fixed uninitialized constant in Carto::Visualization when a viewer shares a visualization (#12129).
 * Fix regenerate all api keys in an organization (#12218)

--- a/services/datasources/lib/datasources/url/dropbox.rb
+++ b/services/datasources/lib/datasources/url/dropbox.rb
@@ -213,6 +213,9 @@ module CartoDB
         def revoke_token
           @client.revoke
           true
+        rescue DropboxApi::Errors::HttpError => ex
+          CartoDB::Logger.debug(message: 'Error revoking Dropbox token', exception: ex, user: @user)
+          true
         rescue => ex
           raise AuthError.new("revoke_token: #{ex.message}", DATASOURCE_NAME)
         end


### PR DESCRIPTION
Fixes #12357 