### PR TITLE
Fix mobile apps asset upload

### DIFF
--- a/lib/assets/javascripts/dashboard/data/backbone/sync-options.js
+++ b/lib/assets/javascripts/dashboard/data/backbone/sync-options.js
@@ -22,7 +22,7 @@ var Backbone = require('backbone');
     if (!absoluteUrl) {
       // We need to fix this
       // this comes from cdb.config.prefixUrl
-      options.url = model._config.get('base_url') + url;
+      options.url = (model._configModel || model._config).get('base_url') + url;
     } else {
       options.url = url;
     }

--- a/lib/assets/javascripts/dashboard/mobile-apps.js
+++ b/lib/assets/javascripts/dashboard/mobile-apps.js
@@ -10,9 +10,10 @@ const AppPlatformsLegends = require('dashboard/components/app-platforms-legends'
 const UserModel = require('dashboard/data/user-model');
 const ConfigModel = require('dashboard/data/config-model');
 const ModalsServiceModel = require('builder/components/modals/modals-service-model');
+require('dashboard/data/backbone/sync-options');
 
 const configModel = new ConfigModel(
-  _.defaults({ base_url: window.base_url }, window.config)
+  _.defaults({ base_url: window.user_data.base_url }, window.config)
 );
 
 if (window.trackJs) {


### PR DESCRIPTION
This PR fixes the asset upload in mobile apps page when user belongs to an organization.

I provided a fallback to `sync-options` because it couldn't get `base_url` as it was in `_configModel` instead of `_config`.