### PR TITLE
Adding fullstory to both dashboard alternatives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Development
 -----------
 
 ### Features
+* Add FullStory (if available) in user dashboard
 * Change default style for polygon, point and line geometries (design#983)
 * Unify scrollbars style (#12184)
 * Add endpoint for current user account deletion (#12841)
@@ -63,7 +64,7 @@ Development
 * Improve legends for torque (CartoDB/support#979)
 * CSV export allowed without geometries (#12888)
 * Fix handling of imports with long file names and existing tables with almost the same name (#12732)
-* Update cartodb.js version 
+* Update cartodb.js version
 * Don't allow csv export for polygon or line (#9855)
 * Fix a problem with Unifont Medium font (#support/1002, #support/989)
 * Hide the_geom_webmercator column from dataset view (#11045)

--- a/app/helpers/frontend_config_helper.rb
+++ b/app/helpers/frontend_config_helper.rb
@@ -14,6 +14,8 @@ module FrontendConfigHelper
       google_analytics_domain:    Cartodb.get_config(:google_analytics, 'domain'),
       hubspot_enabled:            CartoDB::Hubspot::instance.enabled?,
       intercom_app_id:            Cartodb.get_config(:intercom, 'app_id'),
+      fullstory_enabled:          user.account_type.downcase == 'free' && Cartodb.get_config(:fullstory, 'org').present?,
+      fullstory_org:              Cartodb.get_config(:fullstory, 'org'),
       dropbox_api_key:            Cartodb.get_config(:dropbox_api_key),
       gdrive_api_key:             Cartodb.get_config(:gdrive, 'api_key'),
       gdrive_app_id:              Cartodb.get_config(:gdrive, 'app_id'),
@@ -31,9 +33,6 @@ module FrontendConfigHelper
       licenses:                   Carto::License.all,
       data_library_enabled:       CartoDB::Visualization::CommonDataService.configured?
     }
-
-    config[:fullstory_enabled] = user.account_type.downcase == 'free' && Cartodb.get_config(:fullstory, 'org').present?
-    config[:fullstory_org] = Cartodb.get_config(:fullstory, 'org')
 
     if CartoDB::Hubspot::instance.enabled? && !CartoDB::Hubspot::instance.token.blank?
       config[:hubspot_token] = CartoDB::Hubspot::instance.token

--- a/app/helpers/frontend_config_helper.rb
+++ b/app/helpers/frontend_config_helper.rb
@@ -32,6 +32,9 @@ module FrontendConfigHelper
       data_library_enabled:       CartoDB::Visualization::CommonDataService.configured?
     }
 
+    config[:fullstory_enabled] = user.account_type.downcase == 'free' && Cartodb.get_config(:fullstory, 'org').present?
+    config[:fullstory_org] = Cartodb.get_config(:fullstory, 'org')
+
     if CartoDB::Hubspot::instance.enabled? && !CartoDB::Hubspot::instance.token.blank?
       config[:hubspot_token] = CartoDB::Hubspot::instance.token
       config[:hubspot_ids] = CartoDB::Hubspot::instance.event_ids.to_json.html_safe

--- a/app/helpers/frontend_config_helper.rb
+++ b/app/helpers/frontend_config_helper.rb
@@ -14,7 +14,7 @@ module FrontendConfigHelper
       google_analytics_domain:    Cartodb.get_config(:google_analytics, 'domain'),
       hubspot_enabled:            CartoDB::Hubspot::instance.enabled?,
       intercom_app_id:            Cartodb.get_config(:intercom, 'app_id'),
-      fullstory_enabled:          user.account_type.downcase == 'free' && Cartodb.get_config(:fullstory, 'org').present?,
+      fullstory_enabled:          Cartodb.get_config(:fullstory, 'org').present? && user && user.account_type.casecmp('FREE').zero?,
       fullstory_org:              Cartodb.get_config(:fullstory, 'org'),
       dropbox_api_key:            Cartodb.get_config(:dropbox_api_key),
       gdrive_api_key:             Cartodb.get_config(:gdrive, 'api_key'),

--- a/app/views/admin/visualizations/index.html.erb
+++ b/app/views/admin/visualizations/index.html.erb
@@ -37,3 +37,4 @@
 <% end %>
 
 <%= render 'admin/shared/footer' %>
+<%= insert_fullstory %>

--- a/lib/assets/javascripts/cartodb/dashboard/vendor_scripts_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/vendor_scripts_view.js
@@ -23,6 +23,8 @@ module.exports = cdb.core.View.extend({
         trackjsAppKey: this.config.trackjs_app_key,
         trackjsCustomer: this.config.trackjs_customer,
         trackjsEnabled: !!this.config.trackjs_enabled,
+        fullstoryEnabled: !!this.config.fullstory_enabled,
+        fullstoryOrg: this.config.fullstoryOrg,
         userEmail: this.user.get('email'),
         userName: this.user.get('username')
       })

--- a/lib/assets/javascripts/cartodb/dashboard/views/vendor_scripts.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/vendor_scripts.jst.ejs
@@ -62,3 +62,28 @@
     (function(){var w=window;var ic=w.Intercom;if(typeof ic==='function'){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/<%= intercomAppId %>';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
   </script>
 <% } %>
+
+<% if (fullstoryEnabled) { %>
+  <script type='text/javascript'>
+    window['_fs_debug'] = false;
+    window['_fs_host'] = 'www.fullstory.com';
+    window['_fs_org'] = '<%= fullstoryOrg %>';
+    window['_fs_namespace'] = 'FS';
+    (function(m,n,e,t,l,o,g,y){
+        if (e in m && m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'); return;}
+        g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
+        o=n.createElement(t);o.async=1;o.src='https://'+_fs_host+'/s/fs.js';
+        y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+        g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
+        g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+        g.clearUserCookie=function(c,d,i){if(!c || document.cookie.match('fs_uid=[`;`]*`[`;`]*`[`;`]*`')){
+        d=n.domain;while(1){n.cookie='fs_uid=;domain='+d+
+        ';path=/;expires='+new Date(0).toUTCString();i=d.indexOf('.');if(i<0)break;d=d.slice(i+1)}}};
+    })(window,document,window['_fs_namespace'],'script','user');
+    FS.clearUserCookie();
+    FS.identify('<%= userName %>', {
+      displayName: '<%= userName %>',
+      email: '<%= userEmail %>'
+    });
+  </script>
+<% } %>

--- a/lib/assets/test/spec/cartodb/dashboard/vendor_scripts_view.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/vendor_scripts_view.spec.js
@@ -10,6 +10,8 @@ var CONFIG = {
   google_analytics_domain: 'carto.com',
   hubspot_enabled: true,
   hubspot_token: 'yourtoken',
+  fullstoryEnabled: false,
+  fullstoryOrg: '',
   hubspot_ids: '{}',
   intercom_app_id: 'intercom_app_id'
 };
@@ -52,6 +54,8 @@ describe('dashboard/vendor_scripts_view', function () {
       trackjsAppKey: 'trackjs_app_key',
       trackjsCustomer: 'trackjs_customer',
       trackjsEnabled: true,
+      fullstoryEnabled: false,
+      fullstoryOrg: '',
       userEmail: 'e00000002@d00000002.com',
       userName: 'pepe'
     });
@@ -102,6 +106,8 @@ describe('dashboard/vendor_scripts_view', function () {
       trackjsAppKey: 'trackjs_app_key',
       trackjsCustomer: 'trackjs_customer',
       trackjsEnabled: false,
+      fullstoryEnabled: false,
+      fullstoryOrg: '',
       userEmail: 'e00000002@d00000002.com',
       userName: 'pepe'
     });


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb-management/issues/5002

Adding FullStory in both dashboards:

- The current one, with erb templates.
- The new and shiny one, with static content, no ruby templates, smarter, cooler,...

@arianaescobar @nobuti @rubenmoya @noguerol 


**ACCEPTANCE**

- Deploy in staging these changes.
- Choose a FREE user (if not FullStory will not be loaded).
- Check in staging that Fullstory is enabled*.
- If you don't have `static_dashboard` flag enabled, just check if the script is present in the HTML code.
- If you have `static_dashboard` flag enabled, you will need to check if the script is loaded in the network tab.


*We will need to set Fullstory org code for staging servers 🎉 .