### PR TITLE
Update charlock_holmes gem to version 0.7.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ end
 gem 'roo',                     '1.13.2'
 gem 'state_machine',           '1.1.2'
 gem 'typhoeus',                '0.7.2'
-gem 'charlock_holmes',         '0.7.2'
+gem 'charlock_holmes',         '0.7.5'
 gem 'dbf',                     '2.0.6'
 gem 'faraday',                 '0.9.0'
 gem 'retriable',               '1.4.1'  # google-api-client needs this

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 0.1.4)
-    charlock_holmes (0.7.2)
+    charlock_holmes (0.7.5)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -371,7 +371,7 @@ DEPENDENCIES
   bartt-ssl_requirement (~> 1.4.0)
   byebug
   capybara (= 1.1.2)
-  charlock_holmes (= 0.7.2)
+  charlock_holmes (= 0.7.5)
   ci_reporter (= 1.8.4)
   compass (= 1.0.3)
   db-query-matchers (= 0.4.0)


### PR DESCRIPTION
This PR updates charlock_holmes gem from version 0.7.2 to version 0.7.5.

You can see the changelog here: https://github.com/brianmario/charlock_holmes/compare/0.7.2...0.7.5

Most of the changes between versions are for having better support for native gem compilation, like support for latest ICU4C version and latest macOS version.

