### PR TITLE
14165 1416 finish oauth flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/models/carto/notification_spec.rb \
 	spec/models/carto/oauth_app_spec.rb \
 	spec/models/carto/oauth_app_user_spec.rb \
+	spec/models/carto/oauth_authorization_spec.rb \
 	spec/models/carto/overlay_spec.rb \
 	spec/models/carto/rate_limit_spec.rb \
 	spec/models/carto/received_notification_spec.rb \

--- a/app/controllers/carto/api/api_keys_controller.rb
+++ b/app/controllers/carto/api/api_keys_controller.rb
@@ -43,7 +43,7 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
   def index
     page, per_page, order = page_per_page_order_params(VALID_ORDER_PARAMS)
 
-    api_keys = Carto::User.find(current_viewer.id).api_keys.non_internal
+    api_keys = Carto::User.find(current_viewer.id).api_keys.user_visible
     api_keys = request_api_key.master? ? api_keys : api_keys.where(id: request_api_key.id)
     filtered_api_keys = Carto::PagedModel.paged_association(api_keys, page, per_page, order)
 
@@ -73,7 +73,7 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
 
   def load_api_key
     name = params[:id]
-    @viewed_api_key = Carto::ApiKey.where(user_id: current_viewer.id, name: name).non_internal.first
+    @viewed_api_key = Carto::ApiKey.where(user_id: current_viewer.id, name: name).user_visible.first
     if !@viewed_api_key || !request_api_key.master? && @viewed_api_key != request_api_key
       raise Carto::LoadError.new("API key not found: #{name}")
     end

--- a/app/controllers/carto/api/api_keys_controller.rb
+++ b/app/controllers/carto/api/api_keys_controller.rb
@@ -43,7 +43,7 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
   def index
     page, per_page, order = page_per_page_order_params(VALID_ORDER_PARAMS)
 
-    api_keys = Carto::User.find(current_viewer.id).api_keys
+    api_keys = Carto::User.find(current_viewer.id).api_keys.non_internal
     api_keys = request_api_key.master? ? api_keys : api_keys.where(id: request_api_key.id)
     filtered_api_keys = Carto::PagedModel.paged_association(api_keys, page, per_page, order)
 
@@ -66,13 +66,14 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
   end
 
   private
+
   def check_engine_enabled
     render_404 unless current_viewer.try(:engine_enabled?)
   end
 
   def load_api_key
     name = params[:id]
-    @viewed_api_key = Carto::ApiKey.where(user_id: current_viewer.id, name: name).first
+    @viewed_api_key = Carto::ApiKey.where(user_id: current_viewer.id, name: name).non_internal.first
     if !@viewed_api_key || !request_api_key.master? && @viewed_api_key != request_api_key
       raise Carto::LoadError.new("API key not found: #{name}")
     end

--- a/app/controllers/carto/controller_helper.rb
+++ b/app/controllers/carto/controller_helper.rb
@@ -1,66 +1,7 @@
 require_dependency 'carto/uuidhelper'
+require_dependency 'carto/errors'
 
 module Carto
-  class CartoError < StandardError
-    attr_reader :message, :status, :user_message, :errors_cause
-
-    def initialize(message, status, user_message: message, errors_cause: nil)
-      @message = message
-      @status = status
-      @user_message = user_message
-      @errors_cause = errors_cause
-    end
-
-    def self.with_full_messages(active_record_exception)
-      new(active_record_exception.record.errors.full_messages.join(', '))
-    end
-  end
-
-  class OrderParamInvalidError < CartoError
-    def initialize(valid_values)
-      super("Wrong 'order' parameter value. Valid values are one of #{valid_values}", 400)
-    end
-  end
-
-  class UUIDParameterFormatError < CartoError
-    def initialize(parameter:, value:, status: 400)
-      super("Parameter not UUID format. Parameter: #{parameter}. Value: #{value}", status)
-    end
-  end
-
-  class UnauthorizedError < CartoError
-    def initialize(message = "You don't have permission to access that resource", status = 403)
-      super(message, status)
-    end
-  end
-
-  class PasswordConfirmationError < CartoError
-    def initialize(message = "Confirmation password sent does not match your current password", status = 403)
-      super(message, status)
-    end
-  end
-
-  class LoadError < CartoError
-    def initialize(message, status = 404, errors_cause: nil)
-      super(message, status, errors_cause: errors_cause)
-    end
-  end
-
-  class ProtectedVisualizationLoadError < LoadError
-    def initialize(visualization)
-      @visualization = visualization
-      super('Visualization not viewable', 403, errors_cause: 'privacy_password')
-    end
-
-    attr_reader :visualization
-  end
-
-  class UnprocesableEntityError < CartoError
-    def initialize(message, status = 422)
-      super(message, status)
-    end
-  end
-
   module ControllerHelper
     include Carto::UUIDHelper
 

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -11,6 +11,7 @@ module Carto
 
     layout 'frontend'
 
+    before_action :login_required, only: [:consent, :authorize]
     before_action :set_redirection_error_handling, only: [:consent, :authorize]
     before_action :load_oauth_app, :verify_redirect_uri
     before_action :validate_response_type, :validate_scopes, :ensure_state, only: [:consent, :authorize]

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -35,6 +35,8 @@ module Carto
       # redirect_uri
       # client_id
 
+      # TODO: Check that code is recently generated (< 10 min, or even less)
+
       # Out
       # {
       #   "access_token":"87as6das87tdy",

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -19,7 +19,7 @@ module Carto
     before_action :load_oauth_app, :verify_redirect_uri
     before_action :validate_response_type, :validate_scopes, :ensure_state, only: [:consent, :authorize]
     before_action :load_oauth_app_user, only: [:consent, :authorize]
