### PR TITLE
Don't export logo if it's disable in map settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,8 +54,9 @@ Development
 * Remove data-observatory-multiple-measures feature flag (#304)
 
 ### Bug fixes / enhancements
+* Fix image export when logo is disabled.
 * Fix infowindow break word (CartoDB/support#965)
-* Update cartodb.js version 
+* Update cartodb.js version
 * Fix extraneous labels layer.
 * Fix timeseries glitches (#12217)
 * Rename 'Select a text' placeholder to 'Select a value' in Filter analysis (#11861)

--- a/lib/assets/core/javascripts/cartodb3/data/map-settings.js
+++ b/lib/assets/core/javascripts/cartodb3/data/map-settings.js
@@ -7,48 +7,48 @@ module.exports = function (overlaysCollection, mapDefModel, userModel) {
     label: _t('editor.settings.preview.options.elements.search'),
     related: 'overlays',
     disabled: false,
-    active: overlays.indexOf('search') > 0
+    enabler: overlays.indexOf('search') > 0
   },
   {
     setting: 'zoom',
     label: _t('editor.settings.preview.options.elements.zoom'),
     related: 'overlays',
     disabled: false,
-    active: overlays.indexOf('zoom') > 0
+    enabler: overlays.indexOf('zoom') > 0
   },
   {
     setting: 'logo',
     label: _t('editor.settings.preview.options.elements.logo'),
     related: 'overlays',
     disabled: !canRemoveLogo,
-    active: overlays.indexOf('logo') > 0
+    enabler: overlays.indexOf('logo') > 0
   },
   {
     setting: 'legends',
     label: _t('editor.settings.preview.options.elements.legends'),
     related: 'map',
     disabled: false,
-    active: mapDefModel.get('legends') === true
+    enabler: mapDefModel.get('legends') === true
   },
   {
     setting: 'layer_selector',
     label: _t('editor.settings.preview.options.elements.layer_selector'),
     related: 'map',
     disabled: false,
-    active: mapDefModel.get('layer_selector') === true
+    enabler: mapDefModel.get('layer_selector') === true
   },
   {
     setting: 'dashboard_menu',
     label: _t('editor.settings.preview.options.elements.dashboard_menu'),
     related: 'map',
     disabled: false,
-    active: mapDefModel.get('dashboard_menu') === true
+    enabler: mapDefModel.get('dashboard_menu') === true
   },
   {
     setting: 'scrollwheel',
     label: _t('editor.settings.preview.options.elements.scrollwheel'),
     related: 'map',
     disabled: false,
-    active: mapDefModel.get('scrollwheel') === true
+    enabler: mapDefModel.get('scrollwheel') === true
   }];
 };

--- a/lib/assets/core/javascripts/cartodb3/editor.js
+++ b/lib/assets/core/javascripts/cartodb3/editor.js
@@ -355,6 +355,8 @@ if (visDefinitionModel.get('version') === 2 && modals) {
   mapCreation();
 }
 
+var settingsCollection = new Backbone.Collection(SettingsOptions(overlaysCollection, mapDefModel, userModel));
+
 var editorTabPaneView = createEditorMenuTabPane([
   {
     icon: 'pencilMenu',
@@ -380,7 +382,8 @@ var editorTabPaneView = createEditorMenuTabPane([
         legendDefinitionsCollection: legendDefinitionsCollection,
         mapModeModel: mapModeModel,
         stateDefinitionModel: stateDefModel,
-        onboardingNotification: onboardingNotification
+        onboardingNotification: onboardingNotification,
+        settingsCollection: settingsCollection
       });
     }
   }, {
@@ -397,7 +400,7 @@ var editorTabPaneView = createEditorMenuTabPane([
         userModel: userModel,
         modals: modals,
         editorModel: editorModel,
-        settingsCollection: new Backbone.Collection(SettingsOptions(overlaysCollection, mapDefModel, userModel)),
+        settingsCollection: settingsCollection,
         stateDefinitionModel: stateDefModel
       });
     }
@@ -457,3 +460,4 @@ window.mapDefModel = mapDefModel;
 window.overlaysCollection = overlaysCollection;
 window.mapcapsCollection = mapcapsCollection;
 window.stateDefModel = stateDefModel;
+window.settingsCollection = settingsCollection;

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-map-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-map-view.js
@@ -30,7 +30,8 @@ var REQUIRED_OPTS = [
   'mapDefinitionModel',
   'mapModeModel',
   'stateDefinitionModel',
-  'onboardingNotification'
+  'onboardingNotification',
+  'settingsCollection'
 ];
 
 module.exports = CoreView.extend({
@@ -72,7 +73,8 @@ module.exports = CoreView.extend({
           mapStackLayoutModel: stackLayoutModel,
           selectedTabItem: selectedTabItem,
           mapModeModel: self._mapModeModel,
-          stateDefinitionModel: self._stateDefinitionModel
+          stateDefinitionModel: self._stateDefinitionModel,
+          settingsCollection: self._settingsCollection
         });
       }
     }, {

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-settings-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-settings-view.js
@@ -17,7 +17,8 @@ var REQUIRED_OPTS = [
   'settingsCollection',
   'visDefinitionModel',
   'userModel',
-  'stateDefinitionModel'
+  'stateDefinitionModel',
+  'settingsCollection'
 ];
 
 module.exports = CoreView.extend({
@@ -92,7 +93,8 @@ module.exports = CoreView.extend({
       visDefinitionModel: this._visDefinitionModel,
       stateDefinitionModel: this._stateDefinitionModel,
       mapDefinitionModel: this._mapDefinitionModel,
-      editorModel: this._editorModel
+      editorModel: this._editorModel,
+      settingsCollection: this._settingsCollection
     });
 
     return view;

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-view.js
@@ -21,7 +21,8 @@ var REQUIRED_OPTS = [
   'visDefinitionModel',
   'mapStackLayoutModel',
   'stateDefinitionModel',
-  'selectedTabItem'
+  'selectedTabItem',
+  'settingsCollection'
 ];
 
 module.exports = CoreView.extend({
@@ -99,7 +100,8 @@ module.exports = CoreView.extend({
       userModel: this._userModel,
       mapDefinitionModel: this._mapDefinitionModel,
       stateDefinitionModel: this._stateDefinitionModel,
-      editorModel: this._editorModel
+      editorModel: this._editorModel,
+      settingsCollection: this._settingsCollection
     });
 
     return view;

--- a/lib/assets/core/javascripts/cartodb3/editor/export-image-pane/export-image-pane.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/export-image-pane/export-image-pane.js
@@ -38,7 +38,8 @@ var REQUIRED_OPTS = [
   'visDefinitionModel',
   'stateDefinitionModel',
   'mapDefinitionModel',
-  'editorModel'
+  'editorModel',
+  'settingsCollection'
 ];
 
 module.exports = CoreView.extend({
@@ -69,6 +70,22 @@ module.exports = CoreView.extend({
       width: width,
       height: height
     });
+  },
+
+  _isLogoActive: function () {
+    var canRemoveLogo = this._userModel.get('actions').remove_logo;
+    var logoSetting = this._settingsCollection.findWhere({
+      setting: 'logo'
+    });
+
+    var isLogoActive = logoSetting && logoSetting.get('enabler') || false;
+    if (!canRemoveLogo || canRemoveLogo && isLogoActive) {
+      return true;
+    }
+
+    if (canRemoveLogo && !isLogoActive) {
+      return false;
+    }
   },
 
   _addErrorNotification: function (error) {
@@ -283,7 +300,10 @@ module.exports = CoreView.extend({
 
       ctx.drawImage(this, 0, 0);
 
-      self._drawLogo(ctx, width, height);
+      if (self._isLogoActive()) {
+        self._drawLogo(ctx, width, height);
+      }
+
       self._drawAttribution(ctx, width, height);
 
       callback(canvas);
@@ -379,15 +399,18 @@ module.exports = CoreView.extend({
     var deferred = $.Deferred();
     var logoUrl = this._configModel.get('app_assets_base_url') + LOGO_PATH;
 
-    this._getImageFromUrl(logoUrl)
-      .then(function (image) {
-        self._logo = image;
-        deferred.resolve();
-      })
-      .fail(function () {
-        deferred.reject(_t('editor.maps.export-image.errors.error-image'));
-      });
-
+    if (this._isLogoActive()) {
+      this._getImageFromUrl(logoUrl)
+        .then(function (image) {
+          self._logo = image;
+          deferred.resolve();
+        })
+        .fail(function () {
+          deferred.reject(_t('editor.maps.export-image.errors.error-image'));
+        });
+    } else {
+      deferred.resolve();
+    }
     return deferred.promise();
   },
 

--- a/lib/assets/core/javascripts/cartodb3/editor/settings/preview/preview-options-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/settings/preview/preview-options-item-view.js
@@ -16,7 +16,7 @@ module.exports = CoreView.extend({
     }, this);
 
     // For enabler compatibility
-    this.model.set(this.model.get('setting'), this.model.get('active'), {silent: true});
+    this.model.set(this.model.get('setting'), this.model.get('enabler'), {silent: true});
   },
 
   render: function () {

--- a/lib/assets/core/test/spec/cartodb3/components/export-image-pane/export-image-pane.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/export-image-pane/export-image-pane.spec.js
@@ -24,6 +24,14 @@ describe('editor/export-image-pane/export-image-pane', function () {
       title: 'wadus'
     };
 
+    this.settingsCollection = new Backbone.Collection([{
+      setting: 'logo',
+      label: _t('editor.settings.options.logo'),
+      enabled: true,
+      default: false,
+      enabler: false
+    }]);
+
     this.getStaticImageURL = jasmine.createSpy('getStaticImageURL');
 
     this.visDefinitionModel = new Backbone.Model({
@@ -44,6 +52,10 @@ describe('editor/export-image-pane/export-image-pane', function () {
       google_maps_api_key: '123456'
     }, {
       configModel: this._configModel
+    });
+
+    this._userModel.set('actions', {
+      remove_logo: false
     });
 
     this.mapDefinitionModel = new MapDefinitionModel({
@@ -83,7 +95,8 @@ describe('editor/export-image-pane/export-image-pane', function () {
       mapStackLayoutModel: new Backbone.Model(),
       stateDefinitionModel: new Backbone.Model(),
       visDefinitionModel: this.visDefinitionModel,
-      mapDefinitionModel: this.mapDefinitionModel
+      mapDefinitionModel: this.mapDefinitionModel,
+      settingsCollection: this.settingsCollection
     });
 
     // mocks
@@ -221,7 +234,8 @@ describe('editor/export-image-pane/export-image-pane', function () {
         mapStackLayoutModel: new Backbone.Model(),
         stateDefinitionModel: new Backbone.Model(),
         visDefinitionModel: this.visDefinitionModel,
-        mapDefinitionModel: this.mapDefinitionModel
+        mapDefinitionModel: this.mapDefinitionModel,
+        settingsCollection: this.settingsCollection
       });
 
       // mocks
@@ -331,7 +345,8 @@ describe('editor/export-image-pane/export-image-pane', function () {
         mapStackLayoutModel: new Backbone.Model(),
         stateDefinitionModel: new Backbone.Model(),
         visDefinitionModel: this.visDefinitionModel,
-        mapDefinitionModel: this.mapDefinitionModel
+        mapDefinitionModel: this.mapDefinitionModel,
+        settingsCollection: this.settingsCollection
       });
 
       // mocks

--- a/lib/assets/core/test/spec/cartodb3/components/export-image-pane/export-image-pane.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/export-image-pane/export-image-pane.spec.js
@@ -190,6 +190,35 @@ describe('editor/export-image-pane/export-image-pane', function () {
     });
   });
 
+  describe('disabled logo', function () {
+    beforeEach(function () {
+      spyOn(this.view, '_getImageFromUrl').and.callThrough();
+    });
+
+    it('can\'t remove logo', function () {
+      this._userModel.get('actions').remove_logo = false;
+
+      this.view.$('.js-ok').click();
+      expect(this.view._getImageFromUrl).toHaveBeenCalled();
+    });
+
+    it('can remove logo and logo is active', function () {
+      this._userModel.get('actions').remove_logo = true;
+      this.settingsCollection.at(0).set('enabler', true);
+
+      this.view.$('.js-ok').click();
+      expect(this.view._getImageFromUrl).toHaveBeenCalled();
+    });
+
+    it('can remove logo and logo is not active', function () {
+      this._userModel.get('actions').remove_logo = true;
+      this.settingsCollection.at(0).set('enabler', false);
+
+      this.view.$('.js-ok').click();
+      expect(this.view._getImageFromUrl).not.toHaveBeenCalled();
+    });
+  });
+
   describe('_validGMapDimension', function () {
     it('should return false if dimension is bigger than limit', function () {
       this.view._exportImageFormView._formView.fields.width.setValue(641);

--- a/lib/assets/core/test/spec/cartodb3/editor/editor-map-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/editor-map-view.spec.js
@@ -155,7 +155,8 @@ describe('editor/editor-map-view', function () {
       legendDefinitionsCollection: new Backbone.Collection(),
       mapModeModel: this.mapModeModel,
       stateDefinitionModel: new Backbone.Model(),
-      onboardingNotification: {}
+      onboardingNotification: {},
+      settingsCollection: new Backbone.Collection()
     });
 
     Notifier.init({

--- a/lib/assets/core/test/spec/cartodb3/editor/editor-settings-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/editor-settings-view.spec.js
@@ -29,25 +29,25 @@ describe('editor/editor-settings-view', function () {
       label: _t('editor.settings.options.title'),
       enabled: true,
       default: false,
-      active: false
+      enabler: false
     }, {
       setting: 'description',
       label: _t('editor.settings.options.description'),
       enabled: true,
       default: false,
-      active: false
+      enabler: false
     }, {
       setting: 'search',
       label: _t('editor.settings.options.search'),
       enabled: true,
       default: false,
-      active: true
+      enabler: true
     }, {
       setting: 'zoom',
       label: _t('editor.settings.options.zoom'),
       enabled: true,
       default: true,
-      active: true
+      enabler: true
     }]);
 
     var privacyCollection = new PrivacyCollection([{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.88",
+  "version": "4.9.88-987",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes https://github.com/CartoDB/support/issues/987.

It avoids the logo inclusion in the export image if the logo is disabled in the map settings.