### PR TITLE
WebglStats

### DIFF
--- a/app/controllers/carto/api/metrics_controller.rb
+++ b/app/controllers/carto/api/metrics_controller.rb
@@ -32,7 +32,9 @@ module Carto
         raise Carto::UnprocesableEntityError.new('name not provided') unless event_name
 
         modulized_name = "Carto::Tracking::Events::#{event_name.parameterize('_').camelize}"
-        @event = modulized_name.constantize.new(current_viewer.id, params[:properties])
+
+        @event = Carto::Tracking::Events::SegmentEvent.build(params[:name], current_viewer.id, params[:properties])
+        @event ||= modulized_name.constantize.new(current_viewer.id, params[:properties])
       rescue NameError
         raise Carto::LoadError.new("Event not found: #{event_name}")
       end

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -280,6 +280,14 @@ module Carto
 
         required_properties :user_id, :visualization_id, :type
       end
+
+      class WebglStats < Event
+        include Carto::Tracking::Services::Segment
+
+        include Carto::Tracking::Validators::User
+
+        required_properties :user_id, :visualization_id
+      end
     end
   end
 end

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -281,12 +281,35 @@ module Carto
         required_properties :user_id, :visualization_id, :type
       end
 
-      class WebglStats < Event
+      class SegmentEvent < Event
         include Carto::Tracking::Services::Segment
 
-        include Carto::Tracking::Validators::User
+        attr_reader :name
 
-        required_properties :user_id, :visualization_id
+        private_class_method :new
+
+        def self.build(name, reporter_id, properties)
+          new(name, reporter_id, properties) if EVENTS.include?(name)
+        end
+
+        private
+
+        EVENTS = ['WebGL stats'].freeze
+
+        def initialize(name, reporter_id, properties)
+          @name = name
+          @properties = properties
+          @format = SegmentFormat.new(properties)
+          @reporter = Carto::User.find(reporter_id)
+        end
+      end
+
+      class SegmentFormat < Carto::Tracking::Formats::Internal
+        def to_segment
+          data = super
+          data[:data_properties] = to_hash['properties']
+          data
+        end
       end
     end
   end

--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -307,7 +307,7 @@ module Carto
       class SegmentFormat < Carto::Tracking::Formats::Internal
         def to_segment
           data = super
-          data[:data_properties] = to_hash['properties']
+          data[:data_properties] = to_hash
           data
         end
       end

--- a/spec/requests/carto/api/metrics_controller_spec.rb
+++ b/spec/requests/carto/api/metrics_controller_spec.rb
@@ -26,6 +26,8 @@ describe Carto::Api::MetricsController do
     user_properties = { user_id: user_id, api_key: @user.api_key }
 
     Carto::Tracking::Events::Event.descendants.each do |event_class|
+      next unless event_class.public_methods.include?(:new)
+
       event = event_class.new(user_id, user_id: user_id)
 
       event_class.any_instance.stubs(:report!)
@@ -48,9 +50,9 @@ describe Carto::Api::MetricsController do
   describe 'validations' do
     it 'should require properties' do
       Carto::Tracking::Events::Event.descendants.each do |event_class|
-        event = event_class.new(@user.id, {})
+        next unless event_class.public_methods.include?(:new)
 
-        puts "Testing #{event_class}"
+        event = event_class.new(@user.id, {})
 
         unless event.required_properties.empty?
           post_json metrics_url, name: event.name, properties: {} do |response|


### PR DESCRIPTION
@dv343 with this change, this is sent to Segment:

![captura de pantalla 2017-12-05 a las 17 00 11](https://user-images.githubusercontent.com/932968/33616663-d2570260-d9dd-11e7-93c5-218b5163a961.png)

~If this is what you're looking for, merge this PR.~~

Once I get your 👍 , @dv343 , I'll ask for CR, because this change should be discussed with other backenders.

PS: you'll get rid of backend test errors at your PR as soon as you merge `master` into `webgl-stats`.