### PR TITLE
Show "Select points in polygons" analysis only for polygons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Show "Select points in polygons" analysis only for polygons (https://github.com/CartoDB/cartodb/pull/13982)
 * Allow only numeric values in latitude/longitude select in georeference analysis (https://github.com/CartoDB/cartodb/pull/13974)
 * Fix dataset name overflow in widgets (https://github.com/CartoDB/cartodb/pull/13972)
 * Fix the public table view for non-migrated-users  (#13969)

--- a/lib/assets/javascripts/builder/components/modals/add-analysis/add-analysis-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-analysis/add-analysis-view.js
@@ -1,6 +1,5 @@
 var _ = require('underscore');
 var CoreView = require('backbone/core-view');
-var Analyses = require('builder/data/analyses');
 var AnalysisOptionsCollection = require('./analysis-options-collection');
 var analysisOptions = require('./analysis-options');
 var AnalysisViewPane = require('./analysis-view-pane');
@@ -30,7 +29,11 @@ module.exports = CoreView.extend({
     this._queryGeometryModel = this._analysisDefinitionNodeModel.queryGeometryModel;
     this.listenTo(this._queryGeometryModel, 'change', this.render);
 
-    this._analysisOptions = analysisOptions(Analyses, this._userModel, this._configModel);
+    this._analysisOptions = analysisOptions({
+      userModel: this._userModel,
+      configModel: this._configModel,
+      queryGeometryModel: this._queryGeometryModel
+    });
     this._analysisOptionsCollection = new AnalysisOptionsCollection();
 
     this._dataservicesApiHealth = DataServicesApiCheck.get();

--- a/lib/assets/javascripts/builder/components/modals/add-analysis/add-analysis-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-analysis/add-analysis-view.js
@@ -6,6 +6,14 @@ var analysisOptions = require('./analysis-options');
 var AnalysisViewPane = require('./analysis-view-pane');
 var renderLoading = require('builder/components/loading/render-loading');
 var DataServicesApiCheck = require('builder/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-info');
+var checkAndBuildOpts = require('builder/helpers/required-opts');
+
+var REQUIRED_OPTS = [
+  'modalModel',
+  'configModel',
+  'userModel',
+  'layerDefinitionModel'
+];
 
 /**
  * View to add a new analysis node.
@@ -15,25 +23,15 @@ module.exports = CoreView.extend({
   className: 'Dialog-content Dialog-content--expanded',
 
   initialize: function (opts) {
-    if (!opts.modalModel) throw new Error('modalModel is required');
-    if (!opts.configModel) throw new Error('configModel is required');
-    if (!opts.userModel) throw new Error('userModel is required');
-    if (!opts.layerDefinitionModel) throw new Error('layerDefinitionModel is required');
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
-    this._modalModel = opts.modalModel;
-    this._layerDefinitionModel = opts.layerDefinitionModel;
-    this._userModel = opts.userModel;
-    this._configModel = opts.configModel;
     this._analysisDefinitionNodeModel = this._layerDefinitionModel.getAnalysisDefinitionNodeModel();
+
+    this._queryGeometryModel = this._analysisDefinitionNodeModel.queryGeometryModel;
+    this.listenTo(this._queryGeometryModel, 'change', this.render);
 
     this._analysisOptions = analysisOptions(Analyses, this._userModel, this._configModel);
     this._analysisOptionsCollection = new AnalysisOptionsCollection();
-
-    this.add_related_model(this._analysisOptionsCollection);
-
-    this._queryGeometryModel = this._analysisDefinitionNodeModel.queryGeometryModel;
-    this._queryGeometryModel.on('change', this.render, this);
-    this.add_related_model(this._queryGeometryModel);
 
     this._dataservicesApiHealth = DataServicesApiCheck.get();
 

--- a/lib/assets/javascripts/builder/components/modals/add-analysis/analysis-options.js
+++ b/lib/assets/javascripts/builder/components/modals/add-analysis/analysis-options.js
@@ -2,30 +2,31 @@ var _ = require('underscore');
 var GeneratedAnalysisOptionModel = require('./analysis-option-models/generated-analysis-option-model');
 var camshaftReference = require('camshaft-reference');
 var latestCamshaftReference = camshaftReference.getVersion('latest');
+var Analyses = require('builder/data/analyses');
 
 /**
  * Analysis definitions, organized in buckets per top-level category
  *
  *  - {Obj} -> analyses list (data/analyses.js file)
- *  - {Obj} -> user model
- *  - {Obj} -> config model
+ *  - {Obj} -> options (userModel, configModel, queryGeometryModel)
  */
-module.exports = function (Analyses, userModel, configModel) {
+module.exports = function (options) {
   var categories = {
     create_clean: {
       title: _t('analysis-category.create-clean'),
-      analyses: Analyses.getAnalysesByModalCategory('create_clean', configModel, userModel)
+      analyses: Analyses.getAnalysesByModalCategory('create_clean', options)
     },
     data_transformation: {
       title: _t('analysis-category.data-transformation'),
-      analyses: Analyses.getAnalysesByModalCategory('data_transformation', configModel, userModel)
+      analyses: Analyses.getAnalysesByModalCategory('data_transformation', options)
     },
     analyze_predict: {
       title: _t('analysis-category.analyze-predict'),
-      analyses: Analyses.getAnalysesByModalCategory('analyze_predict', configModel, userModel)
+      analyses: Analyses.getAnalysesByModalCategory('analyze_predict', options)
     }
   };
-  var alsoGenerateFromCamshaftReference = userModel.featureEnabled('generate_analysis_options');
+
+  var alsoGenerateFromCamshaftReference = options.userModel.featureEnabled('generate_analysis_options');
 
   if (alsoGenerateFromCamshaftReference) {
     var implementedAnalyses = _.reduce(Object.keys(categories), function (memo, category) {
@@ -45,7 +46,7 @@ module.exports = function (Analyses, userModel, configModel) {
             return type !== 'source' && !_.contains(implementedAnalyses, type);
           })
           .map(function (type) {
-            if (!Analyses.isAnalysisValidByType(type, configModel, userModel)) {
+            if (!Analyses.isAnalysisValidByType(type, options)) {
               return false;
             }
 

--- a/lib/assets/javascripts/builder/components/modals/add-analysis/analysis-options.js
+++ b/lib/assets/javascripts/builder/components/modals/add-analysis/analysis-options.js
@@ -7,7 +7,6 @@ var Analyses = require('builder/data/analyses');
 /**
  * Analysis definitions, organized in buckets per top-level category
  *
- *  - {Obj} -> analyses list (data/analyses.js file)
  *  - {Obj} -> options (userModel, configModel, queryGeometryModel)
  */
 module.exports = function (options) {

--- a/lib/assets/javascripts/builder/data/analyses.js
+++ b/lib/assets/javascripts/builder/data/analyses.js
@@ -241,7 +241,10 @@ var MAP = {
     modalCategory: 'data_transformation',
     modalLink: 'https://carto.com/learn/guides/analysis/select-points-in-polygons/',
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/intersection.tpl'),
-    animationTemplate: require('builder/components/modals/add-analysis/animation-templates/filter-by-polygon.tpl')
+    animationTemplate: require('builder/components/modals/add-analysis/animation-templates/filter-by-polygon.tpl'),
+    checkIfEnabled: function (options) {
+      return options.queryGeometryModel.isPolygon();
+    }
   },
   'kmeans': {
     title: _t('analyses.kmeans.title'),

--- a/lib/assets/javascripts/builder/data/analyses.js
+++ b/lib/assets/javascripts/builder/data/analyses.js
@@ -91,8 +91,8 @@ var MAP = {
     modalDesc: _t('components.modals.add-analysis.option-types.data-observatory-measure.desc'),
     modalCategory: 'create_clean',
     modalLink: 'https://carto.com/learn/guides/analysis/enrich-from-data-observatory',
-    checkIfEnabled: function (configModel) {
-      return checkIfDataObservatoryIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfDataObservatoryIsEnabled(options);
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/data-observatory-measure.tpl'),
     animationTemplate: require('builder/components/modals/add-analysis/animation-templates/data-observatory-measure.tpl'),
@@ -106,14 +106,14 @@ var MAP = {
     modalDesc: _t('components.modals.add-analysis.option-types.data-observatory-measure.desc'),
     modalCategory: 'create_clean',
     modalLink: 'https://carto.com/learn/guides/analysis/enrich-from-data-observatory',
-    checkIfEnabled: function (configModel, userModel) {
-      var dataservicesApiHealth = DataServicesApiCheck.get(configModel);
+    checkIfEnabled: function (options) {
+      var dataservicesApiHealth = DataServicesApiCheck.get(options.configModel);
       var doApiData = dataservicesApiHealth.getService('observatory');
       var assignedQuota = doApiData ? doApiData.get('monthly_quota') : 0;
       var softLimit = doApiData ? doApiData.get('soft_limit') : false;
       var hideDataObservatory = assignedQuota === 0 && !softLimit;
 
-      return checkIfDataObservatoryIsEnabled(configModel) && !hideDataObservatory;
+      return checkIfDataObservatoryIsEnabled(options) && !hideDataObservatory;
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/data-observatory-multiple-measure.tpl'),
     animationTemplate: require('builder/components/modals/add-analysis/animation-templates/data-observatory-measure.tpl'),
@@ -156,8 +156,8 @@ var MAP = {
     title: _t('analyses.georeference.title'),
     short_title: _t('analyses.georeference.short-title'),
     FormModel: require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model'),
-    checkIfEnabled: function (configModel) {
-      return checkIfInternalGeocodingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfInternalGeocodingIsEnabled(options);
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/georeference.tpl'),
     genericType: 'georeference'
@@ -166,8 +166,8 @@ var MAP = {
     title: _t('analyses.georeference.title'),
     short_title: _t('analyses.georeference.short-title'),
     FormModel: require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model'),
-    checkIfEnabled: function (configModel) {
-      return checkIfInternalGeocodingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfInternalGeocodingIsEnabled(options);
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/georeference.tpl'),
     genericType: 'georeference'
@@ -176,8 +176,8 @@ var MAP = {
     title: _t('analyses.georeference.title'),
     short_title: _t('analyses.georeference.short-title'),
     FormModel: require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model'),
-    checkIfEnabled: function (configModel) {
-      return checkIfInternalGeocodingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfInternalGeocodingIsEnabled(options);
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/georeference.tpl'),
     genericType: 'georeference'
@@ -206,8 +206,8 @@ var MAP = {
     title: _t('analyses.georeference.title'),
     short_title: _t('analyses.georeference.short-title'),
     FormModel: require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model'),
-    checkIfEnabled: function (configModel) {
-      return checkIfInternalGeocodingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfInternalGeocodingIsEnabled(options);
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/georeference.tpl'),
     genericType: 'georeference'
@@ -216,8 +216,8 @@ var MAP = {
     title: _t('analyses.georeference.title'),
     short_title: _t('analyses.georeference.short-title'),
     FormModel: require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model'),
-    checkIfEnabled: function (configModel) {
-      return checkIfExternalGeocodingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfExternalGeocodingIsEnabled(options);
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/georeference.tpl'),
     genericType: 'georeference'
@@ -226,8 +226,8 @@ var MAP = {
     title: _t('analyses.georeference.title'),
     short_title: _t('analyses.georeference.short-title'),
     FormModel: require('builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model'),
-    checkIfEnabled: function (configModel) {
-      return checkIfInternalGeocodingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfInternalGeocodingIsEnabled(options);
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/georeference.tpl'),
     genericType: 'georeference'
@@ -312,24 +312,24 @@ var MAP = {
     title: _t('analyses.routing.title'),
     short_title: _t('analyses.routing.short-title'),
     FormModel: FallbackFormModel,
-    checkIfEnabled: function (configModel) {
-      return checkIfRoutingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfRoutingIsEnabled(options);
     }
   },
   'routing-to-layer-all-to-all': {
     title: _t('analyses.routing.title'),
     short_title: _t('analyses.routing.short-title'),
     FormModel: FallbackFormModel,
-    checkIfEnabled: function (configModel) {
-      return checkIfRoutingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfRoutingIsEnabled(options);
     }
   },
   'routing-to-single-point': {
     title: _t('analyses.routing.title'),
     short_title: _t('analyses.routing.short-title'),
     FormModel: FallbackFormModel,
-    checkIfEnabled: function (configModel) {
-      return checkIfRoutingIsEnabled(configModel);
+    checkIfEnabled: function (options) {
+      return checkIfRoutingIsEnabled(options);
     }
   },
   'sampling': {
@@ -362,9 +362,9 @@ var MAP = {
     title: _t('analyses.area-of-influence.title'),
     short_title: _t('analyses.area-of-influence.short-title'),
     FormModel: AreaOfInfluenceFormModel,
-    checkIfEnabled: function (configModel) {
-      if (!configModel) throw new Error('configModel is required');
-      return !!configModel.dataServiceEnabled('isolines');
+    checkIfEnabled: function (options) {
+      if (!options.configModel) throw new Error('configModel is required');
+      return !!options.configModel.dataServiceEnabled('isolines');
     },
     onboardingTemplate: require('builder/components/onboardings/analysis/analyses/area-of-influence.tpl'),
     genericType: 'area-of-influence'
@@ -395,30 +395,30 @@ var MAP = {
     modalDesc: _t('components.modals.add-analysis.option-types.deprecated-sql-function.desc'),
     modalCategory: 'data_transformation',
     ModalModel: DeprecatedSQLFunctionOptionModel,
-    checkIfEnabled: function (configModel, userModel) {
-      return userModel.featureEnabled('deprecated-sql-function');
+    checkIfEnabled: function (options) {
+      return options.userModel.featureEnabled('deprecated-sql-function');
     }
   }
 };
 
-var checkIfInternalGeocodingIsEnabled = function (configModel) {
-  if (!configModel) throw new Error('configModel is required');
-  return isDataServicesReady(configModel) && !!configModel.dataServiceEnabled('geocoder_internal');
+var checkIfInternalGeocodingIsEnabled = function (options) {
+  if (!options.configModel) throw new Error('configModel is required');
+  return isDataServicesReady(options.configModel) && !!options.configModel.dataServiceEnabled('geocoder_internal');
 };
 
-var checkIfRoutingIsEnabled = function (configModel) {
-  if (!configModel) throw new Error('configModel is required');
-  return isDataServicesReady(configModel) && !!configModel.dataServiceEnabled('routing');
+var checkIfRoutingIsEnabled = function (options) {
+  if (!options.configModel) throw new Error('configModel is required');
+  return isDataServicesReady(options.configModel) && !!options.configModel.dataServiceEnabled('routing');
 };
 
-var checkIfExternalGeocodingIsEnabled = function (configModel) {
-  if (!configModel) throw new Error('configModel is required');
-  return isDataServicesReady(configModel) && !!configModel.dataServiceEnabled('hires_geocoder');
+var checkIfExternalGeocodingIsEnabled = function (options) {
+  if (!options.configModel) throw new Error('configModel is required');
+  return isDataServicesReady(options.configModel) && !!options.configModel.dataServiceEnabled('hires_geocoder');
 };
 
-var checkIfDataObservatoryIsEnabled = function (configModel) {
-  if (!configModel) throw new Error('configModel is required');
-  return isDataServicesReady(configModel) && !!configModel.dataServiceEnabled('data_observatory');
+var checkIfDataObservatoryIsEnabled = function (options) {
+  if (!options.configModel) throw new Error('configModel is required');
+  return isDataServicesReady(options.configModel) && !!options.configModel.dataServiceEnabled('data_observatory');
 };
 
 var definitionByType = function (m) {
@@ -452,9 +452,9 @@ var isDataServicesReady = function (configModel) {
   return DataServicesApiCheck.get(configModel).isReady();
 };
 
-var isAnalysisValidByType = function (type, configModel, userModel) {
+var _isAnalysisValidByType = function (type, options) {
   var analysis = MAP[type];
-  return analysis && analysis.checkIfEnabled ? analysis.checkIfEnabled(configModel, userModel) : true;
+  return analysis && analysis.checkIfEnabled ? analysis.checkIfEnabled(options) : true;
 };
 
 var DATA_OBSERVATORY_OLD = 'data-observatory-measure';
@@ -469,14 +469,14 @@ module.exports = {
       : UnknownTypeFormModel;
   },
 
-  getAnalysesByModalCategory: function (category, configModel, userModel) {
+  getAnalysesByModalCategory: function (category, options) {
     return _.reduce(MAP, function (memo, item, analysisType) {
       if (analysisType === DATA_OBSERVATORY_OLD) {
         return memo;
       }
 
       if (item.modalCategory === category) {
-        if (isAnalysisValidByType(analysisType, configModel, userModel)) {
+        if (_isAnalysisValidByType(analysisType, options)) {
           var obj = {
             nodeAttrs: {
               type: analysisType
@@ -502,8 +502,8 @@ module.exports = {
     }, []);
   },
 
-  isAnalysisValidByType: function (type, configModel, userModel) {
-    return isAnalysisValidByType(type, configModel, userModel);
+  isAnalysisValidByType: function (type, options) {
+    return _isAnalysisValidByType(type, options);
   },
 
   getAnalysisByType: function (type) {

--- a/lib/assets/javascripts/builder/data/query-geometry-model.js
+++ b/lib/assets/javascripts/builder/data/query-geometry-model.js
@@ -22,6 +22,11 @@ var PARAMS = {
   rows_per_page: 40,
   page: 0
 };
+var GEOMETRIES = {
+  LINE: 'line',
+  POINT: 'point',
+  POLYGON: 'polygon'
+};
 
 /**
  * Model to represent a schema of a SQL query.
@@ -152,5 +157,9 @@ module.exports = BaseModel.extend({
       geom_column: geomColumnName || 'the_geom',
       sql: this.get('query')
     });
+  },
+
+  isPolygon: function () {
+    return this.get('simple_geom') === GEOMETRIES.POLYGON;
   }
 });

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/area-of-influence-form-model.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/area-of-influence-form-model.js
@@ -61,7 +61,7 @@ module.exports = BaseAnalysisFormModel.extend({
           type: 'Radio',
           text: _t('editor.layers.analysis-form.type'),
           options: AREA_OF_INFLUENCE_TYPES.map(function (d) {
-            var isAnalysisTypeEnabled = this._analyses.isAnalysisValidByType(d.type, this._configModel);
+            var isAnalysisTypeEnabled = this._analyses.isAnalysisValidByType(d.type, { configModel: this._configModel });
             var canChangeToType = this._canChangeToType(d.type);
             var isDisabled = !isAnalysisTypeEnabled || !canChangeToType;
             var helpMessage = !isAnalysisTypeEnabled ? _t('editor.layers.analysis-form.disabled-by-config') : _t('editor.layers.analysis-form.valid-type');

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-form-models/georeference-form-model.js
@@ -86,7 +86,7 @@ module.exports = BaseAnalysisFormModel.extend({
         title: _t('editor.layers.analysis-form.type'),
         options: _.compact(
           GEOREFERENCE_TYPES.map(function (d) {
-            if (!this._analyses.isAnalysisValidByType(d.type, this._configModel)) {
+            if (!this._analyses.isAnalysisValidByType(d.type, { configModel: this._configModel })) {
               return false;
             }
 

--- a/lib/assets/test/spec/builder/components/modals/add-analysis/analysis-options.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-analysis/analysis-options.spec.js
@@ -2,7 +2,6 @@ var Backbone = require('backbone');
 var _ = require('underscore');
 var camshaftReferenceAnalyses = require('camshaft-reference').getVersion('latest').analyses;
 var analysisOptions = require('builder/components/modals/add-analysis/analysis-options');
-var Analyses = require('builder/data/analyses');
 var DataServicesApiCheck = require('builder/editor/layers/layer-content-views/analyses/analyses-quota/analyses-quota-info');
 
 describe('builder/components/modals/add-analysis/analysis-options', function () {

--- a/lib/assets/test/spec/builder/components/modals/add-analysis/analysis-options.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-analysis/analysis-options.spec.js
@@ -11,21 +11,33 @@ describe('builder/components/modals/add-analysis/analysis-options', function () 
     sql_api_template: 'foo',
     api_key: 'foo'
   });
+  configModel.dataServiceEnabled = function () { return true; };
+
   var userModel = new Backbone.Model();
   userModel.featureEnabled = function () { return true; };
-  configModel.dataServiceEnabled = function () { return true; };
+
+  var queryGeometryModel = new Backbone.Model();
+  queryGeometryModel.isPolygon = function () { return true; };
 
   DataServicesApiCheck.get(configModel)._state = 'fetched';
 
   it('should not add generated option if feature flag is disabled', function () {
     userModel.featureEnabled = function () { return false; };
     configModel.dataServiceEnabled = function () { return false; };
-    var defaultAnalysisOptions = analysisOptions(Analyses, userModel, configModel);
+    var defaultAnalysisOptions = analysisOptions({
+      userModel: userModel,
+      configModel: configModel,
+      queryGeometryModel: queryGeometryModel
+    });
     expect(defaultAnalysisOptions['generated']).toBeUndefined('should not have any generated options');
   });
 
   describe('each category (including generated)', function () {
-    var options = analysisOptions(Analyses, userModel, configModel);
+    var options = analysisOptions({
+      userModel: userModel,
+      configModel: configModel,
+      queryGeometryModel: queryGeometryModel
+    });
 
     _.each(options, function (item, category) {
       it('should have a key', function () {

--- a/lib/assets/test/spec/builder/data/analyses.spec.js
+++ b/lib/assets/test/spec/builder/data/analyses.spec.js
@@ -53,6 +53,9 @@ describe('builder/data/analyses', function () {
       });
 
       this.userModel = new Backbone.Model();
+
+      this.queryGeometryModel = new Backbone.Model();
+      this.queryGeometryModel.isPolygon = function () { return true; };
     });
 
     describe('data observatory', function () {
@@ -83,7 +86,11 @@ describe('builder/data/analyses', function () {
 
           dataservicesApiHealth._ready = 'ready';
           dataservicesApiHealth.getService.and.returnValue(DO);
-          var analysisModels = analyses.getAnalysesByModalCategory('create_clean', this.configModel, this.userModel);
+          var analysisModels = analyses.getAnalysesByModalCategory('create_clean', {
+            userModel: this.userModel,
+            configModel: this.configModel,
+            queryGeometryModel: this.queryGeometryModel
+          });
           expect(analysisModels.length).toBe(4);
           expect(findDataObservatory(analysisModels, 'data-observatory-measure').length).toBe(0);
         });
@@ -97,7 +104,11 @@ describe('builder/data/analyses', function () {
 
           dataservicesApiHealth._ready = 'ready';
           dataservicesApiHealth.getService.and.returnValue(DO);
-          var analysisModels = analyses.getAnalysesByModalCategory('create_clean', this.configModel, this.userModel);
+          var analysisModels = analyses.getAnalysesByModalCategory('create_clean', {
+            userModel: this.userModel,
+            configModel: this.configModel,
+            queryGeometryModel: this.queryGeometryModel
+          });
           expect(analysisModels.length).toBe(4);
           expect(findDataObservatory(analysisModels, 'data-observatory-measure').length).toBe(0);
         });
@@ -111,7 +122,11 @@ describe('builder/data/analyses', function () {
 
           dataservicesApiHealth._ready = 'ready';
           dataservicesApiHealth.getService.and.returnValue(DO);
-          var analysisModels = analyses.getAnalysesByModalCategory('create_clean', this.configModel, this.userModel);
+          var analysisModels = analyses.getAnalysesByModalCategory('create_clean', {
+            userModel: this.userModel,
+            configModel: this.configModel,
+            queryGeometryModel: this.queryGeometryModel
+          });
           expect(analysisModels.length).toBe(4);
           expect(findDataObservatory(analysisModels, 'data-observatory-measure').length).toBe(0);
         });
@@ -119,7 +134,11 @@ describe('builder/data/analyses', function () {
 
       it('dataservices api not existing', function () {
         DataServicesApiCheck.get(this.configModel)._ready = 'notready';
-        var analysisModels = analyses.getAnalysesByModalCategory('create_clean', this.configModel, this.userModel);
+        var analysisModels = analyses.getAnalysesByModalCategory('create_clean', {
+          userModel: this.userModel,
+          configModel: this.configModel,
+          queryGeometryModel: this.queryGeometryModel
+        });
         expect(analysisModels.length).toBe(3);
         expect(findDataObservatory(analysisModels, 'data-observatory-measure').length).toBe(0);
       });
@@ -272,6 +291,11 @@ describe('builder/data/analyses', function () {
         }
       };
       spyOn(DataServicesApiCheck, 'get').and.returnValue(fakeDS);
+
+      var userModel = new Backbone.Model();
+      var queryGeometryModel = new Backbone.Model();
+      queryGeometryModel.isPolygon = function () { return true; };
+
       _.each(testTypes, function (analysisType) {
         var checkIfEnabled = analyses.MAP[analysisType].checkIfEnabled;
         var configModel = {
@@ -282,7 +306,11 @@ describe('builder/data/analyses', function () {
 
         expect(checkIfEnabled).toBeDefined();
 
-        var result = checkIfEnabled(configModel);
+        var result = checkIfEnabled({
+          userModel: userModel,
+          queryGeometryModel: queryGeometryModel,
+          configModel: configModel
+        });
 
         expect(result).toBe(true);
         expect(readyCalled).toBe(true);


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/10699

This PR checks the layer geometry to show the `Select points in polygons` analysis only for `polygon` layers.

I had to change the parameters we use in most of the functions related to the filtering of analyses to also add the `queryGeometryModel`.