### PR TITLE
Measurement validation before be able to add more.

### DIFF
--- a/app/assets/stylesheets/editor-3/_data-observatory-form.scss
+++ b/app/assets/stylesheets/editor-3/_data-observatory-form.scss
@@ -1,14 +1,19 @@
 @import 'cdb-variables/colors';
 
-.data-observatory-add-measure {
+.DataObservatory-addMeasure {
   width: 100%;
 }
 
-.data-observatory-license {
+.DataObservatory-addMeasure .is-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.DataObservatory-license {
   white-space: normal;
 }
 
-.data-observatory-count {
+.DataObservatory-count {
   padding: 8px 16px;
   border-bottom: 1px solid $cMainLine;
 }

--- a/app/assets/stylesheets/editor-3/_data-observatory-form.scss
+++ b/app/assets/stylesheets/editor-3/_data-observatory-form.scss
@@ -5,8 +5,8 @@
 }
 
 .DataObservatory-addMeasure .is-disabled {
-  opacity: 0.5;
   cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .DataObservatory-license {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/data-observatory-measurements-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/data-observatory-measurements-view.js
@@ -42,9 +42,6 @@ Backbone.Form.editors.DataObservatoryDropdown = Backbone.Form.editors.Base.exten
     this.template = opts.template || template;
     this.dialogMode = this.options.dialogMode || 'nested';
 
-    // update form attributes silently
-    this._silentChangeInitially = this.options.silentChangeInitially;
-
     this.measurementsCollection = this.options.measurements;
 
     this._initBinds();
@@ -127,11 +124,7 @@ Backbone.Form.editors.DataObservatoryDropdown = Backbone.Form.editors.Base.exten
     this._renderLicense(mdl);
     this._renderButton(mdl).focus();
 
-    if (!this._silentChangeInitially) {
-      this.trigger('change', this);
-    } else {
-      this._silentChangeInitially = false;
-    }
+    this.trigger('change', this);
   },
 
   _onButtonClick: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/data-observatory-measurements.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/data-observatory-measurements.tpl
@@ -21,6 +21,6 @@
 
 <div class="js-license CDB-Text CDB-FontSize-small u-altTextColor u-tSpace u-bSpace u-isHidden u-flex">
   <a href="https://cartodb.github.io/bigmetadata/licenses.html" target="_blank">
-    <span class="u-tSpace u-bSpace data-observatory-license"></span>
+    <span class="u-tSpace u-bSpace DataObservatory-license"></span>
   </a>
 </div>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/measurement-item.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/measurement-item.js
@@ -4,7 +4,6 @@ var NestedForm = require('../../nested-form-custom');
 var EditorHelpers = require('../editor-helpers-extend');
 
 Backbone.Form.editors.List.MeasurementModel = Backbone.Form.editors.NestedModel.extend({
-
   initialize: function (options) {
     Backbone.Form.editors.Base.prototype.initialize.call(this, options);
     EditorHelpers.setOptions(this, options);

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/measurements-count.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/measurements-count.tpl
@@ -1,3 +1,3 @@
-<div class="data-observatory-count CDB-Text CDB-Size-small Color-ThirdBackground">
+<div class="DataObservatory-count CDB-Text CDB-Size-small Color-ThirdBackground">
     <%- items %>
 </div>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/list/list.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/list/list.js
@@ -263,6 +263,11 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
     if (!hasErrors) return null;
   },
 
+  _errorPresenter: function (errors) {
+    return _.unique(this.errors.map(function (error) {
+      return error.message;
+    })).join('\n');
+  },
   _setAddButtonState: function (error) {
     var button = this.$('[data-action="add"]');
     button.toggleClass('is-disabled', error);
@@ -272,14 +277,13 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
         el: button,
         gravity: 's',
         offset: 0,
-        title: function () {
-          return _.unique(this.errors.map(function (error) {
-            return error.message;
-          })).join('\n');
-        }.bind(this)
+        title: this._errorPresenter.bind(this)
       });
     } else {
-      this._errorTooltip.clean();
+      if (this._errorTooltip) {
+        this._errorTooltip.clean();
+        this._errorTooltip = null;
+      }
     }
   }
 }, {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/list/list.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/list/list.js
@@ -2,6 +2,7 @@ var $ = require('jquery');
 var _ = require('underscore');
 var Backbone = require('backbone');
 var EditorHelpers = require('../editor-helpers-extend');
+var TipsyTooltipView = require('../../../tipsy-tooltip-view');
 
 var OPTIONS = [
   'userModel',
@@ -16,7 +17,9 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
   events: {
     'click [data-action="add"]': function (event) {
       event.preventDefault();
-      this.addItem(null, true);
+      if (this.errors.length === 0) {
+        this.addItem(null, true);
+      }
     }
   },
 
@@ -66,6 +69,10 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
     // Store a reference to the list (item container)
     this.$list = $el.is('[data-items]') ? $el : $el.find('[data-items]');
 
+    this.setElement($el);
+    this.$el.attr('id', this.id);
+    this.$el.attr('name', this.key);
+
     // Add existing items
     if (value.length) {
       _.each(value, function (itemValue) {
@@ -73,15 +80,12 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
       });
     } else {
       // If no existing items create an empty one, unless the editor specifies otherwise
-      if (!this.Editor.isAsync) this.addItem();
+      if (!this.Editor.isAsync) this.addItem(null, true);
     }
-
-    this.setElement($el);
-    this.$el.attr('id', this.id);
-    this.$el.attr('name', this.key);
 
     if (this.hasFocus) this.trigger('blur', this);
 
+    this.validate();
     return this;
   },
 
@@ -251,18 +255,32 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
       return item.validate();
     });
 
