### PR TITLE
Fix Category Widget search on android

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -150,6 +150,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix category widget search on Android (https://github.com/CartoDB/support/issues/1074)
 * Don't fetch rows when fetching columns for analyses (#13654)
 * Fix pagination style for category widgets (https://github.com/CartoDB/support/issues/1161)
 * Add isSourceType false by default to select-view (#13655)

--- a/lib/assets/javascripts/deep-insights/widgets/category/title/search-title-view.js
+++ b/lib/assets/javascripts/deep-insights/widgets/category/title/search-title-view.js
@@ -72,20 +72,12 @@ module.exports = CoreView.extend({
   },
 
   _initBinds: function () {
-    this.model.bind('change:search', this._onSearchToggled, this);
-    this.model.bind('change:title change:collapsed change:autoStyle change:style', this.render, this);
-    this.model.lockedCategories.bind('change add remove', this.render, this);
-    this.add_related_model(this.model.lockedCategories);
-
-    this.dataviewModel.bind('change:column', this.render, this);
-    this.add_related_model(this.dataviewModel);
-
-    this.dataviewModel.filter.bind('change', this.render, this);
-    this.add_related_model(this.dataviewModel.filter);
-
-    this.layerModel.bind('change:visible change:cartocss', this.render, this);
-    this.layerModel.bind('change:layer_name', this.render, this);
-    this.add_related_model(this.layerModel);
+    this.listenTo(this.model, 'change:search', this._onSearchToggled);
+    this.listenTo(this.model, 'change:title change:collapsed change:autoStyle change:style', this.render);
+    this.listenTo(this.model.lockedCategories, 'change add remove', this.render);
+    this.listenTo(this.dataviewModel, 'change:column', this.render);
+    this.listenTo(this.dataviewModel.filter, 'change', this.render);
+    this.listenTo(this.layerModel, 'change:visible change:cartocss change:layer_name', this.render);
   },
 
   _initViews: function () {

--- a/lib/assets/javascripts/deep-insights/widgets/category/title/search-title-view.js
+++ b/lib/assets/javascripts/deep-insights/widgets/category/title/search-title-view.js
@@ -77,11 +77,8 @@ module.exports = CoreView.extend({
     this.model.lockedCategories.bind('change add remove', this.render, this);
     this.add_related_model(this.model.lockedCategories);
 
-    this.dataviewModel.bind('change:data', this.render, this);
+    this.dataviewModel.bind('change:column', this.render, this);
     this.add_related_model(this.dataviewModel);
-
-    this.dataviewModel.filter.bind('change', this.render, this);
-    this.add_related_model(this.dataviewModel.filter);
 
     this.layerModel.bind('change:visible change:cartocss', this.render, this);
     this.layerModel.bind('change:layer_name', this.render, this);

--- a/lib/assets/javascripts/deep-insights/widgets/category/title/search-title-view.js
+++ b/lib/assets/javascripts/deep-insights/widgets/category/title/search-title-view.js
@@ -80,6 +80,9 @@ module.exports = CoreView.extend({
     this.dataviewModel.bind('change:column', this.render, this);
     this.add_related_model(this.dataviewModel);
 
+    this.dataviewModel.filter.bind('change', this.render, this);
+    this.add_related_model(this.dataviewModel.filter);
+
     this.layerModel.bind('change:visible change:cartocss', this.render, this);
     this.layerModel.bind('change:layer_name', this.render, this);
     this.add_related_model(this.layerModel);

--- a/lib/assets/test/spec/deep-insights/widgets/category/search-title-view.spec.js
+++ b/lib/assets/test/spec/deep-insights/widgets/category/search-title-view.spec.js
@@ -25,6 +25,34 @@ describe('widgets/category/search-title-view', function () {
     }]);
   });
 
+  describe('render events', function () {
+    beforeEach(function () {
+      spyOn(SearchTitleView.prototype, 'render');
+
+      this.widgetModel = new CategoryWidgetModel({}, {
+        dataviewModel: this.dataviewModel,
+        layerModel: this.layer
+      }, {autoStyleEnabled: true});
+
+      this.view = new SearchTitleView({
+        widgetModel: this.widgetModel,
+        dataviewModel: this.dataviewModel,
+        layerModel: this.layer
+      });
+    });
+
+    // Re-rendering on data change breaks things on Android
+    it('should not re-render on data change', function () {
+      this.dataviewModel.set('data', null);
+      expect(this.view.render).not.toHaveBeenCalled();
+    });
+
+    it('should re-render on column change', function () {
+      this.dataviewModel.set('column', 'OtherColumn');
+      expect(this.view.render).toHaveBeenCalled();
+    });
+  });
+
   describe('with autoStyleEnabled as true', function () {
     beforeEach(function () {
       this.widgetModel = new CategoryWidgetModel({}, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.67",
+  "version": "4.11.67-androidpls",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix support ticket https://github.com/CartoDB/support/issues/1074

There's no point in re-rendering the search title component when the data changes. The only data used from this model is the column, so we should re-render on such

Also I've added specs + comment so this does not happen again

