### PR TITLE
Compass: Invalid US-ASCII character

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ This release changes the way Google ouath login works. If you are using it, you 
 to the oauth.google_plus section of the configuration file.
 
 ### Features
+* Force UTF-8 encoding in the Compass task
 * Trigger error when interactivity request fails (#13093)
 * Add interactivity error infobox (#13027)
 * Add limits for torque (#13085)

--- a/lib/build/tasks/compass.js
+++ b/lib/build/tasks/compass.js
@@ -23,7 +23,8 @@ exports.task = function () {
         outputStyle: 'compressed',
         noLineComments: true,
         force: false,
-        time: true
+        time: true,
+        raw: 'Encoding.default_external = \'utf-8\'\n'
       }
     }
   };


### PR DESCRIPTION
I've been having issues building builder for a while (currently running node 9.2.0, npm 5.5.1, ruby 2.4.2p198), and here is the only thing I could not solve by changing how to create the package:

```
Running "compass:dist" (compass) task
directory public/assets/4.10.82/stylesheets/api_keys
    write public/assets/4.10.82/stylesheets/api_keys/api_keys.css (0.002s)
directory public/assets/4.10.82/stylesheets/common
    error tmp/sass/editor/common/account_forms.scss (Line 6 of tmp/sass/editor/variables/mixins.scss: Invalid US-ASCII character "\xC2")
Sass::SyntaxError on line ["6"] of /home/raul/dev/public/cartodb/tmp/sass/editor/variables/mixins.scss: Invalid US-ASCII character "\xC2"
Run with --trace to see the full backtrace
Warning: ↑ Use --force to continue.
```
Fixed by setting the encoding in the compass task.

I'm tagging @xavijam as I see you've committed recently but feel free to redirect the PR to more appropriate devs. Can you please take a look?