### PR TITLE
Remove migration FF check for public pages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@ You can then run `bundle exec rake carto:db:sync_basemaps_from_app_config` to sy
 This upgrade changes AWS gem version. Now you must specify `region` within your AWS configurations. Check `app_config.yml.sample`.
 
 ### Features
+* Show migrated public pages (/me, /maps, /datasets) for all builder users (#14039)
 * Allow users to edit all their information in Profile (#13793)
 * Ask for password confirmation when updating organization or user settings (#13795)
 * Public dataset migration (#13803)

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -305,7 +305,7 @@ class Admin::PagesController < Admin::AdminController
     ff_user = @viewed_user || @viewed_org.try(:owner)
 
     unless ff_user.nil?
-      @has_new_dashboard = ff_user.builder_enabled? && ff_user.has_feature_flag?('dashboard_migration')
+      @has_new_dashboard = ff_user.builder_enabled?
     end
   end
 

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -118,7 +118,7 @@ class Admin::VisualizationsController < Admin::AdminController
 
     get_viewed_user
     ff_user = @viewed_user || @org.try(:owner)
-    @has_new_dashboard = ff_user.has_feature_flag?('dashboard_migration')
+    @has_new_dashboard = ff_user.builder_enabled?
 
     if @visualization.derived?
       if current_user.nil? || current_user.username != request.params[:user_domain]


### PR DESCRIPTION
With the migration done™️, we should incrementally remove the FF check from certain places, and just leave the regular condition.