### PR TITLE
12326 export missing models org exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/services/carto/user_table_index_service_spec.rb \
 	spec/services/carto/user_metadata_export_service_spec.rb \
 	spec/services/carto/organization_metadata_export_service_spec.rb \
+	spec/services/carto/redis_export_service_spec.rb \
 	spec/lib/carto/strong_password_validator_spec.rb \
 	spec/lib/initializers/zz_patch_reconnect_spec.rb \
 	spec/lib/cartodb/redis_vizjson_cache_spec.rb \

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@ Development
 
 ### Features
 * New loading button styles (#12132)
-* [WIP] Export/import organization/user metadata to allow user migration (#12271, #12304, #12323)
+* [WIP] Export/import organization/user metadata to allow user migration (#12271, #12304, #12323, #12380)
 * New force param in EUMAPI organization users destroy operation to force deletion even with unregistered tables (#11654).
 * Removed the usage of the `organizations_admin` feature flag (#12131)
 * Show number of selected items in Time-Series widgets (#12179).

--- a/app/models/carto/group.rb
+++ b/app/models/carto/group.rb
@@ -24,8 +24,6 @@ module Carto
     has_many :users_group, dependent: :destroy, class_name: Carto::UsersGroup
     has_many :users, through: :users_group
 
-    private_class_method :new
-
     validates :name, :database_role, :organization_id, presence: true
 
     # Constructor for groups already existing in the database

--- a/app/models/carto/group.rb
+++ b/app/models/carto/group.rb
@@ -52,6 +52,16 @@ module Carto
       group
     end
 
+    # Constructor for groups metadata, ignores database roles. Should be generally avoided.
+    def self.new_instance_without_validation(name:, database_role:, display_name: name, auth_token: nil)
+      new(
+        name: name,
+        display_name: display_name,
+        database_role: database_role,
+        auth_token: auth_token
+      )
+    end
+
     def rename_group_with_extension(new_display_name)
       raise CartoDB::ModelAlreadyExistsError if Group.find_by_organization_id_and_display_name(organization.id, new_display_name)
 

--- a/app/models/carto/group.rb
+++ b/app/models/carto/group.rb
@@ -24,6 +24,8 @@ module Carto
     has_many :users_group, dependent: :destroy, class_name: Carto::UsersGroup
     has_many :users, through: :users_group
 
+    private_class_method :new
+
     validates :name, :database_role, :organization, presence: true
 
     # Constructor for groups already existing in the database

--- a/app/models/carto/group.rb
+++ b/app/models/carto/group.rb
@@ -24,7 +24,7 @@ module Carto
     has_many :users_group, dependent: :destroy, class_name: Carto::UsersGroup
     has_many :users, through: :users_group
 
-    validates :name, :database_role, :organization_id, presence: true
+    validates :name, :database_role, :organization, presence: true
 
     # Constructor for groups already existing in the database
     def self.new_instance(database_name, name, database_role, display_name = name)

--- a/app/models/carto/notification.rb
+++ b/app/models/carto/notification.rb
@@ -29,6 +29,8 @@ module Carto
 
     def send_to_organization_members
       return unless organization
+      # This avoids resending an already sent notification. Example: importing notifications
+      return unless received_notifications.empty?
       users = if recipients == 'builders'
                 organization.builder_users
               elsif recipients == 'viewers'

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -177,8 +177,8 @@ module Carto
       organization_json = export_organization_json_string(organization_id)
       root_dir.join("organization_#{organization_id}.json").open('w') { |file| file.write(organization_json) }
 
-      redis_json = Carto::RedisExportService.new.export_organizatio_json_string(user_id)
-      root_dir.join("redis_organization_#{user_id}.json").open('w') { |file| file.write(redis_json) }
+      redis_json = Carto::RedisExportService.new.export_organization_json_string(organization_id)
+      root_dir.join("redis_organization_#{organization_id}.json").open('w') { |file| file.write(redis_json) }
 
       # Export users
       organization.users.each do |user|
@@ -193,8 +193,8 @@ module Carto
       organization_file = Dir["#{path}/organization_*.json"].first
       organization = build_organization_from_json_export(File.read(organization_file))
 
-      organization_file = Dir["#{path}/redis_organization_*.json"].first
-      Carto::RedisExportService.new.restore_redis_from_json_export(organization_file)
+      organization_redis_file = Dir["#{path}/redis_organization_*.json"].first
+      Carto::RedisExportService.new.restore_redis_from_json_export(File.read(organization_redis_file))
 
       # Groups and notifications must be saved after users
       groups = organization.groups.dup

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -74,6 +74,7 @@ module Carto
         auth_token: exported_group[:auth_token]
       )
       g.users_group = exported_group[:user_ids].map { |uid| UsersGroup.new(user_id: uid) }
+      g.id = exported_group[:id]
 
       g
     end
@@ -136,6 +137,7 @@ module Carto
 
     def export_group(group)
       {
+        id: group.id,
         name: group.name,
         display_name: group.display_name,
         database_role: group.database_role,

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -177,6 +177,9 @@ module Carto
       organization_json = export_organization_json_string(organization_id)
       root_dir.join("organization_#{organization_id}.json").open('w') { |file| file.write(organization_json) }
 
+      redis_json = Carto::RedisExportService.new.export_organizatio_json_string(user_id)
+      root_dir.join("redis_organization_#{user_id}.json").open('w') { |file| file.write(redis_json) }
+
       # Export users
       organization.users.each do |user|
         user_path = root_dir.join("user_#{user.id}")
@@ -189,6 +192,9 @@ module Carto
       # Import organization
       organization_file = Dir["#{path}/organization_*.json"].first
       organization = build_organization_from_json_export(File.read(organization_file))
+
+      organization_file = Dir["#{path}/redis_organization_*.json"].first
+      Carto::RedisExportService.new.restore_redis_from_json_export(organization_file)
 
       # Groups and notifications must be saved after users
       groups = organization.groups.dup

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -38,6 +38,7 @@ module Carto
     end
 
     def save_imported_organization(organization)
+      organization.groups.each { |g| g.users_group.clear }
       organization.save!
       ::Organization[organization.id].after_save
     end

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -69,13 +69,15 @@ module Carto
     end
 
     def build_group_from_hash(exported_group)
-      Group.new(
+      g = Group.new_instance_without_validation(
         name: exported_group[:name],
         display_name: exported_group[:display_name],
         database_role: exported_group[:database_role],
-        auth_token: exported_group[:auth_token],
-        users_group: exported_group[:users].map { |uid| UsersGroup.new(user_id: uid) }
+        auth_token: exported_group[:auth_token]
       )
+      g.users_group = exported_group[:user_ids].map { |uid| UsersGroup.new(user_id: uid) }
+
+      g
     end
 
     def build_notification_from_hash(notification)
@@ -140,7 +142,7 @@ module Carto
         display_name: group.display_name,
         database_role: group.database_role,
         auth_token: group.auth_token,
-        users: group.users.map(&:id)
+        user_ids: group.users.map(&:id)
       }
     end
 

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -48,6 +48,7 @@ module Carto
       organization = Organization.new(exported_organization.slice(*EXPORTED_ORGANIZATION_ATTRIBUTES))
 
       organization.assets = exported_organization[:assets].map { |asset| build_asset_from_hash(asset.symbolize_keys) }
+      organization.groups = exported_organization[:groups].map { |group| build_group_from_hash(group.symbolize_keys) }
 
       # Must be the last one to avoid attribute assignments to try to run SQL
       organization.id = exported_organization[:id]
@@ -59,6 +60,15 @@ module Carto
         public_url: exported_asset[:public_url],
         kind: exported_asset[:kind],
         storage_info: exported_asset[:storage_info]
+      )
+    end
+
+    def build_group_from_hash(exported_group)
+      Group.new(
+        name: exported_group[:name],
+        display_name: exported_group[:display_name],
+        database_role: exported_group[:database_role],
+        auth_token: exported_group[:auth_token]
       )
     end
   end
@@ -84,6 +94,7 @@ module Carto
       organization_hash = EXPORTED_ORGANIZATION_ATTRIBUTES.map { |att| [att, organization.attributes[att.to_s]] }.to_h
 
       organization_hash[:assets] = organization.assets.map { |a| export_asset(a) }
+      organization_hash[:groups] = organization.groups.map { |g| export_group(g) }
 
       organization_hash
     end
@@ -93,6 +104,15 @@ module Carto
         public_url: asset.public_url,
         kind: asset.kind,
         storage_info: asset.storage_info
+      }
+    end
+
+    def export_group(group)
+      {
+        name: group.name,
+        display_name: group.display_name,
+        database_role: group.database_role,
+        auth_token: group.auth_token
       }
     end
   end

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -37,14 +37,12 @@ module Carto
       build_organization_from_hash(exported_hash[:organization])
     end
 
+    private
+
     def save_imported_organization(organization)
-      organization.groups.each { |g| g.users_group.clear }
-      organization.notifications.each { |n| n.received_notifications.clear }
       organization.save!
       ::Organization[organization.id].after_save
     end
-
-    private
 
     def build_organization_from_hash(exported_organization)
       organization = Organization.new(exported_organization.slice(*EXPORTED_ORGANIZATION_ATTRIBUTES))

--- a/app/services/carto/redis_export_service.rb
+++ b/app/services/carto/redis_export_service.rb
@@ -77,7 +77,7 @@ module Carto
     end
 
     def export_dataservices(prefix)
-      $users_metadata.keys("#{prefix}:*").map { |key| export_key($users_metadata, key) }.reduce(&:merge)
+      $users_metadata.keys("#{prefix}:*").map { |key| export_key($users_metadata, key) }.reduce({}, &:merge)
     end
 
     def export_key(redis_db, key)

--- a/app/services/carto/redis_export_service.rb
+++ b/app/services/carto/redis_export_service.rb
@@ -1,0 +1,99 @@
+require 'json'
+
+# Version History
+# 1.0.0: export organization metadata
+module Carto
+  module RedisExportServiceConfiguration
+    CURRENT_VERSION = '1.0.0'.freeze
+
+    def compatible_version?(version)
+      version.to_i == CURRENT_VERSION.split('.')[0].to_i
+    end
+  end
+
+  module RedisExportServiceImporter
+    include RedisExportServiceConfiguration
+
+    def restore_redis_from_json_export(exported_json_string)
+      restore_redis_from_hash_export(JSON.parse(exported_json_string).deep_symbolize_keys)
+    end
+
+    def restore_redis_from_hash_export(exported_hash)
+      raise 'Wrong export version' unless compatible_version?(exported_hash[:version])
+
+      restore_redis(exported_hash[:redis])
+    end
+
+    private
+
+    def restore_redis(redis_export)
+      restore_keys($users_metadata, redis_export[:users_metadata])
+    end
+
+    def restore_keys(redis_db, redis_keys)
+      redis_keys.each do |key, value|
+        redis_db.restore(key, value[:ttl], Base64.decode64(value[:value]))
+      end
+    end
+  end
+
+  module RedisExportServiceExporter
+    include RedisExportServiceConfiguration
+
+    def export_organization_json_string(organization_id)
+      export_organization_json_hash(organization_id).to_json
+    end
+
+    def export_organization_json_hash(organization_id)
+      {
+        version: CURRENT_VERSION,
+        redis: export_organization(Organization.find(organization_id))
+      }
+    end
+
+    def export_user_json_string(user_id)
+      export_user_json_hash(user_id).to_json
+    end
+
+    def export_user_json_hash(user_id)
+      {
+        version: CURRENT_VERSION,
+        redis: export_user(User.find(user_id))
+      }
+    end
+
+    private
+
+    def export_organization(organization)
+      {
+        users_metadata: export_dataservices("org:#{organization.name}")
+      }
+    end
+
+    def export_user(user)
+      {
+        users_metadata: export_dataservices("user:#{user.username}")
+      }
+    end
+
+    def export_dataservices(prefix)
+      $users_metadata.keys("#{prefix}:*").map { |key| export_key($users_metadata, key) }.reduce(&:merge)
+    end
+
+    def export_key(redis_db, key)
+      {
+        key => {
+          ttl: [0, redis_db.pttl(key)].max, # PTTL returns -1 if not set, clamp to 0
+          value: Base64.encode64(redis_db.dump(key))
+        }
+      }
+    end
+  end
+
+  # Both String and Hash versions are provided because `deep_symbolize_keys` won't symbolize through arrays
+  # and having separated methods make handling and testing much easier.
+  class RedisExportService
+    include RedisExportServiceImporter
+    include RedisExportServiceExporter
+  end
+end

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -141,6 +141,9 @@ module Carto
       user_json = export_user_json_string(user_id)
       root_dir.join("user_#{user_id}.json").open('w') { |file| file.write(user_json) }
 
+      redis_json = Carto::RedisExportService.new.export_user_json_string(user_id)
+      root_dir.join("redis_user_#{user_id}.json").open('w') { |file| file.write(redis_json) }
+
       # Export visualizations (include type in the name to be able to import datasets before maps)
       export_user_visualizations_to_directory(user, Carto::Visualization::TYPE_CANONICAL, path)
       export_user_visualizations_to_directory(user, Carto::Visualization::TYPE_DERIVED, path)
@@ -151,6 +154,8 @@ module Carto
       user_file = Dir["#{path}/user_*.json"].first
       user = build_user_from_json_export(File.read(user_file))
       save_imported_user(user)
+
+      Carto::RedisExportService.new.restore_redis_from_json_export(File.read(Dir["#{path}/redis_user_*.json"].first))
 
       if import_visualizations
         with_non_viewer_user(user) do

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -190,7 +190,6 @@ module Carto
       end
 
       yield
-
     ensure
       if was_viewer
         user.update_attributes(viewer: true)

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -158,19 +158,19 @@ module Carto
       Carto::RedisExportService.new.restore_redis_from_json_export(File.read(Dir["#{path}/redis_user_*.json"].first))
 
       if import_visualizations
-        with_non_viewer_user(user) do
-          import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_CANONICAL, path)
-          import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_DERIVED, path)
-        end
+        import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_CANONICAL, path)
+        import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_DERIVED, path)
       end
 
       user
     end
 
     def import_user_visualizations_from_directory(user, type, path)
