### PR TITLE
Add loading state to API Keys button

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Add loading state to API Keys form button
 * Add helper text to mapbox basemap view (#13699)
 * Fix legends not refreshing when moving layers (#13696)
 * Fix broken api keys for organization users

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
@@ -178,8 +178,13 @@ module.exports = CoreView.extend({
     this._errorTooltip && this._errorTooltip.clean();
   },
 
-  _onFormSubmit: function () {
-    if (this._hasErrors()) return;
+  _onFormSubmit: function (event) {
+    const saveButtonClasses = event.currentTarget.classList;
+    const isButtonLoading = saveButtonClasses.contains('is-loading');
+
+    if (this._hasErrors() || isButtonLoading) return;
+
+    saveButtonClasses.add('is-loading');
 
     const errors = this._formView.commit({ validate: true });
 
@@ -193,6 +198,7 @@ module.exports = CoreView.extend({
       },
       error: (model, request) => {
         this._handleServerErrors(request.responseText);
+        saveButtonClasses.remove('is-loading');
       }
     });
   },

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
@@ -179,7 +179,7 @@ module.exports = CoreView.extend({
   },
 
   _onFormSubmit: function (event) {
-    const saveButtonClasses = event.currentTarget.classList;
+    const saveButtonClasses = this.el.querySelector('.js-submit').classList;
     const isButtonLoading = saveButtonClasses.contains('is-loading');
 
     if (this._hasErrors() || isButtonLoading) return;

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
@@ -179,12 +179,12 @@ module.exports = CoreView.extend({
   },
 
   _onFormSubmit: function (event) {
-    const saveButtonClasses = this.el.querySelector('.js-submit').classList;
-    const isButtonLoading = saveButtonClasses.contains('is-loading');
+    const saveButton = this.$('.js-submit');
+    const isButtonLoading = saveButton.hasClass('is-loading');
 
     if (this._hasErrors() || isButtonLoading) return;
 
-    saveButtonClasses.add('is-loading');
+    saveButton.addClass('is-loading');
 
     const errors = this._formView.commit({ validate: true });
 
@@ -198,7 +198,7 @@ module.exports = CoreView.extend({
       },
       error: (model, request) => {
         this._handleServerErrors(request.responseText);
-        saveButtonClasses.remove('is-loading');
+        saveButton.removeClass('is-loading');
       }
     });
   },

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form.tpl
@@ -19,8 +19,13 @@
     <p class="CDB-Text CDB-Size-medium u-altTextColor">Changes to the key permissions are not possible once key is generated</p>
 
     <% if (modelIsNew) { %>
-      <button type="submit" class="CDB-Button CDB-Button--primary is-disabled js-submit">
+      <button type="submit" class="CDB-Button CDB-Button--primary CDB-Button--loading is-disabled js-submit">
         <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Save changes</span>
+        <div class="CDB-Button-loader CDB-LoaderIcon is-white">
+          <svg class="CDB-LoaderIcon-spinner" viewbox="0 0 50 50">
+            <circle class="CDB-LoaderIcon-path" cx="25" cy="25" r="20" fill="none"/>
+          </svg>
+        </div>
       </button>
     <% } %>
   </footer>


### PR DESCRIPTION
This PR adds a loading state to the button in the API Keys form.

![loadingapikeys](https://user-images.githubusercontent.com/4319728/37401245-c17ffb52-2787-11e8-8bb5-2534492310ec.gif)


### Acceptance Steps

- [ ] Check that the button loading state is shown when the form is submitted
- [ ] Check that the button loading state is hidden when the form submit returns has an error