### PR TITLE
Skip verify_authenticity_token in show_protected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -100,6 +100,7 @@ Development
 * Fixed bounds and center of thumbnails after updating a map
 * Fixed a bug in cartodb.js regarding the featureCount (#12490)
 * Fix a problem with responsive in deep-insights.js
+* Fix 403 error in password protected embed maps (#12469)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -21,6 +21,7 @@ module Carto
                       :load_google_maps_qs, only: [:show, :show_protected]
 
         skip_before_filter :builder_users_only # This is supposed to be public even in beta
+        skip_before_filter :verify_authenticity_token, only: [:show_protected]
 
         layout false
 


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/12469

This issue turned out to be (as far as I know) related to backend, so summoning @juanignaciosl.

I'm not sure if that's the correct approach to fix it, but we are skipping `verify_authenticity_token` in `visualizations_controller.rb` for embed maps too, so I thought it was related.