### PR TITLE
#13139 collision_strategy=overwrite from query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,7 @@ ion for time-series (#12670)
 
 ### Bug fixes / enhancements
 * Redirect to login from static pages if there is no user (#13277)
+* Add support for collision_strategy=overwrite when creating a dataset from a query (#13139)
 * Fix popup content in time series widget (#1269)
 * Update pop up when applying HTML changes (#1263)
 * Rollback make new widgets appear on top (#13244)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -276,6 +276,7 @@ module CartoDB
         database.transaction do
           log("Replacing #{name} with #{result.table_name}")
           begin
+            # the logic inside the transaction may vary, so we let the caller to implement it
             yield(database, @destination_schema)
           rescue => e
             log("Unable to replace #{name} with #{result.table_name}. Rollingback transaction and dropping #{result.table_name}: #{e}")

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -85,7 +85,12 @@ module CartoDB
         overwrite = overwrite_strategy? && taken_names.include?(name)
 
         if overwrite
-          overwrite_register(result,name)
+          raise ::CartoDB::Importer2::IncompatibleSchemas.new unless compatible_schemas_for_overwrite?(name)
+          move_to_schema(result, result.table_name, ORIGIN_SCHEMA, @destination_schema)
+          overwrite_register(result, name) do
+            drop("\"#{@destination_schema}\".\"#{name}\"")
+            rename(result, result.table_name, name, @destination_schema)
+          end
         else
           new_register(name, result)
         end
@@ -265,27 +270,13 @@ module CartoDB
         @data_import ||= DataImport[@data_import_id]
       end
 
-      def overwrite_register(result, name, from_query: nil)
-        if from_query.nil?
-          raise ::CartoDB::Importer2::IncompatibleSchemas.new unless compatible_schemas_for_overwrite?(name)
-          move_to_schema(result, result.table_name, ORIGIN_SCHEMA, @destination_schema)
-        end
-
+      def overwrite_register(result, name)
         index_statements = @table_setup.generate_index_statements(@destination_schema, name)
 
         database.transaction do
           log("Replacing #{name} with #{result.table_name}")
           begin
-            if from_query.nil?
-              drop("\"#{@destination_schema}\".\"#{name}\"")
-              rename(result, result.table_name, name, @destination_schema)
-            else
-              database.execute(%{CREATE TABLE #{result.table_name} AS #{from_query}})
-              drop("\"#{@destination_schema}\".\"#{name}\"")
-              database.execute(%{
-                ALTER TABLE "#{@destination_schema}"."#{result.table_name}" RENAME TO "#{name}"
-              })
-            end
+            yield(database, @destination_schema)
           rescue => e
             log("Unable to replace #{name} with #{result.table_name}. Rollingback transaction and dropping #{result.table_name}: #{e}")
             drop("\"#{@destination_schema}\".\"#{result.table_name}\"")

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -796,7 +796,7 @@ class DataImport < Sequel::Model
   # This methods returns an array with two elements:
   # * importer: the new importer (nil if download errors detected)
   def new_importer_with_unused_runner
-    importer, runner = new_importer_with_runner(nil, nil, nil)
+    importer, = new_importer_with_runner(nil, nil, nil)
     importer
   end
 

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -488,7 +488,7 @@ class DataImport < Sequel::Model
 
     query = table_copy ? "SELECT * FROM #{table_copy}" : from_query
     new_table_name = import_from_query(table_name, query)
-    return true unless new_table_name and not overwrite_strategy?
+    return true unless new_table_name && !overwrite_strategy?
 
     sanitize_columns(new_table_name)
 

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -548,13 +548,13 @@ class DataImport < Sequel::Model
   def overwrite_table_from_query(new_table_name, overwrite_table_name, query, user)
     database            = user.in_database
     destination_schema  = user.database_schema
-    overviews_creator   = CartoDB::Importer2::Overviews.new(nil, user, { log: log })
-    table_setup         = ::Carto::Importer::TableSetup.new(
-                              user: user,
-                              overviews_creator: overviews_creator,
-                              log: log
-                            )
-    index_statements    = table_setup.generate_index_statements(destination_schema, overwrite_table_name)
+    overviews_creator   = CartoDB::Importer2::Overviews.new(nil, user, log: log)
+    table_setup = ::Carto::Importer::TableSetup.new(
+      user: user,
+      overviews_creator: overviews_creator,
+      log: log
+    )
+    index_statements = table_setup.generate_index_statements(destination_schema, overwrite_table_name)
 
     database.transaction do
       begin
@@ -566,7 +566,7 @@ class DataImport < Sequel::Model
         })
       rescue Sequel::DatabaseError => exception
         log.append "Unable to replace #{overwrite_table_name} with #{new_table_name}"
-        log.append "Rollingback transaction and dropping #{new_table_name}: #{e}"
+        log.append "Rollingback transaction and dropping #{new_table_name}: #{exception}"
         drop(database, "\"#{destination_schema}\".\"#{new_table_name}\"")
         raise e
       end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -525,7 +525,9 @@ class DataImport < Sequel::Model
       overwrite_table_from_query(table_name, name, query)
       results.push CartoDB::Importer2::Result.new(success: true, error: nil)
     else
-      current_user.db_service.in_database_direct_connection(statement_timeout: DIRECT_STATEMENT_TIMEOUT) do |user_direct_conn|
+      current_user.db_service.in_database_direct_connection(
+        statement_timeout: DIRECT_STATEMENT_TIMEOUT
+      ) do |user_direct_conn|
         user_direct_conn.run(%{CREATE TABLE #{table_name} AS #{query}})
       end
     end

--- a/services/importer/lib/importer/overviews.rb
+++ b/services/importer/lib/importer/overviews.rb
@@ -26,7 +26,7 @@ module CartoDB
                              Cartodb.get_config(:overviews, 'tolerance_px') ||
                              DEFAULT_TOLERANCE_PX
         @importer_stats = CartoDB::Stats::Importer.instance # TODO: delegate to @runner?
-        @logger            = options[:log]
+        @logger = options[:log]
       end
 
       attr_reader :user, :min_rows, :schema

--- a/services/importer/lib/importer/overviews.rb
+++ b/services/importer/lib/importer/overviews.rb
@@ -26,6 +26,7 @@ module CartoDB
                              Cartodb.get_config(:overviews, 'tolerance_px') ||
                              DEFAULT_TOLERANCE_PX
         @importer_stats = CartoDB::Stats::Importer.instance # TODO: delegate to @runner?
+        @logger            = options[:log]
       end
 
       attr_reader :user, :min_rows, :schema
@@ -36,7 +37,8 @@ module CartoDB
       end
 
       def log(message)
-        @runner.log.append(message)
+        log = @logger || @runner.log
+        log.append(message)
       end
 
       def get_table(table_name)

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -144,9 +144,8 @@ describe DataImport do
   end
 
   it 'should raise an error if overwriting with non existent table in query' do
-    data_import = create_import(
+    data_import = create_import_from_query(
       overwrite: true,
-      truncated: false,
       from_query: 'select * from walmart_latlon_wtf limit 1'
     )
     data_import.run_import!

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -116,6 +116,23 @@ describe DataImport do
     data_import.table_name.should eq 'walmart_latlon'
     data_import.user.in_database["select count(*) from #{data_import.table_name}"].all[0][:count].should eq 2
     user_tables_should_be_registered
+
+    data_import = create_import(overwrite: true, truncated: false, from_query: 'select * from walmart_latlon limit 1')
+    data_import.run_import!
+    carto_user.reload
+    carto_user.visualizations.count.should eq 3
+    data_import.state.should eq 'complete'
+    data_import.table_name.should eq 'walmart_latlon'
+    data_import.user.in_database["select count(*) from #{data_import.table_name}"].all[0][:count].should eq 1
+    user_tables_should_be_registered
+  end
+
+  it 'should raise an error if overwriting with non existent table in query' do
+    data_import = create_import(overwrite: true, truncated: false, from_query: 'select * from walmart_latlon_wtf limit 1')
+    data_import.run_import!
+    data_import.state.should eq 'failure'
+    data_import.error_code.should eq 8003
+    data_import.log.entries.should match(/relation.*does not exist/)
   end
 
   it 'should raise an exception if overwriting with missing data' do
@@ -190,20 +207,37 @@ describe DataImport do
     Carto::GhostTablesManager.new(@user.id).user_tables_synced_with_db?.should eq(true), "Tables not properly registered"
   end
 
-  def create_import(user: @user, overwrite:, truncated:, incomplete_schema: false)
-    DataImport.create(
-      user_id: user.id,
-      data_source: Rails.root.join("spec/support/data/#{truncated ? 'truncated/' : ''}#{incomplete_schema ? 'incomplete_schema/' : ''}walmart_latlon.csv").to_s,
-      data_type: "file",
-      table_name: 'walmart_latlon',
-      state: "pending",
-      success: false,
-      updated_at: Time.now,
-      created_at: Time.now,
-      original_url: Rails.root.join("spec/support/data/walmart_latlon.csv").to_s,
-      cartodbfy_time: 0.0,
-      collision_strategy: overwrite ? 'overwrite' : nil
-    )
+  def create_import(user: @user, overwrite:, truncated:, incomplete_schema: false, from_query: '')
+    if from_query.empty?
+      DataImport.create(
+        user_id: user.id,
+        data_source: Rails.root.join("spec/support/data/#{truncated ? 'truncated/' : ''}#{incomplete_schema ? 'incomplete_schema/' : ''}walmart_latlon.csv").to_s,
+        data_type: "file",
+        table_name: 'walmart_latlon',
+        state: "pending",
+        success: false,
+        updated_at: Time.now,
+        created_at: Time.now,
+        original_url: Rails.root.join("spec/support/data/walmart_latlon.csv").to_s,
+        cartodbfy_time: 0.0,
+        collision_strategy: overwrite ? 'overwrite' : nil
+      )
+    else
+      DataImport.create(
+        user_id: user.id,
+        data_source: from_query,
+        from_query: from_query,
+        data_type: "query",
+        table_name: 'walmart_latlon',
+        state: "pending",
+        success: false,
+        updated_at: Time.now,
+        created_at: Time.now,
+        original_url: Rails.root.join("spec/support/data/walmart_latlon.csv").to_s,
+        cartodbfy_time: 0.0,
+        collision_strategy: overwrite ? 'overwrite' : nil
+      )
+    end
   end
 
   it 'raises a meaningful error if over storage quota' do

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -117,6 +117,7 @@ describe DataImport do
     data_import.user.in_database["select count(*) from #{data_import.table_name}"].all[0][:count].should eq 2
     user_tables_should_be_registered
 
+    # overwriting from a sql is a different case needs to be tackled -> https://github.com/CartoDB/cartodb/issues/13139
     data_import = create_import(overwrite: true, truncated: false, from_query: 'select * from walmart_latlon limit 1')
     data_import.run_import!
     carto_user.reload

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -129,10 +129,10 @@ describe DataImport do
 
   it 'should raise an error if overwriting with non existent table in query' do
     data_import = create_import(
-                                overwrite: true,
-                                truncated: false,
-                                from_query: 'select * from walmart_latlon_wtf limit 1'
-                                )
+      overwrite: true,
+      truncated: false,
+      from_query: 'select * from walmart_latlon_wtf limit 1'
+    )
     data_import.run_import!
     data_import.state.should eq 'failure'
     data_import.error_code.should eq 8003

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -128,7 +128,11 @@ describe DataImport do
   end
 
   it 'should raise an error if overwriting with non existent table in query' do
-    data_import = create_import(overwrite: true, truncated: false, from_query: 'select * from walmart_latlon_wtf limit 1')
+    data_import = create_import(
+                                overwrite: true,
+                                truncated: false,
+                                from_query: 'select * from walmart_latlon_wtf limit 1'
+                                )
     data_import.run_import!
     data_import.state.should eq 'failure'
     data_import.error_code.should eq 8003


### PR DESCRIPTION
Add support for `collision_strategy=overwrite` when creating a dataset from a query. See #13139