### PR TITLE
Disable limit error message

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/map-integration.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/map-integration.js
@@ -1,7 +1,6 @@
 var _ = require('underscore');
 var checkAndBuildOpts = require('../helpers/required-opts');
 var VisNotifications = require('../vis-notifications');
-var AppNotifications = require('../app-notifications');
 
 var REQUIRED_OPTS = [
   'diDashboardHelpers',
@@ -40,10 +39,6 @@ module.exports = {
 
     this._map.on('reload', this._visReload, this);
     this._map.on('change:error', this._visErrorChange, this);
-    this._vis.on('error:tile', function (error) {
-      error.type = 'limit';
-      AppNotifications.addNotification(error);
-    }, this);
 
     VisNotifications.track(this._map);
 


### PR DESCRIPTION
Fixes #12968

This PR temporarily disables the error message that's being shown if ***any*** error occurs when loading the tiles.

No NEWS.md because this isn't NEWSworthy