### PR TITLE
Fix user permissions when organization should take preference

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@ Development
 * Fix vector problem with lines
 * Fixed "see all formats" url, from the Connect Dataset module, to open in new windown and changed the url.
 * Added a data attribute for Backbone views that points to the module that implements it (Leapfrog #12341)
+* Fix permission model and added tests (#12393)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.1`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/data/permission-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/permission-model.js
@@ -211,17 +211,20 @@ var PermissionModel = module.exports = Backbone.Model.extend({
   },
 
   _ownAclItem: function (model) {
-    if (!model) {
+    if (!model || !_.isFunction(model.isNew)) {
       console.log('model is required to find an ACL item');
     }
 
-    return this.acl.find(function (aclItem) {
-      return aclItem.get('entity').id === model.id;
-    });
+    if (!model.isNew()) {
+      return this.acl.find(function (aclItem) {
+        return aclItem.get('entity').id === model.id;
+      });
+    }
   },
 
   _organizationAclItem: function (m) {
-    var org = m.get('organization');
+    // try to get the organization from the group, then from the user
+    var org = _.result(m.collection, 'organization', m.organization) || m._organizationModel;
 
     if (org) {
       return this._ownAclItem(org);

--- a/lib/assets/core/javascripts/cartodb3/data/permission-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/permission-model.js
@@ -226,7 +226,7 @@ var PermissionModel = module.exports = Backbone.Model.extend({
     // try to get the organization from the user groups collection,
     // then from the user model (Editor),
     // and finally from the user model (Builder)
-    var org = _.result(m.collection, 'organization') || m.organization || m.get('organization');
+    var org = _.result(m.collection, 'organization') || m.organization || m._organizationModel;
 
     if (org) {
       return this._ownAclItem(org);

--- a/lib/assets/core/javascripts/cartodb3/data/permission-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/permission-model.js
@@ -223,9 +223,9 @@ var PermissionModel = module.exports = Backbone.Model.extend({
   },
 
   _organizationAclItem: function (m) {
-    // try to get the organization from the Group Collection,
-    // then from the User Model (Editor),
-    // and finally from the User Model (Builder)
+    // try to get the organization from the user groups collection,
+    // then from the user model (Editor),
+    // and finally from the user model (Builder)
     var org = _.result(m.collection, 'organization') || m.organization || m.get('organization');
 
     if (org) {
@@ -234,9 +234,7 @@ var PermissionModel = module.exports = Backbone.Model.extend({
   },
 
   _mostPrivilegedGroupAclItem: function (m) {
-    // try to get the groups from the organization (Editor),
-    // then from the User Model (both Editor and Builder)
-    var groups = _.result(m.groups, 'models') || m.groups;
+    var groups = _.result(m.groups, 'models');
 
     if (groups) {
       return this._findMostPrivilegedAclItem(groups, this._ownAclItem);

--- a/lib/assets/core/javascripts/cartodb3/data/permission-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/permission-model.js
@@ -223,8 +223,10 @@ var PermissionModel = module.exports = Backbone.Model.extend({
   },
 
   _organizationAclItem: function (m) {
-    // try to get the organization from the group, then from the user
-    var org = _.result(m.collection, 'organization', m.organization) || m._organizationModel;
+    // try to get the organization from the Group Collection,
+    // then from the User Model (Editor),
+    // and finally from the User Model (Builder)
+    var org = _.result(m.collection, 'organization') || m.organization || m.get('organization');
 
     if (org) {
       return this._ownAclItem(org);
@@ -232,7 +234,9 @@ var PermissionModel = module.exports = Backbone.Model.extend({
   },
 
   _mostPrivilegedGroupAclItem: function (m) {
-    var groups = m.get('groups');
+    // try to get the groups from the organization (Editor),
+    // then from the User Model (both Editor and Builder)
+    var groups = _.result(m.groups, 'models') || m.groups;
 
     if (groups) {
       return this._findMostPrivilegedAclItem(groups, this._ownAclItem);

--- a/lib/assets/core/javascripts/cartodb3/data/permission-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/permission-model.js
@@ -187,6 +187,7 @@ var PermissionModel = module.exports = Backbone.Model.extend({
       return this._newAclItem(model, READ_WRITE);
     } else {
       var checkList = ['_ownAclItem', '_organizationAclItem', '_mostPrivilegedGroupAclItem'];
+
       return this._findMostPrivilegedAclItem(checkList, function (fnName) {
         return this[fnName](model);
       });
@@ -210,25 +211,26 @@ var PermissionModel = module.exports = Backbone.Model.extend({
   },
 
   _ownAclItem: function (model) {
-    if (!model || !_.isFunction(model.isNew)) {
+    if (!model) {
       console.log('model is required to find an ACL item');
     }
-    if (!model.isNew()) {
-      return this.acl.find(function (aclItem) {
-        return aclItem.get('entity').id === model.id;
-      });
-    }
+
+    return this.acl.find(function (aclItem) {
+      return aclItem.get('entity').id === model.id;
+    });
   },
 
   _organizationAclItem: function (m) {
-    var org = _.result(m.collection, 'organization') || m.organization;
+    var org = m.get('organization');
+
     if (org) {
       return this._ownAclItem(org);
     }
   },
 
   _mostPrivilegedGroupAclItem: function (m) {
-    var groups = _.result(m.groups, 'models');
+    var groups = m.get('groups');
+
     if (groups) {
       return this._findMostPrivilegedAclItem(groups, this._ownAclItem);
     }

--- a/lib/assets/core/test/spec/cartodb3/data/permission-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/permission-model.spec.js
@@ -35,24 +35,20 @@ describe('data/permission-model', function () {
       configModel: 'c'
     });
 
-    user2 = new UserModel({
-      id: 'uuid2',
-      username: 'u2',
-      viewer: false
+    this.organization = org = new OrganizationModel({
+      id: 'org_uuid'
     }, {
       configModel: 'c'
     });
 
-    this.organization = org = new OrganizationModel({
-      id: 'org_uuid',
-      users: [{
-        id: 'uuid2',
-        username: 'u2'
-      }]
+    user2 = new UserModel({
+      id: 'uuid2',
+      username: 'u2',
+      viewer: false,
+      organization: this.organization
     }, {
       configModel: 'c'
     });
-    user2.set('organization', org);
   });
 
   describe('.isOwner', function () {
@@ -229,123 +225,118 @@ describe('data/permission-model', function () {
 
       describe('w/o own access but member of group with read access', function () {
         beforeEach(function () {
-          user1.groups.add(this.groupA);
+          user2.groups.add(this.groupA);
         });
 
         it('should have the group access', function () {
-          expect(this.permission.hasAccess(user1)).toBe(true);
-          expect(this.permission.hasReadAccess(user1)).toBe(true);
-          expect(this.permission.hasWriteAccess(user1)).toBe(false);
+          expect(this.permission.hasAccess(user2)).toBe(true);
+          expect(this.permission.hasReadAccess(user2)).toBe(true);
+          expect(this.permission.hasWriteAccess(user2)).toBe(false);
         });
 
         it('should only be able to change write access', function () {
-          expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-          expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+          expect(this.permission.canChangeReadAccess(user2)).toBe(false);
+          expect(this.permission.canChangeWriteAccess(user2)).toBe(true);
         });
 
         describe('member of multiple groups', function () {
           beforeEach(function () {
-            user1.groups.add(this.groupB);
+            user2.groups.add(this.groupB);
           });
 
           it('should have the most privileged access of the groups', function () {
-            expect(this.permission.hasAccess(user1)).toBe(true);
-            expect(this.permission.hasReadAccess(user1)).toBe(true);
-            expect(this.permission.hasWriteAccess(user1)).toBe(true);
+            expect(this.permission.hasAccess(user2)).toBe(true);
+            expect(this.permission.hasReadAccess(user2)).toBe(true);
+            expect(this.permission.hasWriteAccess(user2)).toBe(true);
           });
 
           it('should not be able to change any access (since has write inherited)', function () {
-            expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-            expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
+            expect(this.permission.canChangeReadAccess(user2)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user2)).toBe(false);
           });
         });
 
         describe('is also part of organization with read+write access', function () {
           beforeEach(function () {
             this.permission.grantWriteAccess(this.organization);
-            user1.organization = this.organization;
           });
 
           it('should return the organization access since it has precedence over groups', function () {
-            expect(this.permission.hasAccess(user1)).toBe(true);
-            expect(this.permission.hasReadAccess(user1)).toBe(true);
-            expect(this.permission.hasWriteAccess(user1)).toBe(true);
+            expect(this.permission.hasAccess(user2)).toBe(true);
+            expect(this.permission.hasReadAccess(user2)).toBe(true);
+            expect(this.permission.hasWriteAccess(user2)).toBe(true);
           });
 
           it('should not be able to change any access (since has write inherited)', function () {
-            expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-            expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
+            expect(this.permission.canChangeReadAccess(user2)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user2)).toBe(false);
           });
         });
 
         describe('is part of organization with read+write access', function () {
           beforeEach(function () {
-            // treat user1 as if retrieved through Organization Users Collection
-            user1.organization = null;
-            user1.set('organization', this.organization);
             this.permission.grantWriteAccess(this.organization);
           });
 
           it('should return the organization access since it has precedence over groups', function () {
-            expect(this.permission.hasAccess(user1)).toBe(true);
-            expect(this.permission.hasReadAccess(user1)).toBe(true);
-            expect(this.permission.hasWriteAccess(user1)).toBe(true);
+            expect(this.permission.hasAccess(user2)).toBe(true);
+            expect(this.permission.hasReadAccess(user2)).toBe(true);
+            expect(this.permission.hasWriteAccess(user2)).toBe(true);
           });
 
           it('should not be able to change any access (since has write inherited)', function () {
-            expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-            expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
+            expect(this.permission.canChangeReadAccess(user2)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user2)).toBe(false);
           });
         });
 
         describe('is part of organization with read-only access', function () {
           beforeEach(function () {
-            user1.organization = this.organization;
             this.permission.grantReadAccess(this.organization);
           });
 
           it('should return the organization access', function () {
-            expect(this.permission.hasAccess(user1)).toBe(true);
-            expect(this.permission.hasReadAccess(user1)).toBe(true);
-            expect(this.permission.hasWriteAccess(user1)).toBe(false);
+            expect(this.permission.hasAccess(user2)).toBe(true);
+            expect(this.permission.hasReadAccess(user2)).toBe(true);
+            expect(this.permission.hasWriteAccess(user2)).toBe(false);
           });
 
           it('should be able to change write access only', function () {
-            expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-            expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+            expect(this.permission.canChangeReadAccess(user2)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user2)).toBe(true);
           });
 
           describe('has better access than organization', function () {
             beforeEach(function () {
-              this.permission.grantWriteAccess(user1);
+              this.permission.grantWriteAccess(user2);
             });
 
             it('should have read+write access', function () {
-              expect(this.permission.hasAccess(user1)).toBe(true);
-              expect(this.permission.hasReadAccess(user1)).toBe(true);
-              expect(this.permission.hasWriteAccess(user1)).toBe(true);
+              expect(this.permission.hasAccess(user2)).toBe(true);
+              expect(this.permission.hasReadAccess(user2)).toBe(true);
+              expect(this.permission.hasWriteAccess(user2)).toBe(true);
             });
 
             it('should be able to change access', function () {
-              expect(this.permission.canChangeReadAccess(user1)).toBe(true);
-              expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+              expect(this.permission.canChangeReadAccess(user2)).toBe(true);
+              expect(this.permission.canChangeWriteAccess(user2)).toBe(true);
             });
           });
 
           describe('is also owner', function () {
             beforeEach(function () {
-              this.permission.owner = user1;
+              this.permission.owner = user2;
             });
 
             it('should have read+write access', function () {
-              expect(this.permission.hasAccess(user1)).toBe(true);
-              expect(this.permission.hasReadAccess(user1)).toBe(true);
-              expect(this.permission.hasWriteAccess(user1)).toBe(true);
+              expect(this.permission.hasAccess(user2)).toBe(true);
+              expect(this.permission.hasReadAccess(user2)).toBe(true);
+              expect(this.permission.hasWriteAccess(user2)).toBe(true);
             });
 
             it('should be able to change access', function () {
-              expect(this.permission.canChangeReadAccess(user1)).toBe(true);
-              expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+              expect(this.permission.canChangeReadAccess(user2)).toBe(true);
+              expect(this.permission.canChangeWriteAccess(user2)).toBe(true);
             });
           });
         });

--- a/lib/assets/core/test/spec/cartodb3/data/permission-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/permission-model.spec.js
@@ -8,7 +8,7 @@ var READ_ONLY = 'r';
 var READ_WRITE = 'rw';
 
 describe('data/permission-model', function () {
-  var model, user1, user2, org, owner;
+  var model, user1, user2, owner;
   beforeEach(function () {
     this.owner = owner = new UserModel({
       id: 'uuid_owner',
@@ -35,7 +35,7 @@ describe('data/permission-model', function () {
       configModel: 'c'
     });
 
-    this.organization = org = new OrganizationModel({
+    this.organization = new OrganizationModel({
       id: 'org_uuid'
     }, {
       configModel: 'c'

--- a/lib/assets/core/test/spec/cartodb3/data/permission-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/permission-model.spec.js
@@ -1,6 +1,11 @@
-var UserModel = require('../../../../javascripts/cartodb3/data/user-model');
 var PermissionModel = require('../../../../javascripts/cartodb3/data/permission-model');
+var UserModel = require('../../../../javascripts/cartodb3/data/user-model');
+var GroupModel = require('../../../../javascripts/cartodb3/data/group-model');
 var OrganizationModel = require('../../../../javascripts/cartodb3/data/organization-model');
+
+// PermissionModel exports won't play nicely
+var READ_ONLY = 'r';
+var READ_WRITE = 'rw';
 
 describe('data/permission-model', function () {
   var model, user1, user2, org, owner;
@@ -47,7 +52,7 @@ describe('data/permission-model', function () {
     }, {
       configModel: 'c'
     });
-    user2.organization = org;
+    user2.set('organization', org);
   });
 
   describe('.isOwner', function () {
@@ -76,7 +81,6 @@ describe('data/permission-model', function () {
     describe('when owner has no id', function () {
       beforeEach(function () {
         this.other = this.owner.clone();
-      // this.permission.owner.set('id', undefined);
       });
 
       it('should return false when owner has no id', function () {
@@ -100,7 +104,7 @@ describe('data/permission-model', function () {
   describe('.revokeAccess', function () {
     describe('when model has own ACL item', function () {
       beforeEach(function () {
-        this.permission.acl.add(this.permission._newAclItem(user1, PermissionModel.READ_ONLY));
+        this.permission.acl.add(this.permission._newAclItem(user1, READ_ONLY));
         this.permission.revokeAccess(user1);
       });
 
@@ -114,28 +118,15 @@ describe('data/permission-model', function () {
   describe('access', function () {
     beforeEach(function () {
       // Setup various group scenarios for later use
-      // this.groupX = new GroupModel({ id: 'gx' }, { configModel: 'c' });
-      // this.permission.acl.add(this.permission._newAclItem(this.groupX, PermissionModel.READ_ONLY));
-      // this.groupA = new GroupModel({ id: 'ga' }, { configModel: 'c' });
-      // this.permission.acl.add(this.permission._newAclItem(this.groupA, PermissionModel.READ_ONLY));
-      // this.groupB = new GroupModel({ id: 'gb' }, { configModel: 'c' });
-      // this.permission.acl.add(this.permission._newAclItem(this.groupB, PermissionModel.READ_WRITE));
+      this.groupX = new GroupModel({ id: 'gx' }, { configModel: 'c' });
+      this.permission.acl.add(this.permission._newAclItem(this.groupX, READ_ONLY));
+      this.groupA = new GroupModel({ id: 'ga' }, { configModel: 'c' });
+      this.permission.acl.add(this.permission._newAclItem(this.groupA, READ_ONLY));
+      this.groupB = new GroupModel({ id: 'gb' }, { configModel: 'c' });
+      this.permission.acl.add(this.permission._newAclItem(this.groupB, READ_WRITE));
     });
 
-    describe('when given a model w/o any access', function () {
-      it('should not have any access', function () {
-        expect(this.permission.hasAccess(user2)).toBe(false);
-        expect(this.permission.hasReadAccess(user2)).toBe(false);
-        expect(this.permission.hasWriteAccess(user2)).toBe(false);
-      });
-
-      it('should be able to set any access', function () {
-        expect(this.permission.canChangeReadAccess(user2)).toBe(true);
-        expect(this.permission.canChangeWriteAccess(user2)).toBe(true);
-      });
-    });
-
-    describe('when given an owner', function () {
+    describe('owner', function () {
       it('should have all access', function () {
         expect(this.permission.hasAccess(this.owner)).toBe(true);
         expect(this.permission.hasReadAccess(this.owner)).toBe(true);
@@ -148,8 +139,21 @@ describe('data/permission-model', function () {
       });
     });
 
-    describe('when given an user', function () {
-      describe('when user is given read access', function () {
+    describe('user', function () {
+      describe('w/o any access', function () {
+        it('should not have any access', function () {
+          expect(this.permission.hasAccess(user2)).toBe(false);
+          expect(this.permission.hasReadAccess(user2)).toBe(false);
+          expect(this.permission.hasWriteAccess(user2)).toBe(false);
+        });
+
+        it('should be able to set any access', function () {
+          expect(this.permission.canChangeReadAccess(user2)).toBe(true);
+          expect(this.permission.canChangeWriteAccess(user2)).toBe(true);
+        });
+      });
+
+      describe('with read access', function () {
         beforeEach(function () {
           this.permission.grantReadAccess(user2);
         });
@@ -166,7 +170,7 @@ describe('data/permission-model', function () {
         });
       });
 
-      describe('when user is given write access', function () {
+      describe('with write access', function () {
         beforeEach(function () {
           this.permission.grantWriteAccess(user2);
         });
@@ -183,7 +187,7 @@ describe('data/permission-model', function () {
         });
       });
 
-      describe('when user is part of organization with read access', function () {
+      describe('is part of organization with read access', function () {
         beforeEach(function () {
           this.permission.grantReadAccess(this.organization);
         });
@@ -222,203 +226,149 @@ describe('data/permission-model', function () {
           });
         });
       });
+
+      describe('w/o own access but member of group with read access', function () {
+        beforeEach(function () {
+          user1.groups.add(this.groupA);
+        });
+
+        it('should have the group access', function () {
+          expect(this.permission.hasAccess(user1)).toBe(true);
+          expect(this.permission.hasReadAccess(user1)).toBe(true);
+          expect(this.permission.hasWriteAccess(user1)).toBe(false);
+        });
+
+        it('should only be able to change write access', function () {
+          expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+          expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+        });
+
+        describe('member of multiple groups', function () {
+          beforeEach(function () {
+            user1.groups.add(this.groupB);
+          });
+
+          it('should have the most privileged access of the groups', function () {
+            expect(this.permission.hasAccess(user1)).toBe(true);
+            expect(this.permission.hasReadAccess(user1)).toBe(true);
+            expect(this.permission.hasWriteAccess(user1)).toBe(true);
+          });
+
+          it('should not be able to change any access (since has write inherited)', function () {
+            expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
+          });
+        });
+
+        describe('is also part of organization with read+write access', function () {
+          beforeEach(function () {
+            this.permission.grantWriteAccess(this.organization);
+            user1.organization = this.organization;
+          });
+
+          it('should return the organization access since it has precedence over groups', function () {
+            expect(this.permission.hasAccess(user1)).toBe(true);
+            expect(this.permission.hasReadAccess(user1)).toBe(true);
+            expect(this.permission.hasWriteAccess(user1)).toBe(true);
+          });
+
+          it('should not be able to change any access (since has write inherited)', function () {
+            expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
+          });
+        });
+
+        describe('is part of organization with read+write access', function () {
+          beforeEach(function () {
+            // treat user1 as if retrieved through Organization Users Collection
+            user1.organization = null;
+            user1.set('organization', this.organization);
+            this.permission.grantWriteAccess(this.organization);
+          });
+
+          it('should return the organization access since it has precedence over groups', function () {
+            expect(this.permission.hasAccess(user1)).toBe(true);
+            expect(this.permission.hasReadAccess(user1)).toBe(true);
+            expect(this.permission.hasWriteAccess(user1)).toBe(true);
+          });
+
+          it('should not be able to change any access (since has write inherited)', function () {
+            expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
+          });
+        });
+
+        describe('is part of organization with read-only access', function () {
+          beforeEach(function () {
+            user1.organization = this.organization;
+            this.permission.grantReadAccess(this.organization);
+          });
+
+          it('should return the organization access', function () {
+            expect(this.permission.hasAccess(user1)).toBe(true);
+            expect(this.permission.hasReadAccess(user1)).toBe(true);
+            expect(this.permission.hasWriteAccess(user1)).toBe(false);
+          });
+
+          it('should be able to change write access only', function () {
+            expect(this.permission.canChangeReadAccess(user1)).toBe(false);
+            expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+          });
+
+          describe('has better access than organization', function () {
+            beforeEach(function () {
+              this.permission.grantWriteAccess(user1);
+            });
+
+            it('should have read+write access', function () {
+              expect(this.permission.hasAccess(user1)).toBe(true);
+              expect(this.permission.hasReadAccess(user1)).toBe(true);
+              expect(this.permission.hasWriteAccess(user1)).toBe(true);
+            });
+
+            it('should be able to change access', function () {
+              expect(this.permission.canChangeReadAccess(user1)).toBe(true);
+              expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+            });
+          });
+
+          describe('is also owner', function () {
+            beforeEach(function () {
+              this.permission.owner = user1;
+            });
+
+            it('should have read+write access', function () {
+              expect(this.permission.hasAccess(user1)).toBe(true);
+              expect(this.permission.hasReadAccess(user1)).toBe(true);
+              expect(this.permission.hasWriteAccess(user1)).toBe(true);
+            });
+
+            it('should be able to change access', function () {
+              expect(this.permission.canChangeReadAccess(user1)).toBe(true);
+              expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
+            });
+          });
+        });
+      });
     });
 
-  //   describe('when given a group', function () {
-  //     describe('when given group has own access', function () {
-  //       it('should have the expected access', function () {
-  //         expect(this.permission.hasAccess(this.groupX)).toBe(true);
-  //         expect(this.permission.hasReadAccess(this.groupX)).toBe(true);
-  //         expect(this.permission.hasWriteAccess(this.groupX)).toBe(false);
-  //
-  //         expect(this.permission.hasAccess(this.groupA)).toBe(true);
-  //         expect(this.permission.hasReadAccess(this.groupA)).toBe(true);
-  //         expect(this.permission.hasWriteAccess(this.groupA)).toBe(false);
-  //
-  //         expect(this.permission.hasAccess(this.groupB)).toBe(true);
-  //         expect(this.permission.hasReadAccess(this.groupB)).toBe(true);
-  //         expect(this.permission.hasWriteAccess(this.groupB)).toBe(true);
-  //       });
-  //
-  //       describe('when group is part of organization that has more privileged access', function () {
-  //         beforeEach(function () {
-  //           this.permission.grantWriteAccess(this.organization);
-  //           this.organization.groups.add(this.groupA);
-  //         });
-  //
-  //         it('should have organization access', function () {
-  //           expect(this.permission.hasAccess(this.groupA)).toBe(true);
-  //           expect(this.permission.hasReadAccess(this.groupA)).toBe(true);
-  //           expect(this.permission.hasWriteAccess(this.groupA)).toBe(true);
-  //         });
-  //
-  //         it('should not be able to change any access', function () {
-  //           expect(this.permission.canChangeReadAccess(this.groupA)).toBe(false);
-  //           expect(this.permission.canChangeWriteAccess(this.groupA)).toBe(false);
-  //         });
-  //       });
-  //     });
-  //
-  //     describe('when group w/o own access but is part of organization with read access', function () {
-  //       beforeEach(function () {
-  //         this.permission.grantReadAccess(this.organization);
-  //         this.organization.groups.add(this.groupX);
-  //       });
-  //
-  //       it('should have the organization read access', function () {
-  //         expect(this.permission.hasAccess(this.groupX)).toBe(true);
-  //         expect(this.permission.hasReadAccess(this.groupX)).toBe(true);
-  //         expect(this.permission.hasWriteAccess(this.groupX)).toBe(false);
-  //       });
-  //
-  //       it('should only be able to change write access', function () {
-  //         expect(this.permission.canChangeReadAccess(this.groupX)).toBe(false);
-  //         expect(this.permission.canChangeWriteAccess(this.groupX)).toBe(true);
-  //       });
-  //
-  //       describe('when organization has write access', function () {
-  //         beforeEach(function () {
-  //           this.permission.grantWriteAccess(this.organization);
-  //           this.organization.groups.add(this.groupX);
-  //         });
-  //
-  //         it('should have the organization read+write access', function () {
-  //           expect(this.permission.hasAccess(this.groupX)).toBe(true);
-  //           expect(this.permission.hasReadAccess(this.groupX)).toBe(true);
-  //           expect(this.permission.hasWriteAccess(this.groupX)).toBe(true);
-  //         });
-  //
-  //         it('should not be able to change any access', function () {
-  //           expect(this.permission.canChangeReadAccess(this.groupX)).toBe(false);
-  //           expect(this.permission.canChangeWriteAccess(this.groupX)).toBe(false);
-  //         });
-  //       });
-  //     });
-  //   });
-  //
-  //   describe('when given a user w/o own access but is member of group with read access', function () {
-  //     beforeEach(function () {
-  //       user1.groups.add(this.groupA);
-  //     });
-  //
-  //     it('should have the group access', function () {
-  //       expect(this.permission.hasAccess(user1)).toBe(true);
-  //       expect(this.permission.hasReadAccess(user1)).toBe(true);
-  //       expect(this.permission.hasWriteAccess(user1)).toBe(false);
-  //     });
-  //
-  //     it('should only be able to change write access', function () {
-  //       expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-  //       expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
-  //     });
-  //
-  //     describe('when user is member of multiple groups', function () {
-  //       beforeEach(function () {
-  //         user1.groups.add(this.groupB);
-  //       });
-  //
-  //       it('should have the most privileged access of the grops', function () {
-  //         expect(this.permission.hasAccess(user1)).toBe(true);
-  //         expect(this.permission.hasReadAccess(user1)).toBe(true);
-  //         expect(this.permission.hasWriteAccess(user1)).toBe(true);
-  //       });
-  //
-  //       it('should not be able to change any access (since has write inherited)', function () {
-  //         expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-  //         expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
-  //       });
-  //     });
-  //
-  //     describe('when user is also part of organization with read+write access', function () {
-  //       beforeEach(function () {
-  //         this.permission.grantWriteAccess(this.organization);
-  //         user1.organization = this.organization;
-  //       });
-  //
-  //       it('should return the organization access since it has precedence over groups', function () {
-  //         expect(this.permission.hasAccess(user1)).toBe(true);
-  //         expect(this.permission.hasReadAccess(user1)).toBe(true);
-  //         expect(this.permission.hasWriteAccess(user1)).toBe(true);
-  //       });
-  //
-  //       it('should not be able to change any access (since has write inherited)', function () {
-  //         expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-  //         expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
-  //       });
-  //     });
-  //
-  //     describe('when user is part of organization with read+write access', function () {
-  //       beforeEach(function () {
-  //         // treat user1 as if retrieved through org users collection
-  //         user1.organization = null;
-  //         this.organization.users.add(user1);
-  //         this.permission.grantWriteAccess(this.organization);
-  //       });
-  //
-  //       it('should return the organization access since it has precedence over groups', function () {
-  //         expect(this.permission.hasAccess(user1)).toBe(true);
-  //         expect(this.permission.hasReadAccess(user1)).toBe(true);
-  //         expect(this.permission.hasWriteAccess(user1)).toBe(true);
-  //       });
-  //
-  //       it('should not be able to change any access (since has write inherited)', function () {
-  //         expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-  //         expect(this.permission.canChangeWriteAccess(user1)).toBe(false);
-  //       });
-  //     });
-  //
-  //     describe('when user has organization read-only access', function () {
-  //       beforeEach(function () {
-  //         user1.organization = this.organization;
-  //         this.permission.grantReadAccess(this.organization);
-  //       });
-  //
-  //       it('should return the organization access', function () {
-  //         expect(this.permission.hasAccess(user1)).toBe(true);
-  //         expect(this.permission.hasReadAccess(user1)).toBe(true);
-  //         expect(this.permission.hasWriteAccess(user1)).toBe(false);
-  //       });
-  //
-  //       it('should be able to change write access only', function () {
-  //         expect(this.permission.canChangeReadAccess(user1)).toBe(false);
-  //         expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
-  //       });
-  //
-  //       describe('when user has better access than organization', function () {
-  //         beforeEach(function () {
-  //           this.permission.grantWriteAccess(user1);
-  //         });
-  //
-  //         it('should have read+write access', function () {
-  //           expect(this.permission.hasAccess(user1)).toBe(true);
-  //           expect(this.permission.hasReadAccess(user1)).toBe(true);
-  //           expect(this.permission.hasWriteAccess(user1)).toBe(true);
-  //         });
-  //
-  //         it('should be able to change access', function () {
-  //           expect(this.permission.canChangeReadAccess(user1)).toBe(true);
-  //           expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
-  //         });
-  //       });
-  //
-  //       describe('when user is also owner', function () {
-  //         beforeEach(function () {
-  //           this.permission.owner = user1;
-  //         });
-  //
-  //         it('should have read+write access', function () {
-  //           expect(this.permission.hasAccess(user1)).toBe(true);
-  //           expect(this.permission.hasReadAccess(user1)).toBe(true);
-  //           expect(this.permission.hasWriteAccess(user1)).toBe(true);
-  //         });
-  //
-  //         it('should be able to change access', function () {
-  //           expect(this.permission.canChangeReadAccess(user1)).toBe(true);
-  //           expect(this.permission.canChangeWriteAccess(user1)).toBe(true);
-  //         });
-  //       });
-  //     });
-  //   });
+    describe('group', function () {
+      describe('with own access', function () {
+        it('should have the expected access', function () {
+          expect(this.permission.hasAccess(this.groupX)).toBe(true);
+          expect(this.permission.hasReadAccess(this.groupX)).toBe(true);
+          expect(this.permission.hasWriteAccess(this.groupX)).toBe(false);
+
+          expect(this.permission.hasAccess(this.groupA)).toBe(true);
+          expect(this.permission.hasReadAccess(this.groupA)).toBe(true);
+          expect(this.permission.hasWriteAccess(this.groupA)).toBe(false);
+
+          expect(this.permission.hasAccess(this.groupB)).toBe(true);
+          expect(this.permission.hasReadAccess(this.groupB)).toBe(true);
+          expect(this.permission.hasWriteAccess(this.groupB)).toBe(true);
+        });
+      });
+    });
   });
 
   it('should parse owner and acl', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.16",
+  "version": "4.8.15.808.01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.16",
+  "version": "4.8.17",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.17",
+  "version": "4.8.17.808.01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.15.808.01",
+  "version": "4.8.16",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "tangram": "cartodb/tangram-1#master",
     "torque.js": "CartoDB/torque#master",
     "underscore": "1.8.3",
-    "webpack": "3.0.0"
+    "webpack": "2.3.2"
   },
   "devDependencies": {
     "autoprefixer-core": "5.2.1",
@@ -83,7 +83,7 @@
     "semistandard": "7.0.4",
     "semver": "4.3.6",
     "shim-loader": "0.1.0",
-    "source-map-support": "0.4.3",
+    "source-map-support": "0.4.0",
     "stringify": "5.1.0",
     "tpl-loader": "CartoDB/tpl-loader#master",
     "uglify-js": "2.7.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.15",
+  "version": "4.8.16",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "tangram": "cartodb/tangram-1#master",
     "torque.js": "CartoDB/torque#master",
     "underscore": "1.8.3",
-    "webpack": "2.3.2"
+    "webpack": "3.0.0"
   },
   "devDependencies": {
     "autoprefixer-core": "5.2.1",
@@ -83,7 +83,7 @@
     "semistandard": "7.0.4",
     "semver": "4.3.6",
     "shim-loader": "0.1.0",
-    "source-map-support": "0.4.0",
+    "source-map-support": "0.4.3",
     "stringify": "5.1.0",
     "tpl-loader": "CartoDB/tpl-loader#master",
     "uglify-js": "2.7.x",


### PR DESCRIPTION
re: https://github.com/CartoDB/support/issues/808

Perdurable issue that has been around at least since Builder was launched.

When migrating the permission model it took into account the old schema where organization was retrieved from user groups collection. This worked in Editor and Builder, however when retrieving the organization from the user model it only worked in Editor, but not in Builder.

Also, uncommented the specs regarding this. During this task I rephrased a bit the suite where for example didn't make any sense to retrieve the groups from the organization (confirmed with @javitonino) but is only checked for the user.

**acceptance**

- try all the permission combination for user, group, and organization; prevalence order should be organization > group with more permission > group with fewer permission > user
- try both in Editor, and Builder

I'd feel more confident running a smokes through this (this has been brought up several times during smokes testing).
