### PR TITLE
Lazy select

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@ Development
 * Updates Dataservices API client default version to `0.20.0` (#12633)
 
 ### Bug fixes / enhancements
+* Lazy select to fix missing values due to 40 per page items limitation in requests
 * Fix timeseries glitches (#12217)
 * Rename 'Select a text' placeholder to 'Select a value' in Filter analysis (#11861)
 * Highlight new column name (#12662)

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/measurements-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/data-observatory-measurements/measurements-list-view.js
@@ -65,7 +65,6 @@ module.exports = CoreView.extend({
     });
 
     this._listView = new CustomListView({
-      className: 'DO-Measurements',
       typeLabel: _t('components.backbone-forms.data-observatory.dropdown.measurement.type'),
       showSearch: false,
       itemView: CustomListItemView,

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view-states.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view-states.tpl
@@ -1,0 +1,17 @@
+<% if (status === 'fetching') { %>
+  <div class="InputColorCategory-loader js-loader">
+    <div class="CDB-LoaderIcon is-dark">
+      <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
+        <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
+      </svg>
+    </div>
+  </div>
+<% } else if (status === 'error') { %>
+  <div class="u-flex u-alignCenter u-justifyCenter CDB-Text CDB-Size-medium u-bSpace--m u-tSpace--m u-errorTextColor"><%- _t('components.backbone-forms.data-observatory.dropdown.error', {
+    type: type
+  }) %></div>
+<% } else if (status === 'empty') { %>
+  <div class="u-flex u-alignCenter u-justifyCenter CDB-Text CDB-Size-medium u-bSpace--m u-tSpace--m"><%- _t('components.backbone-forms.lazy-select.empty', {
+    type: type
+  }) %></div>
+<% } %>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
@@ -1,0 +1,118 @@
+var Backbone = require('backbone');
+var CoreView = require('backbone/core-view');
+var CustomListView = require('../../../custom-list/custom-view');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
+var template = require('./lazy-list.tpl');
+var SearchView = require('./lazy-search-view');
+var statusTemplate = require('./lazy-list-view-states.tpl');
+
+var REQUIRED_OPTS = [
+  'searchCollection',
+  'lazySearch'
+];
+
+module.exports = CoreView.extend({
+  className: 'CDB-Box-modal CustomList',
+
+  initialize: function (opts) {
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+    this._type = opts.type || _t('components.backbone-forms.lazy-select.type');
+    this.model = new Backbone.Model({
+      query: '',
+      visible: false
+    });
+
+    this._initBinds();
+  },
+
+  render: function () {
+    this.clearSubViews();
+    this.$el.empty();
+    this.$el.html(template());
+    this._createSearchView();
+    this._renderListSection();
+    return this;
+  },
+
+  _initBinds: function () {
+    this.listenTo(this._searchCollection.stateModel, 'change:state', this._renderListSection);
+    this.listenTo(this.model, 'change:query', this._search);
+
+    this.listenTo(this.model, 'change:visible', function (mdl, isVisible) {
+      isVisible ? this.render() : this.clearSubViews();
+      this._toggleVisibility();
+    });
+  },
+
+  _createListView: function () {
+    if (this._listView) {
+      this._listView.clean();
+      this.removeView(this._listView);
+    }
+
+    this._listView = new CustomListView({
+      className: 'DO-Measurements',
+      typeLabel: this._type,
+      showSearch: false,
+      collection: this._searchCollection
+    });
+
+    this.addView(this._listView);
+    this._listView.show();
+    this.$('.js-list').html(this._listView.$el);
+  },
+
+  _createStatusView: function (status) {
+    var el = statusTemplate({
+      status: status,
+      type: this._type
+    });
+
+    this.$('.js-list').html(el);
+  },
+
+  _renderListSection: function () {
+    var status = this._searchCollection.stateModel.get('state');
+
+    if (status === 'fetched') {
+      this._createListView();
+    } else {
+      this._createStatusView(status);
+    }
+  },
+
+  _createSearchView: function () {
+    this._searchView = new SearchView({
+      model: this.model
+    });
+    this.addView(this._searchView);
+    this.$('.js-search').append(this._searchView.render().el);
+  },
+
+  _search: function () {
+    var keyword = this.model.get('query');
+
+    // This function is passed from the parent
+    this._lazySearch(keyword);
+  },
+
+  _isSerching: function () {
+    return !!this.model.get('query');
+  },
+
+  hide: function () {
+    this.model.set('visible', false);
+  },
+
+  toggle: function () {
+    this.model.set('visible', !this.model.get('visible'));
+  },
+
+  isVisible: function () {
+    return this.model.get('visible');
+  },
+
+  _toggleVisibility: function () {
+    this.$el.toggleClass('is-visible', !!this.isVisible());
+  }
+});

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
@@ -13,6 +13,7 @@ var REQUIRED_OPTS = [
 
 module.exports = CoreView.extend({
   className: 'CDB-Box-modal CustomList',
+  module: 'components:lazy-load:lazy-list-view',
 
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
@@ -52,6 +52,7 @@ module.exports = CoreView.extend({
     }
 
     this._listView = new CustomListView({
+      className: '',
       typeLabel: this._type,
       showSearch: false,
       collection: this._searchCollection,

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
@@ -52,7 +52,6 @@ module.exports = CoreView.extend({
     }
 
     this._listView = new CustomListView({
-      className: 'DO-Measurements',
       typeLabel: this._type,
       showSearch: false,
       collection: this._searchCollection,

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list-view.js
@@ -55,7 +55,8 @@ module.exports = CoreView.extend({
       className: 'DO-Measurements',
       typeLabel: this._type,
       showSearch: false,
-      collection: this._searchCollection
+      collection: this._searchCollection,
+      searchPlaceholder: this.options.searchPlaceholder
     });
 
     this.addView(this._listView);
@@ -99,6 +100,10 @@ module.exports = CoreView.extend({
 
   _isSerching: function () {
     return !!this.model.get('query');
+  },
+
+  show: function () {
+    this.model.set('visible', true);
   },
 
   hide: function () {

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-list.tpl
@@ -1,0 +1,2 @@
+<div class="js-search"></div>
+<div class="js-list"></div>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-search-collection.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-search-collection.js
@@ -1,0 +1,115 @@
+var Backbone = require('backbone');
+var _ = require('underscore');
+var $ = require('jquery');
+var cdb = require('cartodb.js');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
+var CustomListCollection = require('../../../custom-list/custom-list-collection');
+var BaseModel = require('../../../custom-list/custom-list-item-model');
+
+var queryTemplate = _.template("SELECT DISTINCT <%= column %> FROM (<%= sql %>) _table_sql WHERE <%= column %> ilike '%<%= search %>%' ORDER BY <%= column %> ASC");
+
+var REQUIRED_OPTS = [
+  'configModel',
+  'rowModel',
+  'column'
+];
+
+module.exports = CustomListCollection.extend({
+  initialize: function (models, options) {
+    checkAndBuildOpts(options, REQUIRED_OPTS, this);
+
+    this._query = options.nodeDefModel.querySchemaModel.get('query');
+
+    var configModel = options.configModel;
+    this.SQL = new cdb.SQL({
+      user: configModel.get('user_name'),
+      sql_api_template: configModel.get('sql_api_template'),
+      api_key: configModel.get('api_key')
+    });
+
+    this.stateModel = new Backbone.Model({
+      state: _.isEmpty(models) ? 'empty' : 'fetched'
+    });
+
+    CustomListCollection.prototype.initialize.call(this, models, options);
+  },
+
+  model: function (attrs, opts) {
+    // label and val to custom list compatibility
+    var key = Object.keys(attrs)[0];
+    var o = {};
+    o.val = attrs[key];
+    o.label = attrs[key];
+
+    return new BaseModel(o);
+  },
+
+  _onSelectedChange: function (changedModel, isSelected) {
+    if (this.type === 'multiple') {
+      return;
+    }
+
+    if (isSelected) {
+      this.each(function (m) {
+        if (m.cid !== changedModel.cid) {
+          m.set({ selected: false }, { silent: true });
+        }
+      }, this);
+    }
+  },
+
+  buildQuery: function (search) {
+    var column = this.options.column;
+    return queryTemplate({
+      sql: this._query,
+      search: search,
+      column: this._rowModel.get(column)
+    });
+  },
+
+  fetch: function (search) {
+    this.deferred = $.Deferred();
+    var sqlQuery = this.buildQuery(search);
+    this.stateModel.set('state', 'fetching');
+
+    this.SQL.execute(sqlQuery, null, {
+      extra_params: ['page', 'rows_per_page'],
+      page: 0,
+      rows_per_page: 40,
+      success: function (data) {
+        this._onFetchSuccess(data);
+        this.stateModel.set('state', 'fetched');
+        this.deferred.resolve();
+      }.bind(this),
+      error: function () {
+        this.stateModel.set('state', 'error');
+        this.deferred.reject();
+      }.bind(this)
+    });
+
+    return this.deferred.promise();
+  },
+
+  _onFetchSuccess: function (data) {
+    this.reset(data.rows);
+    if (_.isEmpty(this.models)) {
+      this.stateModel.set('state', 'empty');
+    }
+  },
+
+  isFetching: function () {
+    return this.getState() === 'fetching';
+  },
+
+  getState: function () {
+    return this.stateModel.get('state');
+  },
+
+  getItem: function (value) {
+    return this.findWhere({ val: value });
+  },
+
+  isAsync: function () {
+    return true;
+  }
+});

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-search-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-search-view.js
@@ -1,0 +1,48 @@
+var _ = require('underscore');
+var CoreView = require('backbone/core-view');
+var checkAndBuildOpts = require('../../../../helpers/required-opts');
+var utils = require('../../../../helpers/utils');
+var template = require('./lazy-search.tpl');
+
+var REQUIRED_OPTS = [
+  'model'
+];
+
+module.exports = CoreView.extend({
+  className: 'CDB-Box-modalHeader',
+
+  events: {
+    'input .js-input-search': '_search'
+  },
+
+  initialize: function (opts) {
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+  },
+
+  render: function () {
+    this.$el.html(template());
+
+    // Focus the input when rendered
+    setTimeout(function () {
+      this._getInput().focus();
+    }.bind(this), 100);
+
+    return this;
+  },
+
+  _onClickFilters: function (e) {
+    this.killEvent(e);
+    this.trigger('filters');
+  },
+
+  _search: _.debounce(function (e) {
+    var query = this._getInput().val();
+    query = query.toLowerCase();
+    query = utils.sanitizeHtml(query);
+    this.model.set('query', query);
+  }, 500),
+
+  _getInput: function () {
+    return this.$('.js-input-search');
+  }
+});

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-search.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-search.tpl
@@ -1,0 +1,7 @@
+<div class="CDB-Box-modalHeaderItem">
+  <div  class="u-flex u-grow">
+    <div class="u-flex u-grow">
+      <input type="text" name="text" autocomplete="off" placeholder="<%- _t('components.backbone-forms.lazy-select.search') %>" class="CDB-InputTextPlain CDB-Text js-input-search">
+    </div>
+  </div>
+</div>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select-item.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select-item.tpl
@@ -1,0 +1,12 @@
+<% if (typeof isLoading != 'undefined' && isLoading) { %>
+  <div class="u-flex">
+    <div class="CDB-LoaderIcon CDB-LoaderIcon--small is-dark">
+      <svg class="CDB-LoaderIcon-spinner" viewBox="0 0 50 50">
+        <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"></circle>
+      </svg>
+    </div>
+    <span class="u-lSpace u-secondaryTextColor"><%- _t('components.backbone-forms.select.loading') %></span>
+  </div>
+<% } else { %>
+  <%- label %>
+<% } %>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select-view.js
@@ -1,0 +1,190 @@
+var Backbone = require('backbone');
+var EditorHelpers = require('../editor-helpers-extend');
+var template = require('./lazy-select.tpl');
+var selectedItemTemplate = require('./lazy-select-item.tpl');
+var ListView = require('./lazy-list-view');
+var PopupManager = require('../../../popup-manager');
+var SearchCollection = require('./lazy-search-collection');
+
+var ENTER_KEY_CODE = 13;
+
+Backbone.Form.editors.LazySelect = Backbone.Form.editors.Base.extend({
+
+  tagName: 'div',
+  className: 'u-ellipsis Editor-formSelect',
+
+  events: {
+    'click .js-button': '_onButtonClick',
+    'keydown .js-button': '_onButtonKeyDown',
+    'focus .js-button': function () {
+      this.trigger('focus', this);
+    },
+    'blur': function () {
+      this.trigger('blur', this);
+    }
+  },
+
+  options: {
+    selectedItemTemplate: selectedItemTemplate
+  },
+
+  initialize: function (options) {
+    Backbone.Form.editors.Base.prototype.initialize.call(this, options);
+    EditorHelpers.setOptions(this, options);
+
+    this.template = options.template || template;
+    this.dialogMode = this.options.dialogMode || 'nested';
+
+    var fetchOptions = {
+      configModel: this.options.configModel,
+      nodeDefModel: this.options.nodeDefModel,
+      rowModel: this.model,
+      column: this.options.column
+    };
+
+    if (this.options.options != null) {
+      this.searchCollection = new SearchCollection(this.options.options, fetchOptions);
+    } else {
+      this.searchCollection = this.options.collection;
+    }
+
+    this._initBinds();
+
+    var lazySearch = function (search) {
+      this.searchCollection.fetch(search);
+    }.bind(this);
+
+    var type = this.model.get(this.options.column);
+
+    this._dialogView = new ListView({
+      configModel: this.options.configModel,
+      searchCollection: this.searchCollection,
+      lazySearch: lazySearch,
+      type: type
+    });
+  },
+
+  render: function () {
+    var isDisabled = this.options.disabled;
+    var name = this.model.get(this.options.keyAttr);
+    var placeholder = this._getPlaceholder();
+    var isNull = this._hasValue();
+    var label = isNull ? placeholder : name;
+    var title = name || '';
+
+    this.$el.html(
+      this.template({
+        title: title,
+        label: label,
+        keyAttr: this.options.keyAttr,
+        isDisabled: isDisabled,
+        isNull: isNull
+      })
+    );
+
+    this._popupManager = new PopupManager(this.cid, this.$el, this._dialogView.$el);
+    this._popupManager.append(this.dialogMode);
+
+    return this;
+  },
+
+  _initBinds: function () {
+    var hide = function () {
+      this._dialogView.hide();
+      this._popupManager && this._popupManager.untrack();
+    }.bind(this);
+
+    this.applyESCBind(hide);
+    this.applyClickOutsideBind(hide);
+
+    this.listenTo(this.searchCollection, 'change:selected', this._onItemSelected);
+  },
+
+  _destroyBinds: function () {
+    this.stopListening(this.searchCollection);
+    Backbone.Form.editors.Base.prototype._destroyBinds.call(this);
+  },
+
+  _getPlaceholder: function (isDisabled) {
+    var keyAttr = this.options.keyAttr;
+    var placeholder = this.options.placeholder || _t('components.backbone-forms.select.placeholder', { keyAttr: keyAttr });
+    return placeholder;
+  },
+
+  _hasValue: function () {
+    var name = this.model.get(this.options.keyAttr);
+    return name == null || name === '';
+  },
+
+  _onItemSelected: function (model) {
+    this._dialogView.hide();
+    this._popupManager.untrack();
+    this._renderButton(model).focus();
+
+    this.trigger('change', this);
+  },
+
+  _onButtonClick: function () {
+    this._dialogView.toggle();
+    this._dialogView.isVisible() ? this._popupManager.track() : this._popupManager.untrack();
+  },
+
+  _onButtonKeyDown: function (ev) {
+    if (ev.which === ENTER_KEY_CODE) {
+      ev.preventDefault();
+      if (!this._dialogView.isVisible()) {
+        ev.stopPropagation();
+        this._onButtonClick();
+      } else {
+        this._popupManager.track();
+      }
+    }
+  },
+
+  focus: function () {
+    this.$('.js-button').focus();
+  },
+
+  blur: function () {
+    this.$('.js-button').blur();
+  },
+
+  getValue: function () {
+    var item = this.searchCollection.getSelectedItem();
+    if (item) {
+      return item.getValue();
+    } else {
+      return this.value;
+    }
+  },
+
+  setValue: function (value) {
+    var selectedModel = this.model;
+    if (selectedModel) {
+      this._renderButton(selectedModel);
+    }
+    this.value = value;
+  },
+
+  _renderButton: function (model) {
+    var button = this.$('.js-button');
+    var label = model.getName();
+    var $html = this.options.selectedItemTemplate({
+      label: label
+    });
+
+    button
+      .removeClass('is-empty')
+      .attr('title', label)
+      .html($html);
+
+    return button;
+  },
+
+  remove: function () {
+    this._popupManager && this._popupManager.destroy();
+    this._dialogView && this._dialogView.clean();
+    this._destroyBinds();
+    Backbone.Form.editors.Base.prototype.remove.call(this);
+  }
+});

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select-view.js
@@ -50,21 +50,27 @@ Backbone.Form.editors.LazySelect = Backbone.Form.editors.Base.extend({
 
     this._initBinds();
 
+    var value = this.model.get(this.options.keyAttr);
+    if (value != null) {
+      this.setValue(value);
+    }
+
     var lazySearch = function (search) {
       this.searchCollection.fetch(search);
     }.bind(this);
-
     var type = this.model.get(this.options.column);
 
-    this._dialogView = new ListView({
+    this._listView = new ListView({
       configModel: this.options.configModel,
       searchCollection: this.searchCollection,
       lazySearch: lazySearch,
-      type: type
+      type: type,
+      searchPlaceholder: this.options.searchPlaceholder
     });
   },
 
   render: function () {
+    var isEmpty = !this.searchCollection.length;
     var isDisabled = this.options.disabled;
     var name = this.model.get(this.options.keyAttr);
     var placeholder = this._getPlaceholder();
@@ -77,12 +83,13 @@ Backbone.Form.editors.LazySelect = Backbone.Form.editors.Base.extend({
         title: title,
         label: label,
         keyAttr: this.options.keyAttr,
+        isEmpty: isEmpty,
         isDisabled: isDisabled,
         isNull: isNull
       })
     );
 
-    this._popupManager = new PopupManager(this.cid, this.$el, this._dialogView.$el);
+    this._popupManager = new PopupManager(this.cid, this.$el, this._listView.$el);
     this._popupManager.append(this.dialogMode);
 
     return this;
@@ -90,7 +97,7 @@ Backbone.Form.editors.LazySelect = Backbone.Form.editors.Base.extend({
 
   _initBinds: function () {
     var hide = function () {
-      this._dialogView.hide();
+      this._listView.hide();
       this._popupManager && this._popupManager.untrack();
     }.bind(this);
 
@@ -117,7 +124,7 @@ Backbone.Form.editors.LazySelect = Backbone.Form.editors.Base.extend({
   },
 
   _onItemSelected: function (model) {
-    this._dialogView.hide();
+    this._listView.hide();
     this._popupManager.untrack();
     this._renderButton(model).focus();
 
@@ -125,14 +132,14 @@ Backbone.Form.editors.LazySelect = Backbone.Form.editors.Base.extend({
   },
 
   _onButtonClick: function () {
-    this._dialogView.toggle();
-    this._dialogView.isVisible() ? this._popupManager.track() : this._popupManager.untrack();
+    this._listView.toggle();
+    this._listView.isVisible() ? this._popupManager.track() : this._popupManager.untrack();
   },
 
   _onButtonKeyDown: function (ev) {
     if (ev.which === ENTER_KEY_CODE) {
       ev.preventDefault();
-      if (!this._dialogView.isVisible()) {
+      if (!this._listView.isVisible()) {
         ev.stopPropagation();
         this._onButtonClick();
       } else {
@@ -159,22 +166,24 @@ Backbone.Form.editors.LazySelect = Backbone.Form.editors.Base.extend({
   },
 
   setValue: function (value) {
-    var selectedModel = this.model;
+    var selectedModel = this.searchCollection.getSelectedItem();
     if (selectedModel) {
       this._renderButton(selectedModel);
+    } else {
+      this._renderButton(value);
     }
     this.value = value;
   },
 
   _renderButton: function (model) {
     var button = this.$('.js-button');
-    var label = model.getName();
+    var label = model.getName && model.getName() || model;
     var $html = this.options.selectedItemTemplate({
       label: label
     });
 
     button
-      .removeClass('is-empty')
+      .toggleClass('is-empty', label === '')
       .attr('title', label)
       .html($html);
 
@@ -183,7 +192,7 @@ Backbone.Form.editors.LazySelect = Backbone.Form.editors.Base.extend({
 
   remove: function () {
     this._popupManager && this._popupManager.destroy();
-    this._dialogView && this._dialogView.clean();
+    this._listView && this._listView.clean();
     this._destroyBinds();
     Backbone.Form.editors.Base.prototype.remove.call(this);
   }

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select.tpl
@@ -4,5 +4,9 @@
   <% if (isNull) { %> is-empty <% } %>"
   tabindex="0"
   title="<%- title %>">
-    <%- label %>
+    <% if (isEmpty && isNull) { %>
+      <%- _t('components.backbone-forms.select.empty') %>
+    <% } else { %>
+      <%- label %>
+    <% } %>
 </div>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-select.tpl
@@ -1,0 +1,8 @@
+<div class="CDB-InputText CDB-Text is-cursor js-button u-ellipsis
+  <% if (isDisabled) { %> is-disabled <% } %>
+  <% if (!label) { %> is-empty <% } %>
+  <% if (isNull) { %> is-empty <% } %>"
+  tabindex="0"
+  title="<%- title %>">
+    <%- label %>
+</div>

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/index.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/index.js
@@ -45,3 +45,4 @@ require('./editors/select/suggest-view.js');
 require('./editors/code-editor');
 require('./editors/data-observatory-measurements/data-observatory-measurements-view.js');
 require('./editors/data-observatory-measurements/measurement-item.js');
+require('./editors/lazy-select/lazy-select-view.js');

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-form-model.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-form-models/filter-form-model.js
@@ -37,26 +37,26 @@ module.exports = BaseAnalysisFormModel.extend({
   initialize: function () {
     BaseAnalysisFormModel.prototype.initialize.apply(this, arguments);
 
-    var nodeDefModel = this._layerDefinitionModel.findAnalysisDefinitionNodeModel(this.get('source'));
+    this._nodeDefModel = this._layerDefinitionModel.findAnalysisDefinitionNodeModel(this.get('source'));
 
     this._columnData = new ColumnData({
       column: this.get('column'),
       type: this._getSelectedColumnType()
     }, {
-      nodeDefModel: nodeDefModel,
+      nodeDefModel: this._nodeDefModel,
       configModel: this._configModel
     });
 
     this._columnRowData = new ColumnRowData({
       column: this.get('column')
     }, {
-      nodeDefModel: nodeDefModel,
+      nodeDefModel: this._nodeDefModel,
       configModel: this._configModel
     });
 
     this._columnOptions = new ColumnOptions({}, {
       configModel: this._configModel,
-      nodeDefModel: nodeDefModel
+      nodeDefModel: this._nodeDefModel
     });
 
     this.on('change:kind change:column', this._updateSchema, this);
@@ -149,8 +149,9 @@ module.exports = BaseAnalysisFormModel.extend({
         options: this._getInputOptions(),
         dialogMode: 'float',
         editorAttrs: {
-          showSearch: !this._isBoolean(),
-          allowFreeTextInput: !this._isBoolean(),
+          column: 'column',
+          nodeDefModel: this._nodeDefModel,
+          configModel: this._configModel,
           placeholder: _t('editor.layers.analysis-form.select-value')
         }
       },
@@ -171,7 +172,7 @@ module.exports = BaseAnalysisFormModel.extend({
 
   _getInputType: function () {
     var rows = this._columnRowData.getRows();
-    return rows && rows.length ? 'Select' : 'Text';
+    return rows && rows.length ? 'LazySelect' : 'Text';
   },
 
   _getMinLabel: function () {

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -1249,6 +1249,12 @@
       "column-type-error": "Column type must be a %{columnType}",
       "interval-error": "Value must be between %{minValue} and %{maxValue}",
       "copy-button": "COPY",
+      "lazy-select": {
+        "search": "Search...",
+        "error": "Error fetching %{type}",
+        "type": "items",
+        "empty": "No results for %{type} column."
+      },
       "data-observatory": {
         "dropdown": {
           "measurement": {

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/lazy-select/lazy-search-collection.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/lazy-select/lazy-search-collection.spec.js
@@ -1,0 +1,84 @@
+var Backbone = require('backbone');
+var LazySearchCollection = require('../../../../../../../javascripts/cartodb3/components/form-components/editors/lazy-select/lazy-search-collection');
+var AnalysisDefinitionNodeModel = require('../../../../../../../javascripts/cartodb3/data/analysis-definition-node-model');
+
+describe('components/form-components/editors/lazy-select/lazy-search-collection', function () {
+  beforeEach(function () {
+    var configModel = new Backbone.Model({
+      base_url: '/u/foo',
+      user_name: 'foo',
+      sql_api_template: 'foo',
+      api_key: 'foo'
+    });
+
+    this.nodeDefModel = new AnalysisDefinitionNodeModel({
+      id: 'a1',
+      source: 'a0'
+    }, {
+      configModel: configModel,
+      collection: new Backbone.Collection()
+    });
+
+    this.querySchemaModel = new Backbone.Model({
+      query: 'select * from wadus'
+    });
+
+    this.nodeDefModel.querySchemaModel = this.querySchemaModel;
+
+    var model = new Backbone.Model({
+      name: 'foo'
+    });
+
+    this.collection = new LazySearchCollection([], {
+      configModel: configModel,
+      nodeDefModel: this.nodeDefModel,
+      rowModel: model,
+      column: 'name'
+    });
+
+    spyOn(this.collection.SQL, 'execute').and.callFake(function (query, vars, params) {
+      params && params.success({
+        rows: [
+          {
+            name: 'foo'
+          },
+          {
+            name: 'bar'
+          },
+          {
+            name: 'carto'
+          }
+        ]
+      });
+    });
+  });
+
+  it('initial state', function () {
+    expect(this.collection.getState()).toBe('empty');
+  });
+
+  it('fetch', function () {
+    this.collection.fetch();
+
+    expect(this.collection.length).toBe(3);
+    expect(this.collection.getState()).toBe('fetched');
+  });
+
+  it('model', function () {
+    this.collection.fetch();
+
+    var m = this.collection.at(0);
+    expect(m.getValue()).toBe('foo');
+    expect(m.getName()).toBe('foo');
+  });
+
+  it('getSelected', function () {
+    this.collection.fetch();
+
+    var m = this.collection.at(0);
+    this.collection.setSelected(m.getValue());
+
+    var selected = this.collection.getSelectedItem();
+    expect(selected.getValue()).toBe(m.getValue());
+  });
+});

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/lazy-select/lazy-select-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/lazy-select/lazy-select-view.spec.js
@@ -1,9 +1,9 @@
 var $ = require('jquery');
 var Backbone = require('backbone');
 var _ = require('underscore');
-var CustomListCollection = require('../../../../../../javascripts/cartodb3/components/custom-list/custom-list-collection');
+var AnalysisDefinitionNodeModel = require('../../../../../../../javascripts/cartodb3/data/analysis-definition-node-model');
 
-describe('components/form-components/editors/select', function () {
+describe('components/form-components/editors/lazy-select', function () {
   var dispatchDocumentEvent = function (type, opts) {
     var e = document.createEvent('HTMLEvents');
     e.initEvent(type, false, true);
@@ -19,15 +19,45 @@ describe('components/form-components/editors/select', function () {
       latitude: undefined
     });
 
+    var configModel = new Backbone.Model({
+      base_url: '/u/foo',
+      user_name: 'foo',
+      sql_api_template: 'foo',
+      api_key: 'foo'
+    });
+
+    var nodeDefModel = new AnalysisDefinitionNodeModel({
+      id: 'a1',
+      source: 'a0'
+    }, {
+      configModel: configModel,
+      collection: new Backbone.Collection()
+    });
+
+    var querySchemaModel = new Backbone.Model({
+      query: 'select * from wadus'
+    });
+
+    nodeDefModel.querySchemaModel = querySchemaModel;
+
     var defaultOptions = {
       key: 'names',
       schema: {
-        options: ['pepe', 'paco', 'juan']
+        options: [{
+          columna: 'foo'
+        }, {
+          columna: 'bar'
+        }, {
+          columna: 'carto'
+        }]
       },
-      model: model
+      model: model,
+      configModel: configModel,
+      nodeDefModel: nodeDefModel,
+      column: 'columna'
     };
 
-    var view = new Backbone.Form.editors.Select(_.extend(defaultOptions, options));
+    var view = new Backbone.Form.editors.LazySelect(_.extend(defaultOptions, options));
 
     view.render();
 
@@ -43,66 +73,54 @@ describe('components/form-components/editors/select', function () {
   });
 
   it('should genereate an options collection', function () {
-    var view = this.createView();
+    this.view = this.createView();
 
-    expect(view.collection).toBeDefined();
-    expect(view.collection.size()).toBe(3);
-
-    view.remove();
+    expect(this.view.searchCollection).toBeDefined();
+    expect(this.view.searchCollection.size()).toBe(3);
   });
 
   describe('render', function () {
     it('should render properly', function () {
-      var view = this.createView();
+      this.view = this.createView();
 
-      expect(view.$('.js-button').length).toBe(1);
-      expect(view.$('.js-button').text()).toContain('pepe');
-
-      view.remove();
+      expect(this.view.$('.js-button').length).toBe(1);
+      expect(this.view.$('.js-button').text()).toContain('pepe');
     });
 
     it('should render custom placeholder if provided', function () {
-      var view = this.createView({
+      this.view = this.createView({
         placeholder: 'quinoa',
         keyAttr: 'latitude'
       });
 
-      expect(view.$('.js-button').length).toBe(1);
-      expect(view.$('.js-button').text()).toContain('quinoa');
-
-      view.remove();
+      expect(this.view.$('.js-button').length).toBe(1);
+      expect(this.view.$('.js-button').text()).toContain('quinoa');
     });
 
     it('should pass searchPlaceholder to CustomListView if present', function () {
       var text = 'Search Machine';
-      var view = this.createView({
+      this.view = this.createView({
         searchPlaceholder: text
       });
 
-      expect(view._listView.options.searchPlaceholder).toEqual(text);
-
-      view.remove();
+      expect(this.view._listView.options.searchPlaceholder).toEqual(text);
     });
 
     it('should disable the component if option is true', function () {
-      var view = this.createView();
+      this.view = this.createView();
 
-      view.options.disabled = true;
-      view.render();
-      expect(view.$('.js-button').hasClass('is-disabled')).toBeTruthy();
-
-      view.remove();
+      this.view.options.disabled = true;
+      this.view.render();
+      expect(this.view.$('.js-button').hasClass('is-disabled')).toBeTruthy();
     });
 
     it('should add is-empty class if there is no value selected', function () {
-      var view = this.createView();
+      this.view = this.createView();
 
-      view.model.set({names: ''});
-      view.setValue('');
+      this.view.model.set({names: ''});
+      this.view.setValue('');
 
-      expect(view.$('.js-button').hasClass('is-empty')).toBeTruthy();
-
-      view.remove();
+      expect(this.view.$('.js-button').hasClass('is-empty')).toBeTruthy();
     });
   });
 
@@ -152,27 +170,20 @@ describe('components/form-components/editors/select', function () {
   });
 
   it('should change button value and hide list when a new item is selected', function () {
-    var view = this.createView();
-    spyOn(view._listView, 'hide');
-    var mdl = view.collection.where({ val: 'juan' });
+    this.view = this.createView();
+    spyOn(this.view._listView, 'hide');
+    var mdl = this.view.searchCollection.where({ val: 'carto' });
     mdl[0].set('selected', true);
-    expect(view.$('.js-button').text()).toContain('juan');
-    expect(view.$('.js-button').hasClass('is-empty')).toBeFalsy();
-    expect(view._listView.hide).toHaveBeenCalled();
+    expect(this.view.$('.js-button').text()).toContain('carto');
+    expect(this.view.$('.js-button').hasClass('is-empty')).toBeFalsy();
+    expect(this.view._listView.hide).toHaveBeenCalled();
   });
 
   it('should open list view if "button" is clicked', function () {
-    var view = this.createView();
-    spyOn(view._listView, 'toggle');
-    view.$('.js-button').trigger('click');
-    expect(view._listView.toggle).toHaveBeenCalled();
-  });
-
-  it('should destroy custom list when element is removed', function () {
-    var view = this.createView();
-    spyOn(view._listView, 'clean');
-    view.remove();
-    expect(view._listView.clean).toHaveBeenCalled();
+    this.view = this.createView();
+    spyOn(this.view._listView, 'toggle');
+    this.view.$('.js-button').trigger('click');
+    expect(this.view._listView.toggle).toHaveBeenCalled();
   });
 
   describe('placeholder', function () {
@@ -188,16 +199,6 @@ describe('components/form-components/editors/select', function () {
       expect(placeholder).toBe('components.backbone-forms.select.empty');
     });
 
-    it('disabled and no value', function () {
-      this.view = this.createView({
-        keyAttr: 'latitude',
-        disabled: true
-      });
-
-      var placeholder = $.trim(this.view.$('.js-button').text());
-      expect(placeholder).toBe('components.backbone-forms.select.disabled-placeholder');
-    });
-
     it('no value', function () {
       this.view = this.createView({
         keyAttr: 'latitude'
@@ -205,47 +206,6 @@ describe('components/form-components/editors/select', function () {
 
       var placeholder = $.trim(this.view.$('.js-button').text());
       expect(placeholder).toBe('components.backbone-forms.select.placeholder');
-    });
-  });
-
-  describe('async collection', function () {
-    beforeEach(function () {
-      var collection = new CustomListCollection();
-      collection.stateModel = new Backbone.Model({
-        state: 'fetching'
-      });
-
-      collection.isAsync = function () { return true; };
-
-      this.view = this.createView({
-        schema: {
-          collection: collection
-        }
-      });
-    });
-
-    it('should show loading if collection is fetching', function () {
-      expect(this.view.$('.js-button .CDB-LoaderIcon').length).toBe(1);
-    });
-
-    it('should show list once collection is fetched', function () {
-      this.view.collection.reset([{
-        label: 'pepe',
-        val: 'pepe'
-      }, {
-        label: 'paco',
-        val: 'paco'
-      }, {
-        label: 'juan',
-        val: 'juan'
-      }]);
-
-      this.view.collection.stateModel.set({
-        state: 'fetched'
-      });
-
-      expect(this.view.$('.CustomList--inner').length).toBe(1);
-      expect(this.view.$('.js-button').text()).toContain('pepe');
     });
   });
 });

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/select/select-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/select/select-view.spec.js
@@ -1,0 +1,251 @@
+var $ = require('jquery');
+var Backbone = require('backbone');
+var _ = require('underscore');
+var CustomListCollection = require('../../../../../../../javascripts/cartodb3/components/custom-list/custom-list-collection');
+
+describe('components/form-components/editors/select', function () {
+  var dispatchDocumentEvent = function (type, opts) {
+    var e = document.createEvent('HTMLEvents');
+    e.initEvent(type, false, true);
+    if (opts.which) {
+      e.which = opts.which;
+    }
+    document.dispatchEvent(e, opts);
+  };
+
+  var createViewFn = function (options) {
+    var model = new Backbone.Model({
+      names: 'pepe',
+      latitude: undefined
+    });
+
+    var defaultOptions = {
+      key: 'names',
+      schema: {
+        options: ['pepe', 'paco', 'juan']
+      },
+      model: model
+    };
+
+    var view = new Backbone.Form.editors.Select(_.extend(defaultOptions, options));
+
+    view.render();
+
+    return view;
+  };
+
+  beforeEach(function () {
+    this.createView = createViewFn.bind(this);
+  });
+
+  afterEach(function () {
+    this.view && this.view.remove();
+  });
+
+  it('should genereate an options collection', function () {
+    var view = this.createView();
+
+    expect(view.collection).toBeDefined();
+    expect(view.collection.size()).toBe(3);
+
+    view.remove();
+  });
+
+  describe('render', function () {
+    it('should render properly', function () {
+      var view = this.createView();
+
+      expect(view.$('.js-button').length).toBe(1);
+      expect(view.$('.js-button').text()).toContain('pepe');
+
+      view.remove();
+    });
+
+    it('should render custom placeholder if provided', function () {
+      var view = this.createView({
+        placeholder: 'quinoa',
+        keyAttr: 'latitude'
+      });
+
+      expect(view.$('.js-button').length).toBe(1);
+      expect(view.$('.js-button').text()).toContain('quinoa');
+
+      view.remove();
+    });
+
+    it('should pass searchPlaceholder to CustomListView if present', function () {
+      var text = 'Search Machine';
+      var view = this.createView({
+        searchPlaceholder: text
+      });
+
+      expect(view._listView.options.searchPlaceholder).toEqual(text);
+
+      view.remove();
+    });
+
+    it('should disable the component if option is true', function () {
+      var view = this.createView();
+
+      view.options.disabled = true;
+      view.render();
+      expect(view.$('.js-button').hasClass('is-disabled')).toBeTruthy();
+
+      view.remove();
+    });
+
+    it('should add is-empty class if there is no value selected', function () {
+      var view = this.createView();
+
+      view.model.set({names: ''});
+      view.setValue('');
+
+      expect(view.$('.js-button').hasClass('is-empty')).toBeTruthy();
+
+      view.remove();
+    });
+  });
+
+  describe('bindings', function () {
+    beforeEach(function () {
+      this.view = this.createView();
+      spyOn(this.view._listView, 'hide');
+    });
+
+    it('should close list view if ESC is pressed', function () {
+      dispatchDocumentEvent('keydown', { which: 27 });
+      expect(this.view._listView.hide).toHaveBeenCalled();
+    });
+
+    it('should close list view if user clicks out the select', function () {
+      dispatchDocumentEvent('click', { target: 'body' });
+      expect(this.view._listView.hide).toHaveBeenCalled();
+    });
+
+    afterEach(function () {
+      this.view.remove();
+    });
+  });
+
+  describe('on ENTER pressed', function () {
+    beforeEach(function () {
+      this.view = this.createView();
+      spyOn(this.view._listView, 'toggle');
+      this._event = $.Event('keydown');
+      this._event.which = 13;
+    });
+
+    it('should open custom list', function () {
+      this.view.$('.js-button').trigger(this._event);
+      expect(this.view._listView.toggle).toHaveBeenCalled();
+    });
+
+    it('should not open custom list if it is already visible', function () {
+      this.view._listView.show();
+      this.view.$('.js-button').trigger(this._event);
+      expect(this.view._listView.toggle).not.toHaveBeenCalled();
+    });
+
+    afterEach(function () {
+      this.view.remove();
+    });
+  });
+
+  it('should change button value and hide list when a new item is selected', function () {
+    var view = this.createView();
+    spyOn(view._listView, 'hide');
+    var mdl = view.collection.where({ val: 'juan' });
+    mdl[0].set('selected', true);
+    expect(view.$('.js-button').text()).toContain('juan');
+    expect(view.$('.js-button').hasClass('is-empty')).toBeFalsy();
+    expect(view._listView.hide).toHaveBeenCalled();
+  });
+
+  it('should open list view if "button" is clicked', function () {
+    var view = this.createView();
+    spyOn(view._listView, 'toggle');
+    view.$('.js-button').trigger('click');
+    expect(view._listView.toggle).toHaveBeenCalled();
+  });
+
+  it('should destroy custom list when element is removed', function () {
+    var view = this.createView();
+    spyOn(view._listView, 'clean');
+    view.remove();
+    expect(view._listView.clean).toHaveBeenCalled();
+  });
+
+  describe('placeholder', function () {
+    it('empty and no value', function () {
+      this.view = this.createView({
+        keyAttr: 'latitude',
+        schema: {
+          options: []
+        }
+      });
+
+      var placeholder = $.trim(this.view.$('.js-button').text());
+      expect(placeholder).toBe('components.backbone-forms.select.empty');
+    });
+
+    it('disabled and no value', function () {
+      this.view = this.createView({
+        keyAttr: 'latitude',
+        disabled: true
+      });
+
+      var placeholder = $.trim(this.view.$('.js-button').text());
+      expect(placeholder).toBe('components.backbone-forms.select.disabled-placeholder');
+    });
+
+    it('no value', function () {
+      this.view = this.createView({
+        keyAttr: 'latitude'
+      });
+
+      var placeholder = $.trim(this.view.$('.js-button').text());
+      expect(placeholder).toBe('components.backbone-forms.select.placeholder');
+    });
+  });
+
+  describe('async collection', function () {
+    beforeEach(function () {
+      var collection = new CustomListCollection();
+      collection.stateModel = new Backbone.Model({
+        state: 'fetching'
+      });
+
+      collection.isAsync = function () { return true; };
+
+      this.view = this.createView({
+        schema: {
+          collection: collection
+        }
+      });
+    });
+
+    it('should show loading if collection is fetching', function () {
+      expect(this.view.$('.js-button .CDB-LoaderIcon').length).toBe(1);
+    });
+
+    it('should show list once collection is fetched', function () {
+      this.view.collection.reset([{
+        label: 'pepe',
+        val: 'pepe'
+      }, {
+        label: 'paco',
+        val: 'paco'
+      }, {
+        label: 'juan',
+        val: 'juan'
+      }]);
+
+      this.view.collection.stateModel.set({
+        state: 'fetched'
+      });
+
+      expect(this.view.$('.CustomList--inner').length).toBe(1);
+      expect(this.view.$('.js-button').text()).toContain('pepe');
+    });
+  });
+});

--- a/lib/assets/core/test/spec/cartodb3/components/form-components/editors/track-class.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/form-components/editors/track-class.spec.js
@@ -60,6 +60,23 @@ var OPTIONS_BY_TYPE = {
     }),
     nodeDefModel: {},
     region: 'wadus'
+  },
+  'LazySelect': {
+    configModel: new Backbone.Model({
+      base_url: '/u/foo',
+      user_name: 'foo',
+      sql_api_template: 'foo',
+      api_key: 'foo'
+    }),
+    nodeDefModel: {
+      querySchemaModel: new Backbone.Model({
+        query: ''
+      })
+    },
+    column: 'foo',
+    model: new Backbone.Model({
+      foo: 'bar'
+    })
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.88",
+  "version": "4.9.88-952",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.92",
+  "version": "4.9.92-952",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes https://github.com/CartoDB/support/issues/952.

A new lazy select component to manage the 40 rows per page request's limitation has been created. Basically, when the user fills the search input, a new request is made to grab all items that match with the value filled.

![lazy-select](https://user-images.githubusercontent.com/1366843/30645791-1c249932-9e17-11e7-80f4-4b30e6520743.gif)

In order to make the acceptance, create a filter analysis with a string column:
- [ ] Check that the select works properly. It mainly covers the same functionality that a [select.
- [ ] Check that the searching works properly.
- [ ] No request returns more than 40 rows.
- [ ] it's important to check if the analysis itself works properly with this change. 

cc @noguerol @ramiroaznar 