### PR TITLE
Send internal metrics in Dashboard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl)
 
 ### Bug fixes / enhancements
+* Send `Visited Private Page` event from Dashboard (#14041)
 * Fix `Create map` from data library https://github.com/CartoDB/cartodb/issues/14020#event-1655755501
 * Fix wrong requests because of bad png tile urls generation (https://github.com/CartoDB/cartodb/pull/14000)
 * Fix migration of users with invalid search_tweets.data_import_id (#13904)

--- a/lib/assets/javascripts/builder/components/metrics/metrics-model.js
+++ b/lib/assets/javascripts/builder/components/metrics/metrics-model.js
@@ -13,7 +13,6 @@ module.exports = Backbone.Model.extend({
   },
 
   initialize: function (attrs, opts) {
-    if (!opts.visId) { throw new Error('visId is required'); }
     if (!opts.configModel) { throw new Error('configModel is required'); }
 
     this._userId = opts.userId;

--- a/lib/assets/javascripts/builder/components/metrics/metrics-tracker.js
+++ b/lib/assets/javascripts/builder/components/metrics/metrics-tracker.js
@@ -8,9 +8,7 @@ var MetricsModel = require('./metrics-model');
 module.exports = (function () {
   return {
     init: function (opts) {
-      if (!opts) { throw new Error('visId, userId and configModel are required'); }
-      if (!opts.visId) { throw new Error('visId is required'); }
-      if (!opts.configModel) { throw new Error('configModel is required'); }
+      if (!opts || !opts.configModel) { throw new Error('configModel is required'); }
 
       this._userId = opts.userId;
       this._visId = opts.visId;

--- a/lib/assets/javascripts/dashboard/dashboard.js
+++ b/lib/assets/javascripts/dashboard/dashboard.js
@@ -72,8 +72,6 @@ function dataLoaded (data) {
 
   document.title = currentUser.get('username') + ' | CARTO';
 
-  // cdb.config.set('user', currentUser);
-
   const router = new Router({
     dashboardUrl: currentUser.viewUrl().dashboard()
   });
@@ -129,9 +127,18 @@ function dataLoaded (data) {
 
   router.enableAfterMainView();
 
-  const metrics = new MetricsTracker();
-
   // Event tracking "Visited Dashboard"
+  const InternalMetricsTracker = require('builder/components/metrics/metrics-tracker');
+  InternalMetricsTracker.init({
+    userId: currentUser.get('id'),
+    configModel
+  });
+
+  InternalMetricsTracker.track('visited_private_page', {
+    page: 'dashboard'
+  });
+
+  const metrics = new MetricsTracker();
   metrics.trackEvent('visited_dashboard', {
     email: userData.email
   });

--- a/lib/assets/test/spec/builder/components/metrics/metrics-tracker.spec.js
+++ b/lib/assets/test/spec/builder/components/metrics/metrics-tracker.spec.js
@@ -6,14 +6,6 @@ describe('components/metrics/metrics-tracker', function () {
   describe('.init', function () {
     it('should require userId and visId from the initialization', function () {
       expect(function () {
-        MetricsTracker.init();
-      }).toThrowError('visId, userId and configModel are required');
-
-      expect(function () {
-        MetricsTracker.init({ userId: 'vis' });
-      }).toThrowError('visId is required');
-
-      expect(function () {
         MetricsTracker.init({ userId: 'user', visId: 'vis' });
       }).toThrowError('configModel is required');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.14",
+  "version": "4.12.14-events",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR send `visited_private_page` event to API, missing since the new dashboard deploy.

We were sending the event to HubSpot but we weren't sending it to our API, as Rails was doing it previously.

Related to https://github.com/CartoDB/cartodb/issues/14041