### PR TITLE
12708 no current user in dataimport

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -275,7 +275,7 @@ class DataImport < Sequel::Model
 
     CartoDB::notify_exception(
       CartoDB::Importer2::GenericImportError.new('Import timed out or got stuck'),
-      user: current_user
+      user: user
     )
     true
   end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -575,10 +575,10 @@ class DataImport < Sequel::Model
   def pg_options
     Rails.configuration.database_configuration[Rails.env].symbolize_keys
       .merge(
-        username: current_user.database_username,
-        password: current_user.database_password,
-        database: current_user.database_name,
-        host:     current_user.database_host
+        username: user.database_username,
+        password: user.database_password,
+        database: user.database_name,
+        host:     user.database_host
       ) {|key, o, n| n.nil? || n.empty? ? o : n}
   end
 

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -840,7 +840,7 @@ class DataImport < Sequel::Model
 
     metadata = datasource_provider.get_resource_metadata(service_item_id)
 
-    if hit_platform_limit?(datasource_provider, metadata, current_user)
+    if hit_platform_limit?(datasource_provider, metadata, user)
       raise CartoDB::Importer2::FileTooBigError.new(metadata.inspect)
     end
 
@@ -850,19 +850,19 @@ class DataImport < Sequel::Model
 
       log.append "File will be downloaded from #{resource_url}"
 
