### PR TITLE
Fix embed footer when there is no toolbar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix embed maps footer when there is no toolbar (#13704)
 * Add helper text to mapbox basemap view (#13699)
 * Fix legends not refreshing when moving layers (#13696)
 * Fix broken api keys for organization users

--- a/app/assets/stylesheets/deep-insights/themes/scss/map/_canvas.scss
+++ b/app/assets/stylesheets/deep-insights/themes/scss/map/_canvas.scss
@@ -62,7 +62,7 @@ $canvas-dark: #293A41;
     padding: 0;
   }
 
-  .CDB-Dashboard-mapWrapper {
+  .CDB-Dashboard-mapWrapper--withMenu {
     height: calc(100% - 38px);
   }
 
@@ -81,11 +81,14 @@ $canvas-dark: #293A41;
     box-sizing: border-box;
     flex-direction: column;
     width: 100%;
-    height: calc(100% - 38px);
     margin: 0;
     padding: 0;
     overflow: hidden;
     border-radius: 0;
+  }
+
+  .CDB-Dashboard-canvas--withMenu {
+    height: calc(100% - 38px);
   }
 
   .CDB-Map {

--- a/lib/assets/javascripts/deep-insights/dashboard-view.js
+++ b/lib/assets/javascripts/deep-insights/dashboard-view.js
@@ -30,6 +30,8 @@ module.exports = CoreView.extend({
     var view;
     var doRenderMenu = this.model.get('renderMenu');
 
+    this.$el.toggleClass('CDB-Dashboard-canvas--withMenu', doRenderMenu)
+
     if (doRenderMenu) {
       view = new DashboardMenuView({
         model: this.model

--- a/lib/assets/javascripts/deep-insights/dashboard-view.js
+++ b/lib/assets/javascripts/deep-insights/dashboard-view.js
@@ -30,7 +30,7 @@ module.exports = CoreView.extend({
     var view;
     var doRenderMenu = this.model.get('renderMenu');
 
-    this.$el.toggleClass('CDB-Dashboard-canvas--withMenu', doRenderMenu)
+    this.$el.toggleClass('CDB-Dashboard-canvas--withMenu', doRenderMenu);
 
     if (doRenderMenu) {
       view = new DashboardMenuView({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.78",
+  "version": "4.11.78.embed",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.78.embed",
+  "version": "4.11.78",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/1385

This PR removes the white space in the footer for embed maps when the `Show toolbar` option is disabled.

## Acceptance
Both with and without widgets:
- Check the embed map renders correctly with `Show toolbar` enabled
- Check the embed map renders correctly with `Show toolbar` disabled