### PR TITLE
Fix category name overflow when styling by value 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 
 ### Bug fixes / enhancements
+* Fix category name overflow when styling by value (https://github.com/CartoDB/support/issues/1644)
 * Improve input image when color changes (https://github.com/CartoDB/cartodb/issues/11326)
 * Fix pagination buttons style (https://github.com/CartoDB/cartodb/issues/13456)
 * Fix edit month in table cell (https://github.com/CartoDB/support/issues/1352)

--- a/lib/assets/javascripts/builder/components/input-color/input-color-picker/input-color-picker-header.tpl
+++ b/lib/assets/javascripts/builder/components/input-color/input-color-picker/input-color-picker-header.tpl
@@ -1,6 +1,6 @@
 <div class="CDB-Box-modalHeader">
   <ul class="CDB-Box-modalHeaderItem CDB-Box-modalHeaderItem CDB-Box-modalHeaderItem--paddingHorizontal">
-    <li class="CDB-ListDecoration-item CDB-ListDecoration-itemDisplay--flex CDB-Text CDB-Size-medium u-secondaryTextColor">
+    <li class="CDB-ListDecoration-item CDB-ListDecoration-itemDisplay--flex CDB-Text CDB-Size-medium u-secondaryTextColor u-ellipsis">
       <div class="CDB-ListDecoration-secondaryContainer">
         <button class="u-rSpace u-actionTextColor js-back" type="button">
           <i class="CDB-IconFont CDB-IconFont-arrowPrev Size-large"></i>
@@ -8,7 +8,9 @@
       </div>
 
       <div class="CDB-ListDecoration-secondaryContainer CDB-ListDecoration-title u-rSpace--m">
-        <span class="label u-ellipsis js-label"><%- label %></span>
+        <span class="label u-ellipsis js-label">
+          <%- label %>
+        </span>
       </div>
 
       <% if (isCategorized && imageEnabled) { %>
@@ -17,22 +19,25 @@
             <ul class='CDB-NavMenu-Inner CDB-NavMenu-inner--no-margin js-menu'>
               <li class='CDB-NavMenu-item is-selected'>
                 <div class='CDB-NavMenu-link CDB-ListDecoration-rampNav-item'>
-                  <button class='ColorBar ColorBar--disableHighlight CDB-ListDecoration-rampItemBar u-rSpace--xl js-colorPicker' type="button" style="background-color: <%= color %>;"></button>
+                  <button class='ColorBar ColorBar--disableHighlight CDB-ListDecoration-rampItemBar u-rSpace--xl js-colorPicker' type="button"
+                    style="background-color: <%= color %>;"></button>
                 </div>
               </li>
               <li class='CDB-NavMenu-item'>
                 <div class='CDB-NavMenu-link CDB-ListDecoration-rampNav-item'>
                   <% if (image) { %>
                     <button class="CDB-ListDecoration-rampImg js-image-container" type="button"></button>
-                  <% } else { %>
-                    <button class="CDB-ListDecoration-rampImg CDB-Text u-actionTextColor js-assetPicker" type="button"><%= _t('form-components.editors.fill.input-color.img') %></button>
-                  <% } %>
+                    <% } else { %>
+                      <button class="CDB-ListDecoration-rampImg CDB-Text u-actionTextColor js-assetPicker" type="button">
+                        <%= _t('form-components.editors.fill.input-color.img') %>
+                      </button>
+                      <% } %>
                 </div>
               </li>
             </ul>
           </nav>
         </div>
-      <% } %>
+        <% } %>
     </li>
   </ul>
 </div>
@@ -42,8 +47,9 @@
     <li class="CDB-ListDecoration-item CDB-ListDecoration-itemPadding--vertical CDB-Text CDB-Size-medium u-secondaryTextColor">
       <ul class="ColorBarContainer ColorBarContainer--rampEditing">
         <% _.each(ramp, function (color, i) { %>
-        <li class="ColorBar ColorBar--spaceless ColorBar--clickable is-link js-color<%- i === index ? ' is-selected' : '' %>" data-label="<%- color.title %>" data-color="<%- color.color %>" style="background-color: <%- color.color %>;"></li>
-        <% }); %>
+          <li class="ColorBar ColorBar--spaceless ColorBar--clickable is-link js-color<%- i === index ? ' is-selected' : '' %>" data-label="<%- color.title %>"
+            data-color="<%- color.color %>" style="background-color: <%- color.color %>;"></li>
+          <% }); %>
       </ul>
       <div class="OpacityEditor">
         <div class="OpacityEditor-slider js-slider"></div>


### PR DESCRIPTION
## Related to https://github.com/CartoDB/support/issues/1644

This PR updates the header, adding text-ellipsis

## Acceptance
As described in related issue:
1. Style by value a dataset, based on a string field (to get qualitative ramps). 
2. Have one record with a very long text inside that field, to force the ellipsis
3. Click on that category.
4. Check there is no overflow (text inside the header and, if it is a point layer, also the 'icon')

| Before | After |
|---|---|
| ![bug-overflow](https://user-images.githubusercontent.com/458196/42393241-5b3f142a-811b-11e8-9db7-e73b291a584c.png) | ![fixed-overflow](https://user-images.githubusercontent.com/458196/42393245-5eda7ae8-811b-11e8-8e1d-aa370a6d84a1.png)|
