### PR TITLE
Create method for mobile checking instead of requiring an editors file

### DIFF
--- a/lib/assets/core/javascripts/cartodb3/components/metrics/webgl-metrics.js
+++ b/lib/assets/core/javascripts/cartodb3/components/metrics/webgl-metrics.js
@@ -1,5 +1,9 @@
 
-var helper = require('../../../../../javascripts/cartodb/helpers/map_options');
+var MOBILE_DEVICES_REGEX = /Android|webOS|iPad|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i;
+
+function isMobileDevice () {
+  return MOBILE_DEVICES_REGEX.test(navigator.userAgent);
+}
 
 function getFBstatus (gl) {
   const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
@@ -30,7 +34,7 @@ function getWebGLsupport (canvas) {
     EXT_blend_minmax: '-',
     MAX_RENDERBUFFER_SIZE: '-',
     renderToFloat: '-',
-    mobile: helper.isMobileDevice(),
+    mobile: isMobileDevice(),
     userAgent: navigator.userAgent
   };
 


### PR DESCRIPTION
Yesterday we merged https://github.com/CartoDB/cartodb/pull/13216, which adds a checker for mobile devices to the WebGL metrics tracker, we were requiring an editors file, which breaks the build because of a dependency on `underscore-cdb-v3`.

This PR creates a method for that check instead of requiring that file.

cc @dv343 for awareness