### PR TITLE
user.destroy_account, abstracting the right deletion order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -132,6 +132,9 @@ ion for time-series (#12670)
 * Clean permissions ACL on group deletion (CartoDB/support/issues/1057)
 * Improve legends for torque (CartoDB/support#979)
 * CSV export allowed without geometries (#12888)
+* User destroy order should be Central, local (#CartoDB/cartodb-central/issues/1929)
+* Delete all external sources within one transaction (#13129).
+* NoMethodError: undefined method `has_feature_flag?' for nil:NilClass at visualizations controller (#13145).
 * Fix handling of imports with long file names and existing tables with almost the same name (#12732)
 * Update widgets although source layer is not visible (support/#1135)
 * Update cartodb.js version

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -114,8 +114,7 @@ class Admin::UsersController < Admin::AdminController
       raise PASSWORD_DOES_NOT_MATCH_MESSAGE
     end
 
-    @user.destroy
-    @user.delete_in_central
+    @user.destroy_account
 
     redirect_to logout_url
   rescue CartoDB::CentralCommunicationFailure => e

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -228,7 +228,7 @@ class Admin::VisualizationsController < Admin::AdminController
       end
     end
 
-    return render(file: "public/static/public_map/index.html", layout: false) if @viewed_user.has_feature_flag?('static_public_map')
+    return render(file: "public/static/public_map/index.html", layout: false) if @viewed_user && @viewed_user.has_feature_flag?('static_public_map')
 
     return(embed_forbidden) unless @visualization.is_accesible_by_user?(current_user)
 

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -228,7 +228,9 @@ class Admin::VisualizationsController < Admin::AdminController
       end
     end
 
-    return render(file: "public/static/public_map/index.html", layout: false) if @viewed_user && @viewed_user.has_feature_flag?('static_public_map')
+    if @viewed_user && @viewed_user.has_feature_flag?('static_public_map')
+      return render(file: "public/static/public_map/index.html", layout: false)
+    end
 
     return(embed_forbidden) unless @visualization.is_accesible_by_user?(current_user)
 

--- a/app/controllers/carto/api/users_controller.rb
+++ b/app/controllers/carto/api/users_controller.rb
@@ -103,8 +103,7 @@ module Carto
           render_jsonp({ message: "Error deleting user: #{PASSWORD_DOES_NOT_MATCH_MESSAGE}" }, 400) and return
         end
 
-        user.destroy
-        user.delete_in_central
+        user.destroy_account
 
         render_jsonp({ logout_url: logout_url }, 200)
       rescue CartoDB::CentralCommunicationFailure => e

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1691,6 +1691,13 @@ class User < Sequel::Model
     state == STATE_LOCKED
   end
 
+  # Central will request some data back to cartodb (quotas, for example), so the user still needs to exist.
+  # Corollary: multithreading is needed for deletion to work.
+  def destroy_account
+    delete_in_central
+    destroy
+  end
+
   private
 
   def common_data_outdated?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -432,9 +432,11 @@ class User < Sequel::Model
 
     begin
       # Remove user data imports, maps, layers and assets
-      delete_external_data_imports
-      delete_external_sources
-      Carto::VisualizationQueryBuilder.new.with_user_id(id).build.all.each(&:destroy)
+      ActiveRecord::Base.transaction do
+        delete_external_data_imports
+        delete_external_sources
+        Carto::VisualizationQueryBuilder.new.with_user_id(id).build.all.each(&:destroy)
+      end
 
       # This shouldn't be needed, because previous step deletes canonical visualizations.
       # Kept in order to support old data.

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -1596,12 +1596,12 @@ describe Carto::Api::VisualizationsController do
 
               get_json api_v1_visualizations_show_url(id: @visualization.id) do |response|
                 response.status.should eq 403
-                expect(response.body[:errors]).to eq('Password invalid')
+                expect(response.body[:errors]).to eq('Visualization not viewable')
               end
 
               get_json api_v1_visualizations_show_url(id: @visualization.id, password: password * 2) do |response|
                 response.status.should eq 403
-                expect(response.body[:errors]).to eq('Password invalid')
+                expect(response.body[:errors]).to eq('Visualization not viewable')
               end
 
               get_json api_v1_visualizations_show_url(id: @visualization.id, password: password) do |response|


### PR DESCRIPTION
Related to CartoDB/cartodb-central/issues/1929 .

2. [CartodbCentral::Errors::RecordNotFound: Error updating users monthly uses](https://rollbar.com/carto/CartoDB-Central/items/9168/?item_page=0&item_count=100&#instances).
3. [Response code invalid on safe_api_call](https://rollbar.com/carto/CartoDB-Central/items/4006/occurrences/34021338102/).

Closes CartoDB/cartodb/issues/13129 and CartoDB/cartodb/issues/13145 as well.