### PR TITLE
Don't show 'needs geocoding' status if layer has analyses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -122,6 +122,7 @@ ion for time-series (#12670)
 * Use carto.js v4.0.0-beta.13
 
 ### Bug fixes / enhancements
+* Don't disable delete analysis button if layer already has some [Support#1283](https://github.com/CartoDB/support/issues/1283)
 * Fix publish modal in settings view (#13418)
 * Improve onboarding for when user adds an empty layer (#11876)
 * Don't show the publish modal when the user clicks on the privacy button (#13366)

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-view.js
@@ -237,7 +237,7 @@ module.exports = CoreView.extend({
         });
         analysisFormsCollection.resetByLayerDefinition();
 
-        if (canBeGeoreferenced && !analysisPayload) {
+        if (!self._layerDefinitionModel.hasAnalyses() && canBeGeoreferenced && !analysisPayload) {
           analysisPayload = AnalysesService.generateGeoreferenceAnalysis();
         }
 

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -166,7 +166,7 @@ module.exports = CoreView.extend({
         ? _t('editor.layers.analysis-form.delete-btn')
         : _t('editor.layers.analysis-form.cancel-btn'),
       isDelete: this._analysisNode,
-      disableDelete: this._layerDefinitionModel.canBeGeoreferenced(),
+      disableDelete: !this._canDelete(),
       isDisabled: !this._canSave()
     });
 
@@ -334,7 +334,11 @@ module.exports = CoreView.extend({
 
   _canDelete: function () {
     var nodeDefModel = this._analysisNode;
-    return (!nodeDefModel || nodeDefModel.canBeDeletedByUser()) && !this._layerDefinitionModel.canBeGeoreferenced();
+    var canDeleteNode = (!nodeDefModel || nodeDefModel.canBeDeletedByUser());
+    var canBeGeoreferenced = this._layerDefinitionModel.canBeGeoreferenced();
+    var hasAnalyses = this._layerDefinitionModel.hasAnalyses();
+
+    return (hasAnalyses && canDeleteNode) || (canDeleteNode && !canBeGeoreferenced);
   },
 
   _onDeleteClicked: function () {

--- a/lib/assets/core/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
+++ b/lib/assets/core/javascripts/cartodb3/editor/layers/layer-views/data-layer-view.js
@@ -109,7 +109,7 @@ module.exports = CoreView.extend({
   },
 
   _needsGeocoding: function () {
-    return this.model.canBeGeoreferenced();
+    return this.model.canBeGeoreferenced() && !this.model.hasAnalyses();
   },
 
   _initViews: function () {

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
@@ -97,8 +97,9 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
 
     this.stackLayoutModel = jasmine.createSpyObj('stackLayoutModel', ['prevStep']);
 
-    this._layerDefinitionModel = { canBeGeoreferenced: function () {} };
+    this._layerDefinitionModel = { canBeGeoreferenced: function () {}, hasAnalyses: function () {} };
     spyOn(this._layerDefinitionModel, 'canBeGeoreferenced');
+    spyOn(this._layerDefinitionModel, 'hasAnalyses');
   });
 
   it('should not fetch quota if no analysis node', function () {
@@ -560,6 +561,51 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
 
       it('should delete selectednode', function () {
         expect(this.analysisFormsCollection.deleteNode).toHaveBeenCalledWith('a1');
+      });
+    });
+  });
+
+  describe('delete button', function () {
+    beforeEach(function () {
+      this.view = new AnalysisControlsView({
+        analysisFormsCollection: this.analysisFormsCollection,
+        userModel: this.userModel,
+        userActions: this.userActions,
+        formModel: this.formModel,
+        stackLayoutModel: this.stackLayoutModel,
+        configModel: this.configModel,
+        quotaInfo: this.quotaInfo,
+        querySchemaModel: this.querySchemaModel,
+        layerDefinitionModel: this._layerDefinitionModel
+      });
+    });
+
+    describe('should be disabled', function () {
+      it('if layer needs georeferencing', function () {
+        this._layerDefinitionModel.canBeGeoreferenced.and.returnValue(true);
+
+        this.view.render();
+
+        expect(this.view.$('.js-delete').hasClass('is-disabled')).toBe(true);
+      });
+    });
+
+    describe('should be enabled', function () {
+      it('if layer needs georeferencing but there are analyses already', function () {
+        this._layerDefinitionModel.canBeGeoreferenced.and.returnValue(true);
+        this._layerDefinitionModel.hasAnalyses.and.returnValue(true);
+
+        this.view.render();
+
+        expect(this.view.$('.js-delete').hasClass('is-disabled')).toBe(false);
+      });
+
+      it('if layer does not need georeferencing', function () {
+        this._layerDefinitionModel.canBeGeoreferenced.and.returnValue(false);
+
+        this.view.render();
+
+        expect(this.view.$('.js-delete').hasClass('is-disabled')).toBe(false);
       });
     });
   });

--- a/lib/assets/core/test/spec/cartodb3/editor/layers/layer-views/data-layer-view.spec.js
+++ b/lib/assets/core/test/spec/cartodb3/editor/layers/layer-views/data-layer-view.spec.js
@@ -271,16 +271,39 @@ describe('editor/layers/data-layer-view', function () {
     expect(this.view.$('.js-analyses-widgets-info').hasClass('is-hidden')).toBe(true);
   });
 
-  it('should render geocode button when layer doesn\'t have geometry', function () {
-    expect(this.view.$('.js-geocode').length).toBe(0);
-    this.model.canBeGeoreferenced = function () {
-      return true;
-    };
+  describe('geocode render button', function () {
+    beforeEach(function () {
+      spyOn(this.model, 'canBeGeoreferenced');
+      spyOn(this.model, 'hasAnalyses');
+    });
 
-    this.view.render();
+    describe('should not be rendered', function () {
+      it('if layer does not need geocoding', function () {
+        this.model.canBeGeoreferenced.and.returnValue(false);
+        this.view.render();
 
-    expect(this.view.$('.js-geocode').length).toBe(1);
-    expect(this.view.$('.js-geocode').data('tipsy')).not.toBeUndefined();
+        expect(this.view.$('.js-geocode').length).toBe(0);
+      });
+
+      it('if layer needs geocoding but has analyses', function () {
+        this.model.canBeGeoreferenced.and.returnValue(true);
+        this.model.hasAnalyses.and.returnValue(true);
+        this.view.render();
+
+        expect(this.view.$('.js-geocode').length).toBe(0);
+      });
+    });
+
+    describe('should be rendered', function () {
+      it('if a layer needs geocoding and has no analyses', function () {
+        this.model.canBeGeoreferenced.and.returnValue(true);
+        this.model.hasAnalyses.and.returnValue(false);
+        this.view.render();
+
+        expect(this.view.$('.js-geocode').length).toBe(1);
+        expect(this.view.$('.js-geocode').data('tipsy')).not.toBeUndefined();
+      });
+    });
   });
 
   it('should be with errors when layer has errors', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.17",
+  "version": "4.11.17-1283",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.17-1283",
+  "version": "4.11.17-1283-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related issue is: https://github.com/CartoDB/support/issues/1283

Title says all, we're now checking if a layer has any analyses as well. Not doing this would block the user on certain situations.

We also don't disable the delete analysis button if this is the case.

Added some specs for these cases as well as for some previously untested ones.