-      Dir["#{path}/#{type}_*#{Carto::VisualizationExporter::EXPORT_EXTENSION}"].each do |filename|
-        imported_vis = Carto::VisualizationsExportService2.new.build_visualization_from_json_export(File.read(filename))
-        Carto::VisualizationsExportPersistenceService.new.save_import(user, imported_vis, full_restore: true)
+      with_non_viewer_user(user) do
+        Dir["#{path}/#{type}_*#{Carto::VisualizationExporter::EXPORT_EXTENSION}"].each do |fname|
+          imported_vis = Carto::VisualizationsExportService2.new.build_visualization_from_json_export(File.read(fname))
+          Carto::VisualizationsExportPersistenceService.new.save_import(user, imported_vis, full_restore: true)
+        end
       end
     end
 

--- a/lib/tasks/user_migrator.rake
+++ b/lib/tasks/user_migrator.rake
@@ -1,0 +1,57 @@
+require_relative '../../services/user-mover/export_user.rb'
+require_relative '../../services/user-mover/import_user.rb'
+require_relative '../../app/services/carto/organization_metadata_export_service'
+
+namespace :cartodb do
+  namespace :user_migrator do
+    namespace :export do
+      desc 'Export an organization'
+      task :organization, [:orgname] => :environment do |_task, args|
+        organization = Carto::Organization.find_by_name(args[:orgname])
+        work_dir = Cartodb.get_config(:user_migrator, 'user_exports_folder') || '/tmp'
+        path = "#{work_dir}/#{organization.id}"
+
+        FileUtils.mkdir_p(path + '/data')
+        FileUtils.mkdir_p(path + '/meta')
+
+        CartoDB::DataMover::ExportJob.new(
+          organization_name: organization.name,
+          schema_mode: true,
+          split_user_schemas: true,
+          path: path + '/data/'
+        )
+        Carto::OrganizationMetadataExportService.new.export_organization_to_directory(organization.id, path + '/meta')
+
+        `cd #{work_dir}/ && zip -0 -r \"#{organization.id}.zip\" #{organization.id} && cd -`
+        FileUtils.remove_dir(path)
+        puts "Exported to #{work_dir}/#{organization.id}.zip"
+      end
+    end
+
+    namespace :import do
+      desc 'Import an organization'
+      task :organization, [:export_file] => :environment do |_task, args|
+        export_file = args[:export_file]
+        Dir.mktmpdir do |work_dir|
+          `cd #{work_dir}/ && unzip -u #{export_file} && cd -`
+          path = Dir["#{work_dir}/*"].first
+
+          service = Carto::OrganizationMetadataExportService.new
+          imported_organization = service.import_organization_and_users_from_directory("#{path}/meta")
+          CartoDB::DataMover::ImportJob.new(
+            file: Dir["#{path}/data/org*json"].first,
+            data: true,
+            metadata: false,
+            host: '127.0.0.1',
+            rollback: false,
+            mode: :import,
+            set_banner: false
+          ).run!
+          service.import_organization_visualizations_from_directory(imported_organization, "#{path}/meta")
+
+          imported_organization.users.each { |u| u.update_attribute(:last_common_data_update_date, nil) }
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/user_migrator.rake
+++ b/lib/tasks/user_migrator.rake
@@ -30,7 +30,7 @@ namespace :cartodb do
 
     namespace :import do
       desc 'Import an organization'
