### PR TITLE
Remove unsupported CartoCSS rules for vector rendering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Development
 * Bump Webpack version (#12392).
 
 ### Bug fixes / enhancements
+* Remove unsupported CartoCSS rules for vector rendering (#12410)
 * Refactor Visualization::Member like and notification actions into Carto::Visualization (#12309)
 * Don't try to lowercase null values in custom-list-collection object (support/#744)
 * Tap on iOS10 mobile embed doesn't jump to page bottom (#cartodb.js/1652)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Development
 -----------
 
 ### Features
+* Support for nested properties in CartoCSS (#12411)
 * New loading button styles (#12132)
 * [WIP] Export/import organization/user metadata to allow user migration (#12271, #12304, #12323, #12380)
 * New force param in EUMAPI organization users destroy operation to force deletion even with unregistered tables (#11654).

--- a/lib/carto/styles/polygon.rb
+++ b/lib/carto/styles/polygon.rb
@@ -23,9 +23,11 @@ module Carto::Styles
       color = fill[:color][:fixed]
       opacity = fill[:color][:opacity]
 
-      ["polygon-fill: #{color};",
-       "polygon-opacity: #{opacity};",
-       "polygon-gamma: 0.5;"]
+      [
+        "polygon-fill: #{color};",
+        "polygon-opacity: #{opacity};",
+        "polygon-gamma: 0.5;"
+      ]
     end
 
     def parse_stroke(stroke)
@@ -33,10 +35,14 @@ module Carto::Styles
       color = stroke[:color][:fixed]
       opacity = stroke[:color][:opacity]
 
-      ["line-color: #{color};",
-       "line-width: #{width};",
-       "line-opacity: #{opacity};",
-       "line-comp-op: soft-light;"]
+      [
+        "::outline" => [
+          "line-color: #{color};",
+          "line-width: #{width};",
+          "line-opacity: #{opacity};",
+          "line-comp-op: soft-light;"
+        ]
+      ]
     end
   end
 end

--- a/lib/carto/styles/polygon.rb
+++ b/lib/carto/styles/polygon.rb
@@ -25,8 +25,7 @@ module Carto::Styles
 
       [
         "polygon-fill: #{color};",
-        "polygon-opacity: #{opacity};",
-        "polygon-gamma: 0.5;"
+        "polygon-opacity: #{opacity};"
       ]
     end
 
@@ -39,8 +38,7 @@ module Carto::Styles
         "::outline" => [
           "line-color: #{color};",
           "line-width: #{width};",
-          "line-opacity: #{opacity};",
-          "line-comp-op: soft-light;"
+          "line-opacity: #{opacity};"
         ]
       ]
     end

--- a/lib/carto/styles/presenters/cartocss.rb
+++ b/lib/carto/styles/presenters/cartocss.rb
@@ -27,16 +27,16 @@ module Carto
 
         def format_cartocss_property(cartocss_property)
           case cartocss_property.class.to_s
-            when 'String'
-              "  #{cartocss_property}"
-            when 'Hash'
-              formatted_cartocss_property = cartocss_property.keys.map do |key|
-                "  #{key} {\n"\
-                "#{cartocss_property[key].map {|v| "    #{v}"}.join("\n")}\n"\
-                "  }"
-              end
+          when 'String'
+            "  #{cartocss_property}"
+          when 'Hash'
+            formatted_cartocss_property = cartocss_property.keys.map do |key|
+              "  #{key} {\n"\
+              "#{cartocss_property[key].map { |v| "    #{v}" }.join("\n")}\n"\
+              "  }"
+            end
 
-              formatted_cartocss_property.join("\n")
+            formatted_cartocss_property.join("\n")
           end
         end
       end

--- a/lib/carto/styles/presenters/cartocss.rb
+++ b/lib/carto/styles/presenters/cartocss.rb
@@ -26,7 +26,9 @@ module Carto
         end
 
         def format_cartocss_property(cartocss_property)
-          case cartocss_property.class.to_s
+          property_class = cartocss_property.class.to_s
+
+          case property_class
           when 'String'
             "  #{cartocss_property}"
           when 'Hash'
@@ -37,6 +39,9 @@ module Carto
             end
 
             formatted_cartocss_property.join("\n")
+          else
+            CartoDB::Logger.error(message: "Unrecognized property class given to CartoCSS: #{property_class}")
+            " "
           end
         end
       end

--- a/lib/carto/styles/presenters/cartocss.rb
+++ b/lib/carto/styles/presenters/cartocss.rb
@@ -26,7 +26,18 @@ module Carto
         end
 
         def format_cartocss_property(cartocss_property)
-          "  #{cartocss_property}"
+          case cartocss_property.class.to_s
+            when 'String'
+              "  #{cartocss_property}"
+            when 'Hash'
+              formatted_cartocss_property = cartocss_property.keys.map do |key|
+                "  #{key} {\n"\
+                "#{cartocss_property[key].map {|v| "    #{v}"}.join("\n")}\n"\
+                "  }"
+              end
+
+              formatted_cartocss_property.join("\n")
+          end
         end
       end
     end

--- a/lib/carto/styles/presenters/cartocss.rb
+++ b/lib/carto/styles/presenters/cartocss.rb
@@ -41,7 +41,7 @@ module Carto
             formatted_cartocss_property.join("\n")
           else
             CartoDB::Logger.error(message: "Unrecognized property class given to CartoCSS: #{property_class}")
-            " "
+            ""
           end
         end
       end

--- a/spec/lib/carto/styles/geometry_spec.rb
+++ b/spec/lib/carto/styles/geometry_spec.rb
@@ -26,12 +26,10 @@ module Carto
           "#layer['mapnik::geometry_type'=3] {\n"\
           "  polygon-fill: #374C70;\n"\
           "  polygon-opacity: 0.9;\n"\
-          "  polygon-gamma: 0.5;\n"\
           "  ::outline {\n"\
           "    line-color: #FFF;\n"\
           "    line-width: 1;\n"\
           "    line-opacity: 0.5;\n"\
-          "    line-comp-op: soft-light;\n"\
           "  }\n"\
           "}"
         end

--- a/spec/lib/carto/styles/geometry_spec.rb
+++ b/spec/lib/carto/styles/geometry_spec.rb
@@ -27,10 +27,12 @@ module Carto
           "  polygon-fill: #374C70;\n"\
           "  polygon-opacity: 0.9;\n"\
           "  polygon-gamma: 0.5;\n"\
-          "  line-color: #FFF;\n"\
-          "  line-width: 1;\n"\
-          "  line-opacity: 0.5;\n"\
-          "  line-comp-op: soft-light;\n"\
+          "  ::outline {\n"\
+          "    line-color: #FFF;\n"\
+          "    line-width: 1;\n"\
+          "    line-opacity: 0.5;\n"\
+          "    line-comp-op: soft-light;\n"\
+          "  }\n"\
           "}"
         end
 

--- a/spec/lib/carto/styles/polygon_spec.rb
+++ b/spec/lib/carto/styles/polygon_spec.rb
@@ -11,10 +11,12 @@ module Carto
           "  polygon-fill: #374C70;\n"\
           "  polygon-opacity: 0.9;\n"\
           "  polygon-gamma: 0.5;\n"\
-          "  line-color: #FFF;\n"\
-          "  line-width: 1;\n"\
-          "  line-opacity: 0.5;\n"\
-          "  line-comp-op: soft-light;\n"\
+          "  ::outline {\n"\
+          "    line-color: #FFF;\n"\
+          "    line-width: 1;\n"\
+          "    line-opacity: 0.5;\n"\
+          "    line-comp-op: soft-light;\n"\
+          "  }\n"\
           "}"
         end
 

--- a/spec/lib/carto/styles/polygon_spec.rb
+++ b/spec/lib/carto/styles/polygon_spec.rb
@@ -10,12 +10,10 @@ module Carto
           "#layer {\n"\
           "  polygon-fill: #374C70;\n"\
           "  polygon-opacity: 0.9;\n"\
-          "  polygon-gamma: 0.5;\n"\
           "  ::outline {\n"\
           "    line-color: #FFF;\n"\
           "    line-width: 1;\n"\
           "    line-opacity: 0.5;\n"\
-          "    line-comp-op: soft-light;\n"\
           "  }\n"\
           "}"
         end


### PR DESCRIPTION
This PR implements #12410.

Needs to be merged after #12411.