### PR TITLE
Fix popup order selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@ Development
 * Updates Dataservices API client default version to `0.20.0` (#12633)
 
 ### Bug fixes / enhancements
+* Fix popup order selection (#12694)
 * Fix histogram range sliders stick on buckets (#12661)
 * Fix Time Series resize when switching to advanced mode (#12124)
 * Fix adding/removing widgets when having Time Series (#12123, #12402, #12655)

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
@@ -69,15 +69,13 @@ module.exports = CoreView.extend({
   },
 
   _allFieldsSelected: function () {
-    var self = this;
-
     var selectedAll = true;
 
     _.each(this._getColumnNames(), function (field) {
-      if (!self.model.containsField(field)) {
+      if (!this.model.containsField(field)) {
         selectedAll = false;
       }
-    });
+    }.bind(this));
 
     return selectedAll;
   },
@@ -91,25 +89,23 @@ module.exports = CoreView.extend({
   },
 
   _selectAll: function () {
-    var self = this;
-
     var names = this._sortedFields.map(function (w) { return w.get('name'); });
     var promises = [];
 
     _.each(names, function (f) {
-      if (!self.model.containsField(f)) {
-        promises.push(self.model._addField(f));
+      if (!this.model.containsField(f)) {
+        promises.push(this.model._addField(f));
       }
-    });
+    }.bind(this));
 
     $.when.apply($, promises).then(function () {
-      self.model.sortFields();
-      self.model.trigger('add:fields');
-      self.model.trigger('change:fields', self.model, self.model.get('fields'));
-      self.model.trigger('change', self.model);
+      this.model.sortFields();
+      this.model.trigger('add:fields');
+      this.model.trigger('change:fields', this.model, this.model.get('fields'));
+      this.model.trigger('change', this.model);
 
-      self._toggleSelectAll();
-    });
+      this._toggleSelectAll();
+    }.bind(this));
   },
 
   _unselectAll: function () {
@@ -140,56 +136,50 @@ module.exports = CoreView.extend({
   },
 
   _onSortableFinish: function () {
-    var self = this;
     this._sortedFields.reset([]);
 
     this.$('.js-fields > .js-field').each(function (index, item) {
-      var view = self._subviews[$(item).data('view-cid')];
+      var view = this._subviews[$(item).data('view-cid')];
 
-      self.model.setFieldProperty(view.fieldName, 'position', index);
+      this.model.setFieldProperty(view.fieldName, 'position', index);
       view.position = index;
 
-      self._sortedFields.add({
+      this._sortedFields.add({
         name: view.fieldName,
         position: index
       });
-    });
+    }.bind(this));
   },
 
   _getSortedColumnNames: function () {
-    var self = this;
     var names = this._getColumnNames();
 
-    if (self.model.fieldCount() > 0) {
+    if (this.model.fieldCount() > 0) {
       names.sort(function (a, b) {
-        var pos_a = self.model.getFieldPos(a);
-        var pos_b = self.model.getFieldPos(b);
+        var pos_a = this.model.getFieldPos(a);
+        var pos_b = this.model.getFieldPos(b);
         return pos_a - pos_b;
-      });
+      }.bind(this));
     }
     return names;
   },
 
   _storeSortedFields: function () {
-    var self = this;
-
     this._sortedFields.reset([]);
 
     var names = this._getSortedColumnNames();
     _(names).each(function (name, position) {
-      self._sortedFields.add({
+      this._sortedFields.add({
         name: name,
         position: position
       });
-    });
+    }.bind(this));
   },
 
   _getColumnNames: function () {
-    var self = this;
-
     var filteredColumns = this._querySchemaModel.columnsCollection.filter(function (c) {
-      return !_.contains(self.model.SYSTEM_COLUMNS, c.get('name'));
-    });
+      return !_.contains(this.model.SYSTEM_COLUMNS, c.get('name'));
+    }.bind(this));
 
     var columnNames = [];
 
@@ -201,22 +191,20 @@ module.exports = CoreView.extend({
   },
 
   _renderFields: function () {
-    var self = this;
-
     var names = this._getSortedColumnNames();
 
     _(names).each(function (f, i) {
-      var title = self.model.getFieldProperty(f, 'title');
+      var title = this.model.getFieldProperty(f, 'title');
 
       var view = new FieldView({
-        layerInfowindowModel: self.model,
+        layerInfowindowModel: this.model,
         field: { name: f, title: title },
-        position: self.model.getFieldPos(f)
+        position: this.model.getFieldPos(f)
       });
 
-      self.addView(view);
-      self.$('.js-fields').append(view.render().el);
-    });
+      this.addView(view);
+      this.$('.js-fields').append(view.render().el);
+    }.bind(this));
   },
 
   clean: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
@@ -75,7 +75,7 @@ module.exports = CoreView.extend({
       if (!this.model.containsField(field)) {
         selectedAll = false;
       }
-    }.bind(this));
+    }, this);
 
     return selectedAll;
   },
