### PR TITLE
Remove colors dependency in fix-shrinkwrap-protocol

### DIFF
--- a/lib/build/fix-shrinkwrap.js
+++ b/lib/build/fix-shrinkwrap.js
@@ -5,7 +5,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const colors = require('colors');
 
 const file = path.resolve(__dirname, '../../npm-shrinkwrap.json');
 const buildPattern = (protocol) => `"resolved": "${protocol}://registry.npmjs`;
@@ -15,7 +14,7 @@ let replacements = 0;
 
 console.log('> Fixing npm-shrinkwrap.json');
 if (!fs.existsSync(file)) {
-  console.error(colors.red(`File ${file} does not exist!`));
+  console.error(`File ${file} does not exist!`);
   return 1;
 }
 
@@ -28,5 +27,5 @@ if (matches !== null) {
 } 
 
 replacements
-  ? console.log(colors.yellow(`  Made ${replacements} replacements.`))
-  : console.log(colors.yellow('  Nothing to replace!'));
+  ? console.log(`  Made ${replacements} replacements.`)
+  : console.log('  Nothing to replace!');


### PR DESCRIPTION
Tiny change to avoid needing dependencies before npm install process in `update-internal-deps`