### PR TITLE
Canonical visualization layer fix for missing data layer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@ Development
 * Fixed typo in content_no_datasets.jst.ejs and en.json (Docs)
 * Fixing problem parsing formula widget creation (#support/843)
 * Don't try to lowercase null values in custom-list-collection object (support/#744)
+* Fixes named map creation for datasets imports on users with Google Maps (CartoDB/cartodb/pull/12519).
 * Tap on iOS10 mobile embed doesn't jump to page bottom (#cartodb.js/1652)
 * Don't try to lowercase null values in custom-list-collection object (#support/744)
 * Validate widget form when widget type changes (#11536)

--- a/app/model_factories/carto/visualization_factory.rb
+++ b/app/model_factories/carto/visualization_factory.rb
@@ -28,6 +28,8 @@ module Carto
       visualization.save!
       layers.each do |layer|
         layer.maps << visualization.map
+        # This reload is needed for map.layers to contain the layers
+        visualization.map.reload
         layer.save!
       end
       visualization

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -104,7 +104,7 @@ module Carto
       maps.reload if persisted?
 
       return unless order.nil?
-      max_order = parent.layers.reload.map(&:order).compact.max || -1
+      max_order = parent.layers.map(&:order).compact.max || -1
       self.order = max_order + 1
       save if persisted?
     end


### PR DESCRIPTION
The linked issue contains the steps to reproduce.

Changes might impact everything related to layer sorting (needed on visualization creation and layer addition, among others) and table dependency registration (the logic that shows the modal when you try do delete a dataset with a visualization, warning about related maps).

The problem appeared with a user that has Google Maps as default basemap. That basemap doesn't have labels on top. There's an iteration through layers that reloads the map layers in order to be sure that the map contains the actual layers so we can compute the order. As a side effect, that reloading keeps `map.layers` up-to-date for a next saving. As a map without layers on top doesn't have a layer after the data layer, the data layer addition wasn't refreshed and wasn't saved. The fix refreshes map just after layer addition, keeping it up-to-date as early as possible.