### PR TITLE
Fix copyright symbol not appearing on exported image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 
 ### Bug fixes / enhancements
+* Copyright symbol not appearing on exported image (https://github.com/CartoDB/cartodb/issues/13411)
 * Keep selected popup tab after fetch (https://github.com/CartoDB/support/issues/1396)
 * Fix HTML templates for Hover popups (https://github.com/CartoDB/cartodb/issues/11284)
 * Fix category name overflow when styling by value (https://github.com/CartoDB/support/issues/1644)

--- a/lib/assets/javascripts/builder/editor/export-image-pane/export-image-pane.js
+++ b/lib/assets/javascripts/builder/editor/export-image-pane/export-image-pane.js
@@ -367,6 +367,14 @@ module.exports = CoreView.extend({
     return lat + ',' + lng;
   },
 
+  _parseAttribution: function (attribution) {
+    return Utils.stripHTML(
+      attribution
+        .join(' ')
+        .replace(/&copy;/g, '©')
+    );
+  },
+
   _loadAttribution: function () {
     var self = this;
     var visMetadata = this._mapDefinitionModel.getImageExportMetadata();
@@ -376,7 +384,7 @@ module.exports = CoreView.extend({
     var canvas = document.createElement('canvas');
     var ctx = canvas.getContext('2d');
 
-    var text = this._hasGoogleMapsBasemap() ? CARTO_ATTRIBUTION : Utils.stripHTML(visMetadata.attribution.join(' '));
+    var text = this._hasGoogleMapsBasemap() ? CARTO_ATTRIBUTION : this._parseAttribution(visMetadata.attribution);
     var dimension = ctx.measureText(text);
     var width = dimension.width;
 

--- a/lib/assets/test/spec/builder/components/export-image-pane/export-image-pane.spec.js
+++ b/lib/assets/test/spec/builder/components/export-image-pane/export-image-pane.spec.js
@@ -395,6 +395,13 @@ describe('editor/export-image-pane/export-image-pane', function () {
     });
   });
 
+  it('should turn &copy; into ©', function () {
+    var attr = this.view._parseAttribution(['&copy; © memes should be above copyright law © &copy;']);
+
+    expect(attr).not.toContain('&copy;');
+    expect((attr.match(/©/g) || []).length).toBe(4);
+  });
+
   afterEach(function () {
     Notifier.off();
     this.view.remove();


### PR DESCRIPTION
Fix #13411

Replace `&copy;` with © when creating the attribution text for the exported image.

We could put all the text in an invisble textarea, read it back and we would get all the escaped entities. However I think it's an overkill because most likely we'll only need to parse &copy;