### PR TITLE
Update Heatmap legend after style changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -175,6 +175,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix Heatmap legend does not update after style changes (https://github.com/CartoDB/cartodb/issues/13763)
 * Includes a rake tast to destroy duplicated overlays that should be unique.
 * Disable Twitter Connector and show Warning for users without their own credentials (https://github.com/CartoDB/product/issues/49)
 * Fix Category Widgets height on smaller screens (https://github.com/CartoDB/cartodb/issues/13829)

--- a/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
@@ -27,7 +27,11 @@ var onChange = function (layerDefModel) {
       LegendFactory.removeLegend(layerDefModel, 'category', function () {
         LegendFactory.removeLegend(layerDefModel, 'torque', function () {
           LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-            LegendFactory.createLegend(layerDefModel, 'custom_choropleth', {title: _t('editor.legend.pixel-title')});
+            var colors = StyleHelper.getColorsFromRange(styleModel);
+            LegendFactory.createLegend(layerDefModel, 'custom_choropleth', {
+              title: _t('editor.legend.pixel-title'),
+              colors: colors
+            });
           });
         });
       });

--- a/lib/assets/javascripts/builder/helpers/style.js
+++ b/lib/assets/javascripts/builder/helpers/style.js
@@ -37,6 +37,19 @@ module.exports = {
     return size;
   },
 
+  getColorsFromRange: function (styleModel) {
+    var color = this.getColor(styleModel);
+
+    if (!(color && color.range)) { return []; }
+    var range = color.range.length;
+
+    return _.range(range).map(function (v, index) {
+      return {
+        color: color.range[index]
+      };
+    });
+  },
+
   getStyleCategories: function (styleModel) {
     var color = this.getColor(styleModel);
     var range = 0;

--- a/lib/assets/javascripts/builder/helpers/style.js
+++ b/lib/assets/javascripts/builder/helpers/style.js
@@ -39,29 +39,21 @@ module.exports = {
 
   getColorsFromRange: function (styleModel) {
     var color = this.getColor(styleModel);
-
     if (!(color && color.range)) { return []; }
-    var range = color.range.length;
 
-    return _.range(range).map(function (v, index) {
-      return {
-        color: color.range[index]
-      };
+    return color.range.map(function (v, index) {
+      return { color: v };
     });
   },
 
   getStyleCategories: function (styleModel) {
     var color = this.getColor(styleModel);
-    var range = 0;
-
     if (!color) { return []; }
 
     if (color.range) {
-      range = color.range.length;
-
-      return _.range(range).map(function (v, index) {
+      return color.range.map(function (v, index) {
         return {
-          color: color.range[index],
+          color: v,
           title: color.domain && LegendColorHelper.unquoteColor(color.domain[index]) || _t('editor.legend.legend-form.others'),
           icon: color.images && color.images[index] || ''
         };

--- a/lib/assets/test/spec/builder/deep-insights-integration/legend-manager.spec.js
+++ b/lib/assets/test/spec/builder/deep-insights-integration/legend-manager.spec.js
@@ -679,4 +679,53 @@ describe('deep-insights-integrations/legend-manager', function () {
       });
     });
   });
+
+  describe('heatmap', function () {
+    beforeEach(function () {
+      this.styleModel.set('type', 'heatmap');
+
+      var fillProperties = {
+        color: {
+          attribute: 'cartodb_id',
+          bins: '5',
+          opacity: 1,
+          quantification: 'equal',
+          range: ['#ecda9a', '#f1b973', '#f7945d', '#f86f56', '#ee4d5a']
+        },
+        size: {
+          fixed: 7.5
+        }
+      };
+
+      this.styleModel.set('fill', fillProperties);
+    });
+
+    describe('without existing legend', function () {
+      it('styles color', function () {
+        this.layerDefinitionModel.set({
+          cartocss: 'wadus'
+        });
+
+        expect(LegendFactory.createLegend).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('with existing legend', function () {
+      it('styles color', function () {
+        LegendFactory.createLegend(this.layerDefinitionModel, 'custom_choropleth');
+        jasmine.Ajax.requests.mostRecent().respondWith(getSuccessResponse('save', 1, 'custom_choropleth'));
+
+        this.layerDefinitionModel.set({
+          cartocss: 'wadus'
+        });
+
+        var colors = StyleHelper.getColorsFromRange(this.styleModel);
+        expect(LegendFactory.createLegend).toHaveBeenCalledWith(
+          this.layerDefinitionModel, 'custom_choropleth', {
+            title: 'editor.legend.pixel-title',
+            colors: colors
+          });
+      });
+    });
+  });
 });

--- a/lib/assets/test/spec/builder/helpers/style.spec.js
+++ b/lib/assets/test/spec/builder/helpers/style.spec.js
@@ -1,0 +1,30 @@
+
+var Backbone = require('backbone');
+var StyleHelper = require('builder/helpers/style');
+
+describe('helpers/style', function () {
+  describe('heatmap', function () {
+    var styleModel = new Backbone.Model({
+      type: 'heatmap',
+      fill: {
+        color: {
+          attribute: 'cartodb_id',
+          bins: '5',
+          opacity: 1,
+          quantification: 'equal',
+          range: ['#ecda9a', '#f1b973', '#f7945d', '#f86f56', '#ee4d5a']
+        },
+        size: {
+          fixed: 7.5
+        }
+      }
+    });
+
+    it('can get color objects from colors range', function () {
+      var colors = StyleHelper.getColorsFromRange(styleModel);
+      expect(colors).toEqual([
+        {color: '#ecda9a'}, {color: '#f1b973'}, {color: '#f7945d'}, {color: '#f86f56'}, {color: '#ee4d5a'}
+      ]);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.115",
+  "version": "4.11.115-13763",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.115-13763",
+  "version": "4.11.115",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13763 and https://github.com/CartoDB/onpremises/issues/518
---

- [x] Dev
- [x] Frontend CR
- [x] Deployment to staging
- [x] Acceptance
- [ ] Deployment to production

# Acceptance
- Create a `New map` from a dataset with points
- Go to the layer and then go to the `Style` view.
- Change the Aggregation to `Heatmap`
- Go to the `Legend` view.
- Add a `Custom Chloropleth Legend`
- Go back to the `Style` view and change the color ramp.
- Colorbar at `Legend` must be updated with new color properties
