### PR TITLE
Add Auth API flash message

### DIFF
--- a/app/views/admin/client_applications/_api_keys_form.html.erb
+++ b/app/views/admin/client_applications/_api_keys_form.html.erb
@@ -72,6 +72,6 @@
 <div class="FormAccount-footer">
   <p class="FormAccount-footerText">
     <i class="CDB-IconFont CDB-IconFont-info FormAccount-footerIcon"></i>
-    <span>Learn more about location app authorization and API key management <%= link_to "here", "https://cartodb.github.io/developers/fundamentals/authorization/" %></span>
+    <span>Learn more about location app authorization and API key management <%= link_to "here", "https://carto.com/developers/fundamentals/authorization/" %></span>
   </p>
 </div>

--- a/app/views/admin/client_applications/_api_keys_form.html.erb
+++ b/app/views/admin/client_applications/_api_keys_form.html.erb
@@ -72,6 +72,6 @@
 <div class="FormAccount-footer">
   <p class="FormAccount-footerText">
     <i class="CDB-IconFont CDB-IconFont-info FormAccount-footerIcon"></i>
-    <span>Learn more location app authorization and API key management <%= link_to "here", "https://cartodb.github.io/developers/fundamentals/authorization/" %></span>
+    <span>Learn more about location app authorization and API key management <%= link_to "here", "https://cartodb.github.io/developers/fundamentals/authorization/" %></span>
   </p>
 </div>

--- a/app/views/admin/client_applications/_api_keys_form.html.erb
+++ b/app/views/admin/client_applications/_api_keys_form.html.erb
@@ -72,6 +72,6 @@
 <div class="FormAccount-footer">
   <p class="FormAccount-footerText">
     <i class="CDB-IconFont CDB-IconFont-info FormAccount-footerIcon"></i>
-    <span>Learn more about <%= link_to "using your simple API key", Cartodb.config[:developers_host] + "/carto-editor/your-account/#api-key" %> in CARTO</span>
+    <span>Learn more location app authorization and API key management <%= link_to "here", "https://cartodb.github.io/developers/fundamentals/authorization/" %></span>
   </p>
 </div>

--- a/app/views/admin/client_applications/oauth.html.erb
+++ b/app/views/admin/client_applications/oauth.html.erb
@@ -76,7 +76,7 @@
     <div class="FormAccount-footer">
       <p class="FormAccount-footerText">
         <i class="CDB-IconFont CDB-IconFont-info FormAccount-footerIcon"></i>
-        <span>Learn more location app authorization and API key management <%= link_to "here", "https://cartodb.github.io/developers/fundamentals/authorization/" %></span>
+        <span>Learn more about location app authorization and API key management <%= link_to "here", "https://cartodb.github.io/developers/fundamentals/authorization/" %></span>
       </p>
       <p class="FormAccount-footerText">
         <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />

--- a/app/views/admin/client_applications/oauth.html.erb
+++ b/app/views/admin/client_applications/oauth.html.erb
@@ -76,7 +76,7 @@
     <div class="FormAccount-footer">
       <p class="FormAccount-footerText">
         <i class="CDB-IconFont CDB-IconFont-info FormAccount-footerIcon"></i>
-        <span>Learn more about <%= link_to "using your simple app key", Cartodb.config[:developers_host] + "/documentation/apis-overview.html" %> in CARTO</span>
+        <span>Learn more location app authorization and API key management <%= link_to "here", "https://cartodb.github.io/developers/fundamentals/authorization/" %></span>
       </p>
       <p class="FormAccount-footerText">
         <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />

--- a/app/views/admin/client_applications/oauth.html.erb
+++ b/app/views/admin/client_applications/oauth.html.erb
@@ -76,7 +76,7 @@
     <div class="FormAccount-footer">
       <p class="FormAccount-footerText">
         <i class="CDB-IconFont CDB-IconFont-info FormAccount-footerIcon"></i>
-        <span>Learn more about location app authorization and API key management <%= link_to "here", "https://cartodb.github.io/developers/fundamentals/authorization/" %></span>
+        <span>Learn more about location app authorization and API key management <%= link_to "here", "https://carto.com/developers/fundamentals/authorization/" %></span>
       </p>
       <p class="FormAccount-footerText">
         <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />

