### PR TITLE
Allow only numeric values in latitude/longitude select in georeference analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Allow only numeric values in latitude/longitude select in georeference analysis (https://github.com/CartoDB/cartodb/pull/13974)
 * Fix widgets not updating (https://github.com/CartoDB/cartodb/pull/13971)
 * Fix legend paddings/margins (https://github.com/CartoDB/cartodb/pull/13966)
 * Fix the name of the bundle for public_Table on production (#13965)

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model.js
@@ -128,7 +128,7 @@ module.exports = BaseAnalysisFormModel.extend({
       latitude: {
         type: 'Select',
         title: _t('editor.layers.analysis-form.latitude'),
-        options: this._columnOptions.filterByType(['string', 'number']),
+        options: this._columnOptions.filterByType('number'),
         dialogMode: 'float',
         validators: this._getFieldValidator('latitude'),
         placeholder: _t('editor.layers.analysis-form.georeference.select-latitude'),
@@ -137,7 +137,7 @@ module.exports = BaseAnalysisFormModel.extend({
       longitude: {
         type: 'Select',
         title: _t('editor.layers.analysis-form.longitude'),
-        options: this._columnOptions.filterByType(['string', 'number']),
+        options: this._columnOptions.filterByType('number'),
         dialogMode: 'float',
         validators: this._getFieldValidator('longitude'),
         placeholder: _t('editor.layers.analysis-form.georeference.select-longitude'),

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/georeference-form-model.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-form-models/georeference-form-model.spec.js
@@ -144,4 +144,16 @@ describe('editor/layers/layer-content-views/analyses/analysis-form-models/georef
       expect(this.model.schema.postal_code_country.validators[0]).toBe('required');
     });
   });
+
+  fit('should return only numeric columns for latitude and longitude', function () {
+    this.model._columnOptions._columnOptions = {
+      cartodb_id: { type: 'number' },
+      title: { type: 'string' },
+      created_at: { type: 'date' }
+    };
+    this.model._setSchema();
+
+    expect(this.model.schema.latitude.options.length).toBe(1);
+    expect(this.model.schema.longitude.options.length).toBe(1);
+  });
 });


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/11511

Allow only numeric values in latitude/longitude select in georeference analysis.