### PR TITLE
Org api key migration

### DIFF
--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -209,8 +209,11 @@ module Carto
     end
 
     def role_creation_queries
+      ["CREATE ROLE \"#{db_role}\" NOSUPERUSER NOCREATEDB LOGIN ENCRYPTED PASSWORD '#{db_password}'"]
+    end
+
+    def role_permission_queries
       queries = [
-        "CREATE ROLE \"#{db_role}\" NOSUPERUSER NOCREATEDB LOGIN ENCRYPTED PASSWORD '#{db_password}'",
         "GRANT \"#{user.service.database_public_username}\" TO \"#{db_role}\"",
         "ALTER ROLE \"#{db_role}\" SET search_path TO #{user.db_service.build_search_path}"
       ]
@@ -300,7 +303,7 @@ module Carto
     end
 
     def create_role
-      role_creation_queries.each { |q| db_run(q) }
+      (role_creation_queries + role_permission_queries).each { |q| db_run(q) }
     end
 
     def drop_db_role

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -484,7 +484,7 @@ module CartoDB
       end
 
       def create_user_api_key_roles(user_id)
-        Carto::User.find(user_id).api_keys.select(&:regular?).each do |k|
+        Carto::User.find(user_id).api_keys.regular.each do |k|
           begin
             k.role_creation_queries.each { |q| superuser_user_pg_conn.query(q) }
           rescue PG::Error => e

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -187,9 +187,9 @@ module CartoDB
               grant_org_api_key_roles(@target_org_id)
             elsif File.exists? "#{@path}user_#{@target_userid}.dump"
               create_db(@target_dbname, true)
-              create_org_api_key_roles(@target_userid)
+              create_user_api_key_roles(@target_userid)
               import_pgdump("user_#{@target_userid}.dump")
-              grant_org_api_key_roles(@target_userid)
+              grant_user_api_key_roles(@target_userid)
             elsif File.exists? "#{@path}#{@target_username}.schema.sql"
               create_db(@target_dbname, false)
               run_file_restore_schema("#{@target_username}.schema.sql")

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -495,7 +495,7 @@ module CartoDB
       end
 
       def grant_org_api_key_roles(org_id)
-        Carto::Organization.find(org_id).users.each { |u|grant_user_api_key_roles(u.id) }
+        Carto::Organization.find(org_id).users.each { |u| grant_user_api_key_roles(u.id) }
       end
 
       def grant_user_api_key_roles(user_id)

--- a/services/user-mover/spec/user_mover_spec.rb
+++ b/services/user-mover/spec/user_mover_spec.rb
@@ -7,6 +7,13 @@ RSpec.configure do |c|
   c.include Helpers
 end
 describe CartoDB::DataMover::ExportJob do
+  def stub_api_keys
+    CartoDB::DataMover::ImportJob.any_instance.stubs(:create_org_api_key_roles)
+    CartoDB::DataMover::ImportJob.any_instance.stubs(:create_user_api_key_roles)
+    CartoDB::DataMover::ImportJob.any_instance.stubs(:grant_org_api_key_roles)
+    CartoDB::DataMover::ImportJob.any_instance.stubs(:grant_user_api_key_roles)
+  end
+
   before :each do
     bypass_named_maps
     @tmp_path = Dir.mktmpdir("mover-test") + '/'
@@ -35,6 +42,10 @@ describe CartoDB::DataMover::ExportJob do
   end
 
   describe "a migrated user" do
+    before(:each) do
+      stub_api_keys
+    end
+
     subject do
       create_tables(first_user)
       first_user.save
@@ -192,6 +203,7 @@ describe CartoDB::DataMover::ExportJob do
   end
 
   it "should not touch an user metadata nor update its oids when update_metadata is not set" do
+    stub_api_keys
     user = create_user(
       quota_in_bytes: 100.megabyte, table_quota: 50, private_tables_enabled: true, sync_tables_enabled: true
     )

