### PR TITLE
Recalculate db size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@ sudo make install
 * Redirect to login or fix URL if trying to access another user private pages (https://github.com/CartoDB/cartodb/pull/14013)
 * Add Google Tag Manager to Static Pages (https://github.com/CartoDB/cartodb/issues/14029)
 * List organization admin users in your Organisation settings (https://github.com/CartoDB/support/issues/1583)
-* Send `Visited Private Page` event from Dashboard (#14041) and update user model (#14084)
+* Send `Visited Private Page` event from Dashboard (#14041), update user model (#14084) and db size cache (#14102)
 * Fix Mapviews don't appear on bar chart rollover (https://github.com/CartoDB/support/issues/1573)
 * Fix Broken CTA in the 'Connect Dataset' modal (https://github.com/CartoDB/cartodb/issues/14036)
 * Fix `Create map` from data library https://github.com/CartoDB/cartodb/issues/14020#event-1655755501

--- a/app/controllers/carto/api/users_controller.rb
+++ b/app/controllers/carto/api/users_controller.rb
@@ -25,6 +25,7 @@ module Carto
 
       before_filter :initialize_google_plus_config, only: [:me]
       before_filter :optional_api_authorization, only: [:me]
+      before_filter :recalculate_user_db_size, only: [:me]
       skip_before_filter :api_authorization_required, only: [:me, :get_authenticated_users]
       skip_before_filter :check_user_state, only: [:me, :delete_me]
 
@@ -230,6 +231,10 @@ module Carto
 
       def password_change?(user, attributes)
         (attributes[:new_password].present? || attributes[:confirm_password].present?) && user.can_change_password?
+      end
+
+      def recalculate_user_db_size
+        current_user && Carto::UserDbSizeCache.new.update_if_old(current_user)
       end
     end
   end

--- a/lib/carto/user_db_size_cache.rb
+++ b/lib/carto/user_db_size_cache.rb
@@ -14,7 +14,7 @@ module Carto
     end
 
     def update_if_old(user)
-      if user.dashboard_viewed_at.nil? || user.dashboard_viewed_at < (Time.now.utc - UPDATE_PROPAGATION_THRESHOLD)
+      if last_updated(user) > UPDATE_PROPAGATION_THRESHOLD
         set_db_size_in_bytes(user)
       end
     end
@@ -37,6 +37,10 @@ module Carto
     end
 
     private
+
+    def last_updated(user)
+      DB_SIZE_IN_BYTES_EXPIRATION - @redis.ttl(db_size_in_bytes_key(user.username))
+    end
 
     def set_db_size_in_bytes(user)
       @redis.setex(db_size_in_bytes_key(user.username), DB_SIZE_IN_BYTES_EXPIRATION.to_i, user.db_size_in_bytes)

--- a/spec/lib/carto/users_metadata_redis_cache_spec.rb
+++ b/spec/lib/carto/users_metadata_redis_cache_spec.rb
@@ -23,8 +23,7 @@ describe Carto::UserDbSizeCache do
       umrc.expects(:set_db_size_in_bytes).with(user_mock).once
       umrc.update_if_old(user_mock)
 
-      user_mock.db_size_in_bytes = 0
-      umrc.db_size_in_bytes(user_mock).should == user_mock.db_size_in_bytes
+      umrc.db_size_in_bytes(user_mock).should eq 0
     end
 
     it 'does not set db_size_in_bytes for users that have been updated in an hour' do

--- a/spec/lib/carto/users_metadata_redis_cache_spec.rb
+++ b/spec/lib/carto/users_metadata_redis_cache_spec.rb
@@ -6,27 +6,29 @@ describe Carto::UserDbSizeCache do
     OpenStruct.new(id: 'kk', username: 'myusername', db_size_in_bytes: 123)
   end
 
-  let(:updatable_user_mock) do
-    user_mock.stubs(:dashboard_viewed_at).returns(Time.now.utc - 2.days)
-    user_mock
-  end
-
   let(:umrc) do
     Carto::UserDbSizeCache.new
   end
 
+  let(:redis_key) do
+    umrc.send(:db_size_in_bytes_key, user_mock.username)
+  end
+
+  before(:each) do
+    $users_metadata.del(redis_key)
+  end
+
   describe '#update_if_old' do
-    it 'sets db_size_in_bytes for users that have not seen the dashboard in 2 days' do
-      umrc.expects(:set_db_size_in_bytes).with(updatable_user_mock).once
+    it 'sets db_size_in_bytes for users that have not been updated in 2 days' do
+      umrc.expects(:set_db_size_in_bytes).with(user_mock).once
+      umrc.update_if_old(user_mock)
 
-      umrc.update_if_old(updatable_user_mock)
-
-      updatable_user_mock.db_size_in_bytes = 0
-      umrc.db_size_in_bytes(updatable_user_mock).should == updatable_user_mock.db_size_in_bytes
+      user_mock.db_size_in_bytes = 0
+      umrc.db_size_in_bytes(user_mock).should == user_mock.db_size_in_bytes
     end
 
-    it 'does not set db_size_in_bytes for users that have seen the dashboard in 2 hours' do
-      user_mock.stubs(:dashboard_viewed_at).returns(Time.now.utc - 2.hours)
+    it 'does not set db_size_in_bytes for users that have been updated in an hour' do
+      $users_metadata.setex(redis_key, 2.days - 1.hour, 456)
       umrc.expects(:set_db_size_in_bytes).never
 
       umrc.update_if_old(user_mock)
@@ -35,11 +37,11 @@ describe Carto::UserDbSizeCache do
 
   describe '#db_size_in_bytes_change_users' do
     it 'returns db_size_in_bytes_change in a hash with username keys' do
-      umrc.update_if_old(updatable_user_mock)
+      umrc.update_if_old(user_mock)
 
       db_size_in_bytes_change_users = umrc.db_size_in_bytes_change_users
-      db_size_in_bytes_change_users.keys.include?(updatable_user_mock.username).should be_true
-      db_size_in_bytes_change_users[updatable_user_mock.username].should == updatable_user_mock.db_size_in_bytes
+      db_size_in_bytes_change_users.keys.include?(user_mock.username).should be_true
+      db_size_in_bytes_change_users[user_mock.username].should == user_mock.db_size_in_bytes
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb-management/issues/5171

We were not calling this code with the new dashboard statics. This makes us call this again. Also, given than now we cannot guarantee when `dashboard_viewed_at` is updates (it runs in a concurrent request), we cannot trust it for the update, so instead, I check the redis key expiration date.