-    before_action :validate_grant_type, :verify_client_secret, :load_authorization , only: [:token]
+    before_action :validate_grant_type, :verify_client_secret, :load_authorization, only: [:token]
 
     rescue_from StandardError, with: :rescue_generic_errors
     rescue_from OauthProvider::Errors::BaseError, with: :rescue_oauth_errors

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -40,7 +40,16 @@ module Carto
     end
 
     def token
-      authorization.exchange!
+      @authorization.exchange!
+
+      response = {
+        access_token: @authorization.api_key.token,
+        token_type: 'bearer'
+        # expires_in: seconds
+        # refresh_token:
+      }
+
+      render(json: response)
       # TODO
       # Input
       # grant_type == authorization_code

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -21,7 +21,8 @@ module Carto
     before_action :load_oauth_app_user, only: [:consent, :authorize]
     before_action :validate_grant_type, :verify_client_secret, :load_authorization, only: [:token]
 
-    rescue_from StandardError, with: :rescue_oauth_errors
+    rescue_from StandardError, with: :rescue_generic_errors
+    rescue_from OauthProvider::Errors::BaseError, with: :rescue_oauth_errors
 
     def consent
       return create_authorization if @oauth_app_user.try(:authorized?, @scopes)
@@ -72,17 +73,10 @@ module Carto
     end
 
     def rescue_oauth_errors(exception)
-      if exception.is_a?(OauthProvider::Errors::BaseError)
-        CartoDB::Logger.debug(message: 'OAuth provider error',
-                              exception: exception,
-                              redirect_on_error: @redirect_on_error,
-                              oauth_app: @oauth_app)
-      else
-        CartoDB::Logger.error(message: 'Unexpected OAuth provider error',
-                              exception: exception,
-                              oauth_app: @oauth_app)
-        exception = OauthProvider::Errors::ServerError.new
-      end
+      CartoDB::Logger.debug(message: 'Oauth provider error',
+                            exception: exception,
+                            redirect_on_error: @redirect_on_error,
+                            oauth_app: @oauth_app)
 
       if @redirect_on_error && @oauth_app
         redirect_to_oauth_app(exception.parameters)
@@ -91,6 +85,11 @@ module Carto
       else
         render json: exception.parameters, status: 400
       end
+    end
+
+    def rescue_generic_errors(exception)
+      CartoDB::Logger.error(exception: exception)
+      rescue_oauth_errors(OauthProvider::Errors::ServerError.new)
     end
 
     def validate_response_type

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -21,6 +21,7 @@ module Carto
     before_action :load_oauth_app_user, only: [:consent, :authorize]
     before_action :validate_grant_type, :load_authorization, :verify_client_secret, only: [:token]
 
+    rescue_from StandardError, with: :rescue_generic_errors
     rescue_from OauthProvider::Errors::BaseError, with: :rescue_oauth_errors
 
     def consent
@@ -84,6 +85,11 @@ module Carto
       else
         render json: exception.parameters, status: 400
       end
+    end
+
+    def rescue_generic_errors(exception)
+      CartoDB::Logger.error(exception: exception)
+      rescue_oauth_errors(OauthProvider::Errors::ServerError.new)
     end
 
     def validate_response_type

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -11,6 +11,9 @@ module Carto
 
     layout 'frontend'
 
+    skip_before_action :ensure_org_url_if_org_user
+    skip_before_action :verify_authenticity_token, only: [:token]
+
     before_action :login_required, only: [:consent, :authorize]
     before_action :set_redirection_error_handling, only: [:consent, :authorize]
     before_action :load_oauth_app, :verify_redirect_uri

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -20,10 +20,11 @@ module Carto
 
     rescue_from OauthProvider::Errors::BaseError, with: :rescue_oauth_errors
 
-    def consent; end
+    def consent
+      return create_authorization if @oauth_app_user.try(:authorized?, @scopes)
+    end
 
     def authorize
-      # TODO
       raise OauthProvider::Errors::AccessDenied.new unless params[:accept]
 
       if @oauth_app_user

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -50,20 +50,6 @@ module Carto
       }
 
       render(json: response)
-      # TODO
-      # Input
-      # grant_type == authorization_code
-      # code =
-      # redirect_uri
-      # client_id
-
-      # TODO: Check that code is recently generated (< 10 min, or even less)
-
-      # Out
-      # {
-      #   "access_token":"87as6das87tdy",
-      #   "token_type":"api_key",
-      # }
     end
 
     private

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -81,8 +81,7 @@ module Carto
     scope :master, -> { where(type: TYPE_MASTER) }
     scope :default_public, -> { where(type: TYPE_DEFAULT_PUBLIC) }
     scope :regular, -> { where(type: TYPE_REGULAR) }
-
-    default_scope { where.not(type: TYPE_INTERNAL) }
+    scope :non_internal, -> { where.not(type: TYPE_INTERNAL) }
 
     attr_accessor :skip_role_setup
 

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -38,8 +38,8 @@ module Carto
     TYPE_REGULAR = 'regular'.freeze
     TYPE_MASTER = 'master'.freeze
     TYPE_DEFAULT_PUBLIC = 'default'.freeze
-    TYPE_INTERNAL = 'internal'.freeze
-    VALID_TYPES = [TYPE_REGULAR, TYPE_MASTER, TYPE_DEFAULT_PUBLIC, TYPE_INTERNAL].freeze
+    TYPE_OAUTH = 'oauth'.freeze
+    VALID_TYPES = [TYPE_REGULAR, TYPE_MASTER, TYPE_DEFAULT_PUBLIC, TYPE_OAUTH].freeze
 
     NAME_MASTER = 'Master'.freeze
     NAME_DEFAULT_PUBLIC = 'Default public'.freeze
@@ -81,7 +81,7 @@ module Carto
     scope :master, -> { where(type: TYPE_MASTER) }
     scope :default_public, -> { where(type: TYPE_DEFAULT_PUBLIC) }
     scope :regular, -> { where(type: TYPE_REGULAR) }
