### PR TITLE
Fix issues related to IE11 in onpremise

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,12 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix "Add new analysis" button in IE (CartoDB/onpremises/issues/485)
+* Fix button when addign new widgets (CartoDB/onpremises/issues/513)
+* Fix private map view styles in IE (CartoDB/onpremises/issues/499)
+* Fix privacy modal styles in IE (CartoDB/onpremises/issues/505)
+* Fix auto align in tooltips in IE (CartoDB/onpremises/issues/519)
+* Fix arrows styles for IE in dataset view (CartoDB/onpremises/issues/521)
 * Fix broken api keys for organization users
 * Fix multiple bugs in widgets (#13686)
 * Fix category widget search on Android (https://github.com/CartoDB/support/issues/1074)

--- a/app/assets/stylesheets/common/option-card.css.scss
+++ b/app/assets/stylesheets/common/option-card.css.scss
@@ -18,7 +18,6 @@
   display: flex;
   align-content: space-between;
   align-items: stretch;
-  justify-content: center;
 }
 
 .OptionCard {

--- a/app/assets/stylesheets/editor-3/_modals-layout.scss
+++ b/app/assets/stylesheets/editor-3/_modals-layout.scss
@@ -41,7 +41,6 @@
 .Modal-header {
   display: flex;
   flex: 0 0 auto;
-  justify-content: center;
 }
 
 .Modal-footer {

--- a/app/assets/stylesheets/editor-3/_table.scss
+++ b/app/assets/stylesheets/editor-3/_table.scss
@@ -325,7 +325,7 @@ $tableBorderColor: $cSecondaryLine;
       position: absolute;
       right: 0;
       width: 1px;
-      height: 14px;
+      height: $halfBaseSize * 7;
       background: #F9F9F9;
     }
   }
@@ -339,7 +339,7 @@ $tableBorderColor: $cSecondaryLine;
       position: absolute;
       left: -1px;
       width: 1px;
-      height: 14px;
+      height: $halfBaseSize * 7;
       background: $cThirdBackground;
     }
   }

--- a/app/assets/stylesheets/editor-3/_table.scss
+++ b/app/assets/stylesheets/editor-3/_table.scss
@@ -323,6 +323,7 @@ $tableBorderColor: $cSecondaryLine;
     &::after {
       content: '';
       position: absolute;
+      top: 0;
       right: 0;
       width: 1px;
       height: $halfBaseSize * 7;
@@ -337,6 +338,7 @@ $tableBorderColor: $cSecondaryLine;
     &::before {
       content: '';
       position: absolute;
+      top: 0;
       left: -1px;
       width: 1px;
       height: $halfBaseSize * 7;

--- a/app/assets/stylesheets/editor-3/_table.scss
+++ b/app/assets/stylesheets/editor-3/_table.scss
@@ -325,7 +325,7 @@ $tableBorderColor: $cSecondaryLine;
       position: absolute;
       right: 0;
       width: 1px;
-      height: calc(100% - 4px);
+      height: 14px;
       background: #F9F9F9;
     }
   }
@@ -339,7 +339,7 @@ $tableBorderColor: $cSecondaryLine;
       position: absolute;
       left: -1px;
       width: 1px;
-      height: calc(100% - 4px);
+      height: 14px;
       background: $cThirdBackground;
     }
   }

--- a/app/assets/stylesheets/public/password_protected.css.scss
+++ b/app/assets/stylesheets/public/password_protected.css.scss
@@ -34,7 +34,6 @@ $halfBaseSize: 4px;
 
 .PublicPage-container {
   position: relative;
-  margin: 0 auto;
   text-align: center;
 }
 

