### PR TITLE
React views proof of concept

### DIFF
--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -30,6 +30,7 @@
     <div class="FavMap is-pre-loading" id="<%= fav_map_target_id = 'fav-map-container' %>">
       <div class="Spinner FavMap-spinner js-spinner"></div>
     </div>
+    <div class="react-goes-here"></div>
 
     <% if @is_org %>
       <%= render "shared/public_dashboard_org_header" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,7 @@ require 'carto/configuration'
 CartoDB::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
-  ActiveSupport::Dependencies.autoload_paths << File::join(Rails.root, 'lib')
+  # ActiveSupport::Dependencies.autoload_paths << File::join(Rails.root, 'lib')
   # ActiveSupport::Dependencies.autoload_paths << File::join( Rails.root, 'lib/central')
 
   # The production environment is meant for finished, "live" apps.
@@ -53,7 +53,7 @@ CartoDB::Application.configure do
   # `bundle exec thin start --threaded -p 3000 --threadpool-size 5`.
   # Check your `config/database.yml` has `pool: 50` or higher for `development`.
   # The condition excludes this from resque, since it won't work with it and it doesn't need it.
-  config.threadsafe! unless $rails_rake_task
+  # config.threadsafe! unless $rails_rake_task
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,7 @@ require 'carto/configuration'
 CartoDB::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
-  # ActiveSupport::Dependencies.autoload_paths << File::join(Rails.root, 'lib')
+  ActiveSupport::Dependencies.autoload_paths << File::join(Rails.root, 'lib')
   # ActiveSupport::Dependencies.autoload_paths << File::join( Rails.root, 'lib/central')
 
   # The production environment is meant for finished, "live" apps.
@@ -53,7 +53,7 @@ CartoDB::Application.configure do
   # `bundle exec thin start --threaded -p 3000 --threadpool-size 5`.
   # Check your `config/database.yml` has `pool: 50` or higher for `development`.
   # The condition excludes this from resque, since it won't work with it and it doesn't need it.
-  # config.threadsafe! unless $rails_rake_task
+  config.threadsafe! unless $rails_rake_task
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)

--- a/lib/assets/javascripts/dashboard/components/likes/like.jsx
+++ b/lib/assets/javascripts/dashboard/components/likes/like.jsx
@@ -1,0 +1,28 @@
+import React from 'react'; // eslint-disable-line
+const ReactView = require('dashboard/helpers/react-view');
+
+const Like = (props) => {
+  const {
+    size,
+    likes,
+    show_label,
+    show_count,
+    onClick
+  } = props;
+
+  const extraClass = size === 'big' ? 'LikesIndicator-icon--big Navmenu-icon' : null;
+
+  return (
+    <div onClick={onClick}>
+      <div>
+        <i className={`CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon ${extraClass}`} />
+      </div>
+      { likes > 2 || show_count ? <span className="CDB-Text CDB-Size-medium LikesIndicator-count">{likes}</span> : null }
+      { show_label && likes > 1 ? <span className="CDB-Text CDB-Size-medium LikesIndicator-label">likes</span> : null }
+    </div>
+  );
+};
+
+module.exports = ReactView.extend({
+  component: Like
+});

--- a/lib/assets/javascripts/dashboard/helpers/react-view.js
+++ b/lib/assets/javascripts/dashboard/helpers/react-view.js
@@ -1,0 +1,28 @@
+const ReactDOM = require('react-dom');
+const CoreView = require('backbone/core-view');
+
+module.exports = CoreView.extend({
+
+  template: '<div class="react-view"></div>',
+  component: null,
+
+  initialize: function (opts) {
+    if (opts.model) {
+      this.listenTo(opts.model, 'change', this.reactRender);
+    }
+  },
+
+  render: function () {
+    this.$el.html(
+      this.template
+    );
+    this.reactRender();
+  },
+
+  reactRender: function () {
+    ReactDOM.render(
+      this.component(this.model.attributes),
+      this.$('.react-view').get(0)
+    );
+  }
+});

--- a/lib/assets/javascripts/dashboard/public-dashboard.js
+++ b/lib/assets/javascripts/dashboard/public-dashboard.js
@@ -1,3 +1,4 @@
+const Backbone = require('backbone');
 const $ = require('jquery');
 const _ = require('underscore');
 const ConfigModel = require('dashboard/data/config-model');
@@ -13,6 +14,7 @@ const MapCardPreview = require('dashboard/components/mapcard-preview-view');
 const LikeView = require('dashboard/components/likes/like-view');
 const LikeModel = require('dashboard/data/like-model');
 const ScrollableHeader = require('dashboard/helpers/scroll-tofixed-view');
+const Like = require('dashboard/components/likes/like.jsx');
 
 const configModel = new ConfigModel(
   _.defaults(
@@ -70,6 +72,21 @@ $(function () {
     model: new PaginationModel(window.paginationModelAttrs)
   });
   paginationView.render();
+
+  const RModel = new Backbone.Model({
+    size: 8,
+    likes: 8,
+    show_label: false,
+    show_count: true,
+    onClick: function () { RModel.set('likes', RModel.get('likes') + 1); }
+  });
+
+  const RLike = new Like({
+    model: RModel,
+    el: $('.react-goes-here')
+  });
+
+  RLike.render();
 
   $('.MapCard').each(function () {
     const visId = $(this).data('visId');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "contributors": [],
   "license": "BSD-3-Clause",
   "dependencies": {
+    "babel-preset-react": "^6.24.1",
     "backbone": "1.2.3",
     "backbone-forms": "0.14.0",
     "backbone-model-file-upload": "CartoDB/backbone-model-file-upload#1.0.2",
@@ -43,6 +44,8 @@
     "postcss-strip-inline-comments": "0.1.5",
     "queue-async": "1.2.1",
     "rangeslider.js": "2.3.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "tinycolor2": "^1.4.1",
     "torque.js": "CartoDB/torque#master",
     "underscore": "1.8.3",

--- a/webpack/dashboard/webpack.dev.config.js
+++ b/webpack/dashboard/webpack.dev.config.js
@@ -116,6 +116,16 @@ module.exports = env => {
             presets: ['env'],
             plugins: ['transform-object-rest-spread']
           }
+        },
+        {
+          test: /\.jsx$/,
+          loader: 'babel-loader',
+          include: [
+            resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard')
+          ],
+          options: {
+            presets: ['env', 'react']
+          }
         }
       ]
     },


### PR DESCRIPTION
Something something...leave the past behind :thinking: 

This is a very simplistic proof of concept to have views that work using React under the hood. 

I would love to do the same thing for other interesting view libraries, like Vue. I started with react because I have experience with it.

The idea is to have an adapter backbone view that under the hood calls ReactDOM.render with a custom component on a known node (created with the template). The components props are a Backbone Model attributes, on every change of said backbone model, a render will happen. Because reacts' whole deal is that only the affected nodes are updated, this is fine.

Nice things:
- I found adding this to the build pipeline extremely easy. I didn't do the production build though. This is particularly important in react, which is quite slow on dev.
- Only 3 deps (react, react-dom, babel-preset-react)

Things to look out for /  benchmark:
- Try a more complex example, this doesn't even scratch the surface of what a view might do.
- How does this work if we have several react-views? Will the performance drop?
- Can we have React views in the middle of a hierarchy? Backbone View -> React-view -> Other Backbone Views
- Providing several models to a react view would be interesting, we would only have to provide an array, listen to each, and then provide the props as an object that contains all models props.
- Similarly, can we provide custom event handlers? Maybe not through the model?

