### PR TITLE
Start using ::outline symbolizer for polygon stroke

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,11 @@ Development
 ### Features
 * New loading button styles (#12132)
 * [WIP] Export/import organization/user metadata to allow user migration (#12271, #12304, #12323)
-* New force param in EUMAPI organization users destroy operation to force deletion even with unregistered tables (#11654).
+* New force param in EUMAPI organization users destroy operation to force deletion even with unregistered tables (#11654)
 * Removed the usage of the `organizations_admin` feature flag (#12131)
-* Show number of selected items in Time-Series widgets (#12179).
-* Bump Webpack version (#12392).
+* Show number of selected items in Time-Series widgets (#12179)
+* Bump Webpack version (#12392)
+* Start using ::outline symbolizer for polygon stroke (#12412)
 
 ### Bug fixes / enhancements
 * Tap on iOS10 mobile embed doesn't jump to page bottom (#cartodb.js/1652)

--- a/lib/assets/core/javascripts/cartodb3/data/camshaft-reference.js
+++ b/lib/assets/core/javascripts/cartodb3/data/camshaft-reference.js
@@ -127,7 +127,6 @@ module.exports = {
       '  marker-line-color: <%= point.stroke.color.fixed %>;',
       '  marker-line-width: <%= point.stroke.size.fixed %>;',
       '  marker-line-opacity: <%= point.stroke.color.opacity %>;',
-      '  marker-placement: point;',
       '  marker-type: ellipse;',
       '  marker-allow-overlap: true;',
       '}',

--- a/lib/assets/core/javascripts/cartodb3/data/camshaft-reference.js
+++ b/lib/assets/core/javascripts/cartodb3/data/camshaft-reference.js
@@ -139,11 +139,11 @@ module.exports = {
       "#layer['mapnik::geometry_type'=3] {",
       '  polygon-fill: <%= polygon.fill.color.fixed %>;',
       '  polygon-opacity: <%= polygon.fill.color.opacity %>;',
-      '  polygon-gamma: 0.5;',
-      '  line-color: <%= polygon.stroke.color.fixed%>;',
-      '  line-width: <%= polygon.stroke.size.fixed %>;',
-      '  line-opacity: <%= polygon.stroke.color.opacity %>;',
-      '  line-comp-op: soft-light;',
+      '  ::outline {',
+      '    line-color: <%= polygon.stroke.color.fixed%>;',
+      '    line-width: <%= polygon.stroke.size.fixed %>;',
+      '    line-opacity: <%= polygon.stroke.color.opacity %>;',
+      '  }',
       '}'
     ].join('\n'))(DefaultCartography.simple);
   },

--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-converter.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-converter.js
@@ -434,6 +434,7 @@ function generateCartoCSS (style, geometryType, configModel) {
   var isCategory = isCategoryType(styleDef, geometryType);
   var animationType = style.type === 'animation' && styleDef.style;
 
+  // Animated map 'controls'
   if (geometryType === 'point' && isAnimatable) {
     css += 'Map {\n';
     css += renderBlock({
@@ -442,17 +443,30 @@ function generateCartoCSS (style, geometryType, configModel) {
     css += '}\n';
   }
 
+  // Main styles
+  var omittedStyleAttrs = ['animated', 'labels'];
+  if (geometryType === 'polygon') {
+    omittedStyleAttrs.push('stroke');
+  }
   css += '#layer {\n';
-  css += renderBlock(_.omit(styleDef, 'animated', 'labels'), geometryType, animationType);
+  css += renderBlock(_.omit(styleDef, omittedStyleAttrs), geometryType, animationType);
   css += '}';
 
-  // labels
+  // Outline (stroke for polygons) #12412
+  if (styleDef.stroke && geometryType === 'polygon') {
+    css += '\n#layer::outline {\n';
+    css += renderBlock({ stroke: styleDef.stroke }, geometryType);
+    css += '}';
+  }
+
+  // Labels
   if (styleDef.labels && styleDef.labels.enabled && styleDef.labels.enabled !== 'false') {
     css += '\n#layer::labels {\n';
     css += renderBlock({ labels: styleDef.labels }, geometryType);
     css += '}';
   }
 
+  // Animated Map trails
   if (isAnimatable && styleDef.animated.trails && styleDef.animated.trails > 0) {
     css += cartocssFactory.trails[geometryType](styleDef);
   }

--- a/lib/assets/core/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/style/style-converter-fixtures.spec.js
@@ -145,7 +145,7 @@ module.exports = [
         type: 'CartoDB'
       },
       polygon: {
-        cartocss: '#layer {\nline-width: 2;\nline-color: #000;\nline-opacity: 0.4;\n}',
+        cartocss: '#layer {\n}\n#layer::outline {\nline-width: 2;\nline-color: #000;\nline-opacity: 0.4;\n}',
         type: 'CartoDB'
       }
     }


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/12412

The default camshaft CartoCSS for polygon will not include line properties in the "main layer", it will show them in a symbolizer called `::outline`.

The "chiringito" was ready for adding more symbolizers @rochoa, sorry for not finding them the other day.