-      task :organization, [:export_file] => :environment do |_task, args|
+      task :organization, [:export_file, :database_ip] => :environment do |_task, args|
         export_file = args[:export_file]
         Dir.mktmpdir do |work_dir|
           `cd #{work_dir}/ && unzip -u #{export_file} && cd -`
@@ -42,7 +42,7 @@ namespace :cartodb do
             file: Dir["#{path}/data/org*json"].first,
             data: true,
             metadata: false,
-            host: '127.0.0.1',
+            host: args[:database_ip],
             rollback: false,
             mode: :import,
             set_banner: false

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -72,23 +72,6 @@ describe Carto::OrganizationMetadataExportService do
     end
   end
 
-  describe '#organization export + import' do
-    it 'export + import' do
-      create_organization_with_dependencies
-      export = service.export_organization_json_hash(@organization.id)
-      expect_export_matches_organization(export[:organization], @organization)
-      source_organization = @organization.attributes
-      destroy_organization
-
-      imported_organization = service.build_organization_from_hash_export(export)
-      service.save_imported_organization(imported_organization)
-      imported_organization.reload
-
-      expect_export_matches_organization(export[:organization], imported_organization)
-      compare_excluding_dates(imported_organization.attributes, source_organization)
-    end
-  end
-
   describe '#full export + import (organization, users and visualizations)' do
     it 'export + import organization, users and visualizations' do
       Dir.mktmpdir do |path|

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -262,7 +262,7 @@ describe Carto::OrganizationMetadataExportService do
             display_name: '#group',
             database_role: 'a98f3bc6391fadfe4d1487e2b6912d24_g_g_group',
             auth_token: 'TE7rg6_4RU8vAeTeEeITIQ',