-    scope :non_internal, -> { where.not(type: TYPE_INTERNAL) }
+    scope :user_visible, -> { where(type: [TYPE_MASTER, TYPE_DEFAULT_PUBLIC, TYPE_REGULAR]) }
 
     attr_accessor :skip_role_setup
 
@@ -120,10 +120,10 @@ module Carto
       )
     end
 
-    def self.build_internal_key(user: Carto::User.find(scope_attributes['user_id']), name:, grants:)
+    def self.build_oauth_key(user: Carto::User.find(scope_attributes['user_id']), name:, grants:)
       create!(
         user: user,
-        type: TYPE_INTERNAL,
+        type: TYPE_OAUTH,
         name: name,
         grants: grants
       )
@@ -197,12 +197,12 @@ module Carto
       type == TYPE_REGULAR
     end
 
-    def internal?
-      type == TYPE_INTERNAL
+    def oauth?
+      type == TYPE_OAUTH
     end
 
     def needs_setup?
-      regular? || internal?
+      regular? || oauth?
     end
 
     def valid_name_for_type

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require_dependency 'carto/errors'
 
 class ApiKeyGrantsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -52,7 +52,7 @@ module Carto
     self.inheritance_column = :_type
 
     belongs_to :user
-    has_one :oauth_app_user, inverse_of: :api_key, dependent: :restrict_with_exception
+    has_one :oauth_authorization, inverse_of: :api_key, dependent: :restrict_with_exception
 
     before_create :create_token, if: ->(k) { k.regular? && !k.token }
     before_create :create_db_config, if: ->(k) { k.regular? && !(k.db_role && k.db_password) }

--- a/app/models/carto/oauth_app_user.rb
+++ b/app/models/carto/oauth_app_user.rb
@@ -9,5 +9,13 @@ module Carto
 
     validates :user, presence: true, uniqueness: { scope: :oauth_app }
     validates :oauth_app, presence: true
+
+    def authorized?(requested_scopes)
+      (requested_scopes - scopes).empty?
+    end
+
+    def upgrade!(requested_scopes)
+      update!(scopes: scopes | requested_scopes)
+    end
   end
 end

--- a/app/models/carto/oauth_app_user.rb
+++ b/app/models/carto/oauth_app_user.rb
@@ -5,6 +5,7 @@ module Carto
     belongs_to :user, inverse_of: :oauth_app_users
     belongs_to :oauth_app, inverse_of: :oauth_app_users
     belongs_to :api_key, inverse_of: :oauth_app_user
+    has_many :oauth_authorizations, inverse_of: :oauth_app_users, dependent: :destroy
 
     validates :user, presence: true, uniqueness: { scope: :oauth_app }
     validates :oauth_app, presence: true

--- a/app/models/carto/oauth_app_user.rb
+++ b/app/models/carto/oauth_app_user.rb
@@ -2,8 +2,6 @@
 
 module Carto
   class OauthAppUser < ActiveRecord::Base
-    self.table_name = 'oauth_apps_users'
-
     belongs_to :user, inverse_of: :oauth_app_users
     belongs_to :oauth_app, inverse_of: :oauth_app_users
     belongs_to :api_key, inverse_of: :oauth_app_user

--- a/app/models/carto/oauth_app_user.rb
+++ b/app/models/carto/oauth_app_user.rb
@@ -5,7 +5,7 @@ module Carto
     belongs_to :user, inverse_of: :oauth_app_users
     belongs_to :oauth_app, inverse_of: :oauth_app_users
     belongs_to :api_key, inverse_of: :oauth_app_user
-    has_many :oauth_authorizations, inverse_of: :oauth_app_users, dependent: :destroy
+    has_many :oauth_authorizations, inverse_of: :oauth_app_user, dependent: :destroy
 
     validates :user, presence: true, uniqueness: { scope: :oauth_app }
     validates :oauth_app, presence: true

--- a/app/models/carto/oauth_app_user.rb
+++ b/app/models/carto/oauth_app_user.rb
@@ -8,15 +8,7 @@ module Carto
     belongs_to :oauth_app, inverse_of: :oauth_app_users
     belongs_to :api_key, inverse_of: :oauth_app_user
 
-    validates :user, presence: true
+    validates :user, presence: true, uniqueness: { scope: :oauth_app }
     validates :oauth_app, presence: true
-    validate :code_or_api_key_present
-
-    private
-
-    def code_or_api_key_present
-      # You can have either code if the token is not exchanged yet, or an api_key
-      errors.add(:api_key, 'must be present if code is missing') if code.blank? && api_key.blank?
-    end
   end
 end

--- a/app/models/carto/oauth_authorization.rb
+++ b/app/models/carto/oauth_authorization.rb
@@ -21,7 +21,9 @@ module Carto
       raise OauthProvider::Errors::InvalidGrant.new if expired?
 
       self.code = nil
-      self.api_key = ApiKey.create_regular_key!(name: "_oauth_authorization #{id}", grants: [])
+      self.api_key = oauth_app_user.user.api_keys.create_regular_key!(
+        name: "oauth_authorization #{id}", grants: [{ type: 'apis', apis: [] }]
+      )
       save!
     end
 

--- a/app/models/carto/oauth_authorization.rb
+++ b/app/models/carto/oauth_authorization.rb
@@ -23,13 +23,18 @@ module Carto
       raise OauthProvider::Errors::InvalidGrant.new if expired?
 
       self.code = nil
-      self.api_key = oauth_app_user.user.api_keys.create_regular_key!(
-        name: "oauth_authorization #{id}", grants: [{ type: 'apis', apis: [] }]
-      )
+      self.api_key = build_api_key
       save!
     end
 
     private
+
+    def build_api_key
+      oauth_app_user.user.api_keys.build_internal_key(
+        name: "oauth_authorization #{id}",
+        grants: [{ type: 'apis', apis: [] }]
+      )
+    end
 
     def expired?
       created_at < Time.now - CODE_EXPIRATION_TIME

