### PR TITLE
Public dashboard migration

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -261,11 +261,7 @@ class Admin::PagesController < Admin::AdminController
 
     @page_description = description
 
-    if @viewed_user.nil?
-      @has_new_dashboard = @org.builder_enabled && @org.owner.has_feature_flag?('dashboard_migration')
-    else
-      @has_new_dashboard = @viewed_user.builder_enabled? && @viewed_user.has_feature_flag?('dashboard_migration')
-    end
+    set_vars_for_public_dashboard
 
     respond_to do |format|
       format.html { render 'public_datasets', layout: 'public_dashboard' }
@@ -316,15 +312,22 @@ class Admin::PagesController < Admin::AdminController
 
     @page_description = description
 
+    set_vars_for_public_dashboard
+
+    respond_to do |format|
+      format.html { render 'public_maps', layout: 'public_dashboard' }
+    end
+  end
+
+  def set_vars_for_public_dashboard
     if @viewed_user.nil?
       @has_new_dashboard = @org.builder_enabled && @org.owner.has_feature_flag?('dashboard_migration')
     else
       @has_new_dashboard = @viewed_user.builder_enabled && @viewed_user.has_feature_flag?('dashboard_migration')
     end
 
-    respond_to do |format|
-      format.html { render 'public_maps', layout: 'public_dashboard' }
-    end
+    @needs_gmaps_lib = @most_viewed_vis_map && @most_viewed_vis_map.map.provider == 'googlemaps'
+    @needs_gmaps_lib ||= @default_fallback_basemap['className'] == 'googlemaps'
   end
 
   def set_layout_vars_for_user(user, content_type)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -317,7 +317,7 @@ class Admin::PagesController < Admin::AdminController
     @page_description = description
 
     if @viewed_user.nil?
-      @has_new_dashboard = @org.builder_enabled&& @org.owner.has_feature_flag?('dashboard_migration')
+      @has_new_dashboard = @org.builder_enabled && @org.owner.has_feature_flag?('dashboard_migration')
     else
       @has_new_dashboard = @viewed_user.builder_enabled && @viewed_user.has_feature_flag?('dashboard_migration')
     end

--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -23,7 +23,7 @@
     <meta name="twitter:image" content="<%= @avatar_url %>">
     <meta name="twitter:url" content="<%= request.original_url %>" />
 
-    <%= stylesheet_link_tag 'cartodb', 'common', 'public_dashboard' %>
+    <%= stylesheet_link_tag 'cartodb', 'deep_insights', 'common', 'public_dashboard' %>
   </head>
   <body class="PublicBody PublicBody--grey">
     <%= render 'admin/shared/public_header' %>
@@ -48,21 +48,26 @@
       var login_url = "<%= CartoDB.url(self, 'login') %>";
 
       var favMapViewAttrs = {
+        fallbackBaselayer: <%= raw @default_fallback_basemap.to_json %>,
         el: '#<%= fav_map_target_id %>',
         <% if @most_viewed_vis_map %>
           createVis: {
-            url: '<%= vis_json_url(@most_viewed_vis_map.id, self, (@most_viewed_vis_map.user)) %>',
+            <% if @has_new_dashboard %>
+              url: '<%= vis_json_v3_url(@most_viewed_vis_map.id, self, (@most_viewed_vis_map.user)) %>',
+            <% else %>
+              url: '<%= vis_json_url(@most_viewed_vis_map.id, self, (@most_viewed_vis_map.user)) %>',
+            <% end %>
             opts: {
               no_cdn: <%= Rails.env.production? ? 'false' : 'true' %>
             }
           }
-        <% else %>
-          fallbackBaselayer: <%= raw @default_fallback_basemap.to_json %>
         <% end %>
       };
     </script>
-    <% if @most_viewed_vis_map && @most_viewed_vis_map.map.provider == 'googlemaps' %>
-      <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?sensor=false&v=3.12&<%= @most_viewed_vis_map.user.google_maps_query_string %>"></script>
+    <% if @needs_gmaps_lib %>
+      <script type="text/javascript"
+          src="//maps.googleapis.com/maps/api/js?v=3.12<%= @gmaps_query_string %>">
+      </script>
     <% end %>
     <% if @has_new_dashboard %>
       <%= javascript_include_tag 'common_dashboard.js', 'public_dashboard_new_vendor', 'public_dashboard_new' %>

--- a/app/views/layouts/public_dashboard.html.erb
+++ b/app/views/layouts/public_dashboard.html.erb
@@ -64,7 +64,11 @@
     <% if @most_viewed_vis_map && @most_viewed_vis_map.map.provider == 'googlemaps' %>
       <script type="text/javascript" src="//maps.googleapis.com/maps/api/js?sensor=false&v=3.12&<%= @most_viewed_vis_map.user.google_maps_query_string %>"></script>
     <% end %>
