### PR TITLE
Add dot properties to deep-insights

### DIFF
--- a/lib/assets/core/javascripts/deep-insights/widgets/auto-style/auto-styler.js
+++ b/lib/assets/core/javascripts/deep-insights/widgets/auto-style/auto-styler.js
@@ -36,7 +36,7 @@ var AutoStyler = cdb.core.Model.extend({
   }
 });
 
-AutoStyler.FILL_SELECTORS = ['marker-fill', 'polygon-fill', 'line-color'];
-AutoStyler.OPACITY_SELECTORS = ['marker-fill-opacity', 'polygon-opacity', 'line-opacity'];
+AutoStyler.FILL_SELECTORS = ['dot-fill', 'marker-fill', 'polygon-fill', 'line-color'];
+AutoStyler.OPACITY_SELECTORS = ['dot-opacity', 'marker-fill-opacity', 'polygon-opacity', 'line-opacity'];
 
 module.exports = AutoStyler;

--- a/lib/assets/core/javascripts/deep-insights/widgets/auto-style/histogram.js
+++ b/lib/assets/core/javascripts/deep-insights/widgets/auto-style/histogram.js
@@ -146,6 +146,32 @@ HistogramAutoStyler.SCALES_MAP = {
       palette: 'SunsetDark',
       quantification: 'jenks'
     }
+  },
+  'dot-fill': {
+    'F': {
+      palette: 'RedOr',
+      quantification: 'equal'
+    },
+    'L': {
+      palette: 'BluYl',
+      quantification: 'headtails'
+    },
+    'J': {
+      palette: 'BluYl',
+      quantification: 'headtails'
+    },
+    'A': {
+      palette: 'Geyser',
+      quantification: 'quantiles'
+    },
+    'C': {
+      palette: 'SunsetDark',
+      quantification: 'jenks'
+    },
+    'U': {
+      palette: 'SunsetDark',
+      quantification: 'jenks'
+    }
   }
 };
 

--- a/lib/assets/core/javascripts/deep-insights/widgets/auto-style/style-utils.js
+++ b/lib/assets/core/javascripts/deep-insights/widgets/auto-style/style-utils.js
@@ -3,7 +3,7 @@ var postcss = require('postcss');
 var stripInlineComments = require('postcss-strip-inline-comments');
 var SCSSsyntax = require('postcss-scss');
 
-var OUTLINE_ATTRS = ['line-color', 'line-opacity'];
+var OUTLINE_ATTRS = ['line-color', 'line-opacity', 'dot-fill'];
 
 function generateCSSTreeFromCartoCSS (cartocss) {
   return postcss()

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "carto-zera": "1.0.1",
     "cartocolor": "4.0.0",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.9",
+    "cartodb.js": "CartoDB/cartodb.js#fallback-reference",
     "clipboard": "1.6.1",
     "codemirror": "5.14.2",
     "d3-interpolate": "^1.1.6",


### PR DESCRIPTION
⚠️ This PR is a copy of the correspondant PR in deep-insights. It has been moved because DI is now here, in Builder Repo. Original PR: https://github.com/CartoDB/deep-insights.js/pull/636

Related to https://github.com/CartoDB/cartodb/pull/13147

### Tasks
- [x] Pointing to the proper Carto.js version.
- [x] Make dot properties to be autostyled.