### PR TITLE
List organization admin users in organization settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl)
 
 ### Bug fixes / enhancements
+* List organization admin users in your Organisation settings (https://github.com/CartoDB/support/issues/1583#event-1673573190)
 * Send `Visited Private Page` event from Dashboard (#14041)
 * Fix Mapviews don't appear on bar chart rollover (https://github.com/CartoDB/support/issues/1573)
 * Fix Broken CTA in the 'Connect Dataset' modal (https://github.com/CartoDB/cartodb/issues/14036)

--- a/lib/assets/javascripts/dashboard/views/organization/organization-users/organization-users-view.js
+++ b/lib/assets/javascripts/dashboard/views/organization/organization-users/organization-users-view.js
@@ -56,6 +56,9 @@ module.exports = CoreView.extend({
       per_page: this.pagedSearchModel.get('per_page')
     });
 
+    // Include current user in fetch results
+    this._organizationUsers.excludeCurrentUser(false);
+
     this._initBinds();
 
     this.pagedSearchModel.fetch(this._organizationUsers);
@@ -265,6 +268,7 @@ module.exports = CoreView.extend({
   },
 
   clean: function () {
+    this._organizationUsers.restoreExcludeCurrentUser();
     $(document).off('click', '.js-inviteUser', this._onInviteClick.bind(this));
     CoreView.prototype.clean.apply(this);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.17",
+  "version": "4.12.17-support1583",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR solves https://github.com/CartoDB/support/issues/1583. We were excluding the current logged-in user from the organization users, and we shouldn't have done this.

As per the old code, `currentUserId` is optional and not passed to the Organization model in the Organization page: https://github.com/CartoDB/cartodb/blob/master/lib/assets/javascripts/cartodb/organization/entry.js#L60