### PR TITLE
Fix datasets downloaded as "cartodb-query"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -324,6 +324,7 @@ ion for time-series (#12670)
 * Be sure to delete the analysis cache tables while we're dropping a organization user (#13136)
 * Fix for legends when there is only one element in the ramp (cartodb.js#1938)
 * Treat all time series dataview timestamps as UTC (#13070)
+* Fix datasets downloaded as "cartodb-query" [Support #1179](https://github.com/CartoDB/support/issues/1179)
 
 ### Internals
 * Use engine instead of visModel internally (#12992)

--- a/lib/assets/core/javascripts/cartodb3/components/modals/export-data/modal-export-data-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/export-data/modal-export-data-view.js
@@ -57,6 +57,7 @@ module.exports = CoreView.extend({
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
     this._layerModel = opts.layerModel;
+    this._filename = opts.filename;
 
     this._initBinds();
 
@@ -162,7 +163,7 @@ module.exports = CoreView.extend({
    */
   getBaseOptions: function () {
     return {
-      filename: this._layerModel && this._layerModel.getName(),
+      filename: this._filename,
       apiKey: this._configModel.get('api_key')
     };
   },

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-content/dataset-content-options-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-content/dataset-content-options-view.js
@@ -68,7 +68,7 @@ module.exports = CoreView.extend({
       return new ModalExportDataView({
         modalModel: modalModel,
         configModel: this._configModel,
-        fileName: this._tableModel.getUnquotedName(),
+        filename: this._tableModel.getUnquotedName(),
         queryGeometryModel: this._queryGeometryModel
       });
     }.bind(this));

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-header-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-header-view.js
@@ -355,7 +355,7 @@ module.exports = CoreView.extend({
         modalModel: modalModel,
         queryGeometryModel: queryGeometryModel,
         configModel: this._configModel,
-        fileName: this._layerDefinitionModel.getName()
+        filename: this._layerDefinitionModel.getName()
       });
     }.bind(this));
   },

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
@@ -386,7 +386,8 @@ module.exports = CoreView.extend({
         modalModel: modalModel,
         queryGeometryModel: queryGeometryModel,
         configModel: this._configModel,
-        layerModel: this.model
+        layerModel: this.model,
+        filename: this.model.getName()
       });
     }.bind(this));
   },


### PR DESCRIPTION
https://github.com/CartoDB/support/issues/1179
----

Due to a change made to get metrics of downloaded layers, the dataset export functionality was not including the right filename.

This PR fixes that issue.