### PR TITLE
Update deep-insights dependency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -438,6 +438,7 @@ More information at [Dropbox migration guide](https://www.dropbox.com/developers
 * Color picker disappears in CartoCSS editor after clicking (#12097).
 * Bug found in dataset view when user had Google basemaps enabled (#12155)
 * Fixed incorrect analysis node being selected after deleting (#11899)
+* Time-series range filter is kept after refreshing (#12576)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.0`. Run the following to have it available:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.26",
+  "version": "4.9.27",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -491,7 +491,7 @@
     "backbone-forms": {
       "version": "0.14.0",
       "from": "backbone-forms@0.14.0",
-      "resolved": "https://registry.npmjs.org/backbone-forms/-/backbone-forms-0.14.0.tgz"
+      "resolved": "http://registry.npmjs.org/backbone-forms/-/backbone-forms-0.14.0.tgz"
     },
     "backbone-model-file-upload": {
       "version": "1.0.0",
@@ -728,7 +728,7 @@
     "cartodb-deep-insights.js": {
       "version": "0.0.3",
       "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#4b0690f8d1a7cd4cb5d872057231ff2730438a4e",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#c6817e7e9bc988aa632ff5a0cd50d7dc2717378d",
       "dependencies": {
         "node-polyglot": {
           "version": "2.2.2",
@@ -745,7 +745,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#1069dd117302d691ae657110dcceb8d3425b398c"
+      "resolved": "git://github.com/cartodb/cartodb.js.git#9557909777147d3e25f403c4160592d3a6e9eb4a"
     },
     "caseless": {
       "version": "0.11.0",
@@ -1057,9 +1057,9 @@
       "optional": true
     },
     "electron-to-chromium": {
-      "version": "1.3.17",
+      "version": "1.3.18",
       "from": "electron-to-chromium@>=1.3.17 <2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz"
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz"
     },
     "elliptic": {
       "version": "6.4.0",
@@ -2503,7 +2503,7 @@
     "queue-async": {
       "version": "1.2.1",
       "from": "queue-async@1.2.1",
-      "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz"
+      "resolved": "http://registry.npmjs.org/queue-async/-/queue-async-1.2.1.tgz"
     },
     "quote-stream": {
       "version": "1.0.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.20",
+  "version": "4.9.22-12576-a",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -540,9 +540,9 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
     },
     "bn.js": {
-      "version": "4.11.7",
+      "version": "4.11.8",
       "from": "bn.js@>=4.1.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz"
     },
     "boom": {
       "version": "2.10.1",
@@ -666,9 +666,9 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "browserslist": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "from": "browserslist@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.1.tgz"
     },
     "buffer": {
       "version": "4.9.1",
@@ -711,9 +711,9 @@
       "resolved": "https://registry.npmjs.org/camshaft-reference/-/camshaft-reference-0.33.0.tgz"
     },
     "caniuse-lite": {
-      "version": "1.0.30000712",
-      "from": "caniuse-lite@>=1.0.30000710 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000712.tgz"
+      "version": "1.0.30000713",
+      "from": "caniuse-lite@>=1.0.30000712 <2.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000713.tgz"
     },
     "carto": {
       "version": "0.15.1-cdb4",
@@ -727,8 +727,8 @@
     },
     "cartodb-deep-insights.js": {
       "version": "0.0.3",
-      "from": "cartodb/deep-insights.js#master",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#36511d7925709d6ae6cbbea2b23dffaae8460e10",
+      "from": "cartodb/deep-insights.js#12576-filter-bug",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#8a9b2a15e4e70a1638e0ba76e9d3a431de10b573",
       "dependencies": {
         "node-polyglot": {
           "version": "2.2.2",
@@ -745,7 +745,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#4080b8238d6f311aacb680be308ae35cf951096f"
+      "resolved": "git://github.com/cartodb/cartodb.js.git#bbb619e9c626bcb0eef38648708c8dc3a77bb871"
     },
     "caseless": {
       "version": "0.11.0",
@@ -3063,7 +3063,7 @@
     "tangram.cartodb": {
       "version": "0.4.6",
       "from": "cartodb/tangram.cartodb#master",
-      "resolved": "git://github.com/cartodb/tangram.cartodb.git#7e983d5c1e62548a68dcea7563c2e12d3bf9d896"
+      "resolved": "git://github.com/cartodb/tangram.cartodb.git#d71b7d33c791761f777f31fcd9b4a00918e8af9f"
     },
     "tapable": {
       "version": "0.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.22",
+  "version": "4.9.22-12576-a",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -24,7 +24,7 @@
     "camshaft-reference": "0.33.0",
     "carto": "cartodb/carto#master",
     "cartocolor": "4.0.0",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#12576-filter-bug",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "CartoDB/cartodb.js#v4",
     "clipboard": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "camshaft-reference": "0.33.0",
     "carto": "cartodb/carto#master",
     "cartocolor": "4.0.0",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#12576-filter-bug",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#master",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "CartoDB/cartodb.js#v4",
     "clipboard": "1.6.1",


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/12576

This PR implements applying the filter in time-series widgets (no animated) when loading the map.

**Acceptance**

1. In Builder, create a non animated time-series widget.
2. Filter it. Select a range.
3. Publish the map.
4. Check that if we refresh Builder, the filter is correctly loaded and applied.
5. Open the embed page and check that the filter is correctly loaded and applied.
6. Please, play with the range filter. Destroy the widget, create it again... try to break things.