### PR TITLE
Remove Vector feature flag logic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -130,6 +130,7 @@ ion for time-series (#12670)
 * Use carto.js v4.0.0-beta.13
 
 ### Bug fixes / enhancements
+* Remove Tangram's vector rendering support in Builder embeds ([#13461](https://github.com/CartoDB/cartodb/issues/13461))
 * Remove Tangram references (#13461)
 * Restore translation keys to static pages (#13492)
 * Fix Embed map disappears when reducing size of screen [Support#1299](https://github.com/CartoDB/support/issues/1299)

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -180,7 +180,7 @@ module Carto
       end
 
       def vizjson3
-        render_vizjson(generate_vizjson3(@visualization, vizjson3_options(@visualization, params)))
+        render_vizjson(generate_vizjson3(@visualization))
       end
 
 

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -33,21 +33,21 @@ module Carto
         @redis_vizjson_cache = redis_vizjson_cache
       end
 
-      def to_vizjson(https_request: false, vector: false)
-        generate_vizjson(https_request: https_request, vector: vector, forced_privacy_version: nil)
+      def to_vizjson(https_request: false)
+        generate_vizjson(https_request: https_request, forced_privacy_version: nil)
       end
 
-      def to_named_map_vizjson(https_request: false, vector: false)
-        generate_vizjson(https_request: https_request, vector: vector, forced_privacy_version: :force_named)
+      def to_named_map_vizjson(https_request: false)
+        generate_vizjson(https_request: https_request, forced_privacy_version: :force_named)
       end
 
-      def to_anonymous_map_vizjson(https_request: false, vector: false)
-        generate_vizjson(https_request: https_request, vector: vector, forced_privacy_version: :force_anonymous)
+      def to_anonymous_map_vizjson(https_request: false)
+        generate_vizjson(https_request: https_request, forced_privacy_version: :force_anonymous)
       end
 
       private
 
-      def generate_vizjson(https_request:, vector:, forced_privacy_version:)
+      def generate_vizjson(https_request:, forced_privacy_version:)
         https_request ||= false
         version = case forced_privacy_version
                   when :force_named
@@ -65,10 +65,6 @@ module Carto
                   else
                     calculate_vizjson(https_request: https_request, forced_privacy_version: forced_privacy_version)
                   end
-
-        unless vector.nil? # true or false
-          vizjson[:vector] = vector
-        end
 
         vizjson
       end

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -68,7 +68,7 @@ module Carto
 
         def load_vizjson
           vis = visualization_for_presentation
-          @vizjson = generate_named_map_vizjson3(vis, vizjson3_options(vis, params))
+          @vizjson = generate_named_map_vizjson3(vis)
         end
 
         def load_state

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -33,7 +33,7 @@ module Carto
         @layers_data = @visualization.layers.map do |l|
           Carto::Api::LayerPresenter.new(l, with_style_properties: true).to_poro(migrate_builder_infowindows: true)
         end
-        @vizjson = generate_anonymous_map_vizjson3(@visualization, vector: false)
+        @vizjson = generate_anonymous_map_vizjson3(@visualization)
         @state = @visualization.state.json
         @analyses_data = @visualization.analyses.map { |a| Carto::Api::AnalysisPresenter.new(a).to_poro }
         @basemaps = current_viewer.basemaps

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -97,32 +97,23 @@ module VisualizationsControllerHelper
     viz_locator.matches_visualization?(visualization) ? visualization : nil
   end
 
-  def generate_vizjson3(visualization, vector: false)
+  def generate_vizjson3(visualization)
     Carto::Api::VizJSON3Presenter.new(visualization)
-                                 .to_vizjson(https_request: is_https?, vector: vector)
+                                 .to_vizjson(https_request: is_https?)
   end
 
-  def generate_named_map_vizjson3(visualization, vector: false)
+  def generate_named_map_vizjson3(visualization)
     Carto::Api::VizJSON3Presenter.new(visualization)
-                                 .to_named_map_vizjson(https_request: is_https?, vector: vector)
+                                 .to_named_map_vizjson(https_request: is_https?)
   end
 
-  def generate_anonymous_map_vizjson3(visualization, vector: false)
+  def generate_anonymous_map_vizjson3(visualization)
     Carto::Api::VizJSON3Presenter.new(visualization)
-                                 .to_anonymous_map_vizjson(https_request: is_https?, vector: vector)
+                                 .to_anonymous_map_vizjson(https_request: is_https?)
   end
 
   def vizjson3_options(visualization, params)
     options = {}
-
-    if params[:vector].present?
-      # This forces vector. Useful for testing purposes
-      options[:vector] = params[:vector] == 'true'
-    elsif !visualization.user.has_feature_flag?('vector_vs_raster')
-      # This enables autodetection at cartodb.js
-      options[:vector] = nil
-    end
-
     options
   end
   private

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -111,11 +111,6 @@ module VisualizationsControllerHelper
     Carto::Api::VizJSON3Presenter.new(visualization)
                                  .to_anonymous_map_vizjson(https_request: is_https?)
   end
-
-  def vizjson3_options(visualization, params)
-    options = {}
-    options
-  end
   private
 
   def get_priority_visualization_forcing_name(visualization_id, force_name: false, user_id: nil, organization_id: nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,6 @@ module ApplicationHelper
   include SqlApiHelper
   include Carto::HtmlSafe
   include CartoGearsApi::Helpers::PagesHelper
-  include VectorHelper
 
   def current_user
     super(CartoDB.extract_subdomain(request))

--- a/app/helpers/vector_helper.rb
+++ b/app/helpers/vector_helper.rb
@@ -1,5 +1,0 @@
-module VectorHelper
-  def vector_render?(visualization, params)
-    !visualization.user.has_feature_flag?('vector_vs_raster') || params['vector'] == 'true'
-  end
-end

--- a/lib/assets/javascripts/cartodb3/dataset/dataset-options/preview-map-view.js
+++ b/lib/assets/javascripts/cartodb3/dataset/dataset-options/preview-map-view.js
@@ -58,7 +58,6 @@ module.exports = CoreView.extend({
       this._visModel.vizjsonURL(),
       {
         legends: false,
-        vector: false,
         authToken: this._configModel.get('auth_tokens'),
         mapzenApiKey: this._configModel.get('mapzenApiKey'),
         mapboxApiKey: this._configModel.get('mapboxApiKey')

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -305,8 +305,7 @@ var mapCreation = function () {
     interactiveFeatures: true,
     layerSelectorEnabled: false,
     mapzenApiKey: mapzenApiKey,
-    mapboxApiKey: mapboxApiKey,
-    vector: false // disable vector rendering
+    mapboxApiKey: mapboxApiKey
   }, function (error, dashboard) {
     if (error) {
       console.error('Dashboard has some errors:\n', error);

--- a/lib/assets/javascripts/dashboard/views/public-profile/fav-map-view.js
+++ b/lib/assets/javascripts/dashboard/views/public-profile/fav-map-view.js
@@ -43,8 +43,7 @@ module.exports = CoreView.extend({
       legends: false,
       loader: false,
       fullscreen: false,
-      no_cdn: false,
-      vector: false
+      no_cdn: false
     }));
   },
 

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -437,7 +437,6 @@ describe Carto::Api::VisualizationsController do
       @user_2 = FactoryGirl.create(:valid_user, private_maps_enabled: true)
       @carto_user2 = Carto::User.find(@user_2.id)
       @api_key = @user_1.api_key
-      @feature_flag = FactoryGirl.create(:feature_flag, name: 'vector_vs_raster', restricted: true)
     end
 
     before(:each) do
@@ -1745,9 +1744,8 @@ describe Carto::Api::VisualizationsController do
 
       include_context 'visualization creation helpers'
 
-      def get_vizjson3_url(user, visualization, vector: nil)
+      def get_vizjson3_url(user, visualization)
         args = { user_domain: user.username, id: visualization.id, api_key: user.api_key }
-        args[:vector] = vector unless vector.nil?
         api_v3_visualizations_vizjson_url(args)
       end
 
@@ -2009,47 +2007,6 @@ describe Carto::Api::VisualizationsController do
 
           vizjson3[:user][:fullname].should == (@user_1.name.nil? ? @user_1.username : @user_1.name)
           vizjson3[:user][:avatar_url].should_not be_nil
-        end
-      end
-
-      it 'includes vector flag (default true)' do
-        get_json get_vizjson3_url(@user_1, @visualization), @headers do |response|
-          response.status.should == 200
-          vizjson3 = response.body
-          vizjson3[:vector].should be_nil
-        end
-      end
-
-      it 'includes vector flag if vector_vs_raster feature flag is enabled and vector param is not present' do
-        set_feature_flag @visualization.user, 'vector_vs_raster', true
-        get_json get_vizjson3_url(@user_1, @visualization), @headers do |response|
-          response.status.should == 200
-          vizjson3 = response.body
-          vizjson3.has_key?(:vector).should be_true
-        end
-      end
-
-      it 'includes vector flag if vector_vs_raster feature flag is enabled and vector param is present' do
-        set_feature_flag @visualization.user, 'vector_vs_raster', true
-
-        get_json get_vizjson3_url(@user_1, @visualization, vector: true), @headers do |response|
-          response.status.should == 200
-          vizjson3 = response.body
-          vizjson3[:vector].should eq true
-        end
-
-        get_json get_vizjson3_url(@user_1, @visualization, vector: false), @headers do |response|
-          response.status.should == 200
-          vizjson3 = response.body
-          vizjson3[:vector].should eq false
-        end
-      end
-
-      it 'includes vector flag (true if requested)' do
-        get_json api_v3_visualizations_vizjson_url(user_domain: @user_1.username, id: @visualization.id, api_key: @user_1.api_key, vector: true), @headers do |request|
-          request.status.should == 200
-          vizjson3 = request.body
-          vizjson3[:vector].should == true
         end
       end
 

--- a/spec/requests/carto/api/vizjson3_presenter_spec.rb
+++ b/spec/requests/carto/api/vizjson3_presenter_spec.rb
@@ -84,14 +84,6 @@ describe Carto::Api::VizJSON3Presenter do
       v3n_vizjson[:version].should eq '3.0.0'
     end
 
-    it 'to_vizjson does not cache vector' do
-      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization)
-      vizjson_a = v3_presenter.to_vizjson(vector: true)
-      vizjson_b = v3_presenter.to_vizjson(vector: false)
-      vizjson_a[:vector].should eq true
-      vizjson_b[:vector].should eq false
-    end
-
     it 'to_named_map_vizjson uses the redis vizjson cache' do
       fake_vizjson = { fake: 'sure!', layers: [] }
 
@@ -102,14 +94,6 @@ describe Carto::Api::VizJSON3Presenter do
       v2 = presenter.to_named_map_vizjson
       v1.should eq fake_vizjson
       v1.should eq v2
-    end
-
-    it 'to_named_map_vizjson does not cache vector' do
-      v3_presenter = Carto::Api::VizJSON3Presenter.new(@visualization)
-      vizjson_a = v3_presenter.to_named_map_vizjson(vector: true)
-      vizjson_b = v3_presenter.to_named_map_vizjson(vector: false)
-      vizjson_a[:vector].should eq true
-      vizjson_b[:vector].should eq false
     end
   end
 

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -117,7 +117,7 @@ describe Carto::Builder::Public::EmbedsController do
     end
 
     it 'does not include auth tokens for public/link visualizations' do
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
+      get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 
       response.status.should == 200
       response.body.should include("var authTokens = JSON.parse('[]');")
@@ -129,7 +129,7 @@ describe Carto::Builder::Public::EmbedsController do
       @visualization.create_mapcap!
       @user.google_maps_key = ''
       @user.save
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
+      get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 
       response.status.should == 200
       response.body.should_not include("maps.google.com/maps/api/js")
@@ -141,7 +141,7 @@ describe Carto::Builder::Public::EmbedsController do
       @visualization.create_mapcap!
       @user.google_maps_key = 'client=wadus_cid'
       @user.save
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
+      get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 
       response.status.should == 200
       response.body.should include("maps.google.com/maps/api/js?client=wadus_cid")
@@ -153,7 +153,7 @@ describe Carto::Builder::Public::EmbedsController do
       @visualization.create_mapcap!
       @user.google_maps_key = 'client=wadus_cid'
       @user.save
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
+      get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 
       response.status.should == 200
       response.body.should_not include("maps.google.com/maps/api/js")
@@ -280,7 +280,7 @@ describe Carto::Builder::Public::EmbedsController do
 
       it 'includes auth tokens for privately shared visualizations' do
         login_as(@org_user_1)
-        get builder_visualization_public_embed_url(visualization_id: @org_visualization.id, vector: true)
+        get builder_visualization_public_embed_url(visualization_id: @org_visualization.id)
 
         response.status.should == 200
         @org_user_1.reload
@@ -296,7 +296,7 @@ describe Carto::Builder::Public::EmbedsController do
         @organization.google_maps_key = 'client=wadus_org_cid'
         @organization.save
         login_as(@org_user_1)
-        get builder_visualization_public_embed_url(visualization_id: @org_visualization.id, vector: true)
+        get builder_visualization_public_embed_url(visualization_id: @org_visualization.id)
 
         response.status.should == 200
         response.body.should include("maps.google.com/maps/api/js?client=wadus_org_cid")

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -14,7 +14,6 @@ describe Carto::Builder::Public::EmbedsController do
     @visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, map_id: @map.id, version: 3)
     # Only mapcapped visualizations are presented by default
     Carto::Mapcap.create!(visualization_id: @visualization.id)
-    @feature_flag = FactoryGirl.create(:feature_flag, name: 'vector_vs_raster', restricted: true)
   end
 
   before(:each) do
@@ -115,41 +114,6 @@ describe Carto::Builder::Public::EmbedsController do
       get builder_visualization_public_embed_url(visualization_id: @visualization.id)
 
       response.status.should == 302
-    end
-
-    it 'defaults to generate vizjson with vector=true' do
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id)
-
-      response.status.should == 200
-      response.body.should_not include('\"vector\":true')
-    end
-
-    it 'generates vizjson with vector=true with flag' do
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
-
-      response.status.should == 200
-      response.body.should include('\"vector\":true')
-    end
-
-    it 'doesn\'t include vector flag if vector_vs_raster feature flag is enabled and vector param is not present' do
-      set_feature_flag @visualization.user, 'vector_vs_raster', false
-
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id)
-
-      response.status.should == 200
-      response.body.should_not include('\"vector\"')
-    end
-
-    it 'includes vector flag if vector_vs_raster feature flag is enabled and vector param is present' do
-      set_feature_flag @visualization.user, 'vector_vs_raster', true
-
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: true)
-      response.status.should == 200
-      response.body.should include('\"vector\":true')
-
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id, vector: false)
-      response.status.should == 200
-      response.body.should include('\"vector\":false')
     end
 
     it 'does not include auth tokens for public/link visualizations' do

--- a/spec/requests/carto/builder/visualizations_controller_spec.rb
+++ b/spec/requests/carto/builder/visualizations_controller_spec.rb
@@ -163,13 +163,6 @@ describe Carto::Builder::VisualizationsController do
       response.status.should == 404
     end
 
-    it 'defaults to generate vizjson with vector=false' do
-      get builder_visualization_url(id: @visualization.id)
-
-      response.status.should == 200
-      response.body.should include('\"vector\":false')
-    end
-
     it 'does not generate vizjson with vector=true with flag (Builder should always be raster right now)' do
       get builder_visualization_url(id: @visualization.id, vector: true)
 
@@ -180,7 +173,7 @@ describe Carto::Builder::VisualizationsController do
     it 'displays analysesData' do
       analysis = FactoryGirl.create(:source_analysis, visualization_id: @visualization.id, user_id: @user1.id)
 
-      get builder_visualization_url(id: @visualization.id, vector: true)
+      get builder_visualization_url(id: @visualization.id)
 
       response.status.should == 200
       response.body.should include(analysis.natural_id)


### PR DESCRIPTION
This PR removes Vector feature flag logic from Builder Backend.

We need to remove the actual `vector_vs_raster` feature flag ¿before/after? merging this PR.

Related to https://github.com/CartoDB/cartodb/issues/13461