### PR TITLE
Fix problems when searching datasets for API Keys management

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancement
+* Fix problems when searching datasets for API Keys management (https://github.com/CartoDB/support/issues/1678)
 * Fix legend for style by boolean field (https://github.com/CartoDB/support/issues/1647)
 * Fix disconnect from external data sources (gdrive, box and dropbox) for organization users (https://github.com/CartoDB/support/issues/1671)
 * Fix broken data tab when analyses or custom SQL are present (https://github.com/CartoDB/cartodb/issues/14169)

--- a/lib/assets/javascripts/dashboard/components/table-grants/table-grants-item.tpl
+++ b/lib/assets/javascripts/dashboard/components/table-grants/table-grants-item.tpl
@@ -1,5 +1,5 @@
 <li class="ApiKeysForm-grantsTable-item u-ellipsis">
-  <span class="u-ellipsis" title="<%- tableName %>">
+  <span class="u-ellipsis u-rSpace" title="<%- tableName %>">
     <%- tableName %>
   </span>
   <div data-fields="<%- tableName %>"></div>

--- a/lib/assets/javascripts/dashboard/components/table-grants/table-grants-item.tpl
+++ b/lib/assets/javascripts/dashboard/components/table-grants/table-grants-item.tpl
@@ -1,4 +1,6 @@
-<li class="ApiKeysForm-grantsTable-item">
-  <span><%- tableName %></span>
+<li class="ApiKeysForm-grantsTable-item u-ellipsis">
+  <span class="u-ellipsis" title="<%- tableName %>">
+    <%- tableName %>
+  </span>
   <div data-fields="<%- tableName %>"></div>
 </li>

--- a/lib/assets/javascripts/dashboard/data/user-tables-model.js
+++ b/lib/assets/javascripts/dashboard/data/user-tables-model.js
@@ -37,7 +37,7 @@ module.exports = Backbone.Model.extend({
       page: 1,
       type: '',
       exclude_shared: true,
-      per_page: 10,
+      per_page: null,
       tags: '',
       shared: 'no',
       only_liked: false,

--- a/lib/assets/javascripts/dashboard/data/user-tables-model.js
+++ b/lib/assets/javascripts/dashboard/data/user-tables-model.js
@@ -37,7 +37,6 @@ module.exports = Backbone.Model.extend({
       page: 1,
       type: '',
       exclude_shared: true,
-      per_page: null,
       tags: '',
       shared: 'no',
       only_liked: false,

--- a/lib/assets/test/spec/dashboard/components/table-grants-view.spec.js
+++ b/lib/assets/test/spec/dashboard/components/table-grants-view.spec.js
@@ -139,7 +139,7 @@ describe('dashboard/components/table-grants/table-grants-view', function () {
 
       const formMarkup = view._generateFormMarkup();
 
-      expect(formMarkup).toContain(`<span>${tableName}</span>`);
+      expect(formMarkup).toContain(tableName);
       expect(formMarkup).toContain(`<div data-fields="${tableName}"></div>`);
     });
   });

--- a/lib/assets/test/spec/dashboard/data/user-tables-model.spec.js
+++ b/lib/assets/test/spec/dashboard/data/user-tables-model.spec.js
@@ -52,14 +52,14 @@ describe('dashboard/data/user-tables-model', function () {
 
   describe('.url', function () {
     it('sets the default params in the url', function () {
-      var defaultUrl = 'http://wadus.com/api/v1/viz?tag_name=&q=&page=1&type=&exclude_shared=true&per_page=10&tags=&shared=no&only_liked=false&order=updated_at&types=table&deepInsights=false';
+      var defaultUrl = 'http://wadus.com/api/v1/viz?tag_name=&q=&page=1&type=&exclude_shared=true&tags=&shared=no&only_liked=false&order=updated_at&types=table&deepInsights=false';
       expect(model.url()).toEqual(defaultUrl);
     });
   });
 
   describe('.generateParams', function () {
     it('returns the paramsModel attributes encoded', function () {
-      var encodedParams = 'tag_name=&q=&page=1&type=&exclude_shared=true&per_page=10&tags=&shared=no&only_liked=false&order=updated_at&types=table&deepInsights=false';
+      var encodedParams = 'tag_name=&q=&page=1&type=&exclude_shared=true&tags=&shared=no&only_liked=false&order=updated_at&types=table&deepInsights=false';
       expect(model.generateParams()).toEqual(encodedParams);
     });
   });


### PR DESCRIPTION
### Related to https://github.com/CartoDB/support/issues/1678

This PR will fix several issues, regarding to API-Keys management:
- [x] Fix the wrong style for dataset name
- [x] Remove 10 datasets limit
- [ ] Fix search issues

### Acceptance TBD 
In the API keys view, with an account that has +10 datasets and some of them with really long names:
- Visit the API keys page, click on `New API key`
  - [ ] Check that the list has more than 10 items
  - [ ] Check the datasets with long names are displayed correctly