### PR TITLE
Upgrade chardet to 3.0.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ Development
 * Show number of selected items in Time-Series widgets (#12179)
 * Show ranges in time series widget selection (#12291)
 * Bump Webpack version (#12392)
+* Bump chardet version (#12921)
 * Start using ::outline symbolizer for polygon stroke (#12412)
 * New force param in EUMAPI organization users destroy operation to force deletion even with unregistered tables (#11654).
 * Removed the usage of the `organizations_admin` feature flag (#12131)

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -1,4 +1,4 @@
-chardet==2.3.0
+chardet==3.0.4
 argparse==1.2.1
 brewery==0.6
 redis==2.4.9


### PR DESCRIPTION
This is needed in order to avoid a conflict with googlemaps library. It
also needs to be applied to cookbooks repo.