### PR TITLE
Remove visualization collection from pages controller sitemap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,6 @@ Development
 * Remove unsupported CartoCSS rules for vector rendering (#12410)
 * Fixed typo in content_no_datasets.jst.ejs and en.json (Docs)
 * Fixing problem parsing formula widget creation (#support/843)
-* Refactor Visualization::Member like and notification actions into Carto::Visualization (#12309)
 * Don't try to lowercase null values in custom-list-collection object (support/#744)
 * Tap on iOS10 mobile embed doesn't jump to page bottom (#cartodb.js/1652)
 * Don't try to lowercase null values in custom-list-collection object (#support/744)
@@ -58,8 +57,9 @@ Development
 * Fix regenerate all api keys in an organization (#12218)
 * Refactor:
   * ::User <-> CartoDB::Visualization::Member dependency: #12116, #12221
-  * Removed CartoDB::Visualization::Member from controllers: #12185, #12267
-* Refactor Layer model (#10934) and UserTable (#11589, #11700, #11737).
+  * Removed CartoDB::Visualization::Member and CartoDB::Visualization::Collection from controllers: #12185, #12267, #12485.
+  * Visualization::Member like and notification actions into Carto::Visualization (#12309)
+  * Layer model (#10934) and UserTable (#11589, #11700, #11737).
 * [WIP] Update to Rails 4
   * Update `rails-sequel` (#12118)
   * Changes compatible with Rails 3 (#12117)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -60,14 +60,14 @@ class Admin::PagesController < Admin::AdminController
         redirect_to CartoDB.base_url(@viewed_user.organization.name) << CartoDB.path(self, 'public_sitemap') and return
       end
 
-      visualizations = Carto::VisualizationQueryBuilder.
-        new.
-        with_user_id(@viewed_user.id).
-        with_privacy(Carto::Visualization::PRIVACY_PUBLIC).
-        with_order('visualizations.updated_at', :desc).
-        without_raster.
-        with_prefetch_user(true).
-        build
+      visualizations = Carto::VisualizationQueryBuilder
+        .new
+        .with_user_id(@viewed_user.id)
+        .with_privacy(Carto::Visualization::PRIVACY_PUBLIC)
+        .with_order('visualizations.updated_at', :desc)
+        .without_raster
+        .with_prefetch_user(true)
+        .build
     end
 
     @urls = visualizations.map { |vis|

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -60,26 +60,25 @@ class Admin::PagesController < Admin::AdminController
         redirect_to CartoDB.base_url(@viewed_user.organization.name) << CartoDB.path(self, 'public_sitemap') and return
       end
 
-      visualizations = Visualization::Collection.new.fetch({
-        user_id:  @viewed_user.id,
-        privacy:  Visualization::Member::PRIVACY_PUBLIC,
-        order:    'updated_at',
-        o:        {updated_at: :desc},
-        exclude_shared: true,
-        exclude_raster: true
-      })
+      visualizations = Carto::VisualizationQueryBuilder.new.
+        with_user_id(@viewed_user.id).
+        with_privacy(Carto::Visualization::PRIVACY_PUBLIC).
+        with_order('visualizations.updated_at', :desc).
+        without_raster.
+        with_prefetch_user(true).
+        build
     end
 
-    @urls = visualizations.collect{ |vis|
+    @urls = visualizations.map { |vis|
       case vis.type
-        when Visualization::Member::TYPE_DERIVED
+        when Carto::Visualization::TYPE_DERIVED
           {
-            loc: CartoDB.url(self, 'public_visualizations_public_map', {id: vis[:id] }, vis.user),
+            loc: CartoDB.url(self, 'public_visualizations_public_map', { id: vis.id }, vis.user),
             lastfreq: vis.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z")
           }
-        when Visualization::Member::TYPE_CANONICAL
+        when Carto::Visualization::TYPE_CANONICAL
           {
-            loc: CartoDB.url(self, 'public_table', {id: vis.name }, vis.user),
+            loc: CartoDB.url(self, 'public_table', { id: vis.name }, vis.user),
             lastfreq: vis.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z")
           }
         else

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -60,14 +60,13 @@ class Admin::PagesController < Admin::AdminController
         redirect_to CartoDB.base_url(@viewed_user.organization.name) << CartoDB.path(self, 'public_sitemap') and return
       end
 
-      visualizations = Carto::VisualizationQueryBuilder
-        .new
-        .with_user_id(@viewed_user.id)
-        .with_privacy(Carto::Visualization::PRIVACY_PUBLIC)
-        .with_order('visualizations.updated_at', :desc)
-        .without_raster
-        .with_prefetch_user(true)
-        .build
+      visualizations = Carto::VisualizationQueryBuilder.new
+                                                       .with_user_id(@viewed_user.id)
+                                                       .with_privacy(Carto::Visualization::PRIVACY_PUBLIC)
+                                                       .with_order('visualizations.updated_at', :desc)
+                                                       .without_raster
+                                                       .with_prefetch_user(true)
+                                                       .build
     end
 
     @urls = visualizations.map { |vis|
@@ -82,8 +81,6 @@ class Admin::PagesController < Admin::AdminController
           loc: CartoDB.url(self, 'public_table', { id: vis.name }, vis.user),
           lastfreq: vis.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z")
         }
-      else
-        nil
       end
     }.compact
     render :formats => [:xml]

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -60,7 +60,8 @@ class Admin::PagesController < Admin::AdminController
         redirect_to CartoDB.base_url(@viewed_user.organization.name) << CartoDB.path(self, 'public_sitemap') and return
       end
 
-      visualizations = Carto::VisualizationQueryBuilder.new.
+      visualizations = Carto::VisualizationQueryBuilder.
+        new.
         with_user_id(@viewed_user.id).
         with_privacy(Carto::Visualization::PRIVACY_PUBLIC).
         with_order('visualizations.updated_at', :desc).
@@ -71,18 +72,18 @@ class Admin::PagesController < Admin::AdminController
 
     @urls = visualizations.map { |vis|
       case vis.type
-        when Carto::Visualization::TYPE_DERIVED
-          {
-            loc: CartoDB.url(self, 'public_visualizations_public_map', { id: vis.id }, vis.user),
-            lastfreq: vis.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z")
-          }
-        when Carto::Visualization::TYPE_CANONICAL
-          {
-            loc: CartoDB.url(self, 'public_table', { id: vis.name }, vis.user),
-            lastfreq: vis.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z")
-          }
-        else
-          nil
+      when Carto::Visualization::TYPE_DERIVED
+        {
+          loc: CartoDB.url(self, 'public_visualizations_public_map', { id: vis.id }, vis.user),
+          lastfreq: vis.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z")
+        }
+      when Carto::Visualization::TYPE_CANONICAL
+        {
+          loc: CartoDB.url(self, 'public_table', { id: vis.name }, vis.user),
+          lastfreq: vis.updated_at.strftime("%Y-%m-%dT%H:%M:%S%:z")
+        }
+      else
+        nil
       end
     }.compact
     render :formats => [:xml]

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -51,7 +51,7 @@ class Admin::PagesController < Admin::AdminController
     if @viewed_user.nil?
       username = CartoDB.extract_subdomain(request)
       org = get_organization_if_exists(username)
-      return if org.nil?
+      render_404 and return if org.nil?
       visualizations = (org.public_visualizations.to_a || [])
       visualizations += (org.public_datasets.to_a || [])
     else

--- a/spec/factories/users_helper.rb
+++ b/spec/factories/users_helper.rb
@@ -6,9 +6,9 @@ shared_context 'users helper' do
   end
 
   before(:all) do
-    @user1 = FactoryGirl.create(:valid_user, private_tables_enabled: true)
+    @user1 = FactoryGirl.create(:valid_user, private_tables_enabled: true, private_maps_enabled: true)
     @carto_user1 = Carto::User.find(@user1.id)
-    @user2 = FactoryGirl.create(:valid_user, private_tables_enabled: true)
+    @user2 = FactoryGirl.create(:valid_user, private_tables_enabled: true, private_maps_enabled: true)
     @carto_user2 = Carto::User.find(@user2.id)
   end
 

--- a/spec/requests/admin/pages_controller_spec.rb
+++ b/spec/requests/admin/pages_controller_spec.rb
@@ -291,7 +291,7 @@ describe Admin::PagesController do
         get public_sitemap_url(user_domain: @carto_organization.name)
         last_response.status.should eq 200
         document = Nokogiri::XML(last_response.body)
-        url_and_dates = document.search('url').map { |url| [url.at('loc').text, url.at('lastmod').text ] }
+        url_and_dates = document.search('url').map { |url| [url.at('loc').text, url.at('lastmod').text] }
         url_and_dates.count.should eq 1
 
         url1 = public_visualizations_public_map_url(user_domain: @carto_org_user_1.username, id: visualization.id)
@@ -314,7 +314,7 @@ describe Admin::PagesController do
         get public_sitemap_url(user_domain: @carto_user1.username)
         last_response.status.should eq 200
         document = Nokogiri::XML(last_response.body)
-        url_and_dates = document.search('url').map { |url| [url.at('loc').text, url.at('lastmod').text ] }
+        url_and_dates = document.search('url').map { |url| [url.at('loc').text, url.at('lastmod').text] }
         url_and_dates.count.should eq 1
 
         url1 = public_visualizations_public_map_url(id: visualization.id)

--- a/spec/requests/admin/pages_controller_spec.rb
+++ b/spec/requests/admin/pages_controller_spec.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 require_relative '../../spec_helper'
 require_relative '../../../app/controllers/admin/pages_controller'
+require 'spec/factories/organizations_contexts'
+require 'spec/factories/carto_visualizations'
 
 def app
   CartoDB::Application.new
@@ -25,33 +27,33 @@ describe Admin::PagesController do
     @user_org = true
   end
 
-  before(:each) do
-    host! "#{@org_name}.localhost.lan"
-  end
-
-  after(:each) do
-    ::User.all.each {|u| u.delete}
-  end
-
   describe '#index' do
+    before(:each) do
+      host! "#{@org_name}.localhost.lan"
+    end
+
     it 'returns 404 if user does not belongs to host organization' do
-      prepare_user(@non_org_user_name)
+      user = prepare_user(@non_org_user_name)
 
       get "/u/#{@non_org_user_name}", {}, JSON_HEADER
 
       last_response.status.should == 404
+
+      user.delete
     end
 
     it 'returns 200 if it is an org user and belongs to host organization' do
-      prepare_user(@org_user_name, @user_org, @belongs_to_org)
+      user = prepare_user(@org_user_name, @user_org, @belongs_to_org)
 
       get "/u/#{@org_user_name}", {}, JSON_HEADER
 
       last_response.status.should == 200
+
+      user.delete
     end
 
     it 'redirects if it is an org user but gets called without organization' do
-      prepare_user(@org_user_name, @user_org, @belongs_to_org)
+      user = prepare_user(@org_user_name, @user_org, @belongs_to_org)
 
       host! "#{@org_user_name}.localhost.lan"
       get "", {}, JSON_HEADER
@@ -59,14 +61,18 @@ describe Admin::PagesController do
       last_response.status.should == 302
       follow_redirect!
       last_response.status.should == 200
+
+      user.delete
     end
 
     it 'returns 404 if it is an org user but does NOT belong to host organization' do
-      prepare_user(@other_org_user_name, @user_org, !@belongs_to_org)
+      user = prepare_user(@other_org_user_name, @user_org, !@belongs_to_org)
 
       get "/u/#{@other_org_user_name}", {}, JSON_HEADER
 
       last_response.status.should == 404
+
+      user.delete
     end
 
     it 'returns 404 if user does NOT exist' do
@@ -89,10 +95,12 @@ describe Admin::PagesController do
       uri = URI.parse(last_request.url)
       uri.host.should == 'anyuser.localhost.lan'
       uri.path.should == '/me'
+
+      [anyuser, anyviewer].each(&:delete)
     end
 
     it 'redirects to user feed if not logged in' do
-      prepare_user('anyuser')
+      user = prepare_user('anyuser')
       host! 'anyuser.localhost.lan'
 
       get '', {}, JSON_HEADER
@@ -103,12 +111,14 @@ describe Admin::PagesController do
       uri.path.should == '/me'
       follow_redirect!
       last_response.status.should == 200
+
+      user.delete
     end
 
     it 'redirects to local login page if no user is specified and Central is not enabled' do
       old_cartodb_central_api = Cartodb.config[:cartodb_central_api]
       Cartodb.config[:cartodb_central_api] = {}
-      prepare_user('anyuser')
+      user = prepare_user('anyuser')
       host! 'localhost.lan'
       CartoDB.stubs(:session_domain).returns('localhost.lan')
       CartoDB.stubs(:subdomainless_urls?).returns(true)
@@ -123,6 +133,8 @@ describe Admin::PagesController do
       last_response.status.should == 200
 
       Cartodb.config[:cartodb_central_api] = old_cartodb_central_api
+
+      user.delete
     end
 
     it 'redirects to Central login page if no user is specified and Central is enabled' do
@@ -135,7 +147,7 @@ describe Admin::PagesController do
         'username' => 'api',
         'password' => 'test'
       }
-      prepare_user('anyuser')
+      user = prepare_user('anyuser')
       host! 'localhost.lan'
       CartoDB.stubs(:session_domain).returns('localhost.lan')
       CartoDB.stubs(:subdomainless_urls?).returns(true)
@@ -156,6 +168,8 @@ describe Admin::PagesController do
       follow_redirect!
 
       Cartodb.config[:cartodb_central_api] = old_cartodb_central_api
+
+      user.delete
     end
 
     it 'redirects and loads the dashboard if the user is logged in' do
@@ -171,6 +185,8 @@ describe Admin::PagesController do
       uri = URI.parse(last_response.location)
       uri.host.should == 'localhost.lan'
       uri.path.should == '/user/anyuser/dashboard'
+
+      anyuser.delete
     end
 
     it 'extracts username from redirection for dashboard with subdomainless' do
@@ -193,13 +209,19 @@ describe Admin::PagesController do
       User.any_instance.stubs(:db_size_in_bytes).returns(0)
       get location
       last_response.status.should == 200
+
+      anyuser.delete
     end
 
   end
 
   describe '#explore' do
+    before(:each) do
+      host! "#{@org_name}.localhost.lan"
+    end
+
     it 'should go to explore page' do
-      mock_explore_feature_flag
+      user = mock_explore_feature_flag
       host! 'localhost.lan'
 
       get '/explore', {}, JSON_HEADER
@@ -208,10 +230,12 @@ describe Admin::PagesController do
       uri = URI.parse(last_request.url)
       uri.host.should == 'localhost.lan'
       uri.path.should == '/explore'
+
+      user.delete
     end
 
     it 'should go to explore search page' do
-      mock_explore_feature_flag
+      user = mock_explore_feature_flag
       host! 'localhost.lan'
 
       get '/search', {}, JSON_HEADER
@@ -220,10 +244,12 @@ describe Admin::PagesController do
       uri = URI.parse(last_request.url)
       uri.host.should == 'localhost.lan'
       uri.path.should == '/search'
+
+      user.delete
     end
 
     it 'should go to explore search page with a query variable' do
-      mock_explore_feature_flag
+      user = mock_explore_feature_flag
       host! 'localhost.lan'
 
       get '/search/lala', {}, JSON_HEADER
@@ -232,13 +258,68 @@ describe Admin::PagesController do
       uri = URI.parse(last_request.url)
       uri.host.should == 'localhost.lan'
       uri.path.should == '/search/lala'
+
+      user.delete
     end
   end
 
   describe '#sitemap' do
+    include Carto::Factories::Visualizations
     it 'should return 404 if no user or organization is provided' do
       get '/sitemap.xml'
       last_response.status.should == 404
+    end
+
+    describe 'for organizations' do
+      include_context 'organization with users helper'
+
+      before(:each) do
+        host! "#{@carto_organization.name}.localhost.lan:#{Cartodb.config[:http_port]}"
+      end
+
+      it 'returns an empty body if there are not visualizations' do
+        get public_sitemap_url(user_domain: @carto_organization.name)
+        document = Nokogiri::XML(last_response.body)
+        document.child.child.text.should eq "\n"
+      end
+
+      it 'returns public visualizations' do
+        private_attrs = { privacy: Carto::Visualization::PRIVACY_PRIVATE }
+        create_full_visualization(@carto_org_user_1, visualization_attributes: private_attrs)
+        public_attrs = { privacy: Carto::Visualization::PRIVACY_PUBLIC }
+        _, _, _, visualization = create_full_visualization(@carto_org_user_1, visualization_attributes: public_attrs)
+        get public_sitemap_url(user_domain: @carto_organization.name)
+        last_response.status.should eq 200
+        document = Nokogiri::XML(last_response.body)
+        url_and_dates = document.search('url').map { |url| [url.at('loc').text, url.at('lastmod').text ] }
+        url_and_dates.count.should eq 1
+
+        url1 = public_visualizations_public_map_url(user_domain: @carto_org_user_1.username, id: visualization.id)
+        url_and_dates.map { |url_and_date| url_and_date[0] }.should eq [url1.gsub(/\/user\/[^\/]*\//, '/')]
+      end
+    end
+
+    describe 'for users' do
+      include_context 'users helper'
+
+      before(:each) do
+        host! "#{@carto_user1.username}.localhost.lan:#{Cartodb.config[:http_port]}"
+      end
+
+      it 'returns public visualizations' do
+        private_attrs = { privacy: Carto::Visualization::PRIVACY_PRIVATE }
+        create_full_visualization(@carto_user1, visualization_attributes: private_attrs)
+        public_attrs = { privacy: Carto::Visualization::PRIVACY_PUBLIC }
+        _, _, _, visualization = create_full_visualization(@carto_user1, visualization_attributes: public_attrs)
+        get public_sitemap_url(user_domain: @carto_user1.username)
+        last_response.status.should eq 200
+        document = Nokogiri::XML(last_response.body)
+        url_and_dates = document.search('url').map { |url| [url.at('loc').text, url.at('lastmod').text ] }
+        url_and_dates.count.should eq 1
+
+        url1 = public_visualizations_public_map_url(id: visualization.id)
+        url_and_dates.map { |url_and_date| url_and_date[0] }.should eq [url1.gsub(/\/user\/[^\/]*\//, '/')]
+      end
     end
   end
 
@@ -249,6 +330,7 @@ describe Admin::PagesController do
                           .returns(true)
     ::User.stubs(:where).returns(anyuser)
     anyuser.stubs(:first).returns(anyuser)
+    anyuser
   end
 
   def prepare_user(user_name, org_user=false, belongs_to_org=false)

--- a/spec/requests/admin/pages_controller_spec.rb
+++ b/spec/requests/admin/pages_controller_spec.rb
@@ -235,6 +235,13 @@ describe Admin::PagesController do
     end
   end
 
+  describe '#sitemap' do
+    it 'should return 404 if no user or organization is provided' do
+      get '/sitemap.xml'
+      last_response.status.should == 404
+    end
+  end
+
   def mock_explore_feature_flag
     anyuser = prepare_user('anyuser')
     ::User.any_instance.stubs(:has_feature_flag?)

--- a/spec/requests/admin/pages_controller_spec.rb
+++ b/spec/requests/admin/pages_controller_spec.rb
@@ -105,8 +105,10 @@ describe Admin::PagesController do
       last_response.status.should == 200
     end
 
-    it 'redirects to login page if no user is especified' do
-      anyuser = prepare_user('anyuser')
+    it 'redirects to local login page if no user is specified and Central is not enabled' do
+      old_cartodb_central_api = Cartodb.config[:cartodb_central_api]
+      Cartodb.config[:cartodb_central_api] = {}
+      prepare_user('anyuser')
       host! 'localhost.lan'
       CartoDB.stubs(:session_domain).returns('localhost.lan')
       CartoDB.stubs(:subdomainless_urls?).returns(true)
@@ -119,6 +121,41 @@ describe Admin::PagesController do
       uri.path.should == '/login'
       follow_redirect!
       last_response.status.should == 200
+
+      Cartodb.config[:cartodb_central_api] = old_cartodb_central_api
+    end
+
+    it 'redirects to Central login page if no user is specified and Central is enabled' do
+      old_cartodb_central_api = Cartodb.config[:cartodb_central_api]
+      central_host = 'somewhere.lan'
+      central_port = 4321
+      Cartodb.config[:cartodb_central_api] = {
+        'host' => central_host,
+        'port' => central_port,
+        'username' => 'api',
+        'password' => 'test'
+      }
+      prepare_user('anyuser')
+      host! 'localhost.lan'
+      CartoDB.stubs(:session_domain).returns('localhost.lan')
+      CartoDB.stubs(:subdomainless_urls?).returns(true)
+
+      get '', {}, JSON_HEADER
+
+      last_response.status.should == 302
+      uri = URI.parse(last_response.location)
+      uri.host.should == 'localhost.lan'
+      uri.path.should == '/login'
+      follow_redirect!
+
+      last_response.status.should == 302
+      uri = URI.parse(last_response.location)
+      uri.host.should == central_host
+      uri.port.should == central_port
+      uri.path.should == '/login'
+      follow_redirect!
+
+      Cartodb.config[:cartodb_central_api] = old_cartodb_central_api
     end
 
     it 'redirects and loads the dashboard if the user is logged in' do


### PR DESCRIPTION
This closes #12485.

As `VisualizationQueryBuilder` knows that "public" implies "published" for Builder visualizations, results might be a little different.