### PR TITLE
Improve limit error message

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/infobox/infobox-factory.js
+++ b/lib/assets/core/javascripts/cartodb3/components/infobox/infobox-factory.js
@@ -18,7 +18,8 @@ module.exports = {
       type: opts.type || 'default',
       title: opts.title,
       body: opts.body,
-      closable: closable
+      closable: closable,
+      klass: opts.className
     };
 
     if (opts.mainAction) {

--- a/lib/assets/core/javascripts/cartodb3/components/infobox/infobox-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/infobox/infobox-item-view.js
@@ -27,6 +27,7 @@ module.exports = CoreView.extend({
     this._body = opts.body;
     this._loading = opts.loading;
     this._isClosable = opts.closable;
+    this._klass = opts.klass;
 
     if (opts.quota) {
       this._quota = opts.quota;
@@ -60,6 +61,7 @@ module.exports = CoreView.extend({
     var isLoading = this._loading;
 
     var view = template({
+      className: this._klass,
       title: this._title,
       body: this._body,
       type: this._type,

--- a/lib/assets/core/javascripts/cartodb3/components/infobox/infobox.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/infobox/infobox.tpl
@@ -1,4 +1,4 @@
-<div class="Infobox <%- type %>">
+<div class="Infobox <%- type %> <%- className %>">
   <div class="u-flex u-justifySpace u-bSpace--m">
     <h2 class="Infobox-title CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--m u-rSpace--m"><%- title %></h2>
 

--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/map-integration.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/map-integration.js
@@ -41,7 +41,7 @@ module.exports = {
     this._map.on('reload', this._visReload, this);
     this._map.on('change:error', this._visErrorChange, this);
     this._vis.on('error:tile', function (error) {
-      error.type = 'limit';
+      error.type = 'unknown';
       AppNotifications.addNotification(error);
     }, this);
 

--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/map-integration.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/map-integration.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var checkAndBuildOpts = require('../helpers/required-opts');
 var VisNotifications = require('../vis-notifications');
+var AppNotifications = require('../app-notifications');
 
 var REQUIRED_OPTS = [
   'diDashboardHelpers',
@@ -39,6 +40,10 @@ module.exports = {
 
     this._map.on('reload', this._visReload, this);
     this._map.on('change:error', this._visErrorChange, this);
+    this._vis.on('error:tile', function (error) {
+      error.type = 'limit';
+      AppNotifications.addNotification(error);
+    }, this);
 
     VisNotifications.track(this._map);
 

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
@@ -69,6 +69,7 @@ module.exports = CoreView.extend({
 
     var infoboxStates = [
       this._getMaxLayerInfoBoxForCurrentUser(),
+      this._getUnknownErrorInfobox(),
       this._getLimitInfobox()
     ];
 
@@ -280,6 +281,20 @@ module.exports = CoreView.extend({
     });
   },
 
+  _getUnknownErrorInfobox: function () {
+    return {
+      state: 'unknown',
+      createContentView: function () {
+        return Infobox.createWithAction({
+          type: 'alert',
+          title: _t('editor.messages.generic-error.title'),
+          body: _t('editor.messages.generic-error.body'),
+          className: 'fs-unknown-tile-error'
+        });
+      }
+    };
+  },
+
   _getLimitInfobox: function () {
     var infoboxOpts = {
       type: 'alert',
@@ -332,9 +347,12 @@ module.exports = CoreView.extend({
     var count = this._getDataLayerCount();
     var max = this._getMaxCount();
     var hasLimitError = AppNotifications.getByType('limit');
+    var hasUnknownError = AppNotifications.getByType('unknown');
 
     if (hasLimitError) {
       this._infoboxModel.set('state', 'limit');
+    } else if (hasUnknownError) {
+      this._infoboxModel.set('state', 'unknown');
     } else if (count === max) {
       this._infoboxModel.set('state', MAX_LAYERS_REACHED);
     } else {

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -1492,6 +1492,10 @@
         "body": "This layer is hidden. Changes won't be shown until you make it visible.",
         "show": "Show"
       },
+      "generic-error": {
+        "title": "Some tiles were not displayed",
+        "body": "If the problem persists check our docs or contact us."
+      },
       "limit": {
         "title": "Some tiles might not be working correctly",
         "body": "Looks like you are over your limits when trying to render some of your tiles.",

--- a/lib/assets/core/test/spec/cartodb3/components/infobox/infobox-item-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/infobox/infobox-item-view.spec.js
@@ -29,6 +29,21 @@ describe('components/infobox/infobox-item-view', function () {
     expect(view.$('.Infobox-buttons button').eq(1).text()).toContain('Cancel');
   });
 
+  it('should have className when it is defined', function () {
+    var className = 'fs-class-name';
+
+    var v = new InfoboxView({
+      type: 'alert',
+      title: 'Info',
+      body: 'Lorem ipsum dolor sit amet.',
+      className: className
+    });
+
+    v.render();
+
+    expect(v.$el.hasClass(className)).toBe(true);
+  });
+
   it('should render loading when it is defined', function () {
     var v = new InfoboxView({
       type: 'alert',

--- a/lib/assets/core/test/spec/cartodb3/components/infobox/infobox-item-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/infobox/infobox-item-view.spec.js
@@ -36,7 +36,7 @@ describe('components/infobox/infobox-item-view', function () {
       type: 'alert',
       title: 'Info',
       body: 'Lorem ipsum dolor sit amet.',
-      className: className
+      klass: className
     });
 
     v.render();


### PR DESCRIPTION
Working again on #12593 

@matallo & I are now displaying a more generic message, without a CTA

![screen shot 2017-10-19 at 17 50 32](https://user-images.githubusercontent.com/446970/31780440-05caa9d8-b4f6-11e7-9c67-0255668fe712.png)

We left the limits one there for the future, but it won't be triggered by a tile error for now.

In the future, carto.js should provide with a better error (unknown / limit / timeout / gromenauer) & we can handle them in a more granular way.

This also adds a class to an element so it may be tracked with FS (`fs-unknown-tile-error`)

Tests are pending.