### PR TITLE
Fix join column analysis on IE11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@ Development
 * Mustache conditionals support improved in popups (#support/763)
 
 ### Bug fixes / enhancements
+* Fix broken join from second column on IE11 (#support/875)
 * Fix ghost node problem (#11397)
 * Break down deep-insights-integrations class (#11581)
 * Fix torque categories layer rendering (#cartodb.js/1698)

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
@@ -247,9 +247,8 @@ module.exports = BaseAnalysisFormModel.extend({
   },
 
   _getSourceOptionsForSourceId: function (sourceId, sourceAttrName, requiredSimpleGeometryType) {
-    return this._analysisSourceOptionsModel
-    .getSelectOptions(requiredSimpleGeometryType)
-    .find(function (d) {
+    var options = this._analysisSourceOptionsModel.getSelectOptions(requiredSimpleGeometryType);
+    return _.find(options, function (d) {
       // Can't select own layer as source, so exclude it
       return d.val === sourceId;
     });

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/merge-form-model.js
@@ -248,10 +248,16 @@ module.exports = BaseAnalysisFormModel.extend({
 
   _getSourceOptionsForSourceId: function (sourceId, sourceAttrName, requiredSimpleGeometryType) {
     var options = this._analysisSourceOptionsModel.getSelectOptions(requiredSimpleGeometryType);
-    return _.find(options, function (d) {
+    var searchFn = function (d) {
       // Can't select own layer as source, so exclude it
       return d.val === sourceId;
-    });
+    };
+
+    if (options.find) {
+      return options.find(searchFn);
+    } else {
+      return _.find(options, searchFn);
+    }
   },
 
   _getSourceOptionsForSource: function (sourceAttrName, requiredSimpleGeometryType) {


### PR DESCRIPTION
IE does not support Array.find, using underscore.

I searched around for other instances of this, but I couldn't find any.