### PR TITLE
Unifont

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@ Development
 * Remove data-observatory-multiple-measures feature flag (#304)
 
 ### Bug fixes / enhancements
+* Fix a problem with Unifont Medium font (#support/1002, #support/989)
 * Hide the_geom_webmercator column from dataset view (#11045)
 * Reload vis if needed when feature is save (#11125)
 * Popups improvements (#11430, #10993)

--- a/lib/assets/core/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/style/style-form/style-form-components-dictionary.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var StylesFactory = require('../styles-factory');
 var FONTS_LIST = [
   'DejaVu Sans Book',
-  'unifont Medium',
+  'Unifont Medium',
   'Open Sans Regular',
   'Lato Regular',
   'Lato Bold',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.7",
+  "version": "4.10.7-1002",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.7-1002",
+  "version": "4.10.7",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR is related to https://github.com/CartoDB/support/issues/989 and https://github.com/CartoDB/support/issues/1002.

Changing the font name used in Builder seems to fix it, but we should test it deeply because there might be other use cases where this is not enough.