### PR TITLE
Fix redirection to login

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,7 @@ Development
 * Fix error when revoking a Dropbox token that was revoked from Dropbox side (#12359)
 * Dropbox searches now don't have limit of number of files (#12521)
 * Fix error when a Dropbox folder has an extension matching valid extensions.
+* Fixes login redirect loop with other user urls (#12553).
 * Fixed UI when editing merge analysis (#10850)
 * Fixed viewer invitations (#12514)
 * Fixed uninitialized constant in Carto::Visualization when a viewer shares a visualization (#12129).

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -65,8 +65,7 @@ class SessionsController < ApplicationController
     user = authenticate!(*strategies, scope: username)
     CartoDB::Stats::Authentication.instance.increment_login_counter(user.email)
 
-    return_to = session.delete('return_to')
-    redirect_to return_to || (user.public_url + CartoDB.path(self, 'dashboard', trailing_slash: true))
+    redirect_to session.delete('return_to') || (user.public_url + CartoDB.path(self, 'dashboard', trailing_slash: true))
   end
 
   def destroy

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -65,7 +65,9 @@ class SessionsController < ApplicationController
     user = authenticate!(*strategies, scope: username)
     CartoDB::Stats::Authentication.instance.increment_login_counter(user.email)
 
-    redirect_to session[:return_to] || (user.public_url + CartoDB.path(self, 'dashboard', trailing_slash: true))
+    return_to = session[:return_to]
+    session.delete(:return_to)
+    redirect_to return_to || (user.public_url + CartoDB.path(self, 'dashboard', trailing_slash: true))
   end
 
   def destroy

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -34,7 +34,7 @@ class SessionsController < ApplicationController
   before_filter :api_authorization_required, only: :show
 
   def new
-    if current_viewer.try(:subdomain) == CartoDB.extract_subdomain(request)
+    if current_viewer
       redirect_to(CartoDB.url(self, 'dashboard', { trailing_slash: true }, current_viewer))
     elsif saml_authentication? && !user
       # Automatically trigger SAML request on login view load -- could easily trigger this elsewhere
@@ -65,8 +65,7 @@ class SessionsController < ApplicationController
     user = authenticate!(*strategies, scope: username)
     CartoDB::Stats::Authentication.instance.increment_login_counter(user.email)
 
-    return_to = session[:return_to]
-    session.delete(:return_to)
+    return_to = session.delete('return_to')
     redirect_to return_to || (user.public_url + CartoDB.path(self, 'dashboard', trailing_slash: true))
   end
 

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -576,7 +576,7 @@ describe SessionsController do
       post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
       response.status.should == 302
       response.headers['Location'].should include '/your_apps'
-      Marshal.load(Base64.decode64(response.cookies["_cartodb_session"]))['return_to'].should be_nil
+      Marshal.dump(Base64.decode64(response.cookies["_cartodb_session"]))['return_to'].should be_nil
     end
 
     describe 'events' do

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -559,16 +559,24 @@ describe SessionsController do
       response.headers['Location'].should include '/your_apps'
     end
 
+    it 'redirects to current viewer dashboard if the `return_to` dashboard url belongs to other user' do
+      Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(false)
+      post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
+      cookies["_cartodb_session"] = response.cookies["_cartodb_session"]
+      get login_url(user_domain: 'wadus_user')
+      response.headers['Location'].should include @user.username
+      response.headers['Location'].should include "/dashboard"
+    end
+
     it 'redirects to the `return_to` only once url if present' do
       Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(false)
       get api_key_credentials_url(user_domain: @user.username)
+
       cookies["_cartodb_session"] = response.cookies["_cartodb_session"]
       post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
       response.status.should == 302
       response.headers['Location'].should include '/your_apps'
-      post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
-      response.status.should == 302
-      response.headers['Location'].should_not include '/your_apps'
+      Marshal.load(Base64.decode64(response.cookies["_cartodb_session"]))['return_to'].should be_nil
     end
 
     describe 'events' do

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -559,6 +559,18 @@ describe SessionsController do
       response.headers['Location'].should include '/your_apps'
     end
 
+    it 'redirects to the `return_to` only once url if present' do
+      Cartodb::Central.stubs(:sync_data_with_cartodb_central?).returns(false)
+      get api_key_credentials_url(user_domain: @user.username)
+      cookies["_cartodb_session"] = response.cookies["_cartodb_session"]
+      post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
+      response.status.should == 302
+      response.headers['Location'].should include '/your_apps'
+      post create_session_url(user_domain: @user.username, email: @user.username, password: @user.password)
+      response.status.should == 302
+      response.headers['Location'].should_not include '/your_apps'
+    end
+
     describe 'events' do
       # include HttpAuthenticationHelper
       require 'rack/test'


### PR DESCRIPTION
This changes two behaviours:
- Clears `return_to` after use.
- Doesn't check username matching at URL in order to redirect to dashboard. Otherwise, if you don't redirect and you request another user URL, you get redirected to login forever.

STR:
If your user is "aaa", try http://localhost.lan:3000/user/bbb/dashboard. Without this change, you get stuck at login page.