### PR TITLE
Fix missing qualitative ramps for domains with just one value [WIP]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 
 ### Bug fixes / enhancements
+* Add minimum qualitative ramps for domains with just one value (https://github.com/CartoDB/cartodb/issues/14129)
 * Fix custom carousel item select event (https://github.com/CartoDB/cartodb/issues/14070)
 * Fix gaps in tiles (https://github.com/CartoDB/support/issues/1362)
 * Fix style issues (https://github.com/CartoDB/cartodb/pull/14123)

--- a/lib/assets/javascripts/builder/components/input-color/input-qualitative-ramps/color-ramps-list/list-view/color-ramps-list-view.js
+++ b/lib/assets/javascripts/builder/components/input-color/input-qualitative-ramps/color-ramps-list/list-view/color-ramps-list-view.js
@@ -106,7 +106,8 @@ module.exports = CoreView.extend({
   },
 
   _setupCollection: function () {
-    var ramps = CartoColor.getQualitativeRamps(this._requiredNumberOfColors);
+    var numberOfColorsNeededInRamp = Math.max(2, this._requiredNumberOfColors);
+    var ramps = CartoColor.getQualitativeRamps(numberOfColorsNeededInRamp);
     var range = this.model.get('range');
 
     ramps = _.map(ramps, function (ramp, name) {

--- a/lib/assets/javascripts/builder/components/input-color/input-qualitative-ramps/color-ramps-list/list-view/color-ramps-list-view.js
+++ b/lib/assets/javascripts/builder/components/input-color/input-qualitative-ramps/color-ramps-list/list-view/color-ramps-list-view.js
@@ -106,8 +106,11 @@ module.exports = CoreView.extend({
   },
 
   _setupCollection: function () {
-    var numberOfColorsNeededInRamp = Math.max(2, this._requiredNumberOfColors);
-    var ramps = CartoColor.getQualitativeRamps(numberOfColorsNeededInRamp);
+    var ramps = CartoColor.getQualitativeRamps(this._requiredNumberOfColors);
+    if (ramps.length === 0) {
+      ramps = CartoColor.getMinimumQualitativeRamps();
+    }
+
     var range = this.model.get('range');
 
     ramps = _.map(ramps, function (ramp, name) {
@@ -131,7 +134,7 @@ module.exports = CoreView.extend({
     this.collection = new CustomListCollection(_.compact(ramps), { silent: false });
 
     if (!this.collection.getSelectedItem()) {
-      this._customRamp.set('range', this.model.get('range'));
+      this._customRamp.set('range', range);
     }
   },
 

--- a/lib/assets/javascripts/builder/components/input-color/input-qualitative-ramps/main-view.js
+++ b/lib/assets/javascripts/builder/components/input-color/input-qualitative-ramps/main-view.js
@@ -47,7 +47,6 @@ module.exports = CoreView.extend({
     this._imageEnabled = opts.imageEnabled;
     this._hideTabs = opts.hideTabs;
     this._query = opts.query;
-    this._requiredNumberOfColors = this._computeRequiredNumberOfColors();
     this._viewModel = new Backbone.Model({
       step: 0,
       status: 'idle'
@@ -113,7 +112,7 @@ module.exports = CoreView.extend({
     this.addView(this._stackLayoutView);
   },
 
-  _computeRequiredNumberOfColors: function () {
+  _getRequiredNumberOfColors: function () {
     return this.model.get('domain')
       ? Math.min(this.model.get('domain').length, MAX_VALUES + 1)
       : MAX_VALUES + 1;
@@ -278,7 +277,7 @@ module.exports = CoreView.extend({
       model: this.model,
       maxValues: MAX_VALUES,
       imageEnabled: this._iconStylingEnabled(),
-      requiredNumberOfColors: this._requiredNumberOfColors
+      requiredNumberOfColors: this._getRequiredNumberOfColors()
     });
 
     view.bind('back', function (value) {
@@ -302,7 +301,7 @@ module.exports = CoreView.extend({
     var view = new ColorRampsListView({
       model: this.model,
       maxValues: MAX_VALUES,
-      requiredNumberOfColors: this._requiredNumberOfColors
+      requiredNumberOfColors: this._getRequiredNumberOfColors()
     });
 
     var eventsToListen = [

--- a/lib/assets/javascripts/builder/editor/widgets/time-series-query-model.js
+++ b/lib/assets/javascripts/builder/editor/widgets/time-series-query-model.js
@@ -97,8 +97,8 @@ module.exports = Backbone.Model.extend({
   },
 
   _calculateBuckets: function (max, min) {
-    var end = moment(max);
-    var start = moment(min);
+    var end = moment(max).utc();
+    var start = moment(min).utc();
     var BUCKET_INCREMENT = 1;
 
     var buckets = [{

--- a/lib/assets/javascripts/builder/helpers/carto-color.js
+++ b/lib/assets/javascripts/builder/helpers/carto-color.js
@@ -49,6 +49,11 @@ module.exports = {
     return this.getColorRampsByTag(colorsNumber, Tags.QUALITATIVE);
   },
 
+  getMinimumQualitativeRamps: function () {
+    var MINIMUM_COLORS_NUMBER = 2;
+    return this.getQualitativeRamps(MINIMUM_COLORS_NUMBER);
+  },
+
   getQuantitativeRamps: function (colorsNumber) {
     return this.getColorRampsByTag(colorsNumber, Tags.QUANTITATIVE);
   }

--- a/lib/assets/test/spec/builder/components/form-components/editors/fill/input-color/input-qualitative-ramps/main-view.spec.js
+++ b/lib/assets/test/spec/builder/components/form-components/editors/fill/input-color/input-qualitative-ramps/main-view.spec.js
@@ -149,9 +149,9 @@ describe('components/form-components/editors/fill/input-color/input-qualitative-
   describe('._updateRangeAndDomain', function () {
     var MAX_VALUES = 10; // Mirror the constant from input-color-categories.js
 
-    it('the color for "others" category is the proper one', function () {
+    it('updates correctly the domain and range colors for the current categories', function () {
       var rows = JSON.parse('[{"nombre":"Almagro"},{"nombre":"Arapiles"},{"nombre":"Cortes"},{"nombre":"Embajadores"},{"nombre":"Gaztambide"},{"nombre":"Jerónimos"},{"nombre":"Justicia"},{"nombre":"Palacio"},{"nombre":"RiosRosas"},{"nombre":"Sol"},{"nombre":"Trafalgar"}]');
-      this.view.model.set('attribute', 'nombre');
+      this.view.model.set({ 'attribute': 'nombre' }, { silent: true });
 
       this.view._updateRangeAndDomain(rows);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.41",
+  "version": "4.12.41-14129",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Related to https://github.com/CartoDB/cartodb/issues/14129

This PR ensures there are always some color ramps available when dealing with 'string fields' (qualitative ramps), despite of the number of elements in domain < 3

## Acceptance
1. Load the attached dataset (rename to .geojson)
[bicimad_unique_domain.geojson.txt](https://github.com/CartoDB/cartodb/files/2157605/bicimad_unique_domain.geojson.txt)

2. Create a new map
3. Style by value, using `begin` field (string type / just one value)
3.1. Several qualitative color ramps, with 3 colors, should be available
3.2. Change selected ramp / customize it to test there are no errors

4. Style by value, using `n_anclajes` (string type / several values)
4.1. Several ramps are available, with a higher number of colors

![qualitative_ramps_unique_domain](https://user-images.githubusercontent.com/458196/42223190-c4d24172-7e9c-11e8-895a-08074d3f0ed3.gif)



5. Style by value using some other fields (e.g. `cartodb_id`, numerical type / several values, to check there are no problems with quantitative ramps)

6. Repeat step 3, to check there are no "strange" or random side-effects of other fields.

