### PR TITLE
Remove job roles select

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancement
+* Use input instead of select for `job_profile` (https://github.com/CartoDB/cartodb/pull/14227)
 * Add a warning when the user is about to delete multiple analyses at once (https://github.com/CartoDB/cartodb/pull/14222)
 * Fix problems when searching datasets for API Keys management (https://github.com/CartoDB/support/issues/1678)
 * Fix histogram tooltips not being updated after column change (https://github.com/CartoDB/cartodb/issues/14155)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -191,8 +191,6 @@ class User < Sequel::Model
       errors.add(:org_admin, "cannot be set for non-organization user")
     end
 
-    validates_includes JOB_ROLES + DEPRECATED_JOB_ROLES, :job_role if job_role.present?
-
     errors.add(:geocoding_quota, "cannot be nil") if geocoding_quota.nil?
     errors.add(:here_isolines_quota, "cannot be nil") if here_isolines_quota.nil?
     errors.add(:obs_snapshot_quota, "cannot be nil") if obs_snapshot_quota.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -191,6 +191,8 @@ class User < Sequel::Model
       errors.add(:org_admin, "cannot be set for non-organization user")
     end
 
+    validates_presence :job_role
+
     errors.add(:geocoding_quota, "cannot be nil") if geocoding_quota.nil?
     errors.add(:here_isolines_quota, "cannot be nil") if here_isolines_quota.nil?
     errors.add(:obs_snapshot_quota, "cannot be nil") if obs_snapshot_quota.nil?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -191,8 +191,6 @@ class User < Sequel::Model
       errors.add(:org_admin, "cannot be set for non-organization user")
     end
 
-    validates_presence :job_role
-
     errors.add(:geocoding_quota, "cannot be nil") if geocoding_quota.nil?
     errors.add(:here_isolines_quota, "cannot be nil") if here_isolines_quota.nil?
     errors.add(:obs_snapshot_quota, "cannot be nil") if obs_snapshot_quota.nil?

--- a/lib/assets/javascripts/dashboard/views/profile/profile-form/profile-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/profile/profile-form/profile-form-view.js
@@ -20,17 +20,6 @@ const REQUIRED_OPTS = [
   'onError'
 ];
 
-const JOB_ROLES = [
-  'Founder / Executive',
-  'Developer',
-  'Student',
-  'VP / Director',
-  'Manager / Lead',
-  'Personal / Non-professional',
-  'Media',
-  'Individual Contributor'
-];
-
 const INDUSTRIES = [
   'Academic and Education', 'Architecture and Engineering', 'Banking and Finance',
   'Business Intelligence and Analytics', 'Utilities and Communications', 'GIS and Mapping',
@@ -92,7 +81,6 @@ module.exports = CoreView.extend({
         organizationName: this._userModel.organization ? this._userModel.organization.get('name') : '',
         orgDisplayEmail: this._getOrgAdminEmail(),
         canChangeEmail: this._userModel.get('can_change_email'),
-        jobRoles: JOB_ROLES,
         industries: INDUSTRIES
       }));
 

--- a/lib/assets/javascripts/dashboard/views/profile/profile-form/profile-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/profile/profile-form/profile-form.tpl
@@ -86,17 +86,9 @@
       <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor"><%= _t('profile.views.form.role') %></label>
     </div>
     <div class="FormAccount-rowData">
-      <select class="CDB-SelectFake CDB-Text FormAccount-input FormAccount-input--med is-cursor" id="user_job_role" name="user[job_role]">
-        <option value="">Select one</option>
-
-        <% jobRoles.forEach(function (role) { %>
-          <option<% if (role === user.job_role) { %> selected<% } %>><%= role %></option>
-        <% }); %>
-
-        <% if (!_.contains(jobRoles, user.job_role) && !_.isEmpty(user.job_role)) { %>
-          <option selected><%= user.job_role %></option>
-        <% } %>
-      </select>
+      <div class="FormAccount-rowData">
+        <input class="CDB-InputText CDB-Text FormAccount-input FormAccount-input--med" id="user_job_role" name="user[job_role]" size="30" type="text" value="<%= user.job_role %>">
+      </div>
     </div>
   </div>
 

--- a/lib/assets/test/spec/dashboard/views/profile/profile-form-view.spec.js
+++ b/lib/assets/test/spec/dashboard/views/profile/profile-form-view.spec.js
@@ -109,11 +109,7 @@ describe('dashboard/views/profile/profile-form/profile-form-view', function () {
       `);
       expect(view.$el.html()).toContain('profile.views.form.builder');
       expect(view.$el.html()).toContain('profile.views.form.write_access');
-
-      // Job role dropdown check
-      const roleDropdown = view.$('#user_job_role');
-      expect(roleDropdown.find('option').length).toBe(9);
-      expect(roleDropdown.find('option:checked').text()).toContain(JOB_ROLE);
+      expect(view.$el.html()).toContain(`<input class="CDB-InputText CDB-Text FormAccount-input FormAccount-input--med" id="user_job_role" name="user[job_role]" size="30" type="text" value="${JOB_ROLE}">`);
 
       // Industry
       const industryDropdown = view.$('#user_industry');
@@ -220,7 +216,7 @@ describe('dashboard/views/profile/profile-form/profile-form-view', function () {
 
       view.render();
 
-      expect(view.$('#user_job_role').text()).toContain('unexpected value');
+      expect(view.$('#user_job_role').val()).toEqual('unexpected value');
     });
 
     it('should support previous industry values', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.70",
+  "version": "4.12.70-2357",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.70-2357",
+  "version": "4.12.70",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -458,24 +458,6 @@ describe User do
     user.destroy
   end
 
-  it "should validate job_role and deprecated_job_roles" do
-    user = ::User.new
-    user.username = "adminipop"
-    user.email = "adminipop@example.com"
-    user.password = 'admin123'
-    user.password_confirmation = 'admin123'
-
-    user.job_role = "Developer"
-    user.valid?.should be_true
-
-    user.job_role = "Researcher"
-    user.valid?.should be_true
-
-    user.job_role = "whatever"
-    user.valid?.should be_false
-    user.errors[:job_role].should be_present
-  end
-
   it "should validate password presence and length" do
     user = ::User.new
     user.username = "adminipop"


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb-central/issues/2357

This PR removes the `JOB_ROLES` constants and uses an input instead of a select in the forms.