### PR TITLE
Export gpkg files on builder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,7 @@ You can then run `bundle exec rake carto:db:sync_basemaps_from_app_config` to sy
 This upgrade changes AWS gem version. Now you must specify `region` within your AWS configurations. Check `app_config.yml.sample`.
 
 ### Features
+* Export GPKG files (CartoDB/support#1220)
 * Show migrated public pages (/me, /maps, /datasets) for all builder users (#14039)
 * Allow users to edit all their information in Profile (#13793)
 * Ask for password confirmation when updating organization or user settings (#13795)

--- a/assets/stylesheets/common/icons/illustration-icon.scss
+++ b/assets/stylesheets/common/icons/illustration-icon.scss
@@ -13,6 +13,7 @@ $cRoyal:      rgba(#7882B9, 1);
 $cRoyalDark:  rgba(#9013FE, 1);
 $cMagenta:    rgba(#BD10E0, 1);
 $cLingon:     rgba(#AC638B, 1);
+$cSmaltBlue:  rgba(#577590, 1);
 
 //  Filled circles with an icon in the middle, typically used together with a CDB-IconFont.
 //
@@ -42,6 +43,7 @@ $cLingon:     rgba(#AC638B, 1);
 .IllustrationIcon--royalDark { background-color: $cRoyalDark; }
 .IllustrationIcon--magenta { background-color: $cMagenta; }
 .IllustrationIcon--lingon { background-color: $cLingon; }
+.IllustrationIcon--smaltBlue { background-color: $cSmaltBlue; }
 
 .IllustrationIcon-text {
   font-size: $sFontSize-smallUpperCase;

--- a/lib/assets/javascripts/builder/components/modals/export-data/modal-export-data-view.js
+++ b/lib/assets/javascripts/builder/components/modals/export-data/modal-export-data-view.js
@@ -32,6 +32,10 @@ var FORMATS = [
     format: 'svg',
     fetcher: 'fetchSVG',
     geomRequired: true
+  }, {
+    format: 'gpkg',
+    fetcher: 'fetch',
+    geomRequired: true
   }
 ];
 

--- a/lib/assets/javascripts/dashboard/views/public-dataset/dialogs/export/export-view.js
+++ b/lib/assets/javascripts/dashboard/views/public-dataset/dialogs/export/export-view.js
@@ -37,7 +37,8 @@ module.exports = CoreView.extend({
     { format: 'shp', fetcher: 'fetch', geomRequired: true, illustrationIconModifier: 'IllustrationIcon--magenta' },
     { format: 'kml', fetcher: 'fetch', geomRequired: true, illustrationIconModifier: 'IllustrationIcon--sunrise' },
     { format: 'geojson', label: 'geo json', fetcher: 'fetch', geomRequired: true, illustrationIconModifier: 'IllustrationIcon--cyan' },
-    { format: 'svg', fetcher: 'fetchSVG', geomRequired: true, illustrationIconModifier: 'IllustrationIcon--royalDark' }
+    { format: 'svg', fetcher: 'fetchSVG', geomRequired: true, illustrationIconModifier: 'IllustrationIcon--royalDark' },
+    { format: 'gpkg', fetcher: 'fetch', geomRequired: true, illustrationIconModifier: 'IllustrationIcon--smaltBlue' }
   ],
 
   initialize: function () {

--- a/lib/assets/test/spec/builder/components/modals/export-data/modal-export-data-view.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/export-data/modal-export-data-view.spec.js
@@ -37,7 +37,7 @@ describe('components/modals/export-data/modal-export-data-view', function () {
 
   describe('render', function () {
     it('should render properly for points', function () {
-      expect(this.view.$('.Modal-listFormItem').length).toBe(5);
+      expect(this.view.$('.Modal-listFormItem').length).toBe(6);
       expect(this.view.$('.Modal-listFormItem.is-disabled').length).toBe(0);
       expect(this.view.$('[data-format=csv]:checked').length).toBe(1);
     });
@@ -46,7 +46,7 @@ describe('components/modals/export-data/modal-export-data-view', function () {
       this.queryGeometryModel.set('simple_geom', 'line');
       this.view.render();
 
-      expect(this.view.$('.Modal-listFormItem').length).toBe(5);
+      expect(this.view.$('.Modal-listFormItem').length).toBe(6);
       expect(this.view.$('.Modal-listFormItem.is-disabled').length).toBe(0);
       expect(this.view.$('[data-format=csv]:checked').length).toBe(1);
     });
@@ -55,7 +55,7 @@ describe('components/modals/export-data/modal-export-data-view', function () {
       this.queryGeometryModel.set('simple_geom', 'polygon');
       this.view.render();
 
-      expect(this.view.$('.Modal-listFormItem').length).toBe(5);
+      expect(this.view.$('.Modal-listFormItem').length).toBe(6);
       expect(this.view.$('.Modal-listFormItem.is-disabled').length).toBe(0);
       expect(this.view.$('[data-format=csv]:checked').length).toBe(1);
     });
@@ -64,8 +64,8 @@ describe('components/modals/export-data/modal-export-data-view', function () {
       this.queryGeometryModel.set('simple_geom', null);
       this.view.render();
 
-      expect(this.view.$('.Modal-listFormItem').length).toBe(5);
-      expect(this.view.$('.Modal-listFormItem.is-disabled').length).toBe(4);
+      expect(this.view.$('.Modal-listFormItem').length).toBe(6);
+      expect(this.view.$('.Modal-listFormItem.is-disabled').length).toBe(5);
       expect(this.view.$('[data-format=csv]:disabled').length).toBe(0);
       expect(this.view.$('[data-format=csv]:checked').length).toBe(1);
     });


### PR DESCRIPTION
Fix CartoDB/support#1220

This PR allows users to download GPKG files on CARTO. On Builder, the private dataset view and the public dataset view.

For the import: https://github.com/CartoDB/cartodb/pull/14153