### PR TITLE
Restore vector log and change vector feature flag meaning

### DIFF
--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -118,7 +118,7 @@ module VisualizationsControllerHelper
     if params[:vector].present?
       # This forces vector. Useful for testing purposes
       options[:vector] = params[:vector] == 'true'
-    elsif visualization.user.has_feature_flag?('vector_vs_raster')
+    elsif !visualization.user.has_feature_flag?('vector_vs_raster')
       # This enables autodetection at cartodb.js
       options[:vector] = nil
     end

--- a/app/helpers/vector_helper.rb
+++ b/app/helpers/vector_helper.rb
@@ -1,5 +1,5 @@
 module VectorHelper
   def vector_render?(visualization, params)
-    visualization.user.has_feature_flag?('vector_vs_raster') || params['vector'] == 'true'
+    !visualization.user.has_feature_flag?('vector_vs_raster') || params['vector'] == 'true'
   end
 end

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.9.92",
+  "version": "4.9.94",
   "dependencies": {
     "abbrev": {
       "version": "1.1.0",
@@ -405,7 +405,7 @@
     "cartodb.js": {
       "version": "4.0.0-alpha.1.1.2",
       "from": "cartodb/cartodb.js#v4",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#cb8d381c9bba2e071e0c060bf757e5ee9aeef32e"
+      "resolved": "git://github.com/cartodb/cartodb.js.git#46d205d3a0323f2424294f784cf76449801af744"
     },
     "caseless": {
       "version": "0.12.0",

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1639,20 +1639,20 @@ describe Carto::Api::VisualizationsController do
         end
       end
 
-      it 'includes vector flag (default false)' do
+      it 'includes vector flag (default true)' do
         get_json get_vizjson3_url(@user_1, @visualization), @headers do |response|
           response.status.should == 200
           vizjson3 = response.body
-          vizjson3[:vector].should == false
+          vizjson3[:vector].should be_nil
         end
       end
 
-      it 'doesn\'t include vector flag if vector_vs_raster feature flag is enabled and vector param is not present' do
+      it 'include vector flag if vector_vs_raster feature flag is enabled and vector param is not present' do
         set_feature_flag @visualization.user, 'vector_vs_raster', true
         get_json get_vizjson3_url(@user_1, @visualization), @headers do |response|
           response.status.should == 200
           vizjson3 = response.body
-          vizjson3.has_key?(:vector).should be_false
+          vizjson3.has_key?(:vector).should be_true
         end
       end
 

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1647,7 +1647,7 @@ describe Carto::Api::VisualizationsController do
         end
       end
 
-      it 'include vector flag if vector_vs_raster feature flag is enabled and vector param is not present' do
+      it 'includes vector flag if vector_vs_raster feature flag is enabled and vector param is not present' do
         set_feature_flag @visualization.user, 'vector_vs_raster', true
         get_json get_vizjson3_url(@user_1, @visualization), @headers do |response|
           response.status.should == 200

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -117,11 +117,11 @@ describe Carto::Builder::Public::EmbedsController do
       response.status.should == 302
     end
 
-    it 'defaults to generate vizjson with vector=false' do
+    it 'defaults to generate vizjson with vector=true' do
       get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 
       response.status.should == 200
-      response.body.should include('\"vector\":false')
+      response.body.should_not include('\"vector\":true')
     end
 
     it 'generates vizjson with vector=true with flag' do
@@ -132,7 +132,7 @@ describe Carto::Builder::Public::EmbedsController do
     end
 
     it 'doesn\'t include vector flag if vector_vs_raster feature flag is enabled and vector param is not present' do
-      set_feature_flag @visualization.user, 'vector_vs_raster', true
+      set_feature_flag @visualization.user, 'vector_vs_raster', false
 
       get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 


### PR DESCRIPTION
This PR:
- Restores vector error log (temporal change). Changes from cartodb.js (dependency updated)
- Changes `vector_vs_raster` feature flag meaning.

See https://github.com/CartoDB/cartodb-management/issues/5005