### PR TITLE
Torque hotfix

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/widgets-integration.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/widgets-integration.js
@@ -374,7 +374,7 @@ module.exports = {
         type: 'time-series',
         layer_id: newLayer.get('id'),
         source: {
-          id: newLayer.get('source')
+          id: newLayer.getSourceId()
         },
         options: {
           column: attribute,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.6",
+  "version": "4.10.6-torque",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.6-torque",
+  "version": "4.10.6",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes https://github.com/CartoDB/support/issues/1017.

When a timeseries is created, we are saving the source id as a whole node, polluting the database and, more important, make the vis unusable on refresh. The soon as the user reloads the visualization, an error raises. This issue only happens when the style is changed to animated, creating a time series in consequence. When the timeseries widget is created on demand, the process works as expected.
