### PR TITLE
Avoid configuration changes as side effects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -183,6 +183,7 @@ Development
 * Fix a problem with responsive in deep-insights.js
 * Fix 403 error in password protected embed maps (#12469)
 * Fixed JS error for InfoWindows/Pop-ups (cartodb.js#1703)
+* Freeze configuration hashes (#12586)
 * Lowered log level from error to info for supported cartocss in vector maps (cartodb.js#1706)
 * Histogram UI: Do not show "NULL ROWS" value if it is not received (#12477)
 * Force raster mode in datasets preview map (#12513)

--- a/app/model_factories/carto/layer_factory.rb
+++ b/app/model_factories/carto/layer_factory.rb
@@ -30,7 +30,7 @@ module Carto
       user = user_table.user
       geometry_type = user_table.geometry_type
 
-      data_layer = Carto::Layer.new(Cartodb.config[:layer_opts]['data'])
+      data_layer = Carto::Layer.new(Cartodb.config[:layer_opts]['data'].deep_dup)
       layer_options = data_layer.options
       layer_options['table_name'] = user_table.name
       layer_options['user_name'] = user.username

--- a/app/model_factories/layer_factory.rb
+++ b/app/model_factories/layer_factory.rb
@@ -25,7 +25,7 @@ module ModelFactories
     end
 
     def self.get_default_data_layer(table_name, user, geometry_type)
-      data_layer = ::Layer.new(Cartodb.config[:layer_opts]['data'])
+      data_layer = ::Layer.new(Cartodb.config[:layer_opts]['data'].deep_dup)
       data_layer.options['table_name'] = table_name
       data_layer.options['user_name'] = user.username
       data_layer.options['tile_style'] = tile_style(user, geometry_type)

--- a/app/models/carto/visualization_export.rb
+++ b/app/models/carto/visualization_export.rb
@@ -43,7 +43,7 @@ module Carto
 
       file = CartoDB::FileUploadFile.new(filepath)
 
-      s3_config = Cartodb.config[:exporter]['s3'] || {}
+      s3_config = Cartodb.config[:exporter]['s3'].deep_dup || {}
 
       plain_name = header_encode(file.original_filename.force_encoding('iso-8859-1'))
       utf_name = header_encode(file.original_filename)

--- a/config/initializers/01_app_config.rb
+++ b/config/initializers/01_app_config.rb
@@ -1,4 +1,5 @@
 require_dependency 'carto/configuration'
+require_dependency 'carto/deep_freeze'
 
 module Cartodb
   def self.get_config(*config_chain)
@@ -21,6 +22,7 @@ module Cartodb
       raise "Missing or inaccessible config/app_config.yml: #{e.message}"
     end
     @config ||= config_file_hash[Rails.env].try(:to_options!)
+    Carto.deep_freeze(@config)
 
     if @config.blank?
       raise "Can't find App configuration for #{Rails.env} environment on config/app_config.yml"

--- a/lib/carto/deep_freeze.rb
+++ b/lib/carto/deep_freeze.rb
@@ -1,7 +1,7 @@
 module Carto
-    def self.deep_freeze(obj)
-        obj.freeze
-        obj = obj.values if obj.respond_to?(:values)
-        obj.each { |e| Carto.deep_freeze(e) } if obj.respond_to?(:each)
-    end
+  def self.deep_freeze(obj)
+    obj.freeze
+    obj = obj.values if obj.respond_to?(:values)
+    obj.each { |e| Carto.deep_freeze(e) } if obj.respond_to?(:each)
+  end
 end

--- a/lib/carto/deep_freeze.rb
+++ b/lib/carto/deep_freeze.rb
@@ -1,0 +1,7 @@
+module Carto
+    def self.deep_freeze(obj)
+        obj.freeze
+        obj = obj.values if obj.respond_to?(:values)
+        obj.each { |e| Carto.deep_freeze(e) } if obj.respond_to?(:each)
+    end
+end

--- a/services/importer/spec/unit/connector_spec.rb
+++ b/services/importer/spec/unit/connector_spec.rb
@@ -87,7 +87,6 @@ end
 
 describe Carto::Connector do
   before(:all) do
-    Cartodb.config[:connectors] = {}
     @user = create_user
     @user.save
     @fake_log = CartoDB::Importer2::Doubles::Log.new(@user)
@@ -99,6 +98,10 @@ describe Carto::Connector do
   before(:each) do
     CartoDB::Stats::Aggregator.stubs(:read_config).returns({})
     @executed_commands = []
+  end
+
+  around(:each) do |example|
+    Cartodb.with_config(connectors: {}, &example)
   end
 
   after(:all) do

--- a/services/user-mover/spec/user_mover_spec.rb
+++ b/services/user-mover/spec/user_mover_spec.rb
@@ -118,7 +118,9 @@ describe CartoDB::DataMover::ExportJob do
   it "should move a whole organization" do
     port = find_available_port
     run_test_server(port)
-    Cartodb.with_config(org_metadata_api: { 'host' => '127.0.0.1', 'port' => port }) do
+
+    test_config = Cartodb.get_config(:org_metadata_api).merge('host' => '127.0.0.1', 'port' => port)
+    Cartodb.with_config(org_metadata_api: test_config) do
       org = create_user_mover_test_organization
       user = create_user(
         quota_in_bytes: 100.megabyte, table_quota: 400, organization: org

--- a/services/user-mover/spec/user_mover_spec.rb
+++ b/services/user-mover/spec/user_mover_spec.rb
@@ -118,45 +118,44 @@ describe CartoDB::DataMover::ExportJob do
   it "should move a whole organization" do
     port = find_available_port
     run_test_server(port)
-    Cartodb.config[:org_metadata_api]['port'] = port
-    Cartodb.config[:org_metadata_api]['host'] = '127.0.0.1'
+    Cartodb.with_config(org_metadata_api: { 'host' => '127.0.0.1', 'port' => port }) do
+      org = create_user_mover_test_organization
+      user = create_user(
+        quota_in_bytes: 100.megabyte, table_quota: 400, organization: org
+      )
+      user.save
+      org.reload
 
-    org = create_user_mover_test_organization
-    user = create_user(
-      quota_in_bytes: 100.megabyte, table_quota: 400, organization: org
-    )
-    user.save
-    org.reload
+      create_tables(org.owner)
+      share_tables(org.owner, user)
+      share_tables(user, org.owner)
+      create_tables(user)
 
-    create_tables(org.owner)
-    share_tables(org.owner, user)
-    share_tables(user, org.owner)
-    create_tables(user)
+      carto_org = Carto::Organization.find(org.id)
+      group_1 = carto_org.create_group(String.random(5))
+      group_2 = carto_org.create_group(String.random(5))
 
-    carto_org = Carto::Organization.find(org.id)
-    group_1 = carto_org.create_group(String.random(5))
-    group_2 = carto_org.create_group(String.random(5))
+      group_1.add_user(org.owner.username)
+      group_2.add_user(org.owner.username)
+      group_1.add_user(user.username)
+      group_2.add_user(user.username)
 
-    group_1.add_user(org.owner.username)
-    group_2.add_user(org.owner.username)
-    group_1.add_user(user.username)
-    group_2.add_user(user.username)
+      share_group_tables(org.owner, group_1)
+      share_group_tables(user, group_2)
 
-    share_group_tables(org.owner, group_1)
-    share_group_tables(user, group_2)
+      CartoDB::DataMover::ExportJob.new(organization_name: org.name, path: @tmp_path, split_user_schemas: false)
+      CartoDB::UserModule::DBService.terminate_database_connections(org.owner.database_name, org.owner.database_host)
+      CartoDB::DataMover::ImportJob.new(file: @tmp_path + "org_#{org.id}.json", mode: :rollback, drop_database: true, drop_roles: true).run!
+      CartoDB::DataMover::ImportJob.new(file: @tmp_path + "org_#{org.id}.json", mode: :import, host: '127.0.0.2').run!
 
-    CartoDB::DataMover::ExportJob.new(organization_name: org.name, path: @tmp_path, split_user_schemas: false)
-    CartoDB::UserModule::DBService.terminate_database_connections(org.owner.database_name, org.owner.database_host)
-    CartoDB::DataMover::ImportJob.new(file: @tmp_path + "org_#{org.id}.json", mode: :rollback, drop_database: true, drop_roles: true).run!
-    CartoDB::DataMover::ImportJob.new(file: @tmp_path + "org_#{org.id}.json", mode: :import, host: '127.0.0.2').run!
-
-    moved_user = ::User.find(username: user.username)
-    moved_user.reload
-    moved_user.database_host.should eq '127.0.0.2'
-    Carto::GhostTablesManager.new(moved_user.id).link_ghost_tables_synchronously
-    check_tables(moved_user)
-    moved_user.in_database['SELECT * FROM cdb_tablemetadata']
-    moved_user.organization_id.should_not eq nil
+      moved_user = ::User.find(username: user.username)
+      moved_user.reload
+      moved_user.database_host.should eq '127.0.0.2'
+      Carto::GhostTablesManager.new(moved_user.id).link_ghost_tables_synchronously
+      check_tables(moved_user)
+      moved_user.in_database['SELECT * FROM cdb_tablemetadata']
+      moved_user.organization_id.should_not eq nil
+    end
 
     @server_thread.terminate
   end

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -227,34 +227,33 @@ describe DataImport do
   end
 
   it 'should know that the import is from common data' do
-     Cartodb.config[:common_data] = {}
-    Cartodb.config[:common_data]['username'] = 'mycommondata'
-    Cartodb.config[:common_data]['host'] = 'cartodb.wadus.com'
-    data_import = DataImport.create(
-      user_id: @user.id,
-      data_source: "http://mycommondata.cartodb.wadus.com/foo.csv"
-    )
-    data_import.from_common_data?.should eq true
+    Cartodb.with_config(common_data: { 'username' => 'mycommondata', 'host' => 'cartodb.wadus.com' }) do
+      data_import = DataImport.create(
+        user_id: @user.id,
+        data_source: "http://mycommondata.cartodb.wadus.com/foo.csv"
+      )
+      data_import.from_common_data?.should eq true
+    end
   end
 
   it 'should not consider a import as common data if common_data config does not exist' do
-    Cartodb.config.delete(:common_data)
-    data_import = DataImport.create(
-      user_id: @user.id,
-      data_source: "http://mycommondata.cartodb.wadus.com/foo.csv"
-    )
-    data_import.from_common_data?.should eq false
+    Cartodb.with_config(common_data: nil) do
+      data_import = DataImport.create(
+        user_id: @user.id,
+        data_source: "http://mycommondata.cartodb.wadus.com/foo.csv"
+      )
+      data_import.from_common_data?.should eq false
+    end
   end
 
   it 'should not consider a import as common data if common_data config does not match with url' do
-    Cartodb.config[:common_data] = {}
-    Cartodb.config[:common_data]['username'] = 'mycommondata'
-    Cartodb.config[:common_data]['host'] = 'cartodb.wadus.com'
-    data_import = DataImport.create(
-      user_id: @user.id,
-      data_source: "http://mydatasource.cartodb.wadus.com/foo.csv"
-    )
-    data_import.from_common_data?.should eq false
+    Cartodb.with_config(common_data: { 'username' => 'mycommondata', 'host' => 'cartodb.wadus.com' }) do
+      data_import = DataImport.create(
+        user_id: @user.id,
+        data_source: "http://mydatasource.cartodb.wadus.com/foo.csv"
+      )
+      data_import.from_common_data?.should eq false
+    end
   end
 
   describe 'log' do

--- a/spec/models/synchronization/member_overviews_spec.rb
+++ b/spec/models/synchronization/member_overviews_spec.rb
@@ -23,7 +23,10 @@ describe Synchronization::Member do
 
     before(:each) do
       bypass_named_maps
-      Cartodb.config[:metrics] = {}
+    end
+
+    around(:each) do |example|
+      Cartodb.with_config(metrics: {}, &example)
     end
 
     after(:all) do

--- a/spec/models/synchronization/member_spec.rb
+++ b/spec/models/synchronization/member_spec.rb
@@ -60,7 +60,10 @@ describe Synchronization::Member do
 
     before(:each) do
       bypass_named_maps
-      Cartodb.config[:metrics] = {}
+    end
+
+    around(:each) do |example|
+      Cartodb.with_config(metrics: {}, &example)
     end
 
     after(:all) do

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -206,107 +206,100 @@ describe Table do
       end
 
       it "should create default associated map and layers" do
-        old_basemap_config = Cartodb.config[:basemaps]
-
-        # Basemap with no labels
-        Cartodb.config[:basemaps] = {
-          CartoDB: {
-            "waduson" => {
-              "default" => true,
-              "url" => "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png",
-              "subdomains" => "abcd",
-              "minZoom" => "0",
-              "maxZoom" => "18",
-              "name" => "Waduson",
-              "className" => "waduson",
-              "attribution" => "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
+        Cartodb.with_config(
+          basemaps: {
+            CartoDB: {
+              "waduson" => {
+                "default" => true,
+                "url" => "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png",
+                "subdomains" => "abcd",
+                "minZoom" => "0",
+                "maxZoom" => "18",
+                "name" => "Waduson",
+                "className" => "waduson",
+                "attribution" => "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
+              }
             }
           }
-        }
+        ) do
 
-        visualizations = CartoDB::Visualization::Collection.new.fetch.to_a.length
-        table = create_table(name: "epaminondas_pantulis", user_id: @user.id)
-        CartoDB::Visualization::Collection.new.fetch.to_a.length.should == visualizations + 1
+          visualizations = CartoDB::Visualization::Collection.new.fetch.to_a.length
+          table = create_table(name: "epaminondas_pantulis", user_id: @user.id)
+          CartoDB::Visualization::Collection.new.fetch.to_a.length.should == visualizations + 1
 
-        map = table.map
-        map.should be
-        map.zoom.should eq Carto::Map::DEFAULT_OPTIONS[:zoom]
-        map.bounding_box_sw.should eq Carto::Map::DEFAULT_OPTIONS[:bounding_box_sw]
-        map.bounding_box_ne.should eq Carto::Map::DEFAULT_OPTIONS[:bounding_box_ne]
-        map.center.should eq Carto::Map::DEFAULT_OPTIONS[:center]
-        map.provider.should eq 'leaflet'
-        map.layers.count.should == 2
-        map.layers.map(&:kind).should == ['tiled', 'carto']
-        map.data_layers.first.infowindow["fields"].should == []
-        map.data_layers.first.options["table_name"].should == "epaminondas_pantulis"
+          map = table.map
+          map.should be
+          map.zoom.should eq Carto::Map::DEFAULT_OPTIONS[:zoom]
+          map.bounding_box_sw.should eq Carto::Map::DEFAULT_OPTIONS[:bounding_box_sw]
+          map.bounding_box_ne.should eq Carto::Map::DEFAULT_OPTIONS[:bounding_box_ne]
+          map.center.should eq Carto::Map::DEFAULT_OPTIONS[:center]
+          map.provider.should eq 'leaflet'
+          map.layers.count.should == 2
+          map.layers.map(&:kind).should == ['tiled', 'carto']
+          map.data_layers.first.infowindow["fields"].should == []
+          map.data_layers.first.options["table_name"].should == "epaminondas_pantulis"
 
-        map.layers[0].options["urlTemplate"].should == "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
-        map.layers[0].options["url"].should == "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
-        map.layers[0].options["subdomains"].should == "abcd"
-        map.layers[0].options["minZoom"].should == "0"
-        map.layers[0].options["maxZoom"].should == "18"
-        map.layers[0].options["name"].should == "Waduson"
-        map.layers[0].options["className"].should == "waduson"
-        map.layers[0].options["attribution"].should == "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
-        map.layers[0].order.should == 0
-
-        Cartodb.config[:basemaps] = old_basemap_config
+          map.layers[0].options["urlTemplate"].should == "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
+          map.layers[0].options["url"].should == "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
+          map.layers[0].options["subdomains"].should == "abcd"
+          map.layers[0].options["minZoom"].should == "0"
+          map.layers[0].options["maxZoom"].should == "18"
+          map.layers[0].options["name"].should == "Waduson"
+          map.layers[0].options["className"].should == "waduson"
+          map.layers[0].options["attribution"].should == "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
+          map.layers[0].order.should == 0
+        end
 
         map.visualization.overlays.count.should eq 5
       end
 
       it "should add a layer with labels if the baselayer has that option enabled" do
-        old_basemap_config = Cartodb.config[:basemaps]
-
-        # Basemap with labels on top
-        Cartodb.config[:basemaps] = {
-          CartoDB: {
-            "waduson" => {
-              "default" => true,
-              "url" => "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png",
-              "subdomains" => "abcd",
-              "minZoom" => "0",
-              "maxZoom" => "18",
-              "name" => "Waduson",
-              "className" => "waduson",
-              "attribution" => "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>",
-              "labels" => {
-                "url" => "http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png"
+        Cartodb.with_config(
+          basemaps: {
+            CartoDB: {
+              "waduson" => {
+                "default" => true,
+                "url" => "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png",
+                "subdomains" => "abcd",
+                "minZoom" => "0",
+                "maxZoom" => "18",
+                "name" => "Waduson",
+                "className" => "waduson",
+                "attribution" => "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
               }
             }
           }
-        }
+        ) do
 
-        visualizations = CartoDB::Visualization::Collection.new.fetch.to_a.length
-        table = create_table(name: "epaminondas_pantulis", user_id: @user.id)
-        CartoDB::Visualization::Collection.new.fetch.to_a.length.should == visualizations + 1
+          visualizations = CartoDB::Visualization::Collection.new.fetch.to_a.length
+          table = create_table(name: "epaminondas_pantulis", user_id: @user.id)
+          CartoDB::Visualization::Collection.new.fetch.to_a.length.should == visualizations + 1
 
-        table.map.layers.count.should == 3
-        table.map.layers.map(&:kind).should == ['tiled', 'carto', 'tiled']
+          table.map.layers.count.should == 3
+          table.map.layers.map(&:kind).should == ['tiled', 'carto', 'tiled']
 
-        table.map.layers[0].options["urlTemplate"].should == "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
-        table.map.layers[0].options["url"].should == "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
-        table.map.layers[0].options["subdomains"].should == "abcd"
-        table.map.layers[0].options["minZoom"].should == "0"
-        table.map.layers[0].options["maxZoom"].should == "18"
-        table.map.layers[0].options["name"].should == "Waduson"
-        table.map.layers[0].options["className"].should == "waduson"
-        table.map.layers[0].options["attribution"].should == "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
-        table.map.layers[0].order.should == 0
+          table.map.layers[0].options["urlTemplate"].should == "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
+          table.map.layers[0].options["url"].should == "http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
+          table.map.layers[0].options["subdomains"].should == "abcd"
+          table.map.layers[0].options["minZoom"].should == "0"
+          table.map.layers[0].options["maxZoom"].should == "18"
+          table.map.layers[0].options["name"].should == "Waduson"
+          table.map.layers[0].options["className"].should == "waduson"
+          table.map.layers[0].options["attribution"].should == "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
+          table.map.layers[0].order.should == 0
 
-        table.map.layers[2].options["urlTemplate"].should == "http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png"
-        table.map.layers[2].options["url"].should == "http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png"
-        table.map.layers[2].options["subdomains"].should == "abcd"
-        table.map.layers[2].options["minZoom"].should == "0"
-        table.map.layers[2].options["maxZoom"].should == "18"
-        table.map.layers[2].options["name"].should == "Waduson Labels"
-        table.map.layers[2].options["className"].should be_nil
-        table.map.layers[2].options["attribution"].should == "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
-        table.map.layers[2].options["type"].should == "Tiled"
-        table.map.layers[2].options["labels"].should be_nil
-        table.map.layers[2].order.should == 2
-
-        Cartodb.config[:basemaps] = old_basemap_config
+          table.map.layers[2].options["urlTemplate"].should == "http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png"
+          table.map.layers[2].options["url"].should == "http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png"
+          table.map.layers[2].options["subdomains"].should == "abcd"
+          table.map.layers[2].options["minZoom"].should == "0"
+          table.map.layers[2].options["maxZoom"].should == "18"
+          table.map.layers[2].options["name"].should == "Waduson Labels"
+          table.map.layers[2].options["className"].should be_nil
+          table.map.layers[2].options["attribution"].should == "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
+          table.map.layers[2].options["type"].should == "Tiled"
+          table.map.layers[2].options["labels"].should be_nil
+          table.map.layers[2].order.should == 2
+        end
       end
 
       it "should return a sequel interface" do

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -248,9 +248,9 @@ describe Table do
           map.layers[0].options["className"].should == "waduson"
           map.layers[0].options["attribution"].should == "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
           map.layers[0].order.should == 0
-        end
 
-        map.visualization.overlays.count.should eq 5
+          map.visualization.overlays.count.should eq 5
+        end
       end
 
       it "should add a layer with labels if the baselayer has that option enabled" do
@@ -265,7 +265,10 @@ describe Table do
                 "maxZoom" => "18",
                 "name" => "Waduson",
                 "className" => "waduson",
-                "attribution" => "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>"
+                "attribution" => "© <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors © <a href= \"https://carto.com/attributions\">CARTO</a>",
+                "labels" => {
+                  "url" => "http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png"
+                }
               }
             }
           }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1957,9 +1957,6 @@ describe User do
 
   describe 'User creation and DB critical calls' do
     it 'Properly setups a new user (not belonging to an organization)' do
-      # INFO: avoiding enable_remote_db_user
-      Cartodb.config[:signups] = nil
-
       CartoDB::UserModule::DBService.any_instance.stubs(
         cartodb_extension_version_pre_mu?: nil,
         monitor_user_notification: nil,
@@ -2167,9 +2164,6 @@ describe User do
     end
 
     it 'Properly setups a new organization user' do
-      # INFO: avoiding enable_remote_db_user
-      Cartodb.config[:signups] = nil
-
       CartoDB::UserModule::DBService.any_instance.stubs(
         cartodb_extension_version_pre_mu?: nil,
         monitor_user_notification: nil,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -602,32 +602,18 @@ describe User do
     end
 
     describe '#gravatar_enabled?' do
-      before(:each) do
-        @avatars_config = Cartodb::config[:avatars]
-      end
-
-      after(:each) do
-        Cartodb::config[:avatars] = @avatars_config
-      end
-
       it 'should be enabled by default (every setting but false will enable it)' do
         user = ::User.new
-        Cartodb::config[:avatars] = {}
-        user.gravatar_enabled?.should be_true
-        Cartodb::config[:avatars] = { 'gravatar_enabled' => true }
-        user.gravatar_enabled?.should be_true
-        Cartodb::config[:avatars] = { 'gravatar_enabled' => 'true' }
-        user.gravatar_enabled?.should be_true
-        Cartodb::config[:avatars] = { 'gravatar_enabled' => 'wadus' }
-        user.gravatar_enabled?.should be_true
+        Cartodb.with_config(avatars: {}) { user.gravatar_enabled?.should be_true }
+        Cartodb.with_config(avatars: { 'gravatar_enabled' => true }) { user.gravatar_enabled?.should be_true }
+        Cartodb.with_config(avatars: { 'gravatar_enabled' => 'true' }) { user.gravatar_enabled?.should be_true }
+        Cartodb.with_config(avatars: { 'gravatar_enabled' => 'wadus' }) { user.gravatar_enabled?.should be_true }
       end
 
       it 'can be disabled' do
         user = ::User.new
-        Cartodb::config[:avatars] = { 'gravatar_enabled' => false }
-        user.gravatar_enabled?.should be_false
-        Cartodb::config[:avatars] = { 'gravatar_enabled' => 'false' }
-        user.gravatar_enabled?.should be_false
+        Cartodb.with_config(avatars: { 'gravatar_enabled' => false }) { user.gravatar_enabled?.should be_false }
+        Cartodb.with_config(avatars: { 'gravatar_enabled' => 'false' }) { user.gravatar_enabled?.should be_false }
       end
     end
   end

--- a/spec/requests/admin/pages_controller_spec.rb
+++ b/spec/requests/admin/pages_controller_spec.rb
@@ -116,60 +116,58 @@ describe Admin::PagesController do
     end
 
     it 'redirects to local login page if no user is specified and Central is not enabled' do
-      old_cartodb_central_api = Cartodb.config[:cartodb_central_api]
-      Cartodb.config[:cartodb_central_api] = {}
-      user = prepare_user('anyuser')
-      host! 'localhost.lan'
-      CartoDB.stubs(:session_domain).returns('localhost.lan')
-      CartoDB.stubs(:subdomainless_urls?).returns(true)
+      Cartodb.with_config(cartodb_central_api: {}) do
+        user = prepare_user('anyuser')
+        host! 'localhost.lan'
+        CartoDB.stubs(:session_domain).returns('localhost.lan')
+        CartoDB.stubs(:subdomainless_urls?).returns(true)
 
-      get '', {}, JSON_HEADER
+        get '', {}, JSON_HEADER
 
-      last_response.status.should == 302
-      uri = URI.parse(last_response.location)
-      uri.host.should == 'localhost.lan'
-      uri.path.should == '/login'
-      follow_redirect!
-      last_response.status.should == 200
+        last_response.status.should == 302
+        uri = URI.parse(last_response.location)
+        uri.host.should == 'localhost.lan'
+        uri.path.should == '/login'
+        follow_redirect!
+        last_response.status.should == 200
 
-      Cartodb.config[:cartodb_central_api] = old_cartodb_central_api
-
-      user.delete
+        user.delete
+      end
     end
 
     it 'redirects to Central login page if no user is specified and Central is enabled' do
-      old_cartodb_central_api = Cartodb.config[:cartodb_central_api]
       central_host = 'somewhere.lan'
       central_port = 4321
-      Cartodb.config[:cartodb_central_api] = {
-        'host' => central_host,
-        'port' => central_port,
-        'username' => 'api',
-        'password' => 'test'
-      }
-      user = prepare_user('anyuser')
-      host! 'localhost.lan'
-      CartoDB.stubs(:session_domain).returns('localhost.lan')
-      CartoDB.stubs(:subdomainless_urls?).returns(true)
+      Cartodb.with_config(
+        cartodb_central_api: {
+          'host' => central_host,
+          'port' => central_port,
+          'username' => 'api',
+          'password' => 'test'
+        }
+      ) do
+        user = prepare_user('anyuser')
+        host! 'localhost.lan'
+        CartoDB.stubs(:session_domain).returns('localhost.lan')
+        CartoDB.stubs(:subdomainless_urls?).returns(true)
 
-      get '', {}, JSON_HEADER
+        get '', {}, JSON_HEADER
 
-      last_response.status.should == 302
-      uri = URI.parse(last_response.location)
-      uri.host.should == 'localhost.lan'
-      uri.path.should == '/login'
-      follow_redirect!
+        last_response.status.should == 302
+        uri = URI.parse(last_response.location)
+        uri.host.should == 'localhost.lan'
+        uri.path.should == '/login'
+        follow_redirect!
 
-      last_response.status.should == 302
-      uri = URI.parse(last_response.location)
-      uri.host.should == central_host
-      uri.port.should == central_port
-      uri.path.should == '/login'
-      follow_redirect!
+        last_response.status.should == 302
+        uri = URI.parse(last_response.location)
+        uri.host.should == central_host
+        uri.port.should == central_port
+        uri.path.should == '/login'
+        follow_redirect!
 
-      Cartodb.config[:cartodb_central_api] = old_cartodb_central_api
-
-      user.delete
+        user.delete
+      end
     end
 
     it 'redirects and loads the dashboard if the user is logged in' do

--- a/spec/requests/carto/admin/mobile_apps_controller_spec.rb
+++ b/spec/requests/carto/admin/mobile_apps_controller_spec.rb
@@ -17,13 +17,16 @@ describe Carto::Admin::MobileAppsController do
   }.freeze
 
   before(:all) do
-    Cartodb.config[:cartodb_central_api] = {} unless Cartodb.config[:cartodb_central_api]
     @carto_user = FactoryGirl.create(:carto_user, mobile_max_open_users: 10000)
     @user = ::User[@carto_user.id]
   end
 
   after(:all) do
     @user.destroy
+  end
+
+  around(:each) do |example|
+    Cartodb.with_config(cartodb_central_api: {}, &example)
   end
 
   describe '#index' do

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -86,7 +86,6 @@ module CartoDB
       user = new_user(attributes)
       raise "User not valid: #{user.errors}" unless user.valid?
       # INFO: avoiding enable_remote_db_user
-      Cartodb.config[:signups] = nil
       user.save
       load_user_functions(user)
       user
@@ -96,7 +95,6 @@ module CartoDB
     def create_validated_user(attributes = {})
       user = new_user(attributes)
       # INFO: avoiding enable_remote_db_user
-      Cartodb.config[:signups] = nil
       user.save
       if user.valid?
         load_user_functions(user)


### PR DESCRIPTION
This bug was revealed by master CI:

```ruby
20:42:47   1) Carto::Api::VisualizationsController main behaviour legacy controller migration #create map creation from datasets builder and editor behaviour for editor users doesn't add style properties
20:42:47      Failure/Error: layer.options['style_properties'].should be_nil
20:42:47        expected: nil
20:42:47             got: {"type"=>"simple", "properties"=>{"fill"=>{"size"=>{"fixed"=>7}, "color"=>{"fixed"=>"#FFB927", "opacity"=>0.9}}, "stroke"=>{"size"=>{"fixed"=>1}, "color"=>{"fixed"=>"#FFF", "opacity"=>1}}, "blending"=>"none", "aggregation"=>{}, "labels"=>{"enabled"=>false, "attribute"=>nil, "font"=>"DejaVu Sans Book", "fill"=>{"size"=>{"fixed"=>10}, "color"=>{"fixed"=>"#FFFFFF", "opacity"=>1}}, "halo"=>{"size"=>{"fixed"=>1}, "color"=>{"fixed"=>"#6F808D", "opacity"=>1}}, "offset"=>-10, "overlap"=>true, "placement"=>"point"}}}
20:42:47      # ./spec/requests/carto/api/visualizations_controller_spec.rb:2020:in `block (9 levels) in <top (required)>'
20:42:47      # ./spec/support/helpers.rb:67:in `post_json'
20:42:47      # ./spec/requests/carto/api/visualizations_controller_spec.rb:2013:in `block (8 levels) in <top (required)>'
```

As you see, we're getting an unwanted `style_properties` option. Because of the timing of the error, the failing test must've been caused by #12807. More specifically, by [this test](https://github.com/CartoDB/cartodb/pull/12807/files#diff-269b21489f05a44e780fdd2f484937e0R344). Nevertheless, the root cause is not that.

By doing `::Layer.new(Cartodb.config[:layer_opts]['data'])` we're initializing a layer with some attributes, but they're passed by reference, not by value:

```ruby
(byebug) Cartodb.config[:layer_opts]['data']['options'].object_id
70163319677360
(byebug) data_layer.options.object_id
70163319677360
```

As you see, the `options` attribute is the reference to the configuration hash, which can be reused. I think that this is not a major issue at production because of the request/memory model of Unicorn, but it's certainly wrong: configuration hash shouldn't change.

I'm moving this to CR but I'm not 100% sure on the approach. Feel free to redo it. If you agree on this, nevertheless, we should probably deep-freeze `Cartodb.config` so this can't happen.