### PR TITLE
13904 null data import search tweet

### DIFF
--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -694,6 +694,14 @@ describe Carto::UserMetadataExportService do
             state: 'complete',
             created_at: DateTime.now,
             updated_at: DateTime.now
+          },
+          {
+            data_import: nil,
+            service_item_id: '{\"dates\":{\"fromDate\":\"2014-07-29\",\"fromHour\":0,\"fromMin\":0,\"toDate\":\"2014-08-27\",\"toHour\":23,\"toMin\":59,\"user_timezone\":0,\"max_days\":30},\"categories\":[{\"terms\":[\"cartodb\"],\"category\":\"1\",\"counter\":1007}]}',
+            retrieved_items: 123,
+            state: 'complete',
+            created_at: DateTime.now,
+            updated_at: DateTime.now
           }
         ],
         notifications: {

--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -694,14 +694,6 @@ describe Carto::UserMetadataExportService do
             state: 'complete',
             created_at: DateTime.now,
             updated_at: DateTime.now
-          },
-          {
-            data_import: nil,
-            service_item_id: '{\"dates\":{\"fromDate\":\"2014-07-29\",\"fromHour\":0,\"fromMin\":0,\"toDate\":\"2014-08-27\",\"toHour\":23,\"toMin\":59,\"user_timezone\":0,\"max_days\":30},\"categories\":[{\"terms\":[\"cartodb\"],\"category\":\"1\",\"counter\":1007}]}',
-            retrieved_items: 123,
-            state: 'complete',
-            created_at: DateTime.now,
-            updated_at: DateTime.now
           }
         ],
         notifications: {


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb/issues/13904

`search_tweets.data_import_id` is not nullable. However, the FK is not verified. This problems occurs when exporting from a search tweet with an invalid data import id (points to a non-existing entity). However, we want to keep the search tweet anyway (since it's used for quota calculations), so we resort to doing the same uglyness as in the source DB (write an invalid data import id).

This is ugly, but I couldn't figure out a better way to do it.