### PR TITLE
Add fetch polyfill

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -333,6 +333,7 @@ ion for time-series (#12670)
 * Treat all time series dataview timestamps as UTC (#13070)
 * Fix datasets downloaded as "cartodb-query" [Support #1179](https://github.com/CartoDB/support/issues/1179)
 * Enable CSV exports for polygon and line datasets (#13212)
+* Add fetch polyfill (#13230)
 
 ### Internals
 * Use engine instead of visModel internally (#12992)

--- a/lib/assets/core/javascripts/cartodb3/public_editor.js
+++ b/lib/assets/core/javascripts/cartodb3/public_editor.js
@@ -4,6 +4,7 @@ var LayerStyleCollection = require('./embed/style-collection');
 var EmbedIntegrations = require('./embed/embed-integrations');
 var MetricsTracker = require('./components/metrics/metrics-tracker');
 var WebGLMetrics = require('./components/metrics/webgl-metrics');
+require('whatwg-fetch');
 
 var _ = require('underscore');
 var URLStateHelper = require('cartodb-deep-insights.js/src/api/url-helper.js');

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "tangram": "cartodb/tangram#master",
     "torque.js": "CartoDB/torque#master",
     "underscore": "1.8.3",
-    "webpack": "2.3.2"
+    "webpack": "2.3.2",
+    "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
   },
   "devDependencies": {
     "autoprefixer-core": "5.2.1",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -14,7 +14,7 @@ const isVendor = (module, count) => {
 };
 
 const entryPoints = {
-  builder_embed: './lib/assets/core/javascripts/cartodb3/public_editor.js',
+  builder_embed: ['whatwg-fetch', './lib/assets/core/javascripts/cartodb3/public_editor.js'],
   dataset: './lib/assets/core/javascripts/cartodb3/dataset.js',
   builder: './lib/assets/core/javascripts/cartodb3/editor.js'
 };

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -9,7 +9,7 @@ const isVendor = (module, count) => {
 };
 
 const entryPoints = {
-  builder_embed: './lib/assets/core/javascripts/cartodb3/public_editor.js',
+  builder_embed: ['whatwg-fetch', './lib/assets/core/javascripts/cartodb3/public_editor.js'],
   dataset: './lib/assets/core/javascripts/cartodb3/dataset.js',
   builder: './lib/assets/core/javascripts/cartodb3/editor.js'
 };


### PR DESCRIPTION
Due to last `carto.js` deploy, we've introduced a bug in browsers that don't support `fetch API`.

This PR adds a polyfill for those browsers.