### PR TITLE
Add state column to users without default value

### DIFF
--- a/db/migrate/20171115114600_add_state_to_users_without_default.rb
+++ b/db/migrate/20171115114600_add_state_to_users_without_default.rb
@@ -1,0 +1,12 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  Proc.new do
+    add_column :users, :state, :text
+  end,
+  Proc.new do
+    drop_column :users, :state
+  end
+)


### PR DESCRIPTION
**DO NOT MERGE**

This is the first step in this migration. Next step will be to add the default state `active` to avoid locking problems doing it