--- a/app/models/carto/oauth_authorization.rb
+++ b/app/models/carto/oauth_authorization.rb
@@ -1,0 +1,18 @@
+# encoding: utf-8
+
+module Carto
+  class OauthAuthorization < ActiveRecord::Base
+    belongs_to :oauth_app_user, inverse_of: :oauth_authorizations
+    belongs_to :api_key, inverse_of: :oauth_authorization
+
+    validates :oauth_app_user, presence: true
+    validate :code_or_api_key_present
+
+    private
+
+    def code_or_api_key_present
+      # You can have either code if the token is not exchanged yet, or an api_key
+      errors.add(:api_key, 'must be present if code is missing') if code.blank? && api_key.blank?
+    end
+  end
+end

--- a/app/models/carto/oauth_authorization.rb
+++ b/app/models/carto/oauth_authorization.rb
@@ -30,7 +30,7 @@ module Carto
     private
 
     def build_api_key
-      oauth_app_user.user.api_keys.build_internal_key(
+      oauth_app_user.user.api_keys.build_oauth_key(
         name: "oauth_authorization #{id}",
         grants: [{ type: 'apis', apis: [] }]
       )

--- a/app/models/carto/oauth_authorization.rb
+++ b/app/models/carto/oauth_authorization.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require_dependency 'carto/oauth_provider/errors'
+
 module Carto
   class OauthAuthorization < ActiveRecord::Base
     # Multiple of 3 for pretty base64

--- a/app/models/carto/oauth_authorization.rb
+++ b/app/models/carto/oauth_authorization.rb
@@ -2,11 +2,18 @@
 
 module Carto
   class OauthAuthorization < ActiveRecord::Base
+    # Multiple of 3 for pretty base64
+    CODE_RANDOM_BYTES = 12
+
     belongs_to :oauth_app_user, inverse_of: :oauth_authorizations
     belongs_to :api_key, inverse_of: :oauth_authorization
 
     validates :oauth_app_user, presence: true
     validate :code_or_api_key_present
+
+    def self.create_with_code!
+      create!(code: SecureRandom.urlsafe_base64(CODE_RANDOM_BYTES))
+    end
 
     private
 

--- a/app/views/carto/oauth_provider/consent.html.erb
+++ b/app/views/carto/oauth_provider/consent.html.erb
@@ -8,9 +8,3 @@ Authorize?
 <%= submit_tag 'Cancel' %>
 <%= submit_tag 'Accept', name: 'accept' %>
 <% end %>
-
-      #   response_type code
-      #   client_id findApp
-      #   redirect_uri (optional)
-      #   scope (optional)
-      #   state

--- a/app/views/carto/oauth_provider/consent.html.erb
+++ b/app/views/carto/oauth_provider/consent.html.erb
@@ -1,6 +1,6 @@
 Authorize?
 
-<%= form_tag(oauth2_authorize_url, method: :post) do %>
+<%= form_tag(CartoDB.url(self, :oauth2_authorize, {}, current_user), method: :post) do %>
 <%= hidden_field_tag 'response_type', @response_type %>
 <%= hidden_field_tag 'client_id', @oauth_app.client_id %>
 <%= hidden_field_tag 'scope', @scopes.join(' ') %>

--- a/db/migrate/20180719125312_create_oauth_apps_users.rb
+++ b/db/migrate/20180719125312_create_oauth_apps_users.rb
@@ -4,7 +4,7 @@ include Carto::Db::MigrationHelper
 
 migration(
   Proc.new do
-    create_table :oauth_apps_users do
+    create_table :oauth_app_users do
       Uuid        :id, primary_key: true, default: 'uuid_generate_v4()'.lit
       foreign_key :oauth_app_id, :oauth_apps, type: :uuid, null: false, index: true, on_delete: :cascade
       foreign_key :user_id, :users, type: :uuid, null: false, index: true, on_delete: :cascade
@@ -15,6 +15,6 @@ migration(
     end
   end,
   Proc.new do
-    drop_table :oauth_apps_users
+    drop_table :oauth_app_users
   end
 )

--- a/db/migrate/20180719125312_create_oauth_apps_users.rb
+++ b/db/migrate/20180719125312_create_oauth_apps_users.rb
@@ -8,11 +8,10 @@ migration(
       Uuid        :id, primary_key: true, default: 'uuid_generate_v4()'.lit
       foreign_key :oauth_app_id, :oauth_apps, type: :uuid, null: false, index: true, on_delete: :cascade
       foreign_key :user_id, :users, type: :uuid, null: false, index: true, on_delete: :cascade
-      foreign_key :api_key_id, :api_keys, type: :uuid, null: true, index: true, on_delete: :restrict
       column      :scopes, 'text[]', null: false, default: "'{}'".lit
-      String      :code, null: true, index: { where: 'code IS NOT NULL' }
       DateTime    :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
       DateTime    :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      unique      [:oauth_app_id, :user_id]
     end
   end,
   Proc.new do

--- a/db/migrate/20180727174523_create_oauth_authorizations.rb
+++ b/db/migrate/20180727174523_create_oauth_authorizations.rb
@@ -1,0 +1,21 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  Proc.new do
+    create_table :oauth_authorizations do
+      Uuid        :id, primary_key: true, default: 'uuid_generate_v4()'.lit
+      foreign_key :oauth_app_user_id, :oauth_apps_users, type: :uuid, null: false, index: true, on_delete: :cascade
+      foreign_key :api_key_id, :api_keys, type: :uuid, null: true, on_delete: :restrict,
+                                          index: { where: 'api_key_id IS NOT NULL', unique: true }
+      column      :scopes, 'text[]', null: false, default: "'{}'".lit
+      String      :code, null: true, index: { where: 'code IS NOT NULL' }
+      DateTime    :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      DateTime    :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+    end
+  end,
+  Proc.new do
+    drop_table :oauth_authorizations
+  end
+)

--- a/db/migrate/20180727174523_create_oauth_authorizations.rb
+++ b/db/migrate/20180727174523_create_oauth_authorizations.rb
@@ -6,7 +6,7 @@ migration(
   Proc.new do
     create_table :oauth_authorizations do
       Uuid        :id, primary_key: true, default: 'uuid_generate_v4()'.lit
-      foreign_key :oauth_app_user_id, :oauth_apps_users, type: :uuid, null: false, index: true, on_delete: :cascade
+      foreign_key :oauth_app_user_id, :oauth_app_users, type: :uuid, null: false, index: true, on_delete: :cascade
       foreign_key :api_key_id, :api_keys, type: :uuid, null: true, on_delete: :restrict,
                                           index: { where: 'api_key_id IS NOT NULL', unique: true }
       column      :scopes, 'text[]', null: false, default: "'{}'".lit

--- a/lib/carto/errors.rb
+++ b/lib/carto/errors.rb
@@ -1,0 +1,61 @@
+module Carto
+  class CartoError < StandardError
+    attr_reader :message, :status, :user_message, :errors_cause
+
+    def initialize(message, status, user_message: message, errors_cause: nil)
+      @message = message
+      @status = status
+      @user_message = user_message
+      @errors_cause = errors_cause
+    end
+
+    def self.with_full_messages(active_record_exception)
+      new(active_record_exception.record.errors.full_messages.join(', '))
+    end
+  end
+
+  class OrderParamInvalidError < CartoError
+    def initialize(valid_values)
+      super("Wrong 'order' parameter value. Valid values are one of #{valid_values}", 400)
+    end
+  end
+
+  class UUIDParameterFormatError < CartoError
+    def initialize(parameter:, value:, status: 400)
+      super("Parameter not UUID format. Parameter: #{parameter}. Value: #{value}", status)
+    end
+  end
+
+  class UnauthorizedError < CartoError
+    def initialize(message = "You don't have permission to access that resource", status = 403)
+      super(message, status)
+    end
+  end
+
+  class PasswordConfirmationError < CartoError
+    def initialize(message = "Confirmation password sent does not match your current password", status = 403)
+      super(message, status)
+    end
+  end
+
+  class LoadError < CartoError
+    def initialize(message, status = 404, errors_cause: nil)
+      super(message, status, errors_cause: errors_cause)
+    end
+  end
+
+  class ProtectedVisualizationLoadError < LoadError
+    def initialize(visualization)
+      @visualization = visualization
+      super('Visualization not viewable', 403, errors_cause: 'privacy_password')
+    end
+
+    attr_reader :visualization
+  end
+
+  class UnprocesableEntityError < CartoError
+    def initialize(message, status = 422)
+      super(message, status)
+    end
+  end
+end

--- a/lib/carto/oauth_provider/errors.rb
+++ b/lib/carto/oauth_provider/errors.rb
@@ -58,6 +58,12 @@ module Carto
           super('invalid_grant', 'Provided code is not valid or has expired')
         end
       end
+
+      class InvalidClient < BaseError
+        def initialize
+          super('invalid_client', 'Invalid client ID or secret')
+        end
+      end
     end
   end
 end

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -491,7 +491,7 @@ module CartoDB
       end
 
       def grant_user_api_key_roles(user_id)
-        Carto::User.find(user_id).api_keys.select(&:regular?).each do |k|
+        Carto::User.find(user_id).api_keys.select(&:needs_setup?).each do |k|
           k.role_permission_queries.each { |q| superuser_user_pg_conn.query(q) }
         end
       end

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -17,10 +17,10 @@ FactoryGirl.define do
               apis: ["sql", "maps"] }]
   end
 
-  factory :internal_api_key, class: Carto::ApiKey do
+  factory :oauth_api_key, class: Carto::ApiKey do
     initialize_with { Carto::ApiKey.send :new }
 
-    type Carto::ApiKey::TYPE_INTERNAL
+    type Carto::ApiKey::TYPE_OAUTH
     name { unique_name('internal api key') }
     grants [{ type: "apis", apis: [] }]
   end

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -16,4 +16,12 @@ FactoryGirl.define do
     grants [{ type: "apis",
               apis: ["sql", "maps"] }]
   end
+
+  factory :internal_api_key, class: Carto::ApiKey do
+    initialize_with { Carto::ApiKey.send :new }
+
+    type Carto::ApiKey::TYPE_INTERNAL
+    name { unique_name('internal api key') }
+    grants [{ type: "apis", apis: [] }]
+  end
 end

--- a/spec/factories/oauth_apps.rb
+++ b/spec/factories/oauth_apps.rb
@@ -1,5 +1,3 @@
-require_relative '../../app/models/carto/widget'
-
 FactoryGirl.define do
   factory :oauth_app, class: Carto::OauthApp do
     to_create(&:save!)

--- a/spec/factories/oauth_apps.rb
+++ b/spec/factories/oauth_apps.rb
@@ -2,6 +2,8 @@ require_relative '../../app/models/carto/widget'
 
 FactoryGirl.define do
   factory :oauth_app, class: Carto::OauthApp do
+    to_create(&:save!)
+
     name { unique_name('Oauth application') }
     redirect_uri 'https://redirect.uri'
   end

--- a/spec/models/carto/oauth_app_user_spec.rb
+++ b/spec/models/carto/oauth_app_user_spec.rb
@@ -43,5 +43,18 @@ module Carto
         expect(app_user).to(be_valid)
       end
     end
+
+    describe '#authorized?' do
+      it 'is authorized only if all requested scopes are already granted' do
+        oau = OauthAppUser.new(scopes: ['allowed_1', 'allowed_2'])
+
+        expect(oau).to(be_authorized(['allowed_1']))
+        expect(oau).to(be_authorized(['allowed_2']))
+        expect(oau).to(be_authorized(['allowed_1', 'allowed_2']))
+
+        expect(oau).not_to(be_authorized(['not_allowed']))
+        expect(oau).not_to(be_authorized(['allowed_1', 'not_allowed']))
+      end
+    end
   end
 end

--- a/spec/models/carto/oauth_app_user_spec.rb
+++ b/spec/models/carto/oauth_app_user_spec.rb
@@ -10,6 +10,11 @@ module Carto
         @app = FactoryGirl.create(:oauth_app, user: @user)
       end
 
+      after(:all) do
+        @user.destroy
+        @app.destroy
+      end
+
       it 'requires user' do
         app_user = OauthAppUser.new
         expect(app_user).to_not(be_valid)

--- a/spec/models/carto/oauth_authorization_spec.rb
+++ b/spec/models/carto/oauth_authorization_spec.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+require 'spec_helper_min'
+
+module Carto
+  describe OauthAuthorization do
+    describe '#validation' do
+      before(:all) do
+        @user = FactoryGirl.build(:carto_user)
+        @app = FactoryGirl.build(:oauth_app, user: @user)
+        @app_user = OauthAppUser.new(user: @user, oauth_app: @app)
+      end
+
+      it 'requires code or api_key' do
+        authorization = OauthAuthorization.new
+        expect(authorization).to_not(be_valid)
+        expect(authorization.errors[:api_key]).to(include("must be present if code is missing"))
+
+        authorization.code = ''
+        expect(authorization).to_not(be_valid)
+        expect(authorization.errors[:api_key]).to(include("must be present if code is missing"))
+      end
+
+      it 'validates with api_key' do
+        authorization = OauthAuthorization.new(oauth_app_user: @app_user, api_key: @api_key)
+        expect(authorization).to(be_valid)
+      end
+
+      it 'validates with code' do
+        authorization = OauthAuthorization.new(oauth_app_user: @app_user, code: 'wadus')
+        expect(authorization).to(be_valid)
+      end
+    end
+  end
+end

--- a/spec/models/carto/oauth_authorization_spec.rb
+++ b/spec/models/carto/oauth_authorization_spec.rb
@@ -8,6 +8,7 @@ module Carto
       before(:all) do
         @user = FactoryGirl.build(:carto_user)
         @app = FactoryGirl.build(:oauth_app, user: @user)
+        @api_key = FactoryGirl.build(:master_api_key, user: @user)
         @app_user = OauthAppUser.new(user: @user, oauth_app: @app)
       end
 

--- a/spec/models/carto/oauth_authorization_spec.rb
+++ b/spec/models/carto/oauth_authorization_spec.rb
@@ -65,7 +65,7 @@ module Carto
         @authorization.exchange!
         expect(@authorization.code).to(be_nil)
         expect(@authorization.api_key).to(be)
-        expect(@authorization.api_key.type).to(eq('internal'))
+        expect(@authorization.api_key.type).to(eq('oauth'))
       end
     end
   end

--- a/spec/models/carto/oauth_authorization_spec.rb
+++ b/spec/models/carto/oauth_authorization_spec.rb
@@ -65,6 +65,7 @@ module Carto
         @authorization.exchange!
         expect(@authorization.code).to(be_nil)
         expect(@authorization.api_key).to(be)
+        expect(@authorization.api_key.type).to(eq('internal'))
       end
     end
   end

--- a/spec/requests/carto/api/api_keys_controller_spec.rb
+++ b/spec/requests/carto/api/api_keys_controller_spec.rb
@@ -448,6 +448,15 @@ describe Carto::Api::ApiKeysController do
         end
       end
 
+      it 'returns 404 for internal api keys' do
+        api_key = FactoryGirl.create(:internal_api_key, user_id: @user.id)
+        auth_user(@carto_user)
+        get_json api_key_url(id: api_key.name), auth_params, auth_headers do |response|
+          response.status.should eq 404
+        end
+        api_key.destroy
+      end
+
       it 'returns 404 if the API key does not belong to the user' do
         api_key = FactoryGirl.create(:api_key_apis, user_id: @user.id)
         auth_user(@other_user)

--- a/spec/requests/carto/api/api_keys_controller_spec.rb
+++ b/spec/requests/carto/api/api_keys_controller_spec.rb
@@ -465,6 +465,14 @@ describe Carto::Api::ApiKeysController do
 
         @apikeys = @carto_user_index.api_keys.order(:updated_at).all.to_a
         3.times { @apikeys << FactoryGirl.create(:api_key_apis, user_id: @user_index.id) }
+        @apikeys << FactoryGirl.create(:internal_api_key, user_id: @user_index.id)
+      end
+
+      it 'does not include internal keys' do
+        auth_user(@carto_user_index)
+        get_json api_keys_url, auth_params.merge(per_page: 20), auth_headers do |response|
+          expect(response.body[:result].map { |ak| ak[:type] }).not_to(include('internal'))
+        end
       end
 
       it 'paginates correctly' do

--- a/spec/requests/carto/api/api_keys_controller_spec.rb
+++ b/spec/requests/carto/api/api_keys_controller_spec.rb
@@ -449,7 +449,7 @@ describe Carto::Api::ApiKeysController do
       end
 
       it 'returns 404 for internal api keys' do
-        api_key = FactoryGirl.create(:internal_api_key, user_id: @user.id)
+        api_key = FactoryGirl.create(:oauth_api_key, user_id: @user.id)
         auth_user(@carto_user)
         get_json api_key_url(id: api_key.name), auth_params, auth_headers do |response|
           response.status.should eq 404
@@ -474,7 +474,7 @@ describe Carto::Api::ApiKeysController do
 
         @apikeys = @carto_user_index.api_keys.order(:updated_at).all.to_a
         3.times { @apikeys << FactoryGirl.create(:api_key_apis, user_id: @user_index.id) }
-        @apikeys << FactoryGirl.create(:internal_api_key, user_id: @user_index.id)
+        @apikeys << FactoryGirl.create(:oauth_api_key, user_id: @user_index.id)
       end
 
       it 'does not include internal keys' do

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -262,7 +262,11 @@ describe Carto::OauthProviderController do
       # Login
       login_as(@user, scope: @user.username)
       base_uri = "http://#{@user.username}.localhost.lan"
-      visit "#{base_uri}/login"
+      begin
+        visit "#{base_uri}/login"
+      rescue ActionView::MissingTemplate
+        # Expected error trying to load dashboard statics
+      end
 
       # Request authorization
       state = '123qweasdzxc'

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -22,7 +22,8 @@ describe Carto::OauthProviderController do
   end
 
   before(:each) do
-    login_as(@user)
+    login_as(@user, scope: @user.username)
+    host!("#{@user.username}.localhost.lan")
   end
 
   describe '#consent' do

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -26,13 +26,64 @@ describe Carto::OauthProviderController do
     host!("#{@user.username}.localhost.lan")
   end
 
+  let(:valid_payload) do
+    {
+      client_id: @oauth_app.client_id,
+      response_type: 'code',
+      state: 'random_state_thingy',
+      accept: true
+    }
+  end
+
+  shared_examples_for 'authorization parameter validation' do
+    it 'returns a 404 error if application cannot be found' do
+      request_endpoint(valid_payload.merge(client_id: 'e'))
+
+      expect(response.status).to(eq(404))
+    end
+
+    it 'redirects with an error if invalid response_type' do
+      request_endpoint(valid_payload.merge(response_type: 'err'))
+
+      expect(response.status).to(eq(302))
+      expect(response.location).to(start_with(@oauth_app.redirect_uri))
+      expect(Addressable::URI.parse(response.location).query_values['error']).to(eq('unsupported_response_type'))
+    end
+
+    it 'redirects with an error if missing state' do
+      request_endpoint(valid_payload.merge(state: ''))
+
+      expect(response.status).to(eq(302))
+      expect(response.location).to(start_with(@oauth_app.redirect_uri))
+      qs = Addressable::URI.parse(response.location).query_values
+      expect(qs['error']).to(eq('invalid_request'))
+      expect(qs['error_description']).to(eq('state is mandatory'))
+    end
+
+    it 'redirects with an error if requesting unknown scopes' do
+      request_endpoint(valid_payload.merge(scope: 'invalid wadus'))
+
+      expect(response.status).to(eq(302))
+      expect(response.location).to(start_with(@oauth_app.redirect_uri))
+      expect(Addressable::URI.parse(response.location).query_values['error']).to(eq('invalid_scope'))
+    end
+
+    it 'redirects with an error if requesting with an invalid redirect_uri' do
+      request_endpoint(valid_payload.merge(redirect_uri: 'invalid'))
+
+      expect(response.status).to(eq(302))
+      expect(response.location).to(start_with(@oauth_app.redirect_uri))
+      qs = Addressable::URI.parse(response.location).query_values
+      expect(qs['error']).to(eq('invalid_request'))
+      expect(qs['error_description']).to(eq('The redirect_uri is not authorized for this application'))
+    end
+  end
+
   describe '#consent' do
-    let(:valid_payload) do
-      {
-        client_id: @oauth_app.client_id,
-        response_type: 'code',
-        state: 'random_state_thingy'
-      }
+    it_behaves_like 'authorization parameter validation' do
+      def request_endpoint(parameters)
+        get oauth_provider_authorize_url(parameters)
+      end
     end
 
     it 'logged out, redirects to login' do
@@ -43,54 +94,40 @@ describe Carto::OauthProviderController do
       expect(response.location).to(include('/login'))
     end
 
-    it 'shows the consent form' do
+    it 'with valid payload, shows the consent form' do
       get oauth_provider_authorize_url(valid_payload)
 
       expect(response.status).to(eq(200))
       expect(response.body).to(include(valid_payload[:client_id]))
       expect(response.body).to(include(valid_payload[:state]))
     end
+  end
 
-    it 'returns a 404 error if application cannot be found' do
-      get oauth_provider_authorize_url(valid_payload.merge(client_id: 'e'))
-
-      expect(response.status).to(eq(404))
+  describe '#authorize' do
+    it_behaves_like 'authorization parameter validation' do
+      def request_endpoint(parameters)
+        post oauth_provider_authorize_url(parameters)
+      end
     end
 
-    it 'redirects with an error if invalid response_type' do
-      get oauth_provider_authorize_url(valid_payload.merge(response_type: 'err'))
+    it 'logged out, redirects to login' do
+      logout
+      post oauth_provider_authorize_url(valid_payload)
 
       expect(response.status).to(eq(302))
-      expect(response.location).to(start_with(@oauth_app.redirect_uri))
-      expect(Addressable::URI.parse(response.location).query_values['error']).to(eq('unsupported_response_type'))
+      expect(response.location).to(include('/login'))
     end
 
-    it 'redirects with an error if missing state' do
-      get oauth_provider_authorize_url(valid_payload.merge(state: ''))
+    it 'with valid payload, creates an authorization and redirects back to the application with a code' do
+      post oauth_provider_authorize_url(valid_payload)
+
+      authorization = @oauth_app.oauth_app_users.find_by_user_id!(@user.id).oauth_authorizations.first
+      expect(authorization).to(be)
+      expect(authorization.code).to(be_present)
+      expect(authorization.api_key).not_to(be)
 
       expect(response.status).to(eq(302))
-      expect(response.location).to(start_with(@oauth_app.redirect_uri))
-      qs = Addressable::URI.parse(response.location).query_values
-      expect(qs['error']).to(eq('invalid_request'))
-      expect(qs['error_description']).to(eq('state is mandatory'))
-    end
-
-    it 'redirects with an error if requesting unknown scopes' do
-      get oauth_provider_authorize_url(valid_payload.merge(scope: 'invalid wadus'))
-
-      expect(response.status).to(eq(302))
-      expect(response.location).to(start_with(@oauth_app.redirect_uri))
-      expect(Addressable::URI.parse(response.location).query_values['error']).to(eq('invalid_scope'))
-    end
-
-    it 'redirects with an error if requesting with an invalid redirect_uri' do
-      get oauth_provider_authorize_url(valid_payload.merge(redirect_uri: 'invalid'))
-
-      expect(response.status).to(eq(302))
-      expect(response.location).to(start_with(@oauth_app.redirect_uri))
-      qs = Addressable::URI.parse(response.location).query_values
-      expect(qs['error']).to(eq('invalid_request'))
-      expect(qs['error_description']).to(eq('The redirect_uri is not authorized for this application'))
+      expect(Addressable::URI.parse(response.location).query_values['code']).to(eq(authorization.code))
     end
   end
 end

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -35,6 +35,14 @@ describe Carto::OauthProviderController do
       }
     end
 
