### PR TITLE
Escape prefixes and sufixes in formula widgets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -175,6 +175,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Escape prefixes and sufixes in formula widgets (#13895)
 * Keep widgets list order (#13773)
 * Change analyses short names (#13828)
 * Fix popups with just images on IE and Edge (#13808)

--- a/lib/assets/javascripts/deep-insights/util/unescape-html.js
+++ b/lib/assets/javascripts/deep-insights/util/unescape-html.js
@@ -1,0 +1,5 @@
+var _ = require('underscore');
+
+module.exports = function unescapeHTML (str) {
+  return _.unescape(str);
+};

--- a/lib/assets/javascripts/deep-insights/widgets/formula/animation-template.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/formula/animation-template.tpl
@@ -1,1 +1,1 @@
-<%= _.unescape(prefix) %><%= value %><%= _.unescape(suffix) %>
+<%= prefix %><%= value %><%= suffix %>

--- a/lib/assets/javascripts/deep-insights/widgets/formula/animation-template.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/formula/animation-template.tpl
@@ -1,1 +1,1 @@
-<%- prefix %><%- value %><%- suffix %>
+<%= _.unescape(prefix) %><%= value %><%= _.unescape(suffix) %>

--- a/lib/assets/javascripts/deep-insights/widgets/formula/content-view.js
+++ b/lib/assets/javascripts/deep-insights/widgets/formula/content-view.js
@@ -9,6 +9,7 @@ var AnimateValues = require('../animate-values.js');
 var layerColors = require('../../util/layer-colors');
 var Analyses = require('../../data/analyses');
 var escapeHTML = require('../../util/escape-html');
+var unescapeHTML = require('../../util/unescape-html');
 var TipsyTooltipView = require('../../../builder/components/tipsy-tooltip-view');
 
 /**
@@ -74,8 +75,8 @@ module.exports = CoreView.extend({
         formatedValue: format(value),
         description: this.model.get('description'),
         nulls: nulls,
-        prefix: escapeHTML(prefix),
-        suffix: escapeHTML(suffix),
+        prefix: unescapeHTML(prefix),
+        suffix: unescapeHTML(suffix),
         isCollapsed: isCollapsed,
         sourceColor: sourceColor,
         layerName: escapeHTML(layerName)
@@ -95,8 +96,8 @@ module.exports = CoreView.extend({
         animationSpeed: 700,
         formatter: format,
         templateData: {
-          prefix: prefix,
-          suffix: suffix
+          prefix: unescapeHTML(prefix),
+          suffix: unescapeHTML(suffix)
         }
       }
     );

--- a/lib/assets/javascripts/deep-insights/widgets/formula/content-view.js
+++ b/lib/assets/javascripts/deep-insights/widgets/formula/content-view.js
@@ -74,8 +74,8 @@ module.exports = CoreView.extend({
         formatedValue: format(value),
         description: this.model.get('description'),
         nulls: nulls,
-        prefix: prefix,
-        suffix: suffix,
+        prefix: escapeHTML(prefix),
+        suffix: escapeHTML(suffix),
         isCollapsed: isCollapsed,
         sourceColor: sourceColor,
         layerName: escapeHTML(layerName)

--- a/lib/assets/javascripts/deep-insights/widgets/formula/template.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/formula/template.tpl
@@ -43,7 +43,7 @@
 <div class="CDB-Widget-content CDB-Widget-content--formula">
   <% if (_.isNumber(value)) { %>
     <h4 class="CDB-Text CDB-Size-huge <%- !isCollapsed ? 'js-value' : '' %>" title="<%= value %>">
-      <%= prefix %><%= value %><%= suffix %>
+      <%= _.unescape(prefix) %><%= value %><%= _.unescape(suffix) %>
     </h4>
     <% if (description) { %>
       <p class="CDB-Text CDB-Size-small u-tSpace js-description"><%- description %></p>

--- a/lib/assets/javascripts/deep-insights/widgets/formula/template.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/formula/template.tpl
@@ -42,8 +42,8 @@
 </div>
 <div class="CDB-Widget-content CDB-Widget-content--formula">
   <% if (_.isNumber(value)) { %>
-    <h4 class="CDB-Text CDB-Size-huge <%- !isCollapsed ? 'js-value' : '' %>" title="<%= value %>">
-      <%= _.unescape(prefix) %><%= value %><%= _.unescape(suffix) %>
+    <h4 class="CDB-Text CDB-Size-huge <%- !isCollapsed ? 'js-value' : '' %>" title="<%- value %>">
+      <%= prefix %><%- value %><%= suffix %>
     </h4>
     <% if (description) { %>
       <p class="CDB-Text CDB-Size-small u-tSpace js-description"><%- description %></p>

--- a/lib/assets/javascripts/deep-insights/widgets/formula/template.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/formula/template.tpl
@@ -42,8 +42,8 @@
 </div>
 <div class="CDB-Widget-content CDB-Widget-content--formula">
   <% if (_.isNumber(value)) { %>
-    <h4 class="CDB-Text CDB-Size-huge <%- !isCollapsed ? 'js-value' : '' %>" title="<%- value %>">
-      <%- prefix %><%- value %><%- suffix %>
+    <h4 class="CDB-Text CDB-Size-huge <%- !isCollapsed ? 'js-value' : '' %>" title="<%= value %>">
+      <%= prefix %><%= value %><%= suffix %>
     </h4>
     <% if (description) { %>
       <p class="CDB-Text CDB-Size-small u-tSpace js-description"><%- description %></p>


### PR DESCRIPTION
Related issue: https://github.com/CartoDB/cartodb/issues/11726

![escape](https://user-images.githubusercontent.com/3824953/39254877-767218da-48ab-11e8-8230-24c525f4d72d.gif)
