### PR TITLE
Enhancements to SAML service to support signed logout requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Development
 -----------
 
 ### Features
+* Support for SAML signed logout requests (#12355)
 * Provide CartoCSS attribute within layer info in vizjson v3 (CartoDB/support#858)
 * Support for nested properties in CartoCSS (#12411)
 * New loading button styles (#12132)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -299,7 +299,7 @@ class SessionsController < ApplicationController
       redirect_to default_logout_url
     else
       # Initiate SLO (send Logout Request)
-      redirect_to saml_service.sp_logout_request
+      redirect_to saml_service.sp_logout_request(current_user)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -295,7 +295,14 @@ class SessionsController < ApplicationController
       redirect_to saml_service.idp_logout_request(params[:SAMLRequest], params[:RelayState]) { cdb_logout }
     elsif params[:SAMLResponse]
       # We've been given a response back from the IdP, process it
-      saml_service.process_logout_response(params[:SAMLResponse]) { cdb_logout }
+      begin
+        saml_service.process_logout_response(params[:SAMLResponse])
+      rescue => e
+        CartoDB::Logger.warning(exception: e, message: 'Error proccessing SAML logout')
+      ensure
+        cdb_logout
+      end
+
       redirect_to default_logout_url
     else
       # Initiate SLO (send Logout Request)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ CartoDB::Application.routes.draw do
   get   '(/user/:user_domain)(/u/:user_domain)/account_token_authentication_error' => 'sessions#account_token_authentication_error',     as: :account_token_authentication_error
 
   get   '(/user/:user_domain)/login' => 'sessions#new',     as: :login
-  get   '(/user/:user_domain)(/u/:user_domain)/logout'          => 'sessions#destroy', as: :logout
+  match '(/user/:user_domain)(/u/:user_domain)/logout'          => 'sessions#destroy', as: :logout, via: [:get, :post]
   match '(/user/:user_domain)(/u/:user_domain)/sessions/create' => 'sessions#create',  as: :create_session, via: [:get, :post]
 
   get '(/user/:user_domain)(/u/:user_domain)/status'          => 'home#app_status'

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -116,7 +116,7 @@ module Carto
 
       settings_hash.each do |k, v|
         if k.to_s == 'security'
-          settings.security = v
+          settings.security.merge(v)
         else
           method = "#{k}="
           settings.__send__(method, v) if settings.respond_to?(method)

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -116,7 +116,7 @@ module Carto
 
       settings_hash.each do |k, v|
         if k.to_s == 'security'
-          settings.security.merge!(v)
+          settings.security.merge!(v.symbolize_keys)
         else
           method = "#{k}="
           settings.__send__(method, v) if settings.respond_to?(method)

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -63,9 +63,7 @@ module Carto
 
       logout_response = OneLogin::RubySaml::Logoutresponse.new(saml_response_param, settings)
 
-      if logout_response.validate && logout_response.success?
-        yield
-      else
+      unless logout_response.validate && logout_response.success?
         raise "SAML Logout response error. Validate: #{logout_response.validate}; Success: #{logout_response.success?};"
       end
     end

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -116,7 +116,7 @@ module Carto
 
       settings_hash.each do |k, v|
         if k.to_s == 'security'
-          settings.security.merge(v)
+          settings.security.merge!(v)
         else
           method = "#{k}="
           settings.__send__(method, v) if settings.respond_to?(method)

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -47,7 +47,7 @@ namespace :cartodb do
                       end
 
       if ENV['SAML_SP_PRIVATE_KEY_FILE'].present? && ENV['SAML_SP_CERTIFICATE_FILE'].present? &&
-        configuration[:name_identifier_format].present && configuration[:idp_slo_target_url].present?
+        configuration[:name_identifier_format].present? && configuration[:idp_slo_target_url].present?
         configuration[:security] = {
           logout_requests_signed: true,
           logout_responses_signed: true,

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -47,7 +47,7 @@ namespace :cartodb do
                       end
 
       if ENV['SAML_SP_PRIVATE_KEY_FILE'].present? && ENV['SAML_SP_CERTIFICATE_FILE'].present? &&
-        ENV['SAML_NAME_IDENTIFIER_FORMAT'].present && ENV['SAML_IDP_SLO_TARGET_URL'].present?
+        configuration[:name_identifier_format].present && configuration[:idp_slo_target_url].present?
         configuration[:security] = {
           logout_requests_signed: true,
           logout_responses_signed: true,
@@ -64,7 +64,7 @@ namespace :cartodb do
       configuration[:email_attribute] = ENV['SAML_EMAIL_ATTRIBUTE']
       configuration[:assertion_consumer_service_url] = ENV['SAML_ASSERTION_CONSUMER_SERVICE_URL'] || base_url + '/saml/finalize'
       configuration[:single_logout_service_url] = ENV['SAML_SINGLE_LOGOUT_SERVICE_URL'] || base_url + '/logout'
-      configuration[:name_identifier_format] ||= 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress'
+      configuration[:name_identifier_format] ||= 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
 
       raise "Missing parameter: #{configuration}" unless configuration.values.all?(&:present?)
 

--- a/lib/tasks/saml.rake
+++ b/lib/tasks/saml.rake
@@ -7,11 +7,10 @@ namespace :cartodb do
     # SAML_EMAIL_ATTRIBUTE: attribute with the user email. Example: 'email'.
     # SAML_ASSERTION_CONSUMER_SERVICE_URL: [OPTIONAL] CARTO URL for SAML, including organization name. Examples: 'http://192.168.20.2/user/orgname/saml/finalize'. Defaults to the URL built from configuration and organization name
     # SAML_SINGLE_LOGOUT_SERVICE_URL: [OPTIONAL] CARTO URL for SAML logout, including organization name. Examples: 'http://192.168.20.2/user/orgname/logout'. Defaults to the URL built from configuration and organization name
-    # SAML_SIGNED_LOGOUT: [OPTIONAL] If set to 'true', activates support for SAML signed logout request
     # SAML_SLO_DIGEST_METHOD: [OPTIONAL] Digest method to use in signed logout request. By default: 'http://www.w3.org/2001/04/xmlenc#sha256'
     # SAML_SLO_SIGNATURE_METHOD: [OPTIONAL] Signature method to use in singled logout requests. By default: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
-    # SAML_SP_PRIVATE_KEY: [OPTIONAL] Private key file used for signed logout requests
-    # SAML_SP_CERTIFICATE: [OPTIONAL] Certificate file used for signed logout requests
+    # SAML_SP_PRIVATE_KEY_FILE: [OPTIONAL] Private key file used for signed logout requests
+    # SAML_SP_CERTIFICATE_FILE: [OPTIONAL] Certificate file used for signed logout requests, in .pem format
     # SAML_NAME_IDENTIFIER_FORMAT: [OPTIONAL] Name identifier format to use. By default: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
     #
     # Option 1. Manual configuration
@@ -47,17 +46,17 @@ namespace :cartodb do
                         config
                       end
 
-      if ENV['SAML_SIGNED_LOGOUT'].present? && ENV['SAML_SIGNED_LOGOUT'] == 'true'
+      if ENV['SAML_SP_PRIVATE_KEY_FILE'].present? && ENV['SAML_SP_CERTIFICATE_FILE'].present? &&
+        ENV['SAML_NAME_IDENTIFIER_FORMAT'].present && ENV['SAML_IDP_SLO_TARGET_URL'].present?
         configuration[:security] = {
           logout_requests_signed: true,
           logout_responses_signed: true,
           digest_method: ENV['SAML_SLO_DIGEST_METHOD'] || XMLSecurity::Document::SHA256,
-          signature_method: ENV['SAML_SLO_SIGNATURE_METHOD'] || XMLSecurity::Document::RSA_SHA256,
-          embed_sign: true
+          signature_method: ENV['SAML_SLO_SIGNATURE_METHOD'] || XMLSecurity::Document::RSA_SHA256
         }
 
-        configuration[:private_key] = File.read(ENV['SAML_SP_PRIVATE_KEY']) if ENV['SAML_SP_PRIVATE_KEY'].present?
-        configuration[:certificate] = File.read(ENV['SAML_SP_CERTIFICATE']) if ENV['SAML_SP_CERTIFICATE'].present?
+        configuration[:private_key] = File.read(ENV['SAML_SP_PRIVATE_KEY_FILE'])
+        configuration[:certificate] = File.read(ENV['SAML_SP_CERTIFICATE_FILE'])
       end
 
       base_url = CartoDB.base_url(organization.name)
@@ -65,7 +64,7 @@ namespace :cartodb do
       configuration[:email_attribute] = ENV['SAML_EMAIL_ATTRIBUTE']
       configuration[:assertion_consumer_service_url] = ENV['SAML_ASSERTION_CONSUMER_SERVICE_URL'] || base_url + '/saml/finalize'
       configuration[:single_logout_service_url] = ENV['SAML_SINGLE_LOGOUT_SERVICE_URL'] || base_url + '/logout'
-      configuration[:name_identifier_format] =  ENV['SAML_NAME_IDENTIFIER_FORMAT'] || 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+      configuration[:name_identifier_format] ||= 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress'
 
       raise "Missing parameter: #{configuration}" unless configuration.values.all?(&:present?)
 


### PR DESCRIPTION
This PR implements #12355.

It adds some new parameters to `cartodb:saml:create_saml_configuration` in order to help to configure an organization with support for signed logout requests.

Typical unsigned logout request rake task example:

```
ORGANIZATION_NAME=myorg \
SAML_IDP_METADATA_FILE=https://adfs.cartodb.com/federationmetadata/2007-06/federationmetadata.xml \
SAML_EMAIL_ATTRIBUTE=http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress \
bundle exec rake cartodb:saml:create_saml_configuration
```

Same organization, but activating support for signed logout request, using the default SHA256 digest method and RSA-SHA256 signature method (ex. ADFS):

```
ORGANIZATION_NAME=myorg \
SAML_IDP_METADATA_FILE=https://adfs.cartodb.com/federationmetadata/2007-06/federationmetadata.xml \
SAML_EMAIL_ATTRIBUTE=http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress \
SAML_SP_PRIVATE_KEY_FILE=sp_private.key \
SAML_SP_CERTIFICATE_FILE=sp_certificate..pem \
SAML_NAME_IDENTIFIER_FORMAT=urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress \
bundle exec rake cartodb:saml:create_saml_configuration
```

