### PR TITLE
Fix bubble diagram legend on IE11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Development
 -----------
 
 ### Features
+* Fixed a bug that would break the bubble legend on IE11 (#support/891)
 * Support for SAML signed logout requests (#12355)
 * Provide a way to display broken layers pointing to non existent nodes (#12541)
 * Provide CartoCSS attribute within layer info in vizjson v3 (CartoDB/support#858)

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "update-internal-deps": "rm -rf node_modules && npm install --production --no-shrinkwrap && npm dedupe && npm prune && npm shrinkwrap && npm install",
     "branch-files": "node lib/build/branchFiles/branchFiles.js",
     "affected_specs": "node lib/build/branchFiles/branchFiles.js | xargs node lib/build/affectedFiles/affectedFiles.js",
-    "build": "NODE_ENV=production webpack -p --config webpack.prod.config.js",
+    "build": "NODE_ENV=production webpack --config webpack.prod.config.js",
     "build:stats": "webpack --env.stats --progress --config webpack.dev.config.js",
     "start": "grunt watch:css & webpack --progress --watch --config webpack.dev.config.js",
     "dev": "webpack --progress --config webpack.dev.config.js"

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -65,7 +65,10 @@ module.exports = env => {
         compress: {
           screw_ie8: true
         },
-        comments: false
+        comments: false,
+        output: {
+          ascii_only: true
+        }
       })
     ]),
     module: {


### PR DESCRIPTION
This PR should fix a problem with the Legend for proportional sizes styling.

The problem lied in our sanitizer being 'corrupted' by the minification process, which transformed Unicode literals on strings into actual characters, but not on regular expressions and other places. To fix something on a version of Mozilla, the sanitizer inserts a non-unicode character (\uFFFF) and then removes it immediately afterwards.

The consequence was that in the end the style attribute is being parsed as:

`"ï¿¿width: 80%;height: 90%"`

So it would discard the first CSS property as invalid. Without the proper inline styling, the layout is all wrong.

For some reason, IE11 is the only one that can't understand the ~corrupted~ improved code, so the fix is forcing ascii_output. It's been deployed on ded02 just in case it would break something else, but it seems we're good.