### PR TITLE
12647 legend assets cors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,7 @@ Development
 * Fix broken join from second column on IE11 (#support/875)
 * Fix ghost node problem (#11397)
 * Break down deep-insights-integrations class (#11581)
+* Fix CORS for local images in legends (#12647)
 * Fix torque categories layer rendering (#cartodb.js/1698)
 * Don't provide quantification option when layer is animated (#10947)
 * Remove tracking of liked map events (#12404)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -129,8 +129,7 @@ class Asset < Sequel::Model
     mode = chmod_mode
     FileUtils.chmod(mode, local_filename(filename)) if mode
 
-    p = File.join('/', ASSET_SUBFOLDER, target_asset_path, filename)
-    "#{asset_protocol}//#{CartoDB.account_host}#{p}"
+    File.join('/', ASSET_SUBFOLDER, target_asset_path, filename)
   end
 
   def use_s3?

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -60,7 +60,7 @@ describe Asset do
   end
 
   def local_path(asset)
-    local_url = asset.public_url.gsub(/http:\/\/#{CartoDB.account_host}\/uploads/,'')
+    local_url = asset.public_url.gsub(/\/uploads/,'')
     Carto::Conf.new.public_uploaded_assets_path + local_url
   end
 

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -60,7 +60,7 @@ describe Asset do
   end
 
   def local_path(asset)
-    local_url = asset.public_url.gsub(/\/uploads/,'')
+    local_url = asset.public_url.gsub(/\/uploads/, '')
     Carto::Conf.new.public_uploaded_assets_path + local_url
   end
 
@@ -82,7 +82,6 @@ describe Asset do
         asset = Asset.create(
           user_id: @user.id,
           asset_file: Rack::Test::UploadedFile.new(file_path, 'image/png'))
-        local_url = asset.public_url.gsub(/http:\/\/#{CartoDB.account_host}\/uploads/, '')
         File.exists?(local_path(asset)).should be_true
         asset.public_url.should =~ /.*test\/#{@user.username}\/assets\/\d+cartofante_blue.png.*/
       end


### PR DESCRIPTION
Fixes #12647 

This change is a bit brave. This works because the `index` controller for assets calls `absolute_public_url` in the presenter, which will prepend the correct domain for the user if it is missing.

I tried a simpler change, just by adjusting CORS headers, but it implied some ugly monkey-patches of Rails asset-serving code, or a reimplementation of those. This is simpler, probably more correct, and follows the same approach as the more modern `Carto::Asset` model. 

We can consider going the extra mile and pushing the refactor of this model to remove the old version, but I don't think that fits in RT.

**Acceptance**
It needs good acceptance in the local environment (dev) and onpremise. Staging is not needed (S3 is not affected). Regression tests must cover editor, builder and dashboard: in general, everywhere where an asset is used. Won't be listing them here to avoid a partial list.