### PR TITLE
Re-enable production source maps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Triggering ghost tables and common data when visiting the dashboard (#14010)
 
 ### Internals
+* Re-enable sourcemaps in production, they were broken since the move to webpack v4
 * Add `internal-carto.js` to transpilation process in Webpack (https://github.com/CartoDB/cartodb/pull/14117)
 * Create a new JS bundle for Lockout page (https://github.com/CartoDB/cartodb/issues/14019)
 * Update to Webpack 4, move CSS processing from Grunt to Webpack (https://github.com/CartoDB/cartodb/pull/14033)

--- a/webpack/v4/webpack.prod.config.js
+++ b/webpack/v4/webpack.prod.config.js
@@ -21,8 +21,8 @@ module.exports = merge(baseConfig, {
       new UglifyJsPlugin({
         cache: false,
         parallel: true,
+        sourceMap: true,
         uglifyOptions: {
-          sourceMap: true,
           keep_fnames: true,
           output: {
             ascii_only: true,


### PR DESCRIPTION
We accidentally the source maps when we migrated to webpack v4, this PR re-enables them

This probably means the build's going to be a bit slower. But I'll take slower builds over not being able to consistently set breakpoints on prod 😬 