### PR TITLE
Clean up builder tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -728,6 +728,7 @@ ion for time-series (#12670)
 * Fix bugs in legends (https://github.com/CartoDB/support/issues/1339, )
 
 ### Internals
+* Fix test error output for builder (#14158)
 * Editor assets are frozen now (#14090)
 * Added specs for the migrated dashboard (#14037)
 * Profile and Account pages are now static and served via NGINX in production/staging enviroment (#13958)

--- a/lib/assets/javascripts/builder/components/form-components/editors/size/size-by-value-view.js
+++ b/lib/assets/javascripts/builder/components/form-components/editors/size/size-by-value-view.js
@@ -57,7 +57,10 @@ module.exports = CoreView.extend({
     var columnSelected = this.model.get('attribute');
     if (_.isUndefined(columnSelected)) {
       var self = this;
-      setTimeout(function () { self._showByValueDialog(); }, 200);
+      this.timeoutId = setTimeout(function () {
+        self.timeoutId = null;
+        self._showByValueDialog();
+      }, 200);
     }
   },
 
@@ -289,5 +292,13 @@ module.exports = CoreView.extend({
 
   _onClickBack: function (e) {
     this.killEvent(e);
+  },
+
+  clean: function () {
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+    }
+
+    CoreView.prototype.clean.apply(this);
   }
 });

--- a/lib/assets/javascripts/builder/components/form-components/editors/size/size.js
+++ b/lib/assets/javascripts/builder/components/form-components/editors/size/size.js
@@ -226,6 +226,9 @@ Backbone.Form.editors.Size = Backbone.Form.editors.Base.extend({
     this._removeDialogs();
     this._removePopupManagers();
     Backbone.Form.editors.Base.prototype.remove.apply(this);
+    this._tabPaneView.clean();
+    this._valueView && this._valueView.clean();
+    this._fixedView && this._fixedView.clean();
   },
 
   clean: function () {

--- a/lib/assets/test/spec/builder/components/form-components/editors/fill-color/fill-color.spec.js
+++ b/lib/assets/test/spec/builder/components/form-components/editors/fill-color/fill-color.spec.js
@@ -98,5 +98,9 @@ describe('components/form-components/editors/fill-color/fill-color', function ()
 
       expect(ColorByValueView.prototype.render).toHaveBeenCalled();
     });
+
+    afterEach(function () {
+      color.remove();
+    });
   });
 });

--- a/lib/assets/test/spec/builder/components/form-components/editors/size/size-fixed-view.spec.js
+++ b/lib/assets/test/spec/builder/components/form-components/editors/size/size-fixed-view.spec.js
@@ -19,6 +19,10 @@ describe('components/form-components/editors/size/size-fixed-view', function () 
     createView();
   });
 
+  afterEach(function () {
+    sizeFixedView.clean();
+  });
+
   it('renders with the expected schema', function () {
     sizeFixedView.render();
 

--- a/lib/assets/test/spec/builder/components/form-components/editors/size/size.spec.js
+++ b/lib/assets/test/spec/builder/components/form-components/editors/size/size.spec.js
@@ -34,11 +34,11 @@ describe('/components/form-components/editors/size/size', function () {
     return new Backbone.Form.editors.Size(options);
   }
 
-  afterEach(function () {
-    size.clean();
-  });
-
   describe('render', function () {
+    afterEach(function () {
+      size.remove();
+    });
+
     it('both fixed and value if no options passed about it', function () {
       size = createSize();
 
@@ -69,6 +69,9 @@ describe('/components/form-components/editors/size/size', function () {
     describe('by value', function () {
       beforeEach(function () {
         spyOn(SizeByValueView.prototype, 'initialize');
+        spyOn(SizeByValueView.prototype, 'removeDialog');
+        spyOn(SizeByValueView.prototype, 'removePopupManager');
+        spyOn(SizeByValueView.prototype, '_showByValueDialog');
         spyOn(SizeByValueView.prototype, 'render').and.returnValue('<div class="fake-by-value"></div>');
       });
       it('only by value if hidePanes set with `fixed`', function () {
@@ -84,6 +87,8 @@ describe('/components/form-components/editors/size/size', function () {
 
         // Form content
         expect(SizeByValueView.prototype.render).toHaveBeenCalled();
+
+        size.remove();
       });
     });
   });

--- a/lib/assets/test/spec/builder/components/form-components/editors/track-class.spec.js
+++ b/lib/assets/test/spec/builder/components/form-components/editors/track-class.spec.js
@@ -151,6 +151,7 @@ describe('components/form-components/editors/track-class', function () {
           var view = new _class(options);
           expect(view.$el.hasClass('track-class-whatever')).toBeFalsy();
           expect(view.options.trackingClass).toBeUndefined();
+          view.remove();
         });
 
         it('should add the class if it is specified', function () {
@@ -161,6 +162,7 @@ describe('components/form-components/editors/track-class', function () {
           );
 
           expect(view.$el.hasClass('track-class-whatever')).toBeTruthy();
+          view.remove();
         });
       });
     });


### PR DESCRIPTION
Please remember to clean up your views and check from time to time if your tests are throwing errors (even if they pass). By not removing some views properly, we were leaving some event listeners appended to document, which would fire on completely different tests.

Also, our [SpecHelper](https://github.com/CartoDB/cartodb/blob/master/lib/assets/test/spec/SpecHelper3.js) does behind-the-curtains magic for you if you put your views on `this.view`

The CI test output is basically unreadable, travis won't even fully show it and make you get the TXT file => https://api.travis-ci.org/v3/job/402757078/log.txt

There's still a test suite (layer-header-view) that I'm unable to leave clean, because there's something fishy going on with the spies. It throws 15 errors (cannot read * of undefined).

I'm going to try and remove the perfect-scrollbar leaks as well, and I'll try to add Polly (https://netflix.github.io/pollyjs) to avoid having thousands of Network Errors. These don't affect the output, but I feel like my browser dies if I run all the tests with the devtools open