### PR TITLE
Expose auth_tokens in editor visualization controller

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,7 @@ ion for time-series (#12670)
 * Added lockout page to show when a user is locked up due to expiration of the trial (#13100)
 
 ### Bug fixes / enhancements
+* Fixes image export in editor (#13089)
 * Improve the discoverability of the table view switch (#13050)
 * Change Basemap layer style (#13091)
 * Rename point/polygon count to feature count (#13066)

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -103,7 +103,7 @@ class Admin::VisualizationsController < Admin::AdminController
     end
 
     if @visualization.is_privacy_private? && @visualization.has_read_permission?(current_user)
-        @auth_tokens = current_user.get_auth_tokens
+      @auth_tokens = current_user.get_auth_tokens
     end
 
     respond_to { |format| format.html }

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -102,6 +102,10 @@ class Admin::VisualizationsController < Admin::AdminController
       return redirect_to CartoDB.url(self, 'builder_visualization', { id: request.params[:id] }, current_user)
     end
 
+    if @visualization.is_privacy_private? && @visualization.has_read_permission?(current_user)
+        @auth_tokens = current_user.get_auth_tokens
+    end
+
     respond_to { |format| format.html }
   end
 

--- a/app/views/admin/visualizations/show.html.erb
+++ b/app/views/admin/visualizations/show.html.erb
@@ -13,6 +13,7 @@
     var config = <%= safe_js_object frontend_config %>;
     var map_data = <%= safe_js_object @visualization.map.public_values.to_json %>;
     var basemaps = <%=raw Cartodb.config[:basemaps].present? ? Cartodb.config[:basemaps].to_json.html_safe: 'null' %>;
+    var authTokens = <%= safe_js_object @auth_tokens.to_json %>;
   </script>
 
   <% content_for(:js) do %>

--- a/lib/assets/javascripts/cartodb/table/export_image_view.js
+++ b/lib/assets/javascripts/cartodb/table/export_image_view.js
@@ -325,7 +325,7 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
     bounds.push([options.bounds[0][1], options.bounds[0][0]]);
     bounds.push([options.bounds[1][1], options.bounds[1][0]]);
 
-    cdb.Image(this.url, { https: this._isHTTPS() })
+    cdb.Image(this.url, { https: this._isHTTPS(), auth_tokens: authTokens })
     .size(width, height)
     .bbox(bounds)
     .format(format)
@@ -361,7 +361,7 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
     var width  = this.model.get("width");
     var height = this.model.get("height");
 
-    cdb.Image(this.url, { https: this._isHTTPS() })
+    cdb.Image(this.url, { https: this._isHTTPS(), auth_tokens: authTokens })
     .format(this.model.get('format'))
     .size(width, height)
     .center([center.lat, center.lng])

--- a/lib/assets/test/spec/cartodb/table/map/export_image_view.spec.js
+++ b/lib/assets/test/spec/cartodb/table/map/export_image_view.spec.js
@@ -1,6 +1,8 @@
 describe("ExportImage", function() {
 
   describe("cdb.admin.ExportImageView", function() {
+    var authTokens = ['authTokens'];
+
     beforeEach(function() {
       this.map = new cdb.geo.Map();
 

--- a/lib/assets/test/spec/cartodb/table/map/export_image_view.spec.js
+++ b/lib/assets/test/spec/cartodb/table/map/export_image_view.spec.js
@@ -1,9 +1,8 @@
 describe("ExportImage", function() {
 
   describe("cdb.admin.ExportImageView", function() {
-    var authTokens = ['authTokens'];
-
     beforeEach(function() {
+      window.authTokens = ['authTokens'];
       this.map = new cdb.geo.Map();
 
       this.container = $('<div>').css({ width: '500px', height: '500px' });
@@ -90,6 +89,8 @@ describe("ExportImage", function() {
 
     afterEach(function() {
       this.view.clean();
+      window.authTokens = undefined;
+      delete window.authTokens;
     });
 
     it("should render", function() {


### PR DESCRIPTION
Fixes #13089 

This PR exposes the user's auth_tokens in the visualization
controller for the editor. It only happens if the user has read
permissions to the visualization and if the privacy of the visualization
is set to private.

CartoDB.js part: https://github.com/CartoDB/cartodb.js/pull/1928