### PR TITLE
Fix HTML escape in all notifications

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/notifier/notifier-model.js
+++ b/lib/assets/core/javascripts/cartodb3/components/notifier/notifier-model.js
@@ -1,5 +1,4 @@
 var Backbone = require('backbone');
-var utils = require('../../helpers/utils');
 
 module.exports = Backbone.Model.extend({
   defaults: {
@@ -46,7 +45,7 @@ module.exports = Backbone.Model.extend({
   },
 
   getInfo: function () {
-    return utils.escapeHTML(this.get('info'));
+    return this.get('info');
   },
 
   getAction: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/operations/rename-layer.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/operations/rename-layer.js
@@ -1,5 +1,6 @@
 var Notifier = require('../../../components/notifier/notifier');
 var errorParser = require('../../../helpers/error-parser');
+var utils = require('../../../helpers/utils');
 
 module.exports = function (opts) {
   if (!opts.userActions) throw new Error('userActions is required');
@@ -26,7 +27,7 @@ module.exports = function (opts) {
       successCallback && successCallback(newName);
       notification.set({
         status: 'success',
-        info: _t('editor.layers.rename.success', {name: newName}),
+        info: _t('editor.layers.rename.success', {name: utils.escapeHTML(newName)}),
         closable: true
       });
     })
@@ -34,7 +35,7 @@ module.exports = function (opts) {
       errorCallback && errorCallback(oldName);
       notification.set({
         status: 'error',
-        info: _t('editor.layers.rename.error', {name: oldName, error: errorParser(e)}),
+        info: _t('editor.layers.rename.error', {name: utils.escapeHTML(oldName), error: errorParser(e)}),
         closable: true
       });
     });

--- a/lib/assets/core/javascripts/cartodb3/editor/map-operations/rename-map.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/map-operations/rename-map.js
@@ -1,5 +1,7 @@
 var Notifier = require('../../components/notifier/notifier');
 var errorParser = require('../../helpers/error-parser');
+var utils = require('../../helpers/utils');
+
 var TITLE_SUFIX = require('../../components/modals/visualization-title-suffix-metadata');
 
 module.exports = function (opts) {
@@ -27,7 +29,7 @@ module.exports = function (opts) {
       document.title = newName + TITLE_SUFIX;
       notification.set({
         status: 'success',
-        info: _t('editor.maps.rename.success', {name: newName}),
+        info: _t('editor.maps.rename.success', {name: utils.escapeHTML(newName)}),
         closable: true
       });
     },
@@ -35,7 +37,7 @@ module.exports = function (opts) {
       errorCallback && errorCallback(oldName);
       notification.set({
         status: 'error',
-        info: _t('editor.maps.rename.error', {name: oldName, error: errorParser(e)}),
+        info: _t('editor.maps.rename.error', {name: utils.escapeHTML(oldName), error: errorParser(e)}),
         closable: true
       });
     }

--- a/lib/assets/core/test/spec/cartodb3/components/notifier/notifier-model.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/notifier/notifier-model.spec.js
@@ -6,9 +6,9 @@ describe('components/notifier/notifier-model', function () {
   describe('.getInfo', function () {
     model.updateInfo('< & Hello >');
 
-    it('should escape HTML characters in getInfo', function () {
-      var escapedInfo = model.getInfo();
-      expect(escapedInfo).toBe('&lt; &amp; Hello &gt;');
+    it('should return current info', function () {
+      var info = model.getInfo();
+      expect(info).toBe('< & Hello >');
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.64",
+  "version": "4.9.64-12756",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: #12756

Allow HTML in notifications. Only escape HTML in rename-map and rename-layer to prevent XSS

![fix-notifier-html](https://user-images.githubusercontent.com/2227572/30176034-3b32fc26-9401-11e7-999d-b25e1a5e899d.gif)

For acceptance:
1. Load a dataset in a map
2. Check the progress in the notification