### PR TITLE
vizjson3 updated_at should be taken from the viz

### DIFF
--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -93,7 +93,7 @@ module Carto
           map_provider:   map.provider,
           overlays:       overlays_vizjson(@visualization),
           title:          @visualization.qualified_name(user),
-          updated_at:     map.viz_updated_at,
+          updated_at:     @visualization.updated_at,
           user:           user_info_vizjson(user),
           version:        VIZJSON_VERSION,
           widgets:        widgets_vizjson,


### PR DESCRIPTION
This fixes CartoDB/deep-insights.js/issues/592.

This change is caused by CartoDB/deep-insights.js/issues/592.
The problem is that the in-memory visualization doesn't have mapcaps (as
it's a mapcap itself), so Map#viz_updated_at will try to get the date
with get_the_last_time_tiles_have_changed_to_render_it_in_vizjsons,
which is nil because the visualization is a mapcap.

viz_updated_at currently first try to get the date from the mapcap, so
we could say that updated_at is essentially the one from the
visualization, unrelated to the tiles. As vizjson3 presenter receives
the mapcapped visualization, it shouldn't care of getting the mapcap, so
just getting the `updated_at` date from the visualization should be
fine.

I kept the old approach for the old vizjson, though.