### PR TITLE
Similar notifications should be stacked

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -154,6 +154,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Do not add new notifications if notification content already exists (#13407)
 * Fix histogram widgets collapsing (#13705)
 * Use Promises in query models to handle async states (#13478)
 * Fix "Add new analysis" button in IE (CartoDB/onpremises/issues/485)

--- a/lib/assets/javascripts/builder/components/modals/add-widgets/add-widgets-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-widgets/add-widgets-view.js
@@ -106,8 +106,12 @@ module.exports = CoreView.extend({
 
     if (selectedOptionModels.length > 0) {
       this._saveSelectedWidgets(selectedOptionModels)
-        .then(self._userActions.updateWidgetsOrder)
-        .catch(self._userActions.updateWidgetsOrder);
+        .then(function () {
+          self._userActions.updateWidgetsOrder(selectedOptionModels);
+        })
+        .catch(function () {
+          self._userActions.updateWidgetsOrder(selectedOptionModels);
+        });
 
       this._modalModel.destroy();
     }

--- a/lib/assets/javascripts/builder/components/modals/add-widgets/category/category-option-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-widgets/category/category-option-model.js
@@ -36,8 +36,6 @@ module.exports = WidgetOptionModel.extend({
       }
     };
 
-    widgetDefinitionsCollection.trigger('loading', model);
-
     return widgetDefinitionsCollection.addWidget(model, attrs);
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-widgets/formula/formula-option-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-widgets/formula/formula-option-model.js
@@ -23,8 +23,6 @@ module.exports = WidgetOptionModel.extend({
       }
     };
 
-    widgetDefinitionsCollection.trigger('loading', model);
-
     return widgetDefinitionsCollection.addWidget(model, attrs);
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-widgets/histogram/histogram-option-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-widgets/histogram/histogram-option-model.js
@@ -35,8 +35,6 @@ module.exports = WidgetOptionModel.extend({
       }
     };
 
-    widgetDefinitionsCollection.trigger('loading', model);
-
     return widgetDefinitionsCollection.addWidget(model, attrs);
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-widgets/time-series/time-series-option-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-widgets/time-series/time-series-option-model.js
@@ -55,10 +55,6 @@ module.exports = WidgetOptionModel.extend({
       widgetDefinitionsCollection.trigger('error', model, e);
     };
 
-    var createLoadingNotification = function () {
-      widgetDefinitionsCollection.trigger('loading', model);
-    };
-
     var createUpdatingNotification = function () {
       widgetDefinitionsCollection.trigger('updating', model);
     };
@@ -75,7 +71,6 @@ module.exports = WidgetOptionModel.extend({
         });
       }
     } else {
-      createLoadingNotification();
       return widgetDefinitionsCollection.addWidget(model, attrs);
     }
   },

--- a/lib/assets/javascripts/builder/components/notifier/notifier-collection.js
+++ b/lib/assets/javascripts/builder/components/notifier/notifier-collection.js
@@ -11,12 +11,12 @@ module.exports = Backbone.Collection.extend({
   },
 
   addNotification: function (attrs, options) {
-    if (!this._sameTextNotificationExists(attrs)) {
-      return this.add(attrs, options);
-    }
+    var notification = this._findNotificationByAttrs(attrs);
+
+    return notification ? notification.update(attrs) : this.add(attrs, options);
   },
 
-  _sameTextNotificationExists: function (attrs) {
+  _findNotificationByAttrs: function (attrs) {
     return this.findWhere({ info: attrs.info });
   }
 });

--- a/lib/assets/javascripts/builder/components/notifier/notifier-collection.js
+++ b/lib/assets/javascripts/builder/components/notifier/notifier-collection.js
@@ -8,5 +8,15 @@ module.exports = Backbone.Collection.extend({
 
   findById: function (id) {
     return this.findWhere({id: id});
+  },
+
+  addNotification: function (attrs, options) {
+    if (!this._sameTextNotificationExists(attrs)) {
+      return this.add(attrs, options);
+    }
+  },
+
+  _sameTextNotificationExists: function (attrs) {
+    return this.findWhere({ info: attrs.info });
   }
 });

--- a/lib/assets/javascripts/builder/components/notifier/notifier.js
+++ b/lib/assets/javascripts/builder/components/notifier/notifier.js
@@ -56,13 +56,9 @@ var manager = (function () {
     },
 
     getNotification: function (model) {
-      var notification;
-      if (typeof model === 'string') {
-        notification = collection.findById(model);
-      } else {
-        notification = collection.findById(model.id);
-      }
-      return notification;
+      return typeof model === 'string'
+        ? collection.findById(model)
+        : collection.findById(model.id);
     },
 
     addNotification: function (attrs) {
@@ -73,12 +69,10 @@ var manager = (function () {
     },
 
     removeNotification: function (model) {
-      var notification;
-      if (typeof model === 'string') {
-        notification = collection.findById(model);
-      } else {
-        notification = collection.findById(model.id);
-      }
+      var notification = typeof model === 'string'
+        ? collection.findById(model)
+        : collection.findById(model.id);
+
       return collection.remove(notification);
     }
   };

--- a/lib/assets/javascripts/builder/components/notifier/notifier.js
+++ b/lib/assets/javascripts/builder/components/notifier/notifier.js
@@ -51,6 +51,10 @@ var manager = (function () {
       return collection;
     },
 
+    getCount: function () {
+      return collection.size();
+    },
+
     getNotification: function (model) {
       var notification;
       if (typeof model === 'string') {
@@ -62,7 +66,7 @@ var manager = (function () {
     },
 
     addNotification: function (attrs) {
-      return collection.add(attrs, {
+      return collection.addNotification(attrs, {
         visDefinitionModel: this._visDefinitionModel,
         delay: this.DEFAULT_DELAY
       });

--- a/lib/assets/javascripts/builder/data/user-actions.js
+++ b/lib/assets/javascripts/builder/data/user-actions.js
@@ -76,15 +76,18 @@ module.exports = function (params) {
     var notification;
     var restoringError;
     var onWidgetFinished = _.after(affectedWidgets.length, function () {
-      if (!restoringError) {
-        notification.set({
-          status: 'success',
-          info: _t('notifications.widgets.restored'),
-          closable: true
-        });
-      } else {
-        Notifier.removeNotification(notification);
+      if (notification) {
+        if (!restoringError) {
+          notification.set({
+            status: 'success',
+            info: _t('notifications.widgets.restored'),
+            closable: true
+          });
+        } else {
+          Notifier.removeNotification(notification);
+        }
       }
+
       callback(layerDefModel, callbackOptions);
     });
 

--- a/lib/assets/javascripts/builder/data/user-actions.js
+++ b/lib/assets/javascripts/builder/data/user-actions.js
@@ -210,8 +210,8 @@ module.exports = function (params) {
       return widgetOptionModel.save(widgetDefinitionsCollection);
     },
 
-    updateWidgetsOrder: function () {
-      return widgetDefinitionsCollection.updateWidgetsOrder();
+    updateWidgetsOrder: function (widgets) {
+      return widgetDefinitionsCollection.updateWidgetsOrder(widgets);
     },
 
     saveWidget: function (widgetDefModel) {

--- a/lib/assets/javascripts/builder/data/widget-definitions-collection.js
+++ b/lib/assets/javascripts/builder/data/widget-definitions-collection.js
@@ -119,35 +119,37 @@ module.exports = Backbone.Collection.extend({
       self.create(attrs, {
         wait: true,
         success: function (model) {
-          self.trigger('successAdd', widgetModel);
           resolve(model);
         },
         error: function (response, error) {
-          self.trigger('error', widgetModel, error);
           reject(error);
         }
       });
     });
   },
 
-  updateWidgetsOrder: function () {
+  updateWidgetsOrder: function (numberOfWidgets) {
     this.each(function (widgetDefinitionModel, index) {
       widgetDefinitionModel.set({ order: index });
     });
 
-    return this.saveAsync();
+    return this.saveAsync(numberOfWidgets);
   },
 
-  saveAsync: function () {
+  saveAsync: function (updatedWidgets) {
     var self = this;
+
+    this.trigger('loading', updatedWidgets);
 
     return new Promise(function (resolve, reject) {
       self.save({
         wait: true,
         success: function (collection) {
+          self.trigger('successAdd', updatedWidgets);
           resolve(collection);
         },
         error: function (response, error) {
+          self.trigger('errorAdd', response);
           reject(error);
         }
       });

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/data/data-content-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/data/data-content-view.js
@@ -179,7 +179,7 @@ module.exports = CoreView.extend({
           self._normalizeTimeSeriesColumn(model);
         }
 
-        return self._userActions.updateWidgetsOrder();
+        return self._userActions.updateWidgetsOrder(model);
       })
       .then(function () {
         self.render();

--- a/lib/assets/javascripts/builder/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layers-view.js
@@ -109,14 +109,25 @@ module.exports = CoreView.extend({
   },
 
   _createNotification: function (layerDefinitionModel) {
-    Notifier.addNotification({
+    var LAYER_ADDED_NOTIFICATION = 'layer-added';
+    var notification = Notifier.getNotification(LAYER_ADDED_NOTIFICATION);
+
+    var notificationAttrs = {
       status: 'success',
       info: _t('notifications.layer.added_pluralize', {
         smart_count: Notifier.getCount()
       }),
       closable: true,
       delay: Notifier.DEFAULT_DELAY
-    });
+    };
+
+    if (notification) {
+      notification.set(notificationAttrs);
+    } else {
+      Notifier.addNotification(_.extend(notificationAttrs, {
+        id: LAYER_ADDED_NOTIFICATION
+      }));
+    }
   },
 
   _addLayerView: function (model) {

--- a/lib/assets/javascripts/builder/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layers-view.js
@@ -108,11 +108,11 @@ module.exports = CoreView.extend({
     modal.show();
   },
 
-  _createNotification: function (m) {
+  _createNotification: function (layerDefinitionModel) {
     Notifier.addNotification({
       status: 'success',
-      info: _t('notifications.layer.added', {
-        name: m.getName()
+      info: _t('notifications.layer.added_pluralize', {
+        smart_count: Notifier.getCount()
       }),
       closable: true,
       delay: Notifier.DEFAULT_DELAY

--- a/lib/assets/javascripts/builder/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layers-view.js
@@ -114,9 +114,7 @@ module.exports = CoreView.extend({
 
     var notificationAttrs = {
       status: 'success',
-      info: _t('notifications.layer.added_pluralize', {
-        smart_count: Notifier.getCount()
-      }),
+      info: _t('notifications.layer.added'),
       closable: true,
       delay: Notifier.DEFAULT_DELAY
     };

--- a/lib/assets/javascripts/builder/widgets-notifications.js
+++ b/lib/assets/javascripts/builder/widgets-notifications.js
@@ -45,7 +45,9 @@ var WidgetsNotifications = {
 
     var notificationAttrs = {
       status: 'success',
-      info: _t('notifications.widgets.delete'),
+      info: _t('notifications.widgets.delete_pluralize', {
+        smart_count: Notifier.getCount()
+      }),
       closable: true,
       delay: Notifier.DEFAULT_DELAY
     };
@@ -56,7 +58,9 @@ var WidgetsNotifications = {
     var notificationId = widgetOptionModel.cid;
     var notificationAttrs = {
       status: 'success',
-      info: _t('notifications.widgets.add'),
+      info: _t('notifications.widgets.add_pluralize', {
+        smart_count: Notifier.getCount()
+      }),
       closable: true
     };
     this._addOrUpdateNotification(notificationId, notificationAttrs);
@@ -66,7 +70,9 @@ var WidgetsNotifications = {
     var notificationId = widgetOptionModel.cid;
     var notificationAttrs = {
       status: 'success',
-      info: _t('notifications.widgets.replace'),
+      info: _t('notifications.widgets.replace_pluralize', {
+        smart_count: Notifier.getCount()
+      }),
       closable: true
     };
     this._addOrUpdateNotification(notificationId, notificationAttrs);

--- a/lib/assets/javascripts/builder/widgets-notifications.js
+++ b/lib/assets/javascripts/builder/widgets-notifications.js
@@ -3,6 +3,15 @@ var Notifier = require('builder/components/notifier/notifier');
 var errorParser = require('builder/helpers/error-parser');
 
 var NOTIFICATION_ERROR_TEMPLATE = _.template("<span class='u-errorTextColor'><%- title %></span>");
+var ADD_NOTIFICATION_ID = 'add-notification';
+var NOTIFICATION_STATUS = {
+  loading: 'loading',
+  updating: 'loading',
+  added: 'success',
+  removed: 'success',
+  replaced: 'success',
+  error: 'error'
+};
 
 var WidgetsNotifications = {
 
@@ -11,31 +20,33 @@ var WidgetsNotifications = {
     this._widgetDefinitionsCollection.on('successAdd', this._showAddNotification, this);
     this._widgetDefinitionsCollection.on('successReplace', this._showReplaceNotification, this);
     this._widgetDefinitionsCollection.on('destroy', this._showRemoveNotification, this);
-    this._widgetDefinitionsCollection.on('error', this._showErrorNotification, this);
+    this._widgetDefinitionsCollection.on('errorAdd', this._showErrorNotification, this);
     this._widgetDefinitionsCollection.on('loading', this._showLoadingNotification, this);
     this._widgetDefinitionsCollection.on('updating', this._showUpdatingNotification, this);
   },
 
-  _showLoadingNotification: function (widgetOptionModel) {
-    var notificationId = widgetOptionModel.cid;
+  _showLoadingNotification: function (widgets) {
     var notificationAttrs = {
-      status: 'loading',
-      info: _t('notifications.widgets.loading'),
+      status: NOTIFICATION_STATUS.loading,
+      info: _t('notifications.widgets.loading_pluralize', {
+        smart_count: widgets && widgets.length ? widgets.length : 1
+      }),
       closable: false
     };
 
-    this._addNotification(notificationId, notificationAttrs);
+    this._addNotification(ADD_NOTIFICATION_ID, notificationAttrs);
   },
 
-  _showUpdatingNotification: function (widgetOptionModel) {
-    var notificationId = widgetOptionModel.cid;
+  _showUpdatingNotification: function (widgets) {
     var notificationAttrs = {
-      status: 'loading',
-      info: _t('notifications.widgets.updating'),
+      status: NOTIFICATION_STATUS.updating,
+      info: _t('notifications.widgets.updating_pluralize', {
+        smart_count: widgets && widgets.length ? widgets.length : 1
+      }),
       closable: false
     };
 
-    this._addNotification(notificationId, notificationAttrs);
+    this._addNotification(ADD_NOTIFICATION_ID, notificationAttrs);
   },
 
   _showRemoveNotification: function (widgetModel) {
@@ -44,48 +55,48 @@ var WidgetsNotifications = {
     }
 
     var notificationAttrs = {
-      status: 'success',
+      status: NOTIFICATION_STATUS.removed,
       info: _t('notifications.widgets.delete_pluralize', {
-        smart_count: Notifier.getCount()
+        smart_count: 1
       }),
       closable: true,
       delay: Notifier.DEFAULT_DELAY
     };
-    this._addNotification(widgetModel.cid, notificationAttrs);
+
+    this._addNotification(ADD_NOTIFICATION_ID, notificationAttrs);
   },
 
-  _showAddNotification: function (widgetOptionModel) {
-    var notificationId = widgetOptionModel.cid;
+  _showAddNotification: function (widgets) {
     var notificationAttrs = {
-      status: 'success',
+      status: NOTIFICATION_STATUS.added,
       info: _t('notifications.widgets.add_pluralize', {
-        smart_count: Notifier.getCount()
+        smart_count: widgets && widgets.length ? widgets.length : 1
       }),
       closable: true
     };
-    this._addOrUpdateNotification(notificationId, notificationAttrs);
+
+    this._addOrUpdateNotification(ADD_NOTIFICATION_ID, notificationAttrs);
   },
 
-  _showReplaceNotification: function (widgetOptionModel) {
-    var notificationId = widgetOptionModel.cid;
+  _showReplaceNotification: function (widgets) {
     var notificationAttrs = {
-      status: 'success',
+      status: NOTIFICATION_STATUS.replaced,
       info: _t('notifications.widgets.replace_pluralize', {
-        smart_count: Notifier.getCount()
+        smart_count: widgets && widgets.length ? widgets.length : 1
       }),
       closable: true
     };
-    this._addOrUpdateNotification(notificationId, notificationAttrs);
+
+    this._addOrUpdateNotification(ADD_NOTIFICATION_ID, notificationAttrs);
   },
 
-  _showErrorNotification: function (widgetOptionModel, error) {
+  _showErrorNotification: function (data, error) {
     if (this._isAbortion(error)) {
       return;
     }
 
-    var notificationId = widgetOptionModel.cid;
     var notificationAttrs = {
-      status: 'error',
+      status: NOTIFICATION_STATUS.error,
       info: _t('notifications.widgets.error.body', {
         body: NOTIFICATION_ERROR_TEMPLATE({
           title: _t('notifications.widgets.error.title')
@@ -94,11 +105,13 @@ var WidgetsNotifications = {
       }),
       closable: true
     };
-    this._addOrUpdateNotification(notificationId, notificationAttrs);
+
+    this._addOrUpdateNotification(ADD_NOTIFICATION_ID, notificationAttrs);
   },
 
   _addOrUpdateNotification: function (notificationId, notificationAttrs) {
     var notification = this._getNotification(notificationId);
+
     if (notification) {
       notification.set(notificationAttrs);
     } else {
@@ -110,6 +123,7 @@ var WidgetsNotifications = {
     notificationAttrs = _.extend({
       id: notificationId
     }, notificationAttrs);
+
     Notifier.addNotification(notificationAttrs);
   },
 

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -2799,8 +2799,7 @@
     },
     "layer": {
       "error": "Layer error: %{error}",
-      "added": "Layer added successfully",
-      "added_pluralize": "Layer added successfully |||| Layers added successfully"
+      "added": "Layer added successfully"
     },
     "cartocss": {
       "error": {

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -2782,9 +2782,10 @@
       }
     },
     "widgets": {
-      "add": "Widget successfully added",
+      "add_pluralize": "Widget successfully added |||| Widgets successfully added",
       "replace": "Widget successfully replaced",
-      "delete": "Widget deleted correctly",
+      "replace_pluralize": "Widget successfully replaced |||| Widgets successfully replaced",
+      "delete_pluralize": "Widget deleted correctly",
       "error": {
         "title": "Error adding widget:",
         "body": "%{body} %{error}"
@@ -2796,7 +2797,8 @@
     },
     "layer": {
       "error": "Layer error: %{error}",
-      "added": "Layer added successfully"
+      "added": "Layer added successfully",
+      "added_pluralize": "Layer added successfully |||| Layers added successfully"
     },
     "cartocss": {
       "error": {

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -2785,13 +2785,15 @@
       "add_pluralize": "Widget successfully added |||| Widgets successfully added",
       "replace": "Widget successfully replaced",
       "replace_pluralize": "Widget successfully replaced |||| Widgets successfully replaced",
-      "delete_pluralize": "Widget deleted correctly",
+      "delete_pluralize": "Widget deleted correctly |||| Widgets deleted correctly",
       "error": {
         "title": "Error adding widget:",
         "body": "%{body} %{error}"
       },
       "loading": "Adding widget…",
+      "loading_pluralize": "Adding widget… |||| Adding widgets...",
       "updating": "Updating widget…",
+      "updating_pluralize": "Updating widget… |||| Updating widgets...",
       "restoring": "Restoring widgets…",
       "restored": "Widgets restored"
     },

--- a/lib/assets/test/spec/builder/components/modals/add-widgets/category-option-model.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-widgets/category-option-model.spec.js
@@ -54,15 +54,6 @@ describe('components/modals/add-widgets/category/category-option-model', functio
     expect(model.get('type')).toEqual('category');
   });
 
-  it('should trigger a loading state', function () {
-    spyOn(widgetDefinitionsCollection, 'addWidget').and.returnValue(true);
-    var triggerLoadingSpy = spyOn(widgetDefinitionsCollection, 'trigger').and.callThrough();
-
-    model.save(widgetDefinitionsCollection);
-
-    expect(triggerLoadingSpy).toHaveBeenCalledWith('loading', model);
-  });
-
   it('should return the result of the "addWidget" function from the given widgetDefinitionsCollection', function () {
     var addWidgetSpy = spyOn(widgetDefinitionsCollection, 'addWidget').and.returnValue(true);
 

--- a/lib/assets/test/spec/builder/components/modals/add-widgets/formula-option-model.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-widgets/formula-option-model.spec.js
@@ -54,15 +54,6 @@ describe('components/modals/add-widgets/formula/formula-option-model', function 
     expect(model.get('type')).toEqual('formula');
   });
 
-  it('should trigger a loading state', function () {
-    spyOn(widgetDefinitionsCollection, 'addWidget').and.returnValue(true);
-    var triggerLoadingSpy = spyOn(widgetDefinitionsCollection, 'trigger').and.callThrough();
-
-    model.save(widgetDefinitionsCollection);
-
-    expect(triggerLoadingSpy).toHaveBeenCalledWith('loading', model);
-  });
-
   it('should return the result of the "addWidget" function from the given widgetDefinitionsCollection', function () {
     var addWidgetSpy = spyOn(widgetDefinitionsCollection, 'addWidget').and.returnValue(true);
 

--- a/lib/assets/test/spec/builder/components/modals/add-widgets/histogram-option-model.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-widgets/histogram-option-model.spec.js
@@ -54,15 +54,6 @@ describe('components/modals/add-widgets/histogram/histogram-option-model', funct
     expect(model.get('type')).toEqual('histogram');
   });
 
-  it('should trigger a loading state', function () {
-    spyOn(widgetDefinitionsCollection, 'addWidget').and.returnValue(true);
-    var triggerLoadingSpy = spyOn(widgetDefinitionsCollection, 'trigger').and.callThrough();
-
-    model.save(widgetDefinitionsCollection);
-
-    expect(triggerLoadingSpy).toHaveBeenCalledWith('loading', model);
-  });
-
   it('should return the result of the "addWidget" function from the given widgetDefinitionsCollection', function () {
     var addWidgetSpy = spyOn(widgetDefinitionsCollection, 'addWidget').and.returnValue(true);
 

--- a/lib/assets/test/spec/builder/components/modals/add-widgets/time-series-option-model.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-widgets/time-series-option-model.spec.js
@@ -54,15 +54,6 @@ describe('components/modals/add-widgets/time-series/time-series-option-model', f
     expect(model.get('type')).toEqual('time-series');
   });
 
-  it('should trigger a loading state', function () {
-    spyOn(widgetDefinitionsCollection, 'addWidget').and.returnValue(true);
-    var triggerLoadingSpy = spyOn(widgetDefinitionsCollection, 'trigger').and.callThrough();
-
-    model.save(widgetDefinitionsCollection);
-
-    expect(triggerLoadingSpy).toHaveBeenCalledWith('loading', model);
-  });
-
   it('should return the result of the "addWidget" function from the given widgetDefinitionsCollection', function () {
     var addWidgetSpy = spyOn(widgetDefinitionsCollection, 'addWidget').and.returnValue(true);
 

--- a/lib/assets/test/spec/builder/components/notifier/notifier-collection.spec.js
+++ b/lib/assets/test/spec/builder/components/notifier/notifier-collection.spec.js
@@ -4,7 +4,8 @@ describe('components/notifier/notifier-collection', function () {
   beforeEach(function () {
     this.collection = new NotifierCollection();
     this.collection.add({
-      id: 'foo'
+      id: 'foo',
+      info: 'Test'
     });
   });
 
@@ -21,5 +22,25 @@ describe('components/notifier/notifier-collection', function () {
     var model = this.collection.findById('foo');
     this.collection.remove(model);
     expect(this.collection.length).toBe(0);
+  });
+
+  describe('.addNotification', function () {
+    it('should add a notification if there are no other notifications with the same info', function () {
+      this.collection.addNotification({
+        id: 'Test 1',
+        info: 'Test 1'
+      });
+
+      expect(this.collection.size()).toEqual(2);
+    });
+
+    it('should not add a notification if there is another notification with the same info', function () {
+      this.collection.addNotification({
+        id: 'Test 1',
+        info: 'Test'
+      });
+
+      expect(this.collection.size()).toEqual(1);
+    });
   });
 });

--- a/lib/assets/test/spec/builder/components/notifier/notifier.spec.js
+++ b/lib/assets/test/spec/builder/components/notifier/notifier.spec.js
@@ -132,4 +132,18 @@ describe('components/notifier/notifier', function () {
       expect(Notifier.getCount()).toBe(3);
     });
   });
+
+  describe('.addNotification', function () {
+    it('should call collection.addNotification', function () {
+      spyOn(this.model.collection, 'addNotification');
+
+      Notifier.addNotification({
+        status: 'success',
+        info: 'First',
+        closable: true
+      });
+
+      expect(this.model.collection.addNotification).toHaveBeenCalled();
+    });
+  });
 });

--- a/lib/assets/test/spec/builder/components/notifier/notifier.spec.js
+++ b/lib/assets/test/spec/builder/components/notifier/notifier.spec.js
@@ -117,13 +117,13 @@ describe('components/notifier/notifier', function () {
 
   describe('.getCount', function () {
     it('should return the collection size', function () {
-      var n1 = Notifier.addNotification({
+      Notifier.addNotification({
         status: 'success',
         info: 'First',
         closable: true
       });
 
-      var n2 = Notifier.addNotification({
+      Notifier.addNotification({
         status: 'error',
         info: 'Second',
         closable: true

--- a/lib/assets/test/spec/builder/components/notifier/notifier.spec.js
+++ b/lib/assets/test/spec/builder/components/notifier/notifier.spec.js
@@ -39,6 +39,7 @@ describe('components/notifier/notifier', function () {
 
   it('should return the view properly', function () {
     expect(Notifier.getView()).toBeDefined();
+    expect(Notifier.getCount()).toBeDefined();
   });
 
   it('should set collection properly', function () {
@@ -112,5 +113,23 @@ describe('components/notifier/notifier', function () {
     var result = Notifier.getNotification('whatever');
     Notifier.removeNotification(result);
     expect(Notifier.getCollection().length).toBe(0);
+  });
+
+  describe('.getCount', function () {
+    it('should return the collection size', function () {
+      var n1 = Notifier.addNotification({
+        status: 'success',
+        info: 'First',
+        closable: true
+      });
+
+      var n2 = Notifier.addNotification({
+        status: 'error',
+        info: 'Second',
+        closable: true
+      });
+
+      expect(Notifier.getCount()).toBe(3);
+    });
   });
 });

--- a/lib/assets/test/spec/builder/data/widget-definitions-collection.spec.js
+++ b/lib/assets/test/spec/builder/data/widget-definitions-collection.spec.js
@@ -187,28 +187,24 @@ describe('data/widget-definitions-collection', function () {
     });
 
     it('should return a success response if it has been created successfully', function (done) {
-      var triggerSpy = spyOn(this.collection, 'trigger');
       var widgetModel = new Backbone.Model();
 
       callback = 'success';
 
       this.collection.addWidget(widgetModel, {})
         .then(function (response) {
-          expect(triggerSpy).toHaveBeenCalledWith('successAdd', widgetModel);
           expect(response).toEqual(successResponse);
           done();
         });
     });
 
     it('should return an error response if the it could not be created', function (done) {
-      var triggerSpy = spyOn(this.collection, 'trigger');
       var widgetModel = new Backbone.Model();
 
       callback = 'error';
 
       this.collection.addWidget(widgetModel, {})
         .catch(function (response) {
-          expect(triggerSpy).toHaveBeenCalledWith('error', widgetModel, errorResponse);
           expect(response).toEqual(errorResponse);
           done();
         });
@@ -246,6 +242,43 @@ describe('data/widget-definitions-collection', function () {
 
     beforeEach(function () {
       spyOn(Backbone, 'sync').and.callFake(syncFn);
+    });
+
+    it('should trigger a loading event when called', function () {
+      var testModel = new Backbone.Model();
+
+      spyOn(this.collection, 'trigger');
+      this.collection.saveAsync(testModel);
+
+      expect(this.collection.trigger).toHaveBeenCalledWith('loading', testModel);
+    });
+
+    it('should trigger "errorAdd" if the save function has not worked', function (done) {
+      var testModel = new Backbone.Model();
+
+      callback = 'error';
+
+      spyOn(this.collection, 'trigger');
+      this.collection.saveAsync(testModel);
+
+      setTimeout(function () {
+        expect(this.collection.trigger).toHaveBeenCalledWith('errorAdd', 'error');
+        done();
+      }.bind(this));
+    });
+
+    it('should trigger "successAdd" if the save function has worked', function (done) {
+      var testModel = new Backbone.Model();
+
+      callback = 'success';
+
+      spyOn(this.collection, 'trigger');
+      this.collection.saveAsync(testModel);
+
+      setTimeout(function () {
+        expect(this.collection.trigger).toHaveBeenCalledWith('successAdd', testModel);
+        done();
+      }.bind(this));
     });
 
     it('should return a resolved promise if the save function works', function (done) {

--- a/lib/assets/test/spec/builder/editor/layers/layers-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layers-view.spec.js
@@ -139,7 +139,7 @@ describe('editor/layers/layers-view', function () {
 
       var args = NotifierCollection.prototype.add.calls.mostRecent().args[0];
 
-      expect(args.info).toEqual('notifications.layer.added_pluralize');
+      expect(args.info).toEqual('notifications.layer.added');
       expect(_.size(this.view._subviews)).toEqual(4);
     });
   });

--- a/lib/assets/test/spec/builder/editor/layers/layers-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layers-view.spec.js
@@ -1,4 +1,5 @@
 var $ = require('jquery');
+var _ = require('underscore');
 var Backbone = require('backbone');
 var ModalsServiceModel = require('builder/components/modals/modals-service-model');
 var StackLayoutModel = require('builder/components/stack-layout/stack-layout-model');
@@ -9,6 +10,7 @@ var LayersView = require('builder/editor/layers/layers-view');
 var EditorModel = require('builder/data/editor-model');
 var ConfigModel = require('builder/data/config-model');
 var UserModel = require('builder/data/user-model');
+var NotifierCollection = require('builder/components/notifier/notifier-collection.js');
 
 describe('editor/layers/layers-view', function () {
   beforeEach(function () {
@@ -119,6 +121,26 @@ describe('editor/layers/layers-view', function () {
     it('should add all layer views but labels layer', function () {
       var n = this.layerDefinitionsCollection.size();
       expect(this.view._layerViewFactory.createLayerView).toHaveBeenCalledTimes(n - 1);
+    });
+
+    it('should show a notification when the layer is added', function () {
+      spyOn(NotifierCollection.prototype, 'add');
+
+      expect(_.size(this.view._subviews)).toEqual(3);
+
+      this.layerDefinitionsCollection.add({
+        id: 'l-2',
+        options: {
+          type: 'torque',
+          table_name: 'fee',
+          source: 'a1'
+        }
+      });
+
+      var args = NotifierCollection.prototype.add.calls.mostRecent().args[0];
+
+      expect(args.info).toEqual('notifications.layer.added_pluralize');
+      expect(_.size(this.view._subviews)).toEqual(4);
     });
   });
 

--- a/lib/assets/test/spec/builder/widgets-notifications.spec.js
+++ b/lib/assets/test/spec/builder/widgets-notifications.spec.js
@@ -1,4 +1,5 @@
 var widgetsNotifications = require('builder/widgets-notifications');
+var ADD_NOTIFICATION_ID = 'add-notification';
 
 describe('widget-notifications', function () {
   describe('._showErrorNotification', function () {
@@ -21,7 +22,7 @@ describe('widget-notifications', function () {
 
       widgetsNotifications._showAddNotification({ cid: '1234' });
 
-      expect(widgetsNotifications._addOrUpdateNotification).toHaveBeenCalledWith('1234', jasmine.objectContaining({
+      expect(widgetsNotifications._addOrUpdateNotification).toHaveBeenCalledWith(ADD_NOTIFICATION_ID, jasmine.objectContaining({
         info: _t('notifications.widgets.add_pluralize')
       }));
     });
@@ -33,7 +34,7 @@ describe('widget-notifications', function () {
 
       widgetsNotifications._showReplaceNotification({ cid: '1234' });
 
-      expect(widgetsNotifications._addOrUpdateNotification).toHaveBeenCalledWith('1234', jasmine.objectContaining({
+      expect(widgetsNotifications._addOrUpdateNotification).toHaveBeenCalledWith(ADD_NOTIFICATION_ID, jasmine.objectContaining({
         info: _t('notifications.widgets.replace_pluralize')
       }));
     });

--- a/lib/assets/test/spec/builder/widgets-notifications.spec.js
+++ b/lib/assets/test/spec/builder/widgets-notifications.spec.js
@@ -22,7 +22,7 @@ describe('widget-notifications', function () {
       widgetsNotifications._showAddNotification({ cid: '1234' });
 
       expect(widgetsNotifications._addOrUpdateNotification).toHaveBeenCalledWith('1234', jasmine.objectContaining({
-        info: _t('notifications.widgets.add')
+        info: _t('notifications.widgets.add_pluralize')
       }));
     });
   });
@@ -34,7 +34,7 @@ describe('widget-notifications', function () {
       widgetsNotifications._showReplaceNotification({ cid: '1234' });
 
       expect(widgetsNotifications._addOrUpdateNotification).toHaveBeenCalledWith('1234', jasmine.objectContaining({
-        info: _t('notifications.widgets.replace')
+        info: _t('notifications.widgets.replace_pluralize')
       }));
     });
   });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.95-13407-01",
+  "version": "4.11.95",
   "dependencies": {
     "accessory": {
       "version": "1.0.1",
@@ -321,6 +321,11 @@
         }
       }
     },
+    "buffer-from": {
+      "version": "1.0.0",
+      "from": "buffer-from@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz"
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "from": "buffer-xor@>=1.0.3 <2.0.0",
@@ -382,9 +387,9 @@
       "resolved": "https://registry.npmjs.org/cartodb-pecan/-/cartodb-pecan-0.2.0.tgz"
     },
     "cartodb.js": {
-      "version": "4.0.0-beta.35",
-      "from": "cartodb/cartodb.js#v4.0.0-beta.35",
-      "resolved": "git://github.com/cartodb/cartodb.js.git#e5f384f33635da1b6b029965a694fdbaa7afdf79"
+      "version": "4.0.0-beta.36",
+      "from": "cartodb/cartodb.js#v4.0.0-beta.36",
+      "resolved": "git://github.com/cartodb/cartodb.js.git#76e0b3de91ebfe8e9ee7b2e63ea6fca7a9bd25d8"
     },
     "center-align": {
       "version": "0.1.3",
@@ -404,9 +409,9 @@
       }
     },
     "chokidar": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "from": "chokidar@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz"
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -1162,14 +1167,19 @@
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz"
     },
     "insert-module-globals": {
-      "version": "7.0.2",
+      "version": "7.0.4",
       "from": "insert-module-globals@>=7.0.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.4.tgz",
       "dependencies": {
         "combine-source-map": {
           "version": "0.7.2",
           "from": "combine-source-map@>=0.7.1 <0.8.0",
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz"
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "from": "concat-stream@>=1.6.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz"
         }
       }
     },
@@ -1352,9 +1362,16 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
     },
     "labeled-stream-splicer": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "labeled-stream-splicer@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.4",
+          "from": "isarray@>=2.0.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz"
+        }
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -1449,9 +1466,9 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz"
     },
     "micromatch": {
-      "version": "3.1.9",
+      "version": "3.1.10",
       "from": "micromatch@>=3.1.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.9.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
@@ -2367,7 +2384,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "from": "to-regex@>=3.0.1 <4.0.0",
+      "from": "to-regex@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz"
     },
     "to-regex-range": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.86",
+  "version": "4.11.86-13407-01",
   "dependencies": {
     "accessory": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.95-13407-01",
+  "version": "4.11.95",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.86",
+  "version": "4.11.86-13407-01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related issues:
* https://github.com/CartoDB/onpremises/issues/515
* https://github.com/CartoDB/cartodb/issues/13407

This solutions avoids having multiple notifications with the same content by checking the "info" attribute before adding it. Also, both layers and widgets messages have been pluralized, so if there are several layers / widgets actions implied, it displays the information in plural. I think this is something we could improve, but it fixes the current issues. Please tell me if you think there is a better solution for this :)
![add_multiple_widgets](https://user-images.githubusercontent.com/3824953/37611569-f67894f8-2ba2-11e8-9acf-1ca7c1edb414.gif)


