### PR TITLE
Some css love for ie11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,8 +54,9 @@ Development
 * Remove data-observatory-multiple-measures feature flag (#304)
 
 ### Bug fixes / enhancements
+* Fix some styles for datasets view for IE11.
 * Fix infowindow break word (CartoDB/support#965)
-* Update cartodb.js version 
+* Update cartodb.js version
 * Fix extraneous labels layer.
 * Fix timeseries glitches (#12217)
 * Rename 'Select a text' placeholder to 'Select a value' in Filter analysis (#11861)

--- a/app/assets/stylesheets/editor-3/_editor.scss
+++ b/app/assets/stylesheets/editor-3/_editor.scss
@@ -49,7 +49,7 @@
 }
 .Editor-content {
   @include display-flex();
-  @include flex(1);
+  @include flex(1 1 auto);
   @include flex-direction(column);
   position: relative;
   min-height: 0;

--- a/app/assets/stylesheets/editor-3/_header.scss
+++ b/app/assets/stylesheets/editor-3/_header.scss
@@ -64,7 +64,7 @@
 .Editor-HeaderInfo-details {
   @include display-flex();
   @include align-items(center);
-  @include flex(0 1 100%);
+  @include flex(999);
 }
 .Editor-HeaderInfo-actions {
   @include display-flex();

--- a/app/assets/stylesheets/editor-3/_header.scss
+++ b/app/assets/stylesheets/editor-3/_header.scss
@@ -52,13 +52,14 @@
   @include align-items(center);
 }
 .Editor-HeaderInfo-titleText {
-  @include flex(1);
+  @include flex(1 0 auto);
   display: block;
   width: 0;
   margin-right: 20px;
 
   &.is-larger {
     width: auto;
+    min-width: 40px;
   }
 }
 .Editor-HeaderInfo-details {

--- a/app/assets/stylesheets/editor-3/_inline-editor.scss
+++ b/app/assets/stylesheets/editor-3/_inline-editor.scss
@@ -3,26 +3,23 @@
 @import 'cdb-variables/colors';
 
 .Inline-editor {
-  @include display-flex();
   position: relative;
+  min-width: 0;
 }
 
 .Inline-editor-input {
   display: none;
   position: absolute;
+  top: 0;
   left: 0;
   padding: 10px 8px;
   z-index: 1;
 }
 
 .Inline-editor-text {
-  @include flex(1);
-  width: 0;
 
-  &.is-larger {
-    width: auto;
-  }
 }
+
 .Inline-editor-text.is-hidden {
   opacity: 0.24;
 }

--- a/app/assets/stylesheets/editor-3/_layers-list.scss
+++ b/app/assets/stylesheets/editor-3/_layers-list.scss
@@ -150,7 +150,7 @@
 }
 
 .Editor-ListLayer-titleText {
-  @include flex(1);
+  @include flex(1 0 auto);
   width: 0;
   padding-right: $baseSize * 2;
 }

--- a/app/assets/stylesheets/editor-3/_tab-pane.scss
+++ b/app/assets/stylesheets/editor-3/_tab-pane.scss
@@ -3,7 +3,7 @@
 .Tab-pane,
 .Tab-paneContent {
   @include display-flex();
-  @include flex(1);
+  @include flex(1 1 auto);
   @include flex-direction(column);
   min-height: 0;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.88",
+  "version": "4.9.88-874",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes https://github.com/CartoDB/support/issues/874.

In order to accept it:
- [x] Check that advance editor in dataset view is properly rendered, when the editor is open and closed.
- [x] Check that buttons are vertical aligned correctly.
- [x] Check that dataset title is shown properly and the rename action works fine.

Although these changes are focused in IE, it would be great to check the above in the rest of the browsers.