@@ -96,7 +96,7 @@ module.exports = CoreView.extend({
       if (!this.model.containsField(f)) {
         promises.push(this.model._addField(f));
       }
-    }.bind(this));
+    }, this);
 
     $.when.apply($, promises).then(function () {
       this.model.sortFields();

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/infowindow/infowindow-fields-view.js
@@ -136,19 +136,7 @@ module.exports = CoreView.extend({
   },
 
   _onSortableFinish: function () {
-    this._sortedFields.reset([]);
-
-    this.$('.js-fields > .js-field').each(function (index, item) {
-      var view = this._subviews[$(item).data('view-cid')];
-
-      this.model.setFieldProperty(view.fieldName, 'position', index);
-      view.position = index;
-
-      this._sortedFields.add({
-        name: view.fieldName,
-        position: index
-      });
-    }.bind(this));
+    this._storeSortedFields();
   },
 
   _getSortedColumnNames: function () {
@@ -167,11 +155,15 @@ module.exports = CoreView.extend({
   _storeSortedFields: function () {
     this._sortedFields.reset([]);
 
-    var names = this._getSortedColumnNames();
-    _(names).each(function (name, position) {
+    this.$('.js-fields > .js-field').each(function (index, item) {
+      var view = this._subviews[$(item).data('view-cid')];
+
+      this.model.setFieldProperty(view.fieldName, 'position', index);
+      view.position = index;
+
       this._sortedFields.add({
-        name: name,
-        position: position
+        name: view.fieldName,
+        position: index
       });
     }.bind(this));
   },

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/infowindows/infowindow-field-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/infowindows/infowindow-field-view.spec.js
@@ -50,5 +50,12 @@ describe('editor/layers/layer-content-view/infowindows/infowindow-field-view', f
   it('should not have any leaks', function () {
     expect(view).toHaveNoLeaks();
   });
-});
 
+  describe('._onSortableFinish', function () {
+    it('should call _storeSortedFields function', function () {
+      spyOn(this, '_storeSortedFields');
+      this._onSortableFinish();
+      expect(this._storeSortedFields).toHaveBeenCalled();
+    });
+  });
+});

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/infowindows/infowindow-field-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/infowindows/infowindow-field-view.spec.js
@@ -50,12 +50,4 @@ describe('editor/layers/layer-content-view/infowindows/infowindow-field-view', f
   it('should not have any leaks', function () {
     expect(view).toHaveNoLeaks();
   });
-
-  describe('._onSortableFinish', function () {
-    it('should call _storeSortedFields function', function () {
-      spyOn(this, '_storeSortedFields');
-      this._onSortableFinish();
-      expect(this._storeSortedFields).toHaveBeenCalled();
-    });
-  });
 });

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/infowindows/infowindow-fields-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/infowindows/infowindow-fields-view.spec.js
@@ -103,4 +103,12 @@ describe('editor/layers/layer-content-view/infowindows/infowindow-fields-view', 
   it('should not have any leaks', function () {
     expect(view).toHaveNoLeaks();
   });
+
+  describe('._onSortableFinish', function () {
+    it('should call _storeSortedFields function', function () {
+      spyOn(view, '_storeSortedFields');
+      view._onSortableFinish();
+      expect(view._storeSortedFields).toHaveBeenCalled();
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.54",
+  "version": "4.9.54-12694",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: #12694

- Respect the order in the list for the popup instead of the order we checked.

![popup-order](https://user-images.githubusercontent.com/2227572/29967835-e1235d76-8f18-11e7-94c5-f4486b4925ba.gif)

For acceptance:

1. Create a new map
2. Add a new layer. The Dataset should be more than one field
3. Go to PopUp tab
4. Click on Hover tab
5. In the field's list select some random fields
6. Check that the order in the popup matches with the list