### PR TITLE
12782 ogr2ogr paths

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -675,12 +675,14 @@ class DataImport < Sequel::Model
       database_options = pg_options
       self.host = database_options[:host]
 
+      unp = CartoDB::Importer2::Unp.new(Cartodb.config[:importer], Cartodb.config[:ogr2ogr])
+
       runner = CartoDB::Importer2::Runner.new({
                                                 pg: database_options,
                                                 downloader: downloader,
                                                 log: log,
                                                 user: current_user,
-                                                unpacker: CartoDB::Importer2::Unp.new(Cartodb.config[:importer]),
+                                                unpacker: unp,
                                                 post_import_handler: post_import_handler,
                                                 importer_config: Cartodb.config[:importer],
                                                 collision_strategy: collision_strategy

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -266,7 +266,7 @@ module CartoDB
           downloader: downloader,
           log: log,
           user: user,
-          unpacker: CartoDB::Importer2::Unp.new(Cartodb.config[:importer]),
+          unpacker: CartoDB::Importer2::Unp.new(Cartodb.config[:importer], Cartodb.config[:ogr2ogr]),
           post_import_handler: post_import_handler,
           importer_config: Cartodb.config[:importer]
         )

--- a/config/initializers/01_app_config.rb
+++ b/config/initializers/01_app_config.rb
@@ -78,11 +78,11 @@ module Cartodb
   # Note that since inner keys are strings (not symbols), you must
   # follow the same conventtion and use:
   #
-  #     Cartodb.with_config(ogr2ogr: { 'binary' => 'ogr2ogr2' })
+  #     Cartodb.with_config(ogr2ogr: { 'binary' => 'ogr2ogr' })
   #
   # and not:
   #
-  #     Cartodb.with_config(ogr2ogr: { 'binary': 'ogr2ogr2' })
+  #     Cartodb.with_config(ogr2ogr: { 'binary': 'ogr2ogr' })
   #
   def self.with_config(options)
     original_config = config

--- a/services/importer/lib/importer/gpx_splitter.rb
+++ b/services/importer/lib/importer/gpx_splitter.rb
@@ -20,7 +20,11 @@ module CartoDB
       def initialize(source_file, temporary_directory, ogr2ogr_config = nil)
         @source_file = source_file
         @temporary_directory = temporary_directory
-        @ogr2ogr_binary = @ogr2ogr_config.nil? ? DEFAULT_OGR2OGR_BINARY : ogr2ogr_config['binary']
+        @ogr2ogr_binary = if ogr2ogr_config && ogr2ogr_config['binary'].present?
+                            `#{ogr2ogr_config['binary']}`.strip
+                          else
+                            DEFAULT_OGR2OGR_BINARY
+                          end
       end
 
       def run

--- a/services/importer/lib/importer/gpx_splitter.rb
+++ b/services/importer/lib/importer/gpx_splitter.rb
@@ -11,7 +11,7 @@ module CartoDB
       GPX_LAYERS = ['waypoints', 'routes', 'tracks', 'route_points', 'track_points']
       ITEM_COUNT_REGEX = 'Feature Count:\s'
       OGRINFO_BINARY = 'ogrinfo'
-      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr2'
+      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr'
 
       def self.support?(source_file)
         source_file.extension == '.gpx'

--- a/services/importer/lib/importer/gpx_splitter.rb
+++ b/services/importer/lib/importer/gpx_splitter.rb
@@ -11,7 +11,7 @@ module CartoDB
       GPX_LAYERS = ['waypoints', 'routes', 'tracks', 'route_points', 'track_points']
       ITEM_COUNT_REGEX = 'Feature Count:\s'
       OGRINFO_BINARY = 'ogrinfo'
-      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr'
+      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr'.freeze
 
       def self.support?(source_file)
         source_file.extension == '.gpx'

--- a/services/importer/lib/importer/kml_splitter.rb
+++ b/services/importer/lib/importer/kml_splitter.rb
@@ -9,7 +9,7 @@ module CartoDB
     class KmlSplitter
       MAX_LAYERS = 50
       OGRINFO_BINARY = 'ogrinfo'
-      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr'
+      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr'.freeze
 
       def self.support?(source_file)
         source_file.extension == '.kml'

--- a/services/importer/lib/importer/kml_splitter.rb
+++ b/services/importer/lib/importer/kml_splitter.rb
@@ -18,7 +18,11 @@ module CartoDB
       def initialize(source_file, temporary_directory, ogr2ogr_config = nil)
         @source_file          = source_file
         @temporary_directory  = temporary_directory
-        @ogr2ogr_binary = @ogr2ogr_config.nil? ? DEFAULT_OGR2OGR_BINARY : ogr2ogr_config['binary']
+        @ogr2ogr_binary = if ogr2ogr_config && ogr2ogr_config['binary'].present?
+                            `#{ogr2ogr_config['binary']}`.strip
+                          else
+                            DEFAULT_OGR2OGR_BINARY
+                          end
       end
 
       def run

--- a/services/importer/lib/importer/kml_splitter.rb
+++ b/services/importer/lib/importer/kml_splitter.rb
@@ -9,7 +9,7 @@ module CartoDB
     class KmlSplitter
       MAX_LAYERS = 50
       OGRINFO_BINARY = 'ogrinfo'
-      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr2'
+      DEFAULT_OGR2OGR_BINARY = 'ogr2ogr'
 
       def self.support?(source_file)
         source_file.extension == '.kml'

--- a/services/importer/lib/importer/ogr2ogr.rb
+++ b/services/importer/lib/importer/ogr2ogr.rb
@@ -14,7 +14,7 @@ module CartoDB
       NEW_LAYER_TYPE_OPTION = ['-nlt', 'PROMOTE_TO_MULTI'].freeze
       APPEND_MODE_OPTION    = '-append'.freeze
 
-      DEFAULT_BINARY = 'which ogr2ogr2.1'
+      DEFAULT_BINARY = 'which ogr2ogr'
 
       LATITUDE_POSSIBLE_NAMES   = %w{ latitude lat latitudedecimal
         latitud lati decimallatitude decimallat point_latitude }
@@ -38,7 +38,7 @@ module CartoDB
       def set_default_properties
         self.append_mode = false
         self.overwrite = false
-        self.ogr2ogr2_binary = options.fetch(:ogr2ogr_binary, DEFAULT_BINARY)
+        self.ogr2ogr_binary = options.fetch(:ogr2ogr_binary, DEFAULT_BINARY)
         self.csv_guessing = options.fetch(:ogr2ogr_csv_guessing, false)
         self.quoted_fields_guessing = options.fetch(:quoted_fields_guessing, true)
         self.encoding = options.fetch(:encoding, ENCODING)
@@ -71,7 +71,7 @@ module CartoDB
       end
 
       def executable_path
-        `#{ogr2ogr2_binary}`.strip
+        `#{ogr2ogr_binary}`.strip
       end
 
       def command
@@ -142,7 +142,7 @@ module CartoDB
       private
 
       attr_writer   :exit_code, :command_output
-      attr_accessor :pg_options, :options, :table_name, :layer, :ogr2ogr2_binary, :quoted_fields_guessing
+      attr_accessor :pg_options, :options, :table_name, :layer, :ogr2ogr_binary, :quoted_fields_guessing
 
       def is_csv?
         !(filepath =~ /\.csv$/i).nil?

--- a/services/importer/lib/importer/ogr2ogr.rb
+++ b/services/importer/lib/importer/ogr2ogr.rb
@@ -14,7 +14,7 @@ module CartoDB
       NEW_LAYER_TYPE_OPTION = ['-nlt', 'PROMOTE_TO_MULTI'].freeze
       APPEND_MODE_OPTION    = '-append'.freeze
 
-      DEFAULT_BINARY = 'which ogr2ogr'
+      DEFAULT_BINARY = 'which ogr2ogr'.freeze
 
       LATITUDE_POSSIBLE_NAMES   = %w{ latitude lat latitudedecimal
         latitud lati decimallatitude decimallat point_latitude }

--- a/services/importer/spec/acceptance/csv_spec.rb
+++ b/services/importer/spec/acceptance/csv_spec.rb
@@ -384,7 +384,7 @@ describe 'csv regression tests' do
     }].first
   end
 
