### PR TITLE
Warn te user when deleting multiple analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,8 +21,8 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancement
+* Add a warning when the user is about to delete multiple analyses at once (https://github.com/CartoDB/cartodb/pull/14222)
 * Fix problems when searching datasets for API Keys management (https://github.com/CartoDB/support/issues/1678)
-### Bug fixes / enhancements
 * Update googlemaps api version to v3.32 (https://github.com/CartoDB/cartodb/issues/13902)
 * Fix wrong position for color dialog and sticky popups when styling analysis (https://github.com/CartoDB/support/issues/1649 and https://github.com/CartoDB/support/issues/1673)
 * Fix incorrect metric event styling a layer (https://github.com/CartoDB/cartodb/issues/14183)

--- a/assets/stylesheets/editor-3/_infobox.scss
+++ b/assets/stylesheets/editor-3/_infobox.scss
@@ -66,16 +66,14 @@
 .Infobox-buttons {
   display: flex;
   flex: 10;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .Infobox-buttons--quota {
   flex: 1;
 }
 
-.Infobox-button {
-  flex: 1;
-
-  &.Infobox-button--right {
-    text-align: right;
-  }
+.Infobox-button + .Infobox-button {
+  margin-left: 16px;
 }

--- a/lib/assets/javascripts/builder/components/infobox/infobox-button.tpl
+++ b/lib/assets/javascripts/builder/components/infobox/infobox-button.tpl
@@ -1,13 +1,3 @@
-<% if (type === 'primary') { %>
-  <button class="CDB-Button CDB-Button--primary CDB-Button--medium <% if (disabled) { %>is-disabled<% } %> js-<%- action %> js-action">
-    <span class="CDB-Button-Text CDB-Text is-semibold u-upperCase CDB-Size-small"><%= label %></span>
-  </button>
-<% } else if (type === 'secondary') { %>
-  <button class="CDB-Button CDB-Button--secondary CDB-Button--medium <% if (disabled) { %>is-disabled<% } %> js-<%- action %> js-action">
-    <span class="CDB-Button-Text CDB-Text is-semibold u-upperCase CDB-Size-small"><%= label %></span>
-  </button>
-<% } else { %>
-  <button class="Infobox-buttonLink u-upperCase <% if (disabled) { %>is-disabled<% } %> js-<%- action %> js-action CDB-Text is-semibold CDB-Size-small">
-    <%= label %>
-  </button>
-<% } %>
+<button class="CDB-Button CDB-Button--secondary CDB-Button--medium <% if (disabled) { %>is-disabled<% } %> js-<%- action %> js-action">
+  <span class="CDB-Button-Text CDB-Text is-semibold u-upperCase CDB-Size-small"><%= label %></span>
+</button>

--- a/lib/assets/javascripts/builder/components/infobox/infobox-factory.js
+++ b/lib/assets/javascripts/builder/components/infobox/infobox-factory.js
@@ -22,17 +22,10 @@ module.exports = {
       klass: opts.className
     };
 
-    if (opts.mainAction) {
-      options.mainAction = {
-        label: opts.mainAction.label,
-        type: opts.mainAction.type
-      };
-    }
-
-    if (opts.secondAction) {
-      options.secondAction = {
-        label: opts.secondAction.label,
-        type: opts.secondAction.type
+    if (opts.action) {
+      options.action = {
+        label: opts.action.label,
+        type: opts.action.type
       };
     }
 

--- a/lib/assets/javascripts/builder/components/infobox/infobox-item-view.js
+++ b/lib/assets/javascripts/builder/components/infobox/infobox-item-view.js
@@ -14,9 +14,8 @@ var INFOBOX_TYPE = {
 
 module.exports = CoreView.extend({
   events: {
-    'click .js-mainAction': '_onMainClick',
-    'click .js-secondAction': '_onSecondClick',
-    'click .js-close': '_onClose'
+    'click .js-action': '_onActionClick',
+    'click .js-close': '_onCloseClick'
   },
 
   initialize: function (opts) {
@@ -33,16 +32,10 @@ module.exports = CoreView.extend({
       this._quota = opts.quota;
     }
 
-    if (opts.mainAction) {
-      this._mainLabel = opts.mainAction.label;
-      this._mainType = opts.mainAction.type;
-      this._mainDisabled = opts.mainAction.disabled;
-    }
-
-    if (opts.secondAction) {
-      this._secondLabel = opts.secondAction.label;
-      this._secondType = opts.secondAction.type;
-      this._secondDisabled = opts.secondAction.disabled;
+    if (opts.action) {
+      this._actionLabel = opts.action.label;
+      this._actionType = opts.action.type;
+      this._actionDisabled = opts.action.disabled;
     }
 
     this._type = INFOBOX_TYPE[opts.type || 'default'];
@@ -56,7 +49,6 @@ module.exports = CoreView.extend({
   },
 
   _initViews: function () {
-    var hasButtons = this._mainLabel || this._secondLabel;
     var hasQuota = !_.isEmpty(this._quota);
     var isLoading = this._loading;
 
@@ -67,28 +59,22 @@ module.exports = CoreView.extend({
       type: this._type,
       isLoading: isLoading,
       hasQuota: hasQuota,
-      hasButtons: hasButtons,
-      isClosable: this._isClosable
+      hasButtons: this._actionLabel,
+      isClosable: this._isClosable,
+      closeLabel: _t('editor.messages.common.cancel')
     });
 
     this.setElement(view);
 
-    if (this._mainLabel) {
-      this.$('.js-leftPosition').html(templateButton({
-        action: 'mainAction',
-        label: this._mainLabel,
-        type: this._mainType,
-        disabled: this._mainDisabled
-      }));
-    }
-
-    if (this._secondLabel) {
-      this.$('.js-rightPosition').html(templateButton({
-        action: 'secondAction',
-        label: this._secondLabel,
-        type: this._secondType,
-        disabled: this._secondDisabled
-      }));
+    if (this._actionLabel) {
+      this.$('.js-actionPosition').html(
+        templateButton({
+          action: 'action',
+          label: this._actionLabel,
+          type: this._actionType,
+          disabled: this._actionDisabled
+        })
+      );
     }
 
     if (hasQuota) {
@@ -112,15 +98,11 @@ module.exports = CoreView.extend({
     }
   },
 
-  _onMainClick: function (e) {
+  _onActionClick: function (e) {
     this.trigger('action:main');
   },
 
-  _onSecondClick: function (e) {
-    this.trigger('action:second');
-  },
-
-  _onClose: function (e) {
+  _onCloseClick: function (e) {
     this.trigger('action:close');
   }
 });

--- a/lib/assets/javascripts/builder/components/infobox/infobox-item-view.js
+++ b/lib/assets/javascripts/builder/components/infobox/infobox-item-view.js
@@ -59,7 +59,7 @@ module.exports = CoreView.extend({
       type: this._type,
       isLoading: isLoading,
       hasQuota: hasQuota,
-      hasButtons: this._actionLabel,
+      hasButtons: this._actionLabel || this._isClosable,
       isClosable: this._isClosable,
       closeLabel: _t('editor.messages.common.cancel')
     });

--- a/lib/assets/javascripts/builder/components/infobox/infobox-view.js
+++ b/lib/assets/javascripts/builder/components/infobox/infobox-view.js
@@ -50,23 +50,17 @@ module.exports = CoreView.extend({
   },
 
   _initSubviewBinds: function () {
-    this.listenTo(this.infoboxView, 'action:main', this._onMainAction);
-    this.listenTo(this.infoboxView, 'action:second', this._onSecondAction);
+    this.listenTo(this.infoboxView, 'action:main', this._onAction);
     this.listenTo(this.infoboxView, 'action:close', this._onClose);
   },
 
-  _onMainAction: function () {
-    var action = this._selectedModel.get('mainAction');
-    action && action();
-  },
-
-  _onSecondAction: function () {
-    var action = this._selectedModel.get('secondAction');
+  _onAction: function () {
+    var action = this._selectedModel.get('onAction');
     action && action();
   },
 
   _onClose: function () {
-    var action = this._selectedModel.get('closeAction');
+    var action = this._selectedModel.get('onClose');
     if (action) {
       action();
     } else {

--- a/lib/assets/javascripts/builder/components/infobox/infobox.tpl
+++ b/lib/assets/javascripts/builder/components/infobox/infobox.tpl
@@ -2,11 +2,7 @@
   <div class="u-flex u-justifySpace u-bSpace--m">
     <h2 class="Infobox-title CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--m u-rSpace--m"><%- title %></h2>
 
-    <% if (isClosable) { %>
-    <button class="CDB-Shape js-close">
-      <div class="CDB-Shape-close is-large js-theme is-blue"></div>
-    </button>
-    <% } %>
+
   </div>
 
   <div class="CDB-Text CDB-Size-medium u-bSpace--xl u-flex">
@@ -28,8 +24,14 @@
     <% } %>
     <% if (hasButtons) { %>
       <ul class="Infobox-buttons <% if (hasQuota) { %>Infobox-buttons--quota<% } %>">
-        <li class="Infobox-button js-leftPosition"></li>
-        <li class="Infobox-button Infobox-button--right js-rightPosition"></li>
+        <% if (isClosable) { %>
+          <li class="Infobox-button">
+            <button class="Infobox-buttonLink CDB-Text is-semibold CDB-Size-small u-upperCase js-close">
+              <%= closeLabel %>
+            </button>
+          </li>
+        <% } %>
+        <li class="Infobox-button Infobox-button--right js-actionPosition"></li>
       </ul>
     <% } %>
   </div>

--- a/lib/assets/javascripts/builder/editor/editor-pane.js
+++ b/lib/assets/javascripts/builder/editor/editor-pane.js
@@ -307,7 +307,7 @@ module.exports = CoreView.extend({
       }.bind(this)
     };
 
-    if (this._configModel.isHosted()) {
+    if (!this._configModel.isHosted()) {
       infoboxOpts.action = {
         label: _t('editor.messages.' + type + '.cta.label'),
         type: 'secondary'
@@ -350,7 +350,7 @@ module.exports = CoreView.extend({
     var hasLimitError = AppNotifications.getByType('limit');
     var hasUnknownError = AppNotifications.getByType('unknown');
     var hasInteractivityError = AppNotifications.getByType('interactivity');
-    window.infoBoxModel = this._infoboxModel;
+
     if (hasLimitError) {
       this._infoboxModel.set('state', 'limit');
     } else if (hasInteractivityError) {

--- a/lib/assets/javascripts/builder/editor/editor-pane.js
+++ b/lib/assets/javascripts/builder/editor/editor-pane.js
@@ -251,23 +251,23 @@ module.exports = CoreView.extend({
     // Open-source / local installation
     if (this._configModel.isHosted()) {
       infoboxOpts.body = _t('editor.layers.max-layers-infowindow.custom.body', { maxLayers: this._getMaxCount() });
-      infoboxOpts.mainAction = { label: _t('editor.layers.max-layers-infowindow.custom.contact') };
-      baseState.mainAction = function () { window.open(_t('editor.layers.max-layers-infowindow.custom.contact-url')); };
+      infoboxOpts.action = { label: _t('editor.layers.max-layers-infowindow.custom.contact') };
+      baseState.onAction = function () { window.open(_t('editor.layers.max-layers-infowindow.custom.contact-url')); };
     } else {
       if (this._userModel.isInsideOrg()) {
         if (this._userModel.isOrgAdmin()) {
           infoboxOpts.body = _t('editor.layers.max-layers-infowindow.org-admin.body', { maxLayers: this._getMaxCount() });
-          infoboxOpts.mainAction = { label: _t('editor.layers.max-layers-infowindow.org-admin.upgrade') };
+          infoboxOpts.action = { label: _t('editor.layers.max-layers-infowindow.org-admin.upgrade') };
         } else {
           infoboxOpts.body = _t('editor.layers.max-layers-infowindow.org.body', { maxLayers: this._getMaxCount() });
-          infoboxOpts.mainAction = { label: _t('editor.layers.max-layers-infowindow.org.upgrade') };
+          infoboxOpts.action = { label: _t('editor.layers.max-layers-infowindow.org.upgrade') };
         }
 
-        baseState.mainAction = function () { window.open('mailto:' + this._userModel.upgradeContactEmail()); };
+        baseState.onAction = function () { window.open('mailto:' + this._userModel.upgradeContactEmail()); };
       } else {
-        baseState.mainAction = function () { window.open(_t('editor.layers.max-layers-infowindow.pricing')); };
+        baseState.onAction = function () { window.open(_t('editor.layers.max-layers-infowindow.pricing')); };
         infoboxOpts.body = _t('editor.layers.max-layers-infowindow.regular.body', { maxLayers: this._getMaxCount() });
-        infoboxOpts.mainAction = { label: _t('editor.layers.max-layers-infowindow.regular.upgrade') };
+        infoboxOpts.action = { label: _t('editor.layers.max-layers-infowindow.regular.upgrade') };
       }
     }
 
@@ -300,22 +300,23 @@ module.exports = CoreView.extend({
     };
 
     var baseState = {
-      state: type
+      state: type,
+      onClose: function () {
+        AppNotifications.muteByType(type);
+        this._infoboxModel.set('state', null);
+      }.bind(this)
     };
 
-    baseState.closeAction = function () {
-      AppNotifications.muteByType(type);
-      this._infoboxModel.set('state', null);
-    }.bind(this);
-
-    if (!this._configModel.isHosted()) {
-      baseState.secondAction = function () {
-        window.open(_t('editor.messages.' + type + '.cta.url'));
-      };
-      infoboxOpts.secondAction = {
+    if (this._configModel.isHosted()) {
+      infoboxOpts.action = {
         label: _t('editor.messages.' + type + '.cta.label'),
         type: 'secondary'
       };
+
+      baseState.onAction = function () {
+        window.open(_t('editor.messages.' + type + '.cta.url'));
+      };
+
       infoboxOpts.body = _t('editor.messages.' + type + '.body') + _t('editor.messages.' + type + '.try_to');
     }
 
@@ -349,7 +350,7 @@ module.exports = CoreView.extend({
     var hasLimitError = AppNotifications.getByType('limit');
     var hasUnknownError = AppNotifications.getByType('unknown');
     var hasInteractivityError = AppNotifications.getByType('interactivity');
-
+    window.infoBoxModel = this._infoboxModel;
     if (hasLimitError) {
       this._infoboxModel.set('state', 'limit');
     } else if (hasInteractivityError) {

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-content-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-content-view.js
@@ -23,7 +23,8 @@ var REQUIRED_OPTS = [
   'userModel',
   'stackLayoutModel',
   'overlayModel',
-  'layerContentModel'
+  'layerContentModel',
+  'deleteAnalysisModel'
 ];
 
 /**
@@ -159,7 +160,8 @@ module.exports = CoreView.extend({
       querySchemaModel: this._getQuerySchemaModelForEstimation(),
       stackLayoutModel: this._stackLayoutModel,
       userActions: this._userActions,
-      userModel: this._userModel
+      userModel: this._userModel,
+      deleteAnalysisModel: this._deleteAnalysisModel
     });
     this.addView(view);
     this.$el.append(view.render().el);

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-view.js
@@ -27,11 +27,16 @@ var REQUIRED_OPTS = [
 ];
 
 module.exports = CoreView.extend({
+  module: 'editor/layers/layer-content-views/analyses/analyses-view',
 
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this._selectedNodeId = opts.selectedNodeId;
+
+    this._deleteAnalysisModel = new Backbone.Model({
+      analysisId: null
+    });
 
     this._infoboxModel = new InfoboxModel({
       state: ''
@@ -69,6 +74,7 @@ module.exports = CoreView.extend({
 
   _initBinds: function () {
     this.listenTo(this._layerDefinitionModel, 'change:visible', this._infoboxState);
+    this.listenTo(this._deleteAnalysisModel, 'change:analysisId', this._infoboxState);
     this.listenTo(this._analysisFormsCollection, 'reset remove', this._getQueryAndCheckState);
   },
 
@@ -88,6 +94,25 @@ module.exports = CoreView.extend({
           });
         },
         mainAction: self._showHiddenLayer.bind(self)
+      },
+      {
+        state: 'deleting-analysis',
+        createContentView: function () {
+          return Infobox.createWithAction({
+            type: 'alert',
+            title: _t('editor.messages.deleting-analysis.title'),
+            body: _t('editor.messages.deleting-analysis.body'),
+            mainAction: {
+              label: _t('editor.messages.deleting-analysis.cancel')
+            },
+            secondAction: {
+              label: _t('editor.messages.deleting-analysis.delete'),
+              type: 'secondary'
+            }
+          });
+        },
+        mainAction: self._resetDeletingAnalysis.bind(self),
+        secondAction: self._deleteAnalysis.bind(self)
       }
     ];
 
@@ -111,7 +136,8 @@ module.exports = CoreView.extend({
           stackLayoutModel: self._stackLayoutModel,
           selectedNodeId: self._selectedNodeId,
           overlayModel: self._overlayModel,
-          layerContentModel: self._layerContentModel
+          layerContentModel: self._layerContentModel,
+          deleteAnalysisModel: self._deleteAnalysisModel
         });
       }
     });
@@ -147,6 +173,9 @@ module.exports = CoreView.extend({
     if (this._isLayerHidden()) {
       this._infoboxModel.set({ state: 'layer-hidden' });
       this._overlayModel.set({ visible: true });
+    } else if (this._deleteAnalysisModel.get('analysisId')) {
+      this._infoboxModel.set({ state: 'deleting-analysis' });
+      this._overlayModel.set({ visible: true });
     } else {
       this._infoboxModel.set({ state: '' });
       this._overlayModel.set({ visible: false });
@@ -162,5 +191,14 @@ module.exports = CoreView.extend({
 
   _isLayerHidden: function () {
     return this._layerDefinitionModel.get('visible') === false;
+  },
+
+  _resetDeletingAnalysis: function () {
+    this._deleteAnalysisModel.unset('analysisId');
+  },
+
+  _deleteAnalysis: function () {
+    this._analysisFormsCollection.deleteNode(this._deleteAnalysisModel.get('analysisId'));
+    this._resetDeletingAnalysis();
   }
 });

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-view.js
@@ -88,12 +88,12 @@ module.exports = CoreView.extend({
             type: 'alert',
             title: _t('editor.messages.layer-hidden.title'),
             body: _t('editor.messages.layer-hidden.body'),
-            mainAction: {
+            action: {
               label: _t('editor.messages.layer-hidden.show')
             }
           });
         },
-        mainAction: self._showHiddenLayer.bind(self)
+        onAction: self._showHiddenLayer.bind(self)
       },
       {
         state: 'deleting-analysis',
@@ -102,17 +102,13 @@ module.exports = CoreView.extend({
             type: 'alert',
             title: _t('editor.messages.deleting-analysis.title'),
             body: _t('editor.messages.deleting-analysis.body'),
-            mainAction: {
-              label: _t('editor.messages.deleting-analysis.cancel')
-            },
-            secondAction: {
-              label: _t('editor.messages.deleting-analysis.delete'),
-              type: 'secondary'
+            action: {
+              label: _t('editor.messages.deleting-analysis.delete')
             }
           });
         },
-        mainAction: self._resetDeletingAnalysis.bind(self),
-        secondAction: self._deleteAnalysis.bind(self)
+        onClose: self._resetDeletingAnalysis.bind(self),
+        onAction: self._deleteAnalysis.bind(self)
       }
     ];
 

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -16,14 +16,15 @@ var AnalysisQuotaView = require('./analysis-quota-view');
 
 var REQUIRED_OPTS = [
   'layerDefinitionModel',
-  'analysisFormsCollection',
   'configModel',
   'formModel',
   'quotaInfo',
   'querySchemaModel',
   'stackLayoutModel',
   'userActions',
-  'userModel'
+  'userModel',
+  'analysisFormsCollection',
+  'deleteAnalysisModel'
 ];
 
 /**
@@ -45,7 +46,6 @@ module.exports = CoreView.extend({
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
     this._analysisNode = opts.analysisNode;
-    this._analysisFormsCollection = opts.analysisFormsCollection;
 
     AnalysesQuotaEstimation.init(opts.configModel);
     AnalysesQuotaEnough.init(opts.configModel);
@@ -354,7 +354,9 @@ module.exports = CoreView.extend({
 
   _onDeleteClicked: function () {
     if (this._canDelete()) {
-      this._deleteAnalysis();
+      this._analysisFormsCollection.first() !== this._formModel
+        ? this._deleteAnalysisModel.set('analysisId', this._formModel.get('id'))
+        : this._deleteAnalysis();
     }
   },
 

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -271,7 +271,6 @@ module.exports = CoreView.extend({
         state: 'ready',
         createContentView: function () {
           var payload = this.payload;
-          var confirmLabel = _t('editor.layers.analysis-form.confirm-analysis');
           var quotaMessage = '';
 
           if (payload.creditsLeft > 0) {
@@ -285,8 +284,8 @@ module.exports = CoreView.extend({
 
           var dataInfobox = _.extend(AnalysesQuotaPresenter.make(payload, this._configModel, this._userModel), {
             title: _t('editor.layers.analysis-form.quota.title'),
-            mainAction: {
-              label: confirmLabel,
+            action: {
+              label: _t('editor.layers.analysis-form.confirm-analysis'),
               type: 'primary',
               disabled: !this._canSave() || !payload.canRunAnalysis
             },
@@ -296,7 +295,7 @@ module.exports = CoreView.extend({
 
           return InfoboxFactory.createQuota(dataInfobox);
         }.bind(this),
-        mainAction: function () {
+        onAction: function () {
           var payload = this.payload;
           if (this._canSave() && payload.canRunAnalysis) {
             this._saveAnalysis();
@@ -312,12 +311,12 @@ module.exports = CoreView.extend({
             body: _t('editor.layers.analysis-form.quota.quota-fetch-error', {
               error: this._viewModel.get('error')
             }),
-            mainAction: {
+            action: {
               label: _t('editor.layers.analysis-form.quota.cancel')
             }
           });
         }.bind(this),
-        mainAction: function () {
+        onAction: function () {
           this._stackLayoutModel.prevStep('layers');
         }.bind(this)
       }

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-controls-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analysis-controls-view.js
@@ -353,7 +353,7 @@ module.exports = CoreView.extend({
 
   _onDeleteClicked: function () {
     if (this._canDelete()) {
-      this._analysisFormsCollection.first() !== this._formModel
+      this._isLastAnalysisNodeSelected()
         ? this._deleteAnalysisModel.set('analysisId', this._formModel.get('id'))
         : this._deleteAnalysis();
     }
@@ -365,6 +365,10 @@ module.exports = CoreView.extend({
 
   _isAnalysisDone: function () {
     return this._analysisNode && (this._analysisNode.isDone() || this._analysisNode.hasFailed());
+  },
+
+  _isLastAnalysisNodeSelected: function () {
+    return this._analysisFormsCollection.first() !== this._formModel;
   },
 
   _saveAnalysis: function () {

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/data/data-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/data/data-view.js
@@ -370,12 +370,12 @@ module.exports = DatasetBaseView.extend({
             type: 'code',
             title: _t('editor.data.messages.sql-readonly.title'),
             body: _t('editor.data.messages.sql-readonly.body'),
-            mainAction: {
+            action: {
               label: _t('editor.data.messages.sql-readonly.accept')
             }
           });
         },
-        mainAction: self._confirmReadOnly.bind(self)
+        onAction: self._confirmReadOnly.bind(self)
       }, {
         state: 'no-data',
         createContentView: function () {
@@ -392,12 +392,12 @@ module.exports = DatasetBaseView.extend({
             type: 'alert',
             title: _t('editor.messages.layer-hidden.title'),
             body: _t('editor.messages.layer-hidden.body'),
-            mainAction: {
+            action: {
               label: _t('editor.messages.layer-hidden.show')
             }
           });
         },
-        mainAction: self._showHiddenLayer.bind(self)
+        onAction: self._showHiddenLayer.bind(self)
       }
     ];
 

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/infowindow/infowindow-base-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/infowindow/infowindow-base-view.js
@@ -94,12 +94,12 @@ module.exports = CoreView.extend({
             type: 'alert',
             title: _t('editor.infowindow.messages.custom-html-applied.title'),
             body: _t('editor.infowindow.messages.custom-html-applied.body'),
-            mainAction: {
+            action: {
               label: _t('editor.infowindow.messages.custom-html-applied.accept')
             }
           });
         },
-        mainAction: self._cancelHTML.bind(self)
+        onAction: self._cancelHTML.bind(self)
       }, {
         state: 'layer-hidden',
         createContentView: function () {
@@ -107,12 +107,12 @@ module.exports = CoreView.extend({
             type: 'alert',
             title: _t('editor.messages.layer-hidden.title'),
             body: _t('editor.messages.layer-hidden.body'),
-            mainAction: {
+            action: {
               label: _t('editor.messages.layer-hidden.show')
             }
           });
         },
-        mainAction: self._showHiddenLayer.bind(self)
+        onAction: self._showHiddenLayer.bind(self)
       }
     ];
 

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/legend-base-type-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/legend/legend-base-type-view.js
@@ -211,12 +211,12 @@ module.exports = CoreView.extend({
             type: 'alert',
             title: _t('editor.legend.messages.custom-legend.title'),
             body: _t('editor.legend.messages.custom-legend.body'),
-            mainAction: {
+            action: {
               label: _t('editor.legend.messages.custom-legend.accept')
             }
           });
         },
-        mainAction: self._deleteCustomHtmlLegend.bind(self)
+        onAction: self._deleteCustomHtmlLegend.bind(self)
       }, {
         state: 'layer-hidden',
         createContentView: function () {
@@ -224,12 +224,12 @@ module.exports = CoreView.extend({
             type: 'alert',
             title: _t('editor.messages.layer-hidden.title'),
             body: _t('editor.messages.layer-hidden.body'),
-            mainAction: {
+            action: {
               label: _t('editor.messages.layer-hidden.show')
             }
           });
         },
-        mainAction: self._showHiddenLayer.bind(self)
+        onAction: self._showHiddenLayer.bind(self)
       }, {
         state: 'legends-disabled',
         createContentView: function () {
@@ -237,12 +237,12 @@ module.exports = CoreView.extend({
             type: 'alert',
             title: _t('editor.legend.messages.legends-disabled.title'),
             body: _t('editor.legend.messages.legends-disabled.body'),
-            mainAction: {
+            action: {
               label: _t('editor.legend.messages.legends-disabled.show')
             }
           });
         },
-        mainAction: self._enableLegends.bind(self)
+        onAction: self._enableLegends.bind(self)
       }
     ];
 

--- a/lib/assets/javascripts/builder/editor/style/style-view.js
+++ b/lib/assets/javascripts/builder/editor/style/style-view.js
@@ -153,19 +153,15 @@ module.exports = CoreView.extend({
         createContentView: function () {
           return Infobox.createWithAction({
             type: 'alert',
-            closable: false,
             title: _t('editor.style.messages.cartocss-applied.title'),
             body: _t('editor.style.messages.cartocss-applied.body'),
-            mainAction: {
+            action: {
               label: _t('editor.style.messages.cartocss-applied.clear')
-            },
-            secondAction: {
-              label: _t('editor.style.messages.cartocss-applied.continue')
             }
           });
         },
-        mainAction: self._clearCustomStyles.bind(self),
-        secondAction: self._cancelClearStyles.bind(self)
+        onAction: self._clearCustomStyles.bind(self),
+        onClose: self._cancelClearStyles.bind(self)
       }, {
         state: 'layer-hidden',
         createContentView: function () {
@@ -173,27 +169,26 @@ module.exports = CoreView.extend({
             type: 'alert',
             title: _t('editor.messages.layer-hidden.title'),
             body: _t('editor.messages.layer-hidden.body'),
-            mainAction: {
+            action: {
               label: _t('editor.messages.layer-hidden.show')
             }
           });
         },
-        mainAction: self._showHiddenLayer.bind(self)
+        onAction: self._showHiddenLayer.bind(self)
       }, {
         state: 'torque-exists',
         createContentView: function () {
           return Infobox.createWithAction({
             type: 'alert',
-            closable: false,
             title: _t('editor.style.messages.torque-exists.title'),
             body: _t('editor.style.messages.torque-exists.body'),
-            mainAction: {
+            action: {
               label: _t('editor.style.messages.torque-exists.continue')
             }
           });
         },
-        closeAction: self._cancelTorqueAggregation.bind(self),
-        mainAction: self._applyTorqueAggregation.bind(self)
+        onAction: self._applyTorqueAggregation.bind(self),
+        onClose: self._cancelTorqueAggregation.bind(self)
       }
     ];
 

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -2412,7 +2412,7 @@
         "custom-html-applied": {
           "title": "CUSTOM HTML APPLIED",
           "body": "You just applied a legend with HTML. You can continue or clear all custom HTML.",
-          "accept": "CLEAR"
+          "accept": "Clear custom html"
         }
       }
     },
@@ -2452,8 +2452,8 @@
       "messages": {
         "custom-legend": {
           "title": "CUSTOM LEGEND APPLIED",
-          "body": "You just applied custom html with HTML editor. You can continue and clean all html.",
-          "accept": "Delete custom html"
+          "body": "You just applied custom html with HTML editor. You can continue or clear all custom HTML.",
+          "accept": "Clear custom html"
         },
         "legends-disabled": {
           "title": "LEGENDS DISABLED",

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1677,6 +1677,12 @@
       "label": "Fix them"
     },
     "messages": {
+      "deleting-analysis": {
+        "title": "Delete nested analysis",
+        "body": "The selected analysis has one or more nested analysis that would be removed once this analysis is deleted. Proceed?",
+        "delete": "Delete",
+        "cancel": "Cancel"
+      },
       "layer-hidden": {
         "title": "Layer hidden",
         "body": "This layer is hidden. Changes won't be shown until you make it visible.",

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -2412,7 +2412,7 @@
         "custom-html-applied": {
           "title": "CUSTOM HTML APPLIED",
           "body": "You just applied a legend with HTML. You can continue or clear all custom HTML.",
-          "accept": "CONTINUE"
+          "accept": "CLEAR"
         }
       }
     },

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -2411,7 +2411,7 @@
       "messages": {
         "custom-html-applied": {
           "title": "CUSTOM HTML APPLIED",
-          "body": "You just applied a legend with HTML. You can continue or clear all custom HTML.",
+          "body": "You just applied custom html with HTML editor. You can continue or clear all custom HTML.",
           "accept": "Clear custom html"
         }
       }
@@ -2568,14 +2568,12 @@
         "cartocss-applied": {
           "title": "CARTOCSS APPLIED",
           "body": "You just applied styles with CartoCSS. You can continue or clear all styles.",
-          "continue": "CONTINUE",
           "clear": "CLEAR"
         },
         "torque-exists": {
           "title": "TORQUE LAYER",
           "body": "There is already a torque layer in the layers collection. If you continue, this layer will use the default style.",
-          "continue": "CONTINUE",
-          "cancel": "CANCEL"
+          "continue": "CONTINUE"
         }
       },
       "tooltips": {

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1677,6 +1677,9 @@
       "label": "Fix them"
     },
     "messages": {
+      "common": {
+        "cancel": "Cancel"
+      },
       "deleting-analysis": {
         "title": "Delete nested analysis",
         "body": "The selected analysis has one or more nested analysis that would be removed once this analysis is deleted. Proceed?",

--- a/lib/assets/test/spec/builder/components/infobox/infobox-factory.spec.js
+++ b/lib/assets/test/spec/builder/components/infobox/infobox-factory.spec.js
@@ -22,7 +22,8 @@ describe('components/infobox/infobox-factory', function () {
       });
       view.render();
 
-      expect(view.$('button .CDB-Shape-close').length).toBe(1);
+      expect(view.$('button').length).toBe(1);
+      expect(view.$('button').eq(0).html()).toContain('editor.messages.common.cancel');
     });
   });
 
@@ -32,7 +33,7 @@ describe('components/infobox/infobox-factory', function () {
         title: 'Info',
         body: 'Lorem ipsum dolor sit amet.',
         closable: false,
-        mainAction: {
+        action: {
           label: 'Confirm'
         }
       });
@@ -42,27 +43,6 @@ describe('components/infobox/infobox-factory', function () {
       expect(view.$('.Infobox')).toBeDefined();
       expect(view.$('button').length).toBe(1);
       expect(view.$('button').text()).toContain('Confirm');
-    });
-
-    it('second action', function () {
-      view = Infobox.createWithAction({
-        title: 'Info',
-        body: 'Lorem ipsum dolor sit amet.',
-        mainAction: {
-          label: 'Confirm'
-        },
-        secondAction: {
-          label: 'Cancel'
-        }
-      });
-
-      view.render();
-
-      expect(view.$('.Infobox')).toBeDefined();
-      expect(view.$('.js-close').length).toBe(1);
-      expect(view.$('.Infobox-buttons button').length).toBe(2);
-      expect(view.$('.Infobox-buttons button').eq(0).text()).toContain('Confirm');
-      expect(view.$('.Infobox-buttons button').eq(1).text()).toContain('Cancel');
     });
   });
 });

--- a/lib/assets/test/spec/builder/components/infobox/infobox-item-view.spec.js
+++ b/lib/assets/test/spec/builder/components/infobox/infobox-item-view.spec.js
@@ -8,14 +8,10 @@ describe('components/infobox/infobox-item-view', function () {
       type: 'error',
       title: 'Info',
       body: 'Lorem ipsum dolor sit amet.',
-      mainAction: {
-        label: 'Proceed',
-        position: 'right'
+      action: {
+        label: 'Proceed'
       },
-      secondAction: {
-        label: 'Cancel',
-        position: 'left'
-      }
+      closable: true
     });
 
     view.render();
@@ -25,39 +21,39 @@ describe('components/infobox/infobox-item-view', function () {
     expect(view.$('h2').text()).toBe('Info');
     expect(view.$('div').text()).toContain('Lorem ipsum');
     expect(view.$('.Infobox-buttons button').length).toBe(2);
-    expect(view.$('.Infobox-buttons button').eq(0).text()).toContain('Proceed');
-    expect(view.$('.Infobox-buttons button').eq(1).text()).toContain('Cancel');
+    expect(view.$('.Infobox-buttons button').eq(0).html()).toContain('editor.messages.common.cancel');
+    expect(view.$('.Infobox-buttons button').eq(1).html()).toContain('Proceed');
   });
 
   it('should have className when it is defined', function () {
     var className = 'fs-class-name';
 
-    var v = new InfoboxView({
+    var view = new InfoboxView({
       type: 'alert',
       title: 'Info',
       body: 'Lorem ipsum dolor sit amet.',
       klass: className
     });
 
-    v.render();
+    view.render();
 
-    expect(v.$el.hasClass(className)).toBe(true);
+    expect(view.$el.hasClass(className)).toBe(true);
   });
 
   it('should render loading when it is defined', function () {
-    var v = new InfoboxView({
+    var view = new InfoboxView({
       type: 'alert',
       title: 'Info',
       body: 'Lorem ipsum dolor sit amet.',
       loading: true
     });
 
-    v.render();
-    expect(v.$('.CDB-LoaderIcon').length).toBe(1);
+    view.render();
+    expect(view.$('.CDB-LoaderIcon').length).toBe(1);
   });
 
   it('should render quota when needed', function () {
-    var v = new InfoboxView({
+    var view = new InfoboxView({
       type: 'alert',
       title: 'Info',
       body: 'Lorem ipsum dolor sit amet.',
@@ -65,33 +61,33 @@ describe('components/infobox/infobox-item-view', function () {
         usedQuota: 10,
         totalQuota: 100
       },
-      secondAction: {
+      action: {
         label: 'Proceed'
       }
     });
 
-    v.render();
-    expect(v.$('.js-quota').length).toBe(1);
-    expect(v.$('.Infobox-quotaBar').length).toBe(1);
+    view.render();
+    expect(view.$('.js-quota').length).toBe(1);
+    expect(view.$('.Infobox-quotaBar').length).toBe(1);
   });
 
   it('should trigger events properly', function () {
     var callback = {
       main: function () {},
-      second: function () {}
+      close: function () {}
     };
 
     spyOn(callback, 'main');
-    spyOn(callback, 'second');
+    spyOn(callback, 'close');
 
     view.on('action:main', callback.main);
-    view.on('action:second', callback.second);
+    view.on('action:close', callback.close);
 
     view.$('button').eq(0).trigger('click');
     view.$('button').eq(1).trigger('click');
 
     expect(callback.main.calls.count()).toEqual(1);
-    expect(callback.second.calls.count()).toEqual(1);
+    expect(callback.close.calls.count()).toEqual(1);
   });
 
   it('should not have any leaks', function () {

--- a/lib/assets/test/spec/builder/components/infobox/infobox-view.spec.js
+++ b/lib/assets/test/spec/builder/components/infobox/infobox-view.spec.js
@@ -22,13 +22,13 @@ describe('components/infobox/infobox-view', function () {
           return Infobox.createWithAction({
             title: 'Error',
             body: 'Lorem ipsum dolor sit amet.',
-            mainAction: {
+            action: {
               label: 'Confirm'
             }
           });
         },
-        mainAction: function () {},
-        closeAction: function () {}
+        onAction: function () {},
+        onClose: function () {}
       },
       {
         state: 'wadus',
@@ -36,12 +36,12 @@ describe('components/infobox/infobox-view', function () {
           return Infobox.createWithAction({
             title: 'Wadus',
             body: 'Lorem ipsum dolor sit amet.',
-            mainAction: {
+            action: {
               label: 'Confirm'
             }
           });
         },
-        mainAction: function () {}
+        onAction: function () {}
       }
     ];
 
@@ -68,21 +68,21 @@ describe('components/infobox/infobox-view', function () {
 
     expect(this.view.$('h2').text()).toBe('Error');
     expect(this.view.$('.js-close').length).toBe(1);
-    expect(this.view.$('.Infobox-buttons button').length).toBe(1);
+    expect(this.view.$('.Infobox-buttons button').length).toBe(2);
   });
 
   it('should bind actions properly', function () {
     var model = this.view._infoboxCollection.at(1);
-    spyOn(model.attributes, 'mainAction');
-    spyOn(model.attributes, 'closeAction');
+    spyOn(model.attributes, 'onAction');
+    spyOn(model.attributes, 'onClose');
 
     this.model.set({state: 'error'});
     this.view.$('.Infobox-buttons button').trigger('click');
 
-    expect(model.attributes.mainAction).toHaveBeenCalled();
+    expect(model.attributes.onAction).toHaveBeenCalled();
 
     this.view.$('.js-close').trigger('click');
-    expect(model.attributes.closeAction).toHaveBeenCalled();
+    expect(model.attributes.onClose).toHaveBeenCalled();
   });
 
   it('should close the infobox', function () {

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses-content-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses-content-view.spec.js
@@ -23,6 +23,8 @@ describe('editor/layers/layer-content-view/analyses-content-view', function () {
   var analysisDefinitionNodesCollection;
   var overlayModel;
   var layerContentModel;
+  var deleteAnalysisModel;
+  var stackLayoutModel;
   var renderTooltipSpy;
   var renderSpy;
   var onLayerDefSourceChangedSpy;
@@ -48,6 +50,10 @@ describe('editor/layers/layer-content-view/analyses-content-view', function () {
     spyOn(userModel, 'fetch');
 
     userActions = jasmine.createSpyObj('userActions', ['saveLayer']);
+
+    deleteAnalysisModel = new Backbone.Model({
+      analysisId: null
+    });
 
     overlayModel = new Backbone.Model({
       visible: false
@@ -125,16 +131,19 @@ describe('editor/layers/layer-content-view/analyses-content-view', function () {
     });
     layerContentModel.isErrored = function () { return false; };
 
+    stackLayoutModel = {};
+
     var defaultOptions = {
-      userActions: userActions,
-      analysisDefinitionNodesCollection: analysisDefinitionNodesCollection,
-      analysisFormsCollection: analysisFormsCollection,
-      layerDefinitionModel: layerDefinitionModel,
-      userModel: userModel,
-      configModel: configModel,
-      stackLayoutModel: {},
-      overlayModel: overlayModel,
-      layerContentModel: layerContentModel
+      userActions,
+      analysisDefinitionNodesCollection,
+      analysisFormsCollection,
+      layerDefinitionModel,
+      userModel,
+      configModel,
+      stackLayoutModel,
+      overlayModel,
+      layerContentModel,
+      deleteAnalysisModel
     };
 
     var view = new AnalysesContentView(_.extend(defaultOptions, options));

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analyses-view.spec.js
@@ -263,6 +263,17 @@ describe('editor/layers/layer-content-views/analyses/analyses-view', function ()
       });
     });
 
+    describe('if is deleting layer', function () {
+      it('should set infobox state', function () {
+        this.view._deleteAnalysisModel.set('analysisId', 'a1');
+
+        this.view._infoboxState();
+
+        expect(this.view._infoboxModel.get('state')).toBe('deleting-analysis');
+        expect(this.view._overlayModel.get('visible')).toBe(true);
+      });
+    });
+
     it('should set infobox state', function () {
       this.view._infoboxState();
 

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
@@ -347,7 +347,7 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
       this.formModel.isValid.and.returnValue(false);
       this.userActions.saveAnalysis.calls.reset();
       this.view.render();
-      this.view.$('.js-mainAction').click();
+      this.view.$('.js-action').click();
       expect(this.userActions.saveAnalysis).not.toHaveBeenCalled();
     });
 
@@ -374,7 +374,7 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
 
       expect(this.view.$el.html()).toContain('is-disabled');
 
-      this.view.$('.js-mainAction').click();
+      this.view.$('.js-action').click();
       expect(this.userActions.saveAnalysis).not.toHaveBeenCalled();
     });
 
@@ -400,7 +400,7 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
 
       expect(this.view.$el.html()).toContain('is-disabled');
 
-      this.view.$('.js-mainAction').click();
+      this.view.$('.js-action').click();
       expect(this.userActions.saveAnalysis).not.toHaveBeenCalled();
     });
 
@@ -426,7 +426,7 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
 
       expect(this.view.$el.html()).not.toContain('is-disabled');
 
-      this.view.$('.js-mainAction').click();
+      this.view.$('.js-action').click();
       expect(this.userActions.saveAnalysis).toHaveBeenCalled();
     });
 
@@ -444,7 +444,7 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
 
       this.formModel.trigger('change');
 
-      expect(this.view.$('.js-mainAction').html()).toContain('confirm');
+      expect(this.view.$('.js-action').html()).toContain('confirm');
     });
 
     it('should save changes', function () {

--- a/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/layer-content-view/analyses/analysis-controls-view.spec.js
@@ -30,6 +30,10 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
       query: 'SELECT * from foo'
     });
 
+    this.deleteAnalysisModel = new Backbone.Model({
+      analysisId: null
+    });
+
     this.quotaInfo = AnalysesQuotaInfo.get(this.configModel);
 
     mockSQL.mock(this.quotaInfo, 'success', {
@@ -91,9 +95,7 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
     });
     spyOn(this.analysisFormsCollection, 'deleteNode');
 
-    this.analysisFormsCollection.add([
-      {id: 'a1'}
-    ]);
+    this.analysisFormsCollection.add([{ id: 'a1' }]);
 
     this.stackLayoutModel = jasmine.createSpyObj('stackLayoutModel', ['prevStep']);
 
@@ -119,7 +121,8 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
       configModel: this.configModel,
       quotaInfo: this.quotaInfo,
       querySchemaModel: this.querySchemaModel,
-      layerDefinitionModel: this._layerDefinitionModel
+      layerDefinitionModel: this._layerDefinitionModel,
+      deleteAnalysisModel: this.deleteAnalysisModel
     });
 
     expect(view._viewModel).toBeDefined();
@@ -138,7 +141,8 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
         configModel: this.configModel,
         quotaInfo: this.quotaInfo,
         querySchemaModel: this.querySchemaModel,
-        layerDefinitionModel: this._layerDefinitionModel
+        layerDefinitionModel: this._layerDefinitionModel,
+        deleteAnalysisModel: this.deleteAnalysisModel
       });
     });
 
@@ -190,7 +194,8 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
         configModel: this.configModel,
         quotaInfo: this.quotaInfo,
         querySchemaModel: this.querySchemaModel,
-        layerDefinitionModel: this._layerDefinitionModel
+        layerDefinitionModel: this._layerDefinitionModel,
+        deleteAnalysisModel: this.deleteAnalysisModel
       });
       this.view.render();
     });
@@ -303,7 +308,8 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
         configModel: this.configModel,
         quotaInfo: this.quotaInfo,
         querySchemaModel: this.querySchemaModel,
-        layerDefinitionModel: this._layerDefinitionModel
+        layerDefinitionModel: this._layerDefinitionModel,
+        deleteAnalysisModel: this.deleteAnalysisModel
       });
 
       this.quotaInfo.fetch();
@@ -524,7 +530,8 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
         configModel: this.configModel,
         quotaInfo: this.quotaInfo,
         querySchemaModel: this.querySchemaModel,
-        layerDefinitionModel: this._layerDefinitionModel
+        layerDefinitionModel: this._layerDefinitionModel,
+        deleteAnalysisModel: this.deleteAnalysisModel
       });
 
       this.quotaInfo.fetch();
@@ -563,7 +570,8 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
         configModel: this.configModel,
         quotaInfo: this.quotaInfo,
         querySchemaModel: this.querySchemaModel,
-        layerDefinitionModel: this._layerDefinitionModel
+        layerDefinitionModel: this._layerDefinitionModel,
+        deleteAnalysisModel: this.deleteAnalysisModel
       });
       this.view.render();
     });
@@ -573,12 +581,23 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
     });
 
     describe('when click delete-analysis', function () {
-      beforeEach(function () {
-        this.view.$('.js-delete').click();
+      describe('when the analysis is the last node', function () {
+        it('should delete selectednode', function () {
+          this.view._formModel = this.analysisFormsCollection.first();
+          this.view.$('.js-delete').click();
+          expect(this.analysisFormsCollection.deleteNode).toHaveBeenCalledWith('a1');
+        });
       });
 
-      it('should delete selectednode', function () {
-        expect(this.analysisFormsCollection.deleteNode).toHaveBeenCalledWith('a1');
+      describe('when the analysis is not the last node', function () {
+        it('should set the nodeId in the deleteAnalysisNode model', function () {
+          var newAnalysis = this.analysisFormsCollection.add({ id: 'a2' });
+          this.view._formModel = newAnalysis;
+          this.view.$('.js-delete').click();
+
+          expect(this.analysisFormsCollection.deleteNode).not.toHaveBeenCalled();
+          expect(this.deleteAnalysisModel.get('analysisId')).toEqual('a2');
+        });
       });
     });
   });
@@ -594,7 +613,8 @@ describe('editor/layers/layer-content-view/analyses/analysis-controls-view', fun
         configModel: this.configModel,
         quotaInfo: this.quotaInfo,
         querySchemaModel: this.querySchemaModel,
-        layerDefinitionModel: this._layerDefinitionModel
+        layerDefinitionModel: this._layerDefinitionModel,
+        deleteAnalysisModel: this.deleteAnalysisModel
       });
 
       spyOn(this.view, '_isAnalysisDone').and.returnValue(true);


### PR DESCRIPTION
Related to: https://github.com/CartoDB/design/issues/1163

### Description
This PR adds a warning when the user tries to delete an analysis node which is not the last one.

### Image
![screen shot 2018-08-07 at 10 20 47](https://user-images.githubusercontent.com/905225/43763657-9873a198-9a2b-11e8-928f-08cf22cdd176.png)

### Acceptance
With one analysis:
- The delete button deletes the analysis

With multiple analysis:
- When the analysis is the last one, the analysis is deleted
- When the analysis is not the last one, a warning is shown:
  - Clicking on `cancel` removes the warning and doesn't delete the analysis
  - Clicking on `delete` deletes the analysis

### Extra
This PR also implements the new infobox styles:

When a layer is hidden:
![screen shot 2018-08-07 at 09 44 56](https://user-images.githubusercontent.com/905225/43763686-b468bbe0-9a2b-11e8-92f4-bd4ebac189b3.png)

When a legend has custom HTML:
![screen shot 2018-08-07 at 10 01 28](https://user-images.githubusercontent.com/905225/43763687-b481f560-9a2b-11e8-9a47-f39bffcb3c11.png)

When a popup has custom HTML:
![screen shot 2018-08-07 at 10 02 49](https://user-images.githubusercontent.com/905225/43763688-b49f7a22-9a2b-11e8-973b-e63615166539.png)

When custom CartoCSS is applied:
![screen shot 2018-08-07 at 10 03 30](https://user-images.githubusercontent.com/905225/43763689-b4b7dc98-9a2b-11e8-9b0e-fafd04014284.png)

When the user is over limits:
![screen shot 2018-08-07 at 10 23 22](https://user-images.githubusercontent.com/905225/43763833-14ac0b10-9a2c-11e8-96ff-d2ecdf3e927a.png)