### PR TITLE
SAML service should return emails in DB format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ Development
   * Update `rails-sequel` (#12118)
   * Changes compatible with Rails 3 (#12117)
 * Make scrollwheel zoom on by default (#12214)
+* Fix SAML login error with uppercased emails (#12367)
 * You can configure your API key for the search bar, powered by Mapzen, with `geocoder.mapzen.search_bar_api_key` (#12296).
 * Add last name field to users (#12174)
 * Fix error where a sync of a big dataset without geometry would be deleted from dashboard (#12162)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,12 +4,14 @@ require_dependency 'google_plus_api'
 require_dependency 'oauth/github/config'
 require_dependency 'carto/saml_service'
 require_dependency 'carto/username_proposer'
+require_dependency 'carto/email_cleaner'
 
 require_relative '../../lib/user_account_creator'
 require_relative '../../lib/cartodb/stats/authentication'
 
 class SessionsController < ApplicationController
   include LoginHelper
+  include Carto::EmailCleaner
 
   layout 'frontend'
   ssl_required :new, :create, :destroy, :show, :unauthenticated, :account_token_authentication_error,
@@ -206,7 +208,7 @@ class SessionsController < ApplicationController
   end
 
   def username_from_user_by_email(email)
-    ::User.where(email: email).first.try(:username)
+    ::User.where(email: clean_email(email)).first.try(:username)
   end
 
   def ldap_strategy_username

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,7 +230,7 @@ class User < Sequel::Model
 
   ## Callbacks
   def before_validation
-    self.email = clean_email(email)
+    self.email = clean_email(email.to_s)
     self.geocoding_quota ||= DEFAULT_GEOCODING_QUOTA
     self.here_isolines_quota ||= DEFAULT_HERE_ISOLINES_QUOTA
     self.obs_snapshot_quota ||= DEFAULT_OBS_SNAPSHOT_QUOTA

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,7 @@ require_dependency 'carto/helpers/has_connector_configuration'
 require_dependency 'carto/helpers/batch_queries_statement_timeout'
 require_dependency 'carto/user_authenticator'
 require_dependency 'carto/helpers/billing_cycle'
+require_dependency 'carto/email_cleaner'
 require_dependency 'carto/visualization'
 
 class User < Sequel::Model
@@ -33,6 +34,7 @@ class User < Sequel::Model
   include Carto::HasConnectorConfiguration
   include Carto::BatchQueriesStatementTimeout
   include Carto::BillingCycle
+  include Carto::EmailCleaner
   extend Carto::UserAuthenticator
 
   self.strict_param_setting = false
@@ -228,7 +230,7 @@ class User < Sequel::Model
 
   ## Callbacks
   def before_validation
-    self.email = self.email.to_s.strip.downcase
+    self.email = clean_email(email)
     self.geocoding_quota ||= DEFAULT_GEOCODING_QUOTA
     self.here_isolines_quota ||= DEFAULT_HERE_ISOLINES_QUOTA
     self.obs_snapshot_quota ||= DEFAULT_OBS_SNAPSHOT_QUOTA

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -262,7 +262,7 @@ Warden::Strategies.add(:saml) do
     saml_service = Carto::SamlService.new(organization)
 
     email = saml_service.get_user_email(params[:SAMLResponse])
-    user = organization.users.where(email: email.strip.downcase).first
+    user = organization.users.where(email: email).first
 
     if user
       if user.try(:enabled?)

--- a/lib/carto/email_cleaner.rb
+++ b/lib/carto/email_cleaner.rb
@@ -1,0 +1,5 @@
+module Carto::EmailCleaner
+  def clean_email(email)
+    email.strip.downcase
+  end
+end

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -18,7 +18,7 @@ module Carto
 
     def get_user_email(saml_response_param)
       response = get_saml_response(saml_response_param)
-      response.is_valid? && email_from_saml_response(response).try(:strip).try(:downcase)
+      response.is_valid? && email_from_saml_response(response)
     rescue OneLogin::RubySaml::ValidationError
       debug_response("Invalid SAML response", response)
     end

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -76,7 +76,6 @@ module Carto
     private
 
     def email_from_saml_response(saml_response)
-      CartoDB::Logger.info(message: 'SAML attributes', attributes: saml_response.attributes.to_h)
       email = saml_response.attributes[email_attribute]
 
       email.present? ? email : debug_response("SAML response lacks email", saml_response)
@@ -88,7 +87,8 @@ module Carto
         response_settings: response.settings.to_json,
         response_options: response.options,
         response_errors: response.errors,
-        response_body: response.response
+        response_body: response.response,
+        response_attributes: response.attributes.try(:to_h)
       )
       nil
     end

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -18,7 +18,7 @@ module Carto
 
     def get_user_email(saml_response_param)
       response = get_saml_response(saml_response_param)
-      response.is_valid? && email_from_saml_response(response)
+      response.is_valid? && email_from_saml_response(response).try(:strip).try(:downcase)
     rescue OneLogin::RubySaml::ValidationError
       debug_response("Invalid SAML response", response)
     end
@@ -76,6 +76,7 @@ module Carto
     private
 
     def email_from_saml_response(saml_response)
+      CartoDB::Logger.info(message: 'SAML attributes', attributes: saml_response.attributes.to_h)
       email = saml_response.attributes[email_attribute]
 
       email.present? ? email : debug_response("SAML response lacks email", saml_response)
@@ -86,7 +87,8 @@ module Carto
         message: message,
         response_settings: response.settings.to_json,
         response_options: response.options,
-        response_errors: response.errors
+        response_errors: response.errors,
+        response_body: response.response
       )
       nil
     end

--- a/lib/google_plus_api.rb
+++ b/lib/google_plus_api.rb
@@ -1,8 +1,10 @@
 require_dependency 'google_plus_api_user_data'
 require_dependency 'google_plus_config'
 require_relative 'carto/http/client'
+require_dependency 'carto/email_cleaner'
 
 class GooglePlusAPI
+  include Carto::EmailCleaner
 
   def get_user_data(access_token)
     response = request_user_data(access_token)
@@ -21,7 +23,7 @@ class GooglePlusAPI
   def get_user(access_token)
     google_user_data = GooglePlusAPI.new.get_user_data(access_token)
     # INFO: we assume if a user is queried at a CartoDB instance, user is local
-    google_user_data.present? ? ::User.where(email: google_user_data.email).first : false
+    google_user_data.present? ? ::User.where(email: clean_email(google_user_data.email)).first : false
   end
 
   def request_user_data(access_token)
@@ -35,5 +37,3 @@ class GooglePlusAPI
   end
 
 end
-
-

--- a/spec/lib/carto/saml_service_spec.rb
+++ b/spec/lib/carto/saml_service_spec.rb
@@ -63,13 +63,6 @@ describe Carto::SamlService do
 
         user.delete
       end
-
-      it 'returns a downcased user email (matches User.before_validation behaviour)' do
-        response_mock.stubs(:is_valid?).returns(true)
-        response_mock.stubs(:attributes).returns(saml_config[:email_attribute] => ' Juan.Perez@example.com')
-
-        service.get_user_email(saml_response_param_mock).should eq 'juan.perez@example.com'
-      end
     end
 
     def create_test_saml_user

--- a/spec/lib/carto/saml_service_spec.rb
+++ b/spec/lib/carto/saml_service_spec.rb
@@ -63,6 +63,13 @@ describe Carto::SamlService do
 
         user.delete
       end
+
+      it 'returns a downcased user email (matches User.before_validation behaviour)' do
+        response_mock.stubs(:is_valid?).returns(true)
+        response_mock.stubs(:attributes).returns(saml_config[:email_attribute] => ' Juan.Perez@example.com')
+
+        service.get_user_email(saml_response_param_mock).should eq 'juan.perez@example.com'
+      end
     end
 
     def create_test_saml_user

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -362,6 +362,19 @@ describe SessionsController do
       response.status.should == 403
     end
 
+    it "authenticates users with casing differences in email" do
+      Carto::SamlService.any_instance.stubs(:enabled?).returns(true)
+      Carto::SamlService.any_instance.stubs(:get_user_email).returns(@user.email.upcase)
+
+      post create_session_url(user_domain: user_domain, SAMLResponse: 'xx')
+
+      response.status.should eq 302
+
+      # Double check authentication is correct
+      get response.redirect_url
+      response.status.should eq 200
+    end
+
     describe 'SAML logout' do
       it 'calls SamlService#sp_logout_request from user-initiated logout' do
         stub_saml_service(@user)


### PR DESCRIPTION
The reason that this is required is that the email in the authentication methods is used to [query the database](https://github.com/CartoDB/cartodb/blob/master/app/controllers/sessions_controller.rb#L209) for the corresponding username, in order to set the correct warden scope. The returned email should match [validation rules](https://github.com/CartoDB/cartodb/blob/master/app/models/user.rb#L231)

Without this, the scope was being set to :default on login when the SAML IdP server sent an uppercase email, causing login to fail to set the correct cookies (and redirect from login to dashboard to login)

Fixes #12365 