-            users: []
+            user_ids: []
           }
         ],
         notifications: [

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -20,6 +20,8 @@ describe Carto::OrganizationMetadataExportService do
     @group = FactoryGirl.create(:carto_group, organization: @organization)
     @group.add_user(@non_owner.username)
 
+    FactoryGirl.create(:notification, organization: @organization)
+
     @organization.reload
   end
 
@@ -134,10 +136,19 @@ describe Carto::OrganizationMetadataExportService do
     end
 
     expect(export[:assets].count).to eq organization.assets.size
-    export[:assets].zip(organization.assets).each { |exported_asset, asset| expect_export_matches_asset(exported_asset, asset) }
+    export[:assets].zip(organization.assets).each do |exported_asset, asset|
+      expect_export_matches_asset(exported_asset, asset)
+    end
 
     expect(export[:groups].count).to eq organization.groups.size
-    export[:groups].zip(organization.groups).each { |exported_group, group| expect_export_matches_group(exported_group, group) }
+    export[:groups].zip(organization.groups).each do |exported_group, group|
+      expect_export_matches_group(exported_group, group)
+    end
+
+    expect(export[:notifications].count).to eq organization.notifications.size
+    export[:notifications].zip(organization.notifications).each do |exported_notification, notification|
+      expect_export_matches_notification(exported_notification, notification)
+    end
   end
 
   def expect_export_matches_asset(exported_asset, asset)
@@ -151,6 +162,19 @@ describe Carto::OrganizationMetadataExportService do
     expect(exported_group[:display_name]).to eq group.display_name
     expect(exported_group[:database_role]).to eq group.database_role
     expect(exported_group[:auth_token]).to eq group.auth_token
+  end
+
+  def expect_export_matches_notification(exported_notification, notification)
+    expect(exported_notification[:icon]).to eq notification.icon
+    expect(exported_notification[:recipients]).to eq notification.recipients
+    expect(exported_notification[:body]).to eq notification.body
+    expect(exported_notification[:created_at]).to eq notification.created_at
+  end
+
+  def expect_export_matches_received_notification(exported_received_notification, received_notification)
+    expect(exported_received_notification[:user_id]).to eq received_notification.user_id
+    expect(exported_received_notification[:received_at]).to eq received_notification.received_at
+    expect(exported_received_notification[:read_at]).to eq received_notification.read_at
   end
 
   let(:full_export) do
@@ -216,13 +240,24 @@ describe Carto::OrganizationMetadataExportService do
             identifier: "public/uploads/organization_assets/189d642c-c7da-40aa-bffd-517aa0eb7999/asset_download_148430456220170113-20961-67b7r0"
           }
         }],