-  def runner_with_fixture(file, job=nil)
+  def runner_with_fixture(file, job = nil)
     filepath = path_to(file)
     downloader = Downloader.new(@user.id, filepath)
     runner = Runner.new({

--- a/services/importer/spec/acceptance/csv_spec.rb
+++ b/services/importer/spec/acceptance/csv_spec.rb
@@ -36,7 +36,6 @@ describe 'csv regression tests' do
                                log: CartoDB::Importer2::Doubles::Log.new(@user),
                                user: @user
                              })
-    runner.loader_options = ogr2ogr2_options
     runner.run
 
     result = runner.results.first
@@ -385,15 +384,7 @@ describe 'csv regression tests' do
     }].first
   end
 
-  # Using the version 2.x of ogr2ogr to check features like auto-guessing for example
-  def ogr2ogr2_options
-    {
-      ogr2ogr_binary:         'which ogr2ogr2',
-      ogr2ogr_csv_guessing:   'yes'
-    }
-  end
-
-  def runner_with_fixture(file, job=nil, add_ogr2ogr2_options=false)
+  def runner_with_fixture(file, job=nil)
     filepath = path_to(file)
     downloader = Downloader.new(@user.id, filepath)
     runner = Runner.new({
@@ -403,9 +394,6 @@ describe 'csv regression tests' do
                  user: @user,
                  job: job
                })
