### PR TITLE
Fix table head style for IE11

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -145,6 +145,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix table head style in IE11 (https://github.com/CartoDB/cartodb/issues/13606)
 * Freeze required Google Maps script to v3.30 (https://github.com/CartoDB/cartodb/pull/13562)
 * Add `shield-placement-keyword` CartoCSS property (#13612)
 * Fix icons in custom html legends (#13600)

--- a/app/assets/stylesheets/editor-3/_table.scss
+++ b/app/assets/stylesheets/editor-3/_table.scss
@@ -84,6 +84,7 @@ $tableBorderColor: $cSecondaryLine;
 
 .Table-headItemName {
   box-sizing: border-box;
+  width: 180px; // ie11
   height: auto;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13606

IE11 requires the `width` to be defined for the Table-headItemName element.

**Acceptance**

Enter a table, check the `order` and `dots` icons.

![ie11-table-name](https://user-images.githubusercontent.com/2227572/36830673-eb218240-1d24-11e8-80d4-dc48c3f7b9f6.png)
