### PR TITLE
S1643 wms long urls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Fix legend editor margin (https://github.com/CartoDB/cartodb/issues/13338)
 * Fix slider width for point/stroke size (https://github.com/CartoDB/support/issues/1641)
 * Fix gradient legends margin (https://github.com/CartoDB/support/issues/1640)
-* Fix drag new layer from Torque source (https://github.com/CartoDB/support/issues/1625)  
+* Fix drag new layer from Torque source (https://github.com/CartoDB/support/issues/1625)
 * Fix custom carousel item select event (https://github.com/CartoDB/cartodb/issues/14070)
 * Fix gaps in tiles (https://github.com/CartoDB/support/issues/1362)
 * Fix style issues (https://github.com/CartoDB/cartodb/pull/14123)
@@ -71,6 +71,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Update extension to 0.23.0 to add a new helper function `_CDB_Table_Exists(table_name_with_optional_schema TEXT)` (cartodb-postgresql#332)
 * Log Resque errors (#14116)
 * Do not crash when checking nil password (#14099)
+* Do not crash when saving WMS layers with long metadata (Suppoer#1643)
 * Remove Auth API FF, enable it by default (#13857)
 * User mover does not export user metadata if org metadata is not exported
 * Fail fast instead of locking dashboard / user data size calculation on table deletion (#12829)

--- a/lib/assets/javascripts/builder/components/modals/add-basemap/wms/wms-layer-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-basemap/wms/wms-layer-model.js
@@ -28,6 +28,7 @@ module.exports = Backbone.Model.extend({
     options = options || {};
     options.url = this.url(method.toLowerCase());
     options.dataType = 'jsonp';
+    options.attrs = '_';
     method = 'READ';
 
     return Backbone.sync.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.51",
+  "version": "4.12.51-wms",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.51-wms",
+  "version": "4.12.51",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/CartoDB/support/issues/1643

Plese CR fellow RTer @rjimenezda 

The call to this endpoint is carefully constructed by manipulating the URL. We still use backbone to send the `sync` so it tries to apend attributes that are unneeded and too big (over 64kb request limit). So I just override and avoid sending the model data. Not sure if this is the best approach, since we just need to do a `GET` to a specific URL.

This feels a bit dirty, but it works just fine.