### PR TITLE
Fixing ghost node problem #11397

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@ Development
 * Updates Dataservices API client default version to `0.19.0` (#12494)
 
 ### Bug fixes / enhancements
+* Fix ghost node problem (#11397)
 * Break down deep-insights-integrations class (#11581)
 * Fix torque categories layer rendering (#cartodb.js/1698)
 * Don't provide quantification option when layer is animated (#10947)

--- a/lib/assets/core/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/core/javascripts/cartodb3/data/user-actions.js
@@ -439,7 +439,7 @@ module.exports = function (params) {
 
           analysisDefinitionsCollection.newAnalysisForNode(renamedNodeDefModel); // will be saved by saveAnalysisForLayer later since containing that layer's node
 
-          // Modify all layers using the old node as top source and it doesn't have an anlysis definition associated
+          // Modify all layers using the old node as top source and it doesn't have an analysis definition associated
           layerDefinitionsCollection.each(function (layerDefModel) {
             var containsAnalysisDefinition = analysisDefinitionsCollection.findAnalysisForLayer(layerDefModel);
             if (!containsAnalysisDefinition && layerDefModel.get('source') === nodeId) {

--- a/lib/assets/core/javascripts/cartodb3/data/user-actions.js
+++ b/lib/assets/core/javascripts/cartodb3/data/user-actions.js
@@ -337,10 +337,11 @@ module.exports = function (params) {
     /**
      * A layer for an existing node have different side-effects depending on the context in which the node exists.
      * @param {string} nodeid
+     * @param {string} letter of the layer where the node change comes
      * @param {object} cfg
-     * @param {number} cfg.at
+     *  @param {number} cfg.at
      */
-    createLayerForAnalysisNode: function (nodeId, cfg) {
+    createLayerForAnalysisNode: function (nodeId, fromLayerLetter, cfg) {
       var userMaxLayers = userModel.get('limits').max_layers;
       if (layerDefinitionsCollection.getNumberOfDataLayers() >= userMaxLayers) {
         var err = new Error('max layers reached');
@@ -368,7 +369,7 @@ module.exports = function (params) {
         layerDefinitionsCollection.save(); // to persist layers order
       }.bind(this);
 
-      var prevLayer = layerDefinitionsCollection.findWhere({source: nodeId});
+      var prevLayer = layerDefinitionsCollection.findWhere({ source: nodeId, letter: fromLayerLetter });
       if (prevLayer) {
         if (nodeDefModel.hasPrimarySource()) {
           // Node is head of a layer, e.g. given nodeId A3 it should rename prev layer (A => B), and create a new layer (A)
@@ -384,7 +385,7 @@ module.exports = function (params) {
           //  | [A0] |      | [A0] |  |      |
           //  |______|      |______|  |______|
           var prevOrder = layerDefinitionsCollection.indexOf(prevLayer);
-          var prevLetter = prevLayer.get('letter');
+          var prevLetter = fromLayerLetter;
 
           // Change identity of prevLayer (A) so it appears as the new layer (B), including its analysis
           var renamedNodeId = newLetter + '1';
@@ -437,6 +438,16 @@ module.exports = function (params) {
           }, {ignoreSchemaChange: true});
 
           analysisDefinitionsCollection.newAnalysisForNode(renamedNodeDefModel); // will be saved by saveAnalysisForLayer later since containing that layer's node
+
+          // Modify all layers using the old node as top source and it doesn't have an anlysis definition associated
+          layerDefinitionsCollection.each(function (layerDefModel) {
+            var containsAnalysisDefinition = analysisDefinitionsCollection.findAnalysisForLayer(layerDefModel);
+            if (!containsAnalysisDefinition && layerDefModel.get('source') === nodeId) {
+              layerDefModel
+                .set('source', renamedNodeId)
+                .save();
+            }
+          });
 
           // Remove prevLayer (A) temporarily, to move the layers to expected positions
           layerDefinitionsCollection.remove(prevLayer, {silent: true}); // silent to avoid unwanted side-effects; re-added again later

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-analyses-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-analyses-view.js
@@ -16,6 +16,7 @@ module.exports = CoreView.extend({
   initialize: function (opts) {
     if (!this.options.sortableSelector) throw new Error('sortableSelector is required');
     if (!opts.layerAnalysisViewFactory) throw new Error('layerAnalysisViewFactory is required');
+    if (!this.model) throw new Error('layerDefinitionModel is required');
 
     this._layerAnalysisViewFactory = opts.layerAnalysisViewFactory;
   },
@@ -53,6 +54,7 @@ module.exports = CoreView.extend({
 
     var draggableView = new LayerAnalysisDraggableView({
       model: nodeDefModel,
+      layerDefinitionModel: this.model,
       getNextLetter: this.model.collection.nextLetter.bind(this.model.collection),
       $nodeViewElement: nodeView.$el,
       sortableSelector: this.options.sortableSelector

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-analysis-draggable-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-analysis-draggable-view.js
@@ -16,9 +16,10 @@ module.exports = CoreView.extend({
     $nodeViewElement: null
   },
 
-  initialize: function () {
-    if (!this.options.sortableSelector) throw new Error('sortableSelector is required');
-    if (!this.options.$nodeViewElement) throw new Error('$nodeViewElement is required');
+  initialize: function (opts) {
+    if (!opts.sortableSelector) throw new Error('sortableSelector is required');
+    if (!opts.$nodeViewElement) throw new Error('$nodeViewElement is required');
+    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
 
     this.options.$nodeViewElement.draggable({
       appendTo: this.options.sortableSelector,
@@ -32,9 +33,11 @@ module.exports = CoreView.extend({
 
   _createHelper: function () {
     var nextLetter = this.options.getNextLetter();
+    var layerLetter = this.options.layerDefinitionModel.get('letter');
     return template({
       nodeId: this.model.id,
       nextLetter: nextLetter,
+      layerLetter: layerLetter,
       nextBgColor: layerColors.getColorForLetter(nextLetter),
       title: analyses.title(this.model)
     });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-analysis-draggable.tpl
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-analysis-draggable.tpl
@@ -1,4 +1,4 @@
-<li class="Editor-newLayerContainer" data-analysis-node-id="<%- nodeId %>" style="width: 294px;">
+<li class="Editor-newLayerContainer" data-layer-letter="<%- layerLetter %>" data-analysis-node-id="<%- nodeId %>" style="width: 294px;">
   <div class="Editor-ListLayer-item">
     <div class="Editor-ListLayer-itemHeader">
       <div class="Editor-ListLayer-media u-rSpace--m" style="background: <%- nextBgColor %>; color: #fff">

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layers-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layers-view.js
@@ -130,9 +130,10 @@ module.exports = CoreView.extend({
     }
 
     var analysisNodeId = $draggedLayerElement.data('analysis-node-id');
+    var fromLayerLetter = $draggedLayerElement.data('layer-letter');
     if (analysisNodeId) {
       try {
-        this._userActions.createLayerForAnalysisNode(analysisNodeId, {at: newPosition});
+        this._userActions.createLayerForAnalysisNode(analysisNodeId, fromLayerLetter, {at: newPosition});
       } catch (err) {
         if (/max/.test(err.message)) {
           $draggedLayerElement.remove();

--- a/lib/assets/core/test/spec/cartodb3/data/user-actions.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/user-actions.spec.js
@@ -1124,23 +1124,23 @@ describe('cartodb3/data/user-actions', function () {
     });
 
     it('should not allow to create layer below or on basemap', function () {
-      expect(function () { userActions.createLayerForAnalysisNode('a1'); }).toThrowError(/required/);
-      expect(function () { userActions.createLayerForAnalysisNode('a1', null); }).toThrowError(/required/);
+      expect(function () { userActions.createLayerForAnalysisNode('a1', 'a'); }).toThrowError(/required/);
+      expect(function () { userActions.createLayerForAnalysisNode('a1', null, null); }).toThrowError(/required/);
 
-      expect(function () { userActions.createLayerForAnalysisNode('a1', {}); }).toThrowError(/base layer/);
-      expect(function () { userActions.createLayerForAnalysisNode('a1', { at: 0 }); }).toThrowError(/base layer/);
-      expect(function () { userActions.createLayerForAnalysisNode('a1', { at: null }); }).toThrowError(/base layer/);
+      expect(function () { userActions.createLayerForAnalysisNode('a1', 'a', {}); }).toThrowError(/base layer/);
+      expect(function () { userActions.createLayerForAnalysisNode('a1', 'a', { at: 0 }); }).toThrowError(/base layer/);
+      expect(function () { userActions.createLayerForAnalysisNode('a1', 'a', { at: null }); }).toThrowError(/base layer/);
     });
 
     it('should throw an error if given node does not exist', function () {
-      expect(function () { userActions.createLayerForAnalysisNode('x1', { at: 0 }); }).toThrowError(/does not exist/);
+      expect(function () { userActions.createLayerForAnalysisNode('x1', 'x', { at: 0 }); }).toThrowError(/does not exist/);
     });
 
     it('should throw an error if max layers limit is reached', function () {
       var error;
       spyOn(this.layerDefinitionsCollection, 'getNumberOfDataLayers').and.returnValue(4);
       try {
-        userActions.createLayerForAnalysisNode('x1', { at: 0 });
+        userActions.createLayerForAnalysisNode('x1', 'x', { at: 0 });
       } catch (err) {
         error = err;
       }
@@ -1175,7 +1175,7 @@ describe('cartodb3/data/user-actions', function () {
 
         spyOn(this.layerDefinitionsCollection, 'create').and.callThrough();
         spyOn(this.userActions, '_resetStylePerNode');
-        this.userActions.createLayerForAnalysisNode('a0', { at: 1 });
+        this.userActions.createLayerForAnalysisNode('a0', 'a', { at: 1 });
         this.newLayerDefModel = this.layerDefinitionsCollection.findWhere({ letter: 'b' });
       });
 
@@ -1276,7 +1276,7 @@ describe('cartodb3/data/user-actions', function () {
 
       describe('and does not have saved styles', function () {
         beforeEach(function () {
-          this.userActions.createLayerForAnalysisNode('a2', { at: 2 });
+          this.userActions.createLayerForAnalysisNode('a2', 'a', { at: 2 });
         });
 
         describe('should create new layer with', function () {
@@ -1386,7 +1386,7 @@ describe('cartodb3/data/user-actions', function () {
 
       describe('and does have saved styles', function () {
         beforeEach(function () {
-          this.userActions.createLayerForAnalysisNode('a3', { at: 2 });
+          this.userActions.createLayerForAnalysisNode('a3', 'a', { at: 2 });
           spyOn(this.widgetDefinitionsCollection, 'create').and.callThrough();
           this.layerDefinitionsCollection.create.calls.argsFor(0)[1].success();
           spyOn(this.userActions, '_resetStylePerNode');
@@ -1426,6 +1426,18 @@ describe('cartodb3/data/user-actions', function () {
               source: 'a2'
             }
           });
+
+          // Layer pointing to the dragged icon (no definition associated)
+          this.layerDefinitionsCollection.add({
+            id: 'l2',
+            order: 2,
+            kind: 'carto',
+            options: {
+              cartocss: 'before',
+              source: 'a2'
+            }
+          });
+
           spyOn(LayerDefinitionModel.prototype, 'save').and.callThrough();
           this.widgetDefinitionsCollection.add({
             layer_id: 'l1',
@@ -1448,20 +1460,20 @@ describe('cartodb3/data/user-actions', function () {
 
         beforeEach(function () {
           spyOn(this.userActions, '_resetStylePerNode');
-          this.userActions.createLayerForAnalysisNode('a2', { at: 2 });
+          this.userActions.createLayerForAnalysisNode('a2', 'a', { at: 3 });
         });
 
         it('should have created a new layer that takes over the position of layer with head node', function () {
-          expect(this.layerDefinitionsCollection.pluck('letter')).toEqual(['a', 'b']);
+          expect(this.layerDefinitionsCollection.pluck('letter')).toEqual(['a', 'b', 'c']);
         });
 
         it('should remove all widgets pointing to the affected node', function () {
           expect(this.widgetDefinitionsCollection.size()).toBe(1);
         });
 
-        it('should change the source layer to appear as the new layer B', function () {
-          expect(this.layerDefModel.get('letter')).toEqual('b');
-          expect(this.layerDefModel.get('source')).toEqual('b1');
+        it('should change the source layer to appear as the new layer C', function () {
+          expect(this.layerDefModel.get('letter')).toEqual('c');
+          expect(this.layerDefModel.get('source')).toEqual('c1');
         });
 
         it('should create a new layer which appears to be the source layer A (to preserve styles, popups etc.)', function () {
@@ -1476,8 +1488,13 @@ describe('cartodb3/data/user-actions', function () {
           expect(this.analysisDefinitionNodesCollection.get('a2')).toBeUndefined('should no longer exist since replaced by b1');
         });
 
+        it('should change source of any other layer pointing to that old node and not having any analysis definition', function () {
+          var layerDefModel = this.layerDefinitionsCollection.findWhere({ id: 'l2' });
+          expect(layerDefModel.get('source')).toBe('c1');
+        });
+
         it('should have two analyses, one for each layer', function () {
-          expect(this.analysisDefinitionsCollection.pluck('node_id')).toEqual(['a1', 'b1']);
+          expect(this.analysisDefinitionsCollection.pluck('node_id')).toEqual(['a1', 'c1']);
         });
 
         it('should reset styles from the previous layer', function () {
@@ -1489,7 +1506,8 @@ describe('cartodb3/data/user-actions', function () {
           beforeEach(function () {
             spyOn(this.widgetDefinitionsCollection, 'create').and.callThrough();
             spyOn(this.layerDefinitionsCollection, 'save').and.callThrough();
-            LayerDefinitionModel.prototype.save.calls.argsFor(1)[1].success();
+            // New layer is created and saved
+            LayerDefinitionModel.prototype.save.calls.argsFor(2)[1].success();
           });
 
           it('should recreate all affected widgets', function () {
@@ -1508,7 +1526,7 @@ describe('cartodb3/data/user-actions', function () {
                   sync_on_bbox_change: true
                 }),
                 source: jasmine.objectContaining({
-                  id: 'b1'
+                  id: 'c1'
                 }),
                 avoidNotification: true,
                 order: 1
@@ -1540,7 +1558,7 @@ describe('cartodb3/data/user-actions', function () {
             });
 
             it('should reset order', function () {
-              expect(this.layerDefinitionsCollection.pluck('order')).toEqual([0, 1]);
+              expect(this.layerDefinitionsCollection.pluck('order')).toEqual([0, 1, 2]);
             });
 
             it('should save layers', function () {
@@ -1572,7 +1590,7 @@ describe('cartodb3/data/user-actions', function () {
 
         beforeEach(function () {
           spyOn(this.userActions, '_resetStylePerNode');
-          this.userActions.createLayerForAnalysisNode('a2', { at: 2 });
+          this.userActions.createLayerForAnalysisNode('a2', 'a', { at: 2 });
         });
 
         describe('when created a layer successfully', function () {
@@ -2478,7 +2496,7 @@ describe('cartodb3/data/user-actions', function () {
       expect(this.analysisDefinitionsCollection.pluck('node_id')).toEqual(['a1'], 'should update analysis of layer to point to new head node');
 
       // Go to the layer list and drag the AOI node outside the current layer to create a new one.
-      this.userActions.createLayerForAnalysisNode('a1', { at: 1 });
+      this.userActions.createLayerForAnalysisNode('a1', 'a', { at: 1 });
       expect(this.layerDefinitionsCollection.pluck('letter')).toEqual([undefined, 'b', 'a', undefined], 'should have a new letter representation b for new layer');
       expect(this.analysisDefinitionNodesCollection.pluck('id')).toEqual(['a0', 'b1'], 'should replaced node a1 with b1');
       expect(this.analysisDefinitionsCollection.pluck('node_id')).toEqual(['a0', 'b1'], 'should updated prev layer to have prev node (a0), and created a new analysis for new layer (b1)');

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-analysis-draggable-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-analysis-draggable-view.spec.js
@@ -13,6 +13,7 @@ describe('editor/layers/layer-analysis-draggable-view', function () {
     });
 
     this.view = new LayerAnalysisDraggableView({
+      layerDefinitionModel: new Backbone.Model(),
       model: this.model,
       getNextLetter: function () { return 'b'; },
       sortableSelector: '.js-layers',

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layers-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layers-view.spec.js
@@ -154,7 +154,10 @@ describe('editor/layers/layers-view', function () {
         spyOn(this.userActions, 'createLayerForAnalysisNode');
         this.simulateDragNDrop = function () {
           this.$draggedAnalysis = $('<li class="js-analysis">an analysis node</li>');
-          this.$draggedAnalysis.data('analysis-node-id', 'a2');
+          this.$draggedAnalysis.data({
+            'analysis-node-id': 'a2',
+            'layer-letter': 'a'
+          });
           spyOn(this.$draggedAnalysis, 'remove');
           this.view.$('.js-layers').children().first().after(this.$draggedAnalysis);
           this.sortableArgs.update('event', {item: this.$draggedAnalysis});
@@ -171,7 +174,7 @@ describe('editor/layers/layers-view', function () {
         });
 
         it('should create a new layer', function () {
-          expect(this.userActions.createLayerForAnalysisNode).toHaveBeenCalledWith('a2', {at: 1});
+          expect(this.userActions.createLayerForAnalysisNode).toHaveBeenCalledWith('a2', 'a', {at: 1});
         });
       });
 
@@ -189,7 +192,7 @@ describe('editor/layers/layers-view', function () {
         });
 
         it('should log notification', function () {
-          expect(this.userActions.createLayerForAnalysisNode).toHaveBeenCalledWith('a2', {at: 1});
+          expect(this.userActions.createLayerForAnalysisNode).toHaveBeenCalledWith('a2', 'a', {at: 1});
           expect(this.view._showMaxLayerError).toHaveBeenCalled();
         });
       });


### PR DESCRIPTION
Related ticket #11397.

Two problems in this "node movement":

- We didn't take into account that moved node comes from a defined layer. And if the node is being used in several layers, it could think that the move comes from the first appearance in the layers-collection.
- If a layer doesn't contain any analysis-definition associated because it only points to a defined node, the source of that layer was not replaced correctly.

Test added for validating this case.

cc @javitonino @noguerol 