### PR TITLE
Deprecated job roles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,9 @@ class User < Sequel::Model
   JOB_ROLES = ['Founder / Executive', 'Developer', 'Student', 'VP / Director', 'Manager / Lead',
                'Personal / Non-professional', 'Media', 'Individual Contributor'].freeze
 
+  DEPRECATED_JOB_ROLES = ['Researcher', 'GIS specialist', 'Designer', 'Consultant / Analyst',
+                   'CIO / Executive', 'Marketer', 'Sales', 'Journalist', 'Hobbyist'].freeze
+
   # Make sure the following date is after Jan 29, 2015,
   # which is the date where a message to accept the Terms and
   # conditions and the Privacy policy was included in the Signup page.
@@ -186,7 +189,7 @@ class User < Sequel::Model
     end
 
     validates_includes INDUSTRIES, :industry if industry.present?
-    validates_includes JOB_ROLES, :job_role if job_role.present?
+    validates_includes JOB_ROLES + DEPRECATED_JOB_ROLES, :job_role if job_role.present?
 
     errors.add(:geocoding_quota, "cannot be nil") if geocoding_quota.nil?
     errors.add(:here_isolines_quota, "cannot be nil") if here_isolines_quota.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,7 +61,7 @@ class User < Sequel::Model
                'Personal / Non-professional', 'Media', 'Individual Contributor'].freeze
 
   DEPRECATED_JOB_ROLES = ['Researcher', 'GIS specialist', 'Designer', 'Consultant / Analyst',
-                   'CIO / Executive', 'Marketer', 'Sales', 'Journalist', 'Hobbyist'].freeze
+                          'CIO / Executive', 'Marketer', 'Sales', 'Journalist', 'Hobbyist'].freeze
 
   # Make sure the following date is after Jan 29, 2015,
   # which is the date where a message to accept the Terms and

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -453,6 +453,24 @@ describe User do
     user.destroy
   end
 
+  it "should validate job_role and deprecated_job_roles" do
+    user = ::User.new
+    user.username = "adminipop"
+    user.email = "adminipop@example.com"
+    user.password = 'admin123'
+    user.password_confirmation = 'admin123'
+
+    user.job_role = "Developer"
+    user.valid?.should be_true
+
+    user.job_role = "Researcher"
+    user.valid?.should be_true
+
+    user.job_role = "whatever"
+    user.valid?.should be_false
+    user.errors[:job_role].should be_present
+  end
+
   it "should validate password presence and length" do
     user = ::User.new
     user.username = "adminipop"


### PR DESCRIPTION
Also a couple of UPDATE scripts to avoid sync fails (just in case):

```sql
UPDATE users
SET job_role = ''
WHERE NOT (job_role = ANY(ARRAY['', 'Founder / Executive', 'Developer', 'Student', 'VP / Director', 'Manager / Lead', 'Personal / Non-professional', 'Media', 'Individual Contributor', 'Researcher', 'GIS specialist', 'Designer', 'Consultant / Analyst', 'CIO / Executive', 'Marketer', 'Sales', 'Journalist', 'Hobbyist']));
```

```sql
UPDATE users
SET industry = ''
WHERE NOT (industry = ANY(ARRAY['', 'Academic and Education', 'Architecture and Engineering', 'Banking and Finance', 'Business Intelligence and Analytics', 'Utilities and Communications', 'GIS and Mapping', 'Government', 'Health', 'Marketing and Advertising', 'Media, Entertainment and Publishing', 'Natural Resources', 'Non-Profits', 'Real Estate', 'Software and Technology', 'Transportation and Logistics']));
```