--- a/lib/assets/javascripts/builder/components/tipsy-tooltip-view.js
+++ b/lib/assets/javascripts/builder/components/tipsy-tooltip-view.js
@@ -87,10 +87,10 @@ module.exports = CoreView.extend({
       var gravityOptions = { n: 'bottom', s: 'top', w: 'right', e: 'left' };
 
       var viewportBoundaries = {
-        top: browserWindow.scrollY + margin,
-        right: browserWindow.innerWidth + browserWindow.scrollX - margin,
-        bottom: browserWindow.innerHeight + browserWindow.scrollY - margin,
-        left: browserWindow.scrollX + margin
+        top: browserWindow.pageYOffset + margin,
+        right: browserWindow.innerWidth + browserWindow.pageXOffset - margin,
+        bottom: browserWindow.innerHeight + browserWindow.pageYOffset - margin,
+        left: browserWindow.pageXOffset + margin
       };
 
       var tooltipBoundaries = {

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-workflow-view.js
@@ -1,6 +1,5 @@
 var CoreView = require('backbone/core-view');
 var AnalysesWorkflowListView = require('./analyses-workflow-list-view');
-var ScrollView = require('builder/components/scroll/scroll-view');
 var checkAndBuildOpts = require('builder/helpers/required-opts');
 
 var REQUIRED_OPTS = [
@@ -33,15 +32,11 @@ module.exports = CoreView.extend({
   _renderAnalysesView: function () {
     var self = this;
 
-    var view = new ScrollView({
-      createContentView: function () {
-        return new AnalysesWorkflowListView({
-          analysisDefinitionNodesCollection: self._analysisDefinitionNodesCollection,
-          analysisFormsCollection: self._analysisFormsCollection,
-          layerId: self._layerDefinitionModel.id,
-          selectedNodeId: self._selectedNodeId
-        });
-      }
+    var view = new AnalysesWorkflowListView({
+      analysisDefinitionNodesCollection: self._analysisDefinitionNodesCollection,
+      analysisFormsCollection: self._analysisFormsCollection,
+      layerId: self._layerDefinitionModel.id,
+      selectedNodeId: self._selectedNodeId
     });
 
     this.$el.append(view.render().el);

--- a/lib/assets/test/spec/builder/components/tipsy-tooltip-view.spec.js
+++ b/lib/assets/test/spec/builder/components/tipsy-tooltip-view.spec.js
@@ -65,8 +65,8 @@ describe('components/tipsy-tooltip-view', function () {
     var windowMock = {
       innerHeight: 1024,
       innerWidth: 768,
-      scrollX: 0,
-      scrollY: 0
+      pageXOffset: 0,
+      pageYOffset: 0
     };
 
     it('should return first preferred gravity if there is no tooltipElement', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.73.onpremiseie.1",
+  "version": "4.11.73.onpremiseie.2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -65,7 +65,7 @@
     "bluebird": "3.5.0",
     "brfs": "^1.4.3",
     "browserify-resolutions": "1.1.0",
-    "cartoassets": "CartoDB/CartoAssets#master",
+    "cartoassets": "CartoDB/CartoAssets#fix-option-input-top",
     "colors": "1.1.2",
     "csswring": "^3.0.5",
     "eslint": "~4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.73.onpremiseie",
+  "version": "4.11.73.onpremiseie.1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.73",
+  "version": "4.11.73.onpremiseie",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "bluebird": "3.5.0",
     "brfs": "^1.4.3",
     "browserify-resolutions": "1.1.0",
-    "cartoassets": "CartoDB/CartoAssets#fix-option-input-top",
+    "cartoassets": "CartoDB/CartoAssets#master",
     "colors": "1.1.2",
     "csswring": "^3.0.5",
     "eslint": "~4.8.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "bluebird": "3.5.0",
     "brfs": "^1.4.3",
     "browserify-resolutions": "1.1.0",
-    "cartoassets": "CartoDB/CartoAssets#master",
+    "cartoassets": "CartoDB/CartoAssets#fix-option-input-border",
     "colors": "1.1.2",
     "csswring": "^3.0.5",
     "eslint": "~4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.73.onpremiseie.2",
+  "version": "4.11.73.onpremiseie.3",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "bluebird": "3.5.0",
     "brfs": "^1.4.3",
     "browserify-resolutions": "1.1.0",
-    "cartoassets": "CartoDB/CartoAssets#fix-option-input-border",
+    "cartoassets": "CartoDB/CartoAssets#master",
     "colors": "1.1.2",
     "csswring": "^3.0.5",
     "eslint": "~4.8.0",


### PR DESCRIPTION
## Fixes
- "Add new analysis" button is not shown (IE) https://github.com/CartoDB/onpremises/issues/485
- (IE) Continue button is out of place when adding new widgets https://github.com/CartoDB/onpremises/issues/513
- Private map view styles are broken on IE11 https://github.com/CartoDB/onpremises/issues/499
- Change DATASET privacy modal styles are broken on IE11 https://github.com/CartoDB/onpremises/issues/505
- Autostyle styles and behavior are quite buggy in IE https://github.com/CartoDB/onpremises/issues/519
- Arrows from the horizontal scrollbar in the dataset view looks weird in IE https://github.com/CartoDB/onpremises/issues/521
- Left border is wrong in color/size inputs in IE https://github.com/CartoDB/onpremises/issues/516

## Acceptance
Check the issues listed above are not happening anymore.