### PR TITLE
Avoid parsing errors twice when saving CartoCSS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,7 @@ ion for time-series (#12670)
 * Hide legend title and header if not enabled (https://github.com/CartoDB/support/issues/1349)
 
 ### Bug fixes / enhancements
+* Avoid parsing errors twice when saving CartoCSS (https://github.com/CartoDB/cartodb/pull/13986)
 * Allow only numeric values in latitude/longitude select in georeference analysis (https://github.com/CartoDB/cartodb/pull/13974)
 * Fix dataset name overflow in widgets (https://github.com/CartoDB/cartodb/pull/13972)
 * Fix the public table view for non-migrated-users  (#13969)

--- a/lib/assets/javascripts/builder/editor/style/style-view.js
+++ b/lib/assets/javascripts/builder/editor/style/style-view.js
@@ -259,7 +259,7 @@ module.exports = CoreView.extend({
     }
 
     this._applyButtonStatusModel.set('loading', true);
-    this._codemirrorModel.set('errors', parser.parseError(errors));
+    this._codemirrorModel.set('errors', errors);
 
     if (errors.length === 0) {
       this._cartocssModel.set('content', content);
@@ -283,7 +283,7 @@ module.exports = CoreView.extend({
         mode_type: 'cartocss'
       });
     } else {
-      this._editorModel.get('edition') === false && CartoCSSNotifications.showErrorNotification(parser.parseError(errors));
+      this._editorModel.get('edition') === false && CartoCSSNotifications.showErrorNotification(errors);
       this._applyButtonStatusModel.set('loading', false);
     }
   },

--- a/lib/assets/javascripts/builder/editor/style/style-view.js
+++ b/lib/assets/javascripts/builder/editor/style/style-view.js
@@ -259,7 +259,7 @@ module.exports = CoreView.extend({
     }
 
     this._applyButtonStatusModel.set('loading', true);
-    this._codemirrorModel.set('errors', errors);
+    this._codemirrorModel.set('errors', parser.parseError(errors));
 
     if (errors.length === 0) {
       this._cartocssModel.set('content', content);
@@ -283,7 +283,7 @@ module.exports = CoreView.extend({
         mode_type: 'cartocss'
       });
     } else {
-      this._editorModel.get('edition') === false && CartoCSSNotifications.showErrorNotification(errors);
+      this._editorModel.get('edition') === false && CartoCSSNotifications.showErrorNotification(parser.parseError(errors));
       this._applyButtonStatusModel.set('loading', false);
     }
   },

--- a/lib/assets/javascripts/builder/helpers/parser-css.js
+++ b/lib/assets/javascripts/builder/helpers/parser-css.js
@@ -3,6 +3,8 @@ var carto = require('carto');
 var torque = require('torque.js');
 var _ = require('underscore');
 
+var ERROR_REGEX = /.*:(\d+):(\d+)\s*(.*)/;
+
 var CartoParser = function (cartocss) {
   this.parse_env = null;
   this.ruleset = null;
@@ -132,34 +134,23 @@ CartoParser.prototype = {
    * strings. Parses errors in format:
    *
    *  'style.mss:7:2 Invalid code: asdasdasda'
+   *
+   * it could also get already parsed objects so we return them directly without parsing them again
    */
   parseError: function (errors) {
-    var parsedErrors = [];
-    var i;
-    var g;
-    var err;
+    var parsedErrors = _.compact(errors).map(function (error) {
+      if (_.isObject(error)) return error;
 
-    for (i in errors) {
-      err = errors[i];
-      if (err && err.length > 0) {
-        g = err.match(/.*:(\d+):(\d+)\s*(.*)/);
-        if (g) {
-          parsedErrors.push({
-            line: parseInt(g[1], 10),
-            message: g[3]
-          });
-        } else {
-          parsedErrors.push({
-            line: null,
-            message: err
-          });
-        }
-      }
-    }
+      var matchedError = error.match(ERROR_REGEX);
+      return matchedError
+        ? { line: parseInt(matchedError[1], 10), message: matchedError[3] }
+        : { line: null, message: error };
+    });
 
     // sort by line
     parsedErrors.sort(function (a, b) { return a.line - b.line; });
     parsedErrors = _.uniq(parsedErrors, true, function (a) { return a.line + a.message; });
+
     return parsedErrors;
   },
 

--- a/lib/assets/test/spec/builder/helpers/parser-css.spec.js
+++ b/lib/assets/test/spec/builder/helpers/parser-css.spec.js
@@ -48,5 +48,17 @@ describe('helpers/parser-css', function () {
 
       expect(parsed.length).toBe(1);
     });
+
+    describe('when the error list is empty', function () {
+      it('returns an empty array', function () {
+        expect(parser.parseError([])).toEqual([]);
+      });
+    });
+
+    describe('when the error list is missisng', function () {
+      it('returns an empty array', function () {
+        expect(parser.parseError()).toEqual([]);
+      });
+    });
   });
 });

--- a/lib/assets/test/spec/builder/helpers/parser-css.spec.js
+++ b/lib/assets/test/spec/builder/helpers/parser-css.spec.js
@@ -1,0 +1,50 @@
+var ParserCSS = require('builder/helpers/parser-css');
+
+describe('helpers/parser-css', function () {
+  var parser = new ParserCSS();
+
+  describe('.parseError', function () {
+    describe('when the error is a formatted string', function () {
+      it('returns the error with line and message', function () {
+        var given = ['style.mss:7:2 Invalid code: Kenobi'];
+        var expected = [{ line: 7, message: 'Invalid code: Kenobi' }];
+
+        expect(parser.parseError(given)).toEqual(expected);
+      });
+    });
+
+    describe('when the error is not a formatted string', function () {
+      it('returns the error without line and with message', function () {
+        var given = ['Do not tell me the odds'];
+        var expected = [{ line: null, message: 'Do not tell me the odds' }];
+
+        expect(parser.parseError(given)).toEqual(expected);
+      });
+    });
+
+    describe('when the error is an object', function () {
+      it('returns the same error', function () {
+        var given = [{ line: 66, message: 'Execute order' }];
+
+        expect(parser.parseError(given)).toEqual(given);
+      });
+    });
+
+    it('returns the errors sorted by line order', function () {
+      var errors = parser.parseError([
+        'style.mss:7:2 General Kenobi',
+        'style.mss:3:2 Hello there'
+      ]);
+
+      expect(errors[0].message).toEqual('Hello there');
+      expect(errors[1].message).toEqual('General Kenobi');
+    });
+
+    it('removes duplicated errors', function () {
+      var error = 'style.mss:7:2 You were my brother Anakin';
+      var parsed = parser.parseError([error, error]);
+
+      expect(parsed.length).toBe(1);
+    });
+  });
+});

--- a/lib/assets/test/spec/builder/helpers/parser-css.spec.js
+++ b/lib/assets/test/spec/builder/helpers/parser-css.spec.js
@@ -33,11 +33,13 @@ describe('helpers/parser-css', function () {
     it('returns the errors sorted by line order', function () {
       var errors = parser.parseError([
         'style.mss:7:2 General Kenobi',
-        'style.mss:3:2 Hello there'
+        'style.mss:3:2 Hello there',
+        'this wont have a line number'
       ]);
 
-      expect(errors[0].message).toEqual('Hello there');
-      expect(errors[1].message).toEqual('General Kenobi');
+      expect(errors[0].message).toEqual('this wont have a line number');
+      expect(errors[1].message).toEqual('Hello there');
+      expect(errors[2].message).toEqual('General Kenobi');
     });
 
     it('removes duplicated errors', function () {

--- a/lib/assets/test/spec/builder/helpers/parser-css.spec.js
+++ b/lib/assets/test/spec/builder/helpers/parser-css.spec.js
@@ -55,7 +55,7 @@ describe('helpers/parser-css', function () {
       });
     });
 
-    describe('when the error list is missisng', function () {
+    describe('when the error list is missing', function () {
       it('returns an empty array', function () {
         expect(parser.parseError()).toEqual([]);
       });


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/11805

The errors where already parsed when doing `new ParserCSS`, so calling again to `parser.parseErrors` led to an empty array.