### PR TITLE
Fix sql function error with sources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -154,6 +154,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix SQL function analysis error with dragged source (https://github.com/CartoDB/cartodb/pull/13732)
 * Fix histogram widgets collapsing (#13705)
 * Use Promises in query models to handle async states (#13478)
 * Fix "Add new analysis" button in IE (CartoDB/onpremises/issues/485)

--- a/lib/assets/javascripts/builder/components/modals/add-analysis/analysis-option-models/deprecated-sql-function-option-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-analysis/analysis-option-models/deprecated-sql-function-option-model.js
@@ -1,0 +1,22 @@
+var _ = require('underscore');
+var AnalysisOptionModel = require('./analysis-option-model');
+
+/**
+ * Custom model for deprecated SQL function type, to set correct primary source
+ */
+module.exports = AnalysisOptionModel.extend({
+
+  /**
+   * @override {AnalysisOptionModel.getNodeAttrs}
+   */
+  getFormAttrs: function (layerDefModel) {
+    var attrs = AnalysisOptionModel.prototype.getFormAttrs.apply(this, arguments);
+    delete attrs.source;
+
+    _.extend(attrs, {
+      primary_source: layerDefModel.get('source')
+    });
+
+    return attrs;
+  }
+});

--- a/lib/assets/javascripts/builder/data/analyses.js
+++ b/lib/assets/javascripts/builder/data/analyses.js
@@ -6,6 +6,7 @@ var FilterIntersectionFormModel = require('builder/editor/layers/layer-content-v
 var FallbackFormModel = require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/fallback-form-model');
 var UnknownTypeFormModel = require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/unknown-type-form-model');
 var MergeAnalysisOptionModel = require('builder/components/modals/add-analysis/analysis-option-models/merge-analysis-option-model');
+var DeprecatedSQLFunctionOptionModel = require('builder/components/modals/add-analysis/analysis-option-models/deprecated-sql-function-option-model');
 var DataServicesApiCheck = require('builder/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-info');
 
 var DAO_TYPES = ['age-and-gender', 'boundaries', 'education', 'employment', 'families', 'housing', 'income', 'language', 'migration', 'nationality', 'population-segments', 'race-and-ethnicity', 'religion', 'transportation'];
@@ -357,6 +358,7 @@ var MAP = {
     modalTitle: _t('components.modals.add-analysis.option-types.deprecated-sql-function.title'),
     modalDesc: _t('components.modals.add-analysis.option-types.deprecated-sql-function.desc'),
     modalCategory: 'data_transformation',
+    ModalModel: DeprecatedSQLFunctionOptionModel,
     checkIfEnabled: function (configModel, userModel) {
       return userModel.featureEnabled('deprecated-sql-function');
     }

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/base-analysis-form-model.js
@@ -34,7 +34,7 @@ module.exports = Backbone.Model.extend({
   },
 
   _getSourceOption: function () {
-    var sourceNodeDefModel = this._layerDefinitionModel.findAnalysisDefinitionNodeModel(this.get('source'));
+    var sourceNodeDefModel = this._getSourceNodeDefModel();
     var layerName = sourceNodeDefModel.isSourceType()
       ? this._layerDefinitionModel.getTableName()
       : this._layerDefinitionModel.getName();
@@ -47,6 +47,18 @@ module.exports = Backbone.Model.extend({
       color: sourceNodeDefModel.getColor(),
       isSourceType: sourceNodeDefModel.isSourceType()
     }];
+  },
+
+  _getSourceNodeDefModel: function () {
+    var sourceNames = ['source', 'primary_source'];
+    var sourceNodeDefModel = _.reduce(sourceNames, function (memo, sourceName) {
+      if (!memo) {
+        memo = this._layerDefinitionModel.findAnalysisDefinitionNodeModel(this.get(sourceName));
+      }
+      return memo;
+    }, null, this);
+
+    return sourceNodeDefModel;
   },
 
   _primarySourceSchemaItem: function (customLabel) {

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/deprecated-sql-function-form-model.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/deprecated-sql-function-form-model.js
@@ -36,7 +36,6 @@ module.exports = BaseAnalysisFormModel.extend({
   },
 
   validate: function (attrs, options) {
-    this.set('primary_source', this.get('source'));
     this._serializeFunctionArgs();
 
     return BaseAnalysisFormModel.prototype.validate.call(this, attrs, options);
@@ -72,7 +71,7 @@ module.exports = BaseAnalysisFormModel.extend({
     var selectedFunction = this._getSelectedFunction();
 
     // Source
-    schema.source = this._primarySourceSchemaItem(_t('editor.layers.analysis-form.deprecated-sql-function.input'));
+    schema.primary_source = this._primarySourceSchemaItem(_t('editor.layers.analysis-form.deprecated-sql-function.input'));
 
     // Function
     schema.function_name = {

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/deprecated-sql-function.tpl
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/deprecated-sql-function.tpl
@@ -1,7 +1,7 @@
 <form>
   <div class="Editor-HeaderInfo">
     <div class="Editor-HeaderNumeration CDB-Text is-semibold u-rSpace--m">1</div>
-    <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="source,function_name">
+    <div class="Editor-HeaderInfo-inner CDB-Text" data-fields="primary_source,function_name">
       <div class="Editor-HeaderInfo-title u-bSpace--m">
         <h2 class="CDB-Text CDB-HeaderInfo-titleText CDB-Size-large"><%- _t('editor.layers.analysis-form.deprecated-sql-function.title') %></h2>
       </div>

--- a/lib/assets/test/spec/builder/components/modals/add-analysis/analysis-option-models/deprecated-sql-function-option-model.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-analysis/analysis-option-models/deprecated-sql-function-option-model.spec.js
@@ -1,0 +1,31 @@
+var Backbone = require('backbone');
+var AnalysisOptionModel = require('builder/components/modals/add-analysis/analysis-option-models/analysis-option-model');
+var SQLFunctionOptionModel = require('builder/components/modals/add-analysis/analysis-option-models/deprecated-sql-function-option-model');
+
+describe('deprecated-sql-function-option-model', function () {
+  var model;
+
+  beforeEach(function () {
+    spyOn(AnalysisOptionModel.prototype, 'getFormAttrs').and.returnValue({
+      source: 'y0' // Return always this `source` property. We need to check that it gets deleted.
+    });
+    model = new SQLFunctionOptionModel(null, {
+      nodeAttrs: {
+        key: 'value'
+      }
+    });
+  });
+
+  describe('getFormAttrs', function () {
+    it('should get form attributes, delete source and set primary_source with the layer definition attributes', function () {
+      var fakeLayerDefModel = new Backbone.Model({
+        source: 'z0'
+      });
+
+      var formAttrs = model.getFormAttrs(fakeLayerDefModel);
+
+      expect(AnalysisOptionModel.prototype.getFormAttrs).toHaveBeenCalledWith(fakeLayerDefModel);
+      expect(formAttrs).toEqual({ primary_source: 'z0' });
+    });
+  });
+});

--- a/lib/assets/test/spec/builder/data/analyses.spec.js
+++ b/lib/assets/test/spec/builder/data/analyses.spec.js
@@ -6,6 +6,7 @@ var DataServicesApiCheck = require('builder/editor/layers/layer-content-views/an
 var camshaftReference = require('camshaft-reference').getVersion('latest');
 var UnknownTypeFormModel = require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/unknown-type-form-model');
 var FallbackFormModel = require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/fallback-form-model');
+var DeprecatedSQLFunctionOptionModel = require('builder/components/modals/add-analysis/analysis-option-models/deprecated-sql-function-option-model');
 
 describe('builder/data/analyses', function () {
   Object.keys(analyses.MAP).forEach(function (key) {
@@ -21,6 +22,20 @@ describe('builder/data/analyses', function () {
       });
     });
   }, this);
+
+  describe('deprecated-sql-function analysis', function () {
+    it('should have ModalModel', function () {
+      var sqlAnalysis = analyses.MAP['deprecated-sql-function'];
+
+      var optionModel = new sqlAnalysis.ModalModel(null, {
+        nodeAttrs: {
+          key: 'value'
+        }
+      });
+
+      expect(optionModel instanceof DeprecatedSQLFunctionOptionModel).toBe(true);
+    });
+  });
 
   describe('getAnalysesByModalCategory', function () {
     beforeEach(function () {

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
@@ -164,6 +164,54 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/base-a
     });
   });
 
+  describe('._getSourceOption', function () {
+    it('should call to _getSourceNodeDefModel to retrieve the sourceNodeDefModel', function () {
+      var nodeDefModel = new Backbone.Model({
+        id: 'wutang'
+      });
+      nodeDefModel.isSourceType = function () { return true; };
+      nodeDefModel.getColor = function () { return 'magenta'; };
+      spyOn(this.model, '_getSourceNodeDefModel').and.returnValue(nodeDefModel);
+
+      var sourceOption = this.model._getSourceOption();
+
+      expect(sourceOption[0].val).toEqual(nodeDefModel.id);
+    });
+  });
+
+  describe('_getSourceNodeDefModel', function () {
+    beforeEach(function () {
+      this.model.set('source', 'a0', { silent: true });
+      this.model.set('primary_source', 'z1', { silent: true });
+    });
+
+    it('should return first the `source` node definition model', function () {
+      spyOn(this.model._layerDefinitionModel, 'findAnalysisDefinitionNodeModel').and.callFake(function (name) {
+        return name === 'a0'
+          ? 'the a0'
+          : name === 'z1'
+            ? 'the z1'
+            : null;
+      });
+
+      var sourceNodeDefModel = this.model._getSourceNodeDefModel();
+
+      expect(sourceNodeDefModel).toEqual('the a0');
+    });
+
+    it('should return the `primary_source` node definition model in case there is no `source`', function () {
+      spyOn(this.model._layerDefinitionModel, 'findAnalysisDefinitionNodeModel').and.callFake(function (name) {
+        return name === 'z1'
+          ? 'the z1'
+          : null;
+      });
+
+      var sourceNodeDefModel = this.model._getSourceNodeDefModel();
+
+      expect(sourceNodeDefModel).toEqual('the z1');
+    });
+  });
+
   describe('._getSourceOptionsForSource', function () {
     it('should throw error if no sourceAttrName provided', function () {
       var self = this;

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
@@ -188,7 +188,7 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/base-a
     it('should return first the `source` node definition model', function () {
       spyOn(this.model._layerDefinitionModel, 'findAnalysisDefinitionNodeModel').and.callFake(function (name) {
         return (name === 'a0' || name === 'z1')
-          ? 'the' + name
+          ? 'the ' + name
           : null;
       });
 

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/base-analysis-form-model.spec.js
@@ -187,11 +187,9 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/base-a
 
     it('should return first the `source` node definition model', function () {
       spyOn(this.model._layerDefinitionModel, 'findAnalysisDefinitionNodeModel').and.callFake(function (name) {
-        return name === 'a0'
-          ? 'the a0'
-          : name === 'z1'
-            ? 'the z1'
-            : null;
+        return (name === 'a0' || name === 'z1')
+          ? 'the' + name
+          : null;
       });
 
       var sourceNodeDefModel = this.model._getSourceNodeDefModel();

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/deprecated-sql-function-form-model.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/deprecated-sql-function-form-model.spec.js
@@ -81,10 +81,9 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/deprec
   });
 
   describe('.validate', function () {
-    it('should set primary source and serialize function arguments', function () {
+    it('should serialize function arguments', function () {
       var attrs = 'the attributes';
       var options = 'the options';
-      this.formModel.set('source', 'tatooine');
       var calls = [];
       spyOn(this.formModel, '_serializeFunctionArgs').and.callFake(function () {
         calls.push('serialize');
@@ -95,7 +94,6 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/deprec
 
       this.formModel.validate(attrs, options);
 
-      expect(this.formModel.get('primary_source')).toEqual('tatooine');
       expect(calls[0]).toEqual('serialize');
       expect(calls[1]).toEqual('validate');
     });
@@ -149,10 +147,10 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/deprec
 
       var schema = this.formModel._buildSchema();
 
-      // Source
-      expect(schema.source).toBeDefined();
-      expect(schema.source.title).toEqual('editor.layers.analysis-form.deprecated-sql-function.input');
-      expect(schema.source.type).toEqual('NodeDataset');
+      // Primary source
+      expect(schema.primary_source).toBeDefined();
+      expect(schema.primary_source.title).toEqual('editor.layers.analysis-form.deprecated-sql-function.input');
+      expect(schema.primary_source.type).toEqual('NodeDataset');
 
       // Secondary source
       expect(schema.secondary_source).toBeDefined();

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/deprecated-sql-function-form-template.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/deprecated-sql-function-form-template.spec.js
@@ -1,0 +1,15 @@
+var template = require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/deprecated-sql-function.tpl');
+
+describe('deprecated-sql-function-form-template', function () {
+  it('should have `primary_source` and `function_name` as data fields', function () {
+    var html = template({fields: []});
+
+    expect(html).toContain('data-fields="primary_source,function_name"');
+  });
+
+  it('should have the given data fields', function () {
+    var html = template({fields: ['secondary_source', 'radius']});
+
+    expect(html).toContain('data-fields="secondary_source,radius"');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.86",
+  "version": "4.11.86-1322",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/1322
----

This PR fixes a bug in SQL function analysis.

The problem is that the analysis set a `source` attribute but the analysis reference has `primary_source`. It only failed when drag & dropping the source node of the analysis to create another layer. The code has been modified to use the correct key `primary_source`.

There is code to make the existing analyses work.

### Acceptance

Please create SQL analysis **before** deploying so you can assert that this PR doesn't break existing analyses.