### PR TITLE
Grunt: Run carto-node before browserify

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -320,6 +320,7 @@ module.exports = function (grunt) {
     'cdb',
     'copy:js_cartodb',
     'setConfig:env.browserify_watch:true',
+    'npm-carto-node',
     'run_browserify',
     'concat:js',
     'jst'
@@ -424,7 +425,6 @@ module.exports = function (grunt) {
    * `grunt test`
    */
   grunt.registerTask('test', '(CI env) Re-build JS files and run all tests. For manual testing use `grunt jasmine` directly', [
-    'npm-carto-node',
     'connect:test',
     'beforeDefault',
     'js_editor',

--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,7 @@ ion for time-series (#12670)
 * Added lockout page to show when a user is locked up due to expiration of the trial (#13100)
 
 ### Bug fixes / enhancements
+* Grunt: Run carto-node before browserify (#13187)
 * Enable data tab if layer needs geocoding
 * Fix bug in redirection after analysis is completed (CartoDB/support#1183)
 * Hide Salesforce Connector Form (CartoDB/tech-ops#324)


### PR DESCRIPTION
Arch's package stopped working complaining about a missing file:
```
Running "browserify:test_specs_for_browserify_modules" (browserify) task
>> Error: Cannot find module '../../../../../../vendor/assets/javascripts/carto-node/carto-node' from '/home/raul/dev/PKGBUILDs/carto-builder/src/cartodb/lib/assets/test/spec/cartodb/account'
```

Browserify uses the carto-node files and it couldn't find them, so I've added the task before running browserify. @elenatorro I see you've been the last one tinkering with the file, can you have a look at the change please?