### PR TITLE
Locked password vis export

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -505,6 +505,7 @@ ion for time-series (#12670)
 * Fix error where a sync of a big dataset without geometry would be deleted from dashboard (#12162)
 * `create_dev_user` rake no longer tries to auto-create the database, `cartodb:db:setup` should be run first (#12187).
 * Fix EUMAPI response as per documentation (#12233)
+* Export/import visualization password and locked (Support #1544)
 * Fix dimension check and support for SVG without extension and XML header (#12374).
 * Builder embed doesn't need user DB connection anymore (#12473).
 * Visualization models no longer raise an error checking `password_valid?` (#12270).

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -316,7 +316,7 @@ module Carto
         next if !visualization.remote? && visualization.map.nil?
 
         visualization_export = Carto::VisualizationsExportService2.new.export_visualization_json_string(
-          visualization.id, user
+          visualization.id, user, with_password: true
         )
         filename = "#{visualization.type}_#{visualization.id}#{Carto::VisualizationExporter::EXPORT_EXTENSION}"
         root_dir.join(filename).open('w') { |file| file.write(visualization_export) }

--- a/app/services/carto/visualizations_export_persistence_service.rb
+++ b/app/services/carto/visualizations_export_persistence_service.rb
@@ -139,7 +139,7 @@ module Carto
 
     def apply_user_limits(user, visualization)
       visualization.privacy = Carto::Visualization::PRIVACY_PUBLIC unless user.private_maps_enabled
-      # Since password is not exported we must fallback to private
+      # If password is not exported we must fallback to private
       if visualization.password_protected? && !visualization.has_password?
         visualization.privacy = Carto::Visualization::PRIVACY_PRIVATE
       end

--- a/app/services/carto/visualizations_export_persistence_service.rb
+++ b/app/services/carto/visualizations_export_persistence_service.rb
@@ -61,6 +61,7 @@ module Carto
           visualization.mapcaps.clear
           visualization.created_at = DateTime.now
           visualization.updated_at = DateTime.now
+          visualization.locked = false
         end
 
 
@@ -139,7 +140,7 @@ module Carto
     def apply_user_limits(user, visualization)
       visualization.privacy = Carto::Visualization::PRIVACY_PUBLIC unless user.private_maps_enabled
       # Since password is not exported we must fallback to private
-      if visualization.privacy == Carto::Visualization::PRIVACY_PROTECTED
+      if visualization.password_protected? && !visualization.has_password?
         visualization.privacy = Carto::Visualization::PRIVACY_PRIVATE
       end
 

--- a/app/services/carto/visualizations_export_service_2.rb
+++ b/app/services/carto/visualizations_export_service_2.rb
@@ -21,7 +21,7 @@ require_dependency 'carto/export/data_import_exporter'
 # 2.1.2: export locked and password
 module Carto
   module VisualizationsExportService2Configuration
-    CURRENT_VERSION = '2.1.1'.freeze
+    CURRENT_VERSION = '2.1.2'.freeze
 
     def compatible_version?(version)
       version.to_i == CURRENT_VERSION.split('.')[0].to_i

--- a/app/services/carto/visualizations_export_service_2.rb
+++ b/app/services/carto/visualizations_export_service_2.rb
@@ -18,6 +18,7 @@ require_dependency 'carto/export/data_import_exporter'
 # 2.0.9: export visualization id
 # 2.1.0: export datasets: permissions, user_tables and syncs
 # 2.1.1: export vizjson2 mark
+# 2.1.2: export locked and password
 module Carto
   module VisualizationsExportService2Configuration
     CURRENT_VERSION = '2.1.1'.freeze
@@ -91,7 +92,10 @@ module Carto
         mapcaps: [build_mapcap_from_hash(exported_visualization[:mapcap])].compact,
         external_source: build_external_source_from_hash(exported_visualization[:external_source]),
         created_at: exported_visualization[:created_at],
-        updated_at: exported_visualization[:updated_at]
+        updated_at: exported_visualization[:updated_at],
+        locked: exported_visualization[:locked],
+        encrypted_password: exported_visualization[:encrypted_password],
+        password_salt: exported_visualization[:password_salt]
       )
 
       # This is optional as it was added in version 2.0.2
@@ -299,7 +303,10 @@ module Carto
         mapcap: with_mapcaps ? export_mapcap(visualization.latest_mapcap) : nil,
         external_source: export_external_source(visualization.external_source),
         created_at: visualization.created_at,
-        updated_at: visualization.updated_at
+        updated_at: visualization.updated_at,
+        locked: visualization.locked,
+        encrypted_password: visualization.encrypted_password,
+        password_salt: visualization.password_salt
       }
     end
 

--- a/app/services/carto/visualizations_export_service_2.rb
+++ b/app/services/carto/visualizations_export_service_2.rb
@@ -276,7 +276,7 @@ module Carto
         export_layer(layer, active_layer: active_layer_id == layer.id)
       end
 
-      visualization = {
+      export = {
         id: visualization.id,
         name: visualization.name,
         description: visualization.description,
@@ -309,11 +309,11 @@ module Carto
       }
 
       if with_password
-        visualization[:encrypted_password] = visualization.encrypted_password
-        visualization[:password_salt] = visualization.password_salt
+        export[:encrypted_password] = visualization.encrypted_password
+        export[:password_salt] = visualization.password_salt
       end
 
-      visualization
+      export
     end
 
     def export_user(user)

--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -282,6 +282,24 @@ describe Carto::UserMetadataExportService do
 
       end
     end
+
+    it 'keeps visualization password' do
+      Dir.mktmpdir do |path|
+        create_user_with_rate_limits
+
+        @user.update_attributes(private_maps_enabled: true, private_tables_enabled: true)
+        v = @user.visualizations.first
+        v.password = 'dont_tell_anyone'
+        v.privacy = 'password'
+        v.save!
+
+        full_export_import(path)
+
+        v.reload
+        expect(v.password_protected?).to be_true
+        expect(v.password_valid?('dont_tell_anyone')).to be_true
+      end
+    end
   end
 
   EXCLUDED_USER_META_DATE_FIELDS = ['created_at', 'updated_at'].freeze

--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -292,6 +292,7 @@ describe Carto::UserMetadataExportService do
         v.password = 'dont_tell_anyone'
         v.privacy = 'password'
         v.save!
+        v.update_column(:auth_token, nil) # We don't care about this for comparisons, it's regenerated on import
 
         full_export_import(path)
 

--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -292,7 +292,6 @@ describe Carto::UserMetadataExportService do
         v.password = 'dont_tell_anyone'
         v.privacy = 'password'
         v.save!
-        v.update_column(:auth_token, nil) # We don't care about this for comparisons, it's regenerated on import
 
         full_export_import(path)
 
@@ -304,7 +303,7 @@ describe Carto::UserMetadataExportService do
   end
 
   EXCLUDED_USER_META_DATE_FIELDS = ['created_at', 'updated_at'].freeze
-  EXCLUDED_USER_META_ID_FIELDS = ['map_id', 'permission_id', 'active_layer_id', 'tags'].freeze
+  EXCLUDED_USER_META_ID_FIELDS = ['map_id', 'permission_id', 'active_layer_id', 'tags', 'auth_token'].freeze
 
   def compare_excluding_dates_and_ids(v1, v2)
     filtered1 = v1.reject { |k, _| EXCLUDED_USER_META_ID_FIELDS.include?(k) }

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -1482,7 +1482,7 @@ describe Carto::VisualizationsExportService2 do
         verify_visualizations_match(imported_viz, @visualization, importing_user: @user2)
         expect(imported_viz.password_protected?).to be_true
         expect(imported_viz.has_password?).to be_true
-        expect(imported_viz.password_valid?(@visualization.password)).to be_true
+        expect(imported_viz.password_valid?('super_secure_secret')).to be_true
 
         destroy_visualization(imported_viz.id)
       end

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -55,8 +55,6 @@ describe Carto::VisualizationsExportService2 do
       display_name: 'the display_name',
       uses_vizjson2: true,
       locked: false,
-      encrypted_password: '1234567890',
-      password_salt: '1234567890',
       map: {
         provider: 'leaflet',
         bounding_box_sw: '[-85.0511, -179]',
@@ -682,8 +680,6 @@ describe Carto::VisualizationsExportService2 do
 
           it 'sets password protected visualizations to private' do
             export_2_1_1 = export
-            export_2_1_1[:visualization].delete(:encrypted_password)
-            export_2_1_1[:visualization].delete(:password_salt)
             export_2_1_1[:visualization][:privacy] = 'password'
 
             service = Carto::VisualizationsExportService2.new
@@ -1502,7 +1498,7 @@ describe Carto::VisualizationsExportService2 do
         @visualization.password = 'super_secure_secret'
         @visualization.save!
 
-        exported_string = export_service.export_visualization_json_string(@visualization.id, @user)
+        exported_string = export_service.export_visualization_json_string(@visualization.id, @user, with_password: true)
         built_viz = export_service.build_visualization_from_json_export(exported_string)
         imported_viz = Carto::VisualizationsExportPersistenceService.new.save_import(@user2, built_viz)
 


### PR DESCRIPTION
https://github.com/CartoDB/support/issues/1544

Acceptance:
- Migrating a password protected visualization keeps privacy, and it is accessible in the destination cloud (by using the password). Double check that the map draws stuff (tiler works).
- Normal `.carto` export+import should work as before, aka, convert password protected visualizations to private (since we don't want to expose the password in public exports)