### PR TITLE
Select only files at Dropbox search results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ Development
 * Fixed legend's color mismatch with empty values (#11632)
 * Fixed overlay for legends view (#11825)
 * Fix error when revoking a Dropbox token that was revoked from Dropbox side (#12359)
+* Fix error when a Dropbox folder has an extension matching valid extensions.
 * Fixed UI when editing merge analysis (#10850)
 * Fixed uninitialized constant in Carto::Visualization when a viewer shares a visualization (#12129).
 * Fix regenerate all api keys in an organization (#12218)

--- a/services/datasources/lib/datasources/url/dropbox.rb
+++ b/services/datasources/lib/datasources/url/dropbox.rb
@@ -122,7 +122,7 @@ module CartoDB
 
           @formats.each do |search_query|
             response = @client.search(search_query, '')
-            response.matches.each do |item|
+            response.matches.select { |item| item.resource.is_a?(DropboxApi::Metadata::File) }.each do |item|
               all_results.push(format_item_data(item.resource))
             end
           end


### PR DESCRIPTION
This fixes CartoDB/support/issues/801.

I first try to fix it at API level, but [there's no option for excluding folders](https://www.dropbox.com/developers/documentation/http/documentation#files-search).