### PR TITLE
12568 nil processing named map template

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -145,6 +145,7 @@ Development
 * Adding max items limit for form list editor (#12552)
 * Improve Google Login button (cartodb-central#1808)
 * Implement widget opacity in AutoStyle (#11928)
+* Fix exception thrown when map created without builder is used with it and visualization state data is missing.
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/NEWS.md
+++ b/NEWS.md
@@ -146,7 +146,7 @@ Development
 * Improve Google Login button (cartodb-central#1808)
 * Implement widget opacity in AutoStyle (#11928)
 * Fix histograms data range change (#12622)
-* Fix exception thrown when map created without builder is used with it and visualization state data is missing.
+* Fix exception thrown when map created without builder is used with it and visualization state data is missing (#12568)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -252,8 +252,8 @@ module Carto
       def valid_state?
         state = @visualization.state.json
         map = state[:map]
-        not(state.blank? || map.blank? || map[:center].blank? || map[:sw].blank? || map[:ne].blank? ||
-          map[:sw][0].blank? || map[:sw][1].blank? || map[:ne].blank? || map[:ne][0].blank? || map[:ne][1].blank?)
+        state.present? && map.present? && map[:center].present? && map[:sw].present? && map[:ne].present? &&
+          map[:sw][0].present? && map[:sw][1].present? && map[:ne].present? && map[:ne][0].present? && map[:ne][1].present?
       end
 
       def view_from_map

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -255,10 +255,11 @@ module Carto
       end
 
       protected
-      def invalid_state? (state)
+
+      def invalid_state?(state)
         map = state[:map]
         state.blank? || map.blank? || map[:center].blank? || map[:sw].blank? || map[:ne].blank? ||
-            map[:sw][0].blank? || map[:sw][1].blank? || map[:ne].blank? || map[:ne][0].blank? || map[:ne][1].blank?
+          map[:sw][0].blank? || map[:sw][1].blank? || map[:ne].blank? || map[:ne][0].blank? || map[:ne][1].blank?
       end
 
       def view_from_map
@@ -281,8 +282,8 @@ module Carto
         center_and_zoom = {
             zoom: state[:map][:zoom],
             center: {
-                lng: center_data[1],
-                lat: center_data[0]
+              lng: center_data[1],
+              lat: center_data[0]
             }
         }
         bounds_data = {
@@ -294,7 +295,7 @@ module Carto
         filter_and_merge_view(bounds_data, center_and_zoom)
       end
 
-      def filter_and_merge_view (bounds_data, center_and_zoom)
+      def filter_and_merge_view(bounds_data, center_and_zoom)
         # INFO: Don't return 'bounds' if any of the points is 0 to avoid static map trying to go too small zoom level
         if bounds_data[:west] != 0 || bounds_data[:south] != 0 || bounds_data[:east] != 0 || bounds_data[:north] != 0
           center_and_zoom[:bounds] = bounds_data

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -236,12 +236,7 @@ module Carto
       end
 
       def view
-        state = @visualization.state.json
-        if invalid_state? state # Use map info when there's no state info
-          view_from_map
-        else # Use state information when present
-          view_from_state
-        end
+        valid_state? ? view_from_state : view_from_map
       end
 
       def preview_layers
@@ -254,12 +249,11 @@ module Carto
         preview_layers
       end
 
-      protected
-
-      def invalid_state?(state)
+      def valid_state?
+        state = @visualization.state.json
         map = state[:map]
-        state.blank? || map.blank? || map[:center].blank? || map[:sw].blank? || map[:ne].blank? ||
-          map[:sw][0].blank? || map[:sw][1].blank? || map[:ne].blank? || map[:ne][0].blank? || map[:ne][1].blank?
+        not(state.blank? || map.blank? || map[:center].blank? || map[:sw].blank? || map[:ne].blank? ||
+          map[:sw][0].blank? || map[:sw][1].blank? || map[:ne].blank? || map[:ne][0].blank? || map[:ne][1].blank?)
       end
 
       def view_from_map
@@ -268,8 +262,8 @@ module Carto
         data = {
             zoom: map.zoom,
             center: {
-                lng: center_data[1].to_f,
-                lat: center_data[0].to_f
+              lng: center_data[1].to_f,
+              lat: center_data[0].to_f
             }
         }
         bounds_data = map.view_bounds_data

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -253,7 +253,7 @@ module Carto
         state = @visualization.state.json
         map = state[:map]
         state.present? && map.present? && map[:center].present? && map[:sw].present? && map[:ne].present? &&
-          map[:sw][0].present? && map[:sw][1].present? && map[:ne].present? && map[:ne][0].present? && map[:ne][1].present?
+          map[:sw][0].present? && map[:sw][1].present? && map[:ne][0].present? && map[:ne][1].present?
       end
 
       def view_from_map

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -721,7 +721,7 @@ module Carto
             @visualization.state.json[:map][:ne] = nil
             result = Carto::NamedMaps::Template.new(@visualization).to_hash
             result[:view][:zoom].should eq 3
-            expected_center = {lng: 0.0, lat: 30.0}
+            expected_center = { lng: 0.0, lat: 30.0 }
             result[:view][:center].should eq expected_center
           end
         end

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -716,6 +716,14 @@ module Carto
             expected_bounds = { west: 37.4, south: 41.6, east: -58.9, north: -143.9 }
             @template_hash[:view][:bounds].should eq expected_bounds
           end
+
+          it 'should not fail when invalid state' do
+            @visualization.state.json[:map][:ne] = nil
+            result = Carto::NamedMaps::Template.new(@visualization).to_hash
+            result[:view][:zoom].should eq 3
+            expected_center = {lng: 0.0, lat: 30.0}
+            result[:view][:center].should eq expected_center
+          end
         end
 
         describe '#preview_layers' do


### PR DESCRIPTION
When a named map template is used, if there is some data corruption in the state field, it was throwing an exception.

More conditions have been aded to the [condition](https://github.com/CartoDB/cartodb/compare/12568NilProcessingNamedMapTemplate?diff=unified&expand=1&name=12568NilProcessingNamedMapTemplate#diff-37de14bd6f97d298cf49816cf53dbf67L240) so it takes this into account.

Code refactor to make it more readable and easy to follow

A test has also been added

Fixes #12568 