### PR TITLE
Remove quota checker for data-observatory for multiple measurements

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-options.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-options.js
@@ -51,14 +51,6 @@ var ANALYSES_WITH_QUOTA_MAP = {
     }
   },
   'data-observatory-measure': dataObservatoryQuota,
-  'data-observatory-multiple-measures': _.extend(dataObservatoryQuota, {
-    transform: function (input, formModel) {
-      var measurements = formModel.get('measurements');
-      var factor = measurements ? measurements.length : 1;
-      // the data-observatory analysis consume N rows x M measurements
-      return input * factor;
-    }
-  }),
   'routing-sequential': routingAnalysisQuota,
   'routing-to-layer-all-to-all': routingAnalysisQuota,
   'routing-to-single-point': routingAnalysisQuota

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-quota/analyses-quota-options.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analyses-quota/analyses-quota-options.spec.js
@@ -29,6 +29,10 @@ describe('editor/layers/layer-content-views/analyses/analyses-quota/analyses-quo
       expect(AnalysesQuotaOptions.requiresQuota('data-observatory-measure', this.quotaInfo)).toBe(true);
     });
 
+    it('data observatory multiple should NOT require quota', function () {
+      expect(AnalysesQuotaOptions.requiresQuota('data-observatory-multiple-measures', this.quotaInfo)).toBeFalsy();
+    });
+
     describe('trade-area', function () {
       it('should require quota if provider is set', function () {
         var geocoder = this.quotaInfo.getService('hires_geocoder');
@@ -63,13 +67,13 @@ describe('editor/layers/layer-content-views/analyses/analyses-quota/analyses-quo
       expect(AnalysesQuotaOptions.transformInput('foo', 20, {})).toBe(20);
     });
 
-    it('should return same input for analysis with quota but isolines', function () {
+    it('should return same input for analysis with quota', function () {
       var formModel = new Backbone.Model({
         measurements: [1, 2]
       });
 
       expect(AnalysesQuotaOptions.transformInput('georeference-street-address', 20, {})).toBe(20);
-      expect(AnalysesQuotaOptions.transformInput('data-observatory-measure', 15, formModel)).toBe(30);
+      expect(AnalysesQuotaOptions.transformInput('data-observatory-measure', 15, formModel)).toBe(15);
     });
 
     it('should return input multiplied for tracts for isolines', function () {


### PR DESCRIPTION
![data-observatory-multiple-measures](https://user-images.githubusercontent.com/132146/29067896-d29ddc78-7c34-11e7-9251-1943414deb9e.gif)

There will be a problem when we release the new DO analysis, because the old one is still requiring DO quota. So the thing is, when we open that to everybody, remove the quota checker for old DO analysis too.

cc @noguerol @jorgesancha @javisantana @nobuti 