### PR TITLE
Split size & color - Remove 'Category' in color by value from some aggregation modes 

### DIFF
--- a/lib/assets/javascripts/builder/components/form-components/editors/fill-color/fill-color-by-value-view.js
+++ b/lib/assets/javascripts/builder/components/form-components/editors/fill-color/fill-color-by-value-view.js
@@ -45,6 +45,7 @@ module.exports = InputFillView.extend({
       model: this._valueColorInputModel,
       columns: this.options.columns,
       hideNumericColumns: this.options.hideNumericColumns,
+      removeByValueCategory: this.options.removeByValueCategory,
       query: this.options.query,
       configModel: this.options.configModel,
       userModel: this.options.userModel,

--- a/lib/assets/javascripts/builder/components/form-components/editors/fill-color/fill-color.js
+++ b/lib/assets/javascripts/builder/components/form-components/editors/fill-color/fill-color.js
@@ -164,6 +164,7 @@ Backbone.Form.editors.FillColor = Backbone.Form.editors.Base.extend({
       dialogMode: DialogConstants.Mode.FLOAT,
       categorizeColumns: this.options.categorizeColumns,
       hideNumericColumns: this.options.hideNumericColumns,
+      removeByValueCategory: this.options.removeByValueCategory,
       modals: this.options.modals,
       hideTabs: this.options.hideTabs,
       valueColorInputModel: this._valueColorInputModel,

--- a/lib/assets/javascripts/builder/components/form-components/editors/fill-color/inputs/input-color-by-value.js
+++ b/lib/assets/javascripts/builder/components/form-components/editors/fill-color/inputs/input-color-by-value.js
@@ -34,6 +34,7 @@ module.exports = CoreView.extend({
       this._help = this._editorAttrs.help;
       this._imageEnabled = this.options.imageEnabled;
       this._hideNumericColumns = this.options.hideNumericColumns;
+      this._removeByValueCategory = this.options.removeByValueCategory;
 
       if (this._editorAttrs.hidePanes && !_.contains(this._editorAttrs.hidePanes, FillConstants.Panes.BY_VALUE)) {
         if (!options.configModel) throw new Error('configModel param is required');
@@ -146,6 +147,7 @@ module.exports = CoreView.extend({
       model: this.model,
       columns: this._columns,
       hideNumericColumns: this._hideNumericColumns,
+      removeByValueCategory: this._removeByValueCategory,
       configModel: this._configModel,
       categorizeColumns: this._categorizeColumns,
       imageEnabled: this._imageEnabled,

--- a/lib/assets/javascripts/builder/components/input-color/input-color-value-content-view.js
+++ b/lib/assets/javascripts/builder/components/input-color/input-color-value-content-view.js
@@ -33,7 +33,10 @@ module.exports = CoreView.extend({
   initialize: function (options) {
     checkAndBuildOpts(options, REQUIRED_OPTS, this);
 
-    this._settings = FillConstants.Settings.COLOR;
+    this._settings = _.clone(FillConstants.Settings.COLOR);
+    if (this.options.removeByValueCategory) {
+      this._removeCategoryFrom(this._settings.quantifications.items);
+    }
 
     this._categorizeColumns = options.categorizeColumns;
     this._imageEnabled = options.imageEnabled;
@@ -141,10 +144,23 @@ module.exports = CoreView.extend({
     return view;
   },
 
+  _removeCategoryFrom: function (items) {
+    var categoryIndex = items.indexOf('category');
+    if (categoryIndex !== -1) {
+      items.splice(categoryIndex, 1);
+    }
+  },
+
   _createInputQuantitativeRamps: function (stackLayoutModel, options) {
+    var settings = _.clone(FillConstants.Settings.COLOR_RAMPS);
+    if (this.options.removeByValueCategory) {
+      this._removeCategoryFrom(settings.quantifications.items);
+    }
+
     var view = new InputQuantitativeRamps({
       hideTabs: this.options.hideTabs,
-      model: this.model
+      model: this.model,
+      settings: settings
     });
 
     view.bind('switch', function () {

--- a/lib/assets/javascripts/builder/components/input-color/input-quantitative-ramps/main-view.js
+++ b/lib/assets/javascripts/builder/components/input-color/input-quantitative-ramps/main-view.js
@@ -12,7 +12,7 @@ module.exports = CoreView.extend({
   module: 'components:form-components:editors:fill:input-color:input-quantitative-ramps:main-view',
 
   initialize: function (opts) {
-    this._settings = FillConstants.Settings.COLOR_RAMPS;
+    this._settings = opts.settings || FillConstants.Settings.COLOR_RAMPS;
 
     this._setupModel();
     this._initBinds();

--- a/lib/assets/javascripts/builder/editor/style/style-form/style-form-dictionary/fill-color.js
+++ b/lib/assets/javascripts/builder/editor/style/style-form/style-form-dictionary/fill-color.js
@@ -16,6 +16,7 @@ module.exports = {
       hideTabs: [],
       imageEnabled: false,
       hideNumericColumns: false,
+      removeByValueCategory: false,
       categorizeColumns: false,
       geometryName: params.queryGeometryModel.get('simple_geom')
     };
@@ -27,10 +28,12 @@ module.exports = {
     });
 
     var styleType = this._getStyleType(params);
+
     if (styleType === StyleConstants.Type.REGIONS ||
       styleType === StyleConstants.Type.HEXABINS ||
       styleType === StyleConstants.Type.SQUARES) {
       editorAttrs.geometryName = 'polygon';
+      editorAttrs.removeByValueCategory = true;
     }
 
     this._setColor(editorAttrs, styleType);

--- a/lib/assets/test/spec/builder/editor/style/style-form/style-form-components-dictionary.spec.js
+++ b/lib/assets/test/spec/builder/editor/style/style-form/style-form-components-dictionary.spec.js
@@ -193,6 +193,7 @@ describe('editor/style/style-form/style-form-components-dictionary', function ()
         hideTabs: [],
         imageEnabled: false,
         hideNumericColumns: false,
+        removeByValueCategory: false,
         geometryName: 'point',
         categorizeColumns: false
       });


### PR DESCRIPTION
Related to issue (#10134) 

We remove 'Category' from 'color-by-value' using Aggregations of type: Square, Hexabin and Administrative Region