### PR TITLE
Fixed support for organization assets on org import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,7 @@ ion for time-series (#12670)
 * Don't show basemap's labels layer in layer list (#13000)
 * Fallback to `username` when `name` is empty in share map view
 * Fix bounding box not updating with gmaps basemaps
+* Fix support for organization assets on org import (CartoDB/cartodb-central#1981)
 * Supporting text-placement for labels (CartoDB/support#13015)
 * Google oauth now works without JS (#12977)
 * Add "less or equal than" and "greater or equal than" to filter by value analysis

--- a/app/models/carto/organization.rb
+++ b/app/models/carto/organization.rb
@@ -18,7 +18,7 @@ module Carto
     has_many :users, inverse_of: :organization, order: :username
     belongs_to :owner, class_name: Carto::User, inverse_of: :owned_organization
     has_many :groups, inverse_of: :organization, order: :display_name
-    has_many :assets, class_name: Carto::Asset, dependent: :destroy
+    has_many :assets, inverse_of: :organization, class_name: Carto::Asset, dependent: :destroy
     has_many :notifications, dependent: :destroy, order: 'created_at DESC'
 
     before_destroy :destroy_groups_with_extension

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -233,6 +233,7 @@ module Carto
       organization = Carto::Organization.find(organization.id)
       organization.groups.delete
       organization.notifications.delete
+      organization.assets.delete
       organization.users.delete
       organization.delete
     end

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -233,7 +233,7 @@ module Carto
       organization = Carto::Organization.find(organization.id)
       organization.groups.delete
       organization.notifications.delete
-      organization.assets.delete
+      organization.assets.map(&:destroy)
       organization.users.delete
       organization.delete
     end

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -233,7 +233,7 @@ module Carto
       organization = Carto::Organization.find(organization.id)
       organization.groups.delete
       organization.notifications.delete
-      organization.assets.map(&:destroy)
+      organization.assets.map(&:delete)
       organization.users.delete
       organization.delete
     end

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -101,7 +101,8 @@ describe Carto::OrganizationMetadataExportService do
         clean_redis
         Table.any_instance.stubs(:remove_table_from_user_database)
         @organization.notifications.each(&:destroy)
-        @organization.assets.each(&:destroy)
+        @organization.assets.each(&:delete)
+        @organization.assets.clear
         @organization.users.flat_map(&:visualizations).each(&:destroy)
         @organization.users.each(&:destroy)
         @organization.groups.each(&:destroy)

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -15,7 +15,7 @@ describe Carto::OrganizationMetadataExportService do
     @map, @table, @table_visualization, @visualization = create_full_visualization(@non_owner)
     share_visualization_with_user(@table_visualization, @owner)
 
-    @asset = FactoryGirl.create(:carto_asset, organization: @organization)
+    @asset = FactoryGirl.create(:organization_asset, organization: @organization)
 
     @group = FactoryGirl.create(:carto_group, organization: @organization)
     @group.add_user(@non_owner.username)
@@ -90,6 +90,8 @@ describe Carto::OrganizationMetadataExportService do
         source_users = @organization.users.map(&:attributes)
         source_groups = @organization.groups.map(&:attributes)
         source_group_users = @group.users.map(&:id)
+        source_assets = @organization.assets.map(&:attributes)
+        expect(source_assets).not_to be_empty
         source_notifications = @organization.notifications.map(&:attributes)
         source_received_notifications = @organization.notifications.map { |n|
           [n.id, n.received_notifications.map(&:attributes)]
@@ -98,6 +100,8 @@ describe Carto::OrganizationMetadataExportService do
         # Destroy, keeping the database
         clean_redis
         Table.any_instance.stubs(:remove_table_from_user_database)
+        @organization.notifications.each(&:destroy)
+        @organization.assets.each(&:destroy)
         @organization.users.flat_map(&:visualizations).each(&:destroy)
         @organization.users.each(&:destroy)
         @organization.groups.each(&:destroy)
@@ -120,6 +124,11 @@ describe Carto::OrganizationMetadataExportService do
           compare_excluding_fields(g1.attributes, g2, EXCLUDED_ORG_META_DATE_FIELDS + EXCLUDED_ORG_META_ID_FIELDS)
         end
         expect(imported_organization.groups.first.users.map(&:id)).to eq source_group_users
+
+        expect(imported_organization.assets.length).to eq source_assets.length
+        imported_organization.assets.zip(source_assets).each do |ia, sa|
+          compare_excluding_fields(ia.attributes, sa, EXCLUDED_ASSETS_FIELDS)
+        end
 
         expect(imported_organization.notifications.length).to eq source_notifications.length
         imported_organization.notifications.zip(source_notifications).each do |i_n, s_n|
@@ -148,6 +157,7 @@ describe Carto::OrganizationMetadataExportService do
   EXCLUDED_ORG_META_DATE_FIELDS = ['created_at', 'updated_at', 'period_end_date'].freeze
   EXCLUDED_ORG_META_ID_FIELDS = ['id', 'organization_id'].freeze
   EXCLUDED_NOTIFICATIONS_FIELDS = ['id'].freeze
+  EXCLUDED_ASSETS_FIELDS = ['id'].freeze
 
   # DateTime comparisons fail if they're not stringified
   def stringify_fields(hash, fields)

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -101,6 +101,7 @@ describe Carto::OrganizationMetadataExportService do
         clean_redis
         Table.any_instance.stubs(:remove_table_from_user_database)
         @organization.notifications.each(&:destroy)
+        @organization.assets.each { |a| a.update_attribute(:storage_info, nil) } # Avoids remote deletion attempt
         @organization.assets.each(&:delete)
         @organization.assets.clear
         @organization.users.flat_map(&:visualizations).each(&:destroy)


### PR DESCRIPTION
Fixes CartoDB/cartodb-central/issues/1981.

Acceptance additional notes:
- [ ] Set user and organization avatars, and add some org icons. Use those organization icons at a map. After the migration, the avatars, the icon list at organization settings and the map must display those icons.
- [ ] Check that migrating an org doesn't destroy the remote assets.