+    this.errors = _.compact(errors);
     // Check if any item has errors
-    var hasErrors = !!_.compact(errors).length;
+    var hasErrors = !!this.errors.length;
+    this._setAddButtonState(hasErrors);
+
     if (!hasErrors) return null;
+  },
 
-    // If so create a shared error
-    var fieldError = {
-      type: 'list',
-      message: 'Some of the items in the list failed validation',
-      errors: errors
-    };
+  _setAddButtonState: function (error) {
+    var button = this.$('[data-action="add"]');
+    button.toggleClass('is-disabled', error);
 
-    return fieldError;
+    if (error) {
+      this._errorTooltip = new TipsyTooltipView({
+        el: button,
+        gravity: 's',
+        offset: 0,
+        title: function () {
+          return _.unique(this.errors.map(function (error) {
+            return error.message;
+          })).join('\n');
+        }.bind(this)
+      });
+    } else {
+      this._errorTooltip.clean();
+    }
   }
 }, {
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-list.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-list.tpl
@@ -2,8 +2,8 @@
   <div data-items class="Measurements">
 
   </div>
-  <div class="u-flex u-justifyEnd data-observatory-add-measure">
-    <button class="CDB-Text CDB-Size-small u-actionTextColor u-upperCase" type="button" data-action="add">
+  <div class="u-flex u-justifyEnd DataObservatory-addMeasure">
+    <button class="CDB-Text CDB-Size-small u-actionTextColor  u-upperCase" type="button" data-action="add">
       <%- _t('editor.layers.analysis-form.data-observatory.list.add') %>
     </button>
   </div>

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-model.js
@@ -259,7 +259,7 @@ module.exports = BaseAnalysisFormModel.extend({
           if (hasError) {
             return {
               error: true,
-              message: 'Segment name is required'
+              message: _t('analyses.data-observatory-measure.errors.measurement-required')
             };
           }
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-model.js
@@ -192,7 +192,7 @@ module.exports = BaseAnalysisFormModel.extend({
     if (!_.isEqual(uniques, columnNames)) {
       return {
         error: true,
-        message: 'Foo error message'
+        message: 'Two or more measurements are equal'
       };
     }
   },
@@ -251,8 +251,20 @@ module.exports = BaseAnalysisFormModel.extend({
         editorAttrs: {
           configModel: this._configModel,
           regions: this.regions,
-          nodeDefModel: this.nodeDefModel
-        }
+          nodeDefModel: this.nodeDefModel,
+          notAddItemByDefault: true
+        },
+        validators: [ function (value, formValues) {
+          var hasError = value.segment_name === undefined;
+          if (hasError) {
+            return {
+              error: true,
+              message: 'Segment name is required'
+            };
+          }
+
+          return null;
+        } ]
       }
     };
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-model.js
@@ -192,7 +192,7 @@ module.exports = BaseAnalysisFormModel.extend({
     if (!_.isEqual(uniques, columnNames)) {
       return {
         error: true,
-        message: 'Two or more measurements are equal'
+        message: _t('analyses.data-observatory-measure.errors.measurement-twice')
       };
     }
   },

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-nested-measure-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-nested-measure-model.js
@@ -49,11 +49,6 @@ module.exports = Backbone.Model.extend({
     this.boundaries = new DataObservatoryBoundaries(null, fetchOptions);
     DataObservatoryColumnName.initialize(fetchOptions);
 
-    // this form has async component that fetch data to the server
-    // in order to ignore those changes when fetch to avoid aditional renders of the analysis-control-view
-    // we update the model attributes silently
-    this._silentChangeInitially = !_.isEmpty(attrs);
-
     this._fetchMeasurements = this._fetchMeasurements.bind(this);
     this._syncMeasurements = this._syncMeasurements.bind(this);
     this._fetchNormalize = this._fetchNormalize.bind(this);
@@ -67,7 +62,7 @@ module.exports = Backbone.Model.extend({
     this._setSchema = this._setSchema.bind(this);
 
     if (this.get('normalization') === 'area' && !this.get('normalize')) {
-      this.set({ normalize: 'area' }, { silent: this._silentChangeInitially });
+      this.set({ normalize: 'area' });
     }
 
     this._initBinds();
@@ -229,15 +224,10 @@ module.exports = Backbone.Model.extend({
 
     var suggestedName = metadata[0].suggested_name;
 
-    this.set({ column_name: suggestedName }, { silent: this._silentChangeInitially });
+    this.set({ column_name: suggestedName }, {silent: true});
     this._setSchema();
 
-    if (this._silentChangeInitially) {
-      this._silentChangeInitially = false;
-    } else {
-      this._form.commit(); // To update the hidden input value
-      this._form.trigger('change'); // To force validation
-    }
+    this._form.trigger('change');
   },
 
   _setNormalization: function () {
@@ -327,8 +317,7 @@ module.exports = Backbone.Model.extend({
           model: this._form.model,
           placeholder: _t('editor.layers.analysis-form.data-observatory.measurements.placeholder'),
           measurements: this.measurements,
-          loading: this.measurements.stateModel.get('state') === 'fetching',
-          silentChangeInitially: this._silentChangeInitially
+          loading: this.measurements.stateModel.get('state') === 'fetching'
         },
         dialogMode: 'float',
         region: this._form.model.get('area'),

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-nested-measure-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-nested-measure-model.js
@@ -160,9 +160,12 @@ module.exports = Backbone.Model.extend({
 
   _syncNormalize: function () {
     var deferred = $.Deferred();
+    var measurement = this.measurements.getSelectedItem();
     var normalize = this.get('normalize');
     var selected = this.normalize.setSelected(normalize);
-    if (!selected && normalize !== 'area') {
+    var areaAllowed = (measurement && measurement.get('type') === 'Numeric' && measurement.get('aggregate') === 'sum');
+
+    if (!selected && normalize !== 'area' || !selected && normalize === 'area' && !areaAllowed) {
       this.set({ normalize: '' }, { silent: true });
       this._setSchema();
     }

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -273,7 +273,8 @@
       },
       "search-by-name": "Search by name...",
       "errors": {
-        "measurement-required": "Measurement is required."
+        "measurement-required": "Measurement is required",
+        "measurement-twice": "Two or more measurements are equal"
       }
     },
     "merge": {

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -271,7 +271,10 @@
         "suggested": "Suggested measurements",
         "search": "%{items} results"
       },
-      "search-by-name": "Search by name..."
+      "search-by-name": "Search by name...",
+      "errors": {
+        "measurement-required": "Measurement is required."
+      }
     },
     "merge": {
       "title": "Join columns from 2nd layer",

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/list/list.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/list/list.spec.js
@@ -1,0 +1,77 @@
+var Backbone = require('backbone');
+
+describe('components/form-components/editors/list/list', function () {
+  beforeEach(function () {
+    this.validator = jasmine.createSpy('validator').and.returnValue({
+      error: true,
+      message: 'Foo'
+    });
+
+    this.view = new Backbone.Form.editors.List({
+      trackingClass: 'Foo-trackingClass',
+      value: ['wadus', 'foodie'],
+      schema: {
+        validators: [ this.validator ]
+      }
+    });
+
+    spyOn(this.view, 'addItem').and.callThrough();
+
+    this.view.render();
+  });
+
+  describe('render', function () {
+    it('addItem', function () {
+      var n = this.view.value.length;
+      expect(this.view.addItem).toHaveBeenCalledTimes(n);
+    });
+
+    it('tracking class', function () {
+      var n = this.view.value.length;
+      expect(this.view.$('.Foo-trackingClass').length).toBe(n);
+    });
+  });
+
+  describe('validation', function () {
+    it('should happen on render', function () {
+      var n = this.view.value.length;
+      expect(this.view.errors.length).toBe(n);
+    });
+
+    describe('add item button', function () {
+      it('without validation error', function () {
+        this.validator.and.returnValue(null);
+        this.view.validate();
+
+        var button = this.view.$('[data-action="add"]');
+        expect(button.hasClass('is-disabled')).toBe(false);
+      });
+
+      it('with validation error', function () {
+        this.validator.and.returnValue({
+          error: true,
+          message: 'Important error'
+        });
+
+        this.view.validate();
+
+        var n = this.view.value.length;
+        var button = this.view.$('[data-action="add"]');
+
+        expect(button.hasClass('is-disabled')).toBe(true);
+        expect(this.view.errors.length).toBe(n);
+      });
+
+      it('error presenter', function () {
+        this.validator.and.returnValue({
+          error: true,
+          message: 'Foo'
+        });
+
+        this.view.validate();
+        var error = this.view._errorPresenter();
+        expect(error).toBe('Foo');
+      });
+    });
+  });
+});

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/data-observatory-multiple-nested-measure-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-form-models/data-observatory-multiple-nested-measure-model.spec.js
@@ -131,20 +131,10 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/data-o
       });
     });
 
-    it('should update suggested column and avoid commit for a prepopulated model', function () {
+    it('should update suggested column', function () {
       this.model._fetchNewColumn();
 
       expect(this.model.get('column_name')).toBe('wadus_2010_2014');
-      expect(this.form.commit).not.toHaveBeenCalled();
-    });
-
-    it('should update suggested column and commit for a changed model', function () {
-      // Simulate two fetches to set the model in the changed mode
-      this.model._fetchNewColumn();
-      this.model._fetchNewColumn();
-
-      expect(this.model.get('column_name')).toBe('wadus_2010_2014');
-      expect(this.form.commit).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
This PR fixes #12351.

![add-measurement](https://user-images.githubusercontent.com/1366843/27381222-49d7ce08-5682-11e7-9f2b-4e1969daf344.gif)

- It disables the add measurement button if there is any validation error. For now, only measurements needs to be filled.
- It adds a tooltip to inform the user what is going on.