### PR TITLE
Fix apply button loading state for queries that alter the data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Fix apply button loading state for queries that alter the data (https://github.com/CartoDB/cartodb/pull/13979)
 * Allow only numeric values in latitude/longitude select in georeference analysis (https://github.com/CartoDB/cartodb/pull/13974)
 * Fix dataset name overflow in widgets (https://github.com/CartoDB/cartodb/pull/13972)
 * Fix the public table view for non-migrated-users  (#13969)

--- a/lib/assets/javascripts/builder/components/dataset/dataset-base-view.js
+++ b/lib/assets/javascripts/builder/components/dataset/dataset-base-view.js
@@ -36,6 +36,10 @@ module.exports = CoreView.extend({
       readonly: false
     });
 
+    this._applyButtonStatusModel = new Backbone.Model({
+      loading: false
+    });
+
     SQLNotifications.track(this);
   },
 
@@ -64,6 +68,8 @@ module.exports = CoreView.extend({
         closable: false
       });
 
+      this._applyButtonStatusModel.set('loading', true);
+
       this._sqlModel.set('content', currentQuery);
 
       this._SQL.execute(currentQuery, null, {
@@ -74,16 +80,24 @@ module.exports = CoreView.extend({
             closable: true,
             delay: Notifier.DEFAULT_DELAY
           });
+
+          this._applyButtonStatusModel.set('loading', false);
+
           this._applyDefaultSQLAfterAlteringData();
+
           if (typeof callbackAfterAlterSuccess === 'function') {
             callbackAfterAlterSuccess.call(this);
           }
         }.bind(this),
         error: function (errors) {
-          errors = errors.responseJSON.error;
-          var parsedErrors = this._parseErrors(errors);
+          var parsedErrors = this._parseErrors(errors.responseJSON.error);
+
+          this._applyButtonStatusModel.set('loading', false);
+
           this._codemirrorModel.set('errors', parsedErrors);
+
           SQLNotifications.showErrorNotification(parsedErrors);
+
           this._checkClearButton();
         }.bind(this)
       });

--- a/lib/assets/javascripts/builder/dataset/dataset-options/dataset-actions-edition-view.js
+++ b/lib/assets/javascripts/builder/dataset/dataset-options/dataset-actions-edition-view.js
@@ -13,7 +13,8 @@ var REQUIRED_OPTS = [
   'querySchemaModel',
   'onApply',
   'onClear',
-  'clearSQLModel'
+  'clearSQLModel',
+  'applyButtonStatusModel'
 ];
 
 module.exports = CoreView.extend({
@@ -26,10 +27,6 @@ module.exports = CoreView.extend({
 
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
-
-    this._applyButtonStatusModel = new Backbone.Model({
-      loading: this._querySchemaModel.isFetching()
-    });
 
     this._initViewState();
     this.listenTo(this._queryGeometryModel, 'change:status', this._setViewState);
@@ -65,19 +62,19 @@ module.exports = CoreView.extend({
       applyStatusModel: this._applyButtonStatusModel,
       applyButton: true,
       clearButton: true,
-      onApplyClick: this._onApply.bind(this),
-      onClearClick: this._onClear.bind(this)
+      onApplyClick: this._handleApply.bind(this),
+      onClearClick: this._handleClear.bind(this)
     });
 
     this.$('.js-createMap').before(view.render().el);
     this.addView(view);
   },
 
-  _onApply: function () {
+  _handleApply: function () {
     if (this._onApply) { this._onApply(); }
   },
 
-  _onClear: function () {
+  _handleClear: function () {
     if (this._onClear) { this._onClear(); }
   },
 

--- a/lib/assets/javascripts/builder/dataset/dataset-options/dataset-options-view.js
+++ b/lib/assets/javascripts/builder/dataset/dataset-options/dataset-options-view.js
@@ -176,7 +176,8 @@ module.exports = DatasetBaseView.extend({
           querySchemaModel: self._querySchemaModel,
           onApply: self._parseSQL,
           previewAction: self._previewMap.bind(self),
-          onClear: self._clearSQL.bind(self)
+          onClear: self._clearSQL.bind(self),
+          applyButtonStatusModel: self._applyButtonStatusModel
         };
         if (self._canCreateMap) {
           actionViewOptions.mapAction = self._createMap.bind(self);

--- a/lib/assets/test/spec/builder/dataset/dataset-actions-edition-view.spec.js
+++ b/lib/assets/test/spec/builder/dataset/dataset-actions-edition-view.spec.js
@@ -22,6 +22,10 @@ describe('dataset/dataset-actions-edition-view', function () {
   var createViewFn = function (options) {
     var defaultOptions;
 
+    var applyButtonStatusModel = new Backbone.Model({
+      loading: false
+    });
+
     configModel = new Backbone.Model({});
 
     clearSQLModel = new Backbone.Model({
@@ -66,7 +70,8 @@ describe('dataset/dataset-actions-edition-view', function () {
       onClear: onClear,
       previewAction: previewAction,
       querySchemaModel: querySchemaModel,
-      mapAction: mapAction
+      mapAction: mapAction,
+      applyButtonStatusModel: applyButtonStatusModel
     };
 
     return new DatasetActionsEditionView(_.extend(defaultOptions, options));

--- a/lib/assets/test/spec/builder/dataset/dataset-options-view.spec.js
+++ b/lib/assets/test/spec/builder/dataset/dataset-options-view.spec.js
@@ -163,4 +163,39 @@ describe('dataset/dataset-options-view', function () {
       expect(this.view._onToggleEdition).toHaveBeenCalled();
     });
   });
+
+  describe('._parseSQL', function () {
+    beforeEach(function () {
+      this.view._codemirrorModel.set('content', 'UPDATE test SET name = \'test\'');
+    });
+
+    it('should set loading to true when called', function () {
+      spyOn(this.view, '_SQL');
+      this.view._parseSQL();
+
+      expect(this.view._applyButtonStatusModel.get('loading')).toBe(true);
+    });
+
+    it('should set loading to false when in success callback', function () {
+      spyOn(this.view._SQL, 'execute').and.callFake(function (query, a, options) {
+        options.success();
+      });
+
+      this.view._parseSQL();
+
+      expect(this.view._applyButtonStatusModel.get('loading')).toBe(false);
+    });
+
+    it('should set loading to false when in error callback', function () {
+      spyOn(this.view._SQL, 'execute').and.callFake(function (query, a, options) {
+        options.error({
+          responseJSON: {}
+        });
+      });
+
+      this.view._parseSQL();
+
+      expect(this.view._applyButtonStatusModel.get('loading')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13875

We were checking only the `querySchemaModel` loading state to change the `Apply` button state to `loading` but when the query alters the data it goes through a different path.

This PRs moves the `applyButtonStatusModel` to an upper level so we can handle that problem in the `_internalParseSQL` method.