### PR TITLE
Add helper text to mapbox url view

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Add helper text to mapbox basemap view (#13699)
 * Fix legends not refreshing when moving layers (#13696)
 * Fix broken api keys for organization users
 * Fix multiple bugs in widgets (#13686)

--- a/app/assets/stylesheets/common/form-content.css.scss
+++ b/app/assets/stylesheets/common/form-content.css.scss
@@ -198,6 +198,10 @@ $sLabel-width: 140px;
   margin: 0;
 }
 
+.Form-rowData--noMinHeight {
+  min-height: 0;
+}
+
 // RowData sizes
 .Form-rowData--full {
   width: 100%;

--- a/lib/assets/javascripts/builder/components/modals/add-basemap/mapbox/enter-url.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-basemap/mapbox/enter-url.tpl
@@ -11,7 +11,7 @@
     <label class="Metadata-label Metadata-label--big CDB-Text CDB-Size-small is-semibold u-upperCase u-ellipsis"></label>
     <div class="Form-rowData Form-rowData--noMinHeight Form-rowData--longer">
       <p class="CDB-Text CDB-Size-small Form-rowInfoText--block u-altTextColor">
-        Learn how to get your Mapbox Style URL <a href="https://www.mapbox.com/help/carto/">here</a>
+        Learn how to get your Mapbox Style URL <a href="https://www.mapbox.com/help/carto/" target="_blank">here</a>
       </p>
     </div>
   </div>

--- a/lib/assets/javascripts/builder/components/modals/add-basemap/mapbox/enter-url.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-basemap/mapbox/enter-url.tpl
@@ -7,4 +7,12 @@
       <div class="XYZPanel-error CDB-InfoTooltip CDB-InfoTooltip--left is-error CDB-Text CDB-Size-medium CDB-InfoTooltip-text js-error <%- lastErrorMsg ? 'is-visible' : '' %>"><%- lastErrorMsg %></div>
     </div>
   </div>
+  <div class="u-flex">
+    <label class="Metadata-label Metadata-label--big CDB-Text CDB-Size-small is-semibold u-upperCase u-ellipsis"></label>
+    <div class="Form-rowData Form-rowData--noMinHeight Form-rowData--longer">
+      <p class="CDB-Text CDB-Size-small Form-rowInfoText--block u-altTextColor">
+        Learn how to get your Mapbox Style URL <a href="https://www.mapbox.com/help/carto/">here</a>
+      </p>
+    </div>
+  </div>
 </div>

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -825,8 +825,8 @@
           "couldnt-validate": "We couldn't validate this. If you're sure it contains data click \"add basemap\""
         },
         "mapbox": {
-          "insert": "Insert your Mapbox URL",
-          "enter": "Enter a URL",
+          "insert": "Add Mapbox Style basemap",
+          "enter": "Mapbox Style URL",
           "error": "Error retrieving your basemap. Please check your Mapbox URL.",
           "invalid": "This URL is not valid."
         },


### PR DESCRIPTION
Related to: https://github.com/CartoDB/design/issues/1239

## Description
This PR adds a helper text bellow the mapbox url input:

## Screenshot
![screen shot 2018-03-14 at 11 46 36](https://user-images.githubusercontent.com/905225/37398012-687d5414-277d-11e8-9f55-c9141f8f6430.png)

## Acceptance
Create a map, click on the basemap layer, in the carousel, select mapbox, a modal will open:
- Check the modal has the text `Learn how to get your Mapbox Style URL here`.
- Check the link redirects to the correct page.