### PR TITLE
Fix org redirection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Development
 
 ### Bug fixes / enhancements
 * Fix wrong requests because of bad png tile urls generation (https://github.com/CartoDB/cartodb/pull/14000)
+* Redirect organization users in static pages (https://github.com/CartoDB/cartodb/pull/14009)
 
 
 

--- a/lib/assets/javascripts/dashboard/account.js
+++ b/lib/assets/javascripts/dashboard/account.js
@@ -8,6 +8,7 @@ const ConfigModel = require('dashboard/data/config-model');
 const UserModel = require('dashboard/data/user-model');
 const OrganizationModel = require('dashboard/data/organization-model');
 const AssetsVersionHelper = require('dashboard/helpers/assets-version');
+const redirectOrgUsers = require('dashboard/helpers/redirector').redirectOrgUsers;
 
 const Locale = require('locale/index');
 
@@ -32,6 +33,7 @@ const InitAccount = function () {
     const ASSETS_VERSION = AssetsVersionHelper.getAssetsVersion(PACKAGE.version);
     const dashboard_notifications = data.dashboard_notifications;
     const userData = data.user_data || {};
+    redirectOrgUsers(userData.organization, userData.username, 'account', window.location);
 
     const configModel = new ConfigModel(
       _.extend(

--- a/lib/assets/javascripts/dashboard/dashboard.js
+++ b/lib/assets/javascripts/dashboard/dashboard.js
@@ -2,7 +2,8 @@ const _ = require('underscore');
 
 const Locale = require('locale/index');
 const Polyglot = require('node-polyglot');
-const parseDomains = require('parse-domains');
+const redirectOrgUsers = require('dashboard/helpers/redirector').redirectOrgUsers;
+
 const ACTIVE_LOCALE = 'en';
 
 const polyglot = new Polyglot({
@@ -51,16 +52,8 @@ function dataLoaded (data) {
   const dashboard_notifications = data.dashboard_notifications;
   const isJustLoggedIn = data.isJustLoggedIn;
   const isFirstTimeViewingDashboard = data.isFirstTimeViewingDashboard;
-  const domains = parseDomains(location.href);
 
-  if (userData.organization &&
-    userData.organization.name &&
-    domains.subdomain &&
-    domains.subdomain === userData.username) {
-    const newOrigin = location.origin.replace(domains.subdomain, userData.organization.name);
-    const newPathname = `/u/${userData.username}/dashboard`;
-    location.replace(`${newOrigin}${newPathname}`);
-  }
+  redirectOrgUsers(userData.organization, userData.username, 'dashboard', window.location);
 
   const configModel = new ConfigModel(
     _.extend(

--- a/lib/assets/javascripts/dashboard/dashboard.js
+++ b/lib/assets/javascripts/dashboard/dashboard.js
@@ -2,6 +2,7 @@ const _ = require('underscore');
 
 const Locale = require('locale/index');
 const Polyglot = require('node-polyglot');
+const parseDomains = require('parse-domains');
 const ACTIVE_LOCALE = 'en';
 
 const polyglot = new Polyglot({
@@ -50,6 +51,16 @@ function dataLoaded (data) {
   const dashboard_notifications = data.dashboard_notifications;
   const isJustLoggedIn = data.isJustLoggedIn;
   const isFirstTimeViewingDashboard = data.isFirstTimeViewingDashboard;
+  const domains = parseDomains(location.href);
+
+  if (userData.organization &&
+    userData.organization.name &&
+    domains.subdomain &&
+    domains.subdomain === userData.username) {
+    const newOrigin = location.origin.replace(domains.subdomain, userData.organization.name);
+    const newPathname = `/u/${userData.username}/dashboard`;
+    location.replace(`${newOrigin}${newPathname}`);
+  }
 
   const configModel = new ConfigModel(
     _.extend(

--- a/lib/assets/javascripts/dashboard/helpers/parse-domains.js
+++ b/lib/assets/javascripts/dashboard/helpers/parse-domains.js
@@ -1,0 +1,42 @@
+const URL = require('url-parse');
+
+/**
+ * @param {string} url
+ * @returns {Object|null}
+ */
+function parseDomain (url) {
+  var matches = url.match(/https?:\/\/(www\.)?[^/]+/);
+
+  if (!matches) {
+    return { msg: 'invalid url: ' + url };
+  }
+
+  url = matches[0].replace(/www\./ig, '');
+
+  var urlSplit;
+  var tld;
+  var domain;
+  var subdomain;
+
+  if (!url || typeof url !== 'string') {
+    return null;
+  }
+
+  // parse URL
+  var obj = new URL(url);
+
+  // check if tld is supported
+  urlSplit = obj.host.split('.');
+  tld = urlSplit[urlSplit.length - 1];
+  domain = urlSplit.slice(urlSplit.length - 2, urlSplit.length - 1).join('.');
+  subdomain = urlSplit.slice(0, urlSplit.length - 2).join('.');
+
+  return {
+    tld: tld,
+    domain: domain,
+    subdomain: subdomain,
+    dtld: (subdomain ? subdomain + '.' : '') + domain + '.' + tld
+  };
+}
+
+module.exports = parseDomain;

--- a/lib/assets/javascripts/dashboard/helpers/redirector.js
+++ b/lib/assets/javascripts/dashboard/helpers/redirector.js
@@ -1,0 +1,13 @@
+const parseDomains = require('parse-domains');
+
+module.exports = {
+  redirectOrgUsers: function (organization, username, page, location) {
+    const domains = parseDomains(location.href);
+    if (organization && organization.name && domains.subdomain &&
+      domains.subdomain === username) {
+      const newOrigin = location.origin.replace(domains.subdomain, organization.name);
+      const newPathname = `/u/${username}/${page}`;
+      location.replace(`${newOrigin}${newPathname}`);
+    }
+  }
+};

--- a/lib/assets/javascripts/dashboard/helpers/redirector.js
+++ b/lib/assets/javascripts/dashboard/helpers/redirector.js
@@ -1,4 +1,4 @@
-const parseDomains = require('parse-domains');
+const parseDomains = require('./parse-domains');
 
 module.exports = {
   redirectOrgUsers: function (organization, username, page, location) {

--- a/lib/assets/javascripts/dashboard/profile.js
+++ b/lib/assets/javascripts/dashboard/profile.js
@@ -9,6 +9,7 @@ const ConfigModel = require('dashboard/data/config-model');
 const UserModel = require('dashboard/data/user-model');
 const ModalsServiceModel = require('builder/components/modals/modals-service-model');
 const AssetsVersionHelper = require('dashboard/helpers/assets-version');
+const redirectOrgUsers = require('dashboard/helpers/redirector').redirectOrgUsers;
 
 const Locale = require('locale/index');
 const Polyglot = require('node-polyglot');
@@ -33,6 +34,8 @@ window.CartoConfig = window.CartoConfig || {};
 
 function dataLoaded (data) {
   const {user_data, dashboard_notifications} = data;
+
+  redirectOrgUsers(user_data.organization, user_data.username, 'profile', window.location);
 
   const configModel = new ConfigModel(
     _.extend(

--- a/lib/assets/test/spec/dashboard/helpers/redirector.spec.js
+++ b/lib/assets/test/spec/dashboard/helpers/redirector.spec.js
@@ -1,0 +1,34 @@
+const redirector = require('dashboard/helpers/redirector');
+
+describe('dashboard/helpers/redirector', function () {
+  it('should redirect if it is an org user with subdomain', function () {
+    const fakeLocation = {
+      origin: 'https://gza.carto.com',
+      href: 'https://gza.carto.com/dashboard',
+      replace: function () {}
+    };
+    spyOn(fakeLocation, 'replace');
+    const organization = {
+      name: 'wutangclan'
+    };
+    const username = 'gza';
+
+    redirector.redirectOrgUsers(organization, username, 'dashboard', fakeLocation);
+
+    expect(fakeLocation.replace).toHaveBeenCalledWith('https://wutangclan.carto.com/u/gza/dashboard');
+  });
+
+  it('should not redirect if it not an org user with subdomain', function () {
+    const fakeLocation = {
+      origin: 'https://gza.carto.com',
+      href: 'https://gza.carto.com/dashboard',
+      replace: function () {}
+    };
+    spyOn(fakeLocation, 'replace');
+    const username = 'gza';
+
+    redirector.redirectOrgUsers(null, username, 'dashboard', fakeLocation);
+
+    expect(fakeLocation.replace).not.toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.11",
+  "version": "4.12.11-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -39,7 +39,6 @@
     "moment": "2.18.1",
     "moment-timezone": "^0.5.13",
     "node-polyglot": "1.0.0",
-    "parse-domains": "^1.0.2",
     "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
     "postcss": "5.0.19",
     "postcss-scss": "0.4.0",
@@ -51,6 +50,7 @@
     "torque.js": "CartoDB/torque#master",
     "underscore": "1.8.3",
     "urijs": "^1.19.0",
+    "url-parse": "^1.4.0",
     "webpack": "2.3.2",
     "whatwg-fetch": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "moment": "2.18.1",
     "moment-timezone": "^0.5.13",
     "node-polyglot": "1.0.0",
+    "parse-domains": "^1.0.2",
     "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
     "postcss": "5.0.19",
     "postcss-scss": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.11-2",
+  "version": "4.12.11",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.11",
+  "version": "4.12.11-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.11-1",
+  "version": "4.12.11",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
With the latest static deploy, org users using a subdomain URL were not redirected to the right place.

This PR checks if the user has an organization and if the username equals the subdomain to perform the redirection client side.

After seeing the code, I don't think domainless URLS for OnPrem are not affected since they don't use a subdomain. Correct if I'm wrong @javitonino 