### PR TITLE
Prevent destroying some modals on Builder when route changes

### DIFF
--- a/lib/assets/javascripts/cartodb3/components/modals/modal-view.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/modal-view.js
@@ -29,6 +29,7 @@ module.exports = CoreView.extend({
 
     this._escapeOptionsDisabled = this.options.escapeOptionsDisabled;
     this._breadcrumbsEnabled = this.options.breadcrumbsEnabled;
+    this._keepOnRouteChange = this.options.keepOnRouteChange;
   },
 
   render: function () {
@@ -62,6 +63,10 @@ module.exports = CoreView.extend({
   destroy: function () {
     // 'remove' would be a better name ofc, but there is already an internal method with that name in CoreView
     this.model.destroy();
+  },
+
+  keepOnRouteChange: function () {
+    return this.model.get('keepOnRouteChange');
   },
 
   _onShowChange: function (m, show) {

--- a/lib/assets/javascripts/cartodb3/components/modals/modals-service-model.js
+++ b/lib/assets/javascripts/cartodb3/components/modals/modals-service-model.js
@@ -7,7 +7,7 @@ var DESTROYED_MODAL_EVENT = 'destroyedModal';
 
 /**
  * Top-level API to handle modals.
- * Is intended to be instantiated and registered in some top-level namespace to be accessibel within the lifecycle of
+ * Is intended to be instantiated and registered in some top-level namespace to be accessible within the lifecycle of
  * an client-side application.
  *
  * Example:
@@ -65,8 +65,15 @@ module.exports = Backbone.Model.extend({
     }
   },
 
+  keepOnRouteChange: function () {
+    return this._modalView.keepOnRouteChange();
+  },
+
   _newModalView: function (options) {
-    var viewModel = new ModalViewModel();
+    var viewModel = new ModalViewModel({
+      keepOnRouteChange: options && options.keepOnRouteChange
+    });
+
     this._handleBodyClass(viewModel);
 
     var escapeOptionsDisabled = options && options.escapeOptionsDisabled;

--- a/lib/assets/javascripts/cartodb3/editor.js
+++ b/lib/assets/javascripts/cartodb3/editor.js
@@ -374,7 +374,8 @@ if (visDefinitionModel.get('version') === 2 && modals) {
       visDefinitionModel: visDefinitionModel
     });
   }, {
-    escapeOptionsDisabled: true
+    escapeOptionsDisabled: true,
+    keepOnRouteChange: true
   });
 } else {
   mapCreation();

--- a/lib/assets/javascripts/cartodb3/routes/handle-modals-route.js
+++ b/lib/assets/javascripts/cartodb3/routes/handle-modals-route.js
@@ -1,7 +1,7 @@
 module.exports = function (currentRoute, modals) {
   var routeName = currentRoute[0];
 
-  if (routeName !== 'modal') {
+  if (routeName !== 'modal' && !modals.keepOnRouteChange()) {
     modals.destroy();
   }
 };


### PR DESCRIPTION
This PR fixes a bug that was doing an unexpected redirection when opening a map created with Editor in Builder.

When a map from Editor is opened in Builder, there is a modal shown to tell you that opening your map in Builder may cause unexpected behaviours or something else wrong. That modal was being closed due to Routing feature, that closes any opened modal when the route changes, and when this modal is destroyed it is supposed to make a redirection to dashboard that was failing with 404 error.

This PR implements a new feature that allows modals not to be destroyed when route changes and `keepOnRouteChange` is enabled, preventing the unexpected behaviour of that bug.

Related to https://github.com/CartoDB/support/issues/1293.