### PR TITLE
12286 dropbox connect error handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -172,6 +172,7 @@ ion for time-series (#12670)
 * Remove back arrow and add a tooltip to editor logo (#13067)
 + Track user events (#13051)
 * Fix dashboard redirections (#12775)
+* Fix Dropbox reconnection on token expiration (#13410)
 * Fix upload dataset drag and drop (CartoDB/support#1072)
 * Fix legends request order with slow internet connection (#12733)
 * Documentation, fixed spelling and grammar in en.json

--- a/app/controllers/carto/api/imports_controller.rb
+++ b/app/controllers/carto/api/imports_controller.rb
@@ -78,11 +78,13 @@ module Carto
           format.all  { render text: '<script>window.close();</script>', content_type: 'text/html' }
         end
       rescue CartoDB::Datasources::TokenExpiredOrInvalidError => e
-        CartoDB.notify_exception(e, { user: uri_user, params: params })
-        render_jsonp({ errors: e.message }, 401)
+        CartoDB::Logger.warning(message: "Expired oauth token", exception: e, user: uri_user, params: params)
+        render text: 'Expired token. Try reconnecting<script>setTimeout(function(){window.close()}, 1000);</script>',
+               content_type: 'text/html', status: 401
       rescue => e
-        CartoDB.notify_exception(e, { user: uri_user, params: params })
-        render_jsonp({ errors: { imports: e.message } }, 400)
+        CartoDB::Logger.warning(message: "Error in oauth callback", exception: e, user: uri_user, params: params)
+        render text: 'Connection failed<script>setTimeout(function(){window.close()}, 1000);</script>',
+               content_type: 'text/html', status: 400
       end
 
       private

--- a/services/datasources/lib/datasources/url/dropbox.rb
+++ b/services/datasources/lib/datasources/url/dropbox.rb
@@ -207,9 +207,11 @@ module CartoDB
         # @return bool
         # @throws AuthError
         def token_valid?
-        # Any call would do, we just want to see if communicates or refuses the token
-          raise "Current account not found" unless @client.get_current_account
+          # Any call would do, we just want to see if communicates or refuses the token
+          @client.get_current_account
           true
+        rescue DropboxApi::Errors::HttpError
+          false
         end
 
         # Revokes current set token

--- a/services/datasources/lib/datasources/url/dropbox.rb
+++ b/services/datasources/lib/datasources/url/dropbox.rb
@@ -210,7 +210,8 @@ module CartoDB
           # Any call would do, we just want to see if communicates or refuses the token
           @client.get_current_account
           true
-        rescue DropboxApi::Errors::HttpError
+        rescue DropboxApi::Errors::HttpError => ex
+          CartoDB::Logger.debug(message: 'Invalid Dropbox token', exception: ex, user: @user)
           false
         end
 


### PR DESCRIPTION
Fixes #12286 

Tests
1. Disconnect from Dropbox (if your account is connected)
2. Go to import a new dataset
3. Select connect to dropbox
4. In the oauth popup, choose "cancel"

-> Popup closes, shows error in main window, Rollbar trace (Error in oauth callback)

1. Connect to dropbox
2. Disconnect dropbox from dropbox side
3. Go to import a new dataset

-> Ask to connect again