+    it 'logged out, redirects to login' do
+      logout
+      get oauth_provider_authorize_url(valid_payload)
+
+      expect(response.status).to(eq(302))
+      expect(response.location).to(include('/login'))
+    end
+
     it 'shows the consent form' do
       get oauth_provider_authorize_url(valid_payload)
 

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -178,10 +178,7 @@ describe Carto::OauthProviderController do
         expect(@authorization.api_key).to(be)
 
         expect(response.status).to(eq(200))
-        expect(response.body).to(eq({
-          access_token: @authorization.api_key.token,
-          token_type: "bearer"
-        }))
+        expect(response.body).to(eq(access_token: @authorization.api_key.token, token_type: "bearer"))
       end
     end
 

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -241,5 +241,16 @@ describe Carto::OauthProviderController do
         expect(response.body[:error]).to(eq('unsupported_grant_type'))
       end
     end
+
+    it 'with invalid redirect_uri, returns error without creating the api key' do
+      post_json oauth_provider_token_url(token_payload.merge(redirect_uri: 'invalid')) do |response|
+        @authorization.reload
+        expect(@authorization.code).to(be)
+        expect(@authorization.api_key).to(be_nil)
+
+        expect(response.status).to(eq(400))
+        expect(response.body[:error]).to(eq('invalid_request'))
+      end
+    end
   end
 end

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -250,4 +250,47 @@ describe Carto::OauthProviderController do
       end
     end
   end
