### PR TITLE
Several migration fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix the public table view for non-migrated-users  (#13969)
 * Fix the name of the bundle for public_Table on production (#13965)
 * Fix how to decide which public_table version to show (#13694)
 * GTM DataLayer Tweaks (https://github.com/CartoDB/cartodb/pull/13961)

--- a/app/assets/stylesheets/public/public_map_wrapper_new.css.scss
+++ b/app/assets/stylesheets/public/public_map_wrapper_new.css.scss
@@ -9,10 +9,6 @@
 
 // Public map
 .pane_map {
-  .cartodb-map.public {
-    @include position(8px, 8px, 8px, 65%);
-  }
-
   .Checkbox {
     position: absolute;
     z-index: 30;

--- a/app/assets/stylesheets/public/public_table_wrapper_new.css.scss
+++ b/app/assets/stylesheets/public/public_table_wrapper_new.css.scss
@@ -17,21 +17,82 @@ html {
 body.public {
   min-width: inherit; /* Public table CSS */
 
+  .PublicMap-map {
+    display: flex;
+    overflow: hidden;
+
+    @media (max-width: $sMedia-desktop) {
+      flex-direction: column;
+    }
+  }
+
+  .map {
+    position: relative;
+    padding: 0;
+
+    .cartodb-map {
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
   .pane_table {
-    @include reset-table-cell();
-    @include position(8px, calc(35% + 8px), 8px, 8px);
     z-index: 10;
+    flex: 1 1 auto;
     overflow: hidden;
     border-radius: 3px;
+    text-align: left;
 
     &.is-active {
       background: #FFF;
     }
   }
 
+  div.panes {
+    position: static;
+    max-height: 100%;
+    margin: 8px;
+    clear: both;
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    &.pane_map {
+      margin-left: 0;
+    }
+
+    @media (max-width: $sMedia-desktop) {
+      display: none;
+      margin: 16px;
+
+      &.is-active {
+        display: block;
+      }
+
+      &.pane_map {
+        margin-left: 16px;
+      }
+    }
+
+    div.shadow {
+      display: none;
+    }
+
+    div.table table thead tr th > div > div {
+      position: relative;
+    }
+  }
+
   .pane_map {
+    position: relative;
     top: 0;
+    flex: 1;
+    min-width: 35%;
     overflow-x: hidden;
+
+    @media (max-width: $sMedia-desktop) {
+      min-width: initial;
+    }
   }
 
   .panes .emptyTableContainer {
@@ -148,10 +209,7 @@ body.public {
   .navigation {
     position: relative;
     z-index: 100;
-    width: 100%;
-    margin: auto;
-    clear: both;
-    overflow: hidden;
+    margin: 8px 0 16px;
     opacity: 0;
     text-align: center;
 
@@ -200,50 +258,5 @@ body.public {
     position: relative;
     z-index: 100;
     top: 300px;
-  }
-
-  div.panes {
-    clear: both;
-    overflow-x: auto;
-    overflow-y: hidden;
-
-    div.shadow {
-      display: none;
-    }
-
-    div.table table thead tr th > div > div {
-      position: relative;
-    }
-  }
-
-  div.panes.panes_mobile {
-    top: 0;
-    overflow-x: hidden;
-
-    .table.public {
-      background: #FFF;
-    }
-
-    .Checkbox {
-      position: absolute;
-      z-index: 30;
-      top: 35px;
-      right: 35px;
-      padding: 3px 5px;
-      border-radius: 3px;
-      background-color: rgba(#000, 0.5);
-    }
-
-    .Checkbox-label {
-      color: #FFF;
-    }
-
-    .table.public,
-    .cartodb-map.public {
-      @include position(15px, 15px, 60px, 15px);
-      z-index: 10;
-      overflow: hidden;
-      border-radius: 3px;
-    }
   }
 }

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -8,7 +8,11 @@
 <%= content_for(:facebook_card) do %><%= Carto::StaticMapsURLHelper.new.url_for_static_map(request, @table.table_visualization, 1200, 630) %><% end %>
 
 <%= content_for(:css) do %>
-  <%= stylesheet_link_tag 'cartodb', 'common', 'public_table', 'public_map' %>
+  <% if @has_new_dashboard %>
+    <%= stylesheet_link_tag 'common', 'public_table_new', 'public_map' %>
+  <% else %>
+    <%= stylesheet_link_tag 'cartodb', 'common', 'public_table', 'public_map' %>
+  <% end %>
 <% end %>
 
 <% content_for(:js) do %>
@@ -75,8 +79,14 @@
   <div class="CDB-Text PublicMap-map js-map" id="map">
     <div class="Spinner Spinner--center js-spinner"></div>
 
-    <div class="panes pane_table"></div>
-    <div class="panes pane_map"></div>
+    <% if @has_new_dashboard %>
+      <div class="panes pane_table"></div>
+      <div class="panes pane_map"></div>
+    <% else %>
+      <div class="panes pane_table u-hideOnTablet"></div>
+      <div class="panes pane_map u-hideOnTablet"></div>
+      <div class="panes panes_mobile u-showOnTablet"></div>
+    <% end %>
 
     <div class="navigation u-showOnTablet">
       <ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -192,6 +192,7 @@ module CartoDB
       api_keys.css
 
       api_keys_new.css
+      public_table_new.css
 
       plugins/tipsy.css
 

--- a/lib/assets/javascripts/dashboard/data/like-model.js
+++ b/lib/assets/javascripts/dashboard/data/like-model.js
@@ -14,7 +14,7 @@ var LikeModel = Backbone.Model.extend({
 
   url: function (method) {
     var version = this._config.urlVersion('like', method);
-    return '/api/' + version + '/viz/' + this.get('vis_id') + '/like';
+    return `${this._config.get('base_url')}/api/${version}/viz/${this.get('vis_id')}/like`;
   },
 
   initialize: function (attrs, options) {
@@ -53,15 +53,15 @@ var LikeModel = Backbone.Model.extend({
       id: opts.liked ? opts.vis_id : null
     }, _.omit(opts, 'url', 'config'));
 
-    var m = new LikeModel(d, {
+    var model = new LikeModel(d, {
       config: opts.config
     });
 
     if (opts.url) {
-      m.url = opts.url;
+      model.url = opts.url;
     }
 
-    return m;
+    return model;
   }
 });
 

--- a/lib/assets/javascripts/dashboard/public-dashboard.js
+++ b/lib/assets/javascripts/dashboard/public-dashboard.js
@@ -100,7 +100,7 @@ $(function () {
       likes: likeElement.data('likes-count')
     });
     authenticatedUser.bind('change', function (model) {
-      if (model.get('user_data')) {
+      if (model.get('username')) {
         likeModel.once('change', function () {
           likeModel.set('likeable', true);
         });

--- a/lib/assets/javascripts/dashboard/views/public-profile/feed-view.js
+++ b/lib/assets/javascripts/dashboard/views/public-profile/feed-view.js
@@ -262,7 +262,7 @@ module.exports = CoreView.extend({
   },
 
   _initLike: function (vis, $el) {
-    var likeable = this._authenticatedUser && this._authenticatedUser.get('user_data');
+    var likeable = this._authenticatedUser && this._authenticatedUser.get('username');
 
     var likeModel = LikeModel.newByVisData({
       likeable: false,
@@ -291,7 +291,7 @@ module.exports = CoreView.extend({
   },
 
   _fetchLike: function (model, url) {
-    if (this._authenticatedUser.get('user_data')) {
+    if (this._authenticatedUser.get('username')) {
       // no more loadModelCompleted event
       model.once('change', function () {
         model.set('likeable', true);

--- a/lib/build/files/css_files.js
+++ b/lib/build/files/css_files.js
@@ -74,6 +74,23 @@ module.exports = css_files = {
     '<%= assets_dir %>/stylesheets/cartoassets/entry.css'
   ],
 
+  public_table_new: [
+    '<%= assets_dir %>/stylesheets/table/table.css',
+    '<%= assets_dir %>/stylesheets/old_elements/modal.css',
+    '<%= assets_dir %>/stylesheets/old_elements/dialog_small_edit.css',
+    '<%= assets_dir %>/stylesheets/old_elements/dropdown.css',
+    '<%= assets_dir %>/stylesheets/public/public_map_wrapper_new.css',
+    '<%= assets_dir %>/stylesheets/public/public_table_wrapper_new.css',
+    '<%= assets_dir %>/stylesheets/public/public_map_data.css',
+    '<%= assets_dir %>/stylesheets/public/public_map_body.css',
+    '<%= assets_dir %>/stylesheets/public/public_map_info.css',
+    '<%= assets_dir %>/stylesheets/public/public_export.css',
+    '<%= assets_dir %>/stylesheets/public_table/**/*.css',
+    '<%= assets_dir %>/stylesheets/public/public_map_fullscreen.css',
+    '<%= assets_dir %>/stylesheets/map/map.css',
+    'node_modules/leaflet/dist/leaflet.css',
+  ],
+
   public_map: [
     '<%= assets_dir %>/stylesheets/public_map/**/*.css',
     '<%= assets_dir %>/stylesheets/cartoassets/entry.css'

--- a/lib/build/files/css_files.js
+++ b/lib/build/files/css_files.js
@@ -88,7 +88,7 @@ module.exports = css_files = {
     '<%= assets_dir %>/stylesheets/public_table/**/*.css',
     '<%= assets_dir %>/stylesheets/public/public_map_fullscreen.css',
     '<%= assets_dir %>/stylesheets/map/map.css',
-    'node_modules/leaflet/dist/leaflet.css',
+    'node_modules/leaflet/dist/leaflet.css'
   ],
 
   public_map: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.11.144",
+  "version": "4.11.144-fixes",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes several hiccups:

- [ ] Like buttons now work on the public dashboard, user feed and public table
- [ ] Public table for users without the Feature Flag looks as it used to
- [ ] New public table view map zoom buttons look decent now

First one was a matter of correctly parsing the authenticated user response, as well as taking the url_prefix into account.

Second one was an oversight, we rewrote some styles and markup without taking into account what it would mean for the old version of the code, which is served to users without the feature flag. Nothing's terribly broken, but it could be better.

For now I've reverted the affected SCSS files, added a `${filename}_new` one with the working changes, and created a new public_table css bundle. Also, there are some if/else checks on the rails template to change the HTML / included CSS. The new version requires less CSS now, btw 🎉 

If we start serving the new version for everybody, which hopefully we can, we might be able to unify these changes.