### PR TITLE
Popup displacement on Firefox

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -174,6 +174,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix embed maps on firefox, which caused displaced popups as well (https://github.com/CartoDB/support/issues/1419)
 * Fix a case where the layer selector was displaying incorrectly (https://github.com/CartoDB/support/issues/1430)
 * Update charlock_holmes to 0.7.6 (ICU compatibility)
 * Skip canonical viz with missing tables from metadata export

--- a/app/assets/stylesheets/deep-insights/themes/scss/map/_embed.scss
+++ b/app/assets/stylesheets/deep-insights/themes/scss/map/_embed.scss
@@ -52,7 +52,6 @@ $cEmbedTabs-Shadow: rgba(0, 0, 0, 0.24);
 }
 
 .CDB-Embed-content {
-  flex: 1;
   height: 100%;
 }
 
@@ -187,6 +186,7 @@ $cEmbedTabs-Shadow: rgba(0, 0, 0, 0.24);
 @media (max-width: $sMedia-min-w-vertical - 1px) {
   .CDB-Embed-content {
     // 104px = header + tabs height
+    flex: 1;
     height: calc(100% - 104px);
   }
 


### PR DESCRIPTION
Fixes https://github.com/CartoDB/support/issues/1419

The Flex was screwing with the layout on firefox, making the whole app scroll vertically, instead of getting a scroll on the widgets, also displacing the popups until a resize.

### Acceptance
1. Create a map with the above issues's carto file
2. Go to the embed version on all relevant browsers, check all viewport sizes, check that infoboxes are positioned correctly, check that there's no vertical scroll
