### PR TITLE
Remove ambiguous column in search tweets query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -274,6 +274,7 @@ ion for time-series (#12670)
 * Fix TrackJS missing token in static pages (#12914)
 * Fix missing upgrade link in static dashboard (#12929)
 * Fix histogram zoom (#12945)
+* Fix ambiguous column call in the search tweets query (#13073)
 
 ### Internals
 * Use engine instead of visModel internally (#12992)

--- a/app/models/search_tweet.rb
+++ b/app/models/search_tweet.rb
@@ -21,7 +21,7 @@ class SearchTweet < Sequel::Model
 
   def self.get_twitter_imports_count(dataset, date_from, date_to)
     dataset
-        .where(state: ::SearchTweet::STATE_COMPLETE)
+        .where('search_tweets.state = ?', ::SearchTweet::STATE_COMPLETE)
         .where('search_tweets.created_at >= ? AND search_tweets.created_at <= ?', date_from, date_to + 1.days)
         .sum("retrieved_items".lit).to_i
   end


### PR DESCRIPTION
This will cause errors when we are able to add the `state` column to users in this [PR](https://github.com/CartoDB/cartodb/pull/13057)