--- a/spec/models/carto/user_migration_spec.rb
+++ b/spec/models/carto/user_migration_spec.rb
@@ -629,7 +629,7 @@ describe 'UserMigration' do
         @table1 = create_table(user_id: @carto_org_user_1.id)
         records.each { |row| @table1.insert_row!(row) }
         create_database('test_migration', @organization.owner) if migrate_metadata
-        @regular_api_key = Carto::ApiKey.create_regular_key!(user: @carto_org_user_owner, name: 'Some ApiKey',
+        @regular_api_key = Carto::ApiKey.create_regular_key!(user: @carto_org_user_owner, name: unique_name('api_key'),
                                                              grants: [{type: "apis", apis: ["maps", "sql"]}])
       end
 

--- a/spec/models/carto/user_migration_spec.rb
+++ b/spec/models/carto/user_migration_spec.rb
@@ -625,7 +625,7 @@ describe 'UserMigration' do
     let(:owner_attributes) { @carto_org_user_owner.attributes }
 
     shared_examples_for 'migrating metadata' do |migrate_metadata|
-      before :each do
+      before(:each) do
         @table1 = create_table(user_id: @carto_org_user_1.id)
         records.each { |row| @table1.insert_row!(row) }
         create_database('test_migration', @organization.owner) if migrate_metadata
@@ -633,9 +633,10 @@ describe 'UserMigration' do
                                                            grants: [{ type: "apis", apis: ["maps", "sql"] }])
         @user1_api_key = Carto::ApiKey.create_regular_key!(user: @carto_org_user_1, name: unique_name('api_key'),
                                                            grants: [{ type: "apis", apis: ["maps", "sql"] }])
+        @carto_organization.reload
       end
 
-      after :each do
+      after(:each) do
         drop_database('test_migration', @organization.owner) if migrate_metadata
         @owner_api_key.destroy
         @user1_api_key.destroy

--- a/spec/models/carto/user_migration_spec.rb
+++ b/spec/models/carto/user_migration_spec.rb
@@ -629,12 +629,16 @@ describe 'UserMigration' do
         @table1 = create_table(user_id: @carto_org_user_1.id)
         records.each { |row| @table1.insert_row!(row) }
         create_database('test_migration', @organization.owner) if migrate_metadata
-        @regular_api_key = Carto::ApiKey.create_regular_key!(user: @carto_org_user_owner, name: unique_name('api_key'),
-                                                             grants: [{type: "apis", apis: ["maps", "sql"]}])
+        @owner_api_key = Carto::ApiKey.create_regular_key!(user: @carto_org_user_owner, name: unique_name('api_key'),
+                                                           grants: [{ type: "apis", apis: ["maps", "sql"] }])
+        @user1_api_key = Carto::ApiKey.create_regular_key!(user: @carto_org_user_1, name: unique_name('api_key'),
+                                                           grants: [{ type: "apis", apis: ["maps", "sql"] }])
       end
 
       after :each do
         drop_database('test_migration', @organization.owner) if migrate_metadata
+        @owner_api_key.destroy
+        @user1_api_key.destroy
       end
 
       it "exports and reimports an organization #{migrate_metadata ? 'with' : 'without'} metadata" do

--- a/spec/models/carto/user_migration_spec.rb
+++ b/spec/models/carto/user_migration_spec.rb
@@ -629,6 +629,8 @@ describe 'UserMigration' do
         @table1 = create_table(user_id: @carto_org_user_1.id)
         records.each { |row| @table1.insert_row!(row) }
         create_database('test_migration', @organization.owner) if migrate_metadata
+        @regular_api_key = Carto::ApiKey.create_regular_key!(user: @carto_org_user_owner, name: 'Some ApiKey',
+                                                             grants: [{type: "apis", apis: ["maps", "sql"]}])
       end
 
       after :each do


### PR DESCRIPTION
Properly migrate organization api keys:
https://github.com/CartoDB/cartodb-platform/issues/4364#issuecomment-393148039

The problem was that we were assigning permissions to the api key roles before creating the schemas, and it failed at that point. Now, we first create the roles, then import the data, then assign permissions.

Also, we create the roles for the whole organization, not only for the owner.