-    <%= javascript_include_tag 'cdb.js', 'templates', 'public_dashboard_deps', 'public_dashboard' %>
+    <% if @has_new_dashboard %>
+      <%= javascript_include_tag 'common_dashboard.js', 'public_dashboard_new_vendor', 'public_dashboard_new' %>
+    <% else %>
+      <%= javascript_include_tag 'cdb.js', 'templates', 'public_dashboard_deps', 'public_dashboard' %>
+    <% end %>
     <%= yield :js %>
     <%= insert_google_analytics('embeds', true) %>
     <%= insert_hubspot() %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -130,6 +130,8 @@ module CartoDB
       user_feed_new_vendor.js
       api_keys_new.js
       api_keys_new_vendor.js
+      public_dashboard_new.js
+      public_dashboard_new_vendor.js
       common_dashboard.js
 
       tipsy.js

--- a/lib/assets/javascripts/dashboard/components/dropdown/dropdown-base-view.js
+++ b/lib/assets/javascripts/dashboard/components/dropdown/dropdown-base-view.js
@@ -127,9 +127,9 @@ module.exports = CoreView.extend({
   },
 
   clean: function () {
-    $(this.options.target).off('click', this._handleClick);
+    this.options.target.off('click', this._handleClick);
     $(document).off('keydown', this._keydown);
-    $(document).off('click', this._keydown);
+    $(document).off('click', this._onDocumentClick);
     CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/dashboard/components/dropdown/dropdown-base-view.js
+++ b/lib/assets/javascripts/dashboard/components/dropdown/dropdown-base-view.js
@@ -127,7 +127,7 @@ module.exports = CoreView.extend({
   },
 
   clean: function () {
-    this.options.target.off('click', this._handleClick);
+    this.options.target && this.options.target.off('click', this._handleClick);
     $(document).off('keydown', this._keydown);
     $(document).off('click', this._onDocumentClick);
     CoreView.prototype.clean.apply(this);

--- a/lib/assets/javascripts/dashboard/components/user-info/dropdown-view.js
+++ b/lib/assets/javascripts/dashboard/components/user-info/dropdown-view.js
@@ -1,0 +1,23 @@
+var DropdownAdminView = require('dashboard/components/dropdown/dropdown-admin-view');
+
+/**
+ * The content of the dropdown menu opened by the link at the end of the breadcrumbs menu, e.g.
+ *   username / Maps v
+ *            ______/\____
+ *           |            |
+ *           |    this    |
+ *           |____________|
+ */
+module.exports = DropdownAdminView.extend({
+  className: 'Dropdown',
+
+  render: function () {
+    return this;
+  },
+
+  hide: function () {
+    this.$el.css({
+      opacity: 0
+    });
+  }
+});

--- a/lib/assets/javascripts/dashboard/components/user-info/user-info-view.js
+++ b/lib/assets/javascripts/dashboard/components/user-info/user-info-view.js
@@ -1,0 +1,48 @@
+const $ = require('jquery');
+const CoreView = require('backbone/core-view');
+const BreadcrumbDropdown = require('./dropdown-view.js');
+
+/**
+ * View to render the user info section.
+ * Expected to be created from existing DOM element.
+ */
+module.exports = CoreView.extend({
+
+  events: {
+    'click .js-breadcrumb-dropdown-target': '_createBreadcrumbDropdown'
+  },
+
+  render: function () {
+    return this;
+  },
+
+  _previousDropDown: null,
+
+  _createBreadcrumbDropdown: function (ev) {
+    this.killEvent(ev);
+    var dropdown = new BreadcrumbDropdown({
+      target: $(ev.target),
+      el: $('.js-breadcrumb-dropdown-content'),
+      horizontal_offset: 3, // to match the dropdown indicator/arrow
+      horizontal_position: 'right',
+      tick: 'right'
+    });
+
+    this._closeAnyOtherOpenDialogs();
+    this._previousDropDown = dropdown;
+    this.addView(dropdown);
+    dropdown.on('onDropdownHidden', function () {
+      console.log('onDropdownHidden');
+      dropdown.clean();
+    }, this);
+
+    dropdown.render();
+    dropdown.open();
+  },
+
+  _closeAnyOtherOpenDialogs: function () {
+    if (this._previousDropDown) {
+      this._previousDropDown.hide();
+    }
+  }
+});

--- a/lib/assets/javascripts/dashboard/data/like-model.js
+++ b/lib/assets/javascripts/dashboard/data/like-model.js
@@ -1,5 +1,10 @@
 var Backbone = require('backbone');
 var _ = require('underscore');
+const checkAndBuildOpts = require('builder/helpers/required-opts');
+
+const REQUIRED_OPTS = [
+  'config'
+];
 
 var LikeModel = Backbone.Model.extend({
 
@@ -13,11 +18,7 @@ var LikeModel = Backbone.Model.extend({
   },
 
   initialize: function (attrs, options) {
-    if (!options.config) {
-      throw new Error('config model is required');
-    }
-
-    this._config = options.config;
+    checkAndBuildOpts(options, REQUIRED_OPTS, this);
 
     _.bindAll(this, '_onSaveError');
 

--- a/lib/assets/javascripts/dashboard/public-dashboard.js
+++ b/lib/assets/javascripts/dashboard/public-dashboard.js
@@ -97,9 +97,9 @@ $(function () {
       vis_id: $(this).data('vis-id'),
       likes: $(this).data('likes-count')
     });
-    authenticatedUser.bind('change', function () {
-      if (authenticatedUser.get('username')) {
-        likeModel.bind('loadModelCompleted', function () {
+    authenticatedUser.bind('change', function (model) {
+      if (model.get('user_data')) {
+        likeModel.once('change', function () {
           likeModel.set('likeable', true);
         });
         likeModel.fetch();

--- a/lib/assets/javascripts/dashboard/public-dashboard.js
+++ b/lib/assets/javascripts/dashboard/public-dashboard.js
@@ -4,7 +4,7 @@ const ConfigModel = require('dashboard/data/config-model');
 const AuthenticatedUser = require('dashboard/data/authenticated-user-model');
 const UserModel = require('dashboard/data/user-model');
 const FavMapView = require('dashboard/views/public-profile/fav-map-view');
-// const UserInfoView = require('./user_info_view');
+const UserInfoView = require('dashboard/components/user-info/user-info-view');
 const PaginationModel = require('builder/components/pagination/pagination-model');
 const PaginationView = require('builder/components/pagination/pagination-view');
 const UserSettingsView = require('dashboard/components/navbar/user-settings-view');
@@ -26,14 +26,13 @@ const configModel = new ConfigModel(
 window.configModel = configModel;
 
 $(function () {
-  // cdb.templates.namespace = 'cartodb/';
-  // cdb.config.set(window.config);
-  // cdb.config.set('url_prefix', window.base_url);
-
-  const scrollableHeader = new ScrollableHeader({ // eslint-disable-line no-unused-vars
-    el: $('.js-Navmenu'),
-    anchorPoint: 350
-  });
+  const headerEl = $('.js-Navmenu');
+  if (headerEl.length > 0) {
+    const scrollableHeader = new ScrollableHeader({ // eslint-disable-line no-unused-vars
+      el: headerEl,
+      anchorPoint: 350
+    });
+  }
 
   const userIndustriesView = new UserIndustriesView({ // eslint-disable-line no-unused-vars
     el: $('.js-user-industries')
@@ -61,10 +60,10 @@ $(function () {
   const favMapView = new FavMapView(window.favMapViewAttrs);
   favMapView.render();
 
-  // const userInfoView = new UserInfoView({
-  //   el: $('.js-user-info')
-  // });
-  // userInfoView.render();
+  const userInfoView = new UserInfoView({
+    el: $('.js-user-info')
+  });
+  userInfoView.render();
 
   const paginationView = new PaginationView({
     el: '.js-content-footer',

--- a/lib/assets/javascripts/dashboard/public-dashboard.js
+++ b/lib/assets/javascripts/dashboard/public-dashboard.js
@@ -1,0 +1,117 @@
+const $ = require('jquery');
+const _ = require('underscore');
+const ConfigModel = require('dashboard/data/config-model');
+const AuthenticatedUser = require('dashboard/data/authenticated-user-model');
+const UserModel = require('dashboard/data/user-model');
+const FavMapView = require('dashboard/views/public-profile/fav-map-view');
+// const UserInfoView = require('./user_info_view');
+const PaginationModel = require('builder/components/pagination/pagination-model');
+const PaginationView = require('builder/components/pagination/pagination-view');
+const UserSettingsView = require('dashboard/components/navbar/user-settings-view');
+const UserIndustriesView = require('dashboard/components/navbar/user-industries-view');
+const MapCardPreview = require('dashboard/components/mapcard-preview-view');
+const LikeView = require('dashboard/components/likes/like-view');
+const LikeModel = require('dashboard/data/like-model');
+const ScrollableHeader = require('dashboard/helpers/scroll-tofixed-view');
+
+const configModel = new ConfigModel(
+  _.defaults(
+    {
+      base_url: window.base_url
+    },
+    window.config
+  )
+);
+
+window.configModel = configModel;
+
+$(function () {
+  // cdb.templates.namespace = 'cartodb/';
+  // cdb.config.set(window.config);
+  // cdb.config.set('url_prefix', window.base_url);
+
+  const scrollableHeader = new ScrollableHeader({ // eslint-disable-line no-unused-vars
+    el: $('.js-Navmenu'),
+    anchorPoint: 350
+  });
+
+  const userIndustriesView = new UserIndustriesView({ // eslint-disable-line no-unused-vars
+    el: $('.js-user-industries')
+  });
+
+  const authenticatedUser = new AuthenticatedUser();
+
+  authenticatedUser.on('change', function (model) {
+    if (model.get('user_data')) {
+      var user = new UserModel(authenticatedUser.attributes.user_data, {
+        configModel: configModel
+      });
+
+      const userSettingsView = new UserSettingsView({
+        el: $('.js-user-settings'),
+        model: user
+      });
+      userSettingsView.render();
+
+      $('.js-login').hide();
+      $('.js-learn').show();
+    }
+  });
+
+  const favMapView = new FavMapView(window.favMapViewAttrs);
+  favMapView.render();
+
+  // const userInfoView = new UserInfoView({
+  //   el: $('.js-user-info')
+  // });
+  // userInfoView.render();
+
+  const paginationView = new PaginationView({
+    el: '.js-content-footer',
+    model: new PaginationModel(window.paginationModelAttrs)
+  });
+  paginationView.render();
+
+  $('.MapCard').each(function () {
+    const visId = $(this).data('visId');
+    if (visId) {
+      const username = $(this).data('visOwnerName');
+      const mapCardPreview = new MapCardPreview({
+        el: $(this).find('.js-header'),
+        height: 220,
+        visId: $(this).data('visId'),
+        username: username,
+        mapsApiResource: configModel.getMapsResourceName(username),
+        config: configModel
+      });
+      mapCardPreview.load();
+    }
+  });
+
+  $('.js-likes').each(function () {
+    const likeModel = LikeModel.newByVisData({
+      config: configModel,
+      url: !configModel.get('url_prefix') ? $(this).attr('href') : '',
+      likeable: false,
+      show_count: $(this).data('show-count') || false,
+      show_label: $(this).data('show-label') || false,
+      vis_id: $(this).data('vis-id'),
+      likes: $(this).data('likes-count')
+    });
+    authenticatedUser.bind('change', function () {
+      if (authenticatedUser.get('username')) {
+        likeModel.bind('loadModelCompleted', function () {
+          likeModel.set('likeable', true);
+        });
+        likeModel.fetch();
+      }
+    });
+    const likeView = new LikeView({
+      el: this,
+      model: likeModel
+    });
+    likeView.render();
+  });
+
+  authenticatedUser.fetch();
+});

--- a/lib/assets/javascripts/dashboard/views/public-profile/feed-view.js
+++ b/lib/assets/javascripts/dashboard/views/public-profile/feed-view.js
@@ -262,7 +262,7 @@ module.exports = CoreView.extend({
   },
 
   _initLike: function (vis, $el) {
-    var likeable = this._authenticatedUser && this._authenticatedUser.get('username');
+    var likeable = this._authenticatedUser && this._authenticatedUser.get('user_data');
 
     var likeModel = LikeModel.newByVisData({
       likeable: false,
@@ -291,7 +291,7 @@ module.exports = CoreView.extend({
   },
 
   _fetchLike: function (model, url) {
-    if (this._authenticatedUser.get('username')) {
+    if (this._authenticatedUser.get('user_data')) {
       // no more loadModelCompleted event
       model.once('change', function () {
         model.set('likeable', true);

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "build:stats": "webpack --env.stats --progress --config webpack.dev.config.js",
     "start": "grunt watch:css & webpack --progress --watch --config webpack/builder/webpack.dev.config.js",
     "dashboard": "grunt watch:css & webpack --progress --watch --config webpack/dashboard/webpack.dev.config.js",
+    "webpack:dashboard": "webpack --progress --watch --config webpack/dashboard/webpack.dev.config.js",
     "start:static": "webpack --progress --watch --config webpack/webpack.dev.config.js",
     "dev": "webpack --progress --config webpack/builder/webpack.dev.config.js",
     "fix-shrinkwrap-protocol": "node ./lib/build/fix-shrinkwrap.js"

--- a/webpack/dashboard/webpack.dev.config.js
+++ b/webpack/dashboard/webpack.dev.config.js
@@ -14,6 +14,7 @@ const isVendor = (module, count) => {
 };
 
 const entryPoints = {
+  public_dashboard_new: resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard/public-dashboard.js'),
   user_feed_new: resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard/user-feed.js'),
   api_keys_new: resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard/api-keys.js')
 };


### PR DESCRIPTION
This PR migrates the whole public dashboard part to carto.js 4, backbone 1.2 & so on.

It affects views that change for organizations, so in order to decide whether to show the new dashboard, the organization has to have builder_enabled & the organization owner needs to have the appropriate feature flag.

I've also fixed the like button, which had some issues because of a previous refactor, and the old backbone.core-model 

This will have the same issues as the user-feed, as mentioned on https://github.com/CartoDB/cartodb/issues/13534