### PR TITLE
Hide map title on layer selector on certain breakpoints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -170,6 +170,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix a case where the layer selector was displaying incorrectly (https://github.com/CartoDB/support/issues/1430)
 * Skip canonical viz with missing tables from metadata export
 * Fix dialog footer in some modals (CartoDB/onpremises/issues/507)
 * Fix alignment for formula widget edit form (CartoDB/onpremises/issues/511)

--- a/app/assets/stylesheets/deep-insights/themes/scss/map/_embed.scss
+++ b/app/assets/stylesheets/deep-insights/themes/scss/map/_embed.scss
@@ -154,25 +154,13 @@ $cEmbedTabs-Shadow: rgba(0, 0, 0, 0.24);
     &.is-collapsed {
       margin-bottom: 24px;
     }
-
-    &.is-menu {
-      display: flex;
-    }
   }
 
   .CDB-Overlay-inner {
     margin-top: 0;
 
-    &.is-menu {
-      margin-top: 8px;
-    }
-
     .CDB-Embed-description {
       display: none;
-
-      &.is-menu {
-        display: block;
-      }
     }
   }
 
@@ -204,19 +192,11 @@ $cEmbedTabs-Shadow: rgba(0, 0, 0, 0.24);
 
   .CDB-Overlay-title {
     display: none;
-
-    &.is-menu {
-      display: flex;
-    }
   }
 
   .CDB-Overlay-inner {
     .CDB-Embed-description {
       display: none;
-
-      &.is-menu {
-        display: block;
-      }
     }
   }
 

