### PR TITLE
Fixes error instantiating log if user does not exist

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,7 @@ Development
 * Better handling and reporting of "table with no map associated" error in map privacy changes (#12137).
 * Improve formula widget form (#12242)
 * Fixed alignment problems after CartoAssets update (#12234)
+* Fixed error instantiating the log of a data import if user doesn't exist (#12555)
 * Fixed layer counter (#12236)
 * Fixed problem when icon upload fails (#11980)
 * Boolean fields are visible in the filter by column value analysis (#11546)

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -460,7 +460,7 @@ class DataImport < Sequel::Model
     else
       self.log = CartoDB::Log.new(
         type:     CartoDB::Log::TYPE_DATA_IMPORT,
-        user_id:  current_user.id
+        user_id:  user_id
       )
     end
   end


### PR DESCRIPTION
As logs (and dataimports) are kept without data consistency because
they're are used just for logging, user_id might contain a id of a user
that doesn't exist.