### PR TITLE
Debounce map instantiation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 
 ### Bug fixes / enhancements
+* Map instantiation is now debounced thanks to Carto.js 4.0.12 (https://github.com/CartoDB/cartodb/pull/14142)
 * Fix bug computing next page in datasets (https://github.com/CartoDB/cartodb/issues/14138)
 * Move to the last page after adding a row (https://github.com/CartoDB/cartodb/issues/10720)
 * Fix pagination after deleting a row (https://github.com/CartoDB/cartodb/issues/9868)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "4.12.45",
   "dependencies": {
     "@carto/carto.js": {
-      "version": "4.0.10",
+      "version": "4.0.12",
       "from": "@carto/carto.js@>=4.0.6 <5.0.0",
-      "resolved": "https://registry.npmjs.org/@carto/carto.js/-/carto.js-4.0.10.tgz"
+      "resolved": "https://registry.npmjs.org/@carto/carto.js/-/carto.js-4.0.12.tgz"
     },
     "@carto/zera": {
       "version": "1.0.6",
@@ -1665,9 +1665,9 @@
       }
     },
     "internal-carto.js": {
-      "version": "4.0.11-1",
-      "from": "cartodb/carto.js#v4.0.11-1",
-      "resolved": "git://github.com/cartodb/carto.js.git#a87594d592a085f36ac209b794a97a648df25475"
+      "version": "4.0.12",
+      "from": "cartodb/carto.js#v4.0.12",
+      "resolved": "git://github.com/cartodb/carto.js.git#655211487ceeb22aced27e28135bb9c723b79386"
     },
     "interpret": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "d3-queue": "^3.0.7",
     "fastclick": "^1.0.6",
     "html-webpack-plugin": "^3.2.0",
-    "internal-carto.js": "CartoDB/carto.js#v4.0.11-1",
+    "internal-carto.js": "CartoDB/carto.js#v4.0.12",
     "jquery": "2.1.4",
     "leaflet": "CartoDB/Leaflet#v1.3.1-carto1",
     "moment": "2.18.1",


### PR DESCRIPTION
Point to carto.js 4.0.12, which supports debounced map instantiation.