### PR TITLE
map: rearrange layer options in layers list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Development
 -----------
 
 ### Features
+* Map: rearrange layer options in layers list (#13006)
 * Clean assets script
 * Improve error on widgets (CartoDB/deep-insights.js#574)
 * Add pagination support in data imports listing in superadmin (#12938).

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
@@ -259,6 +259,10 @@ module.exports = CoreView.extend({
 
   _getContextMenuOptions: function () {
     var menuItems = [{
+      label: _t('editor.layers.options.edit'),
+      val: 'edit-layer',
+      action: this._onEditLayer.bind(this)
+    }, {
       label: this._isCollapsed() ? _t('editor.layers.options.expand') : _t('editor.layers.options.collapse'),
       val: 'collapse-expand-layer',
       action: this._onToggleCollapsedLayer.bind(this)
@@ -272,10 +276,6 @@ module.exports = CoreView.extend({
       label: _t('editor.layers.options.export'),
       val: 'export-data',
       action: this._exportLayer.bind(this)
-    }, {
-      label: _t('editor.layers.options.edit'),
-      val: 'edit-layer',
-      action: this._onEditLayer.bind(this)
     }];
 
     if (this._queryGeometryHasGeom()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.52",
+  "version": "4.10.52.12999",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.52.12999",
+  "version": "4.10.52",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
re: https://github.com/CartoDB/cartodb/issues/12999

![screen shot 2017-10-27 at 12 43 53](https://user-images.githubusercontent.com/36676/32100643-d67b6864-bb14-11e7-81eb-95d2b823e042.png)

**acceptance**

"Edit layer" option should always appear first