### PR TITLE
Reload vis when feature metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,7 @@ Development
 * Remove data-observatory-multiple-measures feature flag (#304)
 
 ### Bug fixes / enhancements
+* Reload vis if needed when feature is save (#11125)
 * Popups improvements (#11430, #10993)
 * Added scroll to metadata in the embed view (#12501)
 * Lazy select to fix missing values due to 40 per page items limitation in requests

--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/features-integration.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/features-integration.js
@@ -23,6 +23,9 @@ module.exports = {
     checkAndBuildOpts(options, REQUIRED_OPTS, this);
 
     this._mapModeModel.on('change:mode', this._onMapModeChanged, this);
+    this._mapModeModel.on('reloadVis', function () {
+      this._diDashboardHelpers.invalidateMap();
+    }, this);
     this._diDashboardHelpers.visMap().on('featureClick', this._onFeatureClicked, this);
   },
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-view.js
@@ -13,6 +13,7 @@ var Notifier = require('../../components/notifier/notifier');
 var EditFeatureGeometryFormModel = require('./edit-feature-content-views/edit-feature-geometry-form-model');
 var EditFeatureGeometryPointFormModel = require('./edit-feature-content-views/edit-feature-geometry-point-form-model');
 var EditFeatureAttributesFormModel = require('./edit-feature-content-views/edit-feature-attributes-form-model');
+var StyleHelper = require('../../helpers/style');
 
 var NOTIFICATION_ID = 'editFeatureNotification';
 var NOTIFICATION_ERROR_TEMPLATE = _.template("<span class='u-errorTextColor'><%- title %></span>");
@@ -300,6 +301,14 @@ module.exports = CoreView.extend({
     if (operation === 'add' || operation === 'destroy') {
       this._rowsCollection.resetFetch();
     }
+  },
+
+  _needReloadVis: function () {
+    var style = this._layerDefinitionModel.styleModel;
+    var color = StyleHelper.getColorAttribute(style);
+    var size = StyleHelper.getSizeAttribute(style);
+    var changed = _.keys(this._featureModel.changedAttributes());
+    return (color && _.contains(changed, color) || size && _.contains(changed, size));
   },
 
   _getTable: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/edit-feature-content-view.js
@@ -274,6 +274,7 @@ module.exports = CoreView.extend({
 
   _onSaveFeatureSuccess: function (op) {
     this._onUpdateFeature(op);
+    this._needReloadVis() && this._mapModeModel.trigger('reloadVis');
     this.render();
 
     this.notification.set({

--- a/lib/assets/core/javascripts/cartodb3/helpers/style.js
+++ b/lib/assets/core/javascripts/cartodb3/helpers/style.js
@@ -1,0 +1,38 @@
+var _ = require('underscore');
+
+module.exports = {
+  getStyleAttrs: function (styleModel) {
+    if (!styleModel) return;
+
+    var fill = styleModel.get('fill');
+    var stroke = styleModel.get('stroke');
+    if (!fill && !stroke || _.isEmpty(fill) && _.isEmpty(stroke)) return;
+
+    return {
+      fill: fill,
+      stroke: stroke
+    };
+  },
+
+  getColorAttribute: function (styleModel) {
+    var color = this.getColor(styleModel);
+    return color && color.attribute;
+  },
+
+  getSizeAttribute: function (styleModel) {
+    var size = this.getSize(styleModel);
+    return size && size.attribute;
+  },
+
+  getColor: function (styleModel) {
+    var style = this.getStyleAttrs(styleModel);
+    var color = style ? (style.fill && style.fill.color || style.stroke && style.stroke.color) : null;
+    return color;
+  },
+
+  getSize: function (styleModel) {
+    var style = this.getStyleAttrs(styleModel);
+    var size = style ? (style.fill && style.fill.size || style.stroke && style.stroke.size) : null;
+    return size;
+  }
+};

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/edit-feature-content-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/edit-feature-content-view.spec.js
@@ -9,6 +9,7 @@ var UserModel = require('../../../../../javascripts/cartodb3/data/user-model');
 var FeatureDefinitionModel = require('../../../../../javascripts/cartodb3/data/feature-definition-model');
 var EditorModel = require('../../../../../javascripts/cartodb3/data/editor-model');
 var ModalsService = require('../../../../../javascripts/cartodb3/components/modals/modals-service-model');
+var Stylehelper = require('../../../../../javascripts/cartodb3/helpers/style');
 
 var QueryGeometryModelMock = function (simple_geom) {
   var geom = simple_geom || '';
@@ -222,6 +223,29 @@ describe('editor/layers/edit-feature-content-view', function () {
       this.view._editorModel.trigger('cancelPreviousEditions');
 
       expect(this.view.clean).toHaveBeenCalled();
+    });
+  });
+
+  describe('reload vis', function () {
+    beforeEach(function () {
+      spyOn(Stylehelper, 'getColorAttribute');
+      spyOn(Stylehelper, 'getSizeAttribute');
+    });
+
+    it('should reload vis if metadata changes and layer is styled but that attribute', function () {
+      Stylehelper.getColorAttribute.and.returnValue('foo');
+      Stylehelper.getSizeAttribute.and.returnValue(undefined);
+      this.view._featureModel.set('foo', 10);
+
+      expect(this.view._needReloadVis()).toBeTruthy();
+    });
+
+    it('should reload vis if metadata changes and layer is not styled but that attribute', function () {
+      Stylehelper.getColorAttribute.and.returnValue('bar');
+      Stylehelper.getSizeAttribute.and.returnValue(undefined);
+      this.view._featureModel.set('foo', 10);
+
+      expect(this.view._needReloadVis()).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
This PR fixes #11125.

If a feature metadata changes and the layer is styled by that attribute, then the vis is reloaded, keeping the style and the view in sync.