### PR TITLE
Supress warning from tests.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -444,7 +444,7 @@ module.exports = function (grunt) {
     })
     .value());
 
-  grunt.registerTask('setConfig', 'Set a config property', function(name, val) {
+  grunt.registerTask('setConfig', 'Set a config property', function (name, val) {
     grunt.config.set(name, val);
   });
 

--- a/lib/build/tasks/webpack/webpack.config.js
+++ b/lib/build/tasks/webpack/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
         main: [
           // To be filled by grunt
         ]
-      }, 
+      },
       output: {
         path: path.resolve(path.resolve('.'), '.grunt'),
         filename: '[name].affected-specs.js'
@@ -37,7 +37,7 @@ module.exports = {
             include: [path.resolve(path.resolve('.'), 'node_modules/tangram.cartodb')],
             options: {
               presets: [
-                ["es2015", { "modules": false }]
+                ['es2015', { 'modules': false }]
               ]
             }
           },
@@ -77,15 +77,7 @@ module.exports = {
       target: 'web',
       node: {
         fs: 'empty'
-      },
-      stats: 'normal'
-      // resolve: {
-      //   alias: {
-      //     d3: path.resolve('./node_modules/cartodb.js/node_modules/d3/d3.js'),
-      //     'cartodb.js': path.resolve('./node_modules/cartodb.js'),
-      //     'trangram.cartodb.debug.js': path.resolve('./node_modules/cartodb.js/node_modules/tangram.cartodb/dist/trangram.cartodb.debug.js')
-      //   }
-      // }
+      }
     };
 
     return cfg;

--- a/lib/build/tasks/webpack/webpack.js
+++ b/lib/build/tasks/webpack/webpack.js
@@ -18,31 +18,31 @@ var paths = {
  * affected - To be used as part of a 'registerTask' Grunt definition
  */
 var affected = function (option, grunt) {
-    var done = this.async();
+  var done = this.async();
 
-    affectedSpecs = [
-      './lib/build/source-map-support.js',
-      './lib/assets/javascripts/cartodb3/components/form-components/index.js',
-      './lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-options.spec.js'
-    ];
+  affectedSpecs = [
+    './lib/build/source-map-support.js',
+    './lib/assets/javascripts/cartodb3/components/form-components/index.js',
+    './lib/assets/test/spec/cartodb3/components/modals/add-analysis/analysis-options.spec.js'
+  ];
 
-    if (grunt.option('specs') === 'all' || option === 'all') {
-      var allSpecs = glob.sync(paths.builder_specs);
-      console.log(colors.yellow('All specs. ' + allSpecs.length + ' specs found.'));
-      affectedSpecs = affectedSpecs.concat(allSpecs);
-      done();
-    } else {
-      retrieveAffectedSpecs(grunt)
-        .then(function (specsList) {
-          console.log(colors.yellow(specsList.length + ' specs found.'));
-          affectedSpecs = affectedSpecs.concat(specsList);
-          done();
-        })
-        .catch(function (reason) {
-          throw new Error(reason);
-        });
-    }
-}
+  if (grunt.option('specs') === 'all' || option === 'all') {
+    var allSpecs = glob.sync(paths.builder_specs);
+    console.log(colors.yellow('All specs. ' + allSpecs.length + ' specs found.'));
+    affectedSpecs = affectedSpecs.concat(allSpecs);
+    done();
+  } else {
+    retrieveAffectedSpecs(grunt)
+      .then(function (specsList) {
+        console.log(colors.yellow(specsList.length + ' specs found.'));
+        affectedSpecs = affectedSpecs.concat(specsList);
+        done();
+      })
+      .catch(function (reason) {
+        throw new Error(reason);
+      });
+  }
+};
 
 var bootstrap = function (config, grunt) {
   if (!config) {
@@ -55,7 +55,7 @@ var bootstrap = function (config, grunt) {
 
   cfg[config].entry = function () {
     return affectedSpecs;
-  }
+  };
 
   compiler[config] = webpack(cfg[config]);
   cache[config] = {};
@@ -64,15 +64,15 @@ var bootstrap = function (config, grunt) {
   // Flag stats === true -> write stats.json
   if (grunt.option('stats')) {
     compiler[config].apply(new StatsWriterPlugin({
-      transform: function(data, opts) {
+      transform: function (data, opts) {
         var stats = opts.compiler.getStats().toJson({chunkModules: true});
-        return JSON.stringify(stats, null, 2); 
+        return JSON.stringify(stats, null, 2);
       }
     }));
   }
 };
 
-function logAssets(assets) {
+function logAssets (assets) {
   _.each(assets, function (asset) {
     var trace = asset.name;
     trace += ' ' + pretty(asset.size);
@@ -102,9 +102,6 @@ var compile = function (config) {
 
     var info = stats.toJson();
 
-    if (stats.hasWarnings()) {
-      console.warn(colors.yellow(info.warnings));
-    }
     if (stats.hasErrors()) {
       console.error(colors.red(info.errors));
       console.error('');
@@ -112,7 +109,7 @@ var compile = function (config) {
       console.error(colors.red('THERE WAS AN ERROR WHILE BUNDLING!!!'));
       console.error('🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥 🔥');
     }
-    if (!stats.hasErrors() && !stats.hasWarnings()) {
+    if (!stats.hasErrors()) {
       logAssets(info.assets);
       console.log(colors.yellow('Time: ' + info.time));
     }

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -122,8 +122,6 @@ module.exports = env => {
       fs: 'empty' // This fixes the error Module not found: Error: Can't resolve 'fs'
     },
 
-    stats: {
-      warnings: false
-    }
+    stats: 'normal'
   };
 };


### PR DESCRIPTION
Move them to webpack.config.dev.

The `grunt test` shows this console now:

```
Running "webpack:builder_specs" task
(node:82691) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
main.affected-specs.js 3.3 MB
vendor.affected-specs.js 6.9 MB
main.affected-specs.js.map 4.3 MB
Time: 11874
Task 'webpack:builder_specs' took 12031ms
```

The `grunt dev` task shows the warnings in compilation, IMHO it's where they belong.
