### PR TITLE
Reset analysis button and launch onboarding for cached analyses.

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/analyses-integration.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/analyses-integration.js
@@ -82,8 +82,13 @@ module.exports = {
     return nodeDefModel.hasChanged('id') && _.size(nodeDefModel.changed) === 1;
   },
 
+  _isCachedAnalysis: function (nodeDefModel) {
+    return nodeDefModel.hasChanged('status') && nodeDefModel.get('status') === 'ready' && nodeDefModel.previous('status') === 'pending';
+  },
+
   _tryToSetupDefinitionNodeSync: function (m) {
-    if (m.__syncSetup) return; // only setup once
+    var isCachedAnalysis = this._isCachedAnalysis(m);
+    if (m.__syncSetup && !isCachedAnalysis) return; // only setup once
 
     var node = this._diDashboardHelpers.getAnalysisByNodeId(m.id);
     var layerDefModel = this._layerDefinitionsCollection.findOwnerOfAnalysisNode(m);
@@ -91,6 +96,12 @@ module.exports = {
 
     m.__syncSetup = true;
     m.__initialization = true;
+
+    if (isCachedAnalysis) {
+      AnalysisOnboardingLauncher.launch(node.get('type'), m);
+      m.USER_SAVED = false;
+      return;
+    }
 
     // Don't need to sync source nodes
     if (node.get('type') !== 'source') {

--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/analyses-integration.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/analyses-integration.js
@@ -83,7 +83,7 @@ module.exports = {
   },
 
   _isCachedAnalysis: function (nodeDefModel) {
-    return nodeDefModel.hasChanged('status') && nodeDefModel.get('status') === 'ready' && nodeDefModel.previous('status') === 'pending';
+    return nodeDefModel.hasChanged('status') && nodeDefModel.get('status') === 'ready' && nodeDefModel.previous('status') === 'launched';
   },
 
   _tryToSetupDefinitionNodeSync: function (m) {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -346,10 +346,10 @@ module.exports = CoreView.extend({
       this._bindAnalysisNodeStatusChanges();
     }
 
-    // For cached analysis, if the user edit the analysis to a previous version of it
+    // For cached analysis, if the user edits the analysis to a previous version of it
     // the request returns the status:ready but the analysis node already has this state
-    // so no changes is trigger
-    this._analysisNode.set({ status: 'pending' }, { silent: true });
+    // so no changes are triggered
+    this._analysisNode.set({ status: 'launched' }, { silent: true });
 
     this._viewModel.set({ hasChanges: false, isDone: false });
     this.render();

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -346,6 +346,11 @@ module.exports = CoreView.extend({
       this._bindAnalysisNodeStatusChanges();
     }
 
+    // For cached analysis, if the user edit the analysis to a previous version of it
+    // the request returns the status:ready but the analysis node already has this state
+    // so no changes is trigger
+    this._analysisNode.set({ status: 'pending' }, { silent: true });
+
     this._viewModel.set({ hasChanges: false, isDone: false });
     this.render();
   }

--- a/lib/assets/core/test/spec/cartodb3/deep-insights-integration/analyses-integration.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/deep-insights-integration/analyses-integration.spec.js
@@ -216,7 +216,7 @@ describe('deep-insights-integrations/analyses-integration', function () {
           expect(this.node.USER_SAVED).toBeFalsy();
 
           this.node.USER_SAVED = true;
-          this.node.set('status', 'pending');
+          this.node.set('status', 'launched');
           this.diDashboardHelpers.getAnalysisByNodeId('a2').set({
             query: 'SELECT buffer FROM tmp_result_table_124',
             status: 'ready'

--- a/lib/assets/core/test/spec/cartodb3/deep-insights-integration/analyses-integration.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/deep-insights-integration/analyses-integration.spec.js
@@ -209,6 +209,22 @@ describe('deep-insights-integrations/analyses-integration', function () {
           expect(AnalysisOnboardingLauncher.launch).toHaveBeenCalled();
           expect(this.node.USER_SAVED).toBeFalsy();
         });
+
+        it('should launch the onboarding analysis if the analysis is cached', function () {
+          expect(AnalysisOnboardingLauncher.launch).toHaveBeenCalled();
+          expect(AnalysisOnboardingLauncher.launch.calls.count()).toBe(1);
+          expect(this.node.USER_SAVED).toBeFalsy();
+
+          this.node.USER_SAVED = true;
+          this.node.set('status', 'pending');
+          this.diDashboardHelpers.getAnalysisByNodeId('a2').set({
+            query: 'SELECT buffer FROM tmp_result_table_124',
+            status: 'ready'
+          });
+
+          expect(AnalysisOnboardingLauncher.launch.calls.count()).toBe(2);
+          expect(this.node.USER_SAVED).toBeFalsy();
+        });
       });
 
       describe('when analysis node has finished executing', function () {

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
@@ -419,6 +419,28 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
       expect(this.userActions.saveAnalysis).toHaveBeenCalledWith(this.formModel);
     });
 
+    it('should change analysis node\'s state to pending when saving', function () {
+      spyOn(this.view, '_canSave').and.returnValue(true);
+      this.analysisNode.set('status', 'ready');
+
+      var nodeChange = jasmine.createSpy('nodeChange');
+      this.analysisNode.on('change:status', nodeChange);
+
+      mockSQL.mock(this.quotaInfo, 'success', {
+        rows: [
+          {service: 'isolines', monthly_quota: 2000, used_quota: 1900, soft_limit: false, provider: 'heremaps'}
+        ]
+      });
+
+      this.view.render();
+      this.view.$('.js-save').click();
+
+      // silent when putting pending
+      expect(nodeChange.calls.count()).toBe(0);
+      expect(this.analysisNode.get('status')).toBe('pending');
+      expect(this.userActions.saveAnalysis).toHaveBeenCalledWith(this.formModel);
+    });
+
     it('render a save button disabled after saved an analysis', function () {
       this.view._viewModel.set('hasChanges', false);
       this.view.render();

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
@@ -419,7 +419,7 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
       expect(this.userActions.saveAnalysis).toHaveBeenCalledWith(this.formModel);
     });
 
-    it('should change analysis node\'s state to pending when saving', function () {
+    it('should change analysis node\'s state to launched when saving', function () {
       spyOn(this.view, '_canSave').and.returnValue(true);
       this.analysisNode.set('status', 'ready');
 
@@ -435,9 +435,9 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
       this.view.render();
       this.view.$('.js-save').click();
 
-      // silent when putting pending
+      // silent when putting launched
       expect(nodeChange.calls.count()).toBe(0);
-      expect(this.analysisNode.get('status')).toBe('pending');
+      expect(this.analysisNode.get('status')).toBe('launched');
       expect(this.userActions.saveAnalysis).toHaveBeenCalledWith(this.formModel);
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.25",
+  "version": "4.9.25-225-do-cached-analysis",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes https://github.com/CartoDB/bigmetadata/issues/225.

When the user saves an analysis we change the status to pending to force triggering changes even when the analysis is cached. In this scenario, the analysis save request returns a `ready` state without passing for enqueued or running state, so the UI is not aware of the change.

In order to accept it, follow the STR described [here](https://github.com/CartoDB/bigmetadata/issues/225#issuecomment-319593606) and check:
- [ ] the button resets the label property
- [ ] the onboarding launches for cached analyses