### PR TITLE
Update rb-readline

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    rb-readline (0.5.3)
+    rb-readline (0.5.5)
     rbtrace (0.4.8)
       ffi (>= 1.0.6)
       msgpack (>= 0.4.3)


### PR DESCRIPTION
To fix this bug:
https://github.com/ConnorAtherton/rb-readline/commit/fd882edcd145c26681f9971be5f6675c7f6d1970

Should be pretty safe (the gem is only used for rails console, and is in the development group, not installed in production).