### PR TITLE
legends: don't automatycally add legends on style change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ This release changes the way Google ouath login works. If you are using it, you 
 to the oauth.google_plus section of the configuration file.
 
 ### Features
+* Stop adding legends automatically when styling a layer (#13052)
 * Add onboarding FS events (#13004)
 * Map: rearrange layer options in layers list (#13006)
 * Style: Rename "none" aggregation to "points" (#13005)

--- a/lib/assets/core/javascripts/cartodb3/data/legends/legend-base-definition-model.js
+++ b/lib/assets/core/javascripts/cartodb3/data/legends/legend-base-definition-model.js
@@ -97,7 +97,7 @@ module.exports = Backbone.Model.extend({
 
     // Override attributes with the current custom state
     var state = LegendsState.get(layerDefinitionModel, type);
-    var attributes = _.extend(attrs, {
+    var attributes = _.extend({}, attrs, {
       customState: _.keys(state)
     }, state);
 

--- a/lib/assets/core/javascripts/cartodb3/deep-insights-integration/legend-manager.js
+++ b/lib/assets/core/javascripts/cartodb3/deep-insights-integration/legend-manager.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var LegendFactory = require('../editor/layers/layer-content-views/legend/legend-factory');
 var LegendColorHelper = require('../editor/layers/layer-content-views/legend/form/legend-color-helper');
 var StyleHelper = require('../helpers/style');
@@ -73,24 +74,36 @@ var onChange = function (layerDefModel) {
           : DEFAULT_BUBBLES_COLOR;
       }
 
-      LegendFactory.createLegend(layerDefModel, 'bubble', attrs);
+      var hasBubbleLegend = LegendFactory.find(layerDefModel, 'bubble');
+      if (hasBubbleLegend) {
+        LegendFactory.createLegend(layerDefModel, 'bubble', attrs);
+      }
     } else {
       LegendFactory.removeLegend(layerDefModel, 'bubble');
     }
   }
 
   if (LegendFactory.isEnabledType('color')) {
+    var legendTypes = ['category', 'torque', 'choropleth', 'custom_choropleth'];
+
     if (color && color.attribute !== undefined) {
       var hasCustomLegend = LegendFactory.find(layerDefModel, 'custom');
+      var hasSomeLegend = [];
 
-      if (!hasCustomLegend) {
+      _.each(legendTypes, function (legendType) {
+        var hasLegend = LegendFactory.find(layerDefModel, legendType);
+        if (hasLegend) {
+          hasSomeLegend.push(hasLegend);
+        }
+      });
+
+      if (!hasCustomLegend && hasSomeLegend.length) {
         createColorLegend(layerDefModel, color);
       }
     } else {
-      LegendFactory.removeLegend(layerDefModel, 'category');
-      LegendFactory.removeLegend(layerDefModel, 'torque');
-      LegendFactory.removeLegend(layerDefModel, 'choropleth');
-      LegendFactory.removeLegend(layerDefModel, 'custom_choropleth');
+      _.each(legendTypes, function (legendType) {
+        LegendFactory.removeLegend(layerDefModel, legendType);
+      });
     }
   }
 };

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-content-view.js
@@ -161,7 +161,7 @@ module.exports = CoreView.extend({
   },
 
   _getDefaultAttributes: function (layerDefModel, type) {
-    if (type === 'torque') {
+    if (type === 'torque' || type === 'choropleth') {
       return {
         title: styleHelper.getColorAttribute(layerDefModel.styleModel)
       };

--- a/lib/assets/core/test/spec/cartodb3/deep-insights-integration/legend-manager.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/deep-insights-integration/legend-manager.spec.js
@@ -217,7 +217,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
       });
 
       it('styles color', function () {
@@ -248,8 +248,8 @@ describe('deep-insights-integrations/legend-manager', function () {
         });
 
         expect(LegendFactory.createLegend.calls.count()).toBe(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4', customState: []});
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
       });
 
       it('styles color category quantification', function () {
@@ -275,7 +275,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
       });
     });
   });
@@ -405,7 +405,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
       });
 
       it('styles color', function () {
@@ -436,8 +436,8 @@ describe('deep-insights-integrations/legend-manager', function () {
         });
 
         expect(LegendFactory.createLegend.calls.count()).toBe(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4', customState: []});
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
       });
 
       it('styles color category quantification', function () {
@@ -463,7 +463,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
       });
 
       describe('custom legend', function () {
@@ -495,8 +495,8 @@ describe('deep-insights-integrations/legend-manager', function () {
           });
 
           expect(LegendFactory.createLegend.calls.count()).toBe(1);
-          expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4', customState: []});
-          expect(LegendFactory.createLegend).not.toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number', customState: []});
+          expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
+          expect(LegendFactory.createLegend).not.toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
         });
       });
     });
