### PR TITLE
Auth API docs in Import API reference section

### DIFF
--- a/docs/import-api/reference/swagger.yaml
+++ b/docs/import-api/reference/swagger.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Auth API
+  title: **Auth API**
   description: >
     # Introduction
 


### PR DESCRIPTION
The Auth API section is appearing on the Import API reference on the developer center.