### PR TITLE
Add missing hover and selected state colors to Widgets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -343,6 +343,7 @@ ion for time-series (#12670)
 * Fix wrong padding in widgets list (#13200)
 * Add fetch polyfill (#13230)
 * Remove tooltip when clicking on an analysis and when adding a new geometry (#13235)
+* Add missing hover in widgets (https://github.com/CartoDB/deep-insights.js/issues/640)
 
 ### Internals
 * Use engine instead of visModel internally (#12992)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -30,9 +30,9 @@
       }
     },
     "ajv": {
-      "version": "5.5.1",
+      "version": "5.5.2",
       "from": "ajv@>=5.3.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz"
     },
     "ajv-keywords": {
       "version": "2.1.1",
@@ -393,9 +393,9 @@
       "resolved": "https://registry.npmjs.org/cartocolor/-/cartocolor-4.0.0.tgz"
     },
     "cartodb-deep-insights.js": {
-      "version": "0.4.24",
-      "from": "cartodb/deep-insights.js#v0.4.24",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#6e58a8b41e2fc98b3c2805999a7062202d169af7",
+      "version": "0.4.25",
+      "from": "cartodb/deep-insights.js#640-missing-hover-in-widgets",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#43e7b69e618a6383457e0dd87f5149a8138aeac0",
       "dependencies": {
         "node-polyglot": {
           "version": "2.2.2",
@@ -1535,9 +1535,9 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
     },
     "JSONStream": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "from": "JSONStream@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz"
     },
     "jszip": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "carto": "cartodb/carto#master",
     "carto-zera": "^1.0.0",
     "cartocolor": "4.0.0",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#v0.4.24",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#640-missing-hover-in-widgets",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.3",
     "clipboard": "1.6.1",


### PR DESCRIPTION
This PR points DeepInsights dependency version to the branch created in this PR (https://github.com/CartoDB/deep-insights.js/pull/641)

You can review the changes here: https://github.com/CartoDB/deep-insights.js/pull/641

