### PR TITLE
Updates app_config.yml.sample for unit tests

### DIFF
--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -712,6 +712,8 @@ test:
   api_requests_es_service:
     url: "http://api-calls-service.localhost.lan/search"
     body: ""
+  session_domain:     '.localhost.lan'
+  subdomainless_urls: false
 
 staging:
   <<: *defaults


### PR DESCRIPTION
The unit tests expect session_domain to be '.localhost.lan' and subdomainless_urls to be false.  Therefore by setting these values in the "test" section of app_config.yml.sample it'll reduce the chances that users who overwrite this in other environments will have failures running the unit tests.

This address Issue #13218 