### PR TITLE
Fix locks drop table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Do not crash when checking nil password (#14099)
 * Remove Auth API FF, enable it by default (#13857)
 * User mover does not export user metadata if org metadata is not exported
+* Fail fast instead of locking dashboard / user data size calculation on table deletion (#12829)
 * Triggering ghost tables and common data when visiting the dashboard (#14010)
 
 ### Internals

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@ Development
 -----------
 
 ### NOTICE
-This release upgrades the CartoDB PostgreSQL extension to `0.22.2`. Run the following to have it available:
+This release upgrades the CartoDB PostgreSQL extension to `0.23.0`. Run the following to have it available:
 ```shell
 cd $(git rev-parse --show-toplevel)/lib/sql
 sudo make install
@@ -48,6 +48,8 @@ This release introduces a new API Key system. In order to migrate existing users
 * Retain backwards compatibility with exports without client applications(#14083)
 * Redirect organization users in static pages (https://github.com/CartoDB/cartodb/pull/14009)
 * Update extension to 0.22.1 to fix problems granting permissions to tables with sequences (cartodb-postgresql#330)
+* Update extension to 0.22.2 to fix hyphenates usernames (cartodb-postgresql#331)
+* Update extension to 0.23.0 to add a new helper function `_CDB_Table_Exists(table_name_with_optional_schema TEXT)` (cartodb-postgresql#332)
 * Log Resque errors (#14116)
 * Do not crash when checking nil password (#14099)
 * Remove Auth API FF, enable it by default (#13857)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,8 +10,8 @@ class HomeController < ApplicationController
   OS_VERSION = "Description:\tUbuntu 12.04"
   PG_VERSION = 'PostgreSQL 9.5'.freeze
   POSTGIS_VERSION = '2.2'.freeze
-  CDB_VALID_VERSION = '0.22'.freeze
-  CDB_LATEST_VERSION = '0.22.2'.freeze
+  CDB_VALID_VERSION = '0.23'.freeze
+  CDB_LATEST_VERSION = '0.23.0'.freeze
   REDIS_VERSION = '3'.freeze
   RUBY_BIN_VERSION = 'ruby 2.2.3'.freeze
   NODE_VERSION = 'v0.10'.freeze

--- a/app/models/carto/user_service.rb
+++ b/app/models/carto/user_service.rb
@@ -89,7 +89,6 @@ module Carto
           user_database.execute(%{SET LOCAL lock_timeout = '1s'})
           user_database.execute(%{SELECT cartodb.#{user_data_size_function}}).first['cdb_userdatasize'].to_i
         end
-
       rescue => e
         attempts += 1
         begin

--- a/app/models/carto/user_service.rb
+++ b/app/models/carto/user_service.rb
@@ -86,8 +86,10 @@ module Carto
           "CDB_UserDataSize()" :
           "CDB_UserDataSize('#{@user.database_schema}')"
         in_database(as: :superuser) do |user_database|
-          user_database.execute(%{SET LOCAL lock_timeout = '1s'})
-          user_database.execute(%{SELECT cartodb.#{user_data_size_function}}).first['cdb_userdatasize'].to_i
+          user_database.transaction do
+            user_database.execute(%{SET LOCAL lock_timeout = '1s'})
+            user_database.execute(%{SELECT cartodb.#{user_data_size_function}}).first['cdb_userdatasize'].to_i
+          end
         end
       rescue => e
         attempts += 1

--- a/app/models/carto/user_service.rb
+++ b/app/models/carto/user_service.rb
@@ -85,8 +85,11 @@ module Carto
         user_data_size_function = cartodb_extension_version_pre_mu? ?
           "CDB_UserDataSize()" :
           "CDB_UserDataSize('#{@user.database_schema}')"
-        in_database(as: :superuser).execute("SELECT cartodb.#{user_data_size_function}")
-                                   .first['cdb_userdatasize'].to_i
+        in_database(as: :superuser) do |user_database|
+          user_database.execute(%{SET LOCAL lock_timeout = '1s'})
+          user_database.execute(%{SELECT cartodb.#{user_data_size_function}}).first['cdb_userdatasize'].to_i
+        end
+
       rescue => e
         attempts += 1
         begin

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -455,6 +455,8 @@ class Table
 
   def remove_table_from_user_database
     owner.in_database(:as => :superuser) do |user_database|
+      # Give up if it cannot get ExclusiveLocks for DDL operations in a reasonable time
+      user_database.run(%{SET LOCAL lock_timeout = '1s'})
       begin
         user_database.run("DROP SEQUENCE IF EXISTS cartodb_id_#{oid}_seq")
       rescue => e

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -458,11 +458,7 @@ class Table
       user_database.transaction do
         # Give up if it cannot get ExclusiveLocks for DDL operations in a reasonable time
         user_database.run(%{SET LOCAL lock_timeout = '1s'})
-        begin
-          user_database.run("DROP SEQUENCE IF EXISTS cartodb_id_#{oid}_seq")
-        rescue => e
-          CartoDB::StdoutLogger.info 'Table#after_destroy error', "maybe table #{qualified_table_name} doesn't exist: #{e.inspect}"
-        end
+        user_database.run("DROP SEQUENCE IF EXISTS cartodb_id_#{oid}_seq")
         Carto::OverviewsService.new(user_database).delete_overviews qualified_table_name
         user_database.run(%{DROP TABLE IF EXISTS #{qualified_table_name}})
       end

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -458,7 +458,6 @@ class Table
       user_database.transaction do
         # Give up if it cannot get ExclusiveLocks for DDL operations in a reasonable time
         user_database.run(%{SET LOCAL lock_timeout = '1s'})
-        user_database.run("DROP SEQUENCE IF EXISTS cartodb_id_#{oid}_seq")
         Carto::OverviewsService.new(user_database).delete_overviews qualified_table_name
         user_database.run(%{DROP TABLE IF EXISTS #{qualified_table_name}})
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1389,7 +1389,10 @@ class User < Sequel::Model
       user_data_size_function =
         self.db_service.cartodb_extension_version_pre_mu? ? "CDB_UserDataSize()"
                                                           : "CDB_UserDataSize('#{self.database_schema}')"
-      in_database(:as => :superuser).fetch("SELECT cartodb.#{user_data_size_function}").first[:cdb_userdatasize]
+      in_database(:as => :superuser) do |user_database|
+        user_database.fetch(%{SET LOCAL lock_timeout = '1s'})
+        user_database.fetch(%{SELECT cartodb.#{user_data_size_function}}).first[:cdb_userdatasize]
+      end
     rescue => e
       attempts += 1
       begin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1389,7 +1389,7 @@ class User < Sequel::Model
       user_data_size_function =
         self.db_service.cartodb_extension_version_pre_mu? ? "CDB_UserDataSize()"
                                                           : "CDB_UserDataSize('#{self.database_schema}')"
-      in_database(:as => :superuser) do |user_database|
+      in_database(as: :superuser) do |user_database|
         user_database.fetch(%{SET LOCAL lock_timeout = '1s'})
         user_database.fetch(%{SELECT cartodb.#{user_data_size_function}}).first[:cdb_userdatasize]
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1390,8 +1390,10 @@ class User < Sequel::Model
         self.db_service.cartodb_extension_version_pre_mu? ? "CDB_UserDataSize()"
                                                           : "CDB_UserDataSize('#{self.database_schema}')"
       in_database(as: :superuser) do |user_database|
-        user_database.fetch(%{SET LOCAL lock_timeout = '1s'})
-        user_database.fetch(%{SELECT cartodb.#{user_data_size_function}}).first[:cdb_userdatasize]
+        user_database.transaction do
+          user_database.fetch(%{SET LOCAL lock_timeout = '1s'})
+          user_database.fetch(%{SELECT cartodb.#{user_data_size_function}}).first[:cdb_userdatasize]
+        end
       end
     rescue => e
       attempts += 1

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -537,7 +537,7 @@ module CartoDB
       # Upgrade the cartodb postgresql extension
       def upgrade_cartodb_postgres_extension(statement_timeout = nil, cdb_extension_target_version = nil)
         if cdb_extension_target_version.nil?
-          cdb_extension_target_version = '0.22.2'
+          cdb_extension_target_version = '0.23.0'
         end
 
         @user.in_database(as: :superuser, no_cartodb_in_schema: true) do |db|

--- a/app/services/carto/overviews_service.rb
+++ b/app/services/carto/overviews_service.rb
@@ -26,11 +26,9 @@ module Carto
     end
 
     def delete_overviews(table_name)
-      # TODO: this is not very elegant, we could detect the existence of the
-      # table some otherway or have a CDB_DropOverviews(text)  function...
-      @database.run(%{SELECT cartodb.CDB_DropOverviews('#{table_name}'::REGCLASS)})
-    rescue Carto::Db::SqlInterface::Error => e
-      raise unless e.to_s.match /relation .+ does not exist/
+      if @database.fetch(%{SELECT cartodb._CDB_Table_Exists('#{table_name}')}).first[:_cdb_table_exists]
+        @database.run(%{SELECT cartodb.CDB_DropOverviews('#{table_name}')})
+      end
     end
 
     def overview_tables(table_name)


### PR DESCRIPTION
~~@javitonino adding you in case you're around (otherwise, enjoy! :slightly_smiling_face: )~~

(thanks for your review!)

What this does:
- It wraps the `DROP TABLE` operation in a transaction and sets a `lock_timeout` for it (with scope of transaction). If it cannot acquire a lock, it will timeout and return an error back to the client.
- This way it avoids a situation with queries waiting for each other and blocking the dashboard.
- As an extra ball, I removed some legacy code that is not really needed in c7fc9b553bcc188a1b0bd1899ef737b8dad98219 and 91a770f36b4780957c268a0c903e6596530d8e61
- As another extra, I added similar `lock_timeout`'s to calls to `CDB_UserDataSize()`, as asked by javitonino, since they are pretty prone to slowness because of the locks, and should not be really critical (as the size is cached).

See https://github.com/CartoDB/cartodb/issues/12829 for more info.