### PR TITLE
Use wrapped SequelRails configuration, which fixes adapter naming

### DIFF
--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -607,7 +607,7 @@ class DataImport < Sequel::Model
   end
 
   def pg_options
-    Rails.configuration.database_configuration[Rails.env].symbolize_keys
+    SequelRails.configuration.environment_for(Rails.env)
       .merge(
         username: current_user.database_username,
         password: current_user.database_password,

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -486,7 +486,7 @@ module CartoDB
       end
 
       def pg_options
-        Rails.configuration.database_configuration[Rails.env].symbolize_keys
+        SequelRails.configuration.environment_for(Rails.env)
           .merge(
             username:     user.database_username,
             password: user.database_password,


### PR DESCRIPTION
This is the story. We need to merge this early for Rails 4 support. Here is the plan:

1. This change. It should not affect anything at all.
2. Change database.yml to point to use `adapter: postgresql`.
3. Deploy Rails 4

Why?
Sequel calls the adapter `postgres` and Rails calls it `postgresql`. Before, we used Sequel nomenclature and used a hack for AR: https://github.com/CartoDB/cartodb/blob/master/config/initializers/sequel.rb#L11-L13

With this change, we use `SequelRails` to parse the configuration, which lets us put any adapter in there, and it will be properly converted (new-ish SequelRails translates AR -> Sequel names). The Rails 4 PR needs to use `postgresql` for the `activerecord/railtie` to be correctly loaded (alternative: monkey patching :/). So we can change the configuration in between those two deploys and it should be safe.