### PR TITLE
Show duplicate map and change privacy options when searching a map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,7 @@ Development
 * Improve legends error (cartodb.js#1758)
 
 ### Bug fixes / enhancements
+* Show map options when selecting a map in search view
 * Protects against frozen string manipulation in buggy ruby version `2.2.4p230`
 * Notification for error tiles (#cartodb.js/1717)
 * Make sure widget's source id is a string, reject it otherwise (#12878)

--- a/lib/assets/javascripts/cartodb/dashboard/views/filters.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/filters.jst.ejs
@@ -134,7 +134,7 @@
               <% } %>
             </li>
           <% } %>
-          <% if (shared !== "only" && shared !== "yes" && !library && hasCreateDatasetsFeature) { %>
+          <% if (!library && hasCreateDatasetsFeature) { %>
             <% if (selectedItemsCount === 1 && !liked) { %>
               <li class="Filters-actionsItem">
                 <a class="Filters-actionsLink CDB-Text CDB-Size-medium js-privacy" href="#/change-privacy">Change privacy...</a>


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/689

When searching we set `shared` to `only` in the router model ([navigation-view.js#L210](https://github.com/CartoDB/cartodb/blob/duplicate-map-search-view/lib/assets/core/javascripts/cartodb3/components/modals/add-layer/content/navigation-view.js#L210)), I assumed this is because we also have the search in other routes like `/shared` and `/liked`, but since you can't select the maps you don't own I don't think this conditional is needed because the menu won't show up.

Since this also enables the "Change privacy" button, I'd love some feedback from @CartoDB/frontend in case I'm missing something about why that conditional was needed.