### PR TITLE
Fix require for carto.js at some specs

### DIFF
--- a/lib/assets/test/spec/builder/embed-integrations.spec.js
+++ b/lib/assets/test/spec/builder/embed-integrations.spec.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var deepInsights = require('deep-insights/index');
 var LayerStyleCollection = require('builder/embed/style-collection');
 var EmbedIntegrations = require('builder/embed/embed-integrations');
-var VisModel = require('carto.js/src/vis/vis');
+var VisModel = require('@carto/carto.js/src/vis/vis');
 
 describe('embed-integrations', function () {
   var el;

--- a/lib/assets/test/spec/deep-insights/widgets/time-series/torque-histogram-view.spec.js
+++ b/lib/assets/test/spec/deep-insights/widgets/time-series/torque-histogram-view.spec.js
@@ -3,7 +3,7 @@ var TorqueHistogramView = require('../../../../../javascripts/deep-insights/widg
 var specHelper = require('../../spec-helper');
 var HistogramChartView = require('../../../../../javascripts/deep-insights/widgets/histogram/chart');
 var HistogramView = require('../../../../../javascripts/deep-insights/widgets/time-series/histogram-view');
-var TorqueLayer = require('carto.js/src/geo/map/torque-layer');
+var TorqueLayer = require('@carto/carto.js/src/geo/map/torque-layer');
 
 describe('widgets/time-series/torque-histogram-view', function () {
   beforeEach(function () {

--- a/lib/assets/test/spec/deep-insights/widgets/time-series/torque-time-slider-view.spec.js
+++ b/lib/assets/test/spec/deep-insights/widgets/time-series/torque-time-slider-view.spec.js
@@ -4,7 +4,7 @@ var specHelper = require('../../spec-helper');
 var HistogramChartView = require('../../../../../javascripts/deep-insights/widgets/histogram/chart');
 var TorqueTimeSliderView = require('../../../../../javascripts/deep-insights/widgets/time-series/torque-time-slider-view');
 var formatter = require('../../../../../javascripts/deep-insights/formatter');
-var TorqueLayer = require('carto.js/src/geo/map/torque-layer');
+var TorqueLayer = require('@carto/carto.js/src/geo/map/torque-layer');
 var cdb = require('@carto/carto.js');
 
 describe('widgets/time-series/torque-time-slider-view', function () {


### PR DESCRIPTION
Just fixing require to `carto.js` at some specs, using `@carto/carto.js`

This was generating an internal error when executing `grunt test` (at `webpack:builder_specs` task) , although the global process ended successfully.