### PR TITLE
Fix error when styling points by value in animated aggregation style

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl)
 
 ### Bug fixes / enhancements
+* Fix error when styling points by value in animated aggregation style (https://github.com/CartoDB/cartodb/issues/14085)
 * Show errors coming from QueryRowsCollection in Dataset/Builder (https://github.com/CartoDB/cartodb/issues/14066)
 * Export JPG image as JPEG format instead of PNG (https://github.com/CartoDB/cartodb/issues/14042)
 * Redirect to login or fix URL if trying to access another user private pages (https://github.com/CartoDB/cartodb/pull/14013)

--- a/lib/assets/javascripts/builder/editor/style/style-converter.js
+++ b/lib/assets/javascripts/builder/editor/style/style-converter.js
@@ -565,7 +565,7 @@ function animation (style, mapContext) {
   }
 
   function _normalizeValue (v) {
-    return v.replace(/\n/g, '\\n').replace(/\"/g, '\\"').replace();
+    return v.replace(/\n/g, '\\n').replace(/\"/g, '\\"').replace(/'/g, "''").replace();
   }
 
   for (var i = 0, l = categoryCount; i < l; i++) {

--- a/lib/assets/javascripts/builder/editor/style/style-converter.js
+++ b/lib/assets/javascripts/builder/editor/style/style-converter.js
@@ -565,7 +565,7 @@ function animation (style, mapContext) {
   }
 
   function _normalizeValue (v) {
-    return v.replace(/\n/g, '\\n').replace(/\"/g, '\\"').replace(/'/g, "''").replace();
+    return v.replace(/\n/g, '\\n').replace(/\"/g, '\\"').replace(/'/g, "''");
   }
 
   for (var i = 0, l = categoryCount; i < l; i++) {

--- a/lib/assets/test/spec/builder/editor/style/style-converter-fixtures.spec.js
+++ b/lib/assets/test/spec/builder/editor/style/style-converter-fixtures.spec.js
@@ -1005,6 +1005,40 @@ module.exports = [
     }
   },
 
+  {
+    // Animated with strings containing single quotes in domain
+    style: {
+      type: 'animation',
+      properties: {
+        style: 'simple',
+        fill: {
+          color: {
+            attribute: 'columnA',
+            attribute_type: 'string',
+            range: ['#555', '#5B3F95'],
+            domain: ["Perfect room in Madrid's Center", 'Beautiful and bright room in Callao'],
+            opacity: 1
+          }
+        },
+        animated: {
+          attribute: 'test',
+          overlap: false,
+          duration: 30,
+          steps: 256,
+          resolution: 4,
+          trails: 2
+        }
+      }
+    },
+    result: {
+      point: {
+        cartocss: 'Map {\n-torque-frame-count: 256;\n-torque-animation-duration: 30;\n-torque-time-attribute: "test";\n-torque-aggregation-function: "CDB_Math_Mode(value)";\n-torque-resolution: 4;\n-torque-data-aggregation: linear;\n}\n#layer {\nmarker-fill: ramp([value], (#555, #5B3F95), (1, 2), "=");\nmarker-fill-opacity: 1;\n}',
+        sql: 'select *, (CASE WHEN "columnA" = \'Perfect room in Madrid\'\'s Center\' THEN 1 WHEN "columnA" = \'Beautiful and bright room in Callao\' THEN 2  END) as value FROM (<%= sql %>) __wrapped',
+        type: 'torque'
+      }
+    }
+  },
+
   // Heatmap animated
   {
     style: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.27",
+  "version": "4.12.27-13976",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes an error raised when there was a single quote inside a column value when styling points by value in animated aggregation style.

The query sent before was:
```sql
select *, (CASE WHEN \"name\" = '' THEN 1 WHEN \"name\" = 'Perfect room in Madrid's Center' THEN 2 WHEN \"name\" = 'Beautiful and bright room in Callao' THEN 3 WHEN \"name\" = 'Cozy room in city center' THEN 4 WHEN \"name\" = 'Apartamento en el centro de Madrid' THEN 5 WHEN \"name\" = 'Beautiful room in Madrid's center' THEN 6 WHEN \"name\" = 'Cozy room' THEN 7 WHEN \"name\" = 'Habitación en el centro de Madrid' THEN 8 WHEN \"name\" = 'Habitación privada' THEN 9 WHEN \"name\" = 'Madrid Center: Puerta del Sol, Tirso de Molina' THEN 10  ELSE 11  END) as value FROM (<%= sql %>) __wrapped
```

And now the query is:
```sql
select *, (CASE WHEN \"name\" = '' THEN 1 WHEN \"name\" = 'Perfect room in Madrid''s Center' THEN 2 WHEN \"name\" = 'Beautiful and bright room in Callao' THEN 3 WHEN \"name\" = 'Cozy room in city center' THEN 4 WHEN \"name\" = 'Apartamento en el centro de Madrid' THEN 5 WHEN \"name\" = 'Beautiful room in Madrid''s center' THEN 6 WHEN \"name\" = 'Cozy room' THEN 7 WHEN \"name\" = 'Habitación en el centro de Madrid' THEN 8 WHEN \"name\" = 'Habitación privada' THEN 9 WHEN \"name\" = 'Madrid Center: Puerta del Sol, Tirso de Molina' THEN 10  ELSE 11  END) as value FROM (<%= sql %>) __wrapped
```

The modification consists of using double single quotes to escape quotes in the query, as @enekid pointed in https://github.com/CartoDB/cartodb/issues/13976#issuecomment-398103662.

### Acceptance
See https://github.com/CartoDB/cartodb/issues/13976

Related to https://github.com/CartoDB/cartodb/issues/13976.