### PR TITLE
Add webpack-dashboard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ Development
 * Bump Webpack version (#12392).
 * The selection window on a histogram widget can be dragged (#12180)
 * Move playback on animated time series by clicking on it (#12180)
+* Include webpack-dashboard
 
 ### Bug fixes / enhancements
 * Refactor Visualization::Member like and notification actions into Carto::Visualization (#12309)

--- a/lib/build/tasks/webpack/webpack.config.js
+++ b/lib/build/tasks/webpack/webpack.config.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var webpack = require('webpack');
+var DashboardPlugin = require('webpack-dashboard/plugin');
 
 module.exports = {
   task: function () {
@@ -10,7 +11,7 @@ module.exports = {
         main: [
           // To be filled by grunt
         ]
-      }, 
+      },
       output: {
         path: path.resolve(path.resolve('.'), '.grunt'),
         filename: '[name].affected-specs.js'
@@ -37,7 +38,7 @@ module.exports = {
             include: [path.resolve(path.resolve('.'), 'node_modules/tangram.cartodb')],
             options: {
               presets: [
-                ["es2015", { "modules": false }]
+                ['es2015', { 'modules': false }]
               ]
             }
           },
@@ -69,7 +70,8 @@ module.exports = {
         new webpack.SourceMapDevToolPlugin({
           filename: '[file].map',
           exclude: /vendor/
-        })
+        }),
+        new DashboardPlugin({ port: 2017 })
       ],
       target: 'web',
       node: {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "uglify-js": "2.7.x",
     "watchify": "3.7.0",
     "webpack-bundle-analyzer": "^2.4.0",
+    "webpack-dashboard": "^0.4.0",
     "webpack-stats-plugin": "0.1.4"
   },
   "optionalDependencies": {
@@ -186,6 +187,7 @@
     "build": "NODE_ENV=production webpack -p --config webpack.prod.config.js",
     "build:stats": "webpack --env.stats --progress --config webpack.dev.config.js",
     "start": "grunt watch:css & webpack --progress --watch --config webpack.dev.config.js",
+    "dashboard": "webpack-dashboard -p 1987",
     "dev": "webpack --progress --config webpack.dev.config.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "build:stats": "webpack --env.stats --progress --config webpack.dev.config.js",
     "start": "grunt watch:css & webpack --progress --watch --config webpack.dev.config.js",
     "dashboard": "webpack-dashboard -p 1987",
+    "dashboard-affected": "webpack-dashboard -p 2017",
     "dev": "webpack --progress --config webpack.dev.config.js"
   }
 }

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -3,6 +3,7 @@ const {resolve} = require('path');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const PACKAGE = require('./package.json');
 const version = PACKAGE.version;
+var DashboardPlugin = require('webpack-dashboard/plugin');
 
 const stats = (env) => {
   return env && env.stats;
@@ -72,6 +73,9 @@ module.exports = env => {
       new webpack.DefinePlugin({
         __IN_DEV__: JSON.stringify(true)
       })
+    ])
+    .concat([
+      new DashboardPlugin({ port: 1987 })
     ])
     .filter(p => !!p), // undefined is not a valid plugin, so filter undefined values here
     module: {


### PR DESCRIPTION
This PR adds webpack-dashboard in the most non-intrusive way possible.

Because we are bundling CSS through webpack (**for now!**), we can't directly run webpack-dashboard, but we run add the plugin through a port & run the dashboard on a different terminal.

I added the necessary plugin to webpack.dev.config & an extra command to run the dashboard `npm run dashboard`

This is what the dashboard looks like:
![screen shot 2017-07-07 at 16 07 56](https://user-images.githubusercontent.com/446970/27961269-774cacec-632e-11e7-8031-e4361ccef6f8.png)

All those panels are scrollable if you have mouse support on your terminal emulator

It could be run for the tests as well, if there's interest.