@@ -598,7 +598,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
       });
 
       it('styles color category quantification', function () {
@@ -621,7 +621,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
       });
     });
   });
@@ -675,7 +675,7 @@ describe('deep-insights-integrations/legend-manager', function () {
         });
 
         var items = StyleHelper.getStyleCategories(this.styleModel);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'torque', {title: 'number', items: items, customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'torque', {title: 'number', items: items});
       });
     });
   });

--- a/lib/assets/core/test/spec/cartodb3/deep-insights-integration/legend-manager.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/deep-insights-integration/legend-manager.spec.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var Backbone = require('backbone');
 var ConfigModel = require('../../../../javascripts/cartodb3/data/config-model');
 var LegendManager = require('../../../../javascripts/cartodb3/deep-insights-integration/legend-manager');
@@ -5,11 +6,43 @@ var LegendFactory = require('../../../../javascripts/cartodb3/editor/layers/laye
 var LayerDefinitionModel = require('../../../../javascripts/cartodb3/data/layer-definition-model');
 var StyleDefinitionModel = require('../../../../javascripts/cartodb3/editor/style/style-definition-model');
 var LegendDefinitionsCollection = require('../../../../javascripts/cartodb3/data/legends/legend-definitions-collection');
+var LegendBaseDefModel = require('../../../../javascripts/cartodb3/data/legends/legend-base-definition-model');
 var CustomLegendModel = require('../../../../javascripts/cartodb3/data/legends/legend-custom-definition-model');
 var StyleHelper = require('../../../../javascripts/cartodb3/helpers/style');
+var Validations = require('../../../../javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-validations');
+
+var LEGEND_TYPES = ['category', 'torque', 'choropleth', 'custom_choropleth'];
+
+function getSuccessResponse (response, id, type, title) {
+  var success = _.clone(TestResponses[response].success);
+  success.responseText = _.template(success.responseText)({
+    id: id,
+    type: type,
+    title: title || ''
+  });
+
+  return success;
+}
+
+var TestResponses = {
+  save: {
+    success: {
+      'status': '200',
+      'content-type': 'application/json',
+      responseText: '{"created_at":"2016-09-30T07:57:15+00:00","id":"<%= id %>","layer_id":"l-1","title":"<%= title %>","type":"<%= type %>","definition": {"color":"#fabada", "prefix":"", "suffix": "" }}'
+    }
+  },
+  destroy: {
+    success: {
+      status: 204
+    }
+  }
+};
 
 describe('deep-insights-integrations/legend-manager', function () {
   beforeEach(function () {
+    jasmine.Ajax.install();
+
     this.configModel = new ConfigModel({
       base_url: '/u/pepe'
     });
@@ -45,18 +78,13 @@ describe('deep-insights-integrations/legend-manager', function () {
       vizId: 'v-123'
     });
 
+    spyOn(Validations, 'bubble').and.returnValue(true);
+    spyOn(Validations, 'choropleth').and.returnValue(true);
+    spyOn(Validations, 'category').and.returnValue(true);
+
     LegendFactory.init(this.legendDefinitionsCollection);
 
-    this.originalAjax = Backbone.ajax;
-    Backbone.ajax = function () {
-      return {
-        always: function (cb) {
-          cb();
-        }
-      };
-    };
-
-    spyOn(LegendFactory, 'createLegend');
+    spyOn(LegendFactory, 'createLegend').and.callThrough();
     spyOn(LegendFactory, 'removeLegend').and.callThrough();
     spyOn(StyleDefinitionModel.prototype, 'on').and.callThrough();
 
@@ -65,11 +93,11 @@ describe('deep-insights-integrations/legend-manager', function () {
 
   afterEach(function () {
     this.layerDefinitionModel.off();
-    Backbone.ajax = this.originalAjax;
+    jasmine.Ajax.uninstall();
   });
 
   describe('points', function () {
-    describe('without autostyle', function () {
+    describe('without existing legend', function () {
       it('styles fixed', function () {
         this.styleModel.set('fill', {
           color: {
@@ -102,7 +130,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
 
       it('styles color', function () {
@@ -125,9 +153,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
 
       it('styles color category quantification', function () {
@@ -148,16 +174,31 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(1);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
     });
 
-    describe('with autostyle', function () {
-      beforeEach(function () {
-        this.layerDefinitionModel.set({
-          autoStyle: 'wadus'
+    describe('with existing legend', function () {
+      it('styles fixed', function () {
+        this.styleModel.set('fill', {
+          color: {
+            fixed: '#fabada'
+          },
+          size: {
+            fixed: 7
+          }
         });
+
+        LegendFactory.createLegend(this.layerDefinitionModel, 'category');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'category'));
+
+        LegendFactory.createLegend.calls.reset();
+
+        this.layerDefinitionModel.set({
+          cartocss: 'wadus'
+        });
+
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
 
       it('styles size', function () {
@@ -171,24 +212,16 @@ describe('deep-insights-integrations/legend-manager', function () {
           }
         });
 
+        LegendFactory.createLegend(this.layerDefinitionModel, 'bubble');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'bubble'));
+
         LegendFactory.createLegend.calls.reset();
 
         this.layerDefinitionModel.set({
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
-
-        LegendFactory.removeLegend.calls.reset();
-        LegendFactory.createLegend.calls.reset();
-
-        this.layerDefinitionModel.set({
-          autoStyle: false,
-          cartocss: 'sudaw'
-        });
-
-        expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'custom_choropleth');
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275', customState: []});
       });
 
       it('styles color', function () {
@@ -207,26 +240,20 @@ describe('deep-insights-integrations/legend-manager', function () {
           }
         });
 
+        LegendFactory.createLegend(this.layerDefinitionModel, 'choropleth');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'choropleth'));
+        LegendFactory.createLegend(this.layerDefinitionModel, 'bubble');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 2, 'bubble'));
+
         LegendFactory.createLegend.calls.reset();
 
         this.layerDefinitionModel.set({
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
-
-        LegendFactory.removeLegend.calls.reset();
-        LegendFactory.createLegend.calls.reset();
-
-        this.layerDefinitionModel.set({
-          autoStyle: false,
-          cartocss: 'sudaw'
-        });
-
-        expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'custom_choropleth', jasmine.any(Function));
         expect(LegendFactory.createLegend.calls.count()).toBe(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number', customState: []});
       });
 
       it('styles color category quantification', function () {
@@ -243,28 +270,22 @@ describe('deep-insights-integrations/legend-manager', function () {
           }
         });
 
-        LegendFactory.removeLegend.calls.reset();
+        LegendFactory.createLegend(this.layerDefinitionModel, 'category');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'category'));
+
+        LegendFactory.createLegend.calls.reset();
 
         this.layerDefinitionModel.set({
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(0);
-        expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category');
-
-        this.layerDefinitionModel.set({
-          autoStyle: false,
-          cartocss: 'sudaw'
-        });
-
-        expect(LegendFactory.createLegend.calls.count()).toBe(1);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number', customState: []});
       });
     });
   });
 
   describe('lines', function () {
-    describe('without autostyle', function () {
+    describe('without existing legend', function () {
       it('styles fixed', function () {
         this.styleModel.set('fill', {
           color: {
@@ -297,7 +318,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
 
       it('styles color', function () {
@@ -320,9 +341,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
 
       it('styles color category quantification', function () {
@@ -343,16 +362,31 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(1);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
     });
 
-    describe('with autostyle', function () {
-      beforeEach(function () {
-        this.layerDefinitionModel.set({
-          autoStyle: 'wadus'
+    describe('with existing legend', function () {
+      it('styles fixed', function () {
+        this.styleModel.set('fill', {
+          color: {
+            fixed: '#fabada'
+          },
+          size: {
+            fixed: 7
+          }
         });
+
+        LegendFactory.createLegend(this.layerDefinitionModel, 'category');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'category'));
+
+        LegendFactory.createLegend.calls.reset();
+
+        this.layerDefinitionModel.set({
+          cartocss: 'wadus'
+        });
+
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
 
       it('styles size', function () {
@@ -366,22 +400,16 @@ describe('deep-insights-integrations/legend-manager', function () {
           }
         });
 
+        LegendFactory.createLegend(this.layerDefinitionModel, 'bubble');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'bubble'));
+
         LegendFactory.createLegend.calls.reset();
 
         this.layerDefinitionModel.set({
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
-
-        LegendFactory.createLegend.calls.reset();
-
-        this.layerDefinitionModel.set({
-          autoStyle: false,
-          cartocss: 'sudaw'
-        });
-
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#045275', customState: []});
       });
 
       it('styles color', function () {
@@ -400,26 +428,20 @@ describe('deep-insights-integrations/legend-manager', function () {
           }
         });
 
+        LegendFactory.createLegend(this.layerDefinitionModel, 'choropleth');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'choropleth'));
+        LegendFactory.createLegend(this.layerDefinitionModel, 'bubble');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 2, 'bubble'));
+
         LegendFactory.createLegend.calls.reset();
 
         this.layerDefinitionModel.set({
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number'});
-
-        LegendFactory.removeLegend.calls.reset();
-        LegendFactory.createLegend.calls.reset();
-
-        this.layerDefinitionModel.set({
-          autoStyle: false,
-          cartocss: 'sudaw'
-        });
-
-        expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'custom_choropleth', jasmine.any(Function));
         expect(LegendFactory.createLegend.calls.count()).toBe(2);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4', customState: []});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number', customState: []});
       });
 
       it('styles color category quantification', function () {
@@ -436,28 +458,56 @@ describe('deep-insights-integrations/legend-manager', function () {
           }
         });
 
-        LegendFactory.removeLegend.calls.reset();
+        LegendFactory.createLegend(this.layerDefinitionModel, 'category');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'category'));
+
+        LegendFactory.createLegend.calls.reset();
 
         this.layerDefinitionModel.set({
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(0);
-        expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category');
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number', customState: []});
+      });
 
-        this.layerDefinitionModel.set({
-          autoStyle: false,
-          cartocss: 'sudaw'
+      describe('custom legend', function () {
+        it('styles color', function () {
+          this.styleModel.set('stroke', {
+            color: {
+              attribute: 'number',
+              attribute_type: 'number',
+              bins: '3',
+              quantification: 'quantiles',
+              range: ['#ffc6c4', '#cc607d', '#672044']
+            },
+            size: {
+              attribute: 'number',
+              quantification: 'quantiles',
+              range: [1.05, 1.95]
+            }
+          });
+
+          LegendFactory.createLegend(this.layerDefinitionModel, 'custom');
+          jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'custom'));
+          LegendFactory.createLegend(this.layerDefinitionModel, 'bubble');
+          jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 2, 'bubble'));
+
+          LegendFactory.createLegend.calls.reset();
+
+          this.layerDefinitionModel.set({
+            cartocss: 'wadus'
+          });
+
+          expect(LegendFactory.createLegend.calls.count()).toBe(1);
+          expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4', customState: []});
+          expect(LegendFactory.createLegend).not.toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number', customState: []});
         });
-
-        expect(LegendFactory.createLegend.calls.count()).toBe(1);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
       });
     });
   });
 
   describe('polygons', function () {
-    describe('without autostyle', function () {
+    describe('without existing legend', function () {
       it('styles fixed', function () {
         this.styleModel.set('fill', {
           color: {
@@ -487,8 +537,7 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(1);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
 
       it('styles color category quantification', function () {
@@ -506,16 +555,31 @@ describe('deep-insights-integrations/legend-manager', function () {
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(1);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
     });
 
-    describe('with autostyle', function () {
-      beforeEach(function () {
-        this.layerDefinitionModel.set({
-          autoStyle: 'wadus'
+    describe('with existing legend', function () {
+      it('styles fixed', function () {
+        this.styleModel.set('fill', {
+          color: {
+            fixed: '#fabada'
+          },
+          size: {
+            fixed: 7
+          }
         });
+
+        LegendFactory.createLegend(this.layerDefinitionModel, 'category');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'category'));
+
+        LegendFactory.createLegend.calls.reset();
+
+        this.layerDefinitionModel.set({
+          cartocss: 'wadus'
+        });
+
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
       });
 
       it('styles color', function () {
@@ -529,23 +593,16 @@ describe('deep-insights-integrations/legend-manager', function () {
           }
         });
 
-        LegendFactory.removeLegend.calls.reset();
+        LegendFactory.createLegend(this.layerDefinitionModel, 'choropleth');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'choropleth'));
+
+        LegendFactory.createLegend.calls.reset();
 
         this.layerDefinitionModel.set({
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(0);
-        expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth');
-
-        LegendFactory.createLegend.calls.reset();
-
-        this.layerDefinitionModel.set({
-          autoStyle: false,
-          cartocss: 'sudaw'
-        });
-
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number', customState: []});
       });
 
       it('styles color category quantification', function () {
@@ -559,24 +616,16 @@ describe('deep-insights-integrations/legend-manager', function () {
           }
         });
 
-        LegendFactory.removeLegend.calls.reset();
+        LegendFactory.createLegend(this.layerDefinitionModel, 'category');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'category'));
+
+        LegendFactory.createLegend.calls.reset();
 
         this.layerDefinitionModel.set({
           cartocss: 'wadus'
         });
 
-        expect(LegendFactory.createLegend.calls.count()).toBe(0);
-        expect(LegendFactory.removeLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category');
-
-        LegendFactory.createLegend.calls.reset();
-
-        this.layerDefinitionModel.set({
-          autoStyle: false,
-          cartocss: 'sudaw'
-        });
-
-        expect(LegendFactory.createLegend.calls.count()).toBe(1);
-        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number'});
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'category', {title: 'number', customState: []});
       });
     });
   });
@@ -586,75 +635,52 @@ describe('deep-insights-integrations/legend-manager', function () {
       this.styleModel.set('type', 'animation');
     });
 
-    it('styles color', function () {
-      this.styleModel.set('fill', {
-        color: {
-          attribute: 'number',
-          attribute_type: 'number',
-          range: ['#ffc6c4', '#cc607d', '#672044'],
-          domain: [20, 21, 22]
-        },
-        size: {
-          fixed: 7
-        }
-      });
-
-      this.layerDefinitionModel.set({
-        cartocss: 'wadus'
-      });
-
-      var items = StyleHelper.getStyleCategories(this.styleModel);
-      expect(LegendFactory.createLegend).toHaveBeenCalled();
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'torque', {title: 'number', items: items});
-    });
-  });
-
-  describe('custom legend', function () {
-    beforeEach(function () {
-      var customLegend = new CustomLegendModel({
-        title: 'custom',
-        items: [
-          {
-            title: 'Foo',
-            color: '#f4b4d4'
+    describe('without existing legend', function () {
+      it('styles color', function () {
+        this.styleModel.set('fill', {
+          color: {
+            attribute: 'number',
+            attribute_type: 'number',
+            range: ['#ffc6c4', '#cc607d', '#672044'],
+            domain: [20, 21, 22]
+          },
+          size: {
+            fixed: 7
           }
-        ]
-      }, {
-        configModel: this.configModel,
-        layerDefinitionModel: this.layerDefinitionModel,
-        vizId: 'v-123'
-      });
+        });
 
-      this.legendDefinitionsCollection.add(customLegend);
+        this.layerDefinitionModel.set({
+          cartocss: 'wadus'
+        });
+
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
+      });
     });
 
-    it('styles color doesn\'t create a new color legend', function () {
-      this.styleModel.set('fill', {
-        color: {
-          attribute: 'number',
-          attribute_type: 'number',
-          bins: '3',
-          quantification: 'quantiles',
-          range: ['#ffc6c4', '#cc607d', '#672044']
-        },
-        size: {
-          attribute: 'number',
-          quantification: 'quantiles',
-          range: [1.05, 1.95]
-        }
+    describe('with existing legend', function () {
+      it('styles color', function () {
+        this.styleModel.set('fill', {
+          color: {
+            attribute: 'number',
+            attribute_type: 'number',
+            range: ['#ffc6c4', '#cc607d', '#672044'],
+            domain: [20, 21, 22]
+          },
+          size: {
+            fixed: 7
+          }
+        });
+
+        LegendFactory.createLegend(this.layerDefinitionModel, 'torque');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'torque'));
+
+        this.layerDefinitionModel.set({
+          cartocss: 'wadus'
+        });
+
+        var items = StyleHelper.getStyleCategories(this.styleModel);
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'torque', {title: 'number', items: items, customState: []});
       });
-
-      this.layerDefinitionModel.set({
-        cartocss: 'wadus'
-      });
-
-      // if there is a custom legend (custom is a color legend type), changes in color style don't create a new color
-      // legend. In this test the style is changing its color and size attributes, so createLegend should be called
-      // only once to create a bubble legend, but no choropleth legend
-
-      expect(LegendFactory.createLegend.calls.count()).toBe(1);
-      expect(LegendFactory.createLegend).toHaveBeenCalledWith(this.layerDefinitionModel, 'bubble', {title: 'number', fillColor: '#ffc6c4'});
-      expect(LegendFactory.createLegend).not.toHaveBeenCalledWith(this.layerDefinitionModel, 'choropleth', {title: 'number'});
     });
   });
 });

--- a/lib/assets/core/test/spec/cartodb3/deep-insights-integration/legend-manager.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/deep-insights-integration/legend-manager.spec.js
@@ -6,12 +6,8 @@ var LegendFactory = require('../../../../javascripts/cartodb3/editor/layers/laye
 var LayerDefinitionModel = require('../../../../javascripts/cartodb3/data/layer-definition-model');
 var StyleDefinitionModel = require('../../../../javascripts/cartodb3/editor/style/style-definition-model');
 var LegendDefinitionsCollection = require('../../../../javascripts/cartodb3/data/legends/legend-definitions-collection');
-var LegendBaseDefModel = require('../../../../javascripts/cartodb3/data/legends/legend-base-definition-model');
-var CustomLegendModel = require('../../../../javascripts/cartodb3/data/legends/legend-custom-definition-model');
 var StyleHelper = require('../../../../javascripts/cartodb3/helpers/style');
 var Validations = require('../../../../javascripts/cartodb3/editor/layers/layer-content-views/legend/legend-validations');
-
-var LEGEND_TYPES = ['category', 'torque', 'choropleth', 'custom_choropleth'];
 
 function getSuccessResponse (response, id, type, title) {
   var success = _.clone(TestResponses[response].success);

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/legend/legend-factory.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/legend/legend-factory.spec.js
@@ -126,14 +126,18 @@ describe('editor/layers/layer-content-view/legend/legend-factory', function () {
     model.set.calls.reset();
 
     LegendFactory.createLegend(this.layerDefinitionModel, 'bubble', {title: 'bar'});
-    expect(model.set).toHaveBeenCalledWith({title: 'fiu', customState: ['title']});
+    expect(model.set).toHaveBeenCalledWith({title: 'bar'});
+    expect(model.get('title')).toEqual('fiu');
+    expect(model.get('customState')).toEqual(['title']);
 
     // Mimic the remove the title action by the UI form
     model.setAttributes({title: 'foo'});
 
     model.set.calls.reset();
     LegendFactory.createLegend(this.layerDefinitionModel, 'bubble', {title: 'bar'});
-    expect(model.set).toHaveBeenCalledWith({title: 'foo', customState: ['title']});
+    expect(model.set).toHaveBeenCalledWith({title: 'bar'});
+    expect(model.get('title')).toEqual('foo');
+    expect(model.get('customState')).toEqual(['title']);
   });
 
   it('remove legend', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.10.66",
+  "version": "4.10.66.13002",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
re: https://github.com/CartoDB/cartodb/issues/13002

I have some concerns I already raised on the issue, nevertheless proceeded with the change.

Tests have been changed a lot, also removed the autostyle sections as currently when you change the style WITH autostyle activated it disables autostyle so I don't think it really made sense anymore. 

Finally, when you toggle autostyle and at the same time are in the legends panel, it won't update, but this is already happening in production so this is not related to the changes at hand, feel free to open a new issue.

**acceptance**

- legends should still behave the same way on style change ONLY if they have previously been added, otherwise style change will have no effect on them
