### PR TITLE
🔥 Remove steps strategy

### DIFF
--- a/lib/carto/db/user_schema_mover.rb
+++ b/lib/carto/db/user_schema_mover.rb
@@ -5,11 +5,8 @@ module Carto
     class UserSchemaMover
       # Approach: move object by object (tables, views, materialized and functions)
       STEPS_STRATEGY = :move_schema_content_step_by_step
-      # Alternative approach: rename the schema and handle the exceptions.
-      # Currently experimental, prone to side effects and not as generic as expected.
-      RENAMING_STRATEGY = :move_schema_content_by_renaming
 
-      STRATEGIES = [STEPS_STRATEGY, RENAMING_STRATEGY].freeze
+      STRATEGIES = [STEPS_STRATEGY].freeze
 
       def initialize(user)
         @user = user
@@ -110,57 +107,6 @@ module Carto
       def functions(db, schema = @user.database_schema, owner_role = @user.database_username)
         Carto::Db::Database.new(@user.database_name, db).functions(schema, owner_role)
       end
-
-      # Moves the schema by renaming + moving some things back
-      # EXPERIMENTAL. See #6295 and #6467.
-      # move_schema_content_step_by_step is preferred right now.
-      def move_schema_content_by_renaming(old_name, new_name)
-        @user.in_database(as: :superuser) do |database|
-          database.transaction do
-            cartodbfied_tables = {}
-            @user.real_tables(old_name).each do |t|
-              cartodbfied_tables[t] = cdb_drop_triggers(t, database, old_name)
-            end
-
-            rename_schema_with_database(database, old_name, new_name)
-
-            Database.new(@database_name, database).create_schema(old_name)
-            move_postgis_to_schema(database, old_name)
-            move_plproxy_to_schema(database, old_name, new_name)
-            move_odbc_fdw_to_schema(database, old_name)
-            @user.db_service.rebuild_quota_trigger_with_database(database)
-
-            cartodbfied_tables.select { |_, is_cartodbfied| is_cartodbfied }.map do |t, _|
-              cdb_cartodbfy(t, database, new_name)
-            end
-          end
-        end
-      end
-
-      def rename_schema_with_database(database, old_name, new_name)
-        database.run(%{ALTER SCHEMA "#{old_name}" RENAME TO "#{new_name}"})
-      end
-
-      def move_postgis_to_schema(database, schema)
-        database.run(%{ALTER EXTENSION postgis SET SCHEMA "#{schema}"})
-      end
-
-      def move_odbc_fdw_to_schema(database, schema)
-        odbc_fdw_installed = database.fetch(%{
-          SELECT count(*) FROM pg_extension WHERE extname='odbc_fdw'
-        }).first[:count] > 0
-        if odbc_fdw_installed
-          database.run %{ALTER EXTENSION odbc_fdw SET SCHEMA "#{schema}"}
-        end
-      end
-
-      def move_plproxy_to_schema(database, old_schema, new_schema)
-        # extension "plproxy" does not support SET SCHEMA
-        functions(database, @user.database_username, old_schema).
-          select { |f| /^plproxy/.match(f.name) }.
-          each { |f| move_function_to_schema(f, database, old_schema, new_schema) }
-      end
-
     end
   end
 end

--- a/spec/models/user_organization_spec.rb
+++ b/spec/models/user_organization_spec.rb
@@ -295,12 +295,4 @@ describe UserOrganization do
       Carto::Db::UserSchemaMover.any_instance.stubs(:default_strategy).returns(Carto::Db::UserSchemaMover::STEPS_STRATEGY)
     end
   end
-
-  describe 'move_schema_content_by_renaming' do
-    it_behaves_like 'promoting a user to owner'
-
-    before(:each) do
-      Carto::Db::UserSchemaMover.any_instance.stubs(:default_strategy).returns(Carto::Db::UserSchemaMover::RENAMING_STRATEGY)
-    end
-  end
 end


### PR DESCRIPTION
This was not used and breaks in postgis 2.3+ because the extension is no longer relocatable.
