### PR TITLE
Rename 'Select a text' placeholder to 'Select a value' in Filter analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,7 @@ Development
 * Updates Dataservices API client default version to `0.20.0` (#12633)
 
 ### Bug fixes / enhancements
+* Rename 'Select a text' placeholder to 'Select a value' in Filter analysis (#11861)
 * Rename 'SHARE' button to 'PUBLISH' and 'Not published yet' to 'Unpublished map' (#12730)
 * Move Analysis cancel/delete button to the controls zone (#11414)
 * Rename SIZE/COLOR input label to COLOR in polygons style (#12768)

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-form-model.js
@@ -150,7 +150,8 @@ module.exports = BaseAnalysisFormModel.extend({
         dialogMode: 'float',
         editorAttrs: {
           showSearch: !this._isBoolean(),
-          allowFreeTextInput: !this._isBoolean()
+          allowFreeTextInput: !this._isBoolean(),
+          placeholder: _t('editor.layers.analysis-form.select-value')
         }
       },
       accept_reject: {

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -1943,6 +1943,7 @@
         "select-data-source": "Select a data source",
         "select-second-source": "Select a second data source to join",
         "select-type": "Select data type",
+        "select-value": "Select a value",
         "setup-analysis": "Setup analysis",
         "show": "Show",
         "significance": "Significance",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.79",
+  "version": "4.9.79-11861",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: #11861 

![rename-placeholder-filter-analysis](https://user-images.githubusercontent.com/2227572/30435629-7bd99762-996a-11e7-9102-008f2f0ced01.png)
