### PR TITLE
14198 multiple redirect uris

### DIFF
--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -61,9 +61,9 @@ module Carto
     end
 
     def redirect_to_oauth_app(parameters)
-      redirect_uri = Addressable::URI.parse(@oauth_app.redirect_uri)
+      redirect_uri = Addressable::URI.parse(@redirect_uri || @oauth_app.redirect_uris.first)
       query = redirect_uri.query_values || {}
-      redirect_uri.query_values = query.merge(parameters)
+      redirect_uri.query_values = query.merge(parameters).merge(state: @state)
 
       redirect_to redirect_uri.to_s
     end
@@ -112,8 +112,9 @@ module Carto
     end
 
     def verify_redirect_uri
-      redirect_uri = params[:redirect_uri]
-      if redirect_uri.present? && redirect_uri != @oauth_app.redirect_uri
+      @redirect_uri = params[:redirect_uri]
+      if @redirect_uri.present? && !@oauth_app.redirect_uris.include?(@redirect_uri)
+        @redirect_uri = nil
         raise OauthProvider::Errors::InvalidRequest.new('The redirect_uri is not authorized for this application')
       end
     end

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -136,7 +136,7 @@ module Carto
     def load_authorization
       @authorization = OauthAuthorization.find_by_code!(params[:code])
       raise OauthProvider::Errors::InvalidGrant.new unless @authorization.oauth_app_user.oauth_app == @oauth_app
-      unless @redirect_uri == @authorization.redirect_uri
+      if (@redirect_uri || @authorization.redirect_uri) && @redirect_uri != @authorization.redirect_uri
         raise OauthProvider::Errors::InvalidRequest.new('The redirect_uri must match the authorization request')
       end
     rescue ActiveRecord::RecordNotFound

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -56,7 +56,7 @@ module Carto
     private
 
     def create_authorization
-      authorization = @oauth_app_user.oauth_authorizations.create_with_code!
+      authorization = @oauth_app_user.oauth_authorizations.create_with_code!(@redirect_uri)
       redirect_to_oauth_app(code: authorization.code, state: @state)
     end
 
@@ -136,6 +136,9 @@ module Carto
     def load_authorization
       @authorization = OauthAuthorization.find_by_code!(params[:code])
       raise OauthProvider::Errors::InvalidGrant.new unless @authorization.oauth_app_user.oauth_app == @oauth_app
+      unless @redirect_uri == @authorization.redirect_uri
+        raise OauthProvider::Errors::InvalidRequest.new('The redirect_uri must match the authorization request')
+      end
     rescue ActiveRecord::RecordNotFound
       raise OauthProvider::Errors::InvalidGrant.new
     end

--- a/app/models/carto/oauth_app.rb
+++ b/app/models/carto/oauth_app.rb
@@ -13,8 +13,8 @@ module Carto
     validates :name, presence: true
     validates :client_id, presence: true
     validates :client_secret, presence: true
-    validates :redirect_uri, presence: true
-    validate :validate_uri
+    validates :redirect_uris, presence: true
+    validate :validate_uris
 
     before_validation :ensure_keys_generated
 
@@ -25,13 +25,17 @@ module Carto
       self.client_secret ||= SecureRandom.urlsafe_base64(CLIENT_SECRET_RANDOM_BYTES)
     end
 
-    def validate_uri
+    def validate_uris
+      redirect_uris && redirect_uris.each { |uri| validate_uri(uri) }
+    end
+
+    def validate_uri(redirect_uri)
       uri = URI.parse(redirect_uri)
-      errors.add(:redirect_uri, "must be absolute") unless uri.absolute?
-      errors.add(:redirect_uri, "must be https") unless uri.scheme == 'https'
-      errors.add(:redirect_uri, "must not contain a fragment") unless uri.fragment.nil?
+      errors.add(:redirect_uris, "must be absolute") unless uri.absolute?
+      errors.add(:redirect_uris, "must be https") unless uri.scheme == 'https'
+      errors.add(:redirect_uris, "must not contain a fragment") unless uri.fragment.nil?
     rescue URI::InvalidURIError
-      errors.add(:redirect_uri, "must be valid")
+      errors.add(:redirect_uris, "must be valid")
     end
   end
 end

--- a/app/models/carto/oauth_authorization.rb
+++ b/app/models/carto/oauth_authorization.rb
@@ -15,8 +15,8 @@ module Carto
     validates :oauth_app_user, presence: true
     validate :code_or_api_key_present
 
-    def self.create_with_code!
-      create!(code: SecureRandom.urlsafe_base64(CODE_RANDOM_BYTES))
+    def self.create_with_code!(redirect_uri)
+      create!(code: SecureRandom.urlsafe_base64(CODE_RANDOM_BYTES), redirect_uri: redirect_uri)
     end
 
     def exchange!

--- a/app/views/carto/oauth_provider/consent.html.erb
+++ b/app/views/carto/oauth_provider/consent.html.erb
@@ -5,6 +5,7 @@ Authorize?
 <%= hidden_field_tag 'client_id', @oauth_app.client_id %>
 <%= hidden_field_tag 'scope', @scopes.join(' ') %>
 <%= hidden_field_tag 'state', @state %>