-        groups: [{
-          name: 'g_group',
-          display_name: '#group',
-          database_role: 'a98f3bc6391fadfe4d1487e2b6912d24_g_g_group',
-          auth_token: 'TE7rg6_4RU8vAeTeEeITIQ',
-          users: []
-        }]
+        groups: [
+          {
+            name: 'g_group',
+            display_name: '#group',
+            database_role: 'a98f3bc6391fadfe4d1487e2b6912d24_g_g_group',
+            auth_token: 'TE7rg6_4RU8vAeTeEeITIQ',
+            users: []
+          }
+        ],
+        notifications: [
+          {
+            icon: "alert",
+            recipients: "all",
+            body: "Empty body",
+            created_at: DateTime.now,
+            received_by: []
+          }
+        ]
       }
     }
   end

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -114,12 +114,22 @@ describe Carto::OrganizationMetadataExportService do
 
     expect(export[:assets].count).to eq organization.assets.size
     export[:assets].zip(organization.assets).each { |exported_asset, asset| expect_export_matches_asset(exported_asset, asset) }
+
+    expect(export[:groups].count).to eq organization.groups.size
+    export[:groups].zip(organization.groups).each { |exported_group, group| expect_export_matches_group(exported_group, group) }
   end
 
   def expect_export_matches_asset(exported_asset, asset)
     expect(exported_asset[:public_url]).to eq asset.public_url
     expect(exported_asset[:kind]).to eq asset.kind
     expect(exported_asset[:storage_info]).to eq asset.storage_info
