### PR TITLE
Change error log level for supported cartocss in vector maps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,7 @@ Development
 * Fix a problem with responsive in deep-insights.js
 * Fix 403 error in password protected embed maps (#12469)
 * Fixed JS error for InfoWindows/Pop-ups (cartodb.js#1703)
+* Lowered log level from error to info for supported cartocss in vector maps (cartodb.js#1706)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.5",
+  "version": "4.9.6",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -750,7 +750,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#bc349b4c010957532055fc1ed739e5cfc0e27d8c"
+      "resolved": "git://github.com/cartodb/cartodb.js.git#d8fbcd03aff1f63219be47fe771781f6498b9295"
     },
     "caseless": {
       "version": "0.11.0",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb.js/issues/1706