### PR TITLE
Sets the timezone to UTC in twitter spec

### DIFF
--- a/services/datasources/spec/unit/twitter_spec.rb
+++ b/services/datasources/spec/unit/twitter_spec.rb
@@ -141,7 +141,7 @@ describe Search::Twitter do
       }.to raise_error ParameterError
 
 
-      current_time = Time.now
+      current_time = Time.now.utc
       output = twitter_datasource.send :build_date_from_fields, {
         dates: {
           toDate:   current_time.strftime("%Y-%m-%d"),


### PR DESCRIPTION
Sets the timezone to UTC in twitter spec to match expectation regardless of system timezone

This address Issue #13348 