### PR TITLE
Don't try to lowercase null values in custom-list-collection object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Development
 * Removed the usage of the `organizations_admin` feature flag (#12131)
 
 ### Bug fixes / enhancements
+* Don't try to lowercase null values in custom-list-collection object (support/#744)
 * Validate widget form when widget type changes (#11536)
 * Updated text of widget tooltips (#11467)
 * Fixed error where analysis overlay/infobox wasn't shown when hiding a layer (#11767)

--- a/lib/assets/core/javascripts/cartodb3/components/custom-list/custom-list-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/components/custom-list/custom-list-collection.js
@@ -48,7 +48,7 @@ module.exports = Backbone.Collection.extend({
      *  in that case, we convert it to a string
      */
 
-    if (_.isUndefined(name)) return name;
+    if (_.isUndefined(name) || _.isNull(name)) return name;
 
     return _.isString(name) ? name.toLowerCase() : name.toString().toLowerCase();
   },

--- a/lib/assets/core/test/spec/cartodb3/components/custom-list/custom-list-collection.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/custom-list/custom-list-collection.spec.js
@@ -31,10 +31,28 @@ describe('components/custom-list/custom-list-collection', function () {
     expect(this.collection.where({ selected: true }).length).toBe(0);
   });
 
-  it('should sort the collection by value', function () {
-    this.collection.sortByKey('val');
-    expect(this.collection.at(0).get('val')).toBe('hello');
-    expect(this.collection.at(1).get('val')).toBe('hi');
-    expect(this.collection.at(2).get('val')).toBe('howdy');
+  describe('sort', function () {
+    it('should sort the collection by value', function () {
+      this.collection.sortByKey('val');
+      expect(this.collection.at(0).get('val')).toBe('hello');
+      expect(this.collection.at(1).get('val')).toBe('hi');
+      expect(this.collection.at(2).get('val')).toBe('howdy');
+    });
+
+    it('should sort the collection correctly if there is a null or an undefined value', function () {
+      var collection = new CustomListCollection([
+        { val: 'hi' },
+        { val: 'howdy' },
+        { val: 'hello' },
+        { val: 'hola' },
+        { val: null },
+        { val: undefined }
+      ]);
+      collection.sortByKey('val');
+
+      expect(collection.at(2).get('val')).toBe('hola');
+      expect(collection.at(4).get('val')).toBeNull();
+      expect(collection.at(5).get('val')).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Related ticket: cartodb/support#757

We shouldn't let a null value to be converted into lowercase.

## Steps to accept
- Create a dataset with a column where there is at least a field with a null value (for example: 3 rows with geometry points, where **description** column has null, whatever, whoever).
- Create a map with that dataset.
- Try to edit any feature from the map.
- Once in the edit-feature form, open that column field with null values and type any string.
- It should let you store any new value and any JS error shouldn't appear.

cc @matallo 