--- a/lib/assets/javascripts/dashboard/api-keys.js
+++ b/lib/assets/javascripts/dashboard/api-keys.js
@@ -19,6 +19,7 @@ const DashboardHeaderView = require('dashboard/components/dashboard-header-view'
 const SupportView = require('dashboard/components/support-view');
 const HeaderViewModel = require('dashboard/views/api-keys/header-view-model');
 const UpgradeMessageView = require('dashboard/components/upgrade-message-view');
+const AuthMessageView = require('dashboard/components/auth-message-view');
 const UserNotificationView = require('dashboard/components/user-notification/user-notification-view');
 const ApiKeysListView = require('dashboard/views/api-keys/api-keys-list-view');
 const ApiKeysFormView = require('dashboard/views/api-keys/api-keys-form-view');
@@ -72,6 +73,11 @@ $(function () {
   });
 
   $('.Header').after(upgradeMessage.render().el);
+
+  if (userModel.featureEnabled('auth_api')) {
+    const authMessageView = new AuthMessageView();
+    $('.Header').after(authMessageView.render().el);
+  }
 
   const supportView = new SupportView({
     el: $('#support-banner'),

--- a/lib/assets/javascripts/dashboard/components/auth-message-view.js
+++ b/lib/assets/javascripts/dashboard/components/auth-message-view.js
@@ -1,0 +1,9 @@
+const CoreView = require('backbone/core-view');
+const template = require('./auth-message.tpl');
+
+module.exports = CoreView.extend({
+  render: function () {
+    this.$el.html(template());
+    return this;
+  }
+});

--- a/lib/assets/javascripts/dashboard/components/auth-message.tpl
+++ b/lib/assets/javascripts/dashboard/components/auth-message.tpl
@@ -1,5 +1,5 @@
 <div class="FlashMessage FlashMessage--main CDB-Text">
   <div class="u-inner">
-    <p class="FlashMessage-info">Surprise! We've just released a more advanced authorization system. Learn about the latest security enhancements and <a href="https://cartodb.github.io/developers/fundamentals/authorization/" target="_blank">get&nbsp;started&nbsp;here.</a></p>
+    <p class="FlashMessage-info">Surprise! We've just released a more advanced authorization system. Learn about the latest security enhancements and <a href="https://carto.com/developers/fundamentals/authorization/" target="_blank">get&nbsp;started&nbsp;here.</a></p>
   </div>
 </div>

--- a/lib/assets/javascripts/dashboard/components/auth-message.tpl
+++ b/lib/assets/javascripts/dashboard/components/auth-message.tpl
@@ -1,0 +1,5 @@
+<div class="FlashMessage FlashMessage--main CDB-Text">
+  <div class="u-inner">
+    <p class="FlashMessage-info">Surprise! We've just released a more advanced authorization system. Learn about the latest security enhancements and <a href="https://cartodb.github.io/developers/fundamentals/authorization/" target="_blank">get&nbsp;started&nbsp;here.</a></p>
+  </div>
+</div>

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-list.tpl
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-list.tpl
@@ -44,6 +44,6 @@
 <footer class="ApiKeys-footer">
   <p class="ApiKeys-footer-text">
     <i class="CDB-IconFont CDB-IconFont-info ApiKeys-footer-icon"></i>
-    <span>Learn more about <a href="https://carto.com/docs/carto-editor/your-account/#api-key" target="_blank">using your simple API key</a> in CARTO</span>
+    <span>Learn more location app authorization and API key management <a href="https://cartodb.github.io/developers/fundamentals/authorization/" target="_blank">here</a></span>
   </p>
 </footer>

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-list.tpl
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-list.tpl
@@ -44,6 +44,6 @@
 <footer class="ApiKeys-footer">
   <p class="ApiKeys-footer-text">
     <i class="CDB-IconFont CDB-IconFont-info ApiKeys-footer-icon"></i>
-    <span>Learn more location app authorization and API key management <a href="https://cartodb.github.io/developers/fundamentals/authorization/" target="_blank">here</a></span>
+    <span>Learn more about location app authorization and API key management <a href="https://cartodb.github.io/developers/fundamentals/authorization/" target="_blank">here</a></span>
   </p>
 </footer>

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-list.tpl
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-list.tpl
@@ -44,6 +44,6 @@
 <footer class="ApiKeys-footer">
   <p class="ApiKeys-footer-text">
     <i class="CDB-IconFont CDB-IconFont-info ApiKeys-footer-icon"></i>
-    <span>Learn more about location app authorization and API key management <a href="https://cartodb.github.io/developers/fundamentals/authorization/" target="_blank">here</a></span>
+    <span>Learn more about location app authorization and API key management <a href="https://carto.com/developers/fundamentals/authorization/" target="_blank">here</a></span>
   </p>
 </footer>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.113-13849",
+  "version": "4.11.113",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.113",
+  "version": "4.11.113-13849",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a fixed flash message that tells the users that a new Auth API workflow has been released.

It also change the copy and links in footer.

![image](https://user-images.githubusercontent.com/1078228/38835689-25b1898e-41cc-11e8-8364-3f033f530aad.png)

⚠️ Temporal links until new developer center is deployed.

### Acceptance

- Set `auth_api` FF on to a user.
- Check that the banner shows up and that it links to the correct place.
- Remove `auth_api` FF from the user.
- Check that the banner doesn't appear.
- In both cases, check that the footer link points to the correct docs place.