+  end
+
+  def expect_export_matches_group(exported_group, group)
+    expect(exported_group[:name]).to eq group.name
+    expect(exported_group[:display_name]).to eq group.display_name
+    expect(exported_group[:database_role]).to eq group.database_role
+    expect(exported_group[:auth_token]).to eq group.auth_token
   end
 
   let(:full_export) do
@@ -184,6 +194,12 @@ describe Carto::OrganizationMetadataExportService do
             location: "organization_assets",
             identifier: "public/uploads/organization_assets/189d642c-c7da-40aa-bffd-517aa0eb7999/asset_download_148430456220170113-20961-67b7r0"
           }
+        }],
+        groups: [{
+          name: 'g_group',
+          display_name: '#group',
+          database_role: 'a98f3bc6391fadfe4d1487e2b6912d24_g_g_group',
+          auth_token: 'TE7rg6_4RU8vAeTeEeITIQ'
         }]
       }
     }

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -24,6 +24,8 @@ describe Carto::OrganizationMetadataExportService do
   end
 
   def destroy_organization
+    @organization.groups.each(&:destroy)
+    @organization.groups.clear
     Organization[@organization.id].destroy_cascade
   end
 
@@ -218,7 +220,8 @@ describe Carto::OrganizationMetadataExportService do
           name: 'g_group',
           display_name: '#group',
           database_role: 'a98f3bc6391fadfe4d1487e2b6912d24_g_g_group',
-          auth_token: 'TE7rg6_4RU8vAeTeEeITIQ'
+          auth_token: 'TE7rg6_4RU8vAeTeEeITIQ',
+          users: []
         }]
       }
     }

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -152,6 +152,7 @@ describe Carto::OrganizationMetadataExportService do
   end
 
   def expect_export_matches_group(exported_group, group)
+    expect(exported_group[:id]).to eq group.id
     expect(exported_group[:name]).to eq group.name
     expect(exported_group[:display_name]).to eq group.display_name
     expect(exported_group[:database_role]).to eq group.database_role

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -126,7 +126,8 @@ describe Carto::OrganizationMetadataExportService do
           compare_excluding_fields(
             stringify_fields(i_n.attributes, ['created_at']),
             stringify_fields(s_n, ['created_at']),
-            EXCLUDED_NOTIFICATIONS_FIELDS)
+            EXCLUDED_NOTIFICATIONS_FIELDS
+          )
           i_received = i_n.received_notifications.map(&:attributes)
           s_received = source_received_notifications[s_n['id']]
 
@@ -136,7 +137,8 @@ describe Carto::OrganizationMetadataExportService do
             compare_excluding_fields(
               stringify_fields(i_rn, ['received_at', 'read_at']),
               stringify_fields(s_rn, ['received_at', 'read_at']),
-              ['id', 'notification_id'])
+              ['id', 'notification_id']
+            )
           end
         end
       end
