### PR TITLE
Update charlock_holmes to 0.7.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ end
 gem 'roo',                     '1.13.2'
 gem 'state_machine',           '1.1.2'
 gem 'typhoeus',                '0.7.2'
-gem 'charlock_holmes',         '0.7.5'
+gem 'charlock_holmes',         '0.7.6'
 gem 'dbf',                     '2.0.6'
 gem 'faraday',                 '0.9.0'
 gem 'retriable',               '1.4.1'  # google-api-client needs this

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 2.0)
       xpath (~> 0.1.4)
-    charlock_holmes (0.7.5)
+    charlock_holmes (0.7.6)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -381,7 +381,7 @@ DEPENDENCIES
   bartt-ssl_requirement (~> 1.4.0)
   byebug
   capybara (= 1.1.2)
-  charlock_holmes (= 0.7.5)
+  charlock_holmes (= 0.7.6)
   ci_reporter (= 1.8.4)
   compass (= 1.0.3)
   db-query-matchers (= 0.4.0)
@@ -451,4 +451,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   1.15.1
+   1.16.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -172,6 +172,7 @@ ion for time-series (#12670)
 
 ### Bug fixes / enhancements
 * Fix a case where the layer selector was displaying incorrectly (https://github.com/CartoDB/support/issues/1430)
+* Update charlock_holmes to 0.7.6 (ICU compatibility)
 * Skip canonical viz with missing tables from metadata export
 * Fix dialog footer in some modals (CartoDB/onpremises/issues/507)
 * Fix alignment for formula widget edit form (CartoDB/onpremises/issues/511)


### PR DESCRIPTION
This is needed for [ICU 61 compatibility](https://github.com/brianmario/charlock_holmes/commit/018be8532670c618034951f611748259689447a1)

From Arch with :heart: 