### PR TITLE
Infowindow html tip

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,7 @@ Development
 * Country dropdown should be mandatory in postal code georeference (#12420)
 * Fixed bounds and center of thumbnails after updating a map
 * Fixed a bug in cartodb.js regarding the featureCount (#12490)
+* Add tip about sanitising values in popup's InfoWindow (#11340)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror-view.js
@@ -25,6 +25,8 @@ var ADDONS = {
 };
 
 module.exports = CoreView.extend({
+  module: 'components:code-mirror:code-mirror-view',
+
   className: 'Editor-content',
 
   options: {
@@ -38,7 +40,7 @@ module.exports = CoreView.extend({
     if (!opts.model) throw new Error('Model for codemirror is required.');
     if (opts.model.get('content') === void 0 &&
         opts.placeholder === void 0) throw new Error('Content property or placeholder for codemirror is required.');
-    if (opts.tip === void 0) throw new Error('tip message is required');
+    if (opts.tips === void 0) throw new Error('tip messages are required');
 
     this._autocompleteChars = opts.autocompleteChars || this.options.autocompleteChars;
     this._mode = opts.mode || 'cartocss';
@@ -48,7 +50,7 @@ module.exports = CoreView.extend({
     this._autocompleteTriggers = opts.autocompleteTriggers;
     this._autocompleteSuffix = opts.autocompleteSuffix;
     this._errorTemplate = opts.errorTemplate || errorTemplate;
-    this._tip = opts.tip;
+    this._tips = opts.tips;
     this._lineWithErrors = [];
     this._onInputRead = _.bind(this._onKeyUpEditor, this);
     this._placeholder = opts.placeholder;
@@ -58,7 +60,7 @@ module.exports = CoreView.extend({
     this.$el.html(
       template({
         content: this.model.get('content'),
-        tip: this._tip
+        tip: this._tips.join('<br>')
       })
     );
 

--- a/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror-view.js
@@ -60,7 +60,7 @@ module.exports = CoreView.extend({
     this.$el.html(
       template({
         content: this.model.get('content'),
-        tip: this._tips.join(' ')
+        tips: this._tips.join(' ')
       })
     );
 

--- a/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror-view.js
@@ -60,7 +60,7 @@ module.exports = CoreView.extend({
     this.$el.html(
       template({
         content: this.model.get('content'),
-        tip: this._tips.join('<br>')
+        tip: this._tips.join(' ')
       })
     );
 

--- a/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror-view.js
@@ -40,7 +40,7 @@ module.exports = CoreView.extend({
     if (!opts.model) throw new Error('Model for codemirror is required.');
     if (opts.model.get('content') === void 0 &&
         opts.placeholder === void 0) throw new Error('Content property or placeholder for codemirror is required.');
-    if (opts.tips === void 0) throw new Error('tip messages are required');
+    if (!opts.tips) throw new Error('tip messages are required');
 
     this._autocompleteChars = opts.autocompleteChars || this.options.autocompleteChars;
     this._mode = opts.mode || 'cartocss';

--- a/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror.tpl
@@ -2,9 +2,9 @@
   <textarea class="js-editor"><%- content %></textarea>
 </div>
 
-<% if (tip) { %>
+<% if (tips) { %>
 <div class="CodeMirror-console js-console">
-  <%= tip %>
+  <%- tips %>
   <div class="js-console-error"></div>
 </div>
 <% } %>

--- a/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/code-mirror/code-mirror.tpl
@@ -4,7 +4,7 @@
 
 <% if (tip) { %>
 <div class="CodeMirror-console js-console">
-  <%- tip %>
+  <%= tip %>
   <div class="js-console-error"></div>
 </div>
 <% } %>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/code-editor.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/code-editor.js
@@ -46,7 +46,7 @@ Backbone.Form.editors.CodeEditor = Backbone.Form.editors.TextArea.extend({
       autocompletePrefix: '{{',
       autocompleteSuffix: '}}',
       placeholder: this.options.placeholder,
-      tip: ''
+      tips: []
     });
     this.codeMirrorView.bind('codeChanged', function () {
       this.trigger('change', this.codeMirrorView.getContent());

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-sql-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-sql-view.js
@@ -3,7 +3,7 @@ var CodeMirrorView = require('../../components/code-mirror/code-mirror-view');
 var ErrorTemplate = require('./code-mirror-error.tpl');
 var FactoryHints = require('../../editor/editor-hints/factory-hints');
 var SQLHints = require('../../editor/editor-hints/sql-hints');
-var checkAndBuildOpts = require('../../../../helpers/required-opts');
+var checkAndBuildOpts = require('../../helpers/required-opts');
 
 var REQUIRED_OPTS = [
   'codemirrorModel',

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-sql-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-options/dataset-sql-view.js
@@ -3,20 +3,22 @@ var CodeMirrorView = require('../../components/code-mirror/code-mirror-view');
 var ErrorTemplate = require('./code-mirror-error.tpl');
 var FactoryHints = require('../../editor/editor-hints/factory-hints');
 var SQLHints = require('../../editor/editor-hints/sql-hints');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
+
+var REQUIRED_OPTS = [
+  'codemirrorModel',
+  'onApplyEvent',
+  'querySchemaModel',
+  'layerDefinitionModel'
+];
 
 module.exports = CoreView.extend({
+  module: 'dataset:dataset-options:dataset-sql-view',
 
   className: 'Editor-content Dataset-editor',
 
   initialize: function (opts) {
-    if (!opts.codemirrorModel) throw new Error('codemirrorModel is required');
-    if (!opts.onApplyEvent) throw new Error('onApplyEvent');
-    if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-
-    this._codemirrorModel = opts.codemirrorModel;
-    this._querySchemaModel = opts.querySchemaModel;
-    this._layerDefinitionModel = opts.layerDefinitionModel;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     FactoryHints.init({
       querySchemaModel: this._querySchemaModel,
@@ -39,7 +41,9 @@ module.exports = CoreView.extend({
       model: this._codemirrorModel,
       hints: hints,
       mode: 'text/x-pgsql',
-      tip: _t('editor.data.code-mirror.tip'),
+      tips: [
+        _t('editor.data.code-mirror.tip')
+      ],
       errorTemplate: ErrorTemplate
     });
 
@@ -49,7 +53,6 @@ module.exports = CoreView.extend({
   },
 
   _triggerCodeSaved: function (code, view) {
-    this.options.onApplyEvent && this.options.onApplyEvent();
+    this._onApplyEvent && this._onApplyEvent();
   }
-
 });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/data/data-sql-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/data/data-sql-view.js
@@ -3,20 +3,22 @@ var CodeMirrorView = require('../../../../components/code-mirror/code-mirror-vie
 var ErrorTemplate = require('./code-mirror-error.tpl');
 var FactoryHints = require('../../../editor-hints/factory-hints');
 var SQLHints = require('../../../editor-hints/sql-hints');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
+
+var REQUIRED_OPTS = [
+  'layerDefinitionModel',
+  'querySchemaModel',
+  'codemirrorModel',
+  'onApplyEvent'
+];
 
 module.exports = CoreView.extend({
+  module: 'editor:layers:layer-content-views:data-sql-view',
 
   className: 'Editor-dataContentSQL Editor-content',
 
   initialize: function (opts) {
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-    if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
-    if (!opts.codemirrorModel) throw new Error('codemirrorModel is required');
-    if (!opts.onApplyEvent) throw new Error('onApplyEvent');
-
-    this._layerDefinitionModel = opts.layerDefinitionModel;
-    this._querySchemaModel = opts.querySchemaModel;
-    this._codemirrorModel = opts.codemirrorModel;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this._initBinds();
 
@@ -51,7 +53,9 @@ module.exports = CoreView.extend({
       model: this._codemirrorModel,
       hints: hints,
       mode: 'text/x-pgsql',
-      tip: _t('editor.data.code-mirror.tip'),
+      tips: [
+        _t('editor.data.code-mirror.tip')
+      ],
       errorTemplate: ErrorTemplate
     });
 
@@ -65,6 +69,6 @@ module.exports = CoreView.extend({
   },
 
   _triggerCodeSaved: function (code, view) {
-    this.options.onApplyEvent && this.options.onApplyEvent();
+    this._onApplyEvent && this._onApplyEvent();
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-html-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-html-view.js
@@ -9,6 +9,8 @@ var REQUIRED_OPTS = [
 ];
 
 module.exports = CoreView.extend({
+  module: 'editor:layers:layer-content-views:infowindow:infowindow-html-view',
+
   className: 'Editor-content',
 
   initialize: function (opts) {
@@ -25,7 +27,10 @@ module.exports = CoreView.extend({
   _initViews: function () {
     this.codeMirrorView = new CodeMirrorView({
       model: this._codemirrorModel,
-      tip: _t('editor.infowindow.code-mirror.save') + '<br>' + _t('editor.infowindow.code-mirror.sanitize'),
+      tips: [
+        _t('editor.infowindow.code-mirror.save'),
+        _t('editor.infowindow.code-mirror.sanitize')
+      ],
       errorTemplate: ErrorTemplate
     });
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-html-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-html-view.js
@@ -1,16 +1,18 @@
 var CoreView = require('backbone/core-view');
 var CodeMirrorView = require('../../../../components/code-mirror/code-mirror-view');
 var ErrorTemplate = require('./code-mirror-error.tpl');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
+
+var REQUIRED_OPTS = [
+  'codemirrorModel',
+  'onApplyEvent'
+];
 
 module.exports = CoreView.extend({
-
   className: 'Editor-content',
 
   initialize: function (opts) {
-    if (!opts.codemirrorModel) throw new Error('codemirrorModel is required');
-    if (!opts.onApplyEvent) throw new Error('onApplyEvent');
-
-    this._codemirrorModel = opts.codemirrorModel;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
   },
 
   render: function () {
@@ -23,7 +25,7 @@ module.exports = CoreView.extend({
   _initViews: function () {
     this.codeMirrorView = new CodeMirrorView({
       model: this._codemirrorModel,
-      tip: _t('editor.infowindow.code-mirror.save'),
+      tip: _t('editor.infowindow.code-mirror.save') + '<br>' + _t('editor.infowindow.code-mirror.sanitize'),
       errorTemplate: ErrorTemplate
     });
 
@@ -33,7 +35,6 @@ module.exports = CoreView.extend({
   },
 
   _triggerCodeSaved: function (code, view) {
-    this.options.onApplyEvent && this.options.onApplyEvent();
+    this._onApplyEvent && this._onApplyEvent();
   }
-
 });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-editor-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-editor-view.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var CodeMirrorView = require('../../../../components/code-mirror/code-mirror-view');
 var ErrorTemplate = require('./code-mirror-error.tpl');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
 
 var REQUIRED_OPTS = [
   'codemirrorModel',
@@ -12,14 +13,12 @@ var REQUIRED_OPTS = [
 var PLACEHOLDER = '[[Legend]]';
 
 module.exports = CoreView.extend({
+  module: 'editor:layers:layer-content-views:legend:legend-editor-view',
 
   className: 'Editor-content',
 
   initialize: function (opts) {
-    _.each(REQUIRED_OPTS, function (item) {
-      if (opts[item] === undefined) throw new Error(item + ' is required');
-      this['_' + item] = opts[item];
-    }, this);
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
   },
 
   render: function () {
@@ -32,7 +31,9 @@ module.exports = CoreView.extend({
   _initViews: function () {
     this.codeMirrorView = new CodeMirrorView({
       model: this._codemirrorModel,
-      tip: _t('editor.legend.code-mirror.save'),
+      tips: [
+        _t('editor.legend.code-mirror.save')
+      ],
       errorTemplate: ErrorTemplate
     });
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-editor-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-editor-view.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var CoreView = require('backbone/core-view');
 var CodeMirrorView = require('../../../../components/code-mirror/code-mirror-view');
 var ErrorTemplate = require('./code-mirror-error.tpl');

--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-cartocss-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-cartocss-view.js
@@ -2,24 +2,24 @@ var CoreView = require('backbone/core-view');
 var CodeMirrorView = require('../../components/code-mirror/code-mirror-view');
 var FactoryHints = require('../editor-hints/factory-hints');
 var CSSHints = require('../editor-hints/css-hints');
+var checkAndBuildOpts = require('../../helpers/required-opts');
+
+var REQUIRED_OPTS = [
+  'layerDefinitionModel',
+  'styleModel',
+  'codemirrorModel',
+  'editorModel',
+  'querySchemaModel',
+  'onApplyEvent'
+];
 
 module.exports = CoreView.extend({
+  module: 'editor:style:style-cartocss-view',
 
   className: 'Editor-styleContentCartoCSS Editor-content',
 
   initialize: function (opts) {
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
-    if (!opts.styleModel) throw new Error('styleModel is required');
-    if (!opts.codemirrorModel) throw new Error('codemirrorModel is required');
-    if (!opts.editorModel) throw new Error('editorModel is required');
-    if (!opts.querySchemaModel) throw new Error('querySchemaModel is required');
-    if (!opts.onApplyEvent) throw new Error('onApplyEvent');
-
-    this._layerDefinitionModel = opts.layerDefinitionModel;
-    this._styleModel = this._layerDefinitionModel.styleModel;
-    this._codemirrorModel = opts.codemirrorModel;
-    this._editorModel = opts.editorModel;
-    this._querySchemaModel = opts.querySchemaModel;
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this._initBinds();
 
@@ -48,7 +48,9 @@ module.exports = CoreView.extend({
       model: this._codemirrorModel,
       addons: ['color-picker'],
       hints: hints,
-      tip: _t('editor.style.code-mirror.save')
+      tips: [
+        _t('editor.style.code-mirror.save')
+      ]
     });
     this.codeMirrorView.bind('codeSaved', this._triggerCodeSaved, this);
     this.addView(this.codeMirrorView);
@@ -62,7 +64,7 @@ module.exports = CoreView.extend({
   },
 
   _triggerCodeSaved: function (code, view) {
-    this.options.onApplyEvent && this.options.onApplyEvent();
+    this._onApplyEvent && this._onApplyEvent();
   }
 
 });

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -2026,7 +2026,7 @@
       },
       "code-mirror": {
         "save": "CMD + S to apply your html.",
-        "sanitize": "Use {{{value}}} to sanitize values.",
+        "sanitize": "Use {{{column}}} to sanitize values.",
         "errors": {
           "empty": "Template can't be empty."
         }

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -2026,6 +2026,7 @@
       },
       "code-mirror": {
         "save": "CMD + S to apply your html.",
+        "sanitize": "Use {{{value}}} to sanitize values.",
         "errors": {
           "empty": "Template can't be empty."
         }

--- a/lib/assets/core/test/spec/cartodb3/components/code-mirror/code-mirror-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/code-mirror/code-mirror-view.spec.js
@@ -45,7 +45,9 @@ describe('components/code-mirror/code-mirror-view', function () {
       hints: this.hints,
       addons: ['color-picker'],
       mode: 'text/x-pgsql',
-      tip: _t('editor.data.code-mirror.tip'),
+      tips: [
+        _t('editor.data.code-mirror.tip')
+      ],
       placeholder: 'placeholder'
     };
 


### PR DESCRIPTION
Related to: #11340

I've added a second tip about sanitising values with `{{{}}}`, I changed the tip template to allow multiple lines, this is how it looks:

![screen shot 2017-07-24 at 10 30 00](https://user-images.githubusercontent.com/905225/28514700-4d29caa0-705b-11e7-9c45-bbf97cfea491.png)

And this is how it looks in one line:

![screen shot 2017-07-24 at 10 29 38](https://user-images.githubusercontent.com/905225/28514716-5c4ab17a-705b-11e7-8446-5fb698d8ef26.png)

This is with two lines and a border between the tips:

![screen shot 2017-07-24 at 10 47 11](https://user-images.githubusercontent.com/905225/28515318-76bd0bf0-705d-11e7-8045-f949de058ded.png)

I'm not sure at all about the text, pinging: @noguerol
Also pinging @CartoDB/design about the 1 line / 2 lines / 2 lines + border