### PR TITLE
wayfinding: modals breadcrumbs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,7 @@ ion for time-series (#12670)
 * Added lockout page to show when a user is locked up due to expiration of the trial (#13100)
 
 ### Bug fixes / enhancements
+* Wayfinding: modals breadcrumbs (#13205)
 * Improve wayfinding in layer view (#13185)
 * Fix bug in add layer showing my datasets disabled (CartoDB/support#1184)
 * Grunt: Run carto-node before browserify (#13187)

--- a/app/assets/stylesheets/editor-3/_modals-layout.scss
+++ b/app/assets/stylesheets/editor-3/_modals-layout.scss
@@ -69,6 +69,15 @@
 .Modal-header {
   padding: $baseSize * 3 0;
 }
+.Dialog-contentWrapper--withBreadcrumbs .Modal-header {
+  padding-top: 0;
+}
+.Dialog-headerWrapper {
+  flex: 0 0 auto;
+  width: 940px;
+  margin: 0 auto;
+  padding-top: $baseSize * 3;
+}
 .Modal-inner--with-navigation {
   padding: 32px 0 0;
 }

--- a/app/assets/stylesheets/editor-3/_modals.scss
+++ b/app/assets/stylesheets/editor-3/_modals.scss
@@ -226,6 +226,9 @@
   flex: 0 0 auto;
   padding: $baseSize * 3 0;
 }
+.Dialog-contentWrapper--withBreadcrumbs .Publish-modalHeader {
+  padding-top: 0;
+}
 
 .Publish-modalBody {
   display: flex;

--- a/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/form-components/editors/fill/input-color/input-color-file-view.js
@@ -162,6 +162,8 @@ module.exports = CoreView.extend({
       }, self);
 
       return view;
+    }, {
+      breadcrumbsEnabled: true
     });
   }
 });

--- a/lib/assets/core/javascripts/cartodb3/components/modals/add-widgets/add-widgets.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/add-widgets/add-widgets.tpl
@@ -5,9 +5,9 @@
       <h3 class="CDB-Text CDB-Size-medium u-altTextColor"><%- _t('components.modals.add-widgets.modal-desc') %></h3>
     </div>
   </div>
-  <div class="Modal-container js-body">
-    
-  </div>
+
+  <div class="Modal-container js-body"></div>
+
   <div class="Modal-footer">
     <div class="Modal-footerContainer u-flex u-justifyEnd">
       <button class="CDB-Button CDB-Button--primary is-disabled js-continue">

--- a/lib/assets/core/javascripts/cartodb3/components/modals/modal-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/modal-view.js
@@ -36,14 +36,16 @@ module.exports = CoreView.extend({
 
     this.$el.html(
       template({
-        escapeOptionsDisabled: this.options.escapeOptionsDisabled || false,
-        breadcrumbsEnabled: this.options.breadcrumbsEnabled || false
+        escapeOptionsDisabled: this._escapeOptionsDisabled || false,
+        breadcrumbsEnabled: this._breadcrumbsEnabled || false
       })
     );
 
     var view = this.model.createContentView();
     this.addView(view);
+
     view.render();
+
     this.$('.js-content').append(view.el);
 
     return this;

--- a/lib/assets/core/javascripts/cartodb3/components/modals/modal-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/modal-view.js
@@ -7,11 +7,16 @@ var CLOSE_DELAY_MS = 120;
 
 module.exports = CoreView.extend({
   className: function () {
-    if (this.options.escapeOptionsDisabled) {
-      return 'Dialog is-white';
-    } else {
-      return 'Dialog is-opening is-white';
+    var classes = ['Dialog', 'is-white'];
+    if (!this.options.escapeOptionsDisabled) {
+      classes.push('is-opening');
     }
+
+    if (this.options.breadcrumbsEnabled) {
+      classes.push('Dialog--withBreadcrumbs');
+    }
+
+    return classes.join(' ');
   },
 
   events: {
@@ -23,13 +28,16 @@ module.exports = CoreView.extend({
     this.listenTo(this.model, 'destroy', this._onDestroy);
 
     this._escapeOptionsDisabled = this.options.escapeOptionsDisabled;
+    this._breadcrumbsEnabled = this.options.breadcrumbsEnabled;
   },
 
   render: function () {
     this.clearSubViews();
+
     this.$el.html(
       template({
-        escapeOptionsDisabled: this.options.escapeOptionsDisabled || false
+        escapeOptionsDisabled: this.options.escapeOptionsDisabled || false,
+        breadcrumbsEnabled: this.options.breadcrumbsEnabled || false
       })
     );
 

--- a/lib/assets/core/javascripts/cartodb3/components/modals/modal.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/modal.tpl
@@ -1,6 +1,21 @@
 <% if (!escapeOptionsDisabled) { %>
-  <button class="CDB-Shape js-close Dialog-closeBtn">
-    <div class="CDB-Shape-close is-blue is-huge"></div>
-  </button>
+  <% if (breadcrumbsEnabled) { %>
+    <div class="Dialog-headerWrapper">
+      <ul class="Editor-breadcrumb">
+        <li class="Editor-breadcrumbItem CDB-Text CDB-Size-medium u-actionTextColor">
+          <button class="js-close">
+            <i class="CDB-IconFont CDB-IconFont-arrowPrev Size-large"></i>
+
+            <span class="Editor-breadcrumbLink"><%- _t('back') %></span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  <% } else { %>
+    <button class="CDB-Shape js-close Dialog-closeBtn">
+      <div class="CDB-Shape-close is-blue is-huge"></div>
+    </button>
+  <% } %>
 <% } %>
-<div class="Dialog-contentWrapper js-content"></div>
+
+<div class="Dialog-contentWrapper <% if (breadcrumbsEnabled) { %>Dialog-contentWrapper--withBreadcrumbs<% } %> js-content"></div>

--- a/lib/assets/core/javascripts/cartodb3/components/modals/modals-service-model.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/modals-service-model.js
@@ -27,11 +27,17 @@ module.exports = Backbone.Model.extend({
    * @param {Function} createContentView
    * @return {View} the new modal view
    */
-  create: function (createContentView, escapeOptionsDisabled) {
+  create: function (createContentView, options) {
     if (!_.isFunction(createContentView)) throw new Error('createContentView is required');
 
-    if (escapeOptionsDisabled) {
-      this._escapeOptionsDisabled = escapeOptionsDisabled;
+    if (options) {
+      if (options.escapeOptionsDisabled) {
+        this._escapeOptionsDisabled = options.escapeOptionsDisabled;
+      }
+
+      if (options.breadcrumbsEnabled) {
+        this._breadcrumbsEnabled = options.breadcrumbsEnabled;
+      }
     }
 
     if (!this._modalView) {
@@ -70,7 +76,6 @@ module.exports = Backbone.Model.extend({
   },
 
   _newModalView: function () {
-    var self = this;
     var viewModel = new ModalViewModel();
     this._handleBodyClass(viewModel);
 
@@ -83,9 +88,11 @@ module.exports = Backbone.Model.extend({
       this.trigger.apply(this, [DESTROYED_MODAL_EVENT].concat(Array.prototype.slice.call(arguments)));
       this.stopListening(viewModel);
     });
+
     return new ModalView({
       model: viewModel,
-      escapeOptionsDisabled: self._escapeOptionsDisabled
+      escapeOptionsDisabled: this._escapeOptionsDisabled,
+      breadcrumbsEnabled: this._breadcrumbsEnabled
     });
   },
 

--- a/lib/assets/core/javascripts/cartodb3/components/modals/modals-service-model.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/modals-service-model.js
@@ -30,19 +30,9 @@ module.exports = Backbone.Model.extend({
   create: function (createContentView, options) {
     if (!_.isFunction(createContentView)) throw new Error('createContentView is required');
 
-    if (options) {
-      if (options.escapeOptionsDisabled) {
-        this._escapeOptionsDisabled = options.escapeOptionsDisabled;
-      }
-
-      if (options.breadcrumbsEnabled) {
-        this._breadcrumbsEnabled = options.breadcrumbsEnabled;
-      }
-    }
-
     if (!this._modalView) {
       this.trigger('willCreateModal');
-      this._modalView = this._newModalView();
+      this._modalView = this._newModalView(options);
       this.trigger('didCreateModal', this._modalView);
       document.body.appendChild(this._modalView.el);
     }
@@ -75,11 +65,14 @@ module.exports = Backbone.Model.extend({
     }
   },
 
-  _newModalView: function () {
+  _newModalView: function (options) {
     var viewModel = new ModalViewModel();
     this._handleBodyClass(viewModel);
 
-    if (!this._escapeOptionsDisabled) {
+    var escapeOptionsDisabled = options && options.escapeOptionsDisabled;
+    var breadcrumbsEnabled = options && options.breadcrumbsEnabled;
+
+    if (!escapeOptionsDisabled) {
       this._destroyOnEsc(viewModel);
     }
 
@@ -91,8 +84,8 @@ module.exports = Backbone.Model.extend({
 
     return new ModalView({
       model: viewModel,
-      escapeOptionsDisabled: this._escapeOptionsDisabled,
-      breadcrumbsEnabled: this._breadcrumbsEnabled
+      escapeOptionsDisabled: escapeOptionsDisabled,
+      breadcrumbsEnabled: breadcrumbsEnabled
     });
   },
 

--- a/lib/assets/core/javascripts/cartodb3/dataset/dataset-header/dataset-header-view.js
+++ b/lib/assets/core/javascripts/cartodb3/dataset/dataset-header/dataset-header-view.js
@@ -243,6 +243,8 @@ module.exports = CoreView.extend({
           });
         }
       });
+    }, {
+      escapeOptionsDisabled: true
     });
   },
 

--- a/lib/assets/core/javascripts/cartodb3/editor.js
+++ b/lib/assets/core/javascripts/cartodb3/editor.js
@@ -355,7 +355,9 @@ if (visDefinitionModel.get('version') === 2 && modals) {
       modalModel: modalModel,
       visDefinitionModel: visDefinitionModel
     });
-  }, true);
+  }, {
+    escapeOptionsDisabled: true
+  });
 } else {
   mapCreation();
 }

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
@@ -483,6 +483,8 @@ module.exports = CoreView.extend({
         layerDefinitionsCollection: self._layerDefinitionsCollection,
         widgetDefinitionsCollection: self._widgetDefinitionsCollection
       });
+    }, {
+      breadcrumbsEnabled: true
     });
   },
 

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-pane.js
@@ -500,6 +500,8 @@ module.exports = CoreView.extend({
         userModel: self._userModel,
         configModel: self._configModel
       });
+    }, {
+      breadcrumbsEnabled: true
     });
   },
 

--- a/lib/assets/core/javascripts/cartodb3/editor/editor-settings-pane.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/editor-settings-pane.js
@@ -93,7 +93,9 @@ module.exports = CoreView.extend({
         userModel: this._userModel,
         configModel: this._configModel
       });
-    }.bind(this));
+    }.bind(this), {
+      breadcrumbsEnabled: true
+    });
   },
 
   _onRemoveMap: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-mosaic-add-item-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/basemap-content-views/basemap-mosaic-add-item-view.js
