### PR TITLE
UserAccountCreator should create viewer UserCreations with viewer invitations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,7 @@ Development
 * Dropbox searches now don't have limit of number of files (#12521)
 * Fix error when a Dropbox folder has an extension matching valid extensions.
 * Fixed UI when editing merge analysis (#10850)
+* Fixed viewer invitations (#12514)
 * Fixed uninitialized constant in Carto::Visualization when a viewer shares a visualization (#12129).
 * Fix template generation without center at state (#12453).
 * Fix regenerate all api keys in an organization (#12218)

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -162,14 +162,14 @@ class Carto::UserCreation < ActiveRecord::Base
     !valid_invitation.nil?
   end
 
+  def pertinent_invitation
+    @pertinent_invitation ||= select_valid_invitation_token(Carto::Invitation.query_with_unused_email(email).all)
+  end
+
   private
 
   def enabled?
     cartodb_user.enable_account_token.nil? && cartodb_user.enabled
-  end
-
-  def pertinent_invitation
-    @pertinent_invitation ||= select_valid_invitation_token(Carto::Invitation.query_with_unused_email(email).all)
   end
 
   def valid_invitation

--- a/lib/user_account_creator.rb
+++ b/lib/user_account_creator.rb
@@ -194,7 +194,10 @@ module CartoDB
     def build_user_creation
       build
 
-      Carto::UserCreation.new_user_signup(@user, @created_via).with_invitation_token(@invitation_token)
+      user_creation = Carto::UserCreation.new_user_signup(@user, @created_via).with_invitation_token(@invitation_token)
+      user_creation.viewer = true if user_creation.pertinent_invitation.try(:viewer?)
+
+      user_creation
     end
 
     def build

--- a/spec/requests/signup_controller_spec.rb
+++ b/spec/requests/signup_controller_spec.rb
@@ -241,6 +241,29 @@ describe SignupController do
       invitation.used_emails.should include(invited_email)
     end
 
+    it 'triggers a viewer creation that creates a viewer user' do
+      invited_email = 'viewer_user@whatever.com'
+      invitation = Carto::Invitation.create_new(Carto::User.find(@org_user_owner.id), [invited_email], 'W!', true)
+      invitation.save
+      Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(false)
+      ::Resque.expects(:enqueue).
+        with(::Resque::UserJobs::Signup::NewUser, instance_of(String), anything, instance_of(FalseClass)).
+        returns(true)
+
+      host! "#{@organization.name}.localhost.lan"
+      post signup_organization_user_url(user_domain: @organization.name,
+                                        user: { username: 'viewer-user',
+                                                email: invited_email,
+                                                password: '2{Patrañas}' },
+                                        invitation_token: invitation.token(invited_email))
+      last_user_creation = Carto::UserCreation.order('created_at desc').limit(1).first
+      last_user_creation.next_creation_step until last_user_creation.finished?
+
+      last_user_creation.state.should eq 'success'
+      last_user_creation.viewer.should be_true
+      last_user_creation.user.viewer.should be_true
+    end
+
     describe 'ldap signup' do
 
       before(:all) do


### PR DESCRIPTION
This fixes #12514.

I'm not too proud of this PR because of two aspects:
- `pertinent_invitation` visibility becomes public. It's a side effect of the ugly coupling between `UserCreation` and `UserAccountCreator`.  As it's a safe quick fix for an error I chose the visibility tradeoff. When we eventually refactor `UserAccountCreator` into `UserCreation` it can be fixed.
- `user_creation.viewer = true` is needed because `viewer` can be null. I chose that over refactors at `Invitation` (adding a `viewer?` method, setting `viewer` to false and not nullable and so on) because this is a fix, and I don't think that investing in those refactors, that can have side effects, worth it. BTW, I didn't add a comment because this was caught by a test ❤️ 