### PR TITLE
Remove redirections in dataset / map dashboard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,7 @@ ion for time-series (#12670)
 * Now is possible to use wildcard character (*) in the whitelist emails for organization signups (#12991)
 
 ### Bug fixes / enhancements
+* Fix dashboard redirections (#12775)
 * Fix upload dataset drag and drop (CartoDB/support#1072)
 * Fix legends request order with slow internet connection (#12733)
 * Documentation, fixed spelling and grammar in en.json

--- a/lib/assets/javascripts/cartodb/dashboard/content_controller_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/content_controller_view.js
@@ -202,38 +202,18 @@ module.exports = cdb.core.View.extend({
 
     if (this.collection.size() === 0) {
       if (!tag && !q && shared === "no" && !locked && !liked) {
-
         if (this.router.model.get('content_type') === "maps") {
-          // If there are no maps, let's show onboarding
-          if (this.collection.total_shared > 0) {
-            this.router.navigate(this.user.viewUrl().dashboard().maps().urlToPath('shared'), { trigger: true });
-            return;
-          } else {
-            this.$el.addClass('on-boarding');
-            activeViews = ['onboarding', 'filters'];
-          }
+          this.$el.addClass('on-boarding');
+          activeViews = ['onboarding', 'filters'];
         } else if (library) {
           // Library is loaded async on 1st visit by user, so this code path is only reached until the library has been
           // stocked up. Show an intermediate loading info, and retry fetching data until while user stays here.
           // See https://github.com/CartoDB/cartodb/pull/2741 for more details.
           activeViews.push('loading_library');
           this.controlledViews['loading_library'].retrySoonAgainOrAbortIfLeavingLibrary(this.collection, this.router.model);
-        } else if (!library && this.router.model.get('content_type') === "datasets") {
-          if (this.collection.total_shared > 0) {
-            this.router.navigate(this.user.viewUrl().dashboard().datasets().urlToPath('shared'), { trigger: true });
-            return;
-          } else if (this.user.hasCreateDatasetsFeature() && cdb.config.get('data_library_enabled')) {
-            this.router.navigate(this.user.viewUrl().dashboard().datasets().dataLibrary(), { trigger: true });
-            return;
-          } else {
-            activeViews.push('no_results');
-          }
         } else {
-
-          // None of the rest, no-results
           activeViews.push('no_results');
         }
-
       } else {
         activeViews.push('no_results');
       }

--- a/lib/assets/test/spec/cartodb/dashboard/content_controller_view.spec.js
+++ b/lib/assets/test/spec/cartodb/dashboard/content_controller_view.spec.js
@@ -126,7 +126,7 @@ describe('dashboard/content_controller_view', function() {
       expect(_.size(this.view.enabledViews)).toBe(2);
     });
 
-    it('should redirect to shared route when collection is empty, none of the filters are applied but shared datasets are present, being in datasets', function() {
+    it('should not redirect to shared route when collection is empty, none of the filters are applied but shared datasets are present, being in datasets', function() {
       var url = '';
       var options;
       this.router.navigate = function(u, opts) {
@@ -136,11 +136,10 @@ describe('dashboard/content_controller_view', function() {
       this.router.model.set({ content_type: 'datasets' }, { silent: true });
       this.collection.total_shared = 10;
       this.collection.reset([]);
-      expect(url.toString().search('shared') !== -1).toBeTruthy();
-      expect(options).toEqual({ trigger: true });
+      expect(url.toString().search('shared') === -1).toBeTruthy();
     });
 
-    it('should redirect to library route when collection is empty and none of the filters are applied, being in datasets', function() {
+    it('should not redirect to library route when collection is empty and none of the filters are applied, being in datasets', function() {
       cdb.config.set('data_library_enabled', true);
       var url = '';
       var options;
@@ -151,8 +150,7 @@ describe('dashboard/content_controller_view', function() {
       this.router.model.set({ content_type: 'datasets' }, { silent: true });
       this.collection.total_shared = 0;
       this.collection.reset([]);
-      expect(url.toString().search('library') !== -1).toBeTruthy();
-      expect(options).toEqual({ trigger: true });
+      expect(url.toString().search('library') === -1).toBeTruthy();
     });
 
     it('should show empty datasets when collection is empty, none of the filters are applied and data library is disabled', function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.63",
+  "version": "4.10.63-12775",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Pretty much the title, user is no longer redirected to shared / data library, to prevent some confusing behaviour with all locked datasets