### PR TITLE
CARTO now requires PostgreSQL 9.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,8 +17,11 @@ recommended that you replace the `basemaps` section completely, since this relea
 resolution maps, which have added `urlTemplate2x` keys to the configuration.
 
 You can then run `bundle exec rake carto:db:sync_basemaps_from_app_config` to synchronize existing layers.
-### NOTICE
 
+### NOTICE
+PostgreSQL 9.6 is needed.
+
+### NOTICE
 This upgrade changes AWS gem version. Now you must specify `region` within your AWS configurations. Check `app_config.yml.sample`.
 
 ### Features

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,7 @@ class HomeController < ApplicationController
   STATUS[false] = 'error'
 
   OS_VERSION = "Description:\tUbuntu 12.04"
-  PG_VERSION = 'PostgreSQL 9.5'.freeze
+  PG_VERSION = 'PostgreSQL 9.6'.freeze
   POSTGIS_VERSION = '2.2'.freeze
   CDB_VALID_VERSION = '0.22'.freeze
   CDB_LATEST_VERSION = '0.22.0'.freeze

--- a/doc/manual/source/components/postgresql.rst
+++ b/doc/manual/source/components/postgresql.rst
@@ -12,7 +12,7 @@ CartoDB uses PostgreSQL for two purposes:
 Both metadata database and users databases can be hosted either in the same PostgreSQL cluster or different ones. Having both the in the same cluster is the recommended approach for small environments.
 The editor only knows how to connect to metadata database. However, within every request it checks the connection info of the user database which is stored in metadata database, as described before.
 
-At this moment CartoDB requires PostgreSQL 9.5.x version.
+At this moment CartoDB requires PostgreSQL 9.6.x version.
 
 .. _postgis_label:
 

--- a/doc/manual/source/install.rst
+++ b/doc/manual/source/install.rst
@@ -63,7 +63,7 @@ PostgreSQL
 
   .. code-block:: bash
 
-    sudo add-apt-repository ppa:cartodb/postgresql-9.5 && sudo apt-get update
+    sudo add-apt-repository ppa:cartodb/postgresql-9.6 && sudo apt-get update
 
 
 * Install client packages
@@ -72,22 +72,22 @@ PostgreSQL
 
     sudo apt-get install libpq5 \
                          libpq-dev \
-                         postgresql-client-9.5 \
+                         postgresql-client-9.6 \
                          postgresql-client-common
 
 * Install server packages
 
   .. code-block:: bash
 
-    sudo apt-get install postgresql-9.5 \
-                         postgresql-contrib-9.5 \
-                         postgresql-server-dev-9.5 \
-                         postgresql-plpython-9.5
+    sudo apt-get install postgresql-9.6 \
+                         postgresql-contrib-9.6 \
+                         postgresql-server-dev-9.6 \
+                         postgresql-plpython-9.6
 
 
 
 
-PostgreSQL access authorization is managed through pg_hba.conf configuration file, which is normally in /etc/postgresql/9.5/main/pg_hba.conf. Here it's defined how the users created in postgresql cluster can access the server. This involves several aspects like type of authentication (md5, no password, etc..) or source IP of the connection. In order to simplify the process of the installation we are going to allow connections with postgres user from localhost without authentication. Of course this can be configured in a different way at any moment but changes here should imply changes in database access configuration of CartoDB apps.
+PostgreSQL access authorization is managed through pg_hba.conf configuration file, which is normally in /etc/postgresql/9.6/main/pg_hba.conf. Here it's defined how the users created in postgresql cluster can access the server. This involves several aspects like type of authentication (md5, no password, etc..) or source IP of the connection. In order to simplify the process of the installation we are going to allow connections with postgres user from localhost without authentication. Of course this can be configured in a different way at any moment but changes here should imply changes in database access configuration of CartoDB apps.
 
 This is the pg_hba.conf with the no password access from localhost:
 
@@ -164,7 +164,7 @@ PostGIS
   .. code-block:: bash
 
     sudo apt-get install libxml2-dev
-    sudo apt-get install liblwgeom-2.2.2 postgis postgresql-9.5-postgis-2.2 postgresql-9.5-postgis-scripts
+    sudo apt-get install liblwgeom-2.2.2 postgis postgresql-9.6-postgis-2.2 postgresql-9.6-postgis-scripts
 
 * Initialize template postgis database. We create a template database in postgresql that will contain the postgis extension. This way, every time CartoDB creates a new user database it just clones this template database
 


### PR DESCRIPTION
As detected [at this email list thread](https://groups.google.com/forum/#!topic/cartodb/TxB7pS_Nr9s), CARTO now requires PostgreSQL 9.6. It's caused by the need of `extensions` option at `postgres_fdw`, which [was added in 9.6](https://www.postgresql.org/docs/9.6/static/postgres-fdw.html) (check [9.5](https://www.postgresql.org/docs/9.5/static/postgres-fdw.html)). Our servers are running [a patch](https://commitfest.postgresql.org/7/304/) that was applied in 9.6.

This is just documentation. cc-ing @javitonino and @jvillarf for awareness. I'll merge on your agreement. Many thanks to @ibrahimmenem , who helped confirming this and the version at the servers.