### PR TITLE
Fix histogram tooltips not updating

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancements
+* Fix histogram tooltips not being updated after column change (https://github.com/CartoDB/cartodb/issues/14155)
 * Update googlemaps api version to v3.32 (https://github.com/CartoDB/cartodb/issues/13902)
 * Fix wrong position for color dialog and sticky popups when styling analysis (https://github.com/CartoDB/support/issues/1649 and https://github.com/CartoDB/support/issues/1673)
 * Fix incorrect metric event styling a layer (https://github.com/CartoDB/cartodb/issues/14183)

--- a/lib/assets/javascripts/deep-insights/widgets/histogram/chart.js
+++ b/lib/assets/javascripts/deep-insights/widgets/histogram/chart.js
@@ -1502,6 +1502,9 @@ module.exports = CoreView.extend({
       .attr('width', Math.max(0, this.barWidth - 1));
 
     bars
+      .attr('data-tooltip', function (d) {
+        return self._tooltipFormatter(d.freq);
+      })
       .transition()
       .duration(200)
       .attr('height', function (d) {
@@ -1591,6 +1594,9 @@ module.exports = CoreView.extend({
       .attr('width', Math.max(1, this.barWidth - spacing));
 
     bars
+      .attr('data-tooltip', function (d) {
+        return self._tooltipFormatter(d.freq);
+      })
       .transition()
       .ease(this.options.transitionType)
       .duration(this.options.animationSpeed)

--- a/lib/assets/javascripts/deep-insights/widgets/histogram/content-view.js
+++ b/lib/assets/javascripts/deep-insights/widgets/histogram/content-view.js
@@ -141,7 +141,7 @@ module.exports = CoreView.extend({
 
     this.tooltip = new TipsyTooltipView({
       el: event.target,
-      title: function () { return event.data; },
+      title: 'data-tooltip',
       trigger: 'manual'
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.65",
+  "version": "4.12.65-14155",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/14155

### Description
This PR fixes a problem with the histogram tooltips not being updated after changing the column.

### Acceptance
- Create a histogram
- Check the values in the tooltip
- Change the column
- Check the values have changed