### PR TITLE
Change Type title to APIs, and put consistent and bigger margins in Auth API UI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -174,6 +174,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Consistent margins in Auth API UI
 * FullStory tweaks (https://github.com/CartoDB/cartodb/pull/13753)
 * Allows imports of synchronizations without a log
 * Fix embed maps on firefox, which caused displaced popups as well (https://github.com/CartoDB/support/issues/1419)

--- a/app/assets/stylesheets/new_dashboard/api-keys.scss
+++ b/app/assets/stylesheets/new_dashboard/api-keys.scss
@@ -82,7 +82,7 @@
   }
 
   .Editor-formInner {
-    margin-top: 16px;
+    margin-top: 24px;
   }
 }
 
@@ -100,8 +100,6 @@
 }
 
 .ApiKeysForm-grantsTable {
-  margin-top: 16px;
-
   &.showOnlySelect {
     [data-name='insert'],
     [data-name='update'],

--- a/lib/assets/javascripts/dashboard/components/table-grants/table-grants.tpl
+++ b/lib/assets/javascripts/dashboard/components/table-grants/table-grants.tpl
@@ -1,4 +1,4 @@
-<div class="u-tSpace-xl">
+<div class="CDB-Text Editor-formInner">
   <label class="CDB-Legend u-upperCase CDB-Text is-semibold CDB-Size-small">Datasets</label>
 
   <div class="CDB-Box-modal ApiKeysForm-box-modal">

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
@@ -92,7 +92,7 @@ module.exports = CoreView.extend({
       },
       apis: {
         type: 'MultiCheckbox',
-        title: 'Type',
+        title: 'APIs',
         validators: ['required'],
         hideValidationErrors: true,
         fieldClass: 'u-iBlock',


### PR DESCRIPTION
This PR adds consistency to the margins in the Auth API sections, and changes `Type` title to `APIs`

![screen shot 2018-04-10 at 12 29 50](https://user-images.githubusercontent.com/4319728/38552040-140bec3a-3cbb-11e8-9256-b04db187bf6f.png)
