### PR TITLE
Adding max items limit for form list editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,7 @@ Development
 * Lowered log level from error to info for supported cartocss in vector maps (cartodb.js#1706)
 * Histogram UI: Do not show "NULL ROWS" value if it is not received (#12477)
 * Force raster mode in datasets preview map (#12513)
+* Adding max items limit for form list editor (#12552)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/list/list.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/list/list.js
@@ -17,7 +17,7 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
   events: {
     'click [data-action="add"]': function (event) {
       event.preventDefault();
-      if (this.errors.length === 0) {
+      if (this._canAddNewItems()) {
         this.addItem(null, true);
       }
     }
@@ -57,6 +57,8 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
     }, this);
 
     this.items = [];
+
+    this._initBinds();
   },
 
   render: function () {
@@ -87,6 +89,12 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
 
     this.validate();
     return this;
+  },
+
+  _initBinds: function () {
+    if (this.options.maxItems) {
+      this.on('add remove', this._setAddButtonState);
+    }
   },
 
   /**
@@ -255,10 +263,15 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
       return item.validate();
     });
 
+    // Max items Check
+    if (this.options.maxItems && this.options.maxItems < this.items.length) {
+      errors.push(_t('form-components.editors.list.max-items'));
+    }
+
     this.errors = _.compact(errors);
     // Check if any item has errors
     var hasErrors = !!this.errors.length;
-    this._setAddButtonState(hasErrors);
+    this._setAddButtonState();
 
     if (!hasErrors) return null;
   },
@@ -269,13 +282,15 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
     })).join('\n');
   },
 
-  _setAddButtonState: function (error) {
-    var button = this.$('[data-action="add"]');
-    button.toggleClass('is-disabled', error);
+  _setAddButtonState: function () {
+    var $button = this._getAddButtonElement();
+    var hasErrors = !!this.errors.length;
 
-    if (error) {
+    $button.toggleClass('is-disabled', hasErrors);
+
+    if (hasErrors) {
       this._errorTooltip = new TipsyTooltipView({
-        el: button,
+        el: $button,
         gravity: 's',
         offset: 0,
         title: this._errorPresenter.bind(this)
@@ -286,6 +301,20 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
         this._errorTooltip = null;
       }
     }
+
+    if (this.options.maxItems) {
+      $button.toggle(this.items.length < this.options.maxItems);
+    }
+  },
+
+  _getAddButtonElement: function () {
+    return this.$('[data-action="add"]');
+  },
+
+  _canAddNewItems: function () {
+    var opts = this.options;
+    var maxItemsReached = (opts.maxItems && opts.maxItems <= this.items.length) || false;
+    return !this.errors.length && !maxItemsReached;
   }
 }, {
 

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/list/list.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/list/list.js
@@ -94,7 +94,7 @@ Backbone.Form.editors.List = Backbone.Form.editors.Base.extend({
 
   _initBinds: function () {
     if (this.options.maxItems) {
-      this.on('add remove', this._setAddButtonState);
+      this.listenTo(this, 'add remove', this._setAddButtonState);
     }
   },
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/data-observatory-multiple-measure-model.js
@@ -268,6 +268,7 @@ module.exports = BaseAnalysisFormModel.extend({
           configModel: this._configModel,
           regions: this.regions,
           nodeDefModel: this.nodeDefModel,
+          maxItems: 10,
           notAddItemByDefault: true
         },
         validators: [ function (value, formValues) {

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -401,9 +401,6 @@
       },
       "slide": {
         "no-values": "No values"
-      },
-      "list": {
-        "max-items": "Max items reached"
       }
     }
   },

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -273,6 +273,7 @@
       },
       "search-by-name": "Search by name...",
       "errors": {
+        "max-items": "Max items reached",
         "measurement-required": "Measurement is required",
         "measurement-twice": "Two or more measurements are equal",
         "column-name-mismatch": "Segment names and column names don't match",
@@ -400,6 +401,9 @@
       },
       "slide": {
         "no-values": "No values"
+      },
+      "list": {
+        "max-items": "Max items reached"
       }
     }
   },

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/list/list.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/list/list.spec.js
@@ -74,4 +74,74 @@ describe('components/form-components/editors/list/list', function () {
       });
     });
   });
+
+  describe('maxItems', function () {
+    var view;
+
+    beforeEach(function () {
+      spyOn(Backbone.Form.editors.List.prototype, '_setAddButtonState').and.callThrough();
+      view = new Backbone.Form.editors.List({
+        trackingClass: 'Foo-trackingClass',
+        value: ['wadus', 'foodie'],
+        schema: {
+          maxItems: 4,
+          validators: ['required']
+        }
+      });
+
+      view.render();
+    });
+
+    it('should check if add-button has to be visible or not', function () {
+      expect(Backbone.Form.editors.List.prototype._setAddButtonState).toHaveBeenCalled();
+    });
+
+    it('should hide add-button when maxItems is reached', function () {
+      Backbone.Form.editors.List.prototype._setAddButtonState.calls.reset();
+      view._getAddButtonElement().click();
+      expect(Backbone.Form.editors.List.prototype._setAddButtonState).toHaveBeenCalled();
+      expect(view._getAddButtonElement().css('display')).not.toBe('none'); // 3 items, you can add a new one
+      view._getAddButtonElement().click();
+      expect(view._getAddButtonElement().css('display')).toBe('none');
+    });
+
+    it('should show add-button when maxItems is not reached', function () {
+      Backbone.Form.editors.List.prototype._setAddButtonState.calls.reset();
+      view.removeItem(view.items[0]);
+      expect(Backbone.Form.editors.List.prototype._setAddButtonState).toHaveBeenCalled();
+      expect(view._getAddButtonElement().css('display')).not.toBe('none');
+    });
+
+    it('should provide a custom error when maxItems is reached after validating it', function () {
+      view.options.maxItems = 1;
+      view.validate();
+      expect(view.errors.length > 0).toBeTruthy();
+      expect(view.errors[0]).toBe('form-components.editors.list.max-items');
+    });
+  });
+
+  describe('_canAddNewItems', function () {
+    it('should be falsy if there is any validation error', function () {
+      this.view.errors = ['error'];
+      expect(this.view._canAddNewItems()).toBeFalsy();
+    });
+
+    it('should be truthy if maxItems is not defined and no errors', function () {
+      this.view.errors = [];
+      delete this.view.options.maxItems; // JUst in case
+      expect(this.view._canAddNewItems()).toBeTruthy();
+    });
+
+    it('should be truthy if maxItems has not been reached and no errors', function () {
+      this.view.errors = [];
+      this.view.options.maxItems = 3;
+      expect(this.view._canAddNewItems()).toBeTruthy();
+    });
+
+    it('should be falsy if maxItems is defined and limit is reached', function () {
+      this.view.errors = [];
+      this.view.options.maxItems = 2;
+      expect(this.view._canAddNewItems()).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/bigmetadata/issues/199

Adding max items limit for form editor list. If you reach the limit, the add-button will be hidden.

## Acceptance.
- Enable new DO analysis in your testing account.
- Create a map with points.
- Choose a DO analysis and try to add 10 measurements (crazy thing but...).
- Check you can't add the 11th.
- Celebrate it if works (:tada:).