### PR TITLE
Shortcircuit shared entities check in forced user deletion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -187,6 +187,7 @@ ion for time-series (#12670)
 * Safe check for destination DB on user import (CartoDB/cartodb-central/issues/1945)
 * Improve legends for torque (CartoDB/support#979)
 * CSV export allowed without geometries (#12888)
+* Do not check shared entities in force deletion (#13352)
 * User destroy order should be Central, local (#CartoDB/cartodb-central/issues/1929)
 * Delete all external sources within one transaction (#13129).
 * NoMethodError: undefined method `has_feature_flag?` for nil:NilClass at visualizations controller (#13145).

--- a/app/controllers/carto/api/organization_users_controller.rb
+++ b/app/controllers/carto/api/organization_users_controller.rb
@@ -126,7 +126,7 @@ module Carto
 
         force_destroy = params[:force].present?
 
-        if @user.has_shared_entities? && !force_destroy
+        if !force_destroy && @user.has_shared_entities?
           error_message = "Can't delete @user. 'Has shared entities"
           render_jsonp(error_message, 410 ) and return
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -423,7 +423,7 @@ class User < Sequel::Model
         end
       end
 
-      if has_shared_entities? && !@force_destroy
+      if !@force_destroy && has_shared_entities?
         raise CartoDB::SharedEntitiesError.new('Cannot delete user, has shared entities')
       end
 


### PR DESCRIPTION
Fixes #13352 

As boolean logic is shortcircuited, this avoids an expensive shared entities check when it's not needed.