### PR TITLE
Flaky tests

### DIFF
--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -339,7 +339,9 @@ class Carto::User < ActiveRecord::Base
   end
 
   #TODO: Remove unused param `use_total`
-  def remaining_quota(use_total = false, db_size = service.db_size_in_bytes)
+  def remaining_quota(_use_total = false, db_size = service.db_size_in_bytes)
+    return nil unless db_size
+
     self.quota_in_bytes - db_size
   end
 

--- a/app/models/carto/user_service.rb
+++ b/app/models/carto/user_service.rb
@@ -15,6 +15,8 @@ module Carto
 
     # Only returns owned tables (not shared ones)
     def table_count
+      return 0 unless @user.id
+
       Carto::VisualizationQueryBuilder.new
                                       .with_user_id(@user.id)
                                       .with_type(Carto::Visualization::TYPE_CANONICAL)
@@ -23,6 +25,8 @@ module Carto
     end
 
     def owned_visualization_count
+      return 0 unless @user.id
+
       Carto::VisualizationQueryBuilder.new
                                       .with_user_id(@user.id)
                                       .with_type(Carto::Visualization::TYPE_DERIVED)
@@ -31,6 +35,8 @@ module Carto
     end
 
     def visualization_count
+      return 0 unless @user.id
+
       Carto::VisualizationQueryBuilder.new
                                       .with_owned_by_or_shared_with_user_id(@user.id)
                                       .build
@@ -38,12 +44,16 @@ module Carto
     end
 
     def public_visualization_count
+      return 0 unless @user.id
+
       Carto::VisualizationQueryBuilder.user_public_visualizations(@user)
                                       .build
                                       .count
     end
 
     def all_visualization_count
+      return 0 unless @user.id
+
       Carto::VisualizationQueryBuilder.user_all_visualizations(@user)
         .build
         .count

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -137,7 +137,7 @@ class Table
   end
 
   def geometry_types_key
-    @geometry_types_key ||= "#{redis_key}:geometry_types"
+    "#{redis_key}:geometry_types"
   end
 
   def geometry_types
@@ -529,7 +529,7 @@ class Table
   end
 
   def redis_key
-    key ||= "rails:table:#{id}"
+    "rails:table:#{id}"
   end
 
   # TODO: change name and refactor for ActiveRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1220,8 +1220,10 @@ class User < Sequel::Model
     self.over_disk_quota? || self.over_table_quota?
   end
 
-  def remaining_quota(use_total = false, db_size_in_bytes = self.db_size_in_bytes)
-    self.quota_in_bytes - db_size_in_bytes
+  def remaining_quota(_use_total = false, db_size_in_bytes = self.db_size_in_bytes)
+    return nil unless db_size_in_bytes
+
+    quota_in_bytes - db_size_in_bytes
   end
 
   def disk_quota_overspend

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1306,6 +1306,8 @@ class User < Sequel::Model
 
   # Get a count of visualizations with some optional filters
   def visualization_count(filters = {})
+    return 0 unless id
+
     vqb = Carto::VisualizationQueryBuilder.new
     vqb.with_type(filters[:type]) if filters[:type]
     vqb.with_privacy(filters[:privacy]) if filters[:privacy]

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1905,7 +1905,7 @@ describe Table do
       it 'tests the_geom conversions and expected results' do
         def check_query_geometry(query, schema)
           tablename = unique_name('table')
-          table = new_table(:name => nil, :user_id => @user.id)
+          table = new_table(name: nil, user_id: @user.id)
           table.migrate_existing_table = tablename
           @user.db_service.run_pg_query("CREATE TABLE #{tablename} AS #{query}")
           table.save

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1903,6 +1903,16 @@ describe Table do
 
     describe '#the_geom_conversions' do
       it 'tests the_geom conversions and expected results' do
+        def check_query_geometry(query, schema)
+          tablename = unique_name('table')
+          table = new_table(:name => nil, :user_id => @user.id)
+          table.migrate_existing_table = tablename
+          @user.db_service.run_pg_query("CREATE TABLE #{tablename} AS #{query}")
+          table.save
+          table.the_geom_type_value = nil # Reset geometry cache
+          check_schema(table, schema)
+        end
+
         # Empty table/default schema (no conversion)
         table = new_table(:name => 'one', :user_id => @user.id)
         table.save
