### PR TITLE
Improve spec runner / bundles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ The development tracker for CartoDB is on GitHub:
 http://github.com/cartodb/cartodb
 
 Bug fixes are best reported as pull requests over there.
-Features are best discussed on the mailing list:
+Features are best discussed on the mailing list:  
 https://groups.google.com/d/forum/cartodb
 
 ---
@@ -123,25 +123,21 @@ If you want to run simultaneously the application and the specs generation follo
 
 The development of Builder specs is separated from regular development. This means that you can develop new specs or modify the existing ones without having the whole application running. This speeds up the development task.
 
-Another feature of Builder specs is that we only generate the affected ones by default. That means that we check the current branch changes against `master` branch and only build those specs that are affected by those changes. This way, we pass only the needed subset of specs.
-
 To start specs development type the next command:
 
 ```bash
-grunt test:browser
+grunt test:browser:builder
 ```
 
-After building the whole suite for the first time, a webpage will show up with a link to the Jasmine page with all the specs. This suite is at `http://localhost:8088/_SpecRunner-affected.html`
-
-Then, the process will watch changes in the codebase and will regenerate the specs as needed. Just refresh the Jasmine page to pass again the tests.
-
-If you prefer to generate all specs anyway, you can pass a flag to the grunt task:
+You can optionally provide an argument to grunt to filter what specs will be generated, like this:
 
 ```bash
-grunt test:browser --specs=all
+grunt test:browser:builder --match=dropdown
 ```
 
-This will generate the whole Builder suite, not only the specs affected by the current branch.
+After building the whole suite for the first time, a web server will be started on port 8088 and the spec runner webpage will show up. If you need to use a different port, change the port & URL values on the [connect task](lib/build/tasks/connect.js)
+
+The process will watch changes in the codebase and will regenerate the specs as needed. Just refresh the Jasmine page to pass again the tests.
 
 **Run specs and regular codebase simultaneously**
 
@@ -149,11 +145,9 @@ If you want to run simultaneously the application and the specs generation follo
 
 1. Open a terminal with Node v6.9.2 (use nvm) and run `grunt dev`. This will build the application assets and will watch for changes.
 
-2. Open a second terminal and run `grunt test:browser`.
+2. Open a second terminal and run `grunt test:browser:builder`.
 
