### PR TITLE
Fix logo alignment in small viewports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -106,6 +106,7 @@ ion for time-series (#12670)
 * Add decade aggregation to time series widget [Support #1071](https://github.com/CartoDB/support/issues/1071)
 
 ### Bug fixes / enhancements
+* Fix logo alignment in small viewports (#13302)
 * Fix hover in widgets (#13293)
 * Fix autostyling with category widget (using a numeric field) [Support #611](https://github.com/CartoDB/support/issues/611)
 * Fix grammar errors in analysis description (#13258)

--- a/app/assets/stylesheets/editor-3/_menu.scss
+++ b/app/assets/stylesheets/editor-3/_menu.scss
@@ -54,8 +54,8 @@
 
 .EditorMenu-logo {
   display: flex;
-  flex-direction: center;
   align-items: center;
+  justify-content: center;
   width: 32px;
   height: 32px;
   margin: 0 auto 48px;

--- a/app/assets/stylesheets/editor-3/_menu.scss
+++ b/app/assets/stylesheets/editor-3/_menu.scss
@@ -3,18 +3,15 @@
 @import 'vars';
 
 .EditorMenu {
+  display: flex;
   position: relative;
   flex: 0 0 72px;
+  flex-direction: column;
+  align-items: center;
   width: 72px;
   min-height: 450px;
   padding: 20px 0 $baseSize * 2;
   background: $cBlue;
-}
-
-.EditorMenu-navigation {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 }
 
 .EditorMenu-navigationItem {
@@ -53,12 +50,12 @@
 }
 
 .EditorMenu-logo {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
   margin: 0 auto 48px;
+
+  svg {
+    width: 32px;
+    height: 32px;
+  }
 
   .point {
     transform-origin: 50%;


### PR DESCRIPTION
Related to: #13301 

The logo in small viewports wasn't aligned

![screen shot 2017-12-28 at 09 01 33](https://user-images.githubusercontent.com/905225/34404428-c57a34d6-ebad-11e7-910d-e35941f23fa3.png)

Acceptance:

- Go to a map
- Reduce window size so breakpoints are applied
- The logo should be centered