### PR TITLE
Better popups with just images on IE and Edge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -175,6 +175,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix popups with just images on IE and Edge (#13808)
 * Handle redirection when adding widgets (https://github.com/CartoDB/support/issues/1464)
 * Add overlap option in animated heatmap style form (https://github.com/CartoDB/support/issues/1331)
 * Fix bottom extra space in legends (#13765)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.120",
+  "version": "4.11.120-13808.1",
   "dependencies": {
     "accessory": {
       "version": "1.0.1",
@@ -387,9 +387,9 @@
       "resolved": "https://registry.npmjs.org/carto-zera/-/carto-zera-1.0.2.tgz"
     },
     "carto.js": {
-      "version": "4.0.0-2",
-      "from": "cartodb/carto.js#v4.0.0-2",
-      "resolved": "git://github.com/cartodb/carto.js.git#21da8044c8d954449fb7be7c2b2ac05054e658b1"
+      "version": "4.0.1-1",
+      "from": "cartodb/carto.js#v4.0.1-1",
+      "resolved": "git://github.com/cartodb/carto.js.git#506219dae1864040cb85c79ca417cfc8ac0d01bd"
     },
     "cartocolor": {
       "version": "4.0.0",
@@ -1374,9 +1374,9 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
     },
     "lodash": {
-      "version": "4.17.5",
+      "version": "4.17.10",
       "from": "lodash@>=4.17.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.120-13808",
+  "version": "4.11.120-13808.1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.120",
+  "version": "4.11.120-13808",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "carto-zera": "1.0.2",
     "cartocolor": "4.0.0",
     "cartodb-pecan": "0.2.x",
-    "carto.js": "CartoDB/carto.js#v4.0.0-2",
+    "carto.js": "CartoDB/carto.js#v4.0.1-1",
     "clipboard": "1.6.1",
     "codemirror": "5.14.2",
     "d3-interpolate": "^1.1.6",


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/13808

This includes a fallback for IE and Edge popups through `carto.js` (https://github.com/CartoDB/carto.js/pull/2105)

- [x] Dev
- [x] Frontend CR (at carto.js)
- [x] Deployment to staging
- [x] Acceptance
- [ ] Deployment to production

---

To check for the fix:
1. Visualize a layer in a `map`, having an url to an `image` in one of its fields
2. Configure a popup with style `Pop-Up with header image` 
3. Find a feature and Click on it, to show its `popup` with image.

A `carto file` is attached to easily reproduce steps 1 and 2. Download, extract .carto and import [bulding_with popup.carto.zip](https://github.com/CartoDB/cartodb/files/1944544/bulding_with.popup.carto.zip)


**Acceptance** 
- [x] From IE11 or Edge browser: image is displayed, popup has no hook and close button is correctly positioned over the image.
- [x] From another browser (eg. Chrome): popup has a hook and there is a piece of the image clipped on it.
