### PR TITLE
Add cookie privacy setting to embed via queryString parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ This release changes the way Google ouath login works. If you are using it, you 
 to the oauth.google_plus section of the configuration file.
 
 ### Features
+* Add cookie privacy setting to embed via queryString parameter ([#13510](https://github.com/CartoDB/cartodb/pull/13510))
 * User feed migration
 * Add legends to mobile view in embed maps (#13417)
 * Unplug pluggable frontends (#13446)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,7 +119,7 @@ module ApplicationHelper
   end
 
   def insert_fullstory
-    if Cartodb.get_config(:fullstory, 'org').present? && current_user && current_user.account_type.casecmp('FREE').zero?
+    if Cartodb.get_config(:fullstory, 'org').present? && current_user && current_user.account_type.casecmp('FREE').zero? && params[:cookies] != '0'
       render(partial: 'shared/fullstory', locals: { org: Cartodb.get_config(:fullstory, 'org') })
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,7 +119,8 @@ module ApplicationHelper
   end
 
   def insert_fullstory
-    if Cartodb.get_config(:fullstory, 'org').present? && current_user && current_user.account_type.casecmp('FREE').zero? && params[:cookies] != '0'
+    if Cartodb.get_config(:fullstory, 'org').present? && current_user &&
+       current_user.account_type.casecmp('FREE').zero? && params[:cookies] != '0'
       render(partial: 'shared/fullstory', locals: { org: Cartodb.get_config(:fullstory, 'org') })
     end
   end

--- a/app/helpers/frontend_config_helper.rb
+++ b/app/helpers/frontend_config_helper.rb
@@ -20,7 +20,7 @@ module FrontendConfigHelper
       google_analytics_domain:    Cartodb.get_config(:google_analytics, 'domain'),
       hubspot_enabled:            CartoDB::Hubspot::instance.enabled?,
       intercom_app_id:            Cartodb.get_config(:intercom, 'app_id'),
-      fullstory_enabled:          Cartodb.get_config(:fullstory, 'org').present? && user && user.account_type.casecmp('FREE').zero?,
+      fullstory_enabled:          Cartodb.get_config(:fullstory, 'org').present? && user && user.account_type.casecmp('FREE').zero? && params[:cookies] != '0',
       fullstory_org:              Cartodb.get_config(:fullstory, 'org'),
       dropbox_api_key:            Cartodb.get_config(:dropbox_api_key),
       gdrive_api_key:             Cartodb.get_config(:gdrive, 'api_key'),

--- a/app/helpers/frontend_config_helper.rb
+++ b/app/helpers/frontend_config_helper.rb
@@ -20,7 +20,8 @@ module FrontendConfigHelper
       google_analytics_domain:    Cartodb.get_config(:google_analytics, 'domain'),
       hubspot_enabled:            CartoDB::Hubspot::instance.enabled?,
       intercom_app_id:            Cartodb.get_config(:intercom, 'app_id'),
-      fullstory_enabled:          Cartodb.get_config(:fullstory, 'org').present? && user && user.account_type.casecmp('FREE').zero? && params[:cookies] != '0',
+      fullstory_enabled:          Cartodb.get_config(:fullstory, 'org').present? && user &&
+                                  user.account_type.casecmp('FREE').zero? && params[:cookies] != '0',
       fullstory_org:              Cartodb.get_config(:fullstory, 'org'),
       dropbox_api_key:            Cartodb.get_config(:dropbox_api_key),
       gdrive_api_key:             Cartodb.get_config(:gdrive, 'api_key'),

--- a/app/helpers/google_analytics_helper.rb
+++ b/app/helpers/google_analytics_helper.rb
@@ -1,7 +1,7 @@
 module GoogleAnalyticsHelper
   def insert_google_analytics(track, public_view = false, custom_vars = {})
     if !Cartodb.config[:google_analytics].blank? && !Cartodb.config[:google_analytics][track].blank? &&
-       !Cartodb.config[:google_analytics]["domain"].blank? && params[:cookie] != '0'
+       !Cartodb.config[:google_analytics]["domain"].blank? && params[:cookies] != '0'
       ua = Cartodb.config[:google_analytics][track]
       domain = Cartodb.config[:google_analytics]["domain"]
 

--- a/app/helpers/google_analytics_helper.rb
+++ b/app/helpers/google_analytics_helper.rb
@@ -1,6 +1,7 @@
 module GoogleAnalyticsHelper
   def insert_google_analytics(track, public_view = false, custom_vars = {})
-    if !Cartodb.config[:google_analytics].blank? && !Cartodb.config[:google_analytics][track].blank? && !Cartodb.config[:google_analytics]["domain"].blank?
+    if !Cartodb.config[:google_analytics].blank? && !Cartodb.config[:google_analytics][track].blank? &&
+       !Cartodb.config[:google_analytics]["domain"].blank? && params[:cookie] != '0'
       ua = Cartodb.config[:google_analytics][track]
       domain = Cartodb.config[:google_analytics]["domain"]
 

--- a/app/helpers/hubspot_helper.rb
+++ b/app/helpers/hubspot_helper.rb
@@ -1,6 +1,6 @@
 module HubspotHelper
   def insert_hubspot(app = 'editor')
-    if CartoDB::Hubspot::instance.enabled? && !CartoDB::Hubspot::instance.token.blank?
+    if CartoDB::Hubspot::instance.enabled? && !CartoDB::Hubspot::instance.token.blank? && params[:cookies] != '0'
       token = CartoDB::Hubspot::instance.token
       event_ids = CartoDB::Hubspot::instance.event_ids
 

--- a/app/helpers/trackjs_helper.rb
+++ b/app/helpers/trackjs_helper.rb
@@ -1,6 +1,6 @@
 module TrackjsHelper
   def insert_trackjs(app = 'editor')
-    if Cartodb.get_config(:trackjs, 'customer')
+    if Cartodb.get_config(:trackjs, 'customer') && params[:cookie] != '0'
       customer = Cartodb.get_config(:trackjs, 'customer')
       enabled = Cartodb.get_config(:trackjs, 'enabled')
       app_key = Cartodb.get_config(:trackjs, 'app_keys', app)

--- a/app/helpers/trackjs_helper.rb
+++ b/app/helpers/trackjs_helper.rb
@@ -1,6 +1,6 @@
 module TrackjsHelper
   def insert_trackjs(app = 'editor')
-    if Cartodb.get_config(:trackjs, 'customer') && params[:cookie] != '0'
+    if Cartodb.get_config(:trackjs, 'customer') && params[:cookies] != '0'
       customer = Cartodb.get_config(:trackjs, 'customer')
       enabled = Cartodb.get_config(:trackjs, 'enabled')
       app_key = Cartodb.get_config(:trackjs, 'app_keys', app)

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -195,6 +195,14 @@ describe Carto::Builder::Public::EmbedsController do
       response.body.should_not include("maps.google.com/maps/api/js")
     end
 
+    it 'does not include 3rd party scripts if cookies=0 query param is present' do
+      get builder_visualization_public_embed_url(visualization_id: @visualization.id, cookies: '0')
+
+      response.body.should_not include("www.google-analytics.com/analytics")
+      response.body.should_not include("d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js")
+      response.body.should_not include("js.hs-analytics.net/analytics")
+    end
+
     it 'does not embed password protected viz' do
       stub_passwords(TEST_PASSWORD)
       @visualization.privacy = Carto::Visualization::PRIVACY_PROTECTED

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -195,12 +195,50 @@ describe Carto::Builder::Public::EmbedsController do
       response.body.should_not include("maps.google.com/maps/api/js")
     end
 
-    it 'does not include 3rd party scripts if cookies=0 query param is present' do
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id, cookies: '0')
+    it 'includes 3rd party scripts for analytics' do
+      Cartodb.with_config(
+        trackjs: {
+          'customer' => 'fake_trackjs_customer'
+        },
+        metrics: {
+          'hubspot': {
+            'enabled' => true,
+            'token' => 'fake_hubspot_token'
+          }
+        },
+        google_analytics: {
+          'embeds' => 'fake_embed_id',
+          'domain' => 'carto-test.com'
+        }
+      ) do
+        get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 
-      response.body.should_not include("www.google-analytics.com/analytics")
-      response.body.should_not include("d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js")
-      response.body.should_not include("js.hs-analytics.net/analytics")
+        response.body.should include("www.google-analytics.com/analytics")
+        response.body.should include("d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js")
+      end
+    end
+
+    it 'does not include 3rd party scripts if cookies=0 query param is present' do
+      Cartodb.with_config(
+        trackjs: {
+          'customer' => 'fake_trackjs_customer'
+        },
+        metrics: {
+          'hubspot': {
+            'enabled' => true,
+            'token' => 'fake_hubspot_token'
+          }
+        },
+        google_analytics: {
+          'embeds' => 'fake_embed_id',
+          'domain' => 'carto-test.com'
+        }
+      ) do
+        get builder_visualization_public_embed_url(visualization_id: @visualization.id, cookies: '0')
+
+        response.body.should_not include("www.google-analytics.com/analytics")
+        response.body.should_not include("d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js")
+      end
     end
 
     it 'does not embed password protected viz' do


### PR DESCRIPTION
This PR adds the possibility to opt out of cookies in Builder embed.

When this `Do not track` mode is enabled via the query string parameter (`cookies=0`), we do not include either the Google Analytics script or the TrackJS script.

I talked to @javitonino and he told me that the best way to do it was to prevent the script from inserting, instead of conditional insertion in the template as I thought at first. This behaviour will allow us to share the same behaviour in all of our views by inserting `cookies=0` query parameter.

The services adding cookies in our platform are **Google Analytics**, **Hubspot**, **FullStory** and **TrackJS**. FullStory script is not currently being rendered in our embed views, but as we need to be GDPR compliant I thought it was a good idea to disable it as well.

Related to https://github.com/CartoDB/support/issues/1296