### PR TITLE
Old vis map safe access

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -150,6 +150,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Safe access to vis map for old visualizations without maps (#13665)
 * Don't fetch rows when fetching columns for analyses (#13654)
 * Fix pagination style for category widgets (https://github.com/CartoDB/support/issues/1161)
 * Add isSourceType false by default to select-view (#13655)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -131,7 +131,7 @@ class Admin::PagesController < Admin::AdminController
       @website_clean       = @website ? @website.gsub(/https?:\/\//, "") : ""
       @has_new_dashboard   = @viewed_user.builder_enabled? && @viewed_user.has_feature_flag?('dashboard_migration')
       @gmaps_query_string  = @viewed_user.google_maps_query_string
-      @needs_gmaps_lib     = @most_viewed_vis_map && @most_viewed_vis_map.map.provider == 'googlemaps'
+      @needs_gmaps_lib     = @most_viewed_vis_map.try(:map).try(:provider) == 'googlemaps'
 
       @needs_gmaps_lib ||= @default_fallback_basemap['className'] == 'googlemaps'
 


### PR DESCRIPTION
Use .try to safely access the most_viewed_map map property, which might be nil, curiously.

I'm still curious as to why this wasn't failing on the template :D