### PR TITLE
Fix category autostyle on numeric types

### DIFF
--- a/lib/assets/core/javascripts/deep-insights/widgets/auto-style/category.js
+++ b/lib/assets/core/javascripts/deep-insights/widgets/auto-style/category.js
@@ -52,7 +52,7 @@ module.exports = AutoStyler.extend({
 
       catListColors += '"' + this.colors.getColorByCategory(cat.name) + '"' + next;
       if (!cat.agg) {
-        if (!isNaN(cat.name)) {
+        if (typeof cat.name !== 'string') {
           catListValues += cat.name + next;
         } else {
           catListValues += '"' + String(cat.name).replace(/"/g, '\\"') + '"' + next;

--- a/lib/assets/core/test/spec/deep-insights/widgets/auto-style/category.spec.js
+++ b/lib/assets/core/test/spec/deep-insights/widgets/auto-style/category.spec.js
@@ -77,6 +77,19 @@ describe('src/widgets/auto-style/category', function () {
       expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74", "#A5AA99"), ("soccer", "basketball", "baseball", "handball", "hockey"), \'=\');  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     });
 
+    it('should generate the ramp with quotation marks when the name are strings containing numbers', function () {
+      this.dataview.set('data', [
+        { name: '1' },
+        { name: '2' },
+        { name: '3' },
+        { name: '-4' },
+        { name: '235.52' }
+      ]);
+      this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; }');
+      this.updateColorsByData();
+      expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74"), ("1", "2", "3", "-4", "235.52"), \'=\');  polygon-fill-opacity: 0.9; }');
+    });
+
     it('should generate the ramp without quotation marks when the name are ints', function () {
       this.dataview.set('data', [
         { name: 1 },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -341,9 +341,9 @@
       "resolved": "https://registry.npmjs.org/cartodb-pecan/-/cartodb-pecan-0.2.0.tgz"
     },
     "cartodb.js": {
-      "version": "4.0.0-beta.14",
-      "from": "cartodb/cartodb.js#fix-category-stringify",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#f9f91404cc63cc9ebb8e4ec48eea371e305af9e3"
+      "version": "4.0.0-beta.15",
+      "from": "cartodb/cartodb.js#v4.0.0-beta.15",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#dfa5858ba4c3b70d69fbe273b410bf64fe149350"
     },
     "center-align": {
       "version": "0.1.3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -342,8 +342,8 @@
     },
     "cartodb.js": {
       "version": "4.0.0-beta.14",
-      "from": "cartodb/cartodb.js#v4.0.0-beta.14",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#caf89961c830a9fd1ec3492b8220e008e84f7899"
+      "from": "cartodb/cartodb.js#fix-category-stringify",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#f9f91404cc63cc9ebb8e4ec48eea371e305af9e3"
     },
     "center-align": {
       "version": "0.1.3",
@@ -1115,9 +1115,9 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
     },
     "js-base64": {
-      "version": "2.4.1",
+      "version": "2.4.3",
       "from": "js-base64@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz"
     },
     "js-yaml": {
       "version": "3.5.3",
@@ -1393,9 +1393,14 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
         },
         "timers-browserify": {
-          "version": "2.0.4",
+          "version": "2.0.6",
           "from": "timers-browserify@>=2.0.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz"
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "from": "tty-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         }
       }
     },
@@ -1861,9 +1866,9 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
     },
     "sha.js": {
-      "version": "2.4.9",
+      "version": "2.4.10",
       "from": "sha.js@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz"
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz"
     },
     "shallow-copy": {
       "version": "0.0.1",
@@ -2183,9 +2188,9 @@
       }
     },
     "tty-browserify": {
-      "version": "0.0.0",
+      "version": "0.0.1",
       "from": "tty-browserify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz"
     },
     "turbo-carto": {
       "version": "0.19.0",
@@ -2203,9 +2208,9 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uglify-js": {
-      "version": "3.3.7",
+      "version": "3.3.9",
       "from": "uglify-js@>=3.3.0 <3.4.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.9.tgz",
       "dependencies": {
         "commander": {
           "version": "2.13.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "carto-zera": "1.0.2",
     "cartocolor": "4.0.0",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.14",
+    "cartodb.js": "CartoDB/cartodb.js#fix-category-stringify",
     "clipboard": "1.6.1",
     "codemirror": "5.14.2",
     "d3-interpolate": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "carto-zera": "1.0.2",
     "cartocolor": "4.0.0",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "CartoDB/cartodb.js#fix-category-stringify",
+    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.15",
     "clipboard": "1.6.1",
     "codemirror": "5.14.2",
     "d3-interpolate": "^1.1.6",


### PR DESCRIPTION
This bugfix uses the type of the category names to conditionally put quotation marks when the type of the category names is Number.
Previous behavior used isNan(cat.name) as condition, but this introduced quotation marks to category names of type string when the string contained a number.