### PR TITLE
Render timeouts migrations

### DIFF
--- a/db/migrate/20170704094757_add_render_timeouts_to_users.rb
+++ b/db/migrate/20170704094757_add_render_timeouts_to_users.rb
@@ -1,0 +1,15 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  Proc.new do
+    # The 0 value means: "apply default render timeouts" (defined by the tiler)
+    add_column :users, :user_render_timeout, :integer, default: 0, null: false
+    add_column :users, :database_render_timeout, :integer, default: 0, null: false
+  end,
+  Proc.new do
+    drop_column :users, :user_render_timeout
+    drop_column :users, :database_render_timeout
+  end
+)


### PR DESCRIPTION
This is the migration from #12425
It adds render timeouts to the users table.