### PR TITLE
S1276 capitalization rename

### DIFF
--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -638,7 +638,7 @@ class Carto::Visualization < ActiveRecord::Base
   def propagate_privacy_and_name_to
     raise "Empty table sent to propagate_privacy_and_name_to()" unless table
     propagate_privacy if privacy_changed? && canonical?
-    propagate_name if name_changed?
+    propagate_name if name_was != name # name_changed? returns false positives in changes like a->A->a (sanitization)
   end
 
   def propagate_privacy
@@ -655,9 +655,10 @@ class Carto::Visualization < ActiveRecord::Base
     table.name = name
     if table.name != name
       # Sanitization. For example, spaces -> _
-      self.name = table.name
+      update_column(:name, table.name)
     end
     table.update(name: name)
+
     if name_changed?
       support_tables.rename(name_was, name, true, name_was)
     end

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -324,6 +324,27 @@ describe Carto::Visualization do
     end
   end
 
+  describe '#update' do
+    before(:all) do
+      @map, @table, @table_visualization, @visualization = create_full_visualization(@carto_user2)
+      @visualization.create_mapcap!
+      @visualization.reload
+    end
+
+    after(:all) do
+      destroy_full_visualization(@map, @table, @table_visualization, @visualization)
+    end
+
+    it 'sanitizes name on rename' do
+      original = @table_visualization.name
+      @table_visualization.name = @table_visualization.name.upcase
+      @table_visualization.save!
+
+      @table_visualization.reload
+      expect(@table_visualization.name).to eq(original)
+    end
+  end
+
   describe '#invalidation_service' do
     before(:all) do
       @visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, type: 'table')


### PR DESCRIPTION
Closes https://github.com/CartoDB/support/issues/1276

Avoid incorrect rename when the previous name matches the sanitized name

Example: renaming abc -> ABC caused the visualization to keep the non-sanitized name, which caused the dashboard to break.

