### PR TITLE
Fix safari drag

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancement
+* Fix panning and interactivity in Safari (https://github.com/CartoDB/cartodb/issues/14115)
 * Add a warning when the user is about to delete multiple analyses at once (https://github.com/CartoDB/cartodb/pull/14222)
 * Fix problems when searching datasets for API Keys management (https://github.com/CartoDB/support/issues/1678)
 * Fix histogram tooltips not being updated after column change (https://github.com/CartoDB/cartodb/issues/14155)

--- a/lib/assets/javascripts/builder/deep-insights-integration/edit-feature-overlay.js
+++ b/lib/assets/javascripts/builder/deep-insights-integration/edit-feature-overlay.js
@@ -111,7 +111,6 @@ var EditFeatureOverlay = CoreView.extend({
   hide: function (event) {
     this.killEvent(event);
     this.$el.hide();
-    $(document).off('click', this.hide);
   },
 
   show: function () {
@@ -122,8 +121,6 @@ var EditFeatureOverlay = CoreView.extend({
       position: 'absolute'
     });
     this.$el.show();
-
-    $(document).on('click', this.hide);
   },
 
   setPosition: function (position) {

--- a/lib/assets/javascripts/builder/deep-insights-integration/features-integration.js
+++ b/lib/assets/javascripts/builder/deep-insights-integration/features-integration.js
@@ -23,10 +23,14 @@ module.exports = {
   track: function (options) {
     checkAndBuildOpts(options, REQUIRED_OPTS, this);
     var visMap = this._diDashboardHelpers.visMap();
+    var mapModel = this._diDashboardHelpers.getMap();
+
     this._mapModeModel.on('change:mode', this._onMapModeChanged, this);
     this._mapModeModel.on('reloadVis', function () {
       this._diDashboardHelpers.invalidateMap();
     }, this);
+
+    mapModel.on('click', this._onFeatureOut, this);
     visMap.on('featureClick', this._onFeatureClicked, this);
     visMap.on('featureError', this._onFeatureError, this);
   },
@@ -37,6 +41,10 @@ module.exports = {
         type: 'interactivity'
       });
     }
+  },
+
+  _onFeatureOut: function () {
+    this._editFeatureOverlay.hide();
   },
 
   _onFeatureClicked: function (event) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,14 +3,14 @@
   "version": "4.12.68",
   "dependencies": {
     "@carto/carto.js": {
-      "version": "4.1.2",
-      "from": "@carto/carto.js@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/@carto/carto.js/-/carto.js-4.1.2.tgz"
+      "version": "4.1.3",
+      "from": "@carto/carto.js@>=4.1.3 <5.0.0",
+      "resolved": "https://registry.npmjs.org/@carto/carto.js/-/carto.js-4.1.3.tgz"
     },
     "@carto/zera": {
-      "version": "1.0.6",
-      "from": "@carto/zera@1.0.6",
-      "resolved": "https://registry.npmjs.org/@carto/zera/-/zera-1.0.6.tgz"
+      "version": "1.0.7",
+      "from": "@carto/zera@1.0.7",
+      "resolved": "https://registry.npmjs.org/@carto/zera/-/zera-1.0.7.tgz"
     },
     "@webassemblyjs/ast": {
       "version": "1.5.12",
@@ -1080,9 +1080,9 @@
       }
     },
     "elliptic": {
-      "version": "6.4.0",
+      "version": "6.4.1",
       "from": "elliptic@>=6.0.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz"
     },
     "emojis-list": {
       "version": "2.1.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1596,9 +1596,9 @@
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz"
     },
     "inquirer": {
-      "version": "6.0.0",
+      "version": "6.1.0",
       "from": "inquirer@>=6.0.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.1.0.tgz",
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -1666,8 +1666,15 @@
     },
     "internal-carto.js": {
       "version": "4.1.2",
-      "from": "cartodb/carto.js#v4.1.2",
-      "resolved": "git://github.com/cartodb/carto.js.git#8f7c2121107e7f41a1d80d8930e3160ac64a3021"
+      "from": "cartodb/carto.js#fix-safari-drag",
+      "resolved": "git://github.com/cartodb/carto.js.git#31b5ea1a11fd2249ec57360a2aeb184bb463b4af",
+      "dependencies": {
+        "@carto/zera": {
+          "version": "1.0.6-staging.2",
+          "from": "@carto/zera@1.0.6-staging.2",
+          "resolved": "https://registry.npmjs.org/@carto/zera/-/zera-1.0.6-staging.2.tgz"
+        }
+      }
     },
     "interpret": {
       "version": "1.1.0",
@@ -2426,9 +2433,9 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
     },
     "path-parse": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "from": "path-parse@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz"
     },
     "path-platform": {
       "version": "0.11.15",
@@ -2780,9 +2787,9 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
     },
     "schema-utils": {
-      "version": "0.4.5",
+      "version": "0.4.7",
       "from": "schema-utils@>=0.4.4 <0.5.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz"
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz"
     },
     "select": {
       "version": "1.1.2",
@@ -3417,9 +3424,9 @@
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
     },
     "v8-compile-cache": {
-      "version": "2.0.0",
+      "version": "2.0.2",
       "from": "v8-compile-cache@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz"
     },
     "vm-browserify": {
       "version": "0.0.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1665,16 +1665,9 @@
       }
     },
     "internal-carto.js": {
-      "version": "4.1.2",
-      "from": "cartodb/carto.js#fix-safari-drag",
-      "resolved": "git://github.com/cartodb/carto.js.git#31b5ea1a11fd2249ec57360a2aeb184bb463b4af",
-      "dependencies": {
-        "@carto/zera": {
-          "version": "1.0.6-staging.2",
-          "from": "@carto/zera@1.0.6-staging.2",
-          "resolved": "https://registry.npmjs.org/@carto/zera/-/zera-1.0.6-staging.2.tgz"
-        }
-      }
+      "version": "4.1.3",
+      "from": "cartodb/carto.js#v4.1.3",
+      "resolved": "git://github.com/cartodb/carto.js.git#226e3bff375a79ed5e741e05b313f6b2f74c4ec9"
     },
     "interpret": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "d3-queue": "^3.0.7",
     "fastclick": "^1.0.6",
     "html-webpack-plugin": "^3.2.0",
-    "internal-carto.js": "CartoDB/carto.js#v4.1.2",
+    "internal-carto.js": "CartoDB/carto.js#fix-safari-drag",
     "jquery": "2.1.4",
     "leaflet": "CartoDB/Leaflet#v1.3.1-carto1",
     "moment": "2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.68-14115",
+  "version": "4.12.68",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
@@ -14,8 +14,8 @@
   "contributors": [],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@carto/carto.js": "^4.1.2",
-    "@carto/zera": "1.0.6",
+    "@carto/carto.js": "^4.1.3",
+    "@carto/zera": "1.0.7",
     "backbone": "1.2.3",
     "backbone-forms": "0.14.0",
     "backbone-model-file-upload": "CartoDB/backbone-model-file-upload#1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "d3-queue": "^3.0.7",
     "fastclick": "^1.0.6",
     "html-webpack-plugin": "^3.2.0",
-    "internal-carto.js": "CartoDB/carto.js#fix-safari-drag",
+    "internal-carto.js": "CartoDB/carto.js#v4.1.3",
     "jquery": "2.1.4",
     "leaflet": "CartoDB/Leaflet#v1.3.1-carto1",
     "moment": "2.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.68",
+  "version": "4.12.68-14115",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/14115

### Description
This PR fixes a bug introduced in https://github.com/CartoDB/zera/commit/317a82f61b137299f6b959b2addc65c52dd11df0 while trying to fix https://github.com/CartoDB/carto.js/issues/1952

The problem is that Builder is listening directly to document click events, so it closes the edit button as soon as soon as it's shown. Instead of stopping the event propagation to avoid that error we're going to handle it using carto.js events and stop listening to document click.

This PR depends on:
- https://github.com/CartoDB/carto.js/pull/2184
- https://github.com/CartoDB/zera/pull/11

### Acceptance
Create a map with polygons (it happens with points and lines too, but it's easier to test with polygons), and add popups to it and open it with Safari.

- [ ] Check that you can drag the map without problems, both in Builder and embed
- [ ] Check that clicking on a geometry shows the edit button
- [ ] Check that clicking on the map hides the edit button
- [ ] Check other interactivity actions just to be sure everything works, since this includes changes in `zera`, `carto.js` and `builder`