-    if add_ogr2ogr2_options
-      runner.loader_options = ogr2ogr2_options
-    end
     runner
   end
 

--- a/services/importer/spec/acceptance/csv_spec.rb
+++ b/services/importer/spec/acceptance/csv_spec.rb
@@ -36,6 +36,7 @@ describe 'csv regression tests' do
                                log: CartoDB::Importer2::Doubles::Log.new(@user),
                                user: @user
                              })
+    runner.loader_options = ogr2ogr2_options
     runner.run
 
     result = runner.results.first
@@ -384,7 +385,13 @@ describe 'csv regression tests' do
     }].first
   end
 
-  def runner_with_fixture(file, job = nil)
+  def ogr2ogr2_options
+    {
+      ogr2ogr_csv_guessing:   'yes'
+    }
+  end
+
+  def runner_with_fixture(file, job = nil, add_ogr2ogr2_options = false)
     filepath = path_to(file)
     downloader = Downloader.new(@user.id, filepath)
     runner = Runner.new({
@@ -394,6 +401,9 @@ describe 'csv regression tests' do
                  user: @user,
                  job: job
                })
+    if add_ogr2ogr2_options
+      runner.loader_options = ogr2ogr2_options
+    end
     runner
   end
 

--- a/services/importer/spec/unit/gpx_splitter_spec.rb
+++ b/services/importer/spec/unit/gpx_splitter_spec.rb
@@ -11,7 +11,7 @@ describe CartoDB::Importer2::GpxSplitter do
     @one_layer_filepath       = path_to('one_layer.gpx')
     @multiple_layer_filepath  = path_to('multiple_layer.gpx')
     @temporary_directory      = '/var/tmp'
-    @ogr2ogr_config = { 'binary' => 'which ogr2ogr2' }
+    @ogr2ogr_config = {}
   end
 
   describe '#run' do

--- a/services/importer/spec/unit/kml_splitter_spec.rb
+++ b/services/importer/spec/unit/kml_splitter_spec.rb
@@ -11,7 +11,7 @@ describe CartoDB::Importer2::KmlSplitter do
     @one_layer_filepath       = path_to('one_layer.kml')
     @multiple_layer_filepath  = path_to('multiple_layer.kml')
     @temporary_directory      = '/var/tmp'
-    @ogr2ogr_config = { 'binary' => 'which ogr2ogr2' }
+    @ogr2ogr_config = {}
   end
 
   describe '#run' do

--- a/services/importer/spec/unit/ogr2ogr_spec.rb
+++ b/services/importer/spec/unit/ogr2ogr_spec.rb
@@ -73,7 +73,7 @@ describe Ogr2ogr do
 
   describe '#executable_path' do
     it 'returns the path to the ogr2ogr binary' do
-      (@wrapper.executable_path =~ /ogr2ogr2/).should_not be nil
+      (@wrapper.executable_path =~ /ogr2ogr/).should_not be nil
     end
   end
 


### PR DESCRIPTION
Fixes #12782 

- Change default paths to use `ogr2ogr` (instead of version 2 or 2.1)
- Propagate ogr2ogr configuration to splitters (via unpacker)
- Remove test overriding ogr2ogr binary