### PR TITLE
add marker size to layer cartocss props to reinstantiate torque map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -139,6 +139,7 @@ ion for time-series (#12670)
 * Use carto.js v4.0.0-beta.13
 
 ### Bug fixes / enhancements
+* Add marker size to layer cartocss props to reinstantiate torque map (#13590)
 * Fix select geometries dropdown in JOIN analysis ([Support#1281](https://github.com/CartoDB/support/issues/1281))
 * Fix IE11 Drag&Drop ([Support#876](https://github.com/CartoDB/support/issues/876))
 * Removed references to analytics JS files in static pages (#13543)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -333,9 +333,9 @@
       "resolved": "https://registry.npmjs.org/cartodb-pecan/-/cartodb-pecan-0.2.0.tgz"
     },
     "cartodb.js": {
-      "version": "4.0.0-beta.25",
-      "from": "cartodb/cartodb.js#1294-bcg-export",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#55bf49f46fda015ab20b44dcbd7d08248cb6a17d"
+      "version": "4.0.0-beta.26",
+      "from": "cartodb/cartodb.js#v4.0.0-beta.26",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#32fed4a81e0bfaefa3a3a1e848b3814086a96fbf"
     },
     "center-align": {
       "version": "0.1.3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.45",
+  "version": "4.11.4-5.1294.1",
   "dependencies": {
     "accessory": {
       "version": "1.0.1",
@@ -97,9 +97,9 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "asn1.js": {
-      "version": "4.9.2",
+      "version": "4.10.1",
       "from": "asn1.js@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz"
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz"
     },
     "assert": {
       "version": "1.3.0",
@@ -152,9 +152,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
     },
     "base64-js": {
-      "version": "1.2.1",
+      "version": "1.2.3",
       "from": "base64-js@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz"
     },
     "big.js": {
       "version": "3.2.0",
@@ -333,9 +333,9 @@
       "resolved": "https://registry.npmjs.org/cartodb-pecan/-/cartodb-pecan-0.2.0.tgz"
     },
     "cartodb.js": {
-      "version": "4.0.0-beta.23",
-      "from": "cartodb/cartodb.js#v4.0.0-beta.23",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#ef130ad6e04154ddb38a4aac21d04740b85da06c"
+      "version": "4.0.0-beta.25",
+      "from": "cartodb/cartodb.js#1294-bcg-export",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#55bf49f46fda015ab20b44dcbd7d08248cb6a17d"
     },
     "center-align": {
       "version": "0.1.3",
@@ -660,9 +660,9 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "errno": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "from": "errno@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz"
     },
     "error-ex": {
       "version": "1.3.1",
@@ -1574,9 +1574,9 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz"
     },
     "randomfill": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "from": "randomfill@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz"
     },
     "rangeslider.js": {
       "version": "2.3.0",
@@ -1919,9 +1919,9 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uglify-js": {
-      "version": "3.3.10",
+      "version": "3.3.11",
       "from": "uglify-js@>=3.3.0 <3.4.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.10.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.11.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "carto-zera": "1.0.2",
     "cartocolor": "4.0.0",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "CartoDB/cartodb.js#1294-bcg-export",
+    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.26",
     "clipboard": "1.6.1",
     "codemirror": "5.14.2",
     "d3-interpolate": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.45",
+  "version": "4.11.45.1294.01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "carto-zera": "1.0.2",
     "cartocolor": "4.0.0",
     "cartodb-pecan": "0.2.x",
-    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.23",
+    "cartodb.js": "CartoDB/cartodb.js#1294-bcg-export",
     "clipboard": "1.6.1",
     "codemirror": "5.14.2",
     "d3-interpolate": "^1.1.6",


### PR DESCRIPTION
re: https://github.com/CartoDB/support/issues/1294

- cartodb.js: https://github.com/CartoDB/cartodb.js/pull/2057
- cartodb: https://github.com/CartoDB/cartodb/pull/13590

update cartodb.js dependencies, to add `marker-size` to layer cartocss props to reinstantiate torque map
