### PR TITLE
Extraneous basemap labels layer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,7 @@ Development
 * Updates Dataservices API client default version to `0.20.0` (#12633)
 
 ### Bug fixes / enhancements
+* Fix extraneous labels layer.
 * Rename 'Select a text' placeholder to 'Select a value' in Filter analysis (#11861)
 * Highlight new column name (#12662)
 * Add drag icon to each item in the widget list (#12692)

--- a/lib/assets/core/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -64,6 +64,8 @@ module.exports = Backbone.Collection.extend({
         .compact()
         .value()
     });
+
+    this._sanitizeLabels();
   },
 
   comparator: function (m) {
@@ -279,6 +281,7 @@ module.exports = Backbone.Collection.extend({
       silent: true,
       wait: true, // do not add/remove the layer unless it's created/removed/updated successfully
       success: function () {
+        this._sanitizeLabels();
         this.trigger('baseLayerChanged');
       }.bind(this),
       error: function () {

--- a/lib/assets/core/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -304,6 +304,7 @@ module.exports = Backbone.Collection.extend({
           if (labelsLayer) {
             this._destroyLabelsLayer(labelsLayerOptions);
           } else {
+            this._sanitizeLabels();
             this.trigger('baseLayerChanged');
           }
         }

--- a/lib/assets/core/javascripts/cartodb3/data/layer-definitions-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/data/layer-definitions-collection.js
@@ -250,6 +250,20 @@ module.exports = Backbone.Collection.extend({
     return _.union(valuesFromAddedModels, valuesFromModelsNotYetAdded, otherLetters);
   },
 
+  // This ensures that we don't end up with more than one labels layer
+  _sanitizeLabels: function () {
+    var troubled = this.models.filter(function (layer) {
+      return layerTypesAndKinds.isTiledType(layer.get('type'));
+    }).filter(function (layer) {
+      var index = this.models.indexOf(layer);
+      return (index > 0 && index < this.length - 1);
+    }.bind(this));
+
+    troubled.length > 0 && _.each(troubled, function (layer) {
+      layer.destroy();
+    });
+  },
+
   setBaseLayer: function (newBaseLayerAttrs) {
     this.trigger('changingBaseLayer');
 

--- a/lib/assets/core/test/spec/cartodb3/data/layer-definitions-collection.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/data/layer-definitions-collection.spec.js
@@ -125,6 +125,22 @@ describe('data/layer-definitions-collection', function () {
     expect(this.collection.pluck('color')).toEqual([layerColors.COLORS[0], layerColors.COLORS[1]]);
   });
 
+  it('should sanitize labels layer when create layers collection', function () {
+    var layersData = [
+      { kind: 'tiled', order: 0 }, // a basemap
+      { kind: 'carto', order: 1 },
+      { kind: 'tiled', order: 2 },
+      { kind: 'carto', order: 3 },
+      { kind: 'tiled', order: 4 }
+    ];
+
+    this.collection.resetByLayersData(layersData);
+    expect(this.collection.length).toEqual(layersData.length - 1);
+    expect(this.collection.filter(function (layer) {
+      return layer.get('type') === 'Tiled';
+    }).length).toEqual(2);
+  });
+
   it('should create a layer with the owner of the table in the query', function () {
     var layer1 = this.collection.add({
       kind: 'carto',


### PR DESCRIPTION
This PR fixes https://github.com/CartoDB/support/issues/963.

I couldn't reproduce the issue, even migrating maps from the editor, neither locally or in staging. We are almost sure this is a problem related to the migration between editor and builder, so I started to work on a different angle. Once we face this issue, the map itself will be able to autofix it, deleting those extra tiled layers.