### PR TITLE
Fix platform_controller tests in parallel

### DIFF
--- a/spec/requests/carto/api/organization_users_controller_spec.rb
+++ b/spec/requests/carto/api/organization_users_controller_spec.rb
@@ -97,11 +97,15 @@ describe Carto::Api::OrganizationUsersController do
 
   before(:each) do
     @old_soft_limits = soft_limits(@organization.owner)
+    @old_whitelisted_email_domains = @organization.whitelisted_email_domains
   end
 
   after(:each) do
     set_soft_limits(@organization.owner, @old_soft_limits)
     @organization.owner.save
+
+    @organization.whitelisted_email_domains = @old_whitelisted_email_domains
+    @organization.save
   end
 
   describe 'user creation' do
@@ -219,8 +223,6 @@ describe Carto::Api::OrganizationUsersController do
       last_user_created = @organization.users.find { |u| u.username == username }
       last_user_created.username.should eq username
       last_user_created.email.should eq email
-      @organization.whitelisted_email_domains = old_whitelisted_email_domains
-      @organization.save
     end
 
     it 'assigns soft_geocoding_limit to false by default' do

--- a/spec/requests/superadmin/platform_controller_spec.rb
+++ b/spec/requests/superadmin/platform_controller_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../../app/controllers/superadmin/platform_controller'
 
 describe Superadmin::PlatformController do
   before(:all) do
-    @dbhost = 'platform_controller_spec.localhost'
+    @dbhost = '127.0.0.127'
     CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
     @user1 = FactoryGirl.create(:valid_user)
     @user2 = FactoryGirl.create(:valid_user)

--- a/spec/requests/superadmin/platform_controller_spec.rb
+++ b/spec/requests/superadmin/platform_controller_spec.rb
@@ -7,8 +7,12 @@ describe Superadmin::PlatformController do
   before(:all) do
     @dbhost = 'platform_controller_spec.localhost'
     CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
-    @user1 = FactoryGirl.create(:valid_user, database_host: @dbhost)
-    @user2 = FactoryGirl.create(:valid_user, database_host: @dbhost)
+    @user1 = FactoryGirl.create(:valid_user)
+    @user2 = FactoryGirl.create(:valid_user)
+    [@user1, @user2].each do |u|
+      u.database_host = @dbhost
+      u.save
+    end
   end
 
   after(:all) do

--- a/spec/requests/superadmin/platform_controller_spec.rb
+++ b/spec/requests/superadmin/platform_controller_spec.rb
@@ -4,27 +4,27 @@ require_relative '../../acceptance_helper'
 require_relative '../../../app/controllers/superadmin/platform_controller'
 
 describe Superadmin::PlatformController do
-  before(:each) do
+  before(:all) do
+    @dbhost = 'platform_controller_spec.localhost'
     CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
-    @user1 = FactoryGirl.create(:valid_user)
-    @user2 = FactoryGirl.create(:valid_user)
+    @user1 = FactoryGirl.create(:valid_user, database_host: @dbhost)
+    @user2 = FactoryGirl.create(:valid_user, database_host: @dbhost)
   end
 
-  after(:each) do
+  after(:all) do
     @user1.destroy
     @user2.destroy
   end
 
   describe '#databases info' do
     it 'returns just one database info if passed as argument' do
-      old_db_host = @user1.database_host
       @user1.database_host = 'test1.dbhost.com'
       get superadmin_get_databases_info_url, { database_host: @user1.database_host }, superadmin_headers
       response.status.should == 200
       body = JSON.parse(response.body)
       body.has_key?('test1.dbhost.com').should == true
       body.size.should == 1
-      @user1.database_host = old_db_host
+      @user1.database_host = @dbhost
     end
 
     it 'returns just two databases info if none passed as argument' do
@@ -42,7 +42,7 @@ describe Superadmin::PlatformController do
     end
 
     it 'validate for database checking for active users using metadata' do
-      get superadmin_database_validation_url, { database_host: 'localhost' }, superadmin_headers
+      get superadmin_database_validation_url, { database_host: @dbhost }, superadmin_headers
       response.status.should == 200
       body = JSON.parse(response.body)
       body['carto_users'].size.should == 2
@@ -54,7 +54,7 @@ describe Superadmin::PlatformController do
       old_db_host = @user2.database_host
       @user2.database_host = 'test2.dbhost.com'
       @user2.save
-      get superadmin_database_validation_url, { database_host: 'localhost' }, superadmin_headers
+      get superadmin_database_validation_url, { database_host: @dbhost }, superadmin_headers
       response.status.should == 200
       body = JSON.parse(response.body)
       body['carto_users'].size.should == 1


### PR DESCRIPTION
Hopefully fixes https://github.com/CartoDB/cartodb/issues/12305

Contains a fix for organization users randomly failing. It's a bit of a blind shot, so it may not work.

Also fixes platform controller tests in parallel mode, they relied in the database having no users before running (which is not always true). Now, they use a custom database name to be able to work conflict-free.