### PR TITLE
Change how we delete the analysis cache tables in the user deletion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -297,6 +297,7 @@ ion for time-series (#12670)
 * Fix histogram zoom (#12945)
 * Fix ambiguous column call in the search tweets query (#13073)
 * Fix email validator failing with empty emails (#13078)
+* Be sure to delete the analysis cache tables while we're dropping a organization user (#13136)
 * Treat all time series dataview timestamps as UTC (#13070)
 
 ### Internals

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -30,9 +30,6 @@ class Carto::User < ActiveRecord::Base
   STATE_ACTIVE = 'active'.freeze
   STATE_LOCKED = 'locked'.freeze
 
-  # TODO Remove and get the data from central
-  LOCKED_USER_DELETION_PERIOD = 90.days
-
   # INFO: select filter is done for security and performance reasons. Add new columns if needed.
   DEFAULT_SELECT = "users.email, users.username, users.admin, users.organization_id, users.id, users.avatar_url," \
                    "users.api_key, users.database_schema, users.database_name, users.name, users.location," \

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,9 +126,6 @@ class User < Sequel::Model
   STATE_ACTIVE = 'active'.freeze
   STATE_LOCKED = 'locked'.freeze
 
-  #TODO Remove, get the data from Central
-  LOCKED_USER_DELETION_PERIOD = 90.days
-
   self.raise_on_typecast_failure = false
   self.raise_on_save_failure = false
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1547,9 +1547,9 @@ describe User do
 
       it 'deletes temporary analysis tables' do
         db = @org_user_2.in_database
-        db.run('CREATE TABLE analysis_123 (a int)')
+        db.run('CREATE TABLE analysis_cd60938c7b_2ad1345b134ed3cd363c6de651283be9bd65094e (a int)')
         db.run(%{INSERT INTO cdb_analysis_catalog (username, cache_tables, node_id, analysis_def)
-                 VALUES ('#{@org_user_2.username}', '{analysis_123}', 'a0', '{}')})
+                 VALUES ('#{@org_user_2.username}', '{analysis_cd60938c7b_2ad1345b134ed3cd363c6de651283be9bd65094e}', 'a0', '{}')})
         @org_user_2.destroy
 
         db = @org_user_owner.in_database


### PR DESCRIPTION
We have been deleting the analysis cache tables using the reference
is stored in the `cab_analysis_catalog` table but for some reason
sometimes we have the table but not the reference in the table.

So in order to avoid this kind of mismatch due to bugs and because
we're not worried about the integrity of this table when we're deleting
the user, we're going to retrieve the analysis tables using pg_tables
and cleaning the metadata table all in the same transaction

The main reason behind this is that if we don't clean all the tables
we end up having owners blocked when they try to delete users