@@ -206,9 +208,9 @@ describe Carto::OrganizationMetadataExportService do
     expect(exported_notification[:received_by].length).to be > 0
     expect(exported_notification[:received_by].length).to eq notification.received_notifications.length
     exported_notification[:received_by].each do |exported_received_notification|
-      received_notification = notification.received_notifications.find { |rn|
+      received_notification = notification.received_notifications.find do |rn|
         rn.user_id == exported_received_notification[:user_id]
-      }
+      end
       expect(exported_received_notification[:received_at]).to eq received_notification.received_at
       expect(exported_received_notification[:read_at]).to eq received_notification.read_at
     end

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -121,18 +121,18 @@ describe Carto::OrganizationMetadataExportService do
         expect(imported_organization.groups.count).to eq source_groups.count
         expect_redis_restored(imported_organization)
         imported_organization.groups.zip(source_groups).each do |g1, g2|
-          compare_excluding_fields(g1.attributes, g2, EXCLUDED_DATE_FIELDS + EXCLUDED_ID_FIELDS)
+          compare_excluding_fields(g1.attributes, g2, EXCLUDED_ORG_META_DATE_FIELDS + EXCLUDED_ORG_META_ID_FIELDS)
         end
         expect(imported_organization.groups.first.users.map(&:id)).to eq source_group_users
       end
     end
   end
 
-  EXCLUDED_DATE_FIELDS = ['created_at', 'updated_at', 'period_end_date'].freeze
-  EXCLUDED_ID_FIELDS = ['id', 'organization_id'].freeze
+  EXCLUDED_ORG_META_DATE_FIELDS = ['created_at', 'updated_at', 'period_end_date'].freeze
+  EXCLUDED_ORG_META_ID_FIELDS = ['id', 'organization_id'].freeze
 
   def compare_excluding_dates(u1, u2)
-    compare_excluding_fields(u1, u2, EXCLUDED_DATE_FIELDS)
+    compare_excluding_fields(u1, u2, EXCLUDED_ORG_META_DATE_FIELDS)
   end
 
   def compare_excluding_fields(u1, u2, fields)

--- a/spec/services/carto/redis_export_service_spec.rb
+++ b/spec/services/carto/redis_export_service_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper_min'
+
+describe Carto::RedisExportService do
+  before(:all) do
+    sequel_organization = FactoryGirl.create(:organization)
+    @organization = Carto::Organization.find(sequel_organization.id)
+    @user = FactoryGirl.create(:carto_user)
+  end
+
+  after(:all) do
+    @organization.destroy
+    @user.destroy
+  end
+
+  def with_redis_keys(prefix)
+    $users_metadata.set("#{prefix}:string", 'something')
+    $users_metadata.zincrby("#{prefix}:set", 5, 'set_key')
+    $users_metadata.hset("#{prefix}:hash", 'hash_key', 'qwerty')
+
+    yield
+  ensure
+    $users_metadata.del("#{prefix}:string", "#{prefix}:set", "#{prefix}:hash")
+  end
+
+  def check_export(export, prefix)
+    expect(export[:redis][:users_metadata].keys.sort).to eq(["#{prefix}:hash", "#{prefix}:set", "#{prefix}:string"])
+  end
+
+  def check_redis(prefix)
+    expect($users_metadata.get("#{prefix}:string")).to eq('something')
+    expect($users_metadata.zrange("#{prefix}:set", 0, -1, withscores: true)).to eq([['set_key', 5.0]])
+    expect($users_metadata.hgetall("#{prefix}:hash")).to eq('hash_key' => 'qwerty')
+  end
+
+  let(:service) { Carto::RedisExportService.new }
+
+  describe '#export' do
+    it 'includes all keys under org:name for organizations' do
+      prefix = "org:#{@organization.name}"
+      with_redis_keys(prefix) do
+        export = service.export_organization_json_hash(@organization.id)
+        check_export(export, prefix)
+      end
+    end
+
+    it 'includes all keys under user:username for users' do
+      prefix = "user:#{@user.username}"
+      with_redis_keys(prefix) do
+        export = service.export_user_json_hash(@user.id)
+        check_export(export, prefix)
+      end
+    end
+  end
+
+  describe '#export + import' do
+    it 'copies all keys under org:name for organizations' do
+      prefix = "org:#{@organization.name}"
+      export = with_redis_keys(prefix) { service.export_organization_json_hash(@organization.id) }
+      service.restore_redis_from_hash_export(export)
+      check_redis(prefix)
+    end
+
+    it 'copies all keys under user:username for users' do
+      prefix = "user:#{@user.username}"
+      export = with_redis_keys(prefix) { service.export_user_json_hash(@user.id) }
+      service.restore_redis_from_hash_export(export)
+      check_redis(prefix)
+    end
+  end
+end

