### PR TITLE
Re-Disable Twitter Connector in Dashboard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 
 ### Bug fixes / enhancements
+* Deprecate Twitter connector in `add dataset` modal (https://github.com/CartoDB/cartodb/issues/14081)
 * Set new message on privacy warning modal when new privacy is LINK (https://github.com/CartoDB/cartodb/issues/14030)
 * Improve size & color UI when styling layers (https://github.com/CartoDB/product/issues/54)
 * Show Organization notifications in static pages (https://github.com/CartoDB/cartodb/issues/14089)

--- a/lib/assets/javascripts/dashboard/views/dashboard/create-dataset-model.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/create-dataset-model.js
@@ -133,8 +133,8 @@ module.exports = Backbone.Model.extend({
 
   // For create-listing-import view
   setActiveImportPane: function (option) {
-    if (option && this.get('listing') === 'import' && this.getImportState() !== option) {
-      this.set('contentPane', 'listing');
+    if (option && this._atImportPane() && this.getImportState() !== option) {
+      this.set('option', 'listing.import.' + option);
     }
   },
 

--- a/lib/assets/javascripts/dashboard/views/dashboard/create-map-model.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/create-map-model.js
@@ -143,8 +143,8 @@ module.exports = Backbone.Model.extend({
 
   // For create-listing-import view
   setActiveImportPane: function (option) {
-    if (option && this.get('listing') === 'import' && this.getImportState() !== option) {
-      this.set('contentPane', 'listing');
+    if (option && this._atImportPane() && this.getImportState() !== option) {
+      this.set('option', 'listing.import.' + option);
     }
   },
 


### PR DESCRIPTION
Due to a Dashboard migration bug, Twitter connector was missing the deprecation message, leaving people without feedback about what was happening.

So this PR fixes the bug to restore the functionality.

### Acceptance
1. Go to Dashboard

#### Add Map modal
2. Click on `NEW MAP` button
3. Click on `CONNECT DATASET` button on the tab selector
4. Click on `TWITTER` tab
5. Check that all the input are disabled and the deprecation message is shown

#### Add Dataset modal
2. Go to the datasets page
3. Click on `NEW DATASET` button
4. Click on `CONNECT DATASET` button on the tab selector
5. Click on `TWITTER` tab
6. Check that all the input are disabled and the deprecation message is shown

The Twitter view in both pages should look like this:
<img src="https://user-images.githubusercontent.com/29546714/41254407-58cc8d46-6d91-11e8-880d-7750054064b4.gif"/>

Related to https://github.com/CartoDB/cartodb/issues/14081