+
+  describe '#acceptance' do
+    include Capybara::DSL
+
+    it 'following the oauth flow produces a valid API Key' do
+      # Since Capybara+rack passes all requests to the local server, we set a redirect URI inside localhost
+      redirect_uri = "https://#{@user.username}.localhost.lan/redirect"
+      @oauth_app.update!(redirect_uri: redirect_uri)
+
+      # Login
+      login_as(@user, scope: @user.username)
+      base_uri = "http://#{@user.username}.localhost.lan"
+      visit "#{base_uri}/login"
+
+      # Request authorization
+      state = '123qweasdzxc'
+      visit "#{base_uri}/oauth2/authorize?client_id=#{@oauth_app.client_id}&state=#{state}&response_type=code"
+
+      begin
+        click_on 'Accept'
+      rescue ActionController::RoutingError
+        # Expected error since /redirect is a made up URL
+      end
+
+      response_parameters = Addressable::URI.parse(current_url).query_values
+      expect(response_parameters['state']).to(eq(state))
+      code = response_parameters['code']
+
+      # Exchange token for API Key
+      payload = {
+        client_id: @oauth_app.client_id,
+        client_secret: @oauth_app.client_secret,
+        grant_type: 'authorization_code',
+        code: code
+      }
+      api_key = post_json oauth_provider_token_url(payload) do |response|
+        expect(response.status).to(eq(200))
+        response.body[:access_token]
+      end
+
+      # TODO: Try to use API Key, must implement some scopes first
+    end
+  end
 end

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -101,6 +101,19 @@ describe Carto::OauthProviderController do
       expect(response.body).to(include(valid_payload[:client_id]))
       expect(response.body).to(include(valid_payload[:state]))
     end
