### PR TITLE
Fix new api keys view for Organizations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix broken api keys for organization users
 * Fix category widget search on Android (https://github.com/CartoDB/support/issues/1074)
 * Improve pagination in category widgets (https://github.com/CartoDB/support/issues/1161)
 * Fix onboardings in layer content views (#13674)

--- a/app/assets/stylesheets/new_dashboard/api-keys.scss
+++ b/app/assets/stylesheets/new_dashboard/api-keys.scss
@@ -147,3 +147,12 @@
 .Editor-formInput {
   position: relative;
 }
+
+.Editor-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 40px;
+  padding: 20px 0;
+  border-top: 1px solid #DDD;
+}

--- a/lib/assets/javascripts/dashboard/api-keys.js
+++ b/lib/assets/javascripts/dashboard/api-keys.js
@@ -13,6 +13,7 @@ const _ = require('underscore');
 const Backbone = require('backbone');
 require('dashboard/data/backbone/sync-options');
 const UserModel = require('dashboard/data/user-model');
+const OrganizationModel = require('dashboard/data/organization-model');
 const ConfigModel = require('dashboard/data/config-model');
 const DashboardHeaderView = require('dashboard/components/dashboard-header-view');
 const SupportView = require('dashboard/components/support-view');
@@ -25,6 +26,7 @@ const StackLayoutView = require('builder/components/stack-layout/stack-layout-vi
 const UserNotificationModel = require('dashboard/components/user-notification/user-notification-model');
 const ApiKeysCollection = require('dashboard/data/api-keys-collection');
 const UserTablesModel = require('dashboard/data/user-tables-model');
+const getObjectValue = require('deep-insights/util/get-object-value');
 
 const configModel = new ConfigModel(
   _.defaults(
@@ -46,6 +48,15 @@ if (window.trackJs) {
  */
 $(function () {
   const userModel = new UserModel(window.user_data, { configModel });
+  // User has an organization
+  if (window.user_data.organization) {
+    const organization = new OrganizationModel(window.user_data, {
+      currentUserId: window.user_data.id,
+      configModel
+    });
+    organization.owner = new UserModel(getObjectValue(window.user_data, 'organization.owner'));
+    userModel.setOrganization(organization);
+  }
 
   const headerView = new DashboardHeaderView({
     el: $('#header'), // pre-rendered in DOM by Rails app

--- a/lib/assets/javascripts/dashboard/data/api-key-model.js
+++ b/lib/assets/javascripts/dashboard/data/api-key-model.js
@@ -77,11 +77,13 @@ module.exports = Backbone.Model.extend({
   },
 
   getTablesGrants: function () {
-    return _.map(this.get('tables'), (value, key) => ({
+    const tables = _.map(this.get('tables'), (value, key) => ({
       name: key,
       schema: this._userModel.getSchema(),
       permissions: Object.keys(value.permissions).filter(name => value.permissions[name])
     }));
+
+    return _.filter(tables, table => table.permissions.length > 0);
   },
 
   _parseApiGrants: function (grants) {

--- a/lib/assets/javascripts/dashboard/data/user-model.js
+++ b/lib/assets/javascripts/dashboard/data/user-model.js
@@ -160,7 +160,7 @@ const UserModel = Backbone.Model.extend({
   },
 
   getOrgName: function () {
-    return this.isInsideOrg() ? this.getOrganization().get('name') : '';
+    return this.isInsideOrg() ? this.organization.get('name') : '';
   },
 
   getMaxLayersPerMap: function () {

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
@@ -150,6 +150,7 @@ module.exports = CoreView.extend({
   _onFormChanged: function () {
     this._handleFormErrors();
     this._handleCheckboxState();
+    this.$('.js-error').hide();
   },
 
   _handleCheckboxState: function () {
@@ -206,6 +207,15 @@ module.exports = CoreView.extend({
     }
 
     message && this._addApiKeyNameError(message);
+
+    if (!message) {
+      this._displayUnhandledError(error);
+    }
+  },
+
+  _displayUnhandledError: function (errorJSON) {
+    const parsed = JSON.parse(errorJSON);
+    this.$('.js-error').text(parsed.errors).show();
   },
 
   clean: function () {

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form.tpl
@@ -15,12 +15,16 @@
   <div class="js-api-keys-form"></div>
   <div class="js-api-keys-tables"></div>
 
-  <footer class="FormAccount-footer">
-    <p class="FormAccount-footerText">Changes to the key permissions are not possible once key is generated</p>
+  <footer class="Editor-footer u-tSpace-m">
+    <p class="CDB-Text CDB-Size-medium u-altTextColor">Changes to the key permissions are not possible once key is generated</p>
+
     <% if (modelIsNew) { %>
       <button type="submit" class="CDB-Button CDB-Button--primary is-disabled js-submit">
         <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Save changes</span>
       </button>
     <% } %>
   </footer>
+  <div class="error">
+    <span class="CDB-Text CDB-Size-small u-errorTextColor js-error"></span>
+  </div>
 </section>


### PR DESCRIPTION
We have to manually add the organization to the User, because of the circular dependencies we've found during the migration. This is why `public` was being sent instead of `${username}`

I've also taken the chance to remove the tables without permissions from the request (:money_with_wings:) & displaying the unhandled server errors, just in case this happens again, it's a bit more user-friendly.