### PR TITLE
Fix spinners

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 
 ### Bug fixes / enhancements
+* Fix SVG spinner animations (https://github.com/CartoDB/cartodb/issues/14105)
 * Fix Dataset header dropdown (https://github.com/CartoDB/support/issues/1614)
 * Remove unneeded space in collapsed legends view (https://github.com/CartoDB/cartodb/issues/14091)
 * Do not assume that if min and max are equal we come from a fixed value (https://github.com/CartoDB/carto.js/issues/2146)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.37-14105",
+  "version": "4.12.37",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.37",
+  "version": "4.12.37-14105",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/webpack/v4/webpack.prod.config.js
+++ b/webpack/v4/webpack.prod.config.js
@@ -32,7 +32,8 @@ module.exports = merge(baseConfig, {
       }),
       new OptimizeCSSAssetsPlugin({
         cssProcessorOptions: {
-          zindex: false
+          zindex: false,
+          reduceIdents: false
         }
       })
     ]


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/14105

New webpack configuration includes CSS optimization using `cssnano`.

One of the default options is causing the bug. By disabling [reduceIndents](https://cssnano.co/optimisations/reduceidents/) in the configuration, CSS animations are now fixed.

![peek 2018-06-25 16-47](https://user-images.githubusercontent.com/2227572/41857450-d4dcf87e-7897-11e8-9af2-b31146e40291.gif)
![peek 2018-06-25 16-46](https://user-images.githubusercontent.com/2227572/41857442-d1b7eb0e-7897-11e8-9e7b-466c6082172f.gif)
