### PR TITLE
Prevent invalid bbox polygons/points

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -206,6 +206,7 @@ Development
 * Axis labels changes in Time-Series (#12658)
 * Removed unused settings in organizations (#4992)
 * Increment maximum buckets in Time-Series for leap years (#12778)
+* Prevent invalid geometries in BoundingBoxUtils.to_polygon, to_point (#12873)
 
 ### NOTICE
 This release upgrades the CartoDB PostgreSQL extension to `0.19.2`. Run the following to have it available:

--- a/lib/carto/bounding_box_utils.rb
+++ b/lib/carto/bounding_box_utils.rb
@@ -40,8 +40,8 @@ module Carto::BoundingBoxUtils
   end
 
   def self.check_bounds_for(x, y)
-    return false if x.to_f > LIMIT_BOUNDS[:maxx].to_f || x.to_f < LIMIT_BOUNDS[:minx].to_f
-    return false if y.to_f > LIMIT_BOUNDS[:maxy].to_f || y.to_f < LIMIT_BOUNDS[:miny].to_f
+    return false if Float(x) > LIMIT_BOUNDS[:maxx].to_f || Float(x) < LIMIT_BOUNDS[:minx].to_f
+    return false if Float(y) > LIMIT_BOUNDS[:maxy].to_f || Float(y) < LIMIT_BOUNDS[:miny].to_f
     true
   rescue
     false

--- a/lib/carto/bounding_box_utils.rb
+++ b/lib/carto/bounding_box_utils.rb
@@ -44,6 +44,8 @@ module Carto::BoundingBoxUtils
     return false if Float(y) > LIMIT_BOUNDS[:maxy].to_f || Float(y) < LIMIT_BOUNDS[:miny].to_f
     true
   rescue
+    # Reject coordinate values for which Float() conversion fails.
+    # e.g. nil values or Strings that do not contain just a valid numeric representation.
     false
   end
 end


### PR DESCRIPTION
We've had some fails of the `cartodb:explore_api:update` task with this error:

```
PG::Error: ERROR:  parse error - invalid geometry
LINE 8: ...visualization_view_box = ST_Transform(ST_Envelope('SRID=4326...
^                                                             ^
HINT:  "SRID=4326;POLYGON((- " <-- parse error at position 21 within geometry
```

I haven't been able to look in detail to a failing case but I think the problem could be due to invalid coordinates passed to `BoundingBoxUtils.to_polygon`.  This PR should prevent those problems and I think it's good to have it in any case.

The `BoundingBoxUtils.check_bounds_for(x,y)` as is now will accept coordinates that are nil or non-numeric strings (because `to_f` converts those to 0.0); I've change it so that it returns false in those cases.
