### PR TITLE
Provide layer cartocss in viz-json v3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Development
 -----------
 
 ### Features
+* Provide CartoCSS attribute within layer info in vizjson v3 (CartoDB/support#858)
 * Support for nested properties in CartoCSS (#12411)
 * New loading button styles (#12132)
 * [WIP] Export/import organization/user metadata to allow user migration (#12271, #12304, #12323)

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -251,7 +251,8 @@ module Carto
           visible: layer_vizjson[:visible],
           options: {
             layer_name: layer_options[:layer_name],
-            attribution: layer_options[:attribution]
+            attribution: layer_options[:attribution],
+            cartocss: layer_options[:cartocss]
           }
         }
 

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -182,7 +182,7 @@ describe Carto::Api::VizJSON3Presenter do
     it 'includes cartocss at layers options' do
       cartocss = '#layer { marker-fill: #fabada; }'
       layer = @visualization.data_layers.first
-      layer.options['cartocss'] = cartocss
+      layer.options['tile_style'] = cartocss
       layer.save
       @table.privacy = Carto::UserTable::PRIVACY_PRIVATE
       @table.save!
@@ -331,11 +331,9 @@ describe Carto::Api::VizJSON3Presenter do
 
       include_examples 'common layer checks'
 
-      it 'should not include sql nor cartocss fields in data layers' do
+      it 'should not include sql field in data layers' do
         data_layer_options = vizjson[:layers][1][:options]
         data_layer_options.should_not include :sql
-        data_layer_options.should_not include :cartocss
-        data_layer_options.should_not include :cartocss_version
       end
 
       it 'should include cartocss but not sql in torque layers' do

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -178,6 +178,19 @@ describe Carto::Api::VizJSON3Presenter do
       v3_vizjson = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user).send :calculate_vizjson
       v3_vizjson[:layers][1][:options][:source].should eq source
     end
+
+    it 'includes cartocss at layers options' do
+      cartocss = '#layer { marker-fill: #fabada; }'
+      layer = @visualization.data_layers.first
+      layer.options['cartocss'] = cartocss
+      layer.save
+      @table.privacy = Carto::UserTable::PRIVACY_PRIVATE
+      @table.save!
+      @visualization.reload
+
+      v3_vizjson = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user).send :calculate_vizjson
+      v3_vizjson[:layers][1][:options][:cartocss].should eq cartocss
+    end
   end
 
   describe 'analyses' do


### PR DESCRIPTION
Related tickets: https://github.com/CartoDB/support/issues/858 and https://github.com/CartoDB/support/issues/859

### THE PROBLEM
We are not providing the CartoCSS within the layers information in the vizJSON v3. Turns out, when map instantiation is completed, CARTO.js takes the CartoCSS info from it and add it to the CARTO.js layer model. Bad thing? It comes "converted", not with turbo-carto, and it makes fail the auto-style.

Adding an example, because it is easier:

- Create a map, imagine you have a layer of points, and you apply this type of CartoCSS (via UI or manually).
```css
#layer {
  marker-fill: ramp([category], (#ff3300, #00ffff, #ffff00, #ff00ff,#66ff33), ("Partiers", "Intra-borough residents", "Working class", "Visitors with Expensive Taste", "Orthodox Jewish"), "=");
  marker-fill-opacity: .5;
  marker-allow-overlap: true;
  marker-line-width: 0;
  marker-line-color: #ffffff;
  marker-line-opacity: 1;
}
```
- Publish it.
- Go to the public embed url and open the browser developer tools.
- Print `vizJSON` object in the console and check that layer doens't contain the CartoCSS.
![screen shot 2017-07-20 at 12 23 55](https://user-images.githubusercontent.com/132146/28413021-5a3d964e-6d46-11e7-8a21-149374795a69.png)

- But, if you check the instantiation response (remember, ```/api/v1/map/named/tpl_xxxx…/jsonp?config=xxxx```), layer info will contain the converted CartoCSS.
![screen shot 2017-07-20 at 12 25 51](https://user-images.githubusercontent.com/132146/28413082-9eb0bf0e-6d46-11e7-9dc1-90a0cc864cc1.png)

CARTO.js will take (you, CARTO.js, smart :) ) that CartoCSS from the instantiation response and will add it in the layer-model.
```css
#layer {
  [ category = "Partiers" ] {
    marker-fill: #ff3300;
  }
  
  [ category = "Intra-borough residents" ] {
    marker-fill: #00ffff;
  }
  
  [ category = "Working class" ] {
    marker-fill: #ffff00;
  }
  
  [ category = "Visitors with Expensive Taste" ] {
    marker-fill: #ff00ff;
  }
  
  [ category = "Orthodox Jewish" ] {
    marker-fill: #66ff33;
  }
  marker-fill-opacity: .5;
  marker-allow-overlap: true;
  marker-line-width: 0;
  marker-line-color: #ffffff;
  marker-line-opacity: 1;
}
```
- Bad thing is when you want to apply the auto-style, it will look into the "current" CartoCSS the main "marker-fill" attribute and it will not find it, because rest of marker-fill are located within conditionals, and we get rid of them in the process of autostyle. So, the CartoCSS of the autostyle ends up to be:

```css
#layer {
  [ category = "Partiers" ] {
  }
  
  [ category = "Intra-borough residents" ] {
  }
  
  [ category = "Working class" ] {
  }
  
  [ category = "Visitors with Expensive Taste" ] {
  }
  
  [ category = "Orthodox Jewish" ] {
  }
  marker-fill-opacity: .5;
  marker-allow-overlap: true;
  marker-line-width: 0;
  marker-line-color: #ffffff;
  marker-line-opacity: 1;
}
```

- And that's why you can find the map with this look:
![screen shot 2017-07-20 at 12 36 01](https://user-images.githubusercontent.com/132146/28413494-04b5bfa6-6d48-11e7-9cb7-6330b8379ade.png)


### THE SOLUTION
Provide the CartoCSS of the CARTO layers in the vizJSON v3.

### QUESTIONS ASKED?
I've been wondering with @matallo and @javisantana about why it was NOT included from the beginning. @javisantana said we didn't want to include it in order to not expose any info about the style, but it doesn't make sense because it appears in the instantiation response, so it is likely there is no problem. In any case, @juanignaciosl, it would be great if you can check it/confirm it.

### HOW MANY MAPS ARE AFFECTED BY THIS PROBLEM?
All **public** maps having a ramp applied in the original CartoCSS, and if the user wants to apply the auto-style.

### DOES IT ONLY AFFECT PUBLIC MAPS?
Yes, because private Builder provides the original CartoCSS from the beginning and CARTO.js initializes layers with that value.

@nobuti @saleiva @noguerol @kevin-reilly for awareness.