### PR TITLE
Fix widgets disabled state

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix widgets disabled state (#13707)
 * Add helper text to mapbox basemap view (#13699)
 * Fix legends not refreshing when moving layers (#13696)
 * Fix broken api keys for organization users

--- a/lib/assets/javascripts/builder/editor.js
+++ b/lib/assets/javascripts/builder/editor.js
@@ -66,6 +66,7 @@ var TipsyTooltipView = require('builder/components/tipsy-tooltip-view');
 var Router = require('builder/routes/router');
 var handleAnalysesRoute = require('builder/routes/handle-analyses-route');
 var handleModalsRoute = require('builder/routes/handle-modals-route');
+var handleWidgetRoute = require('builder/routes/handle-widget-route');
 
 // JSON data passed from entry point (editor/visualizations/show.html):
 var vizJSON = window.vizJSON;
@@ -267,12 +268,6 @@ WidgetsService.init({
   widgetDefinitionsCollection: widgetDefinitionsCollection
 });
 
-var handleWidgetRoute = function (route) {
-  var widgetId = route[0] === 'widget' ? route[1] : null;
-
-  widgetDefinitionsCollection.trigger('setSelected', widgetId);
-};
-
 var mapCreation = function () {
   BuilderOnboardingLauncher.launch();
 
@@ -353,7 +348,7 @@ var mapCreation = function () {
     } */
 
     var currentRoute = Router.getRouteModel().get('currentRoute');
-    handleWidgetRoute(currentRoute);
+    handleWidgetRoute(currentRoute, widgetDefinitionsCollection);
 
     // Expose things after Map initialization
     window.deepInsightsIntegrations = deepInsightsIntegrations;
@@ -386,12 +381,16 @@ var settingsCollection = new Backbone.Collection(SettingsOptions(overlaysCollect
 
 Router.init({
   modals: modals,
+  widgetDefinitionsCollection: widgetDefinitionsCollection,
   editorModel: editorModel,
   handleModalsRoute: function (currentRoute, modals) {
     handleModalsRoute(currentRoute, modals);
   },
   handleAnalysesRoute: function (currentRoute) {
     handleAnalysesRoute(currentRoute);
+  },
+  handleWidgetRoute: function (currentRoute, widgetDefinitionsCollection) {
+    handleWidgetRoute(currentRoute, widgetDefinitionsCollection);
   }
 });
 

--- a/lib/assets/javascripts/builder/routes/handle-widget-route.js
+++ b/lib/assets/javascripts/builder/routes/handle-widget-route.js
@@ -1,0 +1,5 @@
+module.exports = function (currentRoute, widgetDefinitionsCollection) {
+  var widgetId = currentRoute[0] === 'widget' ? currentRoute[1] : null;
+
+  widgetDefinitionsCollection.trigger('setSelected', widgetId);
+};

--- a/lib/assets/javascripts/builder/routes/helpers.js
+++ b/lib/assets/javascripts/builder/routes/helpers.js
@@ -1,4 +1,5 @@
 var handleAnalysesRoute = require('./handle-analyses-route');
+var handleWidgetRoute = require('./handle-widget-route');
 var populateRoute = require('./populate-route');
 
 module.exports = {

--- a/lib/assets/javascripts/builder/routes/helpers.js
+++ b/lib/assets/javascripts/builder/routes/helpers.js
@@ -2,6 +2,7 @@ var handleAnalysesRoute = require('./handle-analyses-route');
 var populateRoute = require('./populate-route');
 
 module.exports = {
+  handleWidgetRoute: handleWidgetRoute,
   handleAnalysesRoute: handleAnalysesRoute,
   populateRoute: populateRoute
 };

--- a/lib/assets/javascripts/builder/routes/router.js
+++ b/lib/assets/javascripts/builder/routes/router.js
@@ -66,11 +66,9 @@ module.exports = (function () {
 
   return {
     init: function (options) {
-      if (initialized) {
-        throw new Error('Router can only be initialized once');
-      }
-
       checkAndBuildOpts(options, REQUIRED_OPTS, this);
+
+      if (initialized) return;
 
       var self = this;
       initialized = true;

--- a/lib/assets/javascripts/builder/routes/router.js
+++ b/lib/assets/javascripts/builder/routes/router.js
@@ -23,8 +23,10 @@ var EDIT_FEATURE = BASE_LAYER_ROUTE + '/edit/:featureId';
 var REQUIRED_OPTS = [
   'modals',
   'editorModel',
+  'widgetDefinitionsCollection',
   'handleModalsRoute',
-  'handleAnalysesRoute'
+  'handleAnalysesRoute',
+  'handleWidgetRoute'
 ];
 
 var ROUTES = [
@@ -100,6 +102,7 @@ module.exports = (function () {
 
       this._handleModalsRoute(currentRoute, this._modals);
       this._handleAnalysesRoute(currentRoute);
+      this._handleWidgetRoute(currentRoute, this._widgetDefinitionsCollection);
 
       this._editorModel.set('edition', false);
     },

--- a/lib/assets/javascripts/builder/routes/router.js
+++ b/lib/assets/javascripts/builder/routes/router.js
@@ -66,9 +66,11 @@ module.exports = (function () {
 
   return {
     init: function (options) {
-      checkAndBuildOpts(options, REQUIRED_OPTS, this);
+      if (initialized) {
+        throw new Error('Router can only be initialized once');
+      }
 
-      if (initialized) return;
+      checkAndBuildOpts(options, REQUIRED_OPTS, this);
 
       var self = this;
       initialized = true;

--- a/lib/assets/test/spec/builder/routes/handle-widget-route.spec.js
+++ b/lib/assets/test/spec/builder/routes/handle-widget-route.spec.js
@@ -1,0 +1,13 @@
+var handleWidgetRoute = require('builder/routes/handle-widget-route');
+
+describe('routes/handleWidgetRoute', function () {
+  it('should handle widget route', function () {
+    const widgetDefinitionsCollection = {
+      trigger: jasmine.createSpy('trigger')
+    };
+
+    handleWidgetRoute(['widget', 'somewidgetid', null, null], widgetDefinitionsCollection);
+
+    expect(widgetDefinitionsCollection.trigger).toHaveBeenCalledWith('setSelected', 'somewidgetid');
+  });
+});

--- a/lib/assets/test/spec/builder/routes/router.spec.js
+++ b/lib/assets/test/spec/builder/routes/router.spec.js
@@ -11,8 +11,10 @@ Backbone.history.start({ pushState: false, hashChange: true, root: 'builder/id' 
 describe('routes/router', function () {
   var editorModel;
   var modals;
+  var widgetDefinitionsCollection;
   var handleModalsRouteSpy;
   var handleAnalysesRouteSpy;
+  var handleWidgetRouteSpy;
   var onChangeRouteSpy;
 
   beforeAll(function () {
@@ -40,7 +42,7 @@ describe('routes/router', function () {
       widgetDefinitionsCollection: widgetDefinitionsCollection,
       handleModalsRoute: handleModalsRouteSpy,
       handleAnalysesRoute: handleAnalysesRouteSpy,
-      handleWidgetRoute: handleWidgetRouteSpy,
+      handleWidgetRoute: handleWidgetRouteSpy
     });
 
     spyOn(Backbone.History.prototype, 'matchRoot').and.returnValue(true);

--- a/lib/assets/test/spec/builder/routes/router.spec.js
+++ b/lib/assets/test/spec/builder/routes/router.spec.js
@@ -15,24 +15,32 @@ describe('routes/router', function () {
   var handleAnalysesRouteSpy;
   var onChangeRouteSpy;
 
-  beforeEach(function () {
+  beforeAll(function () {
     editorModel = new Backbone.Model({
       edition: false
     });
 
+    widgetDefinitionsCollection = {
+      trigger: jasmine.createSpy()
+    };
+
     modals = {
       destroy: jasmine.createSpy()
     };
-    handleModalsRouteSpy = jasmine.createSpy();
-    handleAnalysesRouteSpy = jasmine.createSpy();
+
+    handleModalsRouteSpy = jasmine.createSpy('handleModalsRouteSpy');
+    handleAnalysesRouteSpy = jasmine.createSpy('handleAnalysesRouteSpy');
+    handleWidgetRouteSpy = jasmine.createSpy('handleWidgetRouteSpy');
 
     onChangeRouteSpy = spyOn(Router, '_onChangeRoute');
 
     Router.init({
       modals: modals,
       editorModel: editorModel,
+      widgetDefinitionsCollection: widgetDefinitionsCollection,
       handleModalsRoute: handleModalsRouteSpy,
-      handleAnalysesRoute: handleAnalysesRouteSpy
+      handleAnalysesRoute: handleAnalysesRouteSpy,
+      handleWidgetRoute: handleWidgetRouteSpy,
     });
 
     spyOn(Backbone.History.prototype, 'matchRoot').and.returnValue(true);
@@ -55,6 +63,16 @@ describe('routes/router', function () {
       expect(handleModalsRouteSpy).toHaveBeenCalledWith(routeModel, modals);
       expect(handleAnalysesRouteSpy).toHaveBeenCalledWith(routeModel);
       expect(editorModel.get('edition')).toBe(false);
+    });
+
+    it('should handle widget route', function () {
+      onChangeRouteSpy.and.callThrough();
+
+      Router.navigate('/widget/widget-1337');
+
+      var routeModel = Router.getRouteModel().get('currentRoute');
+
+      expect(handleWidgetRouteSpy).toHaveBeenCalledWith(routeModel, widgetDefinitionsCollection);
     });
   });
 });

--- a/lib/assets/test/spec/builder/routes/router.spec.js
+++ b/lib/assets/test/spec/builder/routes/router.spec.js
@@ -3,10 +3,9 @@ var Router = require('builder/routes/router');
 
 Backbone.history.start({ pushState: false, hashChange: true, root: 'builder/id' });
 
-// // Mock this, because it fails
-// Router.getCurrentRoute = function () {
-//   return '/la/promosio';
-// };
+// REMEMBER:
+// The router is a singletone and can be initialized only once.
+// This means that you'll have to reset the models you need manually before each test.
 
 describe('routes/router', function () {
   var editorModel;
@@ -17,7 +16,7 @@ describe('routes/router', function () {
   var handleWidgetRouteSpy;
   var onChangeRouteSpy;
 
-  beforeEach(function () {
+  beforeAll(function () {
     editorModel = new Backbone.Model({
       edition: false
     });

--- a/lib/assets/test/spec/builder/routes/router.spec.js
+++ b/lib/assets/test/spec/builder/routes/router.spec.js
@@ -17,7 +17,7 @@ describe('routes/router', function () {
   var handleWidgetRouteSpy;
   var onChangeRouteSpy;
 
-  beforeAll(function () {
+  beforeEach(function () {
     editorModel = new Backbone.Model({
       edition: false
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.78",
+  "version": "4.11.78.widgetdisabled",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13342

## Description
This PR brings back the logic added in https://github.com/CartoDB/cartodb/pull/13374 to disable/enable widgets in route changes.

## Acceptance
- [x] Clicking on a widget disables the rest of the widgets
- [x] Clicking on a widget when it's out of view scrolls to it
- [x] Leaving edit widget view cleans the disabled state