### PR TITLE
Remove useless 'delete overviews' message.

### DIFF
--- a/services/importer/lib/importer/overviews.rb
+++ b/services/importer/lib/importer/overviews.rb
@@ -60,7 +60,6 @@ module CartoDB
       end
 
       def delete_overviews!(table_name)
-        CartoDB::Logger.info message: "Deleting overviews", user: @user, table_name: table_name
         @user.transaction_with_timeout statement_timeout: @statement_timeout do |db|
           log("Will delete overviews for #{table_name}")
           Carto::OverviewsService.new(db).delete_overviews(table_name)


### PR DESCRIPTION
Hotfix. Fixes #12561

The message was useless because it was being emitted for every sync update
regardless of whether overviews existed or not. And it was flooding Rollbar.