### PR TITLE
Fix dataset header dropdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 
 ### Bug fixes / enhancements
+* Fix Dataset header dropdown (https://github.com/CartoDB/support/issues/1614)
 * Remove unneeded space in collapsed legends view (https://github.com/CartoDB/cartodb/issues/14091)
 * Do not assume that if min and max are equal we come from a fixed value (https://github.com/CartoDB/carto.js/issues/2146)
 * Add mode to raise max-height when widgets are not present (https://github.com/CartoDB/carto.js/issues/2146)

--- a/lib/assets/javascripts/builder/dataset/dataset-header/create-context-menu.js
+++ b/lib/assets/javascripts/builder/dataset/dataset-header/create-context-menu.js
@@ -10,29 +10,30 @@ var REQUIRED_OPTS = [
 ];
 
 module.exports = function (opts) {
+  var data = {};
   _.each(REQUIRED_OPTS, function (item) {
     if (opts[item] === undefined) throw new Error(item + ' is required');
-    this['_' + item] = opts[item];
-  }, this);
+    data['_' + item] = opts[item];
+  });
 
-  var position = { x: this._ev.clientX, y: this._ev.clientY };
+  var position = { x: data._ev.clientX, y: data._ev.clientY };
   var menuItems = [
     {
-      label: _t('dataset.duplicate.' + (this._isCustomQuery ? 'customOption' : 'option')),
+      label: _t('dataset.duplicate.' + (data._isCustomQuery ? 'customOption' : 'option')),
       val: 'duplicate',
       action: function () {
-        this.trigger('duplicate', this);
+        this.trigger('duplicate');
       }
     }
   ];
 
-  if (this._isTableOwner) {
-    if (!this._isSync) {
+  if (data._isTableOwner) {
+    if (!data._isSync) {
       menuItems.push({
         label: _t('dataset.rename.option'),
         val: 'rename',
         action: function () {
-          this.trigger('rename', this);
+          this.trigger('rename');
         }
       });
     }
@@ -42,20 +43,20 @@ module.exports = function (opts) {
         label: _t('dataset.metadata.option'),
         val: 'metadata',
         action: function () {
-          this.trigger('metadata', this);
+          this.trigger('metadata');
         }
       }, {
         label: _t('dataset.lock.option'),
         val: 'lock',
         action: function () {
-          this.trigger('lock', this);
+          this.trigger('lock');
         }
       }, {
         label: _t('dataset.delete.option'),
         val: 'delete',
         destructive: true,
         action: function () {
-          this.trigger('delete', this);
+          this.trigger('delete');
         }
       }
     ]);
@@ -65,7 +66,7 @@ module.exports = function (opts) {
 
   var view = new ContextMenuView({
     collection: collection,
-    triggerElementID: this._triggerElementID,
+    triggerElementID: data._triggerElementID,
     position: position
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.36-1614",
+  "version": "4.12.36",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.36",
+  "version": "4.12.36-1614",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/1614.

Since the new webpack package system is working, it has appeared an issue in `create-context-menu` because `this` is not defined at the beginning of the function.

To fix this issue and use a better approach, a new object (data) is created to store the option variables instead of `undefined this`. Also, I have removed unnecessary parameters `this` in the `trigger` functions.

In the tests `this` is Window so this fix will only be noticed after the webpack package.