### PR TITLE
Fix thumbnails generation (center, zoom, bounds)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,7 @@ Development
 * Added a data attribute for Backbone views that points to the module that implements it (Leapfrog #12341)
 * Add geometry validation for polygons and lines in edit feature form (#12397)
 * Fix permission model and added tests (#12393)
+* Fixed bounds and center of thumbnails after updating a map
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -533,6 +533,10 @@ class Carto::Visualization < ActiveRecord::Base
     overlays.builder_incompatible.none?
   end
 
+  def state
+    super ? super : build_state
+  end
+
   def can_be_private?
     derived? ? user.try(:private_maps_enabled) : user.try(:private_tables_enabled)
   end

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -533,10 +533,6 @@ class Carto::Visualization < ActiveRecord::Base
     overlays.builder_incompatible.none?
   end
 
-  def state
-    super ? super : build_state
-  end
-
   def can_be_private?
     derived? ? user.try(:private_maps_enabled) : user.try(:private_tables_enabled)
   end

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -236,20 +236,25 @@ module Carto
       end
 
       def view
-        map = @visualization.map
-        center_data = map.center_data
+        state = @visualization.state.json
+        center_data = state[:map][:center]
 
         data = {
-          zoom: map.zoom,
+          zoom: state[:map][:zoom],
           center: {
-            lng: center_data[1].to_f,
-            lat: center_data[0].to_f
+            lng: center_data[1],
+            lat: center_data[0]
           }
         }
 
-        bounds_data = map.view_bounds_data
+        bounds_data = {
+          west: state[:map][:sw][0],
+          south: state[:map][:sw][1],
+          east: state[:map][:ne][0],
+          north: state[:map][:ne][1]
+        }
 
-        # INFO: Don't return 'bounds' if all points are 0 to avoid static map trying to go too small zoom level
+        # INFO: Don't return 'bounds' if any of the points is 0 to avoid static map trying to go too small zoom level
         if bounds_data[:west] != 0 || bounds_data[:south] != 0 || bounds_data[:east] != 0 || bounds_data[:north] != 0
           data[:bounds] = bounds_data
         end

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -237,22 +237,33 @@ module Carto
 
       def view
         state = @visualization.state.json
-        center_data = state[:map][:center]
-
-        data = {
-          zoom: state[:map][:zoom],
-          center: {
-            lng: center_data[1],
-            lat: center_data[0]
+        if state.empty?
+          # Use map info when there's no state info
+          center_data = map.center_data
+          data = {
+            zoom: map.zoom,
+            center: {
+              lng: center_data[1].to_f,
+              lat: center_data[0].to_f
+            }
           }
-        }
-
-        bounds_data = {
-          west: state[:map][:sw][0],
-          south: state[:map][:sw][1],
-          east: state[:map][:ne][0],
-          north: state[:map][:ne][1]
-        }
+          bounds_data = map.view_bounds_data
+        else
+          # Use state information when present
+          data = {
+            zoom: state[:map][:zoom],
+            center: {
+              lng: center_data[1],
+              lat: center_data[0]
+            }
+          }
+          bounds_data = {
+            west: state[:map][:sw][0],
+            south: state[:map][:sw][1],
+            east: state[:map][:ne][0],
+            north: state[:map][:ne][1]
+          }
+        end
 
         # INFO: Don't return 'bounds' if any of the points is 0 to avoid static map trying to go too small zoom level
         if bounds_data[:west] != 0 || bounds_data[:south] != 0 || bounds_data[:east] != 0 || bounds_data[:north] != 0

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -239,6 +239,7 @@ module Carto
         state = @visualization.state.json
         if state.empty?
           # Use map info when there's no state info
+          map = @visualization.map
           center_data = map.center_data
           data = {
             zoom: map.zoom,

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -251,6 +251,7 @@ module Carto
           bounds_data = map.view_bounds_data
         else
           # Use state information when present
+          center_data = state[:map][:center]
           data = {
             zoom: state[:map][:zoom],
             center: {

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -684,7 +684,9 @@ module Carto
 
         describe 'it should use the state when it is present' do
           before do
-            @visualization.state.json = {"map":{"ne":[-58.9,-143.9],"sw":[37.4,41.6],"center":[-16.2,-51.1],"zoom":4}}
+            @visualization.state.json = {
+              map: { ne: [-58.9, -143.9], sw: [37.4, 41.6], center: [-16.2, -51.1], zoom: 4 }
+            }
             @template_hash = Carto::NamedMaps::Template.new(@visualization).to_hash
           end
 
@@ -697,7 +699,7 @@ module Carto
             template_center = @template_hash[:view][:center]
             template_center[:lat].should eq -16.2
             template_center[:lng].should eq -51.1
-            expected_bounds = {west: 37.4, south: 41.6, east: -58.9, north: -143.9}
+            expected_bounds = { west: 37.4, south: 41.6, east: -58.9, north: -143.9 }
             @template_hash[:view][:bounds].should eq expected_bounds
           end
         end

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -682,6 +682,26 @@ module Carto
           @template_hash[:view][:bounds].should eq @map.view_bounds_data
         end
 
+        describe 'it should use the state when it is present' do
+          before do
+            @visualization.state.json = {"map":{"ne":[-58.9,-143.9],"sw":[37.4,41.6],"center":[-16.2,-51.1],"zoom":4}}
+            @template_hash = Carto::NamedMaps::Template.new(@visualization).to_hash
+          end
+
+          after do
+            @visualization.state.json = {}
+          end
+
+          it 'should use the state info for the view when instantiating a named map' do
+            @template_hash[:view][:zoom].should eq 4
+            template_center = @template_hash[:view][:center]
+            template_center[:lat].should eq -16.2
+            template_center[:lng].should eq -51.1
+            expected_bounds = {west: 37.4, south: 41.6, east: -58.9, north: -143.9}
+            @template_hash[:view][:bounds].should eq expected_bounds
+          end
+        end
+
         describe '#preview_layers' do
           before(:all) do
             @carto_layer = FactoryGirl.create(:carto_layer, kind: 'carto', maps: [@map])


### PR DESCRIPTION
Fix the thumbnail generation when a map is updated. When the named map
is updated, instead of using the center, zoom and bounds of the Map
model, use the state of the visualization. The Map models always remain
unchanged. This way the named map contains the right information to
render the correct viewport when requesting an image to the static map
API.