### PR TITLE
Add frontend version to TrackJS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,7 @@ Development
 * Lowered log level from error to info for supported cartocss in vector maps (cartodb.js#1706)
 * Histogram UI: Do not show "NULL ROWS" value if it is not received (#12477)
 * Force raster mode in datasets preview map (#12513)
+* Add assets version to TrackJS
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/app/helpers/embed_redis_cache.rb
+++ b/app/helpers/embed_redis_cache.rb
@@ -3,6 +3,7 @@
 require 'zlib'
 
 class EmbedRedisCache
+  include Carto::Configuration
 
   # This needs to be changed whenever there're changes in the code that require invalidation of old keys
   VERSION = '4'
@@ -68,18 +69,9 @@ class EmbedRedisCache
 
   private
 
-  def frontend_version
-    # INFO: New deploys restart the server, invalidating this value + we want to hit disk as less as possible
-    @@key_fragment_fe_version ||= read_frontend_version
-  end
-
   def embed_template_hash
     # INFO: New deploys restart the server, invalidating this value + we want to hit disk as less as possible
     @@key_fragment_embed_template_hash ||= calculate_embed_template_hash
-  end
-
-  def read_frontend_version
-    JSON::parse(File.read(Rails.root.join("package.json")))["version"]
   end
 
   def calculate_embed_template_hash

--- a/app/helpers/embed_redis_cache.rb
+++ b/app/helpers/embed_redis_cache.rb
@@ -3,8 +3,6 @@
 require 'zlib'
 
 class EmbedRedisCache
-  include Carto::Configuration
-
   # This needs to be changed whenever there're changes in the code that require invalidation of old keys
   VERSION = '4'
 
@@ -56,7 +54,7 @@ class EmbedRedisCache
       "embed",
       protocol,
       VERSION,
-      frontend_version,
+      CartoDB::Application.frontend_version,
       embed_template_hash
     ].join(":")
   end

--- a/app/helpers/trackjs_helper.rb
+++ b/app/helpers/trackjs_helper.rb
@@ -1,12 +1,10 @@
 module TrackjsHelper
-  include Carto::Configuration
-
   def insert_trackjs(app = 'editor')
     if Cartodb.get_config(:trackjs, 'customer')
       customer = Cartodb.get_config(:trackjs, 'customer')
       enabled = Cartodb.get_config(:trackjs, 'enabled')
       app_key = Cartodb.get_config(:trackjs, 'app_keys', app)
-      version = frontend_version
+      version = CartoDB::Application.frontend_version
 
       locals = { customer: customer, enabled: enabled, app_key: app_key, version: version }
       render(partial: 'shared/trackjs', locals: locals)

--- a/app/helpers/trackjs_helper.rb
+++ b/app/helpers/trackjs_helper.rb
@@ -8,7 +8,8 @@ module TrackjsHelper
       app_key = Cartodb.get_config(:trackjs, 'app_keys', app)
       version = frontend_version
 
-      render(:partial => 'shared/trackjs', :locals => { customer: customer, enabled: enabled, app_key: app_key, version: version })
+      locals = { customer: customer, enabled: enabled, app_key: app_key, version: version }
+      render(partial: 'shared/trackjs', locals: locals)
     end
   end
 end

--- a/app/helpers/trackjs_helper.rb
+++ b/app/helpers/trackjs_helper.rb
@@ -1,11 +1,14 @@
 module TrackjsHelper
-  def insert_trackjs(app = 'editor')
-    if !Cartodb.config[:trackjs].blank? && !Cartodb.config[:trackjs]['customer'].blank?
-      customer = Cartodb.config[:trackjs]['customer']
-      enabled = Cartodb.config[:trackjs]['enabled']
-      app_key = Cartodb.config[:trackjs]['app_keys'][app]
+  include Carto::Configuration
 
-      render(:partial => 'shared/trackjs', :locals => { customer: customer, enabled: enabled, app_key: app_key })
+  def insert_trackjs(app = 'editor')
+    if Cartodb.get_config(:trackjs, 'customer')
+      customer = Cartodb.get_config(:trackjs, 'customer')
+      enabled = Cartodb.get_config(:trackjs, 'enabled')
+      app_key = Cartodb.get_config(:trackjs, 'app_keys', app)
+      version = frontend_version
+
+      render(:partial => 'shared/trackjs', :locals => { customer: customer, enabled: enabled, app_key: app_key, version: version })
     end
   end
 end

--- a/app/views/shared/_trackjs.html.erb
+++ b/app/views/shared/_trackjs.html.erb
@@ -1,7 +1,8 @@
 <script>
   window._trackJs = {
     enabled: <%= enabled ? 'true' : 'false' %>,
-    application: '<%= app_key %>'
+    application: '<%= app_key %>',
+    version: '<%= version %>'
     <% if current_user.present? %>
       , userId: '<%= current_user.username %>'
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -176,8 +176,7 @@ module CartoDB
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
 
-    frontend_assets_version = JSON::parse(File.read(Rails.root.join('package.json')))['version']
-    config.action_controller.relative_url_root = "/assets/#{frontend_assets_version}"
+    config.action_controller.relative_url_root = "/assets/#{frontend_version}"
 
     custom_app_views_paths.reverse.each do |custom_views_path|
       config.paths['app/views'].unshift(custom_views_path)

--- a/lib/carto/configuration.rb
+++ b/lib/carto/configuration.rb
@@ -8,6 +8,10 @@ module Carto
       @@app_config ||= YAML.load_file(app_config_file).freeze
     end
 
+    def frontend_version
+      @@frontend_version ||= JSON::parse(File.read(Rails.root.join("package.json")))["version"]
+    end
+
     def env_app_config
       app_config[ENV['RAILS_ENV'] || 'development']
     end


### PR DESCRIPTION
Hi!

I've been working this week in the response team, when I deploy some fix and go to TrackJS to check the error doesn't keep happening there are some times than the error keeps happening and it's because the user doesn't have the last assets, to check it I have to go to the error page, scroll down to the error, check the stack trace and look for the url of the assets to see the version. I think it's faster to add it to the TrackJS configuration so we don't have to go to the stack trace to see it.