### PR TITLE
Do not export user metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ sudo make install
 * Import / export synchronization oauths and connector configurations (#14003)
 * Redirect organization users in static pages (https://github.com/CartoDB/cartodb/pull/14009)
 * Update extension to 0.22.1 to fix problems granting permissions to tables with sequences (cartodb-postgresql#330)
-* User mover does nto export user metadata if org metadata is nto exported
+* User mover does not export user metadata if org metadata is nto exported
 * Triggering ghost tables and common data when visiting the dashboard (#14010)
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@ sudo make install
 * Import / export synchronization oauths and connector configurations (#14003)
 * Redirect organization users in static pages (https://github.com/CartoDB/cartodb/pull/14009)
 * Update extension to 0.22.1 to fix problems granting permissions to tables with sequences (cartodb-postgresql#330)
-* User mover does not export user metadata if org metadata is nto exported
+* User mover does not export user metadata if org metadata is not exported
 * Triggering ghost tables and common data when visiting the dashboard (#14010)
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ sudo make install
 * Import / export synchronization oauths and connector configurations (#14003)
 * Redirect organization users in static pages (https://github.com/CartoDB/cartodb/pull/14009)
 * Update extension to 0.22.1 to fix problems granting permissions to tables with sequences (cartodb-postgresql#330)
+* User mover does nto export user metadata if org metadata is nto exported
 * Triggering ghost tables and common data when visiting the dashboard (#14010)
 
 

--- a/services/user-mover/export_user.rb
+++ b/services/user-mover/export_user.rb
@@ -502,7 +502,6 @@ module CartoDB
                        status:       nil,
                        trace:        nil
                      }
-
         begin
           if @options[:id]
             @user_data = get_user_metadata(options[:id])
@@ -571,6 +570,7 @@ module CartoDB
             @org_users.each do |org_user|
               CartoDB::DataMover::ExportJob.new(id: org_user['username'],
                                                 data: @options[:data] && @options[:split_user_schemas],
+                                                metadata: @options[:metadata],
                                                 path: @options[:path],
                                                 job_uuid: job_uuid,
                                                 from_org: true,


### PR DESCRIPTION
The code was exporting user metadata per-user with the old usermover strategy, which is unnecessary and VERY slow.