### PR TITLE
Update Carto.JS version to v4.0.9-0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ sudo make install
 
 ### Features
 * Password expiration ([Central#2226](https://github.com/CartoDB/cartodb-central#2226))
-* New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl)
+* New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 
 ### Bug fixes / enhancements
 * Fix wrong margins in the layer selector when the top layer has a bubble legend (https://github.com/CartoDB/support/issues/1566)

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl)
 
 ### Bug fixes / enhancements
+* Fix wrong margins in the layer selector when the top layer has a bubble legend (https://github.com/CartoDB/support/issues/1566)
 * Show errors coming from QueryRowsCollection in Dataset/Builder (https://github.com/CartoDB/cartodb/issues/14066)
 * Export JPG image as JPEG format instead of PNG (https://github.com/CartoDB/cartodb/issues/14042)
 * Redirect to login or fix URL if trying to access another user private pages (https://github.com/CartoDB/cartodb/pull/14013)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "4.12.26",
   "dependencies": {
     "@carto/carto.js": {
-      "version": "4.0.6",
+      "version": "4.0.8",
       "from": "@carto/carto.js@>=4.0.6 <5.0.0",
-      "resolved": "https://registry.npmjs.org/@carto/carto.js/-/carto.js-4.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/@carto/carto.js/-/carto.js-4.0.8.tgz"
     },
     "@carto/zera": {
       "version": "1.0.6",
@@ -18,26 +18,19 @@
       "resolved": "https://registry.npmjs.org/accessory/-/accessory-1.0.1.tgz"
     },
     "acorn": {
-      "version": "5.5.3",
+      "version": "5.7.1",
       "from": "acorn@>=5.2.1 <6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz"
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz"
     },
     "acorn-dynamic-import": {
-      "version": "2.0.2",
-      "from": "acorn-dynamic-import@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "from": "acorn@>=4.0.3 <5.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
-        }
-      }
+      "version": "3.0.0",
+      "from": "acorn-dynamic-import@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz"
     },
     "acorn-node": {
-      "version": "1.3.0",
-      "from": "acorn-node@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz"
+      "version": "1.5.2",
+      "from": "acorn-node@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.5.2.tgz"
     },
     "ajv": {
       "version": "4.11.8",
@@ -119,24 +112,24 @@
     "assert": {
       "version": "1.3.0",
       "from": "assert@>=1.3.0 <1.4.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "util@0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+        }
+      }
     },
     "assign-symbols": {
       "version": "1.0.0",
       "from": "assign-symbols@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz"
-    },
-    "astw": {
-      "version": "2.2.0",
-      "from": "astw@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "from": "acorn@>=4.0.3 <5.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
-        }
-      }
     },
     "async": {
       "version": "2.6.1",
@@ -300,9 +293,9 @@
       }
     },
     "browser-resolve": {
-      "version": "1.11.2",
+      "version": "1.11.3",
       "from": "browser-resolve@>=1.11.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
@@ -334,9 +327,9 @@
           }
         },
         "resolve": {
-          "version": "1.7.1",
+          "version": "1.8.1",
           "from": "resolve@>=1.1.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz"
         },
         "through2": {
           "version": "2.0.3",
@@ -393,9 +386,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "buffer-from@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz"
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -470,9 +463,9 @@
       }
     },
     "chokidar": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "from": "chokidar@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz"
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -876,9 +869,9 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz"
     },
     "error-ex": {
-      "version": "1.3.1",
+      "version": "1.3.2",
       "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz"
     },
     "es6-promise": {
       "version": "3.1.2",
@@ -1047,8 +1040,13 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "from": "function-bind@>=1.0.2 <2.0.0",
+      "from": "function-bind@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
+    },
+    "get-assigned-identifiers": {
+      "version": "1.2.0",
+      "from": "get-assigned-identifiers@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz"
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -1093,9 +1091,9 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "has": {
-      "version": "1.0.1",
+      "version": "1.0.3",
       "from": "has@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -1135,9 +1133,9 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz"
     },
     "hash.js": {
-      "version": "1.1.3",
+      "version": "1.1.4",
       "from": "hash.js@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz"
     },
     "he": {
       "version": "1.1.1",
@@ -1187,9 +1185,9 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
     },
     "ieee754": {
-      "version": "1.1.11",
+      "version": "1.1.12",
       "from": "ieee754@>=1.1.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz"
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz"
     },
     "indexof": {
       "version": "0.0.1",
@@ -1212,9 +1210,9 @@
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz"
     },
     "insert-module-globals": {
-      "version": "7.1.0",
+      "version": "7.2.0",
       "from": "insert-module-globals@>=7.0.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.6.2",
@@ -1244,9 +1242,9 @@
       }
     },
     "internal-carto.js": {
-      "version": "4.0.7-3",
-      "from": "cartodb/carto.js#v4.0.7-3",
-      "resolved": "git://github.com/cartodb/carto.js.git#8745f95151e804151889d9120476c3d7d57833b5"
+      "version": "4.0.9-0",
+      "from": "cartodb/carto.js#v4.0.9-0",
+      "resolved": "git://github.com/cartodb/carto.js.git#409aedf4fc20aa110219a301fe98665bb4707f3d"
     },
     "interpret": {
       "version": "1.1.0",
@@ -1439,11 +1437,6 @@
       "from": "leaflet@1.3.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.1.tgz"
     },
