### PR TITLE
Add CDB-Button-noPadding class to delete button

### DIFF
--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-buttons.tpl
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-buttons.tpl
@@ -1,5 +1,8 @@
-<button class="CDB-Button js-delete
-<% if (disableDelete) { %> is-disabled<% } %>
+<button class="
+  CDB-Button
+  CDB-Button--noPadding
+  js-delete
+  <% if (disableDelete) { %> is-disabled<% } %>
 ">
   <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase
   <% if (isDelete) { %> u-errorTextColor<% } else { %> u-actionTextColor<% } %>">


### PR DESCRIPTION
Related to: #12860

This PR adds the class `CDB-Button-noPadding` to the delete button so it's aligned correctly.