+<%= hidden_field_tag 'redirect_uri', @redirect_uri %>
 <%= submit_tag 'Cancel' %>
 <%= submit_tag 'Accept', name: 'accept' %>
 <% end %>

--- a/db/migrate/20180719122729_create_oauth_apps.rb
+++ b/db/migrate/20180719122729_create_oauth_apps.rb
@@ -13,7 +13,7 @@ migration(
       # Oauth parameters
       String      :client_id, unique: true, null: false
       String      :client_secret, null: false
-      String      :redirect_uri, null: false
+      column      :redirect_uris, 'text[]', null: false
     end
   end,
   Proc.new do

--- a/db/migrate/20180727174523_create_oauth_authorizations.rb
+++ b/db/migrate/20180727174523_create_oauth_authorizations.rb
@@ -11,6 +11,7 @@ migration(
                                           index: { where: 'api_key_id IS NOT NULL', unique: true }
       column      :scopes, 'text[]', null: false, default: "'{}'".lit
       String      :code, null: true, index: { where: 'code IS NOT NULL' }
+      String      :redirect_uri, null: true
       DateTime    :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
       DateTime    :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
     end

--- a/spec/factories/oauth_apps.rb
+++ b/spec/factories/oauth_apps.rb
@@ -3,6 +3,6 @@ FactoryGirl.define do
     to_create(&:save!)
 
     name { unique_name('Oauth application') }
-    redirect_uri 'https://redirect.uri'
+    redirect_uris ['https://redirect.uri']
   end
 end

--- a/spec/models/carto/oauth_app_spec.rb
+++ b/spec/models/carto/oauth_app_spec.rb
@@ -29,50 +29,50 @@ module Carto
         it 'rejected if empty' do
           app = OauthApp.new
           expect(app).to_not(be_valid)
-          expect(app.errors[:redirect_uri]).to(include("can't be blank"))
+          expect(app.errors[:redirect_uris]).to(include("can't be blank"))
         end
 
         it 'rejected if invalid' do
-          app = OauthApp.new(redirect_uri: '"invalid"')
+          app = OauthApp.new(redirect_uris: ['"invalid"'])
           expect(app).to_not(be_valid)
-          expect(app.errors[:redirect_uri]).to(include('must be valid'))
+          expect(app.errors[:redirect_uris]).to(include('must be valid'))
         end
 
         it 'rejected if non-absolute' do
-          app = OauthApp.new(redirect_uri: '//wadus.com/path')
+          app = OauthApp.new(redirect_uris: ['//wadus.com/path'])
           expect(app).to_not(be_valid)
-          expect(app.errors[:redirect_uri]).to(include('must be absolute'))
+          expect(app.errors[:redirect_uris]).to(include('must be absolute'))
 
-          app = OauthApp.new(redirect_uri: '/some_path')
+          app = OauthApp.new(redirect_uris: ['/some_path'])
           expect(app).to_not(be_valid)
-          expect(app.errors[:redirect_uri]).to(include('must be absolute'))
+          expect(app.errors[:redirect_uris]).to(include('must be absolute'))
         end
 
         it 'rejected if non-https' do
-          app = OauthApp.new(redirect_uri: 'http://wadus.com/path')
+          app = OauthApp.new(redirect_uris: ['http://wadus.com/path'])
           expect(app).to_not(be_valid)
-          expect(app.errors[:redirect_uri]).to(include('must be https'))
+          expect(app.errors[:redirect_uris]).to(include('must be https'))
 
-          app = OauthApp.new(redirect_uri: 'file://some_path')
+          app = OauthApp.new(redirect_uris: ['file://some_path'])
           expect(app).to_not(be_valid)
-          expect(app.errors[:redirect_uri]).to(include('must be https'))
+          expect(app.errors[:redirect_uris]).to(include('must be https'))
         end
 
         it 'rejected if has fragment' do
-          app = OauthApp.new(redirect_uri: 'https://wad.us/?query#fragment')
+          app = OauthApp.new(redirect_uris: ['https://wad.us/?query#fragment'])
           expect(app).to_not(be_valid)
-          expect(app.errors[:redirect_uri]).to(include('must not contain a fragment'))
+          expect(app.errors[:redirect_uris]).to(include('must not contain a fragment'))
         end
 
         it 'accepted if valid' do
-          app = OauthApp.new(redirect_uri: 'https://wad.us/path?query=value')
+          app = OauthApp.new(redirect_uris: ['https://wad.us/path?query=value'])
           app.valid?
-          expect(app.errors[:redirect_uri]).to(be_empty)
+          expect(app.errors[:redirect_uris]).to(be_empty)
         end
       end
 
       it 'accepts if valid' do
-        app = OauthApp.new(user: @user, name: 'name', redirect_uri: 'https://re.dir')
+        app = OauthApp.new(user: @user, name: 'name', redirect_uris: ['https://re.dir'])
         expect(app).to(be_valid)
       end
     end

--- a/spec/models/carto/oauth_authorization_spec.rb
+++ b/spec/models/carto/oauth_authorization_spec.rb
@@ -47,7 +47,7 @@ module Carto
       end
 
       before(:each) do
-        @authorization = @app_user.oauth_authorizations.create_with_code!
+        @authorization = @app_user.oauth_authorizations.create_with_code!(nil)
       end
 
       after(:each) do

--- a/spec/models/carto/oauth_authorization_spec.rb
+++ b/spec/models/carto/oauth_authorization_spec.rb
@@ -22,6 +22,12 @@ module Carto
         expect(authorization.errors[:api_key]).to(include("must be present if code is missing"))
       end
 
+      it 'redirect_uri cannot be set if api_key is' do
+        authorization = OauthAuthorization.new(api_key: @api_key, redirect_uri: '')
+        expect(authorization).to_not(be_valid)
+        expect(authorization.errors[:redirect_uri]).to(include("must be nil if api_key is present"))
+      end
+
       it 'validates with api_key' do
         authorization = OauthAuthorization.new(oauth_app_user: @app_user, api_key: @api_key)
         expect(authorization).to(be_valid)

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -272,7 +272,7 @@ describe Carto::OauthProviderController do
     it 'following the oauth flow produces a valid API Key' do
       # Since Capybara+rack passes all requests to the local server, we set a redirect URI inside localhost
       redirect_uri = "https://#{@user.username}.localhost.lan/redirect"
-      @oauth_app.update!(redirect_uri: redirect_uri)
+      @oauth_app.update!(redirect_uris: [redirect_uri])
 
       # Login
       login_as(@user, scope: @user.username)

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -44,7 +44,7 @@ describe Carto::OauthProviderController do
       request_endpoint(valid_payload.merge(response_type: 'err'))
 
       expect(response.status).to(eq(302))
-      expect(response.location).to(start_with(@oauth_app.redirect_uri))
+      expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
       expect(Addressable::URI.parse(response.location).query_values['error']).to(eq('unsupported_response_type'))
     end
 
@@ -52,7 +52,7 @@ describe Carto::OauthProviderController do
       request_endpoint(valid_payload.merge(state: ''))
 
       expect(response.status).to(eq(302))
-      expect(response.location).to(start_with(@oauth_app.redirect_uri))
+      expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
       qs = Addressable::URI.parse(response.location).query_values
       expect(qs['error']).to(eq('invalid_request'))
       expect(qs['error_description']).to(eq('state is mandatory'))
@@ -62,7 +62,7 @@ describe Carto::OauthProviderController do
       request_endpoint(valid_payload.merge(scope: 'invalid wadus'))
 
       expect(response.status).to(eq(302))
-      expect(response.location).to(start_with(@oauth_app.redirect_uri))
+      expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
       expect(Addressable::URI.parse(response.location).query_values['error']).to(eq('invalid_scope'))
     end
 
@@ -70,7 +70,7 @@ describe Carto::OauthProviderController do
       request_endpoint(valid_payload.merge(redirect_uri: 'invalid'))
 
       expect(response.status).to(eq(302))
-      expect(response.location).to(start_with(@oauth_app.redirect_uri))
+      expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
       qs = Addressable::URI.parse(response.location).query_values
       expect(qs['error']).to(eq('invalid_request'))
       expect(qs['error_description']).to(eq('The redirect_uri is not authorized for this application'))

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -249,5 +249,20 @@ describe Carto::OauthProviderController do
         expect(response.body[:error]).to(eq('invalid_request'))
       end
     end
+
+    it 'without redirect_uri, returns error without creating the api key' do
+      @authorization.update!(redirect_uri: @oauth_app.redirect_uris.first)
+
+      post_json oauth_provider_token_url(token_payload) do |response|
+        @authorization.reload
+        expect(@authorization.code).to(be)
+        expect(@authorization.api_key).to(be_nil)
+
+        expect(response.status).to(eq(400))
+        expect(response.body[:error]).to(eq('invalid_request'))
+      end
+    end
+
+    # TODO: multiple authorized redirect uris tests (authorize and token)
   end
 end

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -159,7 +159,7 @@ describe Carto::OauthProviderController do
   describe '#token' do
     before(:each) do
       @oauth_app_user = @oauth_app.oauth_app_users.create!(user_id: @user.id)
-      @authorization = @oauth_app_user.oauth_authorizations.create_with_code!
+      @authorization = @oauth_app_user.oauth_authorizations.create_with_code!(nil)
     end
 
     let (:token_payload) do


### PR DESCRIPTION
Support multiple redirect URIs.

DB changes:
- At app level, converted the DB field into an array
- Added `redirect_uri` at the authorization level. OAuth spec says we must verify this parameter in the token exchange, so we need persistence.

How it works:
- If no `redirect_uri` is given, we use the first from the array. This is to avoid making `redirect_uri` a required field. UI-wise, we can mark this differently as the "default URI".
- If a redirect_uri is provided, the app must pass it to both the authorization and token exchange endpoints, and we verify that. We also redirect to that URI instead of the default one.