### PR TITLE
Fix dataset name overflow in widgets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix dataset name overflow in widgets (https://github.com/CartoDB/cartodb/pull/13972)
 * Fix legend paddings/margins (https://github.com/CartoDB/cartodb/pull/13966)
 * Fix the name of the bundle for public_Table on production (#13965)
 * Fix how to decide which public_table version to show (#13694)

--- a/lib/assets/javascripts/deep-insights/widgets/category/title/search-title-template.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/category/title/search-title-template.tpl
@@ -33,7 +33,7 @@
   </div>
   <% if (showSource) { %>
     <dl class="CDB-Widget-info u-tSpace">
-      <div class="u-flex u-alignCenter">
+      <div class="u-flex u-alignCenter u-ellipsis">
         <span class="CDB-Text CDB-Size-small is-semibold u-upperCase" style="color: <%- sourceColor %>;">
           <%- sourceId %>
         </span>

--- a/lib/assets/javascripts/deep-insights/widgets/formula/template.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/formula/template.tpl
@@ -13,7 +13,7 @@
   </div>
   <% if (showSource) { %>
     <dl class="CDB-Widget-info u-tSpace">
-      <div class="u-flex u-alignCenter">
+      <div class="u-flex u-alignCenter u-ellipsis">
         <span class="CDB-Text CDB-Size-small is-semibold u-upperCase" style="color: <%- sourceColor %>;">
           <%- sourceId %>
         </span>

--- a/lib/assets/javascripts/deep-insights/widgets/histogram/content.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/histogram/content.tpl
@@ -2,7 +2,7 @@
   <div class="js-title"></div>
   <% if (showSource) { %>
     <dl class="CDB-Widget-info u-tSpace">
-      <div class="u-flex u-alignCenter">
+      <div class="u-flex u-alignCenter u-ellipsis">
         <span class="CDB-Text CDB-Size-small is-semibold u-upperCase" style="color: <%- sourceColor %>;">
           <%- sourceId %>
         </span>

--- a/lib/assets/javascripts/deep-insights/widgets/time-series/content.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/time-series/content.tpl
@@ -4,7 +4,7 @@
   <% if (showSource) { %>
     <div class="CDB-Widget-contentSpaced CDB-Widget-contentFull">
       <dl class="CDB-Widget-info u-tSpace">
-        <div class="u-flex u-alignCenter">
+        <div class="u-flex u-alignCenter u-ellipsis">
           <span class="CDB-Text CDB-Size-small is-semibold u-upperCase" style="color: <%- sourceColor %>;">
             <%- sourceId %>
           </span>

--- a/lib/assets/javascripts/deep-insights/widgets/time-series/torque-template.tpl
+++ b/lib/assets/javascripts/deep-insights/widgets/time-series/torque-template.tpl
@@ -4,7 +4,7 @@
   <% if (showSource) { %>
     <div class="CDB-Widget-contentSpaced CDB-Widget-contentFull">
       <dl class="CDB-Widget-info u-tSpace">
-        <div class="u-flex u-alignCenter">
+        <div class="u-flex u-alignCenter u-ellipsis">
           <span class="CDB-Text CDB-Size-small is-semibold u-upperCase" style="color: <%- sourceColor %>;">
             <%- sourceId %>
           </span>


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13930

Adds `u-ellipsis` to fix the problem with long dataset names.