### PR TITLE
Enable CSV exports for polygon and line datasets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -325,6 +325,7 @@ ion for time-series (#12670)
 * Fix for legends when there is only one element in the ramp (cartodb.js#1938)
 * Treat all time series dataview timestamps as UTC (#13070)
 * Fix datasets downloaded as "cartodb-query" [Support #1179](https://github.com/CartoDB/support/issues/1179)
+* Enable CSV exports for polygon and line datasets (#13212)
 
 ### Internals
 * Use engine instead of visModel internally (#12992)

--- a/lib/assets/core/javascripts/cartodb3/components/modals/export-data/modal-export-data-view.js
+++ b/lib/assets/core/javascripts/cartodb3/components/modals/export-data/modal-export-data-view.js
@@ -14,8 +14,7 @@ var FORMATS = [
   {
     format: 'csv',
     fetcher: 'fetchCSV',
-    geomRequired: false,
-    geomRestricted: ['point']
+    geomRequired: false
   }, {
     format: 'shp',
     fetcher: 'fetch',

--- a/lib/assets/core/test/spec/cartodb3/components/modals/export-data/modal-export-data-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/components/modals/export-data/modal-export-data-view.spec.js
@@ -41,14 +41,22 @@ describe('components/modals/export-data/modal-export-data-view', function () {
       expect(this.view.$('[data-format=csv]:checked').length).toBe(1);
     });
 
+    it('should render properly for lines', function () {
+      this.queryGeometryModel.set('simple_geom', 'line');
+      this.view.render();
+
+      expect(this.view.$('.Modal-listFormItem').length).toBe(5);
+      expect(this.view.$('.Modal-listFormItem.is-disabled').length).toBe(0);
+      expect(this.view.$('[data-format=csv]:checked').length).toBe(1);
+    });
+
     it('should render properly for polygons', function () {
       this.queryGeometryModel.set('simple_geom', 'polygon');
       this.view.render();
 
       expect(this.view.$('.Modal-listFormItem').length).toBe(5);
-      expect(this.view.$('.Modal-listFormItem.is-disabled').length).toBe(1);
-      expect(this.view.$('[data-format=csv]:checked').length).toBe(0);
-      expect(this.view.$('[data-format=shp]:checked').length).toBe(1);
+      expect(this.view.$('.Modal-listFormItem.is-disabled').length).toBe(0);
+      expect(this.view.$('[data-format=csv]:checked').length).toBe(1);
     });
 
     it('should render properly for no geometries', function () {


### PR DESCRIPTION
Related to #13196
----

This PR enables to download CSV of polygon and line datasets again.

### Acceptance

1. Import three different datasets. One containing points, another with polygons, and another with lines.
2. Try to export them from the layers view, the single layer view and the dataset page.
3. Check that you can select CSV format.