### PR TITLE
Remove unsupported CartoCSS rules for vector rendering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Development
 * Bump Webpack version (#12392).
 
 ### Bug fixes / enhancements
+* Remove unsupported CartoCSS rules for vector rendering (#12410)
 * Refactor Visualization::Member like and notification actions into Carto::Visualization (#12309)
 * Don't try to lowercase null values in custom-list-collection object (support/#744)
 * Tap on iOS10 mobile embed doesn't jump to page bottom (#cartodb.js/1652)

--- a/lib/carto/styles/polygon.rb
+++ b/lib/carto/styles/polygon.rb
@@ -25,8 +25,7 @@ module Carto::Styles
 
       [
         "polygon-fill: #{color};",
-        "polygon-opacity: #{opacity};",
-        "polygon-gamma: 0.5;"
+        "polygon-opacity: #{opacity};"
       ]
     end
 
@@ -39,8 +38,7 @@ module Carto::Styles
         "::outline" => [
           "line-color: #{color};",
           "line-width: #{width};",
-          "line-opacity: #{opacity};",
-          "line-comp-op: soft-light;"
+          "line-opacity: #{opacity};"
         ]
       ]
     end

--- a/spec/lib/carto/styles/geometry_spec.rb
+++ b/spec/lib/carto/styles/geometry_spec.rb
@@ -26,12 +26,10 @@ module Carto
           "#layer['mapnik::geometry_type'=3] {\n"\
           "  polygon-fill: #374C70;\n"\
           "  polygon-opacity: 0.9;\n"\
-          "  polygon-gamma: 0.5;\n"\
           "  ::outline {\n"\
           "    line-color: #FFF;\n"\
           "    line-width: 1;\n"\
           "    line-opacity: 0.5;\n"\
-          "    line-comp-op: soft-light;\n"\
           "  }\n"\
           "}"
         end

--- a/spec/lib/carto/styles/polygon_spec.rb
+++ b/spec/lib/carto/styles/polygon_spec.rb
@@ -10,12 +10,10 @@ module Carto
           "#layer {\n"\
           "  polygon-fill: #374C70;\n"\
           "  polygon-opacity: 0.9;\n"\
-          "  polygon-gamma: 0.5;\n"\
           "  ::outline {\n"\
           "    line-color: #FFF;\n"\
           "    line-width: 1;\n"\
           "    line-opacity: 0.5;\n"\
-          "    line-comp-op: soft-light;\n"\
           "  }\n"\
           "}"
         end


### PR DESCRIPTION
This PR implements #12410.

Needs to be merged after #12411.