### PR TITLE
Do not save empty mapcaps into visualization

### DIFF
--- a/app/services/carto/visualizations_export_service_2.rb
+++ b/app/services/carto/visualizations_export_service_2.rb
@@ -88,11 +88,13 @@ module Carto
         overlays: build_overlays_from_hash(exported_overlays),
         analyses: exported_visualization[:analyses].map { |a| build_analysis_from_hash(a) },
         permission: build_permission_from_hash(exported_visualization[:permission]),
-        mapcaps: [build_mapcap_from_hash(exported_visualization[:mapcap])].compact,
         external_source: build_external_source_from_hash(exported_visualization[:external_source]),
         created_at: exported_visualization[:created_at],
         updated_at: exported_visualization[:updated_at]
       )
+
+      restored_mapcaps = [build_mapcap_from_hash(exported_visualization[:mapcap])].compact
+      visualization.mapcaps = restored_mapcaps if restored_mapcaps.any?
 
       # This is optional as it was added in version 2.0.2
       exported_user = exported_visualization[:user]

--- a/lib/carto/mapcapped_visualization_updater.rb
+++ b/lib/carto/mapcapped_visualization_updater.rb
@@ -31,7 +31,7 @@ module Carto
     def export_in_memory_visualization(visualization, user)
       {
         version: CURRENT_VERSION,
-        visualization: export(visualization, user)
+        visualization: export(visualization, user, with_mapcaps: false)
       }
     end
   end


### PR DESCRIPTION
Fix #12556 

Avoid setting a blank relation cache, which caused the visualization to not be detected as mapcapped