### PR TITLE
Fix authenticated user in migration pages

### DIFF
--- a/lib/assets/javascripts/dashboard/data-library.js
+++ b/lib/assets/javascripts/dashboard/data-library.js
@@ -40,8 +40,8 @@ $(function () {
   });
 
   authenticatedUser.on('change', function (model) {
-    if (model.get('user_data')) {
-      userModel = new UserModel(authenticatedUser.attributes.user_data, {
+    if (model.get('username')) {
+      userModel = new UserModel(model.attributes, {
         configModel: configModel
       });
 

--- a/lib/assets/javascripts/dashboard/data/authenticated-user-model.js
+++ b/lib/assets/javascripts/dashboard/data/authenticated-user-model.js
@@ -7,7 +7,7 @@ module.exports = Backbone.Model.extend({
   },
 
   url: function () {
-    return '//' + this.getHost() + '/api/v3/me';
+    return `//${this.getHost()}/api/v1/get_authenticated_users`;
   },
 
   getHost: function () {

--- a/lib/assets/javascripts/dashboard/user-feed.js
+++ b/lib/assets/javascripts/dashboard/user-feed.js
@@ -37,8 +37,8 @@ $(function () {
   const authenticatedUser = new AuthenticatedUser();
 
   authenticatedUser.on('change', function (model) {
-    if (model.get('user_data')) {
-      var user = new UserModel(authenticatedUser.attributes.user_data, {
+    if (model.get('username')) {
+      var user = new UserModel(authenticatedUser.attributes, {
         configModel: configModel
       });
 

--- a/lib/assets/test/spec/dashboard/data/authenticated-user-model.spec.js
+++ b/lib/assets/test/spec/dashboard/data/authenticated-user-model.spec.js
@@ -8,6 +8,6 @@ describe('dashboard/data/authenticated-user-model', function () {
   it('should return the normal URL', function () {
     spyOn(this.model, 'getHost').and.returnValue('test.carto.com');
 
-    expect(this.model.url()).toBe('//test.carto.com/api/v3/me');
+    expect(this.model.url()).toBe('//test.carto.com/api/v1/get_authenticated_users');
   });
 });


### PR DESCRIPTION
This PR fixes the authentication issue that we had in Data Library, and User Feed pages because we were calling `/api/v3/me` instead of `/api/v1/get_authenticated_users`.

I had to change the affected models as well, because the data formatting has changed between the endpoints.

Related to #13708.