-3. You will see in the first terminal that a lot of changes build the bundle again. That's normal. The first step of the point 3 is to copy all needed files, so the `watch` of `grunt dev` triggers. Don't worry about it.
-
-4. That's it. When you change any Builder Javascript file `grunt dev` will build the application bundle and `grunt test:browser` will build the specs.
+3. That's it. When you change any Builder Javascript file `grunt dev` will build the application bundle and `grunt test:browser` will build the specs.
 
 #### Running a particular spec
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -436,7 +436,7 @@ module.exports = function (grunt) {
   /**
    * `grunt test:browser` compile all Builder specs and launch a webpage in the browser.
    */
-  grunt.registerTask('test:browser', 'Build all Builder specs', [
+  grunt.registerTask('test:browser:builder', 'Build all Builder specs', [
     'generate_builder_specs',
     'bootstrap_webpack_builder_specs',
     'webpack:builder_specs',
@@ -448,7 +448,7 @@ module.exports = function (grunt) {
   /**
    * `grunt dashboard_specs` compile dashboard specs
    */
-  grunt.registerTask('dashboard_specs', 'Build only dashboard specs', [
+  grunt.registerTask('test:browser:dashboard', 'Build only dashboard specs', [
     'generate_dashboard_specs',
     'bootstrap_webpack_dashboard_specs',
     'webpack:dashboard_specs',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -390,7 +390,7 @@ module.exports = function (grunt) {
     'invalidate'
   ]);
 
-  grunt.registerTask('affected', 'Generate only affected specs', function (option) {
+  grunt.registerTask('generate_builder_specs', 'Generate only builder specs', function (option) {
     requireWebpackTask().affected.call(this, option, grunt);
   });
 
@@ -422,14 +422,14 @@ module.exports = function (grunt) {
     'beforeDefault',
     'js_editor',
     'jasmine:cartodbui',
-    'affected',
+    'generate_builder_specs',
     'bootstrap_webpack_builder_specs',
     'webpack:builder_specs',
-    'jasmine:affected',
+    'jasmine:builder',
     'generate_dashboard_specs',
-    'bootstrap_webpack_builder_specs',
-    'webpack:builder_specs',
-    'jasmine:affected',
+    'bootstrap_webpack_dashboard_specs',
+    'webpack:dashboard_specs',
+    'jasmine:dashboard',
     'lint'
   ]);
 
@@ -437,11 +437,11 @@ module.exports = function (grunt) {
    * `grunt test:browser` compile all Builder specs and launch a webpage in the browser.
    */
   grunt.registerTask('test:browser', 'Build all Builder specs', [
-    'affected',
+    'generate_builder_specs',
     'bootstrap_webpack_builder_specs',
     'webpack:builder_specs',
-    'jasmine:affected:build',
-    'connect:specs',
+    'jasmine:builder:build',
+    'connect:specs_builder',
     'watch:js_affected'
   ]);
 
@@ -450,10 +450,10 @@ module.exports = function (grunt) {
    */
   grunt.registerTask('dashboard_specs', 'Build only dashboard specs', [
     'generate_dashboard_specs',
-    'bootstrap_webpack_builder_specs',
-    'webpack:builder_specs',
-    'jasmine:affected:build',
-    'connect:specs',
+    'bootstrap_webpack_dashboard_specs',
+    'webpack:dashboard_specs',
+    'jasmine:dashboard:build',
+    'connect:specs_dashboard',
     'watch:dashboard_specs'
   ]);
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -454,6 +454,7 @@ ion for time-series (#12670)
 * Fix duplicated modules resolution (https://github.com/CartoDB/cartodb/pull/13535)
 
 ### Internals
+* Improve spec bundles / process
 * Replace SCSS-Lint with Stylelint (#13165)
 * Use engine instead of visModel internally (#12992)
 * Remove analysisCollection and refactor analyses-integration (#12947)

--- a/lib/build/tasks/connect.js
+++ b/lib/build/tasks/connect.js
@@ -1,3 +1,15 @@
+const DEFAULT_CONFIG = {
+  livereload: false,
+  hostname: '0.0.0.0', // to be able to access the server not only from localhost
+  base: {
+    path: '.'
+  }
+};
+
+function generateConfig (cfg) {
+  return Object.assign({}, DEFAULT_CONFIG, cfg);
+}
+
 module.exports = {
   task: function () {
     return {
@@ -24,16 +36,18 @@ module.exports = {
         }
       },
       // Watching the specs during development
-      specs: {
-        options: {
+      specs_dashboard: {
+        options: generateConfig({
+          port: 8090,
+          open: 'http://localhost:8090/_SpecRunner_dashboard.html'
+        })
+      },
+
+      specs_builder: {
+        options: generateConfig({
           port: 8088,
-          livereload: false,
-          open: 'http://localhost:8088/builder_specs.html',
-          hostname: '0.0.0.0', // to be able to access the server not only from localhost
-          base: {
-            path: '.'
-          }
-        }
+          open: 'http://localhost:8088/_SpecRunner_builder.html'
+        })
       }
     };
   }

--- a/lib/build/tasks/jasmine.js
+++ b/lib/build/tasks/jasmine.js
@@ -1,5 +1,26 @@
 var js_files = require('../files/js_files');
 
+const DEFAULT_CONFIG = {
+  browser: 'phantomjs',
+  headless: true,
+  timeout: 20000,
+  keepRunner: true,
+  // grunt:test (CI) always generates a server on port 8088
+  host: 'http://localhost:8088',
+  summary: true,
+  display: 'short',
+  helpers: js_files._spec_helpers3,
+  reportSlowerThan: 2000,
+  vendor: [
+    'node_modules/source-map-support/browser-source-map-support.js',
+    'lib/assets/test/spec/deep-insights/install-source-map-support.js',
+    'node_modules/jasmine-ajax/lib/mock-ajax.js',
+    'node_modules/underscore/underscore-min.js'
+  ]
+};
+
+const getJasmineConfig = (config) => (Object.assign({}, DEFAULT_CONFIG, config));
+
 module.exports = {
   cartodbui: {
     src: js_files.all.concat([
@@ -21,26 +42,23 @@ module.exports = {
     }
   },
 
-  affected: {
-    options: {
-      browser: 'phantomjs',
-      headless: true,
-      timeout: 20000,
-      keepRunner: true,
-      outfile: '_SpecRunner-affected.html',
-      host: 'http://localhost:8088',
-      summary: true,
-      display: 'short',
-      helpers: js_files._spec_helpers3,
-      reportSlowerThan: 2000,
+  dashboard: {
+    options: getJasmineConfig({
+      outfile: '_SpecRunner_dashboard.html',
       specs: [
-        '.grunt/vendor.affected-specs.js',
-        '.grunt/main.affected-specs.js'
-      ],
-      vendor: [
-        'node_modules/jasmine-ajax/lib/mock-ajax.js',
-        'node_modules/underscore/underscore-min.js'
+        '.grunt/dashboard_specs/vendor.affected-specs.js',
+        '.grunt/dashboard_specs/main.affected-specs.js'
       ]
-    }
+    })
+  },
+
+  builder: {
+    options: getJasmineConfig({
+      outfile: '_SpecRunner_builder.html',
+      specs: [
+        '.grunt/builder_specs/vendor.affected-specs.js',
+        '.grunt/builder_specs/main.affected-specs.js'
+      ]
+    })
   }
 };

--- a/lib/build/tasks/webpack/webpack.config.js
+++ b/lib/build/tasks/webpack/webpack.config.js
@@ -1,18 +1,20 @@
 var path = require('path');
 var webpack = require('webpack');
 
+/*
+  This function will be called with the config name (dashboard_specs, builder_spec) so
+  you have a change to customize webpack for each bundle.
+*/
 module.exports = {
-  task: function () {
-    var cfg = {};
-
-    cfg.builder_specs = {
+  task: function (config) {
+    return {
       entry: {
         main: [
           // To be filled by grunt
         ]
       },
       output: {
-        path: path.resolve(path.resolve('.'), '.grunt'),
+        path: path.resolve(path.resolve('.'), '.grunt', config),
         filename: '[name].affected-specs.js'
       },
       resolve: {
@@ -38,7 +40,9 @@ module.exports = {
             loader: 'babel-loader',
             include: [
               path.resolve(path.resolve('.'), 'lib/assets/javascripts/carto-node'),
-              path.resolve(path.resolve('.'), 'lib/assets/test/spec/carto-node')
+              path.resolve(path.resolve('.'), 'lib/assets/test/spec/carto-node'),
+              path.resolve(path.resolve('.'), 'lib/assets/test/spec/dashboard'),
+              path.resolve(path.resolve('.'), 'lib/assets/javascripts/dashboard')
             ],
             options: {
               presets: [
@@ -84,7 +88,5 @@ module.exports = {
         fs: 'empty'
       }
     };
-
-    return cfg;
   }
 };

--- a/lib/build/tasks/webpack/webpack.js
+++ b/lib/build/tasks/webpack/webpack.js
@@ -15,6 +15,16 @@ var paths = {
   deep_insights_specs: './lib/assets/test/spec/deep-insights/**/*.spec.js'
 };
 
+// Filter a list of files with a string
+// the string will be converted to a RegExp
+function filterSpecs (affectedSpecs, match) {
+  const re = new RegExp(match);
+  return affectedSpecs.filter(specFile => {
+    const fileName = specFile.split(/spec\//)[1];
+    return re.test(fileName);
+  });
+}
+
 /**
  * affected - To be used as part of a 'registerTask' Grunt definition
  */
@@ -28,7 +38,13 @@ var affected = function (option, grunt) {
     './lib/assets/test/spec/cartodb3/routes/router.spec.js'
   ];
 
-  var allSpecs = glob.sync(paths.builder_specs).concat(glob.sync(paths.deep_insights_specs));
+  let allSpecs = glob.sync(paths.builder_specs).concat(glob.sync(paths.deep_insights_specs));
+  const match = grunt.option('match');
+
+  if (match) {
+    allSpecs = filterSpecs(allSpecs, match);
+  }
+
   console.log(colors.yellow('All specs. ' + allSpecs.length + ' specs found.'));
 
   affectedSpecs = affectedSpecs.concat(allSpecs);
@@ -41,6 +57,12 @@ var affected = function (option, grunt) {
  */
 var dashboard = function (option, grunt) {
   affectedSpecs = glob.sync(paths.dashboard_specs);
+  const match = grunt.option('match');
+
+  if (match) {
+    affectedSpecs = filterSpecs(affectedSpecs, match);
+  }
+
   console.log(colors.yellow('All specs. ' + affectedSpecs.length + ' specs found.'));
 };
 

--- a/lib/build/tasks/webpack/webpack.js
+++ b/lib/build/tasks/webpack/webpack.js
@@ -4,7 +4,7 @@ var colors = require('colors');
 var pretty = require('prettysize');
 var glob = require('glob');
 var StatsWriterPlugin = require('webpack-stats-plugin').StatsWriterPlugin;
-var cfg = require('./webpack.config.js').task();
+var configGenerator = require('./webpack.config.js').task;
 
 var compiler = {};
 var affectedSpecs = [];
@@ -40,11 +40,8 @@ var affected = function (option, grunt) {
  * dashboard - To be used as part of a 'registerTask' Grunt definition
  */
 var dashboard = function (option, grunt) {
-  var done = this.async();
-  var allSpecs = glob.sync(paths.dashboard_specs);
-  console.log(colors.yellow('All specs. ' + allSpecs.length + ' specs found.'));
-  affectedSpecs = [].concat(allSpecs);
-  done();
+  affectedSpecs = glob.sync(paths.dashboard_specs);
+  console.log(colors.yellow('All specs. ' + affectedSpecs.length + ' specs found.'));
 };
 
 var bootstrap = function (config, grunt) {
@@ -52,15 +49,13 @@ var bootstrap = function (config, grunt) {
     throw new Error('Please provide subconfiguration key for webpack.');
   }
 
-  if (!cfg[config]) {
-    throw new Error(config + ' section needed in webpack.config.js');
-  }
+  const cfg = configGenerator(config);
 
-  cfg[config].entry = function () {
+  cfg.entry = function () {
     return affectedSpecs;
   };
 
-  compiler[config] = webpack(cfg[config]);
+  compiler[config] = webpack(cfg);
   cache[config] = {};
   compiler[config].apply(new webpack.CachePlugin(cache[config]));
 


### PR DESCRIPTION
:dancing_men: with @rubenmoya 

Because of the dashboard migration, we have a new task to run dashboard specs. However, said task produces the same files on the same location as the builder specs, so it was impossible to run both at the same time.

This PR solves this by allowing customization of the tests' webpack config based on the config name (builder_specs / dashboard_specs).

Main practical differences:

- You can now run grunt test:browser & grunt dashboard_specs at the same time.
- You can pass --match=<regexp as a string> to filter specs generation

Technical differences:

- (main | vendor)affected-specs.js are now on .grunt/<config_name>
- We're generating separate Specrunner_files, one for each <config_name>
- We're starting a web server for each one of those. This is annoying, but grunt-contrib-connect fails fatally if the port is in use, so 🤷‍♂️ 
- We've enabled babel for the dashboard specs, but not for builder
- affected => generate_builder_specs, there's no affected anymore