### PR TITLE
Setup Google Tag Manager in static pages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl)
 
 ### Bug fixes / enhancements
+* Add Google Tag Manager to Static Pages (https://github.com/CartoDB/cartodb/issues/14029)
 * Fix `Create map` from data library https://github.com/CartoDB/cartodb/issues/14020#event-1655755501
 * Fix wrong requests because of bad png tile urls generation (https://github.com/CartoDB/cartodb/pull/14000)
 * Fix migration of users with invalid search_tweets.data_import_id (#13904)

--- a/app/controllers/carto/api/user_presenter.rb
+++ b/app/controllers/carto/api/user_presenter.rb
@@ -115,6 +115,7 @@ module Carto
           email: @user.email,
           name: @user.name,
           last_name: @user.last_name,
+          created_at: @user.created_at,
           username: @user.username,
           account_type: @user.account_type,
           account_type_display_name: plan_name(@user.account_type),

--- a/app/helpers/frontend_config_helper.rb
+++ b/app/helpers/frontend_config_helper.rb
@@ -19,6 +19,7 @@ module FrontendConfigHelper
       trackjs_app_key:            Cartodb.get_config(:trackjs, 'app_keys', 'editor'),
       google_analytics_ua:        Cartodb.get_config(:google_analytics, 'primary'),
       google_analytics_domain:    Cartodb.get_config(:google_analytics, 'domain'),
+      google_tag_manager_id:      Cartodb.get_config(:google_tag_manager, 'primary'),
       hubspot_enabled:            CartoDB::Hubspot::instance.enabled?,
       intercom_app_id:            Cartodb.get_config(:intercom, 'app_id'),
       fullstory_enabled:          fullstory_enabled?(user),

--- a/app/models/user/user_decorator.rb
+++ b/app/models/user/user_decorator.rb
@@ -17,6 +17,7 @@ module CartoDB
         email: email,
         name: name,
         last_name: last_name,
+        created_at: created_at,
         username: username,
         account_type: account_type,
         account_type_display_name: plan_name(account_type),

--- a/app/views/shared/_google_tag_manager.html.erb
+++ b/app/views/shared/_google_tag_manager.html.erb
@@ -1,4 +1,6 @@
 <!-- Google Tag Manager -->
+<%=# Tags for GTM are being included in VendorScripts templates for static pages as well.
+   # So if you change anything here, please make sure that you change it there too. %>
 
 <% if current_user %>
   <script>

--- a/app/views/shared/_google_tag_manager.html.erb
+++ b/app/views/shared/_google_tag_manager.html.erb
@@ -1,5 +1,5 @@
 <!-- Google Tag Manager -->
-<%=# Tags for GTM are being included in VendorScripts templates for static pages as well.
+<%# Tags for GTM are being included in VendorScripts templates for static pages as well.
    # So if you change anything here, please make sure that you change it there too. %>
 
 <% if current_user %>

--- a/lib/assets/javascripts/dashboard/components/vendor-scripts/vendor-scripts-view.js
+++ b/lib/assets/javascripts/dashboard/components/vendor-scripts/vendor-scripts-view.js
@@ -20,6 +20,7 @@ module.exports = CoreView.extend({
         googleAnalyticsDomain: this._configModel.get('google_analytics_domain'),
         googleAnalyticsMemberType: this._userModel.get('account_type').toUpperCase(),
         googleAnalyticsUa: this._configModel.get('google_analytics_ua'),
+        googleTagManagerId: this._configModel.get('google_tag_manager_id'),
         hubspotEnabled: !!this._configModel.get('hubspot_enabled'),
         hubspotIds: this._configModel.get('hubspot_ids'),
         hubspotToken: this._configModel.get('hubspot_token'),
@@ -31,7 +32,10 @@ module.exports = CoreView.extend({
         fullstoryEnabled: !!this._configModel.get('fullstory_enabled'),
         fullstoryOrg: this._configModel.get('fullstoryOrg'),
         userEmail: this._userModel.get('email'),
-        userName: this._userModel.get('username')
+        userName: this._userModel.get('username'),
+        userId: this._userModel.get('id'),
+        userAccountType: this._userModel.get('account_type'),
+        userCreatedAtInSeconds: Date.parse(this._userModel.get('created_at')) / 1000
       })
     );
 

--- a/lib/assets/javascripts/dashboard/components/vendor-scripts/vendor-scripts.tpl
+++ b/lib/assets/javascripts/dashboard/components/vendor-scripts/vendor-scripts.tpl
@@ -1,5 +1,8 @@
 <% if (googleTagManagerId) { %>
   <!-- Google Tag Manager -->
+  <% // Tags for GTM are being included in _google_tag_manager.html.erb for Rails templates.
+    // So if you change anything here, please make sure that you change it there too. %>
+
   <script>
     dataLayer = [{
       'userId': '<%= userId %>',

--- a/lib/assets/javascripts/dashboard/components/vendor-scripts/vendor-scripts.tpl
+++ b/lib/assets/javascripts/dashboard/components/vendor-scripts/vendor-scripts.tpl
@@ -1,3 +1,21 @@
+<% if (googleTagManagerId) { %>
+  <!-- Google Tag Manager -->
+  <script>
+    dataLayer = [{
+      'userId': '<%= userId %>',
+      'userJobRole': '<%= userAccountType %>',
+      'userSignUpDate': '<%= userCreatedAtInSeconds %>'
+    }];
+  </script>
+
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','<%= googleTagManagerId %>');</script>
+  <!-- End Google Tag Manager -->
+<% } %>
+
 <% if (trackjsEnabled) { %>
   <script type='text/javascript'>
     window._trackJs = {
@@ -14,9 +32,9 @@
     src='//d2zah9y47r7bi2.cloudfront.net/releases/current/tracker.js'
     data-token='<%= trackjsCustomer %>'>
   </script>
-  <% } %>
+<% } %>
 
-  <% if (googleAnalyticsUa) { %>
+<% if (googleAnalyticsUa) { %>
   <script>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
     ga('create', '<%= googleAnalyticsUa %>', {
@@ -26,9 +44,9 @@
     ga('send', 'pageview');
   </script>
   <script async="" src='https://www.google-analytics.com/analytics.js'></script>
-  <% } %>
+<% } %>
 
-  <% if (hubspotEnabled) { %>
+<% if (hubspotEnabled) { %>
   <script type='text/javascript'>
     window.hubspot_ids = <%= hubspotIds %>;
 
@@ -40,41 +58,41 @@
       e.parentNode.insertBefore(n, e);
     })(document,'script','hs-analytics',300000);
   </script>
-  <% } %>
+<% } %>
 
-  <% if (intercomEnabled) { %>
-    <script type='text/javascript'>
-      window.intercomSettings = {
-        app_id: '<%= intercomAppId %>',
-        email: '<%= userEmail %>'
-      };
-    </script>
-    <script type='text/javascript'>
-      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/<%= intercomAppId %>';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
-    </script>
-  <% } %>
+<% if (intercomEnabled) { %>
+  <script type='text/javascript'>
+    window.intercomSettings = {
+      app_id: '<%= intercomAppId %>',
+      email: '<%= userEmail %>'
+    };
+  </script>
+  <script type='text/javascript'>
+    (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/<%= intercomAppId %>';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+  </script>
+<% } %>
 
-  <% if (fullstoryEnabled) { %>
-    <script type='text/javascript'>
-      window['_fs_debug'] = false;
-      window['_fs_host'] = 'www.fullstory.com';
-      window['_fs_org'] = '<%= fullstoryOrg %>';
-      window['_fs_namespace'] = 'FS';
-      (function(m,n,e,t,l,o,g,y){
-          if (e in m && m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'); return;}
-          g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
-          o=n.createElement(t);o.async=1;o.src='https://'+_fs_host+'/s/fs.js';
-          y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
-          g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
-          g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
-          g.clearUserCookie=function(c,d,i){if(!c || document.cookie.match('fs_uid=[`;`]*`[`;`]*`[`;`]*`')){
-          d=n.domain;while(1){n.cookie='fs_uid=;domain='+d+
-          ';path=/;expires='+new Date(0).toUTCString();i=d.indexOf('.');if(i<0)break;d=d.slice(i+1)}}};
-      })(window,document,window['_fs_namespace'],'script','user');
-      FS.clearUserCookie();
-      FS.identify('<%= userName %>', {
-        displayName: '<%= userName %>',
-        email: '<%= userEmail %>'
-      });
-    </script>
+<% if (fullstoryEnabled) { %>
+  <script type='text/javascript'>
+    window['_fs_debug'] = false;
+    window['_fs_host'] = 'www.fullstory.com';
+    window['_fs_org'] = '<%= fullstoryOrg %>';
+    window['_fs_namespace'] = 'FS';
+    (function(m,n,e,t,l,o,g,y){
+        if (e in m && m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].'); return;}
+        g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
+        o=n.createElement(t);o.async=1;o.src='https://'+_fs_host+'/s/fs.js';
+        y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+        g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
+        g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+        g.clearUserCookie=function(c,d,i){if(!c || document.cookie.match('fs_uid=[`;`]*`[`;`]*`[`;`]*`')){
+        d=n.domain;while(1){n.cookie='fs_uid=;domain='+d+
+        ';path=/;expires='+new Date(0).toUTCString();i=d.indexOf('.');if(i<0)break;d=d.slice(i+1)}}};
+    })(window,document,window['_fs_namespace'],'script','user');
+    FS.clearUserCookie();
+    FS.identify('<%= userName %>', {
+      displayName: '<%= userName %>',
+      email: '<%= userEmail %>'
+    });
+  </script>
   <% } %>

--- a/lib/assets/test/spec/dashboard/components/vendor-scripts/vendor-scripts.spec.js
+++ b/lib/assets/test/spec/dashboard/components/vendor-scripts/vendor-scripts.spec.js
@@ -15,11 +15,14 @@ const configModelData = {
   fullstoryEnabled: false,
   fullstoryOrg: '',
   hubspot_ids: '{}',
-  intercom_app_id: 'intercom_app_id'
+  intercom_app_id: 'intercom_app_id',
+  google_tag_manager_id: 'google_tag_manager_id'
 };
 
 const userModelData = {
+  id: 'user-id',
   username: 'pepe',
+  created_at: '2018-06-08T00:00:00.000Z',
   base_url: 'http://pepe.carto.com',
   email: 'pepe@carto.com',
   account_type: 'FREE',
@@ -68,8 +71,12 @@ describe('dashboard/components/vendor-scripts/vendor-scripts-view', function () 
       trackjsEnabled: true,
       fullstoryEnabled: false,
       fullstoryOrg: '',
+      userId: 'user-id',
+      userAccountType: 'FREE',
+      userCreatedAtInSeconds: 1528416000,
       userEmail: 'pepe@carto.com',
-      userName: 'pepe'
+      userName: 'pepe',
+      googleTagManagerId: 'google_tag_manager_id'
     }));
   });
 
@@ -91,8 +98,12 @@ describe('dashboard/components/vendor-scripts/vendor-scripts-view', function () 
       trackjsEnabled: true,
       fullstoryEnabled: false,
       fullstoryOrg: '',
+      userId: 'user-id',
+      userAccountType: 'FREE',
+      userCreatedAtInSeconds: 1528416000,
       userEmail: 'pepe@carto.com',
-      userName: 'pepe'
+      userName: 'pepe',
+      googleTagManagerId: 'google_tag_manager_id'
     }));
   });
 
@@ -131,9 +142,37 @@ describe('dashboard/components/vendor-scripts/vendor-scripts-view', function () 
       trackjsEnabled: false,
       fullstoryEnabled: false,
       fullstoryOrg: '',
+      userId: 'user-id',
+      userAccountType: 'FREE',
+      userCreatedAtInSeconds: 1528416000,
       userEmail: 'pepe@carto.com',
-      userName: 'pepe'
+      userName: 'pepe',
+      googleTagManagerId: 'google_tag_manager_id'
     }));
+  });
+
+  it('should not render Google Tag Manager script if its id is not present', function () {
+    const configNoVendor = _.extend(configModelData, {
+      hubspot_enabled: false,
+      trackjs_enabled: false,
+      google_analytics_ua: null,
+      google_tag_manager_id: null
+    });
+
+    const userModelNoVendor = _.extend(userModelData, {
+      intercom: false
+    });
+
+    userModel = new UserModel(userModelNoVendor);
+
+    view = createViewFn({
+      configModel: new ConfigModel(configNoVendor),
+      assetsVersion: '1.0.0',
+      userModel
+    });
+    view.render();
+
+    expect(view.$el.html).not.toContain('https://www.googletagmanager.com/gtm.js');
   });
 
   it('should have no leaks', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.14",
+  "version": "4.12.14-gtmstaticpages",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@alonsogarciapablo setup Google Tag Manager in the previous non-static dashboard pages, but as of June 25th with the new static pages deploy it was lost. So this PR brings them back to life.

Related to https://github.com/CartoDB/cartodb/issues/14029