### PR TITLE
Fixing problem parsing formula widget creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Development
 * Move playback on animated time series by clicking on it (#12180)
 
 ### Bug fixes / enhancements
+* Fixing problem parsing formula widget creation (#support/843)
 * Refactor Visualization::Member like and notification actions into Carto::Visualization (#12309)
 * Don't try to lowercase null values in custom-list-collection object (support/#744)
 * Tap on iOS10 mobile embed doesn't jump to page bottom (#cartodb.js/1652)

--- a/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-formula-schema-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-formula-schema-model.js
@@ -22,6 +22,15 @@ module.exports = WidgetsFormBaseSchema.extend({
     WidgetsFormBaseSchema.prototype.initialize.apply(this, arguments);
   },
 
+  parse: function (r) {
+    r.aggregate = {
+      attribute: r.column,
+      operator: r.operation
+    };
+
+    return r;
+  },
+
   getFields: function () {
     return {
       data: 'aggregate,prefix,suffix,description',

--- a/lib/assets/core/test/spec/cartodb3/editor/widgets/widgets-form/schema/widgets-form-formula-schema-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/widgets/widgets-form/schema/widgets-form-formula-schema-model.spec.js
@@ -1,0 +1,46 @@
+var Backbone = require('backbone');
+var WidgetsFormColumnOptionsFactory = require('../../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/widgets-form-column-options-factory');
+var WidgetsFormFormulaSchemaModel = require('../../../../../../../javascripts/cartodb3/editor/widgets/widgets-form/schema/widgets-form-formula-schema-model');
+var FactoryModals = require('../../../../factories/modals');
+
+describe('editor/widgets/widgets-form/schema/widgets-form-formula-schema-model', function () {
+  beforeEach(function () {
+    var userModel = {
+      featureEnabled: function () {
+        return true;
+      }
+    };
+
+    this.querySchemaModel = new Backbone.Model();
+    this.widgetsFormColumnOptionsFactory = new WidgetsFormColumnOptionsFactory(this.querySchemaModel);
+    spyOn(this.widgetsFormColumnOptionsFactory, 'create').and.returnValue([{
+      val: 'col',
+      label: 'col',
+      type: 'number'
+    }, {
+      val: 'col2',
+      label: 'col2',
+      type: 'string'
+    }]);
+
+    this.modals = FactoryModals.createModalService();
+
+    this.model = new WidgetsFormFormulaSchemaModel({
+      type: 'formula',
+      column: 'cartodb_id',
+      operation: 'avg'
+    }, {
+      columnOptionsFactory: this.widgetsFormColumnOptionsFactory,
+      userModel: userModel,
+      configModel: {},
+      modals: this.modals,
+      parse: true
+    });
+  });
+
+  it('should parse the aggregation correctly', function () {
+    var attrs = this.model.toJSON();
+    expect(attrs.aggregate.operator).toBe('avg');
+    expect(attrs.aggregate.attribute).toBe('cartodb_id');
+  });
+});


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/support/issues/843.

The problem was we didn't take the initial widget values for the creation of the operator component. Fixed with this change.