-    "lexical-scope": {
-      "version": "1.2.0",
-      "from": "lexical-scope@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz"
-    },
     "load-json-file": {
       "version": "1.1.0",
       "from": "load-json-file@>=1.0.0 <2.0.0",
@@ -1463,6 +1456,11 @@
       "version": "4.17.10",
       "from": "lodash@>=4.17.3 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "from": "lodash.debounce@>=4.0.8 <5.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
     },
     "lodash.memoize": {
       "version": "3.0.4",
@@ -1603,9 +1601,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
         },
         "resolve": {
-          "version": "1.7.1",
+          "version": "1.8.1",
           "from": "resolve@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz"
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz"
         },
         "string_decoder": {
           "version": "1.1.1",
@@ -1625,9 +1623,9 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
     },
     "moment-timezone": {
-      "version": "0.5.17",
+      "version": "0.5.20",
       "from": "moment-timezone@>=0.5.13 <0.6.0",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz"
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.20.tgz"
     },
     "mothership": {
       "version": "0.2.0",
@@ -1967,6 +1965,11 @@
       "from": "querystring-es3@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
     },
+    "querystringify": {
+      "version": "2.0.0",
+      "from": "querystringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz"
+    },
     "queue-async": {
       "version": "1.2.1",
       "from": "queue-async@1.2.1",
@@ -2117,6 +2120,11 @@
       "from": "require-main-filename@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "from": "requires-port@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+    },
     "resolve": {
       "version": "0.6.3",
       "from": "resolve@>=0.6.1 <0.7.0",
@@ -2203,6 +2211,11 @@
       "version": "1.6.1",
       "from": "shell-quote@>=1.4.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz"
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "from": "simple-concat@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz"
     },
     "simple-statistics": {
       "version": "0.9.2",
@@ -2365,9 +2378,9 @@
       }
     },
     "stream-http": {
-      "version": "2.8.2",
+      "version": "2.8.3",
       "from": "stream-http@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2555,9 +2568,9 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uglify-js": {
-      "version": "3.3.27",
+      "version": "3.3.28",
       "from": "uglify-js@>=3.3.0 <3.4.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.27.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
@@ -2570,6 +2583,11 @@
       "version": "3.0.3",
       "from": "umd@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz"
+    },
+    "undeclared-identifiers": {
+      "version": "1.1.2",
+      "from": "undeclared-identifiers@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz"
     },
     "underscore": {
       "version": "1.8.3",
@@ -2624,7 +2642,7 @@
     },
     "upath": {
       "version": "1.1.0",
-      "from": "upath@>=1.0.0 <2.0.0",
+      "from": "upath@>=1.0.5 <2.0.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz"
     },
     "upper-case": {
@@ -2654,6 +2672,11 @@
         }
       }
     },
+    "url-parse": {
+      "version": "1.4.1",
+      "from": "url-parse@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz"
+    },
     "use": {
       "version": "3.1.0",
       "from": "use@>=3.1.0 <4.0.0",
@@ -2667,16 +2690,9 @@
       }
     },
     "util": {
-      "version": "0.10.3",
+      "version": "0.10.4",
       "from": "util@>=0.10.1 <0.11.0",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -2712,6 +2728,11 @@
           "version": "4.0.13",
           "from": "acorn@>=4.0.4 <5.0.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+        },
+        "acorn-dynamic-import": {
+          "version": "2.0.2",
+          "from": "acorn-dynamic-import@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz"
         },
         "uglify-js": {
           "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "d3-queue": "^3.0.7",
     "fastclick": "^1.0.6",
     "html-webpack-plugin": "^2.30.1",
-    "internal-carto.js": "CartoDB/carto.js#v4.0.7-3",
+    "internal-carto.js": "CartoDB/carto.js#v4.0.9-0",
     "jquery": "2.1.4",
     "leaflet": "1.3.1",
     "moment": "2.18.1",


### PR DESCRIPTION
This PR updates Carto.JS version to v4.0.9-0 to deploy changes in https://github.com/CartoDB/carto.js/pull/2143