-      http_options = { http_timeout: ::DataImport.http_timeout_for(current_user) }
-      CartoDB::Importer2::Downloader.new(current_user.id,
+      http_options = { http_timeout: ::DataImport.http_timeout_for(user) }
+      CartoDB::Importer2::Downloader.new(user.id,
                                          resource_url,
                                          http_options,
                                          importer_config: Cartodb.config[:importer])
     else
       log.append 'Downloading file data from datasource'
 
-      http_timeout = ::DataImport.http_timeout_for(current_user)
+      http_timeout = ::DataImport.http_timeout_for(user)
       options = {
         http_timeout: http_timeout,
         importer_config: Cartodb.config[:importer],
-        user_id: current_user.id
+        user_id: user.id
       }
 
       CartoDB::Importer2::DatasourceDownloader.new(datasource_provider, metadata, options, log)

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -969,11 +969,11 @@ class DataImport < Sequel::Model
     log.store
     payload = {
       file_url:       public_url,
-      distinct_id:    current_user.username,
-      username:       current_user.username,
-      account_type:   current_user.account_type,
-      database:       current_user.database_name,
-      email:          current_user.email,
+      distinct_id:    user.username,
+      username:       user.username,
+      account_type:   user.account_type,
+      database:       user.database_name,
+      email:          user.email,
       log:            log.to_s
     }
     payload.merge!(

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -319,12 +319,12 @@ class DataImport < Sequel::Model
     save
 
     begin
-      CartoDB::PlatformLimits::Importer::UserConcurrentImportsAmount.new({
-                                                                             user: current_user,
-                                                                             redis: {
-                                                                               db: $users_metadata
-                                                                             }
-                                                                         })
+      CartoDB::PlatformLimits::Importer::UserConcurrentImportsAmount.new(
+        user: user,
+        redis: {
+          db: $users_metadata
+        }
+      )
                                                                     .decrement!
     rescue => exception
       CartoDB::StdoutLogger.info('Error decreasing concurrent import limit',

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -346,13 +346,12 @@ class DataImport < Sequel::Model
     log.store
     self.save
     begin
-      CartoDB::PlatformLimits::Importer::UserConcurrentImportsAmount.new({
-                                                                           user: current_user,
-                                                                           redis: {
-                                                                             db: $users_metadata
-                                                                           }
-                                                                         })
-      .decrement!
+      CartoDB::PlatformLimits::Importer::UserConcurrentImportsAmount.new(
+        user: user,
+        redis: {
+          db: $users_metadata
+        }
+      ).decrement!
     rescue => exception
       CartoDB::StdoutLogger.info('Error decreasing concurrent import limit',
                            "#{exception.message} #{exception.backtrace.inspect}")

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -1052,10 +1052,10 @@ class DataImport < Sequel::Model
   end
 
   def track_results(results, import_id)
-    return unless user
+    user_id = user.id
+    return unless user_id
 
     if visualization_id
-      user_id = user.id
       Carto::Tracking::Events::CreatedMap.new(user_id,
                                               user_id: user_id,
                                               visualization_id: visualization_id,
@@ -1075,8 +1075,8 @@ class DataImport < Sequel::Model
       if map
         vis = Carto::Visualization.where(map_id: map.id).first
 
-        Carto::Tracking::Events::CreatedDataset.new(current_user_id,
-                                                    user_id: current_user_id,
+        Carto::Tracking::Events::CreatedDataset.new(user_id,
+                                                    user_id: user_id,
                                                     visualization_id: vis.id,
                                                     origin: origin).report
       end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -480,7 +480,7 @@ class DataImport < Sequel::Model
     log.append 'from_table()'
 
     number_of_tables = 1
-    quota_checker = CartoDB::QuotaChecker.new(current_user)
+    quota_checker = CartoDB::QuotaChecker.new(user)
     if quota_checker.will_be_over_table_quota?(number_of_tables)
       raise_over_table_quota_error
     end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -190,7 +190,7 @@ class DataImport < Sequel::Model
     rescue TokenExpiredOrInvalidError => ex
       success = false
       begin
-        current_user.oauths.remove(ex.service_name)
+        user.oauths.remove(ex.service_name)
       rescue => ex2
         log.append "Exception removing OAuth: #{ex2.message}"
         log.append ex2.backtrace

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -512,7 +512,7 @@ class DataImport < Sequel::Model
     taken_names = Carto::Db::UserSchema.new(user).table_names
     table_name = Carto::ValidTableNameProposer.new.propose_valid_table_name(name, taken_names: taken_names)
     user.db_service.in_database_direct_connection(statement_timeout: DIRECT_STATEMENT_TIMEOUT) do |user_direct_conn|
-        user_direct_conn.run(%{CREATE TABLE #{table_name} AS #{query}})
+      user_direct_conn.run(%{CREATE TABLE #{table_name} AS #{query}})
     end
     if user.over_disk_quota?
       log.append "Over storage quota. Dropping table #{table_name}"

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -217,8 +217,7 @@ class DataImport < Sequel::Model
 
     self
   rescue CartoDB::QuotaExceeded => quota_exception
-    current_user_id = current_user.id
-    Carto::Tracking::Events::ExceededQuota.new(current_user_id, user_id: current_user_id).report
+    Carto::Tracking::Events::ExceededQuota.new(user_id, user_id: user_id).report
 
     CartoDB::notify_warning_exception(quota_exception)
     handle_failure(quota_exception)

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -677,7 +677,7 @@ class DataImport < Sequel::Model
                                                 pg: database_options,
                                                 downloader: downloader,
                                                 log: log,
-                                                user: current_user,
+                                                user: user,
                                                 unpacker: CartoDB::Importer2::Unp.new(Cartodb.config[:importer]),
                                                 post_import_handler: post_import_handler,
                                                 importer_config: Cartodb.config[:importer],
@@ -685,12 +685,12 @@ class DataImport < Sequel::Model
                                               })
       runner.loader_options = ogr2ogr_options.merge content_guessing_options
       runner.set_importer_stats_host_info(Socket.gethostname)
-      registrar     = CartoDB::TableRegistrar.new(current_user, ::Table)
-      quota_checker = CartoDB::QuotaChecker.new(current_user)
-      database      = current_user.in_database
-      destination_schema = current_user.database_schema
-      public_user_roles = current_user.db_service.public_user_roles
-      overviews_creator = CartoDB::Importer2::Overviews.new(runner, current_user)
+      registrar     = CartoDB::TableRegistrar.new(user, ::Table)
+      quota_checker = CartoDB::QuotaChecker.new(user)
+      database      = user.in_database
+      destination_schema = user.database_schema
+      public_user_roles = user.db_service.public_user_roles
+      overviews_creator = CartoDB::Importer2::Overviews.new(runner, user)
       importer      = CartoDB::Connector::Importer.new(runner, registrar, quota_checker, database, id,
                                                        overviews_creator,
                                                        destination_schema, public_user_roles)

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -535,7 +535,6 @@ class DataImport < Sequel::Model
     )
   end
 
-
   def migrate_existing(imported_name=migrate_table, name=nil)
     new_name = imported_name || name
 

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -880,10 +880,6 @@ class DataImport < Sequel::Model
     end
   end
 
-  def current_user
-    @current_user ||= ::User[user_id]
-  end
-
   def notify(results)
     owner = ::User.where(:id => self.user_id).first
     imported_tables = results.select {|r| r.success }.length

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -527,11 +527,12 @@ class DataImport < Sequel::Model
   end
 
   def sanitize_columns(table_name)
-    Table.sanitize_columns(table_name, {
-        connection: current_user.in_database,
-        database_schema: current_user.database_schema,
-        reserved_words: CartoDB::Importer2::Column::RESERVED_WORDS
-      })
+    Table.sanitize_columns(
+      table_name,
+      connection: user.in_database,
+      database_schema: user.database_schema,
+      reserved_words: CartoDB::Importer2::Column::RESERVED_WORDS
+    )
   end
 
 

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -1052,12 +1052,12 @@ class DataImport < Sequel::Model
   end
 
   def track_results(results, import_id)
-    current_user_id = current_user.id
-    return unless current_user_id
+    return unless user
 
     if visualization_id
-      Carto::Tracking::Events::CreatedMap.new(current_user_id,
-                                              user_id: current_user_id,
+      user_id = user.id
+      Carto::Tracking::Events::CreatedMap.new(user_id,
+                                              user_id: user_id,
                                               visualization_id: visualization_id,
                                               origin: 'import').report
     end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -551,7 +551,7 @@ class DataImport < Sequel::Model
       table.save
       table.optimize
       table.map.recalculate_bounds!
-      if current_user.remaining_quota < 0
+      if user.remaining_quota < 0
         log.append 'Over storage quota, removing table'
         self.error_code = 8001
         self.state      = STATE_FAILURE

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -436,7 +436,7 @@ class DataImport < Sequel::Model
 
   def public_url
     return data_source unless uploaded_file
-    "https://#{current_user.username}.carto.com/#{uploaded_file[0]}"
+    "https://#{user.username}.carto.com/#{uploaded_file[0]}"
   end
 
   def valid_uuid?(text)

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -906,7 +906,7 @@ class DataImport < Sequel::Model
                   'import_time'            => import_time,
                   'file_stats'             => ::JSON.parse(self.stats),
                   'resque_ppid'            => self.resque_ppid,
-                  'user_timeout'           => ::DataImport.http_timeout_for(current_user),
+                  'user_timeout'           => ::DataImport.http_timeout_for(user),
                   'error_source'           => get_error_source,
                   'id'                     => self.id,
                   'total_size'             => total_size,

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -704,7 +704,7 @@ class DataImport < Sequel::Model
   # * importer: the new importer (nil if download errors detected)
   # * connector: the connector that the importer uses
   def new_importer_with_connector
-    CartoDB::Importer2::ConnectorRunner.check_availability!(current_user)
+    CartoDB::Importer2::ConnectorRunner.check_availability!(user)
 
     database_options = pg_options
 
@@ -712,18 +712,18 @@ class DataImport < Sequel::Model
 
     connector = CartoDB::Importer2::ConnectorRunner.new(
       service_item_id,
-      user: current_user,
+      user: user,
       pg: database_options,
       log: log,
       collision_strategy: collision_strategy
     )
 
-    registrar     = CartoDB::TableRegistrar.new(current_user, ::Table)
-    quota_checker = CartoDB::QuotaChecker.new(current_user)
-    database      = current_user.in_database
-    destination_schema = current_user.database_schema
-    public_user_roles = current_user.db_service.public_user_roles
-    overviews_creator = CartoDB::Importer2::Overviews.new(connector, current_user)
+    registrar     = CartoDB::TableRegistrar.new(user, ::Table)
+    quota_checker = CartoDB::QuotaChecker.new(user)
+    database      = user.in_database
+    destination_schema = user.database_schema
+    public_user_roles = user.db_service.public_user_roles
+    overviews_creator = CartoDB::Importer2::Overviews.new(connector, user)
     importer = CartoDB::Connector::Importer.new(
       connector, registrar, quota_checker, database, id,
       overviews_creator,

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -995,14 +995,15 @@ class DataImport < Sequel::Model
   # @throws DataSourceError
   def get_datasource(datasource_name, service_item_id)
     begin
-      oauth = current_user.oauths.select(datasource_name)
+      oauth = user.oauths.select(datasource_name)
       # Tables metadata DB also store resque data
       datasource = DatasourcesFactory.get_datasource(
-        datasource_name, current_user, {
-                                          http_timeout: ::DataImport.http_timeout_for(current_user),
-                                          redis_storage: $tables_metadata,
-                                          user_defined_limits: ::JSON.parse(user_defined_limits).symbolize_keys
-                                       })
+        datasource_name,
+        user,
+        http_timeout: ::DataImport.http_timeout_for(user),
+        redis_storage: $tables_metadata,
+        user_defined_limits: ::JSON.parse(user_defined_limits).symbolize_keys
+      )
       datasource.token = oauth.token unless oauth.nil?
     rescue => ex
       log.append "Exception: #{ex.message}"

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -1051,7 +1051,6 @@ class DataImport < Sequel::Model
   end
 
   def track_results(results, import_id)
-    user_id = user.id
     return unless user_id
 
     if visualization_id


### PR DESCRIPTION
Fixes https://github.com/CartoDB/cartodb/issues/12708

## Context

This is a small PR with the sole purpose of removing the `current_user` method usage from the `DataImport` model. It's a non-critical refactor, but it's come up as part of bigger work on `.carto.geopkg`. The idea is to remove noise from important PRs and give way to trivial changes in separate ones.

## Acceptance

Non needed, this a pure refactor. If tests pass, it should be ok.