### PR TITLE
Fix autostyle in embed maps [WIP]

### DIFF
--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -36,6 +36,7 @@
     var layersData = <%= safe_js_object @layers_data.to_json %>;
     var stateJSON = <%= safe_js_object @state.to_json %>;
     var authTokens = <%= safe_js_object @auth_tokens.to_json %>;
+    var frontendConfig = <%= safe_js_object frontend_config %>;
     var baseURL = '<%= @viz_owner_base_url %>';
     var mapzenApiKey = '<%= mapzen_api_key %>';
     var mapboxApiKey = '<%= mapbox_api_key %>';

--- a/lib/assets/javascripts/builder/embed/embed-integrations.js
+++ b/lib/assets/javascripts/builder/embed/embed-integrations.js
@@ -3,7 +3,8 @@ var LegendManager = require('./legend-manager');
 
 var REQUIRED_OPTS = [
   'deepInsightsDashboard',
-  'layerStyleCollection'
+  'layerStyleCollection',
+  'configModel'
 ];
 
 /**
@@ -13,6 +14,7 @@ var EmbedIntegrations = function (opts) {
   checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
   this._getWidgets().each(function (model) {
+    model.set('configModel', this._configModel);
     this._bindWidgetChanges(model);
   }, this);
 

--- a/lib/assets/javascripts/builder/public_editor.js
+++ b/lib/assets/javascripts/builder/public_editor.js
@@ -19,6 +19,7 @@ var vizJSON = window.vizJSON;
 var authTokens = window.authTokens;
 var mapzenApiKey = window.mapzenApiKey;
 var mapboxApiKey = window.mapboxApiKey;
+var frontendConfig = window.frontendConfig;
 var stateJSON = window.stateJSON;
 var layersData = window.layersData;
 var baseURL = window.baseURL;
@@ -26,7 +27,13 @@ var anyLayerWithLegends = vizJSON.layers.some(function (layer) {
   return layer.legends && layer.legends.length;
 });
 
-var configModel = new ConfigModel({ base_url: baseURL });
+var configModel = new ConfigModel(
+  _.defaults({
+    base_url: baseURL
+  },
+  frontendConfig
+  )
+);
 
 var layerStyleCollection = new LayerStyleCollection();
 layerStyleCollection.resetByLayersData(layersData);
@@ -83,7 +90,8 @@ deepInsights.createDashboard('.js-embed-map', vizJSON, dashboardOpts, function (
 
   var embedIntegrations = new EmbedIntegrations({
     deepInsightsDashboard: dashboard,
-    layerStyleCollection: layerStyleCollection
+    layerStyleCollection: layerStyleCollection,
+    configModel: configModel
   });
 
   window.embedIntegrations = embedIntegrations;

--- a/lib/assets/javascripts/deep-insights/widgets/category/category-widget-model.js
+++ b/lib/assets/javascripts/deep-insights/widgets/category/category-widget-model.js
@@ -75,7 +75,10 @@ module.exports = WidgetModel.extend({
 
   autoStyle: function () {
     // NOTE: maybe not pre-assing colors to categories?
-    this.autoStyler.colors.updateData(this.dataviewModel.get('allCategoryNames'));
+    if (this.autoStyler) {
+      this.autoStyler.colors.updateData(this.dataviewModel.get('allCategoryNames'));
+    }
+
     WidgetModel.prototype.autoStyle.call(this);
   },
 

--- a/lib/assets/javascripts/deep-insights/widgets/widget-model.js
+++ b/lib/assets/javascripts/deep-insights/widgets/widget-model.js
@@ -72,7 +72,10 @@ module.exports = cdb.core.Model.extend({
     if (!tableName) {
       return Promise.resolve([]);
     }
-    var url = sqlApiUrl + '?q=' + encodeURIComponent('SELECT * from ' + tableName) + '&api_key=' + apiKey;
+
+    var apiKeyParam = apiKey ? '&api_key=' + apiKey : '';
+    var url = sqlApiUrl + '?q=' + encodeURIComponent('SELECT * from ' + tableName) + apiKeyParam;
+
     return fetch(url)
       .then(function (response) { return response.json(); })
       .then(function (jsonResponse) { return Object.keys(jsonResponse.fields); });


### PR DESCRIPTION
Related issue: https://github.com/CartoDB/support/issues/1399#issuecomment-388161201

This is a WIP fix. With the latest changes, AutoStyle button was not working in embed maps. There are some issues to solve:

- [X] Add `configModel` to embed maps widgets with to check for valid columns. This is already changed but needs to be reviewed.
- [ ] Histogram widgets are not shown with this last commit.
- [ ] Minor: autostyle button takes some time to appear when the page loads because it is now fetching the columns to check if it is valid or not, and it can be confusing.

Pinging RT people involved @ramiroaznar @IagoLast @AleGoiko 