### PR TITLE
Fix blend-mode bug

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-icons/heatmap.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-icons/heatmap.tpl
@@ -1,4 +1,4 @@
-<svg width="56px" height="25px" viewBox="0 0 56 25">
+<svg width="56px" height="25px" viewBox="0 0 56 25" style="will-change: opacity;">
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Aggregation-/-Heatmap" transform="translate(-15.000000, -16.000000)">
             <g id="Group-7">


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/12442

It seems that Chrome has recently changed the way it implements `mix-blend-mode` mixed with `opacity`.

Fix found at https://stackoverflow.com/questions/30479321/chrome-css3-mix-blend-mode-bug-in-chrome