### PR TITLE
Update internal dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,7 @@ Development
 * Country dropdown should be mandatory in postal code georeference (#12420)
 * Fixed bounds and center of thumbnails after updating a map
 * Fixed a bug in cartodb.js regarding the featureCount (#12490)
+* Fix a problem with responsive in deep-insights.js
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.8.62",
+  "version": "4.9.0",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -535,9 +535,9 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
     },
     "binary-extensions": {
-      "version": "1.8.0",
+      "version": "1.9.0",
       "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz"
     },
     "block-stream": {
       "version": "0.0.9",
@@ -671,9 +671,9 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "from": "browserslist@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.2.2.tgz"
     },
     "buffer": {
       "version": "4.9.1",
@@ -716,9 +716,9 @@
       "resolved": "https://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.33.0.tgz"
     },
     "caniuse-lite": {
-      "version": "1.0.30000703",
-      "from": "caniuse-lite@>=1.0.30000701 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000703.tgz"
+      "version": "1.0.30000704",
+      "from": "caniuse-lite@>=1.0.30000704 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000704.tgz"
     },
     "carto": {
       "version": "0.15.1-cdb4",
@@ -733,7 +733,7 @@
     "cartodb-deep-insights.js": {
       "version": "0.0.2",
       "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#7fa417762af4abb5af45e46613198225b713bd29",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#e25bbdd4226edb932c2bddd39b4271d697025551",
       "dependencies": {
         "node-polyglot": {
           "version": "2.2.2",
@@ -1053,7 +1053,7 @@
     },
     "electron-to-chromium": {
       "version": "1.3.16",
-      "from": "electron-to-chromium@>=1.3.15 <2.0.0",
+      "from": "electron-to-chromium@>=1.3.16 <2.0.0",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz"
     },
     "elliptic": {
@@ -1067,9 +1067,9 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
     },
     "enhanced-resolve": {
-      "version": "3.3.0",
+      "version": "3.4.1",
       "from": "enhanced-resolve@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -1872,9 +1872,9 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
     },
     "json-loader": {
-      "version": "0.5.4",
+      "version": "0.5.7",
       "from": "json-loader@>=0.5.4 <0.6.0",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz"
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2091,14 +2091,14 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
     },
     "mime-db": {
-      "version": "1.27.0",
-      "from": "mime-db@>=1.27.0 <1.28.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+      "version": "1.29.0",
+      "from": "mime-db@>=1.29.0 <1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.15",
+      "version": "2.1.16",
       "from": "mime-types@>=2.1.7 <2.2.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -2507,6 +2507,11 @@
       "from": "randombytes@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz"
     },
+    "rangeslider.js": {
+      "version": "2.3.0",
+      "from": "rangeslider.js@2.3.0",
+      "resolved": "https://registry.npmjs.org/rangeslider.js/-/rangeslider.js-2.3.0.tgz"
+    },
     "rc": {
       "version": "1.2.1",
       "from": "rc@1.2.1",
@@ -2520,11 +2525,6 @@
           "optional": true
         }
       }
-    },
-    "rangeslider.js": {
-      "version": "2.3.0",
-      "from": "rangeslider.js@2.3.0",
-      "resolved": "https://registry.npmjs.org/rangeslider.js/-/rangeslider.js-2.3.0.tgz"
     },
     "read-only-stream": {
       "version": "2.0.0",
@@ -2698,9 +2698,9 @@
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz"
     },
     "semver": {
-      "version": "5.3.0",
+      "version": "5.4.1",
       "from": "semver@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -3044,9 +3044,9 @@
       "resolved": "git://github.com/cartodb/tangram.cartodb.git#4a6359fb86f8bb0aec5b8a0cefa3c23a3312201f"
     },
     "tapable": {
-      "version": "0.2.6",
+      "version": "0.2.7",
       "from": "tapable@>=0.2.5 <0.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz"
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.7.tgz"
     },
     "tar": {
       "version": "2.2.1",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/865

PR in Deep-Insights: https://github.com/CartoDB/deep-insights.js/pull/564

The problem was the menu was displayed but with `opacity: 0;`, and it sits on top of the first checkbox if the Layer Selector option is enabled.

The menu has a class called `CDB-Dashboard-hideMobile` which doesn't exist, I just added it to the `max-width: 759px` media-query.