### PR TITLE
Bump Webpack version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Development
 * New force param in EUMAPI organization users destroy operation to force deletion even with unregistered tables (#11654).
 * Removed the usage of the `organizations_admin` feature flag (#12131)
 * Show number of selected items in Time-Series widgets (#12179).
+* Bump Webpack version (#12392).
 
 ### Bug fixes / enhancements
 * Don't try to lowercase null values in custom-list-collection object (support/#744)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.16",
+  "version": "4.8.18",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.18",
+  "version": "4.8.18-bump-webpack",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Webpack 3.0.0 was officially released several days ago [1]. It improves speed significantly.

I've been working locally (and deploying to staging) with no further hassle rather than fixing `source-map-support` version to `0.4.3`.

[1] https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b