### PR TITLE
Remove redirection to shared datasets if user has locked datasets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,7 @@ ion for time-series (#12670)
 * Now is possible to use wildcard character (*) in the whitelist emails for organization signups (#12991)
 
 ### Bug fixes / enhancements
+* Fix shared datasets dashboard redirection
 * Fix upload dataset drag and drop (CartoDB/support#1072)
 * Fix legends request order with slow internet connection (#12733)
 * Documentation, fixed spelling and grammar in en.json

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -93,6 +93,7 @@ module Carto
           response.merge!({
             total_user_entries: VisualizationQueryBuilder.new.with_types(total_types).with_user_id(current_user.id).build.count,
             total_likes: VisualizationQueryBuilder.new.with_types(total_types).with_liked_by_user_id(current_user.id).build.count,
+            total_locked: VisualizationQueryBuilder.new.with_types(total_types).with_locked(true).build.count,
             total_shared: VisualizationQueryBuilder.new.with_types(total_types).with_shared_with_user_id(current_user.id).with_user_id_not(current_user.id).with_prefetch_table.build.count
           })
         end

--- a/lib/assets/javascripts/cartodb/dashboard/content_controller_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/content_controller_view.js
@@ -204,14 +204,9 @@ module.exports = cdb.core.View.extend({
       if (!tag && !q && shared === "no" && !locked && !liked) {
 
         if (this.router.model.get('content_type') === "maps") {
-          // If there are no maps, let's show onboarding
-          if (this.collection.total_shared > 0) {
-            this.router.navigate(this.user.viewUrl().dashboard().maps().urlToPath('shared'), { trigger: true });
-            return;
-          } else {
-            this.$el.addClass('on-boarding');
-            activeViews = ['onboarding', 'filters'];
-          }
+          // If there are no maps at all, let's show onboarding
+          this.$el.addClass('on-boarding');
+          activeViews = ['onboarding', 'filters'];
         } else if (library) {
           // Library is loaded async on 1st visit by user, so this code path is only reached until the library has been
           // stocked up. Show an intermediate loading info, and retry fetching data until while user stays here.
@@ -219,7 +214,9 @@ module.exports = cdb.core.View.extend({
           activeViews.push('loading_library');
           this.controlledViews['loading_library'].retrySoonAgainOrAbortIfLeavingLibrary(this.collection, this.router.model);
         } else if (!library && this.router.model.get('content_type') === "datasets") {
-          if (this.collection.total_shared > 0) {
+          if (this.collection.total_locked > 0) {
+            activeViews.push('no_results');
+          } else if (this.collection.total_shared > 0) {
             this.router.navigate(this.user.viewUrl().dashboard().datasets().urlToPath('shared'), { trigger: true });
             return;
           } else if (this.user.hasCreateDatasetsFeature() && cdb.config.get('data_library_enabled')) {

--- a/lib/assets/javascripts/cartodb/models/vis.js
+++ b/lib/assets/javascripts/cartodb/models/vis.js
@@ -564,6 +564,7 @@ cdb.admin.Visualizations = Backbone.Collection.extend({
     this.total_shared = response.total_shared;
     this.total_likes = response.total_likes;
     this.total_user_entries = response.total_user_entries;
+    this.total_locked = response.total_locked || 0;
     return _.map(response.visualizations, function(v) {
       v.bindMap = false;
       return v;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.60-12775",
+  "version": "4.10.60",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.60",
+  "version": "4.10.60-12775",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Pretty much the title, users won't be redirected to the shared datasets view if they have only locked datasets