### PR TITLE
Migrating to new GA script

### DIFF
--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -426,6 +426,6 @@
   </script>
 
 
-  <%= insert_google_analytics('embeds', true, [{ title: "Public Pages", value: "Other", num: 3 }]) -%>
+  <%= insert_google_analytics('embeds', true, [{ property: "Public Pages", value: "Other"  }]) -%>
   <%= insert_hubspot() -%>
 <% end %>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,17 +1,19 @@
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '<%= ua %>']);
-  _gaq.push(['_setDomainName', '<%= domain %>']);
-  _gaq.push(['_setAllowLinker', true]);
-  <% if defined? custom_vars -%>
-  <% custom_vars.each do |var| %>
-    _gaq.push(['_setCustomVar', 1, '<%= var[:title] %>', '<%= var[:value] %>', <%= var[:num] %> ]);
-  <% end %>
-  <% end -%>
-  <% if !public_view -%>
-  _gaq.push(['_setCustomVar', 1, 'Member Type', '<%= stringified_member_type %>', 1]);
-  <% end -%>
-  _gaq.push(['_trackPageview']);
+<script>
+  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+  ga('create', '<%= ua %>', {
+    cookieDomain: '<%= domain %>'
+  });
 
-  (function() { var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true; ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s); })();
+  <% if defined? custom_vars -%>
+    <% custom_vars.each do |var| %>
+      ga('set', '<%= var[:property] %>', '<%= var[:value] %>');
+    <% end %>
+  <% end -%>
+
+  <% if !public_view -%>
+    ga('set', 'Member Type', '<%= stringified_member_type %>');
+  <% end -%>
+
+  ga('send', 'pageview');
 </script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>

--- a/lib/assets/javascripts/cartodb/common/views/vendor_scripts.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/views/vendor_scripts.jst.ejs
@@ -17,25 +17,15 @@
 <% } %>
 
 <% if (googleAnalyticsUa) { %>
-<script type='text/javascript'>
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', '<%= googleAnalyticsUa %>']);
-  _gaq.push(['_setDomainName', '<%= googleAnalyticsDomain %>']);
-  _gaq.push(['_setAllowLinker', true]);
-  _gaq.push(['_setCustomVar', 1, 'Member Type', '<%= googleAnalyticsMemberType %>', 1]);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script');
-    var s = document.getElementsByTagName('script')[0];
-
-    ga.type = 'text/javascript';
-    ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
-
-    s.parentNode.insertBefore(ga, s);
-  })();
+<script>
+  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+  ga('create', '<%= googleAnalyticsUa %>', {
+    cookieDomain: '<%= googleAnalyticsDomain %>'
+  });
+  ga('set', 'Member Type', '<%= googleAnalyticsMemberType %>');
+  ga('send', 'pageview');
 </script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
 <% } %>
 
 <% if (hubspotEnabled) { %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.38",
+  "version": "4.10.38-12962",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/12906

So, after merging and deploying https://github.com/CartoDB/cartodb/pull/12960, I've checked that it was not working properly. It is due to the fact that we are using an old version of the GA script in CartoDB (Builder, Editor, Dashboard, everywhere there). So I have had to update the Rails erb and the Dashboard template in order to make it work.

cc @matallo because he needs to know it from now on.
cc @arianaescobar @noguerol because I already warned @arianaescobar.
cc @vuxita because I needed to add some [dimensions](https://misterphilip.com/universal-analytics/migration/variables) (old custom vars) in GA in order to make them work.