### PR TITLE
Embed map disappears when reducing size of screen

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -129,6 +129,7 @@ ion for time-series (#12670)
 * Use carto.js v4.0.0-beta.13
 
 ### Bug fixes / enhancements
+* Fix Embed map disappears when reducing size of screen [Support#1299](https://github.com/CartoDB/support/issues/1299)
 * Update Leaflet to version 1.3.1
 * Remove tangram by updating cartodb.js version
 * Remove `To column` option from `Connect with lines` analysis [#12955](https://github.com/CartoDB/cartodb/issues/12955)

--- a/app/assets/stylesheets/editor-3/public.scss
+++ b/app/assets/stylesheets/editor-3/public.scss
@@ -60,7 +60,6 @@
 
 @media (max-width: 600px) {
   .CDB-Embed-content {
-    flex-grow: initial;
     // 103px = header + tabs height
     height: calc(100% - 103px);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.29",
+  "version": "4.11.29-1299support",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes the issue that we were having in embed maps. The issue was that the map was disappearing when resizing the window to a viewport less than 600px wide.

Related to https://github.com/CartoDB/support/issues/1299.