### PR TITLE
Ruby frozen string fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,7 +64,7 @@ Development
 * Improve legends error (cartodb.js#1758)
 
 ### Bug fixes / enhancements
-* Supports frozen string manipulation in newer versions of ruby (2.3+)
+* Protects against frozen string manipulation in buggy ruby version `2.2.4p230`
 * Notification for error tiles (#cartodb.js/1717)
 * Make sure widget's source id is a string, reject it otherwise (#12878)
 * Improve legends for torque (CartoDB/support#979)

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,7 +64,7 @@ Development
 * Improve legends error (cartodb.js#1758)
 
 ### Bug fixes / enhancements
-* Supports frozen string manipulation in newer versions of ruby (2.2.4+)
+* Supports frozen string manipulation in newer versions of ruby (2.3+)
 * Notification for error tiles (#cartodb.js/1717)
 * Make sure widget's source id is a string, reject it otherwise (#12878)
 * Improve legends for torque (CartoDB/support#979)

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,7 @@ Development
 * Improve legends error (cartodb.js#1758)
 
 ### Bug fixes / enhancements
+* Supports frozen string manipulation in newer versions of ruby (2.2.4+)
 * Notification for error tiles (#cartodb.js/1717)
 * Make sure widget's source id is a string, reject it otherwise (#12878)
 * Improve legends for torque (CartoDB/support#979)

--- a/config/initializers/02_extensions.rb
+++ b/config/initializers/02_extensions.rb
@@ -10,6 +10,7 @@ module SequelRails
 end
 
 # Patches for Ruby 2.4
+# TODO: remove .dup when we no longer support buggy ruby version 2.2.4p230
 if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("2.4")
   # ActiveSupport dates, e.g: 3.days (fixed in Rails 5, and no sooner)
   class ActiveSupport::Duration

--- a/config/initializers/02_extensions.rb
+++ b/config/initializers/02_extensions.rb
@@ -10,7 +10,7 @@ module SequelRails
 end
 
 # Patches for Ruby 2.4
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4")
+if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("2.4")
   # ActiveSupport dates, e.g: 3.days (fixed in Rails 5, and no sooner)
   class ActiveSupport::Duration
     def coerce(other)

--- a/gears/carto_gears_api/carto_gears_api.gemspec
+++ b/gears/carto_gears_api/carto_gears_api.gemspec
@@ -4,7 +4,7 @@ require_relative "lib/carto_gears_api/version"
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
   s.name        = "carto_gears_api"
-  s.version     = CartoGearsApi::VERSION
+  s.version     = CartoGearsApi::VERSION.dup
   s.authors     = ["CARTO"]
   s.email       = ["support@carto.com"]
   s.homepage    = "https://carto.com"


### PR DESCRIPTION
## Context

On some open source installations using `ruby 2.3+`, the CARTO gears gem spec errored during `bundle install` due to an offending line that would modify an inmutable string. The simple fix is to duplicate the string, although it could be argued that `String.new(inmutable_string)` is a cleaner solution.

A similar patch is applied to `config/initiliazers/02_extensions.rb`