--- a/spec/services/carto/redis_export_service_spec.rb
+++ b/spec/services/carto/redis_export_service_spec.rb
@@ -35,6 +35,11 @@ describe Carto::RedisExportService do
   let(:service) { Carto::RedisExportService.new }
 
   describe '#export' do
+    it 'exports an empty dictionary' do
+      export = service.export_user_json_hash(@user.id)
+      expect(export[:redis][:users_metadata]).to eq({})
+    end
+
     it 'includes all keys under org:name for organizations' do
       prefix = "org:#{@organization.name}"
       with_redis_keys(prefix) do

--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -32,8 +32,7 @@ describe Carto::UserMetadataExportService do
 
   def destroy_user
     gum = CartoDB::GeocoderUsageMetrics.new(@user.username)
-    key = gum.send(:user_key_prefix, :geocoder_here, :success_responses, DateTime.now)
-    $users_metadata.DEL(key)
+    $users_metadata.DEL(gum.send(:user_key_prefix, :geocoder_here, :success_responses, DateTime.now))
 
     destroy_full_visualization(@map, @table, @table_visualization, @visualization)
     @tiled_layer.destroy

--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -144,18 +144,18 @@ describe Carto::UserMetadataExportService do
     end
   end
 
-  EXCLUDED_DATE_FIELDS = ['created_at', 'updated_at'].freeze
-  EXCLUDED_ID_FIELDS = ['map_id', 'permission_id', 'active_layer_id', 'tags'].freeze
+  EXCLUDED_USER_META_DATE_FIELDS = ['created_at', 'updated_at'].freeze
+  EXCLUDED_USER_META_ID_FIELDS = ['map_id', 'permission_id', 'active_layer_id', 'tags'].freeze
 
   def compare_excluding_dates_and_ids(v1, v2)
-    filtered1 = v1.reject { |k, _| EXCLUDED_ID_FIELDS.include?(k) }
-    filtered2 = v2.reject { |k, _| EXCLUDED_ID_FIELDS.include?(k) }
+    filtered1 = v1.reject { |k, _| EXCLUDED_USER_META_ID_FIELDS.include?(k) }
+    filtered2 = v2.reject { |k, _| EXCLUDED_USER_META_ID_FIELDS.include?(k) }
     compare_excluding_dates(filtered1, filtered2)
   end
 
   def compare_excluding_dates(u1, u2)
-    filtered1 = u1.reject { |k, _| EXCLUDED_DATE_FIELDS.include?(k) }
-    filtered2 = u2.reject { |k, _| EXCLUDED_DATE_FIELDS.include?(k) }
+    filtered1 = u1.reject { |k, _| EXCLUDED_USER_META_DATE_FIELDS.include?(k) }
+    filtered2 = u2.reject { |k, _| EXCLUDED_USER_META_DATE_FIELDS.include?(k) }
     expect(filtered1).to eq filtered2
   end
 

--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -112,12 +112,13 @@ describe Carto::UserMetadataExportService do
     it 'export + import user and visualizations for a viewer user' do
       Dir.mktmpdir do |path|
         create_user_with_basemaps_assets_visualizations
-        @user.update_attribute(:viewer, true)
+        @user.update_attributes(viewer: true)
         ::User[@user.id].reload # Refresh Sequel cache
         service.export_user_to_directory(@user.id, path)
         source_user = @user.attributes
 
         source_visualizations = @user.visualizations.map(&:attributes)
+        @user.update_attributes(viewer: false) # For destruction purposes
         destroy_user
 
         # At this point, the user database is still there, but the tables got destroyed. We recreate some dummy ones


### PR DESCRIPTION
Addresses some of the issues in #12326:
- Groups export
- Notifications export
- Importing a viewer users with visualizations
- Dataservices usage (from redis)
- Rakes to make migration easier (also see https://github.com/CartoDB/cartodb-central/pull/1799). Documented in https://github.com/CartoDB/doc-internal/pull/17

**Acceptance note**: You have to migrate between clouds, or ensure that you delete redis keys if you do it in a single machine (export + delete + import).

Also fixes #12364 