### PR TITLE
nil check for viewed_user at embeds

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -425,7 +425,7 @@ class Admin::VisualizationsController < Admin::AdminController
   end
 
   def embed_map
-    if @viewed_user.has_feature_flag?('static_embed_map')
+    if @viewed_user && @viewed_user.has_feature_flag?('static_embed_map')
       return render(file: "public/static/embed_map/index.html", layout: false)
     end
 


### PR DESCRIPTION
Fix for https://rollbar.com/carto/CartoDB/items/25410/ . A `.try` or researching how come `@viewed_user` can be nil might've been better, but I chose prioritizing safety.