### PR TITLE
Skip layer after_added_to_map callback for in-memory operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,7 @@ Development
 * `create_dev_user` rake no longer tries to auto-create the database, `cartodb:db:setup` should be run first (#12187).
 * Fix EUMAPI response as per documentation (#12233)
 * Fix dimension check and support for SVG without extension and XML header (#12374).
+* Builder embed doesn't need user DB connection anymore (#12473).
 * Visualization models no longer raise an error checking `password_valid?` (#12270).
 * Fix `BUILDER_ENABLED` parameter in `create_dev_user` rake (#12189)
 * User organization or user key for google maps (#12232)

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -36,8 +36,10 @@ module Carto
     def tables_from_query(query)
       query.present? ? tables_from_names(affected_table_names(query), user) : []
     rescue => e
-      # INFO: this covers changes that CartoDB can't track.
+      # INFO: this covers changes that CartoDB can't track, so we must handle it gracefully.
       # For example, if layer SQL contains wrong SQL (uses a table that doesn't exist, or uses an invalid operator).
+      # This warning level is checked in tests to ensure that embed view does not need user DB connection,
+      # so we need to keep it (or change the tests accordingly)
       CartoDB::Logger.warning(message: 'Could not retrieve tables from query', exception: e, user: user, layer: self)
       []
     end

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -38,7 +38,7 @@ module Carto
     rescue => e
       # INFO: this covers changes that CartoDB can't track.
       # For example, if layer SQL contains wrong SQL (uses a table that doesn't exist, or uses an invalid operator).
-      CartoDB::Logger.debug(message: 'Could not retrieve tables from query', exception: e, user: user, layer: self)
+      CartoDB::Logger.warning(message: 'Could not retrieve tables from query', exception: e, user: user, layer: self)
       []
     end
 
@@ -290,6 +290,9 @@ module Carto
     end
 
     def after_added_to_map(map)
+      # This avoids unnecessary operations for in-memory logic. Example: Mapcap recreation. See #12473.
+      return unless map.persisted?
+
       set_default_order(map)
       register_table_dependencies
     end

--- a/spec/models/carto/mapcap_spec.rb
+++ b/spec/models/carto/mapcap_spec.rb
@@ -104,29 +104,31 @@ describe Carto::Mapcap do
   describe '#regenerate_visualization' do
     before(:all) do
       @mapcap = Carto::Mapcap.create!(visualization_id: @visualization.id)
-      @regenerated_visualization = @mapcap.regenerate_visualization
     end
 
     after(:all) do
       @mapcap.destroy
       @ids_json = nil
-      @regenerated_visualization = nil
     end
 
     it 'should preserve map' do
-      @regenerated_visualization.map.id.should eq @map.id
+      regenerated_visualization = @mapcap.regenerate_visualization
+      regenerated_visualization.map.id.should eq @map.id
     end
 
     it 'should preserve visualization' do
-      @regenerated_visualization.id.should eq @visualization.id
+      regenerated_visualization = @mapcap.regenerate_visualization
+      regenerated_visualization.id.should eq @visualization.id
     end
 
     it 'should preserve user' do
-      @regenerated_visualization.user.id.should eq @visualization.user.id
+      regenerated_visualization = @mapcap.regenerate_visualization
+      regenerated_visualization.user.id.should eq @visualization.user.id
     end
 
     it 'should preserve permission' do
-      @regenerated_visualization.permission.id.should eq @visualization.permission.id
+      regenerated_visualization = @mapcap.regenerate_visualization
+      regenerated_visualization.permission.id.should eq @visualization.permission.id
     end
 
     describe 'with layers' do
@@ -135,20 +137,24 @@ describe Carto::Mapcap do
         @visualization.reload
 
         @mapcap = Carto::Mapcap.create!(visualization_id: @visualization.id)
-        @regenerated_visualization = @mapcap.regenerate_visualization
       end
 
       after(:all) do
         @mapcap.destroy
         @carto_layer.destroy
         @visualization.reload
-        @regenerated_visualization = nil
       end
 
       it 'should contain same layers in same order' do
-        @regenerated_visualization.layers.each_with_index do |layer, index|
-          layer.id == @regenerated_visualization.layers[index].id
+        CartoDB::Logger.expects(:warning).never
+        User.any_instance.stubs(:in_database).raises("Mapcap regeneration shouldn't touch user database")
+        Carto::User.any_instance.stubs(:in_database).raises("Mapcap regeneration shouldn't touch user database")
+        regenerated_visualization = @mapcap.regenerate_visualization
+        regenerated_visualization.layers.each_with_index do |layer, index|
+          layer.id == regenerated_visualization.layers[index].id
         end
+        Carto::User.any_instance.unstub(:in_database)
+        User.any_instance.unstub(:in_database)
       end
 
       describe 'with widgets' do
@@ -157,19 +163,18 @@ describe Carto::Mapcap do
           @visualization.reload
 
           @mapcap = Carto::Mapcap.create!(visualization_id: @visualization.id)
-          @regenerated_visualization = @mapcap.regenerate_visualization
         end
 
         after(:all) do
           @widget.destroy
           @visualization.reload
           @mapcap.destroy
-          @regenerated_visualization = nil
         end
 
         it 'should contain widgets only for layers with widgets and in the right order' do
           @visualization.layers.each_with_index do |layer, index|
-            regenerated_layer = @regenerated_visualization.layers[index]
+            regenerated_visualization = @mapcap.regenerate_visualization
+            regenerated_layer = regenerated_visualization.layers[index]
 
             layer.widgets.length.should eq regenerated_layer.widgets.length
 

--- a/spec/models/carto/mapcap_spec.rb
+++ b/spec/models/carto/mapcap_spec.rb
@@ -149,7 +149,9 @@ describe Carto::Mapcap do
 
       it 'should work' do
         CartoDB::Logger.expects(:warning).never
+        User.any_instance.expects(:in_database).never
         @mapcap_nodb.regenerate_visualization
+        User.any_instance.unstub(:in_database)
       end
     end
 
@@ -173,7 +175,7 @@ describe Carto::Mapcap do
         Carto::User.any_instance.stubs(:in_database).raises("Mapcap regeneration shouldn't touch user database")
         regenerated_visualization = @mapcap.regenerate_visualization
         regenerated_visualization.layers.each_with_index do |layer, index|
-          layer.id == regenerated_visualization.layers[index].id
+          expect(layer.id).to eq(regenerated_visualization.layers[index].id)
         end
         Carto::User.any_instance.unstub(:in_database)
         User.any_instance.unstub(:in_database)


### PR DESCRIPTION
This closes #12473 and #12471.

Notes for acceptance: this might affect layer ordering and the detection of table <-> layer dependency (so, deletion of a table might not be detected as a conflict on a map).