### PR TITLE
Fix disconnect from external sources for org users (gdrive, box and dropbox)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,8 @@ This release introduces a new API Key system. In order to migrate existing users
 * New rake to fix inconsistent permissions (`bundle exec rake cartodb:permissions:fix_permission_acl`)
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
-### Bug fixes / enhancements
+### Bug fixes / enhancement
+* Fix disconnect from external data sources (gdrive, box and dropbox) for organization users (https://github.com/CartoDB/support/issues/1671)
 * Fix broken data tab when analyses or custom SQL are present (https://github.com/CartoDB/cartodb/issues/14169)
 * Use setView instead of flyTo to improve zoom transitions (https://github.com/CartoDB/carto.js/pull/2178)
 * Fix torque layers when filter analysis is added (https://github.com/CartoDB/support/issues/1038)

--- a/lib/assets/javascripts/dashboard/components/service-item/service-item-view.js
+++ b/lib/assets/javascripts/dashboard/components/service-item/service-item-view.js
@@ -74,7 +74,11 @@ module.exports = CoreView.extend({
   _disconnect: function () {
     if (this.model.get('state') === 'loading') return;
 
-    this._modals.create(modalModel => new DisconnectDialog({ serviceModel: this.model, modalModel }));
+    this._modals.create(modalModel => new DisconnectDialog({
+      serviceModel: this.model,
+      configModel: this._configModel,
+      modalModel
+    }));
   },
 
   _checkToken: function (successCallback, errorCallback) {

--- a/lib/assets/javascripts/dashboard/views/account/service-disconnect-dialog/service-disconnect-dialog-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/service-disconnect-dialog/service-disconnect-dialog-view.js
@@ -7,7 +7,8 @@ const checkAndBuildOpts = require('builder/helpers/required-opts');
 
 const REQUIRED_OPTS = [
   'serviceModel',
-  'modalModel'
+  'modalModel',
+  'configModel'
 ];
 
 /**
@@ -55,6 +56,8 @@ module.exports = CoreView.extend({
 
   _revokeAccess: function () {
     const invalidateModel = new ServiceInvalidate({ datasource: this._serviceModel.get('name') });
+    invalidateModel._configModel = this._configModel;
+
     this._serviceModel.set('state', 'loading');
 
     invalidateModel.destroy({

--- a/lib/assets/test/spec/dashboard/views/account/service-disconnect-dialog-view.spec.js
+++ b/lib/assets/test/spec/dashboard/views/account/service-disconnect-dialog-view.spec.js
@@ -1,6 +1,7 @@
 const Backbone = require('backbone');
 const ServiceInvalidate = require('dashboard/data/service-invalidate-model');
 const ServiceDisconnectDialog = require('dashboard/views/account/service-disconnect-dialog/service-disconnect-dialog-view');
+const ConfigModelFixture = require('fixtures/dashboard/config-model.fixture');
 
 describe('dashboard/views/account/service-disconnect-dialog-view', function () {
   let view;
@@ -20,7 +21,8 @@ describe('dashboard/views/account/service-disconnect-dialog-view', function () {
         revoke_url: '',
         connected: false
       }),
-      modalModel: new Backbone.Model()
+      modalModel: new Backbone.Model(),
+      configModel: ConfigModelFixture
     });
 
     spyOn(view, '_reloadWindow');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.60",
+  "version": "4.12.60-1671",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Related to https://github.com/CartoDB/support/issues/1671

### Acceptance
The issue affects organization users, when dealing with **gdrive, dropbox and box**

A deployment to staging has been done with these users:
- *gdrive*
- *my-connect-org-1* at my-connect-org

The acceptance should include a test with both of them, for these 3 services.

The test consists in:
1. Go to _Account settings_
2. Click on _Account_
3. _Connect to external data sources_ > select a service
4. _Connect_ (**)
5. **Disconnect** --> EXPECTED result: the disconnection is successful

Tests:
- [x] **gdrive** user --> at https://gdrive.carto-staging.com/account
- [x] **my-connect-org-1** user --> https://my-connect-org.carto-staging.com/u/my-connect-org-1/account

---

(**) **IMPORTANT**: some warnings on security will appear at step 4. Be sure to allow popups AND unverified app