--- a/lib/assets/javascripts/builder/embed/embed-overlay.tpl
+++ b/lib/assets/javascripts/builder/embed/embed-overlay.tpl
@@ -1,4 +1,4 @@
-<div class="CDB-Overlay-title<% if (!description && !legends) { %> is-collapsed<% } %><% if (!showMenu) { %> is-menu<% } %>">
+<div class="CDB-Overlay-title<% if (!description && !legends) { %> is-collapsed<% } %>">
   <h1 class="CDB-Text CDB-Size-large u-ellipsis" title="<%= title %>"><%= title %></h1>
 
   <% if (description || legends) { %>
@@ -11,7 +11,7 @@
 </div>
 
 <% if (description || legends) { %>
-  <div class="CDB-Overlay-inner is-active<% if (!legends) { %> is-description<% } %><% if (!showMenu) { %> is-menu<% } %>">
-    <% if (description) { %><div class="CDB-Embed-description<% if (legends) { %> is-legends<% } %><% if (!showMenu) { %> is-menu<% } %> CDB-Text CDB-Size-medium u-altTextColor" title="<%= description %>"><%= description %></div><% } %>
+  <div class="CDB-Overlay-inner is-active<% if (!legends) { %> is-description<% } %>">
+    <% if (description) { %><div class="CDB-Embed-description<% if (legends) { %> is-legends<% } %> CDB-Text CDB-Size-medium u-altTextColor" title="<%= description %>"><%= description %></div><% } %>
   </div>
 <% } %>

--- a/lib/assets/javascripts/builder/embed/embed-view.js
+++ b/lib/assets/javascripts/builder/embed/embed-view.js
@@ -19,6 +19,7 @@ var TAB_TITLES = {
 };
 
 var MOBILE_VIEWPORT_BREAKPOINT = 599;
+var FULLSCREEN_VIEWPORT_BREAKPOINT = 1199;
 
 var REQUIRED_OPTS = [
   'title',
@@ -106,14 +107,14 @@ var EmbedView = CoreView.extend({
   injectTitle: function (mapEl) {
     var legendsEl = mapEl.find('.CDB-Legends-canvasInner');
 
-    var titleView = new EmbedOverlayView({
+    this.titleView = new EmbedOverlayView({
       title: this._title,
       description: this._description,
       showMenu: this._showMenu
     });
-    this.addView(titleView);
+    this.addView(this.titleView);
 
-    legendsEl.prepend(titleView.render().el);
+    legendsEl.prepend(this.titleView.render().el);
 
     legendsEl.find('.CDB-LayerLegends')
       .detach()
@@ -123,6 +124,10 @@ var EmbedView = CoreView.extend({
   onWindowResized: function () {
     if (window.innerWidth > MOBILE_VIEWPORT_BREAKPOINT && this._tabsModel.get('selected') !== TAB_NAMES.map) {
       this._tabsModel.set({ selected: TAB_NAMES.map });
+    }
+
+    if (this.titleView && window.innerWidth > FULLSCREEN_VIEWPORT_BREAKPOINT) {
+      this.titleView.model.set('collapsed', false);
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.106",
+  "version": "4.11.106-1430",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.106-1430",
+  "version": "4.11.106",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/vendor/assets/stylesheets/cartodb.css
+++ b/vendor/assets/stylesheets/cartodb.css
@@ -107,6 +107,224 @@
     }
   }
   /**
+   *  CartoDB infowindow light styles
+   */
+
+  div.cartodb-popup h4 {
+    color:#CCCCCC;
+  }
+
+  div.cartodb-popup p {
+    color:#333333;
+  }
+
+  div.cartodb-popup p.loading {
+    color:#888;
+  }
+
+  div.cartodb-popup p.error {
+    color:#FF7F7F;
+  }
+
+  div.cartodb-popup p.empty {
+    color:#999999;
+  }
+/**
+ *  CartoDB green header popup styles
+ */
+
+div.cartodb-popup.header.green div.cartodb-popup-header {
+  background:url('../img/headers.png') no-repeat -252px -40px;
+}
+
+div.cartodb-popup.header.green div.cartodb-popup-header h4 {
+  color:#00916D;
+}
+
+div.cartodb-popup.header.green div.cartodb-popup-header span.separator {
+  background:#008E6A;
+}
+
+div.cartodb-popup.header.green a.cartodb-popup-close-button {
+  background:url('../img/headers.png') no-repeat -478px -40px;
+}
+
+div.cartodb-popup.header.green a.cartodb-popup-close-button:hover {
+  background-position:-478px -66px;
+}
+
+
+/* NEW CartoDB 2.0 green header popups */
+
+div.cartodb-popup.v2.header.green div.cartodb-popup-header {
+  background: none;
+  background: -ms-linear-gradient(top, #00CC99, #00B185); 
+  background: -o-linear-gradient(right, #00CC99, #00B185);
+  background: -webkit-linear-gradient(top, #00CC99, #00B185); 
+  background: -moz-linear-gradient(right, #00CC99, #00B185);
+  -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#00CC99',endColorStr='#00B185',GradientType=0)";
+}
+
+div.cartodb-popup.v2.header.green a.cartodb-popup-close-button {
+  background:white;
+}
+
+div.cartodb-popup.v2.header.green a.cartodb-popup-close-button:before,
+div.cartodb-popup.v2.header.green a.cartodb-popup-close-button:after {
+  background:#00CC99;
+}
+
+/* Hello IE */
+@media \0screen\,screen\9 {
+  div.cartodb-popup.v2.header.green a.cartodb-popup-close-button {
+    color:#00CC99;
+  }
+}
+/**
+ *  CartoDB blue header popup styles
+ */
+
+div.cartodb-popup.header.blue div.cartodb-popup-header {
+  background:url('../img/headers.png') no-repeat 0 -40px;
+}
+
+div.cartodb-popup.header.blue.header .cartodb-popup-header a {
+  color:white;
+}
+
+div.cartodb-popup.header.blue div.cartodb-popup-header h4 {
+  color:#1F4C7F;
+}
+
+div.cartodb-popup.header.blue div.cartodb-popup-header span.separator {
+  background:#225386;
+}
+
+div.cartodb-popup.header.blue a.cartodb-popup-close-button {
+  background:url('../img/headers.png') no-repeat -226px -40px;
+}
+
+div.cartodb-popup.header.blue a.cartodb-popup-close-button:hover {
+  background-position:-226px -66px;
+}
+
+
+/* NEW CartoDB 2.0 blue header popups */
+
+div.cartodb-popup.v2.header.blue div.cartodb-popup-header {
+  background: none;
+  background: -ms-linear-gradient(top, #4F9CD7, #2B68A8); 
+  background: -o-linear-gradient(right, #4F9CD7, #2B68A8);
+  background: -webkit-linear-gradient(top, #4F9CD7, #2B68A8); 
+  background: -moz-linear-gradient(right, #4F9CD7, #2B68A8);
+  -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#4F9CD7',endColorStr='#2B68A8',GradientType=0)";
+}
+
+div.cartodb-popup.v2.header.blue a.cartodb-popup-close-button {
+  background:white;
+}
+/**
+ *  CartoDB orange header popup styles
+ */
+
+div.cartodb-popup.header.orange div.cartodb-popup-header {
+  background:url('../img/headers.png') no-repeat -756px -40px;
+}
+
+div.cartodb-popup.header.orange div.cartodb-popup-header h4 {
+  color:#CC2929;
+}
+
+div.cartodb-popup.header.orange div.cartodb-popup-header span.separator {
+  background:#CC2929;
+}
+
+div.cartodb-popup.header.orange a.cartodb-popup-close-button {
+  background:url('../img/headers.png') no-repeat -982px -40px;
+}
+
+div.cartodb-popup.header.orange a.cartodb-popup-close-button:hover {
+  background-position:-982px -66px;
+}
+
+
+/* NEW CartoDB 2.0 orange header popups */
+
+div.cartodb-popup.v2.header.orange div.cartodb-popup-header {
+  background: none;
+  background: -ms-linear-gradient(top, #FF6825, #FF3333); 
+  background: -o-linear-gradient(right, #FF6825, #FF3333);
+  background: -webkit-linear-gradient(top, #FF6825, #FF3333); 
+  background: -moz-linear-gradient(right, #FF6825, #FF3333);
+  -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#FF6825',endColorStr='#FF3333',GradientType=0)";
+}
+
+div.cartodb-popup.v2.header.orange a.cartodb-popup-close-button {
+  background:white;
+}
+
+div.cartodb-popup.v2.header.orange a.cartodb-popup-close-button:before,
+div.cartodb-popup.v2.header.orange a.cartodb-popup-close-button:after {
+  background:#CC2929;
+}
+
+/* Hello IE */
+@media \0screen\,screen\9 {
+  div.cartodb-popup.v2.header.orange a.cartodb-popup-close-button {
+    color:#CC2929;
+  }
+}
+/**
+ *  CartoDB yellow header popup styles
+ */
+
+div.cartodb-popup.header.yellow div.cartodb-popup-header {
+  background:url('../img/headers.png') no-repeat -504px -40px;
+}
+
+div.cartodb-popup.header.yellow div.cartodb-popup-header h4 {
+  color:#D8832A;
+}
+
+div.cartodb-popup.header.yellow div.cartodb-popup-header span.separator {
+  background:#CC7A29;
+}
+
+div.cartodb-popup.header.yellow a.cartodb-popup-close-button {
+  background:url('../img/headers.png') no-repeat -730px -40px;
+}
+
+div.cartodb-popup.header.yellow a.cartodb-popup-close-button:hover {
+  background-position:-730px -66px;
+}
+
+/* NEW CartoDB 2.0 yellow header popups */
+
+div.cartodb-popup.v2.header.yellow div.cartodb-popup-header {
+  background: none;
+  background: -ms-linear-gradient(top, #FFBF0D, #FF9933); 
+  background: -o-linear-gradient(right, #FFBF0D, #FF9933);
+  background: -webkit-linear-gradient(top, #FFBF0D, #FF9933); 
+  background: -moz-linear-gradient(right, #FFBF0D, #FF9933);
+  -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#FFBF0D',endColorStr='#FF9933',GradientType=0)";
+}
+
+div.cartodb-popup.v2.header.yellow a.cartodb-popup-close-button {
+  background:white;
+}
+
+div.cartodb-popup.v2.header.yellow a.cartodb-popup-close-button:before,
+div.cartodb-popup.v2.header.yellow a.cartodb-popup-close-button:after {
+  background:#CC7A29;
+}
+
+/* Hello IE */
+@media \0screen\,screen\9 {
+  div.cartodb-popup.v2.header.yellow a.cartodb-popup-close-button {
+    color:#CC7A29;
+  }
+}
+  /**
    *  CartoDB popup styles (DEFAULT)
    */
 
@@ -655,49 +873,170 @@
     }
   }
 
-/**
- *  CartoDB blue header popup styles
- */
+  /**
+   *  CartoDB header with-image popup styles
+   */
 
-div.cartodb-popup.header.blue div.cartodb-popup-header {
-  background:url('../img/headers.png') no-repeat 0 -40px;
-}
+  div.cartodb-popup.header.with-image div.cartodb-popup-header {
+    position:relative;
 
-div.cartodb-popup.header.blue.header .cartodb-popup-header a {
-  color:white;
-}
+    background:url('../img/headers.png') no-repeat -1008px 0;
+    height:138px;
+    max-height:104px;
+  }
 
-div.cartodb-popup.header.blue div.cartodb-popup-header h4 {
-  color:#1F4C7F;
-}
+  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover {
+    display:block;
+    position:absolute;
+    overflow:hidden;
+    width: 218px;
+    height:135px;
+    top: 4px;
+    left: 4px;
+    border-radius: 4px 4px 0 0;
+  }
 
-div.cartodb-popup.header.blue div.cartodb-popup-header span.separator {
-  background:#225386;
-}
+  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover .shadow {
+    position:absolute;
+    width: 218px;
+    height:55px;
+    bottom: 0;
+    left: 0;
+    background:url('../img/shadow.png') no-repeat;
+    z-index: 100;
+  }
 
-div.cartodb-popup.header.blue a.cartodb-popup-close-button {
-  background:url('../img/headers.png') no-repeat -226px -40px;
-}
+  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover #spinner {
+    position:absolute;
+    top: 67px;
+    left: 109px;
+  }
 
-div.cartodb-popup.header.blue a.cartodb-popup-close-button:hover {
-  background-position:-226px -66px;
-}
+  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover img {
+    position:absolute;
+    border-radius: 4px 4px 0 0;
+    display:none;
+  }
+
+  div.cartodb-popup.header.with-image div.cartodb-popup-header .image_not_found {
+    position:absolute;
+    top: 15px;
+    left: 15px;
+    width: 200px;
+    display:none;
+  }
+
+  div.cartodb-popup.header.with-image div.cartodb-popup-header .image_not_found a {
+    display:-moz-inline-stack;display:inline-block;vertical-align:top;*vertical-align:auto;zoom:1;*display:inline;
+    margin: 3px 0 0 -2px;
+    color: #888888;
+    font-size:13px;
+    font-family: "Helvetica", "Helvetica Neue", Arial, sans-serif;
+    text-decoration: underline;
+  }
+
+  div.cartodb-popup.header.with-image div.cartodb-popup-header .image_not_found a:hover {
+    color: #888888;
+    text-decoration:underline;
+  }
+
+  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover .image_not_found i {
+    display:-moz-inline-stack;display:inline-block;vertical-align:top;*vertical-align:auto;zoom:1;*display:inline;
+    width: 31px;
+    height: 22px;
+    background:transparent url('../img/image_not_found.png');
+  }
+
+  div.cartodb-popup.header.with-image div.cartodb-popup-header h1 {
+    position:absolute;
+    bottom: 13px;
+    left: 18px;
+    width: 188px;
+    z-index: 150;
+  }
+
+  div.cartodb-popup.header.with-image div.cartodb-popup-header h4 {
+    color:#CCC;
+  }
+
+  div.cartodb-popup.header.with-image div.cartodb-popup-header span.separator {
+    background:#CCC;
+  }
+
+  div.cartodb-popup.header.with-image a.cartodb-popup-close-button {
+    background:url('../img/headers.png') no-repeat -226px -40px;
+  }
+
+  div.cartodb-popup.header.with-image a.cartodb-popup-close-button:hover {
+    background-position:-226px -66px;
+  }
+
+  div.cartodb-popup.header.with-image .cartodb-popup-header h1 {
+    display:none;
+  }
+
+  div.cartodb-popup.header.with-image .cartodb-popup-header h1.order1 {
+    display:block;
+  }
+
+  div.cartodb-popup.header.with-image .cartodb-popup-content-wrapper .order1 {
+    display:none;
+  }
 
 
-/* NEW CartoDB 2.0 blue header popups */
+  /* NEW CartoDB 2.0 image header popups */
 
-div.cartodb-popup.v2.header.blue div.cartodb-popup-header {
-  background: none;
-  background: -ms-linear-gradient(top, #4F9CD7, #2B68A8); 
-  background: -o-linear-gradient(right, #4F9CD7, #2B68A8);
-  background: -webkit-linear-gradient(top, #4F9CD7, #2B68A8); 
-  background: -moz-linear-gradient(right, #4F9CD7, #2B68A8);
-  -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#4F9CD7',endColorStr='#2B68A8',GradientType=0)";
-}
+  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header {
+    background: #2C2C2C;
+    background: -ms-linear-gradient(top, #535353, #2C2C2C); 
+    background: -o-linear-gradient(right, #535353, #2C2C2C);
+    background: -webkit-linear-gradient(top, #535353, #2C2C2C); 
+    background: -moz-linear-gradient(right, #535353, #2C2C2C);
+    -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#535353',endColorStr='#2C2C2C',GradientType=0)";
+  }
 
-div.cartodb-popup.v2.header.blue a.cartodb-popup-close-button {
-  background:white;
-}
+  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header h1 {
+    width:85%;
+  }
+
+  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header span.separator {
+    left:0;
+    right:0;
+    background:#CCC;
+  }
+
+  div.cartodb-popup.v2.header.with-image a.cartodb-popup-close-button {
+    background:white;
+  }
+
+  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header .cover {
+    display:block;
+    width:100%;
+    height:138px;
+    top:0;
+    left:0;
+    -moz-border-radius:2px 2px 0 0;
+    -webkit-border-radius:2px 2px 0 0;
+    border-radius:2px 2px 0 0;
+    overflow:hidden;
+  }
+
+  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header .cover .shadow {
+    width: 100%;
+    height:57px;
+    background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, rgba(0,0,0,0)), color-stop(100%, rgba(0,0,0,0.8)));
+    background: -webkit-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.8));
+    background: -moz-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.8));
+    background: -o-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.8));
+    background: linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.8));
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00000000', endColorstr='#000000',GradientType=0 );
+  }
+
+  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header .cover img {
+    -moz-border-radius:2px 2px 0 0;
+    -webkit-border-radius:2px 2px 0 0;
+    border-radius:2px 2px 0 0;
+  }
 /**
  *  CartoDB header popup styles (DEFAULT)
  */
@@ -897,346 +1236,485 @@ div.cartodb-popup.v2.header a.cartodb-popup-close-button:hover {
   }
 
 }
+/* required styles */
 
+.leaflet-map-pane,
+.leaflet-tile,
+.leaflet-marker-icon,
+.leaflet-marker-shadow,
+.leaflet-tile-pane,
+.leaflet-tile-container,
+.leaflet-overlay-pane,
+.leaflet-shadow-pane,
+.leaflet-marker-pane,
+.leaflet-popup-pane,
+.leaflet-overlay-pane svg,
+.leaflet-zoom-box,
+.leaflet-image-layer,
+.leaflet-layer {
+	position: absolute;
+	left: 0;
+	top: 0;
+	}
+.leaflet-container {
+	overflow: hidden;
+	-ms-touch-action: none;
+	}
+.leaflet-tile,
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+	-webkit-user-select: none;
+	   -moz-user-select: none;
+	        user-select: none;
+	-webkit-user-drag: none;
+	}
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+	display: block;
+	}
+/* map is broken in FF if you have max-width: 100% on tiles */
+.leaflet-container img {
+	max-width: none !important;
+	}
+/* stupid Android 2 doesn't understand "max-width: none" properly */
+.leaflet-container img.leaflet-image-layer {
+	max-width: 15000px !important;
+	}
+.leaflet-tile {
+	filter: inherit;
+	visibility: hidden;
+	}
+.leaflet-tile-loaded {
+	visibility: inherit;
+	}
+.leaflet-zoom-box {
+	width: 0;
+	height: 0;
+	}
+/* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */
+.leaflet-overlay-pane svg {
+	-moz-user-select: none;
+	}
+
+.leaflet-tile-pane    { z-index: 2; }
+.leaflet-objects-pane { z-index: 3; }
+.leaflet-overlay-pane { z-index: 4; }
+.leaflet-shadow-pane  { z-index: 5; }
+.leaflet-marker-pane  { z-index: 6; }
+.leaflet-popup-pane   { z-index: 7; }
+
+.leaflet-vml-shape {
+	width: 1px;
+	height: 1px;
+	}
+.lvml {
+	behavior: url(#default#VML);
+	display: inline-block;
+	position: absolute;
+	}
+
+
+/* control positioning */
+
+.leaflet-control {
+	position: relative;
+	z-index: 7;
+	pointer-events: auto;
+	}
+.leaflet-top,
+.leaflet-bottom {
+	position: absolute;
+	z-index: 1000;
+	pointer-events: none;
+	}
+.leaflet-top {
+	top: 0;
+	}
+.leaflet-right {
+	right: 0;
+	}
+.leaflet-bottom {
+	bottom: 0;
+	}
+.leaflet-left {
+	left: 0;
+	}
+.leaflet-control {
+	float: left;
+	clear: both;
+	}
+.leaflet-right .leaflet-control {
+	float: right;
+	}
+.leaflet-top .leaflet-control {
+	margin-top: 10px;
+	}
+.leaflet-bottom .leaflet-control {
+	margin-bottom: 10px;
+	}
+.leaflet-left .leaflet-control {
+	margin-left: 10px;
+	}
+.leaflet-right .leaflet-control {
+	margin-right: 10px;
+	}
+
+
+/* zoom and fade animations */
+
+.leaflet-fade-anim .leaflet-tile,
+.leaflet-fade-anim .leaflet-popup {
+	opacity: 0;
+	-webkit-transition: opacity 0.2s linear;
+	   -moz-transition: opacity 0.2s linear;
+	     -o-transition: opacity 0.2s linear;
+	        transition: opacity 0.2s linear;
+	}
+.leaflet-fade-anim .leaflet-tile-loaded,
+.leaflet-fade-anim .leaflet-map-pane .leaflet-popup {
+	opacity: 1;
+	}
+
+.leaflet-zoom-anim .leaflet-zoom-animated {
+	-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);
+	   -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);
+	     -o-transition:      -o-transform 0.25s cubic-bezier(0,0,0.25,1);
+	        transition:         transform 0.25s cubic-bezier(0,0,0.25,1);
+	}
+.leaflet-zoom-anim .leaflet-tile,
+.leaflet-pan-anim .leaflet-tile,
+.leaflet-touching .leaflet-zoom-animated {
+	-webkit-transition: none;
+	   -moz-transition: none;
+	     -o-transition: none;
+	        transition: none;
+	}
+
+.leaflet-zoom-anim .leaflet-zoom-hide {
+	visibility: hidden;
+	}
+
+
+/* cursors */
+
+.leaflet-clickable {
+	cursor: pointer;
+	}
+.leaflet-container {
+	cursor: -webkit-grab;
+	cursor:    -moz-grab;
+	}
+.leaflet-popup-pane,
+.leaflet-control {
+	cursor: auto;
+	}
+.leaflet-dragging .leaflet-container,
+.leaflet-dragging .leaflet-clickable {
+	cursor: move;
+	cursor: -webkit-grabbing;
+	cursor:    -moz-grabbing;
+	}
+
+
+/* visual tweaks */
+
+.leaflet-container {
+	background: #ddd;
+	outline: 0;
+	}
+.leaflet-container a {
+	color: #0078A8;
+	}
+.leaflet-container a.leaflet-active {
+	outline: 2px solid orange;
+	}
+.leaflet-zoom-box {
+	border: 2px dotted #38f;
+	background: rgba(255,255,255,0.5);
+	}
+
+
+/* general typography */
+.leaflet-container {
+	font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
+	}
+
+
+/* general toolbar styles */
+
+.leaflet-bar {
+	box-shadow: 0 1px 5px rgba(0,0,0,0.65);
+	border-radius: 4px;
+	}
+.leaflet-bar a,
+.leaflet-bar a:hover {
+	background-color: #fff;
+	border-bottom: 1px solid #ccc;
+	width: 26px;
+	height: 26px;
+	line-height: 26px;
+	display: block;
+	text-align: center;
+	text-decoration: none;
+	color: black;
+	}
+.leaflet-bar a,
+.leaflet-control-layers-toggle {
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	display: block;
+	}
+.leaflet-bar a:hover {
+	background-color: #f4f4f4;
+	}
+.leaflet-bar a:first-child {
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
+	}
+.leaflet-bar a:last-child {
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
+	border-bottom: none;
+	}
+.leaflet-bar a.leaflet-disabled {
+	cursor: default;
+	background-color: #f4f4f4;
+	color: #bbb;
+	}
+
+.leaflet-touch .leaflet-bar a {
+	width: 30px;
+	height: 30px;
+	line-height: 30px;
+	}
+
+
+/* zoom control */
+
+.leaflet-control-zoom-in,
+.leaflet-control-zoom-out {
+	font: bold 18px 'Lucida Console', Monaco, monospace;
+	text-indent: 1px;
+	}
+.leaflet-control-zoom-out {
+	font-size: 20px;
+	}
+
+.leaflet-touch .leaflet-control-zoom-in {
+	font-size: 22px;
+	}
+.leaflet-touch .leaflet-control-zoom-out {
+	font-size: 24px;
+	}
+
+
+/* layers control */
+
+.leaflet-control-layers {
+	box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+	background: #fff;
+	border-radius: 5px;
+	}
+.leaflet-control-layers-toggle {
+	background-image: url(images/layers.png);
+	width: 36px;
+	height: 36px;
+	}
+.leaflet-retina .leaflet-control-layers-toggle {
+	background-image: url(images/layers-2x.png);
+	background-size: 26px 26px;
+	}
+.leaflet-touch .leaflet-control-layers-toggle {
+	width: 44px;
+	height: 44px;
+	}
+.leaflet-control-layers .leaflet-control-layers-list,
+.leaflet-control-layers-expanded .leaflet-control-layers-toggle {
+	display: none;
+	}
+.leaflet-control-layers-expanded .leaflet-control-layers-list {
+	display: block;
+	position: relative;
+	}
+.leaflet-control-layers-expanded {
+	padding: 6px 10px 6px 6px;
+	color: #333;
+	background: #fff;
+	}
+.leaflet-control-layers-selector {
+	margin-top: 2px;
+	position: relative;
+	top: 1px;
+	}
+.leaflet-control-layers label {
+	display: block;
+	}
+.leaflet-control-layers-separator {
+	height: 0;
+	border-top: 1px solid #ddd;
+	margin: 5px -10px 5px -6px;
+	}
+
+
+/* attribution and scale controls */
+
+.leaflet-container .leaflet-control-attribution {
+	background: #fff;
+	background: rgba(255, 255, 255, 0.7);
+	margin: 0;
+	}
+.leaflet-control-attribution,
+.leaflet-control-scale-line {
+	padding: 0 5px;
+	color: #333;
+	}
+.leaflet-control-attribution a {
+	text-decoration: none;
+	}
+.leaflet-control-attribution a:hover {
+	text-decoration: underline;
+	}
+.leaflet-container .leaflet-control-attribution,
+.leaflet-container .leaflet-control-scale {
+	font-size: 11px;
+	}
+.leaflet-left .leaflet-control-scale {
+	margin-left: 5px;
+	}
+.leaflet-bottom .leaflet-control-scale {
+	margin-bottom: 5px;
+	}
+.leaflet-control-scale-line {
+	border: 2px solid #777;
+	border-top: none;
+	line-height: 1.1;
+	padding: 2px 5px 1px;
+	font-size: 11px;
+	white-space: nowrap;
+	overflow: hidden;
+	-moz-box-sizing: content-box;
+	     box-sizing: content-box;
+
+	background: #fff;
+	background: rgba(255, 255, 255, 0.5);
+	}
+.leaflet-control-scale-line:not(:first-child) {
+	border-top: 2px solid #777;
+	border-bottom: none;
+	margin-top: -2px;
+	}
+.leaflet-control-scale-line:not(:first-child):not(:last-child) {
+	border-bottom: 2px solid #777;
+	}
+
+.leaflet-touch .leaflet-control-attribution,
+.leaflet-touch .leaflet-control-layers,
+.leaflet-touch .leaflet-bar {
+	box-shadow: none;
+	}
+.leaflet-touch .leaflet-control-layers,
+.leaflet-touch .leaflet-bar {
+	border: 2px solid rgba(0,0,0,0.2);
+	background-clip: padding-box;
+	}
+
+
+/* popup */
+
+.leaflet-popup {
+	position: absolute;
+	text-align: center;
+	}
+.leaflet-popup-content-wrapper {
+	padding: 1px;
+	text-align: left;
+	border-radius: 12px;
+	}
+.leaflet-popup-content {
+	margin: 13px 19px;
+	line-height: 1.4;
+	}
+.leaflet-popup-content p {
+	margin: 18px 0;
+	}
+.leaflet-popup-tip-container {
+	margin: 0 auto;
+	width: 40px;
+	height: 20px;
+	position: relative;
+	overflow: hidden;
+	}
+.leaflet-popup-tip {
+	width: 17px;
+	height: 17px;
+	padding: 1px;
+
+	margin: -10px auto 0;
+
+	-webkit-transform: rotate(45deg);
+	   -moz-transform: rotate(45deg);
+	    -ms-transform: rotate(45deg);
+	     -o-transform: rotate(45deg);
+	        transform: rotate(45deg);
+	}
+.leaflet-popup-content-wrapper,
+.leaflet-popup-tip {
+	background: white;
+
+	box-shadow: 0 3px 14px rgba(0,0,0,0.4);
+	}
+.leaflet-container a.leaflet-popup-close-button {
+	position: absolute;
+	top: 0;
+	right: 0;
+	padding: 4px 4px 0 0;
+	text-align: center;
+	width: 18px;
+	height: 14px;
+	font: 16px/14px Tahoma, Verdana, sans-serif;
+	color: #c3c3c3;
+	text-decoration: none;
+	font-weight: bold;
+	background: transparent;
+	}
+.leaflet-container a.leaflet-popup-close-button:hover {
+	color: #999;
+	}
+.leaflet-popup-scrolled {
+	overflow: auto;
+	border-bottom: 1px solid #ddd;
+	border-top: 1px solid #ddd;
+	}
+
+.leaflet-oldie .leaflet-popup-content-wrapper {
+	zoom: 1;
+	}
+.leaflet-oldie .leaflet-popup-tip {
+	width: 24px;
+	margin: 0 auto;
+
+	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
+	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
+	}
+.leaflet-oldie .leaflet-popup-tip-container {
+	margin-top: -1px;
+	}
+
+.leaflet-oldie .leaflet-control-zoom,
+.leaflet-oldie .leaflet-control-layers,
+.leaflet-oldie .leaflet-popup-content-wrapper,
+.leaflet-oldie .leaflet-popup-tip {
+	border: 1px solid #999;
+	}
+
+
+/* div icon */
+
+.leaflet-div-icon {
+	background: #fff;
+	border: 1px solid #666;
+	}
 /**
- *  CartoDB green header popup styles
- */
-
-div.cartodb-popup.header.green div.cartodb-popup-header {
-  background:url('../img/headers.png') no-repeat -252px -40px;
-}
-
-div.cartodb-popup.header.green div.cartodb-popup-header h4 {
-  color:#00916D;
-}
-
-div.cartodb-popup.header.green div.cartodb-popup-header span.separator {
-  background:#008E6A;
-}
-
-div.cartodb-popup.header.green a.cartodb-popup-close-button {
-  background:url('../img/headers.png') no-repeat -478px -40px;
-}
-
-div.cartodb-popup.header.green a.cartodb-popup-close-button:hover {
-  background-position:-478px -66px;
-}
-
-
-/* NEW CartoDB 2.0 green header popups */
-
-div.cartodb-popup.v2.header.green div.cartodb-popup-header {
-  background: none;
-  background: -ms-linear-gradient(top, #00CC99, #00B185); 
-  background: -o-linear-gradient(right, #00CC99, #00B185);
-  background: -webkit-linear-gradient(top, #00CC99, #00B185); 
-  background: -moz-linear-gradient(right, #00CC99, #00B185);
-  -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#00CC99',endColorStr='#00B185',GradientType=0)";
-}
-
-div.cartodb-popup.v2.header.green a.cartodb-popup-close-button {
-  background:white;
-}
-
-div.cartodb-popup.v2.header.green a.cartodb-popup-close-button:before,
-div.cartodb-popup.v2.header.green a.cartodb-popup-close-button:after {
-  background:#00CC99;
-}
-
-/* Hello IE */
-@media \0screen\,screen\9 {
-  div.cartodb-popup.v2.header.green a.cartodb-popup-close-button {
-    color:#00CC99;
-  }
-}
-/**
- *  CartoDB orange header popup styles
- */
-
-div.cartodb-popup.header.orange div.cartodb-popup-header {
-  background:url('../img/headers.png') no-repeat -756px -40px;
-}
-
-div.cartodb-popup.header.orange div.cartodb-popup-header h4 {
-  color:#CC2929;
-}
-
-div.cartodb-popup.header.orange div.cartodb-popup-header span.separator {
-  background:#CC2929;
-}
-
-div.cartodb-popup.header.orange a.cartodb-popup-close-button {
-  background:url('../img/headers.png') no-repeat -982px -40px;
-}
-
-div.cartodb-popup.header.orange a.cartodb-popup-close-button:hover {
-  background-position:-982px -66px;
-}
-
-
-/* NEW CartoDB 2.0 orange header popups */
-
-div.cartodb-popup.v2.header.orange div.cartodb-popup-header {
-  background: none;
-  background: -ms-linear-gradient(top, #FF6825, #FF3333); 
-  background: -o-linear-gradient(right, #FF6825, #FF3333);
-  background: -webkit-linear-gradient(top, #FF6825, #FF3333); 
-  background: -moz-linear-gradient(right, #FF6825, #FF3333);
-  -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#FF6825',endColorStr='#FF3333',GradientType=0)";
-}
-
-div.cartodb-popup.v2.header.orange a.cartodb-popup-close-button {
-  background:white;
-}
-
-div.cartodb-popup.v2.header.orange a.cartodb-popup-close-button:before,
-div.cartodb-popup.v2.header.orange a.cartodb-popup-close-button:after {
-  background:#CC2929;
-}
-
-/* Hello IE */
-@media \0screen\,screen\9 {
-  div.cartodb-popup.v2.header.orange a.cartodb-popup-close-button {
-    color:#CC2929;
-  }
-}
-  /**
-   *  CartoDB header with-image popup styles
-   */
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header {
-    position:relative;
-
-    background:url('../img/headers.png') no-repeat -1008px 0;
-    height:138px;
-    max-height:104px;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover {
-    display:block;
-    position:absolute;
-    overflow:hidden;
-    width: 218px;
-    height:135px;
-    top: 4px;
-    left: 4px;
-    border-radius: 4px 4px 0 0;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover .shadow {
-    position:absolute;
-    width: 218px;
-    height:55px;
-    bottom: 0;
-    left: 0;
-    background:url('../img/shadow.png') no-repeat;
-    z-index: 100;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover #spinner {
-    position:absolute;
-    top: 67px;
-    left: 109px;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover img {
-    position:absolute;
-    border-radius: 4px 4px 0 0;
-    display:none;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header .image_not_found {
-    position:absolute;
-    top: 15px;
-    left: 15px;
-    width: 200px;
-    display:none;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header .image_not_found a {
-    display:-moz-inline-stack;display:inline-block;vertical-align:top;*vertical-align:auto;zoom:1;*display:inline;
-    margin: 3px 0 0 -2px;
-    color: #888888;
-    font-size:13px;
-    font-family: "Helvetica", "Helvetica Neue", Arial, sans-serif;
-    text-decoration: underline;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header .image_not_found a:hover {
-    color: #888888;
-    text-decoration:underline;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header .cover .image_not_found i {
-    display:-moz-inline-stack;display:inline-block;vertical-align:top;*vertical-align:auto;zoom:1;*display:inline;
-    width: 31px;
-    height: 22px;
-    background:transparent url('../img/image_not_found.png');
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header h1 {
-    position:absolute;
-    bottom: 13px;
-    left: 18px;
-    width: 188px;
-    z-index: 150;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header h4 {
-    color:#CCC;
-  }
-
-  div.cartodb-popup.header.with-image div.cartodb-popup-header span.separator {
-    background:#CCC;
-  }
-
-  div.cartodb-popup.header.with-image a.cartodb-popup-close-button {
-    background:url('../img/headers.png') no-repeat -226px -40px;
-  }
-
-  div.cartodb-popup.header.with-image a.cartodb-popup-close-button:hover {
-    background-position:-226px -66px;
-  }
-
-  div.cartodb-popup.header.with-image .cartodb-popup-header h1 {
-    display:none;
-  }
-
-  div.cartodb-popup.header.with-image .cartodb-popup-header h1.order1 {
-    display:block;
-  }
-
-  div.cartodb-popup.header.with-image .cartodb-popup-content-wrapper .order1 {
-    display:none;
-  }
-
-
-  /* NEW CartoDB 2.0 image header popups */
-
-  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header {
-    background: #2C2C2C;
-    background: -ms-linear-gradient(top, #535353, #2C2C2C); 
-    background: -o-linear-gradient(right, #535353, #2C2C2C);
-    background: -webkit-linear-gradient(top, #535353, #2C2C2C); 
-    background: -moz-linear-gradient(right, #535353, #2C2C2C);
-    -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#535353',endColorStr='#2C2C2C',GradientType=0)";
-  }
-
-  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header h1 {
-    width:85%;
-  }
-
-  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header span.separator {
-    left:0;
-    right:0;
-    background:#CCC;
-  }
-
-  div.cartodb-popup.v2.header.with-image a.cartodb-popup-close-button {
-    background:white;
-  }
-
-  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header .cover {
-    display:block;
-    width:100%;
-    height:138px;
-    top:0;
-    left:0;
-    -moz-border-radius:2px 2px 0 0;
-    -webkit-border-radius:2px 2px 0 0;
-    border-radius:2px 2px 0 0;
-    overflow:hidden;
-  }
-
-  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header .cover .shadow {
-    width: 100%;
-    height:57px;
-    background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, rgba(0,0,0,0)), color-stop(100%, rgba(0,0,0,0.8)));
-    background: -webkit-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.8));
-    background: -moz-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.8));
-    background: -o-linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.8));
-    background: linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.8));
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00000000', endColorstr='#000000',GradientType=0 );
-  }
-
-  div.cartodb-popup.v2.header.with-image div.cartodb-popup-header .cover img {
-    -moz-border-radius:2px 2px 0 0;
-    -webkit-border-radius:2px 2px 0 0;
-    border-radius:2px 2px 0 0;
-  }
-/**
- *  CartoDB yellow header popup styles
- */
-
-div.cartodb-popup.header.yellow div.cartodb-popup-header {
-  background:url('../img/headers.png') no-repeat -504px -40px;
-}
-
-div.cartodb-popup.header.yellow div.cartodb-popup-header h4 {
-  color:#D8832A;
-}
-
-div.cartodb-popup.header.yellow div.cartodb-popup-header span.separator {
-  background:#CC7A29;
-}
-
-div.cartodb-popup.header.yellow a.cartodb-popup-close-button {
-  background:url('../img/headers.png') no-repeat -730px -40px;
-}
-
-div.cartodb-popup.header.yellow a.cartodb-popup-close-button:hover {
-  background-position:-730px -66px;
-}
-
-/* NEW CartoDB 2.0 yellow header popups */
-
-div.cartodb-popup.v2.header.yellow div.cartodb-popup-header {
-  background: none;
-  background: -ms-linear-gradient(top, #FFBF0D, #FF9933); 
-  background: -o-linear-gradient(right, #FFBF0D, #FF9933);
-  background: -webkit-linear-gradient(top, #FFBF0D, #FF9933); 
-  background: -moz-linear-gradient(right, #FFBF0D, #FF9933);
-  -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr='#FFBF0D',endColorStr='#FF9933',GradientType=0)";
-}
-
-div.cartodb-popup.v2.header.yellow a.cartodb-popup-close-button {
-  background:white;
-}
-
-div.cartodb-popup.v2.header.yellow a.cartodb-popup-close-button:before,
-div.cartodb-popup.v2.header.yellow a.cartodb-popup-close-button:after {
-  background:#CC7A29;
-}
-
-/* Hello IE */
-@media \0screen\,screen\9 {
-  div.cartodb-popup.v2.header.yellow a.cartodb-popup-close-button {
-    color:#CC7A29;
-  }
-}
-  /**
-   *  CartoDB infowindow light styles
-   */
-
-  div.cartodb-popup h4 {
-    color:#CCCCCC;
-  }
-
-  div.cartodb-popup p {
-    color:#333333;
-  }
-
-  div.cartodb-popup p.loading {
-    color:#888;
-  }
-
-  div.cartodb-popup p.error {
-    color:#FF7F7F;
-  }
-
-  div.cartodb-popup p.empty {
-    color:#999999;
-  }/**
  *  CartoDB map style components
  */
 @-webkit-keyframes loading {
@@ -3828,507 +4306,13 @@ div.cartodb-timeslider .ui-slider-vertical .ui-slider-range-max {
     width: 90px;
     font-size: 12px;
   }
-}/* required styles */
-
-.leaflet-map-pane,
-.leaflet-tile,
-.leaflet-marker-icon,
-.leaflet-marker-shadow,
-.leaflet-tile-pane,
-.leaflet-tile-container,
-.leaflet-overlay-pane,
-.leaflet-shadow-pane,
-.leaflet-marker-pane,
-.leaflet-popup-pane,
-.leaflet-overlay-pane svg,
-.leaflet-zoom-box,
-.leaflet-image-layer,
-.leaflet-layer {
-	position: absolute;
-	left: 0;
-	top: 0;
-	}
-.leaflet-container {
-	overflow: hidden;
-	-ms-touch-action: none;
-	}
-.leaflet-tile,
-.leaflet-marker-icon,
-.leaflet-marker-shadow {
-	-webkit-user-select: none;
-	   -moz-user-select: none;
-	        user-select: none;
-	-webkit-user-drag: none;
-	}
-.leaflet-marker-icon,
-.leaflet-marker-shadow {
-	display: block;
-	}
-/* map is broken in FF if you have max-width: 100% on tiles */
-.leaflet-container img {
-	max-width: none !important;
-	}
-/* stupid Android 2 doesn't understand "max-width: none" properly */
-.leaflet-container img.leaflet-image-layer {
-	max-width: 15000px !important;
-	}
-.leaflet-tile {
-	filter: inherit;
-	visibility: hidden;
-	}
-.leaflet-tile-loaded {
-	visibility: inherit;
-	}
-.leaflet-zoom-box {
-	width: 0;
-	height: 0;
-	}
-/* workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=888319 */
-.leaflet-overlay-pane svg {
-	-moz-user-select: none;
-	}
-
-.leaflet-tile-pane    { z-index: 2; }
-.leaflet-objects-pane { z-index: 3; }
-.leaflet-overlay-pane { z-index: 4; }
-.leaflet-shadow-pane  { z-index: 5; }
-.leaflet-marker-pane  { z-index: 6; }
-.leaflet-popup-pane   { z-index: 7; }
-
-.leaflet-vml-shape {
-	width: 1px;
-	height: 1px;
-	}
-.lvml {
-	behavior: url(#default#VML);
-	display: inline-block;
-	position: absolute;
-	}
-
-
-/* control positioning */
-
-.leaflet-control {
-	position: relative;
-	z-index: 7;
-	pointer-events: auto;
-	}
-.leaflet-top,
-.leaflet-bottom {
-	position: absolute;
-	z-index: 1000;
-	pointer-events: none;
-	}
-.leaflet-top {
-	top: 0;
-	}
-.leaflet-right {
-	right: 0;
-	}
-.leaflet-bottom {
-	bottom: 0;
-	}
-.leaflet-left {
-	left: 0;
-	}
-.leaflet-control {
-	float: left;
-	clear: both;
-	}
-.leaflet-right .leaflet-control {
-	float: right;
-	}
-.leaflet-top .leaflet-control {
-	margin-top: 10px;
-	}
-.leaflet-bottom .leaflet-control {
-	margin-bottom: 10px;
-	}
-.leaflet-left .leaflet-control {
-	margin-left: 10px;
-	}
-.leaflet-right .leaflet-control {
-	margin-right: 10px;
-	}
-
-
-/* zoom and fade animations */
-
-.leaflet-fade-anim .leaflet-tile,
-.leaflet-fade-anim .leaflet-popup {
-	opacity: 0;
-	-webkit-transition: opacity 0.2s linear;
-	   -moz-transition: opacity 0.2s linear;
-	     -o-transition: opacity 0.2s linear;
-	        transition: opacity 0.2s linear;
-	}
-.leaflet-fade-anim .leaflet-tile-loaded,
-.leaflet-fade-anim .leaflet-map-pane .leaflet-popup {
-	opacity: 1;
-	}
-
-.leaflet-zoom-anim .leaflet-zoom-animated {
-	-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);
-	   -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);
-	     -o-transition:      -o-transform 0.25s cubic-bezier(0,0,0.25,1);
-	        transition:         transform 0.25s cubic-bezier(0,0,0.25,1);
-	}
-.leaflet-zoom-anim .leaflet-tile,
-.leaflet-pan-anim .leaflet-tile,
-.leaflet-touching .leaflet-zoom-animated {
-	-webkit-transition: none;
-	   -moz-transition: none;
-	     -o-transition: none;
-	        transition: none;
-	}
-
-.leaflet-zoom-anim .leaflet-zoom-hide {
-	visibility: hidden;
-	}
-
-
-/* cursors */
-
-.leaflet-clickable {
-	cursor: pointer;
-	}
-.leaflet-container {
-	cursor: -webkit-grab;
-	cursor:    -moz-grab;
-	}
-.leaflet-popup-pane,
-.leaflet-control {
-	cursor: auto;
-	}
-.leaflet-dragging .leaflet-container,
-.leaflet-dragging .leaflet-clickable {
-	cursor: move;
-	cursor: -webkit-grabbing;
-	cursor:    -moz-grabbing;
-	}
-
-
-/* visual tweaks */
-
-.leaflet-container {
-	background: #ddd;
-	outline: 0;
-	}
-.leaflet-container a {
-	color: #0078A8;
-	}
-.leaflet-container a.leaflet-active {
-	outline: 2px solid orange;
-	}
-.leaflet-zoom-box {
-	border: 2px dotted #38f;
-	background: rgba(255,255,255,0.5);
-	}
-
-
-/* general typography */
-.leaflet-container {
-	font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
-	}
-
-
-/* general toolbar styles */
-
-.leaflet-bar {
-	box-shadow: 0 1px 5px rgba(0,0,0,0.65);
-	border-radius: 4px;
-	}
-.leaflet-bar a,
-.leaflet-bar a:hover {
-	background-color: #fff;
-	border-bottom: 1px solid #ccc;
-	width: 26px;
-	height: 26px;
-	line-height: 26px;
-	display: block;
-	text-align: center;
-	text-decoration: none;
-	color: black;
-	}
-.leaflet-bar a,
-.leaflet-control-layers-toggle {
-	background-position: 50% 50%;
-	background-repeat: no-repeat;
-	display: block;
-	}
-.leaflet-bar a:hover {
-	background-color: #f4f4f4;
-	}
-.leaflet-bar a:first-child {
-	border-top-left-radius: 4px;
-	border-top-right-radius: 4px;
-	}
-.leaflet-bar a:last-child {
-	border-bottom-left-radius: 4px;
-	border-bottom-right-radius: 4px;
-	border-bottom: none;
-	}
-.leaflet-bar a.leaflet-disabled {
-	cursor: default;
-	background-color: #f4f4f4;
-	color: #bbb;
-	}
-
-.leaflet-touch .leaflet-bar a {
-	width: 30px;
-	height: 30px;
-	line-height: 30px;
-	}
-
-
-/* zoom control */
-
-.leaflet-control-zoom-in,
-.leaflet-control-zoom-out {
-	font: bold 18px 'Lucida Console', Monaco, monospace;
-	text-indent: 1px;
-	}
-.leaflet-control-zoom-out {
-	font-size: 20px;
-	}
-
-.leaflet-touch .leaflet-control-zoom-in {
-	font-size: 22px;
-	}
-.leaflet-touch .leaflet-control-zoom-out {
-	font-size: 24px;
-	}
-
-
-/* layers control */
-
-.leaflet-control-layers {
-	box-shadow: 0 1px 5px rgba(0,0,0,0.4);
-	background: #fff;
-	border-radius: 5px;
-	}
-.leaflet-control-layers-toggle {
-	background-image: url(images/layers.png);
-	width: 36px;
-	height: 36px;
-	}
-.leaflet-retina .leaflet-control-layers-toggle {
-	background-image: url(images/layers-2x.png);
-	background-size: 26px 26px;
-	}
-.leaflet-touch .leaflet-control-layers-toggle {
-	width: 44px;
-	height: 44px;
-	}
-.leaflet-control-layers .leaflet-control-layers-list,
-.leaflet-control-layers-expanded .leaflet-control-layers-toggle {
-	display: none;
-	}
-.leaflet-control-layers-expanded .leaflet-control-layers-list {
-	display: block;
-	position: relative;
-	}
-.leaflet-control-layers-expanded {
-	padding: 6px 10px 6px 6px;
-	color: #333;
-	background: #fff;
-	}
-.leaflet-control-layers-selector {
-	margin-top: 2px;
-	position: relative;
-	top: 1px;
-	}
-.leaflet-control-layers label {
-	display: block;
-	}
-.leaflet-control-layers-separator {
-	height: 0;
-	border-top: 1px solid #ddd;
-	margin: 5px -10px 5px -6px;
-	}
-
-
-/* attribution and scale controls */
-
-.leaflet-container .leaflet-control-attribution {
-	background: #fff;
-	background: rgba(255, 255, 255, 0.7);
-	margin: 0;
-	}
-.leaflet-control-attribution,
-.leaflet-control-scale-line {
-	padding: 0 5px;
-	color: #333;
-	}
-.leaflet-control-attribution a {
-	text-decoration: none;
-	}
-.leaflet-control-attribution a:hover {
-	text-decoration: underline;
-	}
-.leaflet-container .leaflet-control-attribution,
-.leaflet-container .leaflet-control-scale {
-	font-size: 11px;
-	}
-.leaflet-left .leaflet-control-scale {
-	margin-left: 5px;
-	}
-.leaflet-bottom .leaflet-control-scale {
-	margin-bottom: 5px;
-	}
-.leaflet-control-scale-line {
-	border: 2px solid #777;
-	border-top: none;
-	line-height: 1.1;
-	padding: 2px 5px 1px;
-	font-size: 11px;
-	white-space: nowrap;
-	overflow: hidden;
-	-moz-box-sizing: content-box;
-	     box-sizing: content-box;
-
-	background: #fff;
-	background: rgba(255, 255, 255, 0.5);
-	}
-.leaflet-control-scale-line:not(:first-child) {
-	border-top: 2px solid #777;
-	border-bottom: none;
-	margin-top: -2px;
-	}
-.leaflet-control-scale-line:not(:first-child):not(:last-child) {
-	border-bottom: 2px solid #777;
-	}
-
-.leaflet-touch .leaflet-control-attribution,
-.leaflet-touch .leaflet-control-layers,
-.leaflet-touch .leaflet-bar {
-	box-shadow: none;
-	}
-.leaflet-touch .leaflet-control-layers,
-.leaflet-touch .leaflet-bar {
-	border: 2px solid rgba(0,0,0,0.2);
-	background-clip: padding-box;
-	}
-
-
-/* popup */
-
-.leaflet-popup {
-	position: absolute;
-	text-align: center;
-	}
-.leaflet-popup-content-wrapper {
-	padding: 1px;
-	text-align: left;
-	border-radius: 12px;
-	}
-.leaflet-popup-content {
-	margin: 13px 19px;
-	line-height: 1.4;
-	}
-.leaflet-popup-content p {
-	margin: 18px 0;
-	}
-.leaflet-popup-tip-container {
-	margin: 0 auto;
-	width: 40px;
-	height: 20px;
-	position: relative;
-	overflow: hidden;
-	}
-.leaflet-popup-tip {
-	width: 17px;
-	height: 17px;
-	padding: 1px;
-
-	margin: -10px auto 0;
-
-	-webkit-transform: rotate(45deg);
-	   -moz-transform: rotate(45deg);
-	    -ms-transform: rotate(45deg);
-	     -o-transform: rotate(45deg);
-	        transform: rotate(45deg);
-	}
-.leaflet-popup-content-wrapper,
-.leaflet-popup-tip {
-	background: white;
-
-	box-shadow: 0 3px 14px rgba(0,0,0,0.4);
-	}
-.leaflet-container a.leaflet-popup-close-button {
-	position: absolute;
-	top: 0;
-	right: 0;
-	padding: 4px 4px 0 0;
-	text-align: center;
-	width: 18px;
-	height: 14px;
-	font: 16px/14px Tahoma, Verdana, sans-serif;
-	color: #c3c3c3;
-	text-decoration: none;
-	font-weight: bold;
-	background: transparent;
-	}
-.leaflet-container a.leaflet-popup-close-button:hover {
-	color: #999;
-	}
-.leaflet-popup-scrolled {
-	overflow: auto;
-	border-bottom: 1px solid #ddd;
-	border-top: 1px solid #ddd;
-	}
-
-.leaflet-oldie .leaflet-popup-content-wrapper {
-	zoom: 1;
-	}
-.leaflet-oldie .leaflet-popup-tip {
-	width: 24px;
-	margin: 0 auto;
-
-	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
-	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
-	}
-.leaflet-oldie .leaflet-popup-tip-container {
-	margin-top: -1px;
-	}
-
-.leaflet-oldie .leaflet-control-zoom,
-.leaflet-oldie .leaflet-control-layers,
-.leaflet-oldie .leaflet-popup-content-wrapper,
-.leaflet-oldie .leaflet-popup-tip {
-	border: 1px solid #999;
-	}
-
-
-/* div icon */
-
-.leaflet-div-icon {
-	background: #fff;
-	border: 1px solid #666;
-	}
-
+}
   /**
-   *  CartoDB tooltip dark styles
+   *  CartoDB tooltip light styles
    */
 
-  div.cartodb-tooltip-content-wrapper.dark {
-    background: rgb(0,0,0);
-    background:rgba(0,0,0,0.75);
-    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#bf000000, endColorstr=#bf000000);
-    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#bf000000, endColorstr=#bf000000)";
-  }
+  
 
-  div.cartodb-tooltip-content-wrapper.dark h4 {
-    color:#999;
-  }
-
-  div.cartodb-tooltip-content-wrapper.dark p {
-    color:#FFFFFF;
-  }
-
-  div.cartodb-tooltip-content-wrapper.dark a {
-    color:#397DB9;
-  }
   /**
    *  CartoDB2.0 tooltip styles (DEFAULT)
    */
@@ -4396,7 +4380,24 @@ div.cartodb-timeslider .ui-slider-vertical .ui-slider-range-max {
   }
 
   /**
-   *  CartoDB tooltip light styles
+   *  CartoDB tooltip dark styles
    */
 
-  
+  div.cartodb-tooltip-content-wrapper.dark {
+    background: rgb(0,0,0);
+    background:rgba(0,0,0,0.75);
+    filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#bf000000, endColorstr=#bf000000);
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#bf000000, endColorstr=#bf000000)";
+  }
+
+  div.cartodb-tooltip-content-wrapper.dark h4 {
+    color:#999;
+  }
+
+  div.cartodb-tooltip-content-wrapper.dark p {
+    color:#FFFFFF;
+  }
+
+  div.cartodb-tooltip-content-wrapper.dark a {
+    color:#397DB9;
+  }


### PR DESCRIPTION
Fix https://github.com/CartoDB/support/issues/1430

and an error case in https://github.com/CartoDB/cartodb/issues/13765, when this happens:

![Bug](https://user-images.githubusercontent.com/16247628/37919799-3cd5ef36-3125-11e8-91d2-4894d0d01c83.png)

Acceptance:

1. Create a map with a legend, a title / description
2. On Map settings enable the toolbar, publish
3. Check that all viewport sizes are fine
4. Disable the toolbar
5. Check that all viewports sizes are fine
6. Collapse the legend box on the second-to-biggest viewport, go to the biggest viewport
7. Box should not be collapsed