@@ -1913,73 +1923,37 @@ describe Table do
         ])
 
         # latlong projection
-        table = new_table(:name => nil, :user_id => @user.id)
-        table.migrate_existing_table = 'two'
-        @user.db_service.run_pg_query('
-          CREATE TABLE two AS SELECT CDB_LatLng(0,0) AS the_geom
-        ')
-        table.save
-        check_schema(table, [
+        check_query_geometry('SELECT CDB_LatLng(0,0) AS the_geom', [
             [:cartodb_id, 'bigint'],
             [:the_geom, 'geometry', 'geometry', 'point']
         ])
 
         # single multipoint, without srid
-        table = new_table(:name => nil, :user_id => @user.id)
-        table.migrate_existing_table = 'three'
-        @user.db_service.run_pg_query('
-          CREATE TABLE three AS SELECT ST_Collect(ST_MakePoint(0,0),ST_MakePoint(1,1)) AS the_geom;
-        ')
-        table.save
-        check_schema(table, [
+        check_query_geometry('SELECT ST_Collect(ST_MakePoint(0,0),ST_MakePoint(1,1)) AS the_geom;', [
             [:cartodb_id, 'bigint'],
             [:the_geom, 'geometry', 'geometry', 'point'],
         ])
 
         # same as above (single multipoint), but with a SRID=4326 (latlong)
-        table = new_table(:name => nil, :user_id => @user.id)
-        table.migrate_existing_table = 'four'
-        @user.db_service.run_pg_query('
-          CREATE TABLE four AS SELECT ST_SetSRID(ST_Collect(ST_MakePoint(0,0),ST_MakePoint(1,1)),4326) AS the_geom
-        ')
-        table.save
-        check_schema(table, [
+        check_query_geometry('SELECT ST_SetSRID(ST_Collect(ST_MakePoint(0,0),ST_MakePoint(1,1)),4326) AS the_geom', [
             [:cartodb_id, 'bigint'],
             [:the_geom, 'geometry', 'geometry', 'point']
         ])
 
         # single polygon
-        table = new_table(:name => nil, :user_id => @user.id)
-        table.migrate_existing_table = 'five'
-        @user.db_service.run_pg_query('
-          CREATE TABLE five AS SELECT ST_SetSRID(ST_Buffer(ST_MakePoint(0,0),10), 4326) AS the_geom
-        ')
-        table.save
-        check_schema(table, [
+        check_query_geometry('SELECT ST_SetSRID(ST_Buffer(ST_MakePoint(0,0),10), 4326) AS the_geom', [
             [:cartodb_id, 'bigint'],
             [:the_geom, 'geometry', 'geometry', 'multipolygon']
         ])
 
         # single line
-        table = new_table(:name => nil, :user_id => @user.id)
-        table.migrate_existing_table = 'six'
-        @user.db_service.run_pg_query('
-          CREATE TABLE six AS SELECT ST_SetSRID(ST_Boundary(ST_Buffer(ST_MakePoint(0,0),10,1)), 4326) AS the_geom
-        ')
-        table.save
-        check_schema(table, [
+        check_query_geometry('SELECT ST_SetSRID(ST_Boundary(ST_Buffer(ST_MakePoint(0,0),10,1)), 4326) AS the_geom', [
             [:cartodb_id, 'bigint'],
             [:the_geom, 'geometry', 'geometry', 'multilinestring']
         ])
 
         # field named "the_geom" being _not_ of type geometry
-        table = new_table(:name => nil, :user_id => @user.id)
-        table.migrate_existing_table = 'seven'
-        @user.db_service.run_pg_query(%Q{
-          CREATE TABLE seven AS SELECT 'wadus' AS the_geom;
-        })
-        table.save
-        check_schema(table, [
+        check_query_geometry("SELECT 'wadus' AS the_geom;", [
             [:cartodb_id, 'bigint'],
             [:the_geom, 'geometry', 'geometry', 'geometry'],
             [:the_geom_str, 'unknown']

--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -482,7 +482,7 @@ describe Carto::Api::OrganizationUsersController do
       replace_soft_limits(@organization.owner, [false, false, false])
       login(@organization.owner)
 
-      user_to_update = @organization.users[0]
+      user_to_update = @organization.non_owner_users[0]
       params = { soft_geocoding_limit: true }
       put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
@@ -495,7 +495,7 @@ describe Carto::Api::OrganizationUsersController do
       replace_soft_limits(@organization.owner, [true, true, true])
       login(@organization.owner)
 
-      user_to_update = @organization.users[0]
+      user_to_update = @organization.non_owner_users[0]
       params = { soft_geocoding_limit: true }
       put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
           params
@@ -519,7 +519,7 @@ describe Carto::Api::OrganizationUsersController do
 
       login(@organization.owner)
 
-      user_to_update = @organization.users[0]
+      user_to_update = @organization.non_owner_users[0]
       new_email = "#{user_to_update.email}.es"
       params = { email: new_email,
                  password: 'pataton',
@@ -555,7 +555,7 @@ describe Carto::Api::OrganizationUsersController do
       replace_soft_limits(@organization.owner, [true, true, true, true, true])
 
       login(@organization.owner)
-      user_to_update = @organization.users[0]
+      user_to_update = @organization.non_owner_users[0]
       params = user_params_soft_limits(nil, true)
 
       put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
@@ -571,7 +571,7 @@ describe Carto::Api::OrganizationUsersController do
       replace_soft_limits(@organization.owner, [true, true, true, true, true])
 
       login(@organization.owner)
-      user_to_update = @organization.users[0]
+      user_to_update = @organization.non_owner_users[0]
       params = user_params_soft_limits(nil, false)
 
       put api_v2_organization_users_update_url(id_or_name: @organization.name, u_username: user_to_update.username),
@@ -587,7 +587,7 @@ describe Carto::Api::OrganizationUsersController do
       replace_soft_limits(@organization.owner, [false, false, false, false, false])
 
       login(@organization.owner)
-      user_to_update = @organization.users[0]
+      user_to_update = @organization.non_owner_users[0]
       replace_soft_limits(user_to_update, [false, false, false])
       params = user_params_soft_limits(nil, true)
 


### PR DESCRIPTION
Fixes two tests with a long history of being flaky. They hide some interesting bug-like behaviour, which is why there are changes to the code:

### `table_spec` geometry types
Here, there are two different issues with caching:
- First, the redis key is being cached (memoized), before the table has an id, so it ends up memoizing `rails:table::geometry_types`. Removing the memoization helps with this during the crreation process. A better option would be to review the `Table` creation process, but that is much harder and trickier.
- `the_geom_value` is incorrectly during creation. Not that this is not a DB field, just an in-memory attribute. [Resetting it](https://github.com/CartoDB/cartodb/pull/12801/files#diff-204f9826df1f1c0e768c8f6c964a6022R1912) works around the problem. Again, the correct solution would be to review the creation process, so it doesn't try to get the geometry type before the table exists.

I did a little refactor of this test as a bonus.

### Carto::Api::OrganizationUsersController
A bunch of tests were trying to use the owner for the tests, which is incorrect. Using `non_owner_users` helps with that.

The failure of the creation test is interesting. It fails https://github.com/CartoDB/cartodb/blob/master/spec/requests/carto/api/organization_users_controller_spec.rb#L180. What is happening, is that the presenter [here](https://github.com/CartoDB/cartodb/blob/master/app/controllers/carto/api/organization_users_controller.rb#L76-L80) is getting the result of queueing the account creation. Since the user is not yet persisted, it has no id, so it makes a query for all visualizations without user_id. This fails if other tests have left orphan visualizations lying around. This is actually a bug, the fix makes the code return 0 in these cases.

### Superadmin user spec
Some tests leave broken users in the database (user model present, database destroyed) which cause the index method to 500 when calculating quota. I changed the `remaining_quota` method to return `nil` in this case instead of crashing. This helps with editing users via superadmin when they have DB connectivity problems, which may be useful.