### PR TITLE
 Solution to wrong ACL (deleted user)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,7 @@ Development
 * Fix some styles for datasets view for IE11.
 * Fix image export when logo is disabled.
 * Fix infowindow break word (CartoDB/support#965)
+* Fix for permissions ACL referencing deleted user (CartoDB/support#1036)
 * Update cartodb.js version
 * Fix extraneous labels layer.
 * Fix timeseries glitches (#12217)

--- a/app/controllers/carto/api/permission_presenter.rb
+++ b/app/controllers/carto/api/permission_presenter.rb
@@ -32,12 +32,17 @@ module Carto
             type:     'vis'
           },
           acl:        @permission.acl.map do |entry|
-            {
-              type:   entry[:type],
-              entity: entity_decoration(entry),
-              access: entry[:access]
-            }
-          end,
+            entity = entity_decoration(entry)
+            if entity.blank?
+              nil
+            else
+              {
+                type:   entry[:type],
+                entity: entity,
+                access: entry[:access]
+              }
+            end
+          end.reject(&:nil?),
           created_at: @permission.created_at,
           updated_at: @permission.updated_at
         }

--- a/app/controllers/carto/api/permission_presenter.rb
+++ b/app/controllers/carto/api/permission_presenter.rb
@@ -31,7 +31,7 @@ module Carto
             id:       @permission.visualization.id,
             type:     'vis'
           },
-          acl:        @permission.acl.map do |entry|
+          acl:        @permission.acl.map { |entry|
             entity = entity_decoration(entry)
             if entity.blank?
               nil
@@ -42,7 +42,7 @@ module Carto
                 access: entry[:access]
               }
             end
-          end.reject(&:nil?),
+          }.reject(&:nil?),
           created_at: @permission.created_at,
           updated_at: @permission.updated_at
         }

--- a/app/models/permission/presenter.rb
+++ b/app/models/permission/presenter.rb
@@ -20,7 +20,7 @@ module CartoDB
           id:       @permission.entity_id,
           type:     @permission.entity_type
         },
-        acl:        @permission.acl.map do |entry|
+        acl:        @permission.acl.map { |entry|
           entity = entity_decoration(entry)
           if entity.blank?
             nil
@@ -31,7 +31,7 @@ module CartoDB
               access: entry[:access]
             }
           end
-        end.reject(&:nil?),
+        }.reject(&:nil?),
         created_at: @permission.created_at,
         updated_at: @permission.updated_at
       }

--- a/app/models/permission/presenter.rb
+++ b/app/models/permission/presenter.rb
@@ -20,13 +20,18 @@ module CartoDB
           id:       @permission.entity_id,
           type:     @permission.entity_type
         },
-        acl:        @permission.acl.map { |entry|
-          {
-            type:   entry[:type],
-            entity: entity_decoration(entry),
-            access: entry[:access]
-          }
-        },
+        acl:        @permission.acl.map do |entry|
+          entity = entity_decoration(entry)
+          if entity.blank?
+            nil
+          else
+            {
+              type:   entry[:type],
+              entity: entity,
+              access: entry[:access]
+            }
+          end
+        end.reject(&:nil?),
         created_at: @permission.created_at,
         updated_at: @permission.updated_at
       }

--- a/spec/models/permissions_shared_examples.rb
+++ b/spec/models/permissions_shared_examples.rb
@@ -144,7 +144,7 @@ shared_examples_for 'permission models' do
 
     it 'deals with deleted users gracefully' do
       user_to_be_deleted = create_user
-       map, table, table_visualization, visualization = create_full_visualization(
+      map, table, table_visualization, visualization = create_full_visualization(
         @carto_user,
         visualization_attributes: { type: Carto::Visualization::TYPE_CANONICAL }
       )
@@ -178,7 +178,7 @@ shared_examples_for 'permission models' do
       filtered_acl = acl_from_db.map do |entry|
         {
           type: entry[:type],
-          entity: entry[:entity].select { |k, v| Carto::Permission::ALLOWED_ENTITY_KEYS.include?(k) },
+          entity: entry[:entity].select { |k, _v| Carto::Permission::ALLOWED_ENTITY_KEYS.include?(k) },
           access: entry[:access]
         }
       end

--- a/spec/models/permissions_shared_examples.rb
+++ b/spec/models/permissions_shared_examples.rb
@@ -142,6 +142,51 @@ shared_examples_for 'permission models' do
       visualization2.destroy
     end
 
+    it 'deals with deleted users gracefully' do
+      user_to_be_deleted = create_user
+       map, table, table_visualization, visualization = create_full_visualization(
+        @carto_user,
+        visualization_attributes: { type: Carto::Visualization::TYPE_CANONICAL }
+      )
+      entity_id = table_visualization.id
+      permission = permission_from_visualization_id(entity_id)
+      acl_with_data = [
+        {
+          type: Permission::TYPE_USER,
+          entity: {
+            id: @user.id,
+            username: @user.username,
+            avatar_url: @user.avatar_url
+          },
+          access: Permission::ACCESS_READONLY
+        },
+        {
+          type: Permission::TYPE_USER,
+          entity: {
+            id: user_to_be_deleted.id,
+            username: user_to_be_deleted.username,
+            avatar_url: user_to_be_deleted.avatar_url
+          },
+          access: Permission::ACCESS_READWRITE
+        }
+      ]
+      permission.acl = acl_with_data
+      permission.save
+      # here there's a possible race condition, when updating permissions
+      user_to_be_deleted.delete
+      acl_from_db = PermissionPresenter.new(permission).to_poro[:acl]
+      filtered_acl = acl_from_db.map do |entry|
+        {
+          type: entry[:type],
+          entity: entry[:entity].select { |k, v| Carto::Permission::ALLOWED_ENTITY_KEYS.include?(k) },
+          access: entry[:access]
+        }
+      end
+      permission.acl = filtered_acl
+      permission.save
+      destroy_full_visualization(map, table, table_visualization, visualization)
+    end
+
     it 'fails granting write permission for viewer users' do
       visualization = FactoryGirl.create(:carto_visualization, type: 'table', user: Carto::User.find(@user.id))
       permission = permission_from_visualization_id(visualization.id)


### PR DESCRIPTION
From the commit message:

Here is the scenario we're trying to fix:

- some user A creates a table
- that user A grants permission to some other user B to that table
- the user B is deleted

Usually this is dealt with as part of the user deletion, but we found a
situation in which ACL (permissions table) is wrong because they
reference a deleted user. We don't know exactly how we arrived to that
situation. It is most likely a race condition deleting a user or migrating
a DB, but we don't have enough information to reconstruct the whole
story.

The trouble with that is that the web client is generating requests to
change permissions based on the wrong (referencing the deleted user)
ACL.

Once you have the data inconsistent in the DB you have 3 possible
approaches to get it fixed:

- fix it directly in the database
- filter the input of PUT /api/v1/perm, ignoring deleted entities
- filter the output (viz endopoint, permissions presenter)

Fixing directly in the database is OK as a one-time thing, but that
may cause some maintenance burden.

Returning an error if the input is wrong is OK. Filtering for wrong
inputs could fix it but I don't think it's the right approach, as some
other errors could be masked otherwise.

I think filtering the output from DB is the rigth approach. This way the
permissions can be set correctly by the user. They will get "automatically
fixed" the next time the user tries to modify the permissions.

And this is why the fix for it is in the presenter.