### PR TITLE
updates modal to reflect analysis outputs

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/moran.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/onboardings/analysis/analyses/moran.tpl
@@ -16,8 +16,8 @@
     <p class="CDB-Text Onboarding-description"><%- _t('analyses-onboarding.moran.moran') %></p>
   </li>
   <li class="Onboarding-listItem">
-    <div class="Onboarding-listItemValue">rowid</div>
-    <p class="CDB-Text Onboarding-description"><%- _t('analyses-onboarding.moran.rowid') %></p>
+    <div class="Onboarding-listItemValue">vals</div>
+    <p class="CDB-Text Onboarding-description"><%- _t('analyses-onboarding.moran.vals') %></p>
   </li>
 </ul>
 

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -181,7 +181,7 @@
       "quads": "Classification of the geometry from the analysis",
       "significance": "The statistical significance of the geometry's classification of one of four quadrant types.",
       "moran": "The local statistic calculated from the Moran's I analysis for each geometry/value in the dataset.",
-      "rowid": "The original row id of the geometry (cartodb_id)."
+      "vals": "Value used in analysis. If a denominator is entered, this is the 'standardized' rate (centered on mean, normalized by standard deviation)."
     },
     "kmeans": {
       "title": "Calculating point clusters",


### PR DESCRIPTION
The outlier/cluster analysis outputs `quads`, `significance`, `moran`, and `vals`. This PR updates the modal to reflect the current state of the analysis: https://github.com/CartoDB/camshaft/blob/master/lib/node/nodes/sql/moran-denominator.sql

Ref https://github.com/CartoDB/support/issues/965

cc @ramiroaznar 