### PR TITLE
Fix saml configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -309,6 +309,7 @@ ion for time-series (#12670)
 * Fix email validator failing with empty emails (#13078)
 * Be sure to delete the analysis cache tables while we're dropping a organization user (#13136)
 * Fix for legends when there is only one element in the ramp (cartodb.js#1938)
+* Fix SAML configuration bug that doesn't let access some properties properly (#13161)
 * Treat all time series dataview timestamps as UTC (#13070)
 
 ### Internals

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -125,7 +125,8 @@ module Carto
     end
 
     def carto_saml_configuration
-      @organization.try(:auth_saml_configuration)
+      saml_config = @organization.try(:auth_saml_configuration)
+      saml_config ? saml_config.deep_symbolize_keys : nil
     end
   end
 end

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -125,8 +125,7 @@ module Carto
     end
 
     def carto_saml_configuration
-      saml_config = @organization.try(:auth_saml_configuration)
-      saml_config ? saml_config.deep_symbolize_keys : nil
+      @organization.try(:auth_saml_configuration).try(:deep_symbolize_keys)
     end
   end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -52,7 +52,7 @@ FactoryGirl.define do
           assertion_consumer_service_url: 'https://localhost.lan/saml/finalize',
           name_identifier_format: '',
           email_attribute: 'username'
-        }
+        }.stringify_keys
       end
     end
   end

--- a/spec/lib/carto/saml_service_spec.rb
+++ b/spec/lib/carto/saml_service_spec.rb
@@ -6,11 +6,11 @@ describe Carto::SamlService do
     Carto::SamlService.new(@organization)
   end
 
-  before(:all) do
+  before(:each) do
     @organization = FactoryGirl.create(:saml_organization)
   end
 
-  after(:all) do
+  after(:each) do
     @organization.delete
   end
 
@@ -27,8 +27,12 @@ describe Carto::SamlService do
       service.enabled?.should be_true
     end
 
-    it 'email_attribute not the default if defined' do
-      service.send(:email_attribute).should eq 'username'
+    it 'email_attribute doesnt return the default value if its defined' do
+      saml_config = @organization.auth_saml_configuration
+      saml_config['email_attribute'] = 'defined_username'
+      service.send(:email_attribute).should eq 'defined_username'
+      saml_config['email_attribute'] = nil
+      service.send(:email_attribute).should eq 'name_id'
     end
   end
 

--- a/spec/lib/carto/saml_service_spec.rb
+++ b/spec/lib/carto/saml_service_spec.rb
@@ -26,6 +26,10 @@ describe Carto::SamlService do
     it 'is enabled if there is configuration' do
       service.enabled?.should be_true
     end
+
+    it 'email_attribute not the default if defined' do
+      service.send(:email_attribute).should eq 'username'
+    end
   end
 
   describe 'Integration logic' do

--- a/spec/lib/carto/saml_service_spec.rb
+++ b/spec/lib/carto/saml_service_spec.rb
@@ -61,7 +61,7 @@ describe Carto::SamlService do
       it 'returns the user with matching email' do
         user = create_test_saml_user
         response_mock.stubs(:is_valid?).returns(true)
-        response_mock.stubs(:attributes).returns(saml_config[:email_attribute] => user.email)
+        response_mock.stubs(:attributes).returns(saml_config['email_attribute'] => user.email)
 
         service.get_user_email(saml_response_param_mock).should eq user.email
 


### PR DESCRIPTION
Fixes https://github.com/CartoDB/support/issues/1167
JSON serialized returns the Hash with string instead of symbol in the keys and this default/nil values when try to get them