### PR TITLE
Fix color legends allowed for boolean attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancement
+* Fix legend for style by boolean field (https://github.com/CartoDB/support/issues/1647)
 * Fix disconnect from external data sources (gdrive, box and dropbox) for organization users (https://github.com/CartoDB/support/issues/1671)
 * Fix broken data tab when analyses or custom SQL are present (https://github.com/CartoDB/cartodb/issues/14169)
 * Don't render geometry columns that are not the_geom (https://github.com/CartoDB/support/issues/1404)

--- a/lib/assets/javascripts/builder/data/layer-definition-model.js
+++ b/lib/assets/javascripts/builder/data/layer-definition-model.js
@@ -200,8 +200,8 @@ module.exports = Backbone.Model.extend({
 
   getName: function () {
     return this.get('name') ||
-    this.get('table_name_alias') ||
-    this.get('table_name');
+      this.get('table_name_alias') ||
+      this.get('table_name');
   },
 
   getTableName: function () {
@@ -301,6 +301,11 @@ module.exports = Backbone.Model.extend({
     return this.get('type') === 'torque';
   },
 
+  isAutoStyleApplied: function () {
+    var autoStyle = this.get('autoStyle');
+    return (autoStyle != null && autoStyle !== false);
+  },
+
   _canBeFoldedUnderAnotherLayer: function () {
     var thisNodeDefModel = this.getAnalysisDefinitionNodeModel();
 
@@ -375,7 +380,7 @@ module.exports = Backbone.Model.extend({
     if (layerTypesAndKinds.isGMapsBase(otherAttrs.type)) {
       return this.get('name') === otherAttrs.name &&
         this.get('baseType') === otherAttrs.baseType &&
-          this.get('style') === otherAttrs.style;
+        this.get('style') === otherAttrs.style;
     }
 
     if (layerTypesAndKinds.isPlainType(otherAttrs.type)) {

--- a/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
@@ -1,114 +1,140 @@
 var _ = require('underscore');
 var LegendFactory = require('builder/editor/layers/layer-content-views/legend/legend-factory');
 var LegendColorHelper = require('builder/editor/layers/layer-content-views/legend/form/legend-color-helper');
+var LegendTypes = require('builder/editor/layers/layer-content-views/legend/legend-types');
+
 var StyleHelper = require('builder/helpers/style');
 var DEFAULT_BUBBLES_COLOR = '#999999';
 
-var onChange = function (layerDefModel) {
-  var styleModel = layerDefModel.styleModel;
-  var autoStyle = layerDefModel.get('autoStyle');
-  var isAutoStyleApplied = autoStyle != null && autoStyle !== false;
-  var color;
-  var size;
-
-  function createColorLegend (layerDefModel, color) {
-    var styleModel = layerDefModel.styleModel;
-
-    if (styleModel.get('type') === 'animation') {
-      LegendFactory.removeLegend(layerDefModel, 'category', function () {
-        LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-          LegendFactory.removeLegend(layerDefModel, 'custom_choropleth', function () {
-            var items = StyleHelper.getStyleCategories(styleModel);
-            LegendFactory.createLegend(layerDefModel, 'torque', {title: color.attribute, items: items});
-          });
+function _createLegendForAnimation (layerDefModel, color) {
+  LegendFactory.removeLegend(layerDefModel, LegendTypes.CATEGORY, function () {
+    LegendFactory.removeLegend(layerDefModel, LegendTypes.CHOROPLETH, function () {
+      LegendFactory.removeLegend(layerDefModel, LegendTypes.CUSTOM_CHOROPLETH, function () {
+        var items = StyleHelper.getStyleCategories(layerDefModel.styleModel);
+        LegendFactory.createLegend(layerDefModel, LegendTypes.TORQUE, {
+          title: color.attribute,
+          items: items
         });
       });
-    } else if (styleModel.get('type') === 'heatmap') {
-      LegendFactory.removeLegend(layerDefModel, 'category', function () {
-        LegendFactory.removeLegend(layerDefModel, 'torque', function () {
-          LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-            var colors = StyleHelper.getColorsFromRange(styleModel);
-            LegendFactory.createLegend(layerDefModel, 'custom_choropleth', {
-              title: _t('editor.legend.pixel-title'),
-              colors: colors
-            });
-          });
+    });
+  });
+}
+
+function _createLegendForHeatmap (layerDefModel) {
+  LegendFactory.removeLegend(layerDefModel, LegendTypes.CATEGORY, function () {
+    LegendFactory.removeLegend(layerDefModel, LegendTypes.TORQUE, function () {
+      LegendFactory.removeLegend(layerDefModel, LegendTypes.CHOROPLETH, function () {
+        var colors = StyleHelper.getColorsFromRange(layerDefModel.styleModel);
+        LegendFactory.createLegend(layerDefModel, LegendTypes.CUSTOM_CHOROPLETH, {
+          title: _t('editor.legend.pixel-title'),
+          colors: colors
         });
       });
-    } else {
-      if ((color.attribute_type && color.attribute_type === 'string') || color.quantification === 'category') {
-        LegendFactory.removeLegend(layerDefModel, 'choropleth', function () {
-          LegendFactory.removeLegend(layerDefModel, 'custom_choropleth', function () {
-            if (!isAutoStyleApplied) {
-              LegendFactory.createLegend(layerDefModel, 'category', {title: color.attribute});
-            } else {
-              LegendFactory.removeLegend(layerDefModel, 'category');
-            }
-          });
-        });
+    });
+  });
+}
+
+function _createCategoryLegend (layerDefModel, color) {
+  LegendFactory.removeLegend(layerDefModel, LegendTypes.CHOROPLETH, function () {
+    LegendFactory.removeLegend(layerDefModel, LegendTypes.CUSTOM_CHOROPLETH, function () {
+      if (layerDefModel.isAutoStyleApplied()) {
+        LegendFactory.removeLegend(layerDefModel, LegendTypes.CATEGORY);
       } else {
-        LegendFactory.removeLegend(layerDefModel, 'category', function () {
-          LegendFactory.removeLegend(layerDefModel, 'torque', function () {
-            LegendFactory.removeLegend(layerDefModel, 'custom_choropleth', function () {
-              if (!isAutoStyleApplied) {
-                LegendFactory.createLegend(layerDefModel, 'choropleth', {title: color.attribute});
-              } else {
-                LegendFactory.removeLegend(layerDefModel, 'choropleth');
-              }
-            });
-          });
-        });
+        LegendFactory.createLegend(layerDefModel, LegendTypes.CATEGORY, { title: color.attribute });
       }
+    });
+  });
+}
+
+function _createChoroplethLegend (layerDefModel, color) {
+  LegendFactory.removeLegend(layerDefModel, LegendTypes.CATEGORY, function () {
+    LegendFactory.removeLegend(layerDefModel, LegendTypes.TORQUE, function () {
+      LegendFactory.removeLegend(layerDefModel, LegendTypes.CUSTOM_CHOROPLETH, function () {
+        if (layerDefModel.isAutoStyleApplied()) {
+          LegendFactory.removeLegend(layerDefModel, LegendTypes.CHOROPLETH);
+        } else {
+          LegendFactory.createLegend(layerDefModel, LegendTypes.CHOROPLETH, { title: color.attribute });
+        }
+      });
+    });
+  });
+}
+
+function _createColorLegend (layerDefModel, color) {
+  var styleModel = layerDefModel.styleModel;
+
+  if (styleModel.isAnimation()) {
+    _createLegendForAnimation(layerDefModel, color);
+  } else if (styleModel.isHeatmap()) {
+    _createLegendForHeatmap(layerDefModel);
+  } else {
+    var attributeTypeIsString = (color.attribute_type && color.attribute_type === 'string');
+    var usesCategory = (color && color.quantification === 'category');
+
+    if (attributeTypeIsString || usesCategory) {
+      _createCategoryLegend(layerDefModel, color);
+    } else {
+      _createChoroplethLegend(layerDefModel, color);
     }
   }
+}
 
-  color = StyleHelper.getColor(styleModel);
-  size = StyleHelper.getSize(styleModel);
+function _updateSizeLegend (layerDefModel, size, color) {
+  if (size && size.attribute !== undefined) {
+    var attrs = { title: size.attribute };
+
+    if (!layerDefModel.isAutoStyleApplied()) {
+      // Do not apply the fill color of an autostyle ramp
+      attrs.fillColor = color && (color.fixed || color.range)
+        ? LegendColorHelper.getBubbles(color).color.fixed
+        : DEFAULT_BUBBLES_COLOR;
+    }
+
+    var hasBubbleLegend = LegendFactory.find(layerDefModel, LegendTypes.BUBBLE);
+    if (hasBubbleLegend) {
+      LegendFactory.createLegend(layerDefModel, LegendTypes.BUBBLE, attrs);
+    }
+  } else {
+    LegendFactory.removeLegend(layerDefModel, LegendTypes.BUBBLE);
+  }
+}
+
+function _updateColorLegend (layerDefModel, color) {
+  var colorLegendTypes = [LegendTypes.CATEGORY, LegendTypes.TORQUE, LegendTypes.CHOROPLETH, LegendTypes.CUSTOM_CHOROPLETH];
+
+  if (color && color.attribute !== undefined) {
+    var hasSomeLegend = [];
+
+    _.each(colorLegendTypes, function (legendType) {
+      var hasLegend = LegendFactory.find(layerDefModel, legendType);
+      if (hasLegend) {
+        hasSomeLegend.push(hasLegend);
+      }
+    });
+
+    var hasCustomLegend = LegendFactory.find(layerDefModel, LegendTypes.CUSTOM);
+    if (!hasCustomLegend && hasSomeLegend.length) {
+      _createColorLegend(layerDefModel, color);
+    }
+  } else {
+    _.each(colorLegendTypes, function (legendType) {
+      LegendFactory.removeLegend(layerDefModel, legendType);
+    });
+  }
+}
+
+var onChange = function (layerDefModel) {
+  var color = StyleHelper.getColor(layerDefModel.styleModel);
+  var size = StyleHelper.getSize(layerDefModel.styleModel);
 
   if (color == null && size == null) return;
 
   if (LegendFactory.isEnabledType('size')) {
-    if (size && size.attribute !== undefined) {
-      var attrs = { title: size.attribute };
-
-      if (!isAutoStyleApplied) {
-        // Do not apply the fill color of an autostyle ramp
-        attrs.fillColor = color && (color.fixed || color.range)
-          ? LegendColorHelper.getBubbles(color).color.fixed
-          : DEFAULT_BUBBLES_COLOR;
-      }
-
-      var hasBubbleLegend = LegendFactory.find(layerDefModel, 'bubble');
-      if (hasBubbleLegend) {
-        LegendFactory.createLegend(layerDefModel, 'bubble', attrs);
-      }
-    } else {
-      LegendFactory.removeLegend(layerDefModel, 'bubble');
-    }
+    _updateSizeLegend(layerDefModel, size, color);
   }
 
   if (LegendFactory.isEnabledType('color')) {
-    var legendTypes = ['category', 'torque', 'choropleth', 'custom_choropleth'];
-
-    if (color && color.attribute !== undefined) {
-      var hasCustomLegend = LegendFactory.find(layerDefModel, 'custom');
-      var hasSomeLegend = [];
-
-      _.each(legendTypes, function (legendType) {
-        var hasLegend = LegendFactory.find(layerDefModel, legendType);
-        if (hasLegend) {
-          hasSomeLegend.push(hasLegend);
-        }
-      });
-
-      if (!hasCustomLegend && hasSomeLegend.length) {
-        createColorLegend(layerDefModel, color);
-      }
-    } else {
-      _.each(legendTypes, function (legendType) {
-        LegendFactory.removeLegend(layerDefModel, legendType);
-      });
-    }
+    _updateColorLegend(layerDefModel, color);
   }
 };
 
@@ -128,9 +154,8 @@ module.exports = {
       // so we need to force the onChange for these.
       styleModel.on('change', function () {
         var hasChangedCartocss = layerDefModel.hasChanged('cartocss');
-        var type = styleModel.get('type');
 
-        if (!hasChangedCartocss && type === 'animation') {
+        if (!hasChangedCartocss && styleModel.isAnimation()) {
           onChange(layerDefModel);
         }
       });

--- a/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
@@ -68,10 +68,11 @@ function _createColorLegend (layerDefModel, color) {
   } else if (styleModel.isHeatmap()) {
     _createLegendForHeatmap(layerDefModel);
   } else {
-    var attributeTypeIsString = (color.attribute_type && color.attribute_type === 'string');
     var usesCategory = (color && color.quantification === 'category');
+    var attributeTypeIsString = (color.attribute_type && color.attribute_type === 'string');
+    var attributeTypeIsBoolean = (color.attribute_type && color.attribute_type === 'boolean');
 
-    if (attributeTypeIsString || usesCategory) {
+    if (usesCategory || attributeTypeIsString || attributeTypeIsBoolean) {
       _createCategoryLegend(layerDefModel, color);
     } else {
       _createChoroplethLegend(layerDefModel, color);

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
@@ -1,15 +1,16 @@
 var _ = require('underscore');
+var LegendTypes = require('builder/editor/layers/layer-content-views/legend/legend-types');
 var styleHelper = require('builder/helpers/style');
 var StyleConstants = require('builder/components/form-components/_constants/_style');
 
 module.exports = [
   {
-    value: 'none',
+    value: LegendTypes.NONE,
     tooltipTranslationKey: 'editor.legend.tooltips.style.none',
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/none.tpl'),
     label: _t('editor.legend.types.none')
   }, {
-    value: 'category',
+    value: LegendTypes.CATEGORY,
     tooltipTranslationKey: 'editor.legend.tooltips.style.category',
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/category.tpl'),
     label: _t('editor.legend.types.category'),
@@ -20,10 +21,10 @@ module.exports = [
       if (color == null) return false;
 
       return (styleType !== StyleConstants.Type.ANIMATION && (color && color.quantification === 'category' ||
-             color && color.attribute && color.attribute_type && color.attribute_type === 'string'));
+        color && color.attribute && color.attribute_type && color.attribute_type === 'string'));
     }
   }, {
-    value: 'torque',
+    value: LegendTypes.TORQUE,
     tooltipTranslationKey: 'editor.legend.tooltips.style.torque',
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/category.tpl'),
     label: _t('editor.legend.types.category'),
@@ -33,10 +34,10 @@ module.exports = [
       if (color == null) return false;
 
       return (styleType === StyleConstants.Type.ANIMATION && (color && color.quantification === 'category' ||
-             color && color.attribute && color.attribute_type && color.attribute_type === 'string'));
+        color && color.attribute && color.attribute_type && color.attribute_type === 'string'));
     }
   }, {
-    value: 'choropleth',
+    value: LegendTypes.CHOROPLETH,
     tooltipTranslationKey: 'editor.legend.tooltips.style.choropleth',
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/gradient.tpl'),
     label: _t('editor.legend.types.gradient'),
@@ -56,7 +57,7 @@ module.exports = [
       return color && color.attribute && (color.attribute_type === undefined || color.attribute_type && color.attribute_type !== 'string');
     }
   }, {
-    value: 'custom_choropleth',
+    value: LegendTypes.CUSTOM_CHOROPLETH,
     tooltipTranslationKey: 'editor.legend.tooltips.style.custom_choropleth',
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/gradient.tpl'),
     label: _t('editor.legend.types.gradient'),
@@ -72,7 +73,7 @@ module.exports = [
       return styleType === StyleConstants.Type.HEATMAP && color && color.attribute && (color.attribute_type === undefined || color.attribute_type && color.attribute_type !== 'string');
     }
   }, {
-    value: 'custom',
+    value: LegendTypes.CUSTOM,
     tooltipTranslationKey: 'editor.legend.tooltips.style.custom',
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/custom.tpl'),
     label: _t('editor.legend.types.custom')

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
@@ -14,9 +14,8 @@ module.exports = [
     label: _t('editor.legend.types.category'),
     isStyleCompatible: function (styleModel) {
       var color = styleHelper.getColor(styleModel);
-      if (color == null) return false;
 
-      if (styleModel.isAnimation()) return false;
+      if (color == null || styleModel.isAnimation()) return false;
 
       var usesCategory = (color && color.quantification === 'category');
       var hasStringAttribute = (color && color.attribute &&
@@ -33,9 +32,8 @@ module.exports = [
     label: _t('editor.legend.types.category'),
     isStyleCompatible: function (styleModel) {
       var color = styleHelper.getColor(styleModel);
-      if (color == null) return false;
 
-      if (!styleModel.isAnimation()) return false;
+      if (color == null || !styleModel.isAnimation()) return false;
 
       var usesCategory = (color && color.quantification === 'category');
       var hasStringAttribute = (color && color.attribute &&
@@ -73,16 +71,14 @@ module.exports = [
     label: _t('editor.legend.types.gradient'),
     isStyleCompatible: function (styleModel) {
       var color = styleHelper.getColor(styleModel);
-      if (color == null) return false;
 
-      if (!styleModel.isHeatmap()) return false;
+      if (color == null || !styleModel.isHeatmap()) return false;
 
       var hasAttribute = color && color.attribute;
       var attributeTypeIsUndef = (color.attribute_type === undefined);
       var attributeTypeIsNotString = (color.attribute_type && color.attribute_type !== 'string');
 
-      return styleModel.isHeatmap() && hasAttribute &&
-        (attributeTypeIsUndef || attributeTypeIsNotString);
+      return hasAttribute && (attributeTypeIsUndef || attributeTypeIsNotString);
     }
   }, {
     value: LegendTypes.CUSTOM,

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
@@ -15,13 +15,16 @@ module.exports = [
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/category.tpl'),
     label: _t('editor.legend.types.category'),
     isStyleCompatible: function (styleModel) {
-      var styleType = styleModel.get('type');
       var color = styleHelper.getColor(styleModel);
-
       if (color == null) return false;
 
-      return (styleType !== StyleConstants.Type.ANIMATION && (color && color.quantification === 'category' ||
-        color && color.attribute && color.attribute_type && color.attribute_type === 'string'));
+      if (styleModel.isAnimation()) return false;
+
+      var usesCategory = (color && color.quantification === 'category');
+      var hasStringAttribute = (color && color.attribute &&
+        color.attribute_type && color.attribute_type === 'string');
+
+      return (usesCategory || hasStringAttribute);
     }
   }, {
     value: LegendTypes.TORQUE,
@@ -29,12 +32,16 @@ module.exports = [
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/category.tpl'),
     label: _t('editor.legend.types.category'),
     isStyleCompatible: function (styleModel) {
-      var styleType = styleModel.get('type');
       var color = styleHelper.getColor(styleModel);
       if (color == null) return false;
 
-      return (styleType === StyleConstants.Type.ANIMATION && (color && color.quantification === 'category' ||
-        color && color.attribute && color.attribute_type && color.attribute_type === 'string'));
+      if (!styleModel.isAnimation()) return false;
+
+      var usesCategory = (color && color.quantification === 'category');
+      var hasStringAttribute = (color && color.attribute &&
+        color.attribute_type && color.attribute_type === 'string');
+
+      return (usesCategory || hasStringAttribute);
     }
   }, {
     value: LegendTypes.CHOROPLETH,
@@ -42,19 +49,19 @@ module.exports = [
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/gradient.tpl'),
     label: _t('editor.legend.types.gradient'),
     isStyleCompatible: function (styleModel) {
-      var styleType = styleModel.get('type');
-      var fill = styleModel.get('fill');
-      var stroke = styleModel.get('stroke');
-      var color;
+      var color = styleHelper.getColor(styleModel);
+      if (color == null) return false;
 
-      if (styleType === StyleConstants.Type.ANIMATION || styleType === StyleConstants.Type.HEATMAP) return false;
-      if (!fill && !stroke || _.isEmpty(fill) && _.isEmpty(stroke)) return false;
+      if (styleModel.isAnimation() || styleModel.isHeatmap()) return false;
 
-      color = fill && fill.color || stroke && stroke.color;
+      var usesCategory = (color && color.quantification === 'category');
+      if (usesCategory) return false;
 
-      if (color && color.quantification === 'category') return false;
+      var hasAttribute = color && color.attribute;
+      var attributeTypeIsUndef = (color.attribute_type === undefined);
+      var attributeTypeIsNotString = (color.attribute_type && color.attribute_type !== 'string');
 
-      return color && color.attribute && (color.attribute_type === undefined || color.attribute_type && color.attribute_type !== 'string');
+      return hasAttribute && (attributeTypeIsUndef || attributeTypeIsNotString);
     }
   }, {
     value: LegendTypes.CUSTOM_CHOROPLETH,
@@ -62,15 +69,17 @@ module.exports = [
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/gradient.tpl'),
     label: _t('editor.legend.types.gradient'),
     isStyleCompatible: function (styleModel) {
-      var styleType = styleModel.get('type');
-      var fill = styleModel.get('fill');
-      var stroke = styleModel.get('stroke');
-      var color;
+      var color = styleHelper.getColor(styleModel);
+      if (color == null) return false;
 
-      if (!fill && !stroke || _.isEmpty(fill) && _.isEmpty(stroke)) return false;
+      if (!styleModel.isHeatmap()) return false;
 
-      color = fill && fill.color || stroke && stroke.color;
-      return styleType === StyleConstants.Type.HEATMAP && color && color.attribute && (color.attribute_type === undefined || color.attribute_type && color.attribute_type !== 'string');
+      var hasAttribute = color && color.attribute;
+      var attributeTypeIsUndef = (color.attribute_type === undefined);
+      var attributeTypeIsNotString = (color.attribute_type && color.attribute_type !== 'string');
+
+      return styleModel.isHeatmap() && hasAttribute &&
+        (attributeTypeIsUndef || attributeTypeIsNotString);
     }
   }, {
     value: LegendTypes.CUSTOM,

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
@@ -1,7 +1,5 @@
-var _ = require('underscore');
 var LegendTypes = require('builder/editor/layers/layer-content-views/legend/legend-types');
 var styleHelper = require('builder/helpers/style');
-var StyleConstants = require('builder/components/form-components/_constants/_style');
 
 module.exports = [
   {

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/color/legend-color-types.js
@@ -21,8 +21,10 @@ module.exports = [
       var usesCategory = (color && color.quantification === 'category');
       var hasStringAttribute = (color && color.attribute &&
         color.attribute_type && color.attribute_type === 'string');
+      var hasBooleanAttribute = (color && color.attribute &&
+        color.attribute_type && color.attribute_type === 'boolean');
 
-      return (usesCategory || hasStringAttribute);
+      return (usesCategory || hasStringAttribute || hasBooleanAttribute);
     }
   }, {
     value: LegendTypes.TORQUE,
@@ -54,6 +56,9 @@ module.exports = [
 
       var usesCategory = (color && color.quantification === 'category');
       if (usesCategory) return false;
+
+      var attributeTypeIsBoolean = (color.attribute_type && color.attribute_type === 'boolean');
+      if (attributeTypeIsBoolean) return false;
 
       var hasAttribute = color && color.attribute;
       var attributeTypeIsUndef = (color.attribute_type === undefined);

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/legend-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/legend-types.js
@@ -1,0 +1,11 @@
+var LEGEND_TYPES = {
+  NONE: 'none',
+  BUBBLE: 'bubble',
+  CATEGORY: 'category',
+  CHOROPLETH: 'choropleth',
+  TORQUE: 'torque',
+  CUSTOM: 'custom',
+  CUSTOM_CHOROPLETH: 'custom_choropleth'
+};
+
+module.exports = LEGEND_TYPES;

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/size/legend-size-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/size/legend-size-types.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var LegendTypes = require('builder/editor/layers/layer-content-views/legend/legend-types');
+var styleHelper = require('builder/helpers/style');
 
 module.exports = [
   {
@@ -13,13 +14,9 @@ module.exports = [
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/bubble.tpl'),
     label: _t('editor.legend.types.bubble'),
     isStyleCompatible: function (styleModel) {
-      var fill = styleModel.get('fill');
-      var stroke = styleModel.get('stroke');
-      var size;
+      var size = styleHelper.getSize(styleModel);
+      if (size == null) return false;
 
-      if (!fill && !stroke || _.isEmpty(fill) && _.isEmpty(stroke)) return false;
-
-      size = fill && fill.size || stroke && stroke.size;
       return size && size.attribute !== undefined;
     }
   }

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/size/legend-size-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/size/legend-size-types.js
@@ -1,4 +1,3 @@
-var _ = require('underscore');
 var LegendTypes = require('builder/editor/layers/layer-content-views/legend/legend-types');
 var styleHelper = require('builder/helpers/style');
 

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/size/legend-size-types.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/size/legend-size-types.js
@@ -1,13 +1,14 @@
 var _ = require('underscore');
+var LegendTypes = require('builder/editor/layers/layer-content-views/legend/legend-types');
 
 module.exports = [
   {
-    value: 'none',
+    value: LegendTypes.NONE,
     tooltipTranslationKey: 'editor.legend.tooltips.style.none',
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/none.tpl'),
     label: _t('editor.legend.types.none')
   }, {
-    value: 'bubble',
+    value: LegendTypes.BUBBLE,
     tooltipTranslationKey: 'editor.legend.tooltips.style.bubble',
     legendIcon: require('builder/editor/layers/layer-content-views/legend/carousel-icons/bubble.tpl'),
     label: _t('editor.legend.types.bubble'),

--- a/lib/assets/javascripts/builder/editor/style/style-definition-model.js
+++ b/lib/assets/javascripts/builder/editor/style/style-definition-model.js
@@ -153,6 +153,10 @@ module.exports = Backbone.Model.extend({
     return this.get('type') === StyleConstants.Type.ANIMATION;
   },
 
+  isHeatmap: function () {
+    return this.get('type') === StyleConstants.Type.HEATMAP;
+  },
+
   hasNoneStyles: function () {
     return this.get('type') === StyleConstants.Type.NONE;
   },

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/legend/color/legend-color-types.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/legend/color/legend-color-types.spec.js
@@ -1,0 +1,52 @@
+var _ = require('underscore');
+
+var LegendColorTypes = require('builder/editor/layers/layer-content-views/legend/color/legend-color-types');
+var LegendTypes = require('builder/editor/layers/layer-content-views/legend/legend-types');
+
+var StyleConstants = require('builder/components/form-components/_constants/_style');
+var StyleModel = require('builder/editor/style/style-definition-model');
+
+describe('editor/layers/layer-content-view/legend/color/legend-color-types', function () {
+  function getLegendType (type) {
+    return _.find(LegendColorTypes, function (legendColorType) {
+      return legendColorType.value === type;
+    }, this);
+  }
+
+  var anStyleFillByBooleanAttribute = new StyleModel({
+    type: StyleConstants.Type.SIMPLE,
+    fill: {
+      color: {
+        attribute: 'a_boolean_field',
+        attribute_type: 'boolean',
+        range: ['#2bd900', '#d96b6b', '#e7e7e7'],
+        quantification: undefined
+      }
+    },
+    stroke: {
+      color: {
+        fixed: 'white'
+      }
+    }
+  });
+
+  describe('.category legend', function () {
+    beforeEach(function () {
+      this.legendType = getLegendType(LegendTypes.CATEGORY);
+    });
+
+    it('should be compatible with a boolean attribute in a color by value viz', function () {
+      expect(this.legendType.isStyleCompatible(anStyleFillByBooleanAttribute)).toBe(true);
+    });
+  });
+
+  describe('.choropleth legend', function () {
+    beforeEach(function () {
+      this.legendType = getLegendType(LegendTypes.CHOROPLETH);
+    });
+
+    it('should be incompatible with a boolean attribute in a color by value viz', function () {
+      expect(this.legendType.isStyleCompatible(anStyleFillByBooleanAttribute)).toBe(false);
+    });
+  });
+});

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/legend/legend-content-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/legend/legend-content-view.spec.js
@@ -9,6 +9,8 @@ var LegendDefinitionCollection = require('builder/data/legends/legend-definition
 var LegendFactory = require('builder/editor/layers/layer-content-views/legend/legend-factory');
 var FactoryModals = require('../../../../factories/modals');
 var CategoryFormModel = require('builder/editor/layers/layer-content-views/legend/form/legend-category-definition-form-model');
+var StyleModel = require('builder/editor/style/style-definition-model');
+var StyleConstants = require('builder/components/form-components/_constants/_style');
 
 describe('editor/layers/layer-content-view/legend/legend-content-view', function () {
   var legendType = {
@@ -40,7 +42,8 @@ describe('editor/layers/layer-content-view/legend/legend-content-view', function
       configModel: this.configModel
     });
 
-    this.layerDefinitionModel.styleModel = new Backbone.Model({
+    this.layerDefinitionModel.styleModel = new StyleModel({
+      type: StyleConstants.Type.SIMPLE,
       fill: {
         color: {
           fixed: '#892b27'
@@ -73,7 +76,7 @@ describe('editor/layers/layer-content-view/legend/legend-content-view', function
     });
     this.editorModel.isEditing = function () { return false; };
 
-    function updateLegend () {}
+    function updateLegend () { }
 
     this.view = new LegendContentView({
       overlayModel: new Backbone.Model(),
@@ -338,7 +341,8 @@ describe('editor/layers/layer-content-view/legend/legend-content-view', function
 
   describe('carousel', function () {
     it('should render carousel styleModel for points based', function () {
-      this.layerDefinitionModel.styleModel = new Backbone.Model({
+      this.layerDefinitionModel.styleModel = new StyleModel({
+        type: StyleConstants.Type.SIMPLE,
         fill: {
           color: {
             attribute: 'n_anclajes',
@@ -350,7 +354,7 @@ describe('editor/layers/layer-content-view/legend/legend-content-view', function
       var view = new LegendContentView({
         overlayModel: new Backbone.Model(),
         legendTypes: LegendColorTypes,
-        updateLegend: function () {},
+        updateLegend: function () { },
         editorModel: this.editorModel,
         layerDefinitionModel: this.layerDefinitionModel,
         legendDefinitionModel: this.legendDefinitionModel,
@@ -367,7 +371,8 @@ describe('editor/layers/layer-content-view/legend/legend-content-view', function
     });
 
     it('should render carousel styleModel for lines based', function () {
-      this.layerDefinitionModel.styleModel = new Backbone.Model({
+      this.layerDefinitionModel.styleModel = new StyleModel({
+        type: StyleConstants.Type.SIMPLE,
         stroke: {
           color: {
             attribute: 'n_anclajes',
@@ -379,7 +384,7 @@ describe('editor/layers/layer-content-view/legend/legend-content-view', function
       var view = new LegendContentView({
         overlayModel: new Backbone.Model(),
         legendTypes: LegendColorTypes,
-        updateLegend: function () {},
+        updateLegend: function () { },
         editorModel: this.editorModel,
         layerDefinitionModel: this.layerDefinitionModel,
         legendDefinitionModel: this.legendDefinitionModel,
@@ -396,7 +401,8 @@ describe('editor/layers/layer-content-view/legend/legend-content-view', function
     });
 
     it('should render category legend option in the carousel if styleModel has quantification category', function () {
-      this.layerDefinitionModel.styleModel = new Backbone.Model({
+      this.layerDefinitionModel.styleModel = new StyleModel({
+        type: StyleConstants.Type.SIMPLE,
         fill: {
           color: {
             attribute: 'n_anclajes',
@@ -409,7 +415,7 @@ describe('editor/layers/layer-content-view/legend/legend-content-view', function
       var view = new LegendContentView({
         overlayModel: new Backbone.Model(),
         legendTypes: LegendColorTypes,
-        updateLegend: function () {},
+        updateLegend: function () { },
         editorModel: this.editorModel,
         layerDefinitionModel: this.layerDefinitionModel,
         legendDefinitionModel: this.legendDefinitionModel,

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/legend/legends-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/legend/legends-view.spec.js
@@ -15,6 +15,8 @@ var QueryRowsCollection = require('builder/data/query-rows-collection');
 var FactoryModals = require('../../../../factories/modals');
 var sqlErrorTemplate = require('builder/editor/layers/layer-content-views/legend/legend-content-sql-error.tpl');
 var actionErrorTemplate = require('builder/editor/layers/sql-error-action.tpl');
+var StyleModel = require('builder/editor/style/style-definition-model');
+var StyleConstants = require('builder/components/form-components/_constants/_style');
 
 describe('editor/layers/layer-content-view/legend/legends-view', function () {
   beforeEach(function () {
@@ -92,7 +94,8 @@ describe('editor/layers/layer-content-view/legend/legends-view', function () {
     spyOn(this.layerDefinitionModel, 'save');
     spyOn(this.layerDefinitionModel, 'getAnalysisDefinitionNodeModel').and.returnValue(this.a0);
 
-    this.layerDefinitionModel.styleModel = new Backbone.Model({
+    this.layerDefinitionModel.styleModel = new StyleModel({
+      type: StyleConstants.Type.SIMPLE,
       fill: {
         color: {
           fixed: '#892b27'
@@ -193,7 +196,7 @@ describe('editor/layers/layer-content-view/legend/legends-view', function () {
 
   describe('._initBinds', function () {
     it('should call _changeStyle when editorModel:edition changes', function () {
-      this.editorModel.set({edition: true});
+      this.editorModel.set({ edition: true });
 
       expect(LegendsView.prototype._changeStyle).toHaveBeenCalled();
     });
@@ -246,7 +249,7 @@ describe('editor/layers/layer-content-view/legend/legends-view', function () {
     });
 
     it('should return false if no legend size is compatible', function () {
-      this.view._layerDefinitionModel.styleModel = new Backbone.Model({});
+      this.view._layerDefinitionModel.styleModel = new StyleModel({});
       expect(this.view._isStyleCompatible('size')).toBe(false);
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.62-1647",
+  "version": "4.12.62-1647-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.62",
+  "version": "4.12.62-1647",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.62-1647-1",
+  "version": "4.12.62",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Related to https://github.com/CartoDB/support/issues/1647

### Acceptance
1. `Create a map` with a layer having a boolean attribute (see sample dataset of Chicago at previous issue, with  a field called _arrest_)
2. Give the features a color using `Style by value` and select that attribute.
3. See available `Legends`.
4. Expected result: there are three available options, None, `Category` and Custom Legend. Notice how _Choropleth_ is no longer available.
5. Check `Category` legend is working fine, like this...
![image](https://user-images.githubusercontent.com/458196/43359876-229ca212-92ab-11e8-91a6-889a7cb1fe74.png)
6. Change the `Style` of the layer (eg. alter color for arrest == true) and see how the legend updates accordingly
