### PR TITLE
Add protocol replacer in npm script

### DIFF
--- a/lib/build/fix-shrinkwrap.js
+++ b/lib/build/fix-shrinkwrap.js
@@ -1,0 +1,32 @@
+/** Every now and then npm registry returns non-secure URLs.
+ * This script rewrites http to https to avoid unneeded differences
+ * in npm-shrinkwrap.json
+*/
+
+const fs = require('fs');
+const path = require('path');
+const colors = require('colors');
+
+const file = path.resolve(__dirname, '../../npm-shrinkwrap.json');
+const buildPattern = (protocol) => `"resolved": "${protocol}://registry.npmjs`;
+const from = new RegExp(buildPattern('http'), 'g');
+const to = buildPattern('https');
+let replacements = 0;
+
+console.log('> Fixing npm-shrinkwrap.json');
+if (!fs.existsSync(file)) {
+  console.error(colors.red(`File ${file} does not exist!`));
+  return 1;
+}
+
+const content = fs.readFileSync(file, 'utf8');
+const matches = content.match(from);
+if (matches !== null) {
+  replacements = matches.length;
+  const modifiedContent = content.replace(from, to);
+  fs.writeFileSync(file, modifiedContent, { encoding: 'utf8' });
+} 
+
+replacements
+  ? console.log(colors.yellow(`  Made ${replacements} replacements.`))
+  : console.log(colors.yellow('  Nothing to replace!'));

--- a/package.json
+++ b/package.json
@@ -183,12 +183,13 @@
   },
   "scripts": {
     "test": "echo \"Run 'grunt test' to run specs through command line.\"",
-    "update-internal-deps": "rm -rf node_modules && npm install --production --no-shrinkwrap && npm dedupe && npm prune && npm shrinkwrap && npm install",
+    "update-internal-deps": "rm -rf node_modules && npm install --production --no-shrinkwrap && npm dedupe && npm prune && npm shrinkwrap && npm run fix-shrinkwrap-protocol && npm install",
     "branch-files": "node lib/build/branchFiles/branchFiles.js",
     "affected_specs": "node lib/build/branchFiles/branchFiles.js | xargs node lib/build/affectedFiles/affectedFiles.js",
     "build": "NODE_ENV=production webpack --config webpack.prod.config.js",
     "build:stats": "webpack --env.stats --progress --config webpack.dev.config.js",
     "start": "grunt watch:css & webpack --progress --watch --config webpack.dev.config.js",
-    "dev": "webpack --progress --config webpack.dev.config.js"
+    "dev": "webpack --progress --config webpack.dev.config.js",
+    "fix-shrinkwrap-protocol": "sed -i '' -e 's/\"resolved\": \"http:\\/\\/registry.npmjs.org/\"resolved\": \"https:\\/\\/registry.npmjs.org/g' npm-shrinkwrap.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -190,6 +190,6 @@
     "build:stats": "webpack --env.stats --progress --config webpack.dev.config.js",
     "start": "grunt watch:css & webpack --progress --watch --config webpack.dev.config.js",
     "dev": "webpack --progress --config webpack.dev.config.js",
-    "fix-shrinkwrap-protocol": "sed -i '' -e 's/\"resolved\": \"http:\\/\\/registry.npmjs.org/\"resolved\": \"https:\\/\\/registry.npmjs.org/g' npm-shrinkwrap.json"
+    "fix-shrinkwrap-protocol": "node ./lib/build/fix-shrinkwrap.js"
   }
 }


### PR DESCRIPTION
This PR forces shrinkwrap to use `https` protocol for packages coming from the npm registry. This will diminish unneeded `npm-shrinkwrap.json` diffs.

It does it through a `sed` command to `update-internal-deps` script that replaces `http://registry.npmjs.org` to `https://registry.npmjs.org` in `resolved:` properties. GitHub URLs keep untouched.