### PR TITLE
Fix iconfont

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,7 @@ ion for time-series (#12670)
 * Added lockout page to show when a user is locked up due to expiration of the trial (#13100)
 
 ### Bug fixes / enhancements
+* Fix icons not showing (#13276)
 * Redesign add buttons (#13215)
 * Onboarding: center bounding box automatically when new datasets are added (#13245)
 * Stop building static pages on dev (#13188)

--- a/lib/assets/core/javascripts/cartodb3/components/table/head/table-head-options-item.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/table/head/table-head-options-item.tpl
@@ -4,7 +4,7 @@
       <p class="CDB-Text CDB-Size-medium"><%- name %></p>
       <ul class="u-flex">
         <li class="js-asc">
-          <i class="CDB-Text CDB-IconFont
+          <i class="CDB-IconFont
             CDB-IconFont-arrowNext u-actionTextColor
             Table-columnSorted
             Table-columnSorted--asc
@@ -13,7 +13,7 @@
           "></i>
         </li>
         <li class="js-desc u-lSpace--xl">
-          <i class="CDB-Text CDB-IconFont
+          <i class="CDB-IconFont
             CDB-IconFont-arrowNext u-actionTextColor
             Table-columnSorted
             Table-columnSorted--desc
@@ -28,7 +28,7 @@
   <div class="CDB-ListDecoration-itemLink u-actionTextColor" title="<%- name %>">
     <div class="u-flex u-justifySpace u-alignCenter">
       <span><%- name %></span>
-      <i class="CDB-Text CDB-Size-small is-semibold CDB-IconFont CDB-IconFont-rArrowLight"></i>
+      <i class="CDB-IconFont CDB-Size-small is-semibold CDB-IconFont-rArrowLight"></i>
     </div>
   </div>
 <% } else { %>

--- a/lib/assets/core/javascripts/cartodb3/components/table/paginator/table-paginator.tpl
+++ b/lib/assets/core/javascripts/cartodb3/components/table/paginator/table-paginator.tpl
@@ -3,7 +3,7 @@
     js-prev
   <% } %>
 ">
-  <i class="CDB-Text is-semibold CDB-IconFont CDB-IconFont-lArrowLight CDB-Size-small
+  <i class="CDB-IconFont is-semibold CDB-IconFont-lArrowLight CDB-Size-small
   <% if (isPrevAvailable) { %>
     u-actionTextColor
   <% } else { %>
@@ -25,7 +25,7 @@
     js-next
   <% } %>
 ">
-  <i class="CDB-Text is-semibold CDB-IconFont CDB-IconFont-rArrowLight CDB-Size-small
+  <i class="CDB-IconFont is-semibold CDB-IconFont-rArrowLight CDB-Size-small
   <% if (isNextAvailable) { %>
     u-actionTextColor
   <% } else { %>

--- a/lib/assets/javascripts/cartodb/explore/dataset_item_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/explore/dataset_item_template.jst.ejs
@@ -47,7 +47,7 @@
 
             <div class="MapCard-contentFooterDetails--right">
               <a href="#/like" class="LikesIndicator js-like is-likeable" data-vis-id="<%- vis.id %>">
-                <i class="CDB-Text CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon"></i>
+                <i class="CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon"></i>
                 <span class="CDB-Text CDB-Size-medium LikesIndicator-count"><%- vis.likes %></span>
                 <span class="CDB-Text CDB-Size-medium LikesIndicator-label">like<%- vis.likes !== 1 ? 's' : '' %></span>
               </a>

--- a/lib/assets/javascripts/cartodb/explore/map_item_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/explore/map_item_template.jst.ejs
@@ -36,14 +36,11 @@
 
         <div class="MapCard-contentFooterDetails--right">
         <a href="#/like" class="LikesIndicator js-like is-likeable" data-vis-id="<%- vis.id %>">
-          <i class="CDB-Text CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon"></i>
+          <i class="CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon"></i>
           <span class="CDB-Text CDB-Size-medium LikesIndicator-count"><%- vis.likes %></span>
           <span class="CDB-Text CDB-Size-medium LikesIndicator-label">like<%- vis.likes !== 1 ? 's' : '' %></span>
         </a>
       </div>
-
-
-
       </div>
     </div>
   </div>

--- a/lib/assets/javascripts/cartodb/user_feed/dataset_item_template.jst.ejs
+++ b/lib/assets/javascripts/cartodb/user_feed/dataset_item_template.jst.ejs
@@ -32,7 +32,7 @@
             </div>
             <div class="MapCard-contentFooterDetails--right">
               <a href="#/like" class="LikesIndicator js-like is-likeable" data-vis-id="<%- vis.id %>">
-                <i class="CDB-Text CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon "></i>
+                <i class="CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon "></i>
                 <span class="CDB-Text CDB-Size-medium LikesIndicator-count"><%- vis.likes %></span>
                 <span class="CDB-Text CDB-Size-medium LikesIndicator-label">like<%- vis.likes !== 1 ? 's' : '' %></span>
               </a>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -393,9 +393,9 @@
       "resolved": "https://registry.npmjs.org/cartocolor/-/cartocolor-4.0.0.tgz"
     },
     "cartodb-deep-insights.js": {
-      "version": "0.4.30",
-      "from": "cartodb/deep-insights.js#fix-iconfont",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#feec908f6fc9324ec07b1f0025f5cb8d6f832b6f",
+      "version": "0.4.31",
+      "from": "cartodb/deep-insights.js#v0.4.31",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#f3fa2eeb33289b6a35b6d1b4ada3ead672e384e8",
       "dependencies": {
         "node-polyglot": {
           "version": "2.2.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -394,8 +394,8 @@
     },
     "cartodb-deep-insights.js": {
       "version": "0.4.30",
-      "from": "cartodb/deep-insights.js#v0.4.30",
-      "resolved": "git://github.com/cartodb/deep-insights.js.git#9017e01934d16f1c71f60c8cd0205ef65227015f",
+      "from": "cartodb/deep-insights.js#fix-iconfont",
+      "resolved": "git://github.com/cartodb/deep-insights.js.git#feec908f6fc9324ec07b1f0025f5cb8d6f832b6f",
       "dependencies": {
         "node-polyglot": {
           "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "carto": "cartodb/carto#master",
     "carto-zera": "1.0.1",
     "cartocolor": "4.0.0",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#fix-iconfont",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#v0.4.31",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.8",
     "clipboard": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "carto": "cartodb/carto#master",
     "carto-zera": "1.0.1",
     "cartocolor": "4.0.0",
-    "cartodb-deep-insights.js": "cartodb/deep-insights.js#v0.4.30",
+    "cartodb-deep-insights.js": "cartodb/deep-insights.js#fix-iconfont",
     "cartodb-pecan": "0.2.x",
     "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.8",
     "clipboard": "1.6.1",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/1226#issuecomment-353440135

Some icons were not loading:

<img width="387" alt="screen shot 2017-12-19 at 11 40 44 am" src="https://user-images.githubusercontent.com/1566273/34175529-8af49778-e4b1-11e7-890c-e060e281098c.png">

<img width="177" alt="screen shot 2017-12-19 at 11 37 35 am" src="https://user-images.githubusercontent.com/1566273/34175543-9b954e24-e4b1-11e7-8c95-490b1a4c774a.png">

It was because of: https://github.com/CartoDB/CartoAssets/pull/182