@@ -65,6 +65,8 @@ module.exports = CoreView.extend({
         modalModel: modalModel,
         createModel: addBasemapModel
       });
+    }, {
+      breadcrumbsEnabled: true
     });
     modal.show();
   }

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-service.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analyses-service.js
@@ -61,7 +61,10 @@ module.exports = (function () {
           modalModel: modalModel,
           layerDefinitionModel: layerDefinitionModel
         });
-      }.bind(this));
+      }.bind(this), {
+        breadcrumbsEnabled: true
+      });
+
       this._modals.onDestroyOnce(function (analysisFormAttrs) {
         if (analysisFormAttrs) {
           // A analysis option was seleted, redirect to layer-content view with new attrs

--- a/lib/assets/core/locale/en.json
+++ b/lib/assets/core/locale/en.json
@@ -1,5 +1,6 @@
 {
   "feedback": "Give us feedback!",
+  "back": "Back",
   "back-to-dashboard": "Back to the dashboard",
   "edit-map": "Edit map",
   "map-settings": "Map options",

--- a/lib/assets/core/test/spec/cartodb3/components/modals/modal-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/modals/modal-view.spec.js
@@ -1,58 +1,91 @@
+var _ = require('underscore');
 var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 var ModalViewModel = require('../../../../../javascripts/cartodb3/components/modals/modal-view-model');
 var ModalView = require('../../../../../javascripts/cartodb3/components/modals/modal-view');
 
 describe('components/modals/modal-view', function () {
-  var contentView, contentViewEventSpy;
+  var view, model, contentView, contentViewModel, contentViewEventSpy;
 
-  beforeEach(function () {
+  var createViewFn = function (options) {
     contentViewEventSpy = jasmine.createSpy('test');
+
+    model = new ModalViewModel({
+      createContentView: function () { return contentView; }
+    });
+
     var TestView = CoreView.extend({
       initialize: function () {
         this.model.on('test', contentViewEventSpy, this);
       }
     });
 
-    this.contentViewModel = new Backbone.Model();
-    contentView = new TestView({model: this.contentViewModel});
+    contentViewModel = new Backbone.Model();
+    contentView = new TestView({model: contentViewModel});
     spyOn(contentView, 'render').and.callThrough();
 
-    this.model = new ModalViewModel({
-      createContentView: function () { return contentView; }
-    });
-    this.view = new ModalView({
-      model: this.model
-    });
-    this.view.render();
-  });
+    var defaultOptions = {
+      model: model
+    };
+
+    view = new ModalView(_.extend(defaultOptions, options));
+
+    return view;
+  };
 
   it('should have no leaks', function () {
-    expect(this.view).toHaveNoLeaks();
+    view = createViewFn();
+
+    view.render();
+
+    expect(view).toHaveNoLeaks();
   });
 
   it('should render dialog classes', function () {
-    expect(this.view.$el.html()).toContain('Dialog');
-    expect(this.view.$el.html()).toContain('Dialog-contentWrapper');
+    view = createViewFn();
+
+    view.render();
+
+    expect(view.$el.html()).toContain('Dialog');
+    expect(view.$el.html()).toContain('Dialog-contentWrapper');
   });
 
   it('should not render close button if escapeOptionsDisabled is present', function () {
-    this.view.options.escapeOptionsDisabled = true;
-    this.view.render();
-    expect(this.view.$el.html()).not.toContain('js-close');
+    view = createViewFn({
+      escapeOptionsDisabled: true
+    });
+
+    view.render();
+
+    expect(view.$el.html()).not.toContain('js-close');
+  });
+
+  it('should not render close button if breadcrumbsEnabled is present', function () {
+    view = createViewFn({
+      breadcrumbsEnabled: true
+    });
+
+    view.render();
+
+    expect(view.$el.html()).toContain('<div class="Dialog-headerWrapper">');
+    expect(view.$el.html()).not.toContain('<button class="CDB-Shape js-close Dialog-closeBtn">');
   });
 
   describe('when close is clicked', function () {
     beforeEach(function () {
-      this.contentViewModel.trigger('test', 'asd');
+      view = createViewFn();
+
+      view.render();
+
+      contentViewModel.trigger('test', 'asd');
       expect(contentViewEventSpy).toHaveBeenCalled();
       contentViewEventSpy.calls.reset();
 
       jasmine.clock().install();
-      spyOn(this.view, 'hide').and.callThrough();
-      spyOn(this.view, 'clean').and.callThrough();
-      spyOn(this.model, 'destroy').and.callThrough();
-      this.view.$('.js-close').click();
+      spyOn(view, 'hide').and.callThrough();
+      spyOn(view, 'clean').and.callThrough();
+      spyOn(model, 'destroy').and.callThrough();
+      view.$('.js-close').click();
     });
 
     afterEach(function () {
@@ -60,20 +93,20 @@ describe('components/modals/modal-view', function () {
     });
 
     it('should destroy the model', function () {
-      expect(this.model.destroy).toHaveBeenCalled();
+      expect(model.destroy).toHaveBeenCalled();
     });
 
     it('should hide modal', function () {
-      expect(this.view.hide).toHaveBeenCalled();
+      expect(view.hide).toHaveBeenCalled();
     });
 
     it('should not react to model bindings anymore', function () {
-      this.contentViewModel.trigger('test', 'asd');
+      contentViewModel.trigger('test', 'asd');
       expect(contentViewEventSpy).not.toHaveBeenCalled();
     });
 
     it('should not clean the view right away', function () {
-      expect(this.view.clean).not.toHaveBeenCalled();
+      expect(view.clean).not.toHaveBeenCalled();
     });
 
     describe('when the close animation is done', function () {
@@ -82,16 +115,16 @@ describe('components/modals/modal-view', function () {
       });
 
       it('should have cleaned the view', function () {
-        expect(this.view.clean).toHaveBeenCalled();
+        expect(view.clean).toHaveBeenCalled();
       });
 
       it('should not react to model bindings anymore', function () {
-        this.contentViewModel.trigger('test', 'asd');
+        contentViewModel.trigger('test', 'asd');
         expect(contentViewEventSpy).not.toHaveBeenCalled();
       });
 
       it('should have no leaks', function () {
-        expect(this.view).toHaveNoLeaks();
+        expect(view).toHaveNoLeaks();
       });
     });
   });


### PR DESCRIPTION
re: https://github.com/CartoDB/cartodb/issues/13127

this will eventually point to `master` once https://github.com/CartoDB/cartodb/pull/13185 is merged

![pageshot of refugio lizara bisaurin refugio lizara tracks carto 2017-12-02-1227 14](https://user-images.githubusercontent.com/36676/33882277-df7a05f0-df37-11e7-9b4d-0edbb2bd8c5e.png)
![pageshot of refugio lizara bisaurin refugio lizara tracks carto 2017-12-02-1227 35](https://user-images.githubusercontent.com/36676/33882278-df952ba0-df37-11e7-95b1-c7ebf18537b3.png)

I don't quite like the solution but this is a compromise we can make until all modals have been migrated to new styles
