### PR TITLE
Fix bundle name for public table on production

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix the name of the bundle for public_Table on production (#13965)
 * Fix how to decide which public_table version to show (#13694)
 * GTM DataLayer Tweaks (https://github.com/CartoDB/cartodb/pull/13961)
 * Setup Google Tag Manager (https://github.com/CartoDB/cartodb/pull/13946)

--- a/webpack/dashboard/webpack.prod.config.js
+++ b/webpack/dashboard/webpack.prod.config.js
@@ -14,7 +14,7 @@ const isVendor = (module, count) => {
 };
 
 const entryPoints = {
-  public_dataset_new: resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard/public-dataset.js'),
+  public_table_new: resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard/public-dataset.js'),
   public_dashboard_new: resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard/public-dashboard.js'),
   user_feed_new: resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard/user-feed.js'),
   api_keys_new: resolve(__dirname, '../../', 'lib/assets/javascripts/dashboard/api-keys.js'),


### PR DESCRIPTION
We had a name mismatch between dev / production for the bundle name.

We should consider refactoring the bundles to an external file shared between both to prevent this.