### PR TITLE
S749 allow whitespace layer names for vizjson

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,7 @@ Development
 * Configurable pg_dump/restore bin path (#12297)
 * Redesigned LEARN MORE buttons behaviour (#12135)
 * "vector" key in vizjson is skipped in embeds if user has "vector_vs_raster" feature flag enabled.
+* Allow whitespace as layer name at vizJSONv3 (#12526)
 * Inline editor saves on blur, discard changes on 'ESC' (#11567)
 * Updated look and feel of sync interval dialog (#12145)
 * Organization owner can skip domain whitelisting on user creation (#12452).

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require File.expand_path('../config/application', __FILE__)
 require 'rake/dsl_definition'
 require 'rake'
 require 'resque/tasks'
+require 'active_support/dependencies'
 
 # Do not load rake tasks when running resque: https://github.com/CartoDB/cartodb/issues/11046
 if Rake.application.top_level_tasks.reject { |t| ['environment', 'resque:work'].include?(t) }.empty?

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -419,7 +419,8 @@ module Carto
         layer_alias = @layer.options.fetch('table_name_alias', nil)
         table_name  = @layer.options.fetch('table_name')
 
-        layer_alias.present? ? layer_alias : table_name
+        # .present? is not valid, as we want to allow whitespaced layer names.
+        layer_alias.nil? || layer_alias.empty? ? table_name : layer_alias
       end
 
       def sql_from(layer)

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -1,4 +1,5 @@
 require 'json'
+require_dependency 'carto/export/layer_exporter'
 
 # Version History
 # 1.0.0: export organization metadata

--- a/app/services/carto/visualizations_export_service_2.rb
+++ b/app/services/carto/visualizations_export_service_2.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'carto/export/layer_exporter'
+require_dependency 'carto/export/layer_exporter'
 
 # Version History
 # TODO: documentation at http://cartodb.readthedocs.org/en/latest/operations/exporting_importing_visualizations.html

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -166,6 +166,16 @@ describe Carto::Api::VizJSON3Presenter do
       source_analysis_definition[:params].should be_nil
     end
 
+    it 'allows whitespace layer names' do
+      layer = @visualization.data_layers.first
+      layer.options['table_name_alias'] = ' '
+      layer.save
+      @visualization.reload
+
+      v3_vizjson = Carto::Api::VizJSON3Presenter.new(@visualization, viewer_user).send :calculate_vizjson
+      v3_vizjson[:layers][1][:options][:layer_name].should eq ' '
+    end
+
     it 'includes source at layers options' do
       source = 'a1'
       layer = @visualization.data_layers.first


### PR DESCRIPTION
We allow setting a whitespace as layer name, but in vizjson 3 it got replaced by the table name, making it impossible to hide the name at layers selector. This PR makes the vizjson (and the layer selector) display the empty space, simulating no name).