### PR TITLE
Dropbox importer: Do not request listing jpeg nor png images

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ to the oauth.google_plus section of the configuration file.
 * Embed static view (#12779)
 * Add tooltip on Builder actions (#13102)
 * Add Grunt tasks to generate static files (#13130)
+* Do not request image files in Dropbox sync (CartoDB/support#1192)
 * Improve geocoding onboarding (#13046)
 * Editor static view (#13043)
 * Add trial notification in static views (#13079)

--- a/services/datasources/lib/datasources/url/dropbox.rb
+++ b/services/datasources/lib/datasources/url/dropbox.rb
@@ -27,8 +27,6 @@ module CartoDB
             FORMAT_EXCEL =>       %W( .xls .xlsx ),
             FORMAT_GPX =>         %W( .gpx ),
             FORMAT_KML =>         %W( .kml ),
-            FORMAT_PNG =>         %W( .png ),
-            FORMAT_JPG =>         %W( .jpg .jpeg ),
             FORMAT_SVG =>         %W( .svg ),
             FORMAT_COMPRESSED =>  %W( .zip )
         }


### PR DESCRIPTION
Do not request image files to show from Dropbox as they cannot be imported and are pretty usual in big folders.

@juanignaciosl I'm assigning you the PR because you are the last one that has touched the file and the changes are pretty much obvious, but let me know if somebody else should review it.

Related: https://github.com/CartoDB/support/issues/1192

Tested in my account and the files when from 1600 to ~50 and the time to list files from 12s to ~4.