### PR TITLE
Fix Broken CTA in the 'Connect Dataset' modal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl)
 
 ### Bug fixes / enhancements
+* Fix Broken CTA in the 'Connect Dataset' modal (https://github.com/CartoDB/cartodb/issues/14036)
 * Fix `Create map` from data library https://github.com/CartoDB/cartodb/issues/14020#event-1655755501
 * Fix wrong requests because of bad png tile urls generation (https://github.com/CartoDB/cartodb/pull/14000)
 * Fix migration of users with invalid search_tweets.data_import_id (#13904)

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/datasets/no-datasets.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/datasets/no-datasets.tpl
@@ -4,7 +4,7 @@
 <p class="CDB-Text CDB-Size-medium u-altTextColor">
   <% var connectDatasetHTML = '<button class="Button--link js-connect">' + _t('components.modals.add-layer.datasets.no-datasets.connect-datasets') + '</button>'; %>
   <% var searchHTML = '<strong>' + _t('components.modals.add-layer.datasets.no-datasets.search') + '</strong>'; %>
-  <%- _t('components.modals.add-layer.datasets.no-datasets.desc', {
+  <%= _t('components.modals.add-layer.datasets.no-datasets.desc', {
       connectDataset: connectDatasetHTML,
       search: searchHTML
     }) %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.14",
+  "version": "4.12.14-fixcta",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.14-fixcta",
+  "version": "4.12.14",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes the CTA in Connect Dataset modal.

Related to https://github.com/CartoDB/cartodb/issues/14036.