### PR TITLE
Broken "create map" with Data Library 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl)
 
 ### Bug fixes / enhancements
+* Fix `Create map` from data library https://github.com/CartoDB/cartodb/issues/14020#event-1655755501
 * Fix wrong requests because of bad png tile urls generation (https://github.com/CartoDB/cartodb/pull/14000)
 * Fix migration of users with invalid search_tweets.data_import_id (#13904)
 * Import / export synchronization oauths and connector configurations (#14003)

--- a/lib/assets/javascripts/builder/data/background-importer/imports-model.js
+++ b/lib/assets/javascripts/builder/data/background-importer/imports-model.js
@@ -43,7 +43,6 @@ module.exports = Backbone.Model.extend({
     this._importModel = new ImportModel(opts.import, {
       configModel: this._configModel
     });
-
     this._initBinds();
     this._checkStatus();
   },

--- a/lib/assets/javascripts/builder/data/background-importer/imports-model.js
+++ b/lib/assets/javascripts/builder/data/background-importer/imports-model.js
@@ -43,6 +43,7 @@ module.exports = Backbone.Model.extend({
     this._importModel = new ImportModel(opts.import, {
       configModel: this._configModel
     });
+
     this._initBinds();
     this._checkStatus();
   },
@@ -106,6 +107,10 @@ module.exports = Backbone.Model.extend({
       this.set('step', 'import');
       this._importModel.createImport(this._uploadModel.toJSON());
     }
+  },
+
+  getImportModel: function () {
+    return this._importModel;
   },
 
   pause: function () {
@@ -172,6 +177,10 @@ module.exports = Backbone.Model.extend({
 
   isCartoImport: function () {
     return this._getDisplayName() && this._getDisplayName().match(/\.carto$/i);
+  },
+
+  _getDisplayName: function () {
+    return this._importModel.get('display_name');
   },
 
   _getMapVis: function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.13-1",
+  "version": "4.12.13",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.13",
+  "version": "4.12.13-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds two missing functions. We "lost" them in the dashboard migration since we use the Builder one and it didn't have them.

Fixes https://github.com/CartoDB/cartodb/issues/14020