+
+    it 'with valid payload, and pre-authorized, redirects back to the application' do
+      oau = @oauth_app.oauth_app_users.create!(user_id: @user.id)
+      get oauth_provider_authorize_url(valid_payload)
+
+      authorization = oau.oauth_authorizations.first
+      expect(authorization).to(be)
+      expect(authorization.code).to(be_present)
+      expect(authorization.api_key).not_to(be)
+
+      expect(response.status).to(eq(302))
+      expect(Addressable::URI.parse(response.location).query_values['code']).to(eq(authorization.code))
+    end
   end
 
   describe '#authorize' do

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -114,6 +114,8 @@ describe Carto::OauthProviderController do
       expect(response.status).to(eq(302))
       expect(Addressable::URI.parse(response.location).query_values['code']).to(eq(authorization.code))
     end
+
+    # TODO: Do not auto-consent if requesting more scopes
   end
 
   describe '#authorize' do
@@ -142,5 +144,7 @@ describe Carto::OauthProviderController do
       expect(response.status).to(eq(302))
       expect(Addressable::URI.parse(response.location).query_values['code']).to(eq(authorization.code))
     end
+
+    # TODO: Upgrade oauth_app_user if requesting more scopes
   end
 end


### PR DESCRIPTION
1. Data model changes:
   - Rename `oauth_apps_users` table to `oauth_app_users`. Removes an override from Rails
   - Split `oauth_authorizations` from `oauth_apps_users` since you can have multiple tokens per (app, user)
   - Ensure single `oauth_apps_users` entry per (user, app)
2. New features
   - Create authorization with code
   - Exchange code for api key
   - API Key creation, with no permissions for now (scope implementation is pending)
3. Other changes
   - Move errors to a separate file. APIKey model was relying in controller helper exceptions directly.
   - New type for API Keys (internal) that is hidden from Auth API

With this, we should be able to do acceptance of the complete Oauth flow and merge to master. Still lots to do in the project, but this should cover the basics.