### PR TITLE
Tables cannot be made password protected

### DIFF
--- a/spec/services/carto/user_metadata_export_service_spec.rb
+++ b/spec/services/carto/user_metadata_export_service_spec.rb
@@ -273,7 +273,7 @@ describe Carto::UserMetadataExportService do
         create_user_with_basemaps_assets_visualizations
 
         @user.update_attributes(private_maps_enabled: true, private_tables_enabled: true)
-        v = @user.visualizations.first
+        v = @user.visualizations.where(type: 'derived').first
         v.password = 'dont_tell_anyone'
         v.privacy = 'password'
         v.save!


### PR DESCRIPTION
Closes #14205

This test was failing sometimes because it tried to make a table (canonical visualization) password protected, which is not supported. Instead, we only try to test this with maps (derived visualizations).