### PR TITLE
14208 oauth access token expiration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/models/carto/oauth_app_spec.rb \
 	spec/models/carto/oauth_app_user_spec.rb \
 	spec/models/carto/oauth_authorization_code_spec.rb \
+	spec/models/carto/oauth_refresh_token_spec.rb \
 	spec/models/carto/overlay_spec.rb \
 	spec/models/carto/rate_limit_spec.rb \
 	spec/models/carto/received_notification_spec.rb \

--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/lib/carto/visualization_invalidation_service_spec.rb \
 	spec/lib/tasks/layers_rake_spec.rb \
 	spec/lib/tasks/fix_unique_legends_spec.rb \
+	spec/lib/tasks/oauth_rake_spec.rb \
 	spec/models/carto/username_proposer_spec.rb \
 	spec/services/carto/overquota_users_service_spec.rb \
 	spec/services/visualization/common_data_service_spec.rb \

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -46,8 +46,8 @@ module Carto
 
       response = {
         access_token: access_token.api_key.token,
-        token_type: 'bearer'
-        # expires_in: seconds
+        token_type: 'bearer',
+        expires_in: access_token.expires_in
         # refresh_token:
       }
 

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -6,7 +6,8 @@ require_dependency 'carto/oauth_provider/strategies'
 module Carto
   class OauthProviderController < ApplicationController
     TOKEN_STRATEGIES = {
-      'authorization_code' => OauthProvider::Strategies::AuthorizationCodeStrategy
+      'authorization_code' => OauthProvider::Strategies::AuthorizationCodeStrategy,
+      'refresh_token' => OauthProvider::Strategies::RefreshTokenStrategy
     }
     SUPPORTED_RESPONSE_TYPES = ['code'].freeze
 

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -45,14 +45,15 @@ module Carto
     end
 
     def token
-      access_token = token_strategy.authorize!(@oauth_app, params)
+      access_token, refresh_token = token_strategy.authorize!(@oauth_app, params)
 
       response = {
         access_token: access_token.api_key.token,
         token_type: 'bearer',
         expires_in: access_token.expires_in
-        # refresh_token:
       }
+
+      response[:refresh_token] = refresh_token.token if refresh_token
 
       render(json: response)
     end

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -63,7 +63,9 @@ module Carto
     private
 
     def create_authorization_code
-      authorization_code = @oauth_app_user.oauth_authorization_codes.create!(redirect_uri: @redirect_uri)
+      authorization_code = @oauth_app_user.oauth_authorization_codes.create!(
+        redirect_uri: @redirect_uri, scopes: @scopes
+      )
       redirect_to_oauth_app(code: authorization_code.code, state: @state)
     end
 
@@ -127,7 +129,9 @@ module Carto
 
     def validate_scopes
       @scopes = (params[:scope] || '').split(' ')
-      raise OauthProvider::Errors::InvalidScope.new(@scopes) if @scopes.any?
+
+      invalid_scopes = OauthProvider::Scopes.invalid_scopes(@scopes)
+      raise OauthProvider::Errors::InvalidScope.new(invalid_scopes) if invalid_scopes.present?
     end
 
     def ensure_state

--- a/app/models/carto/oauth_access_token.rb
+++ b/app/models/carto/oauth_access_token.rb
@@ -1,9 +1,12 @@
 # encoding: utf-8
 
 require_dependency 'carto/oauth_provider/errors'
+require_dependency 'carto/oauth_provider/scopes'
 
 module Carto
   class OauthAccessToken < ActiveRecord::Base
+    include OauthProvider::Scopes
+
     ACCESS_TOKEN_EXPIRATION_TIME = 1.hour
 
     belongs_to :oauth_app_user, inverse_of: :oauth_access_tokens
@@ -11,6 +14,7 @@ module Carto
 
     validates :oauth_app_user, presence: true
     validates :api_key, presence: true
+    validates :scopes, scopes: true
 
     before_validation :ensure_api_key
 

--- a/app/models/carto/oauth_access_token.rb
+++ b/app/models/carto/oauth_access_token.rb
@@ -4,6 +4,8 @@ require_dependency 'carto/oauth_provider/errors'
 
 module Carto
   class OauthAccessToken < ActiveRecord::Base
+    ACCESS_TOKEN_EXPIRATION_TIME = 1.hour
+
     belongs_to :oauth_app_user, inverse_of: :oauth_access_tokens
     belongs_to :api_key, inverse_of: :oauth_access_token, dependent: :destroy
 
@@ -11,6 +13,10 @@ module Carto
     validates :api_key, presence: true
 
     before_validation :ensure_api_key
+
+    def expires_in
+      created_at + ACCESS_TOKEN_EXPIRATION_TIME - Time.now
+    end
 
     private
 

--- a/app/models/carto/oauth_access_token.rb
+++ b/app/models/carto/oauth_access_token.rb
@@ -14,6 +14,8 @@ module Carto
 
     before_validation :ensure_api_key
 
+    scope :expired, -> { where('created_at < ?', Time.now - ACCESS_TOKEN_EXPIRATION_TIME) }
+
     def expires_in
       created_at + ACCESS_TOKEN_EXPIRATION_TIME - Time.now
     end

--- a/app/models/carto/oauth_app_user.rb
+++ b/app/models/carto/oauth_app_user.rb
@@ -7,6 +7,7 @@ module Carto
     belongs_to :api_key, inverse_of: :oauth_app_user
     has_many :oauth_authorization_codes, inverse_of: :oauth_app_user, dependent: :destroy
     has_many :oauth_access_tokens, inverse_of: :oauth_app_user, dependent: :destroy
+    has_many :oauth_refresh_tokens, inverse_of: :oauth_app_user, dependent: :destroy
 
     validates :user, presence: true, uniqueness: { scope: :oauth_app }
     validates :oauth_app, presence: true

--- a/app/models/carto/oauth_app_user.rb
+++ b/app/models/carto/oauth_app_user.rb
@@ -1,7 +1,10 @@
 # encoding: utf-8
 
+require_dependency 'carto/oauth_provider/scopes'
+
 module Carto
   class OauthAppUser < ActiveRecord::Base
+    include OauthProvider::Scopes
     belongs_to :user, inverse_of: :oauth_app_users
     belongs_to :oauth_app, inverse_of: :oauth_app_users
     belongs_to :api_key, inverse_of: :oauth_app_user
@@ -11,6 +14,7 @@ module Carto
 
     validates :user, presence: true, uniqueness: { scope: :oauth_app }
     validates :oauth_app, presence: true
+    validates :scopes, scopes: true
 
     def authorized?(requested_scopes)
       (requested_scopes - scopes).empty?

--- a/app/models/carto/oauth_authorization_code.rb
+++ b/app/models/carto/oauth_authorization_code.rb
@@ -19,6 +19,8 @@ module Carto
 
     before_validation :ensure_code_generated
 
+    scope :expired, -> { where('created_at < ?', Time.now - CODE_EXPIRATION_TIME) }
+
     def exchange!
       raise OauthProvider::Errors::InvalidGrant.new if expired?
 

--- a/app/models/carto/oauth_authorization_code.rb
+++ b/app/models/carto/oauth_authorization_code.rb
@@ -1,9 +1,11 @@
 # encoding: utf-8
 
 require_dependency 'carto/oauth_provider/errors'
+require_dependency 'carto/oauth_provider/scopes'
 
 module Carto
   class OauthAuthorizationCode < ActiveRecord::Base
+    include OauthProvider::Scopes
     # Multiple of 3 for pretty base64
     CODE_RANDOM_BYTES = 12
 
@@ -13,6 +15,7 @@ module Carto
 
     validates :oauth_app_user, presence: true
     validates :code, presence: true
+    validates :scopes, scopes: true
 
     before_validation :ensure_code_generated
 

--- a/app/models/carto/oauth_authorization_code.rb
+++ b/app/models/carto/oauth_authorization_code.rb
@@ -24,7 +24,11 @@ module Carto
 
       ActiveRecord::Base.transaction do
         destroy!
-        oauth_app_user.oauth_access_tokens.create!(scopes: scopes)
+        access_token = oauth_app_user.oauth_access_tokens.create!(scopes: scopes)
+        if scopes.include?(SCOPE_OFFLINE)
+          refresh_token = oauth_app_user.oauth_refresh_tokens.create!(scopes: scopes)
+        end
+        [access_token, refresh_token]
       end
     end
 

--- a/app/models/carto/oauth_refresh_token.rb
+++ b/app/models/carto/oauth_refresh_token.rb
@@ -27,7 +27,7 @@ module Carto
       ActiveRecord::Base.transaction do
         regenerate_token
         save!
-        oauth_app_user.oauth_access_tokens.create!(scopes: scopes)
+        [oauth_app_user.oauth_access_tokens.create!(scopes: scopes), self]
       end
     end
 

--- a/app/models/carto/oauth_refresh_token.rb
+++ b/app/models/carto/oauth_refresh_token.rb
@@ -4,6 +4,8 @@ require_dependency 'carto/oauth_provider/scopes'
 
 module Carto
   class OauthRefreshToken < ActiveRecord::Base
+    include OauthProvider::Scopes
+
     # Multiple of 3 for pretty base64
     TOKEN_RANDOM_BYTES = 15
     REFRESH_TOKEN_EXPIRATION_TIME = 6.months
@@ -11,7 +13,7 @@ module Carto
     belongs_to :oauth_app_user, inverse_of: :oauth_refresh_tokens
 
     validates :oauth_app_user, presence: true
-    validates :scopes, presence: true
+    validates :scopes, scopes: true
     validate  :check_offline_scope
 
     before_create :regenerate_token
@@ -29,9 +31,7 @@ module Carto
     private
 
     def check_offline_scope
-      unless scopes.include?(OauthProvider::Scopes::OFFLINE)
-        errors.add(:scopes, "must contain `#{OauthProvider::Scopes::OFFLINE}`")
-      end
+      errors.add(:scopes, "must contain `#{SCOPE_OFFLINE}`") unless scopes.include?(SCOPE_OFFLINE)
     end
 
     def regenerate_token

--- a/app/models/carto/oauth_refresh_token.rb
+++ b/app/models/carto/oauth_refresh_token.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require_dependency 'carto/oauth_provider/errors'
+require_dependency 'carto/oauth_provider/scopes'
 
 module Carto
   class OauthRefreshToken < ActiveRecord::Base
@@ -35,7 +35,7 @@ module Carto
     end
 
     def regenerate_token
-      self.token = SecureRandom.urlsafe_base64(CODE_RANDOM_BYTES)
+      self.token = SecureRandom.urlsafe_base64(TOKEN_RANDOM_BYTES)
     end
   end
 end

--- a/app/models/carto/oauth_refresh_token.rb
+++ b/app/models/carto/oauth_refresh_token.rb
@@ -18,6 +18,14 @@ module Carto
 
     scope :expired, -> { where('updated_at < ?', Time.now - REFRESH_TOKEN_EXPIRATION_TIME) }
 
+    def exchange!
+      ActiveRecord::Base.transaction do
+        regenerate_token
+        save!
+        oauth_app_user.oauth_access_tokens.create!(scopes: scopes)
+      end
+    end
+
     private
 
     def check_offline_scope

--- a/db/migrate/20180809111407_create_oauth_refresh_tokens.rb
+++ b/db/migrate/20180809111407_create_oauth_refresh_tokens.rb
@@ -1,0 +1,19 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  Proc.new do
+    create_table :oauth_refresh_tokens do
+      Uuid        :id, primary_key: true, default: 'uuid_generate_v4()'.lit
+      foreign_key :oauth_app_user_id, :oauth_app_users, type: :uuid, null: false, index: true, on_delete: :cascade
+      text        :token, null: false, index: true
+      column      :scopes, 'text[]', null: false, default: "'{}'".lit
+      DateTime    :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      DateTime    :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+    end
+  end,
+  Proc.new do
+    drop_table :oauth_refresh_tokens
+  end
+)

--- a/lib/carto/oauth_provider/scopes.rb
+++ b/lib/carto/oauth_provider/scopes.rb
@@ -5,11 +5,15 @@ module Carto
 
       SUPPORTED_SCOPES = [SCOPE_OFFLINE].freeze
 
+      def self.invalid_scopes(scopes)
+        scopes - SUPPORTED_SCOPES
+      end
+
       class ScopesValidator < ActiveModel::EachValidator
         def validate_each(record, attribute, value)
           return record.errors[attribute] = ['has to be an array'] unless value && value.is_a?(Array)
 
-          invalid_scopes = value - SUPPORTED_SCOPES
+          invalid_scopes = Scopes.invalid_scopes(value)
           record.errors[attribute] << "contains unsuported scopes: #{invalid_scopes.join(', ')}" if invalid_scopes.any?
         end
       end

--- a/lib/carto/oauth_provider/scopes.rb
+++ b/lib/carto/oauth_provider/scopes.rb
@@ -1,0 +1,7 @@
+module Carto
+  module OauthProvider
+    module Scopes
+      OFFLINE = 'offline'.freeze
+    end
+  end
+end

--- a/lib/carto/oauth_provider/scopes.rb
+++ b/lib/carto/oauth_provider/scopes.rb
@@ -1,7 +1,18 @@
 module Carto
   module OauthProvider
     module Scopes
-      OFFLINE = 'offline'.freeze
+      SCOPE_OFFLINE = 'offline'.freeze
+
+      SUPPORTED_SCOPES = [SCOPE_OFFLINE].freeze
+
+      class ScopesValidator < ActiveModel::EachValidator
+        def validate_each(record, attribute, value)
+          return record.errors[attribute] = ['has to be an array'] unless value && value.is_a?(Array)
+
+          invalid_scopes = value - SUPPORTED_SCOPES
+          record.errors[attribute] << "contains unsuported scopes: #{invalid_scopes.join(', ')}" if invalid_scopes.any?
+        end
+      end
     end
   end
 end

--- a/lib/carto/oauth_provider/strategies.rb
+++ b/lib/carto/oauth_provider/strategies.rb
@@ -22,7 +22,11 @@ module Carto
           refresh_token = OauthRefreshToken.find_by_token!(params[:refresh_token])
           raise OauthProvider::Errors::InvalidGrant.new unless refresh_token.oauth_app_user.oauth_app == oauth_app
 
-          refresh_token.exchange!
+          if params[:scope]
+            refresh_token.exchange!(requested_scopes: params[:scope].split(' '))
+          else
+            refresh_token.exchange!
+          end
         rescue ActiveRecord::RecordNotFound
           raise OauthProvider::Errors::InvalidGrant.new
         end

--- a/lib/carto/oauth_provider/strategies.rb
+++ b/lib/carto/oauth_provider/strategies.rb
@@ -16,6 +16,17 @@ module Carto
           raise OauthProvider::Errors::InvalidGrant.new
         end
       end
+
+      module RefreshTokenStrategy
+        def self.authorize!(oauth_app, params)
+          refresh_token = OauthRefreshToken.find_by_token!(params[:refresh_token])
+          raise OauthProvider::Errors::InvalidGrant.new unless refresh_token.oauth_app_user.oauth_app == oauth_app
+
+          refresh_token.exchange!
+        rescue ActiveRecord::RecordNotFound
+          raise OauthProvider::Errors::InvalidGrant.new
+        end
+      end
     end
   end
 end

--- a/lib/carto/oauth_provider/strategies.rb
+++ b/lib/carto/oauth_provider/strategies.rb
@@ -1,0 +1,21 @@
+module Carto
+  module OauthProvider
+    module Strategies
+      module AuthorizationCodeStrategy
+        def self.authorize!(oauth_app, params)
+          authorization_code = OauthAuthorizationCode.find_by_code!(params[:code])
+          raise OauthProvider::Errors::InvalidGrant.new unless authorization_code.oauth_app_user.oauth_app == oauth_app
+
+          redirect_uri = params[:redirect_uri]
+          if (redirect_uri || authorization_code.redirect_uri) && redirect_uri != authorization_code.redirect_uri
+            raise OauthProvider::Errors::InvalidRequest.new('The redirect_uri must match the authorization request')
+          end
+
+          authorization_code.exchange!
+        rescue ActiveRecord::RecordNotFound
+          raise OauthProvider::Errors::InvalidGrant.new
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/oauth.rake
+++ b/lib/tasks/oauth.rake
@@ -1,0 +1,17 @@
+require_relative '../../lib/cartodb/trending_maps'
+require_relative '../../lib/static_maps_url_helper'
+
+namespace :cartodb do
+  namespace :oauth do
+    desc 'Delete expired oauth access tokens'
+    task destroy_expired_access_tokens: :environment do
+      Carto::OauthAccessToken.expired.find_each do |token|
+        begin
+          token.destroy!
+        rescue => e
+          CartoDB::Logger.error(message: 'Could not destroy expired access token', exception: e)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/oauth.rake
+++ b/lib/tasks/oauth.rake
@@ -13,5 +13,34 @@ namespace :cartodb do
         end
       end
     end
+
+    desc 'Delete expired oauth authorization codes'
+    task destroy_expired_authorization_codes: :environment do
+      Carto::OauthAuthorizationCode.expired.find_each do |code|
+        begin
+          code.destroy!
+        rescue => e
+          CartoDB::Logger.error(message: 'Could not destroy expired authorization code', exception: e)
+        end
+      end
+    end
+
+    desc 'Delete expired oauth refresh tokens'
+    task destroy_expired_refresh_tokens: :environment do
+      Carto::OauthRefreshToken.expired.find_each do |code|
+        begin
+          code.destroy!
+        rescue => e
+          CartoDB::Logger.error(message: 'Could not destroy expired refresh token', exception: e)
+        end
+      end
+    end
+
+    desc 'Delete all expired oauth objects'
+    task destroy_expired_oauth_keys: [
+      :destroy_expired_access_tokens,
+      :destroy_expired_refresh_tokens,
+      :destroy_expired_authorization_codes
+    ]
   end
 end

--- a/spec/lib/tasks/oauth_rake_spec.rb
+++ b/spec/lib/tasks/oauth_rake_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper_min'
+require 'rake'
+
+describe 'oauth.rake' do
+  before(:all) do
+    Rake.application.rake_require('tasks/oauth')
+    Rake::Task.define_task(:environment)
+
+    @sequel_developer = FactoryGirl.create(:valid_user)
+    @developer = Carto::User.find(@sequel_developer.id)
+    @user = FactoryGirl.create(:valid_user)
+    @oauth_app = FactoryGirl.create(:oauth_app, user: @developer)
+  end
+
+  before(:each) do
+    @oauth_app_user = @oauth_app.oauth_app_users.create!(user_id: @user.id)
+  end
+
+  after(:each) do
+    @oauth_app_user.reload.destroy!
+  end
+
+  after(:all) do
+    @oauth_app.destroy!
+    @user.destroy
+    @sequel_developer.destroy
+  end
+
+  describe '#destroy_expired_access_tokens' do
+    before(:each) do
+      Rake::Task['cartodb:oauth:destroy_expired_access_tokens'].reenable
+    end
+
+    it 'does not delete just created access tokens' do
+      access_token = @oauth_app_user.oauth_access_tokens.create!
+      Rake::Task['cartodb:oauth:destroy_expired_access_tokens'].invoke
+      expect(Carto::OauthAccessToken.exists?(access_token.id)).to(be_true)
+    end
+
+    it 'deletes old access tokens' do
+      access_token = @oauth_app_user.oauth_access_tokens.create!
+      Delorean.jump(2.hours)
+      Rake::Task['cartodb:oauth:destroy_expired_access_tokens'].invoke
+      expect(Carto::OauthAccessToken.exists?(access_token.id)).to(be_false)
+    end
+  end
+
+  describe '#destroy_expired_refresh_tokens' do
+    before(:each) do
+      Rake::Task['cartodb:oauth:destroy_expired_refresh_tokens'].reenable
+    end
+
+    it 'does not delete just created access tokens' do
+      refresh_token = @oauth_app_user.oauth_refresh_tokens.create!(scopes: ['offline'])
+      Rake::Task['cartodb:oauth:destroy_expired_refresh_tokens'].invoke
+      expect(Carto::OauthRefreshToken.exists?(refresh_token.id)).to(be_true)
+    end
+
+    it 'deletes old access tokens' do
+      refresh_token = @oauth_app_user.oauth_refresh_tokens.create!(scopes: ['offline'])
+      Delorean.jump(1.year)
+      Rake::Task['cartodb:oauth:destroy_expired_refresh_tokens'].invoke
+      expect(Carto::OauthRefreshToken.exists?(refresh_token.id)).to(be_false)
+    end
+  end
+
+  describe '#destroy_expired_authorization_codes' do
+    before(:each) do
+      Rake::Task['cartodb:oauth:destroy_expired_authorization_codes'].reenable
+    end
+
+    it 'does not delete just created access tokens' do
+      authorization_code = @oauth_app_user.oauth_authorization_codes.create!
+      Rake::Task['cartodb:oauth:destroy_expired_authorization_codes'].invoke
+      expect(Carto::OauthAuthorizationCode.exists?(authorization_code.id)).to(be_true)
+    end
+
+    it 'deletes old access tokens' do
+      authorization_code = @oauth_app_user.oauth_authorization_codes.create!
+      Delorean.jump(2.minutes)
+      Rake::Task['cartodb:oauth:destroy_expired_authorization_codes'].invoke
+      expect(Carto::OauthAuthorizationCode.exists?(authorization_code.id)).to(be_false)
+    end
+  end
+end

--- a/spec/models/carto/oauth_access_token_spec.rb
+++ b/spec/models/carto/oauth_access_token_spec.rb
@@ -11,6 +11,12 @@ module Carto
         @app_user = OauthAppUser.create!(user: @user, oauth_app: @app)
       end
 
+      it 'does not accept invalid scopes' do
+        access_token = OauthAccessToken.new(oauth_app_user: @app_user, scopes: ['wadus'])
+        expect(access_token).to_not(be_valid)
+        expect(access_token.errors[:scopes]).to(include("contains unsuported scopes: wadus"))
+      end
+
       it 'auto generates api_key' do
         access_token = OauthAccessToken.new(oauth_app_user: @app_user)
         expect(access_token).to(be_valid)

--- a/spec/models/carto/oauth_app_user_spec.rb
+++ b/spec/models/carto/oauth_app_user_spec.rb
@@ -38,6 +38,12 @@ module Carto
         end
       end
 
+      it 'does not accept invalid scopes' do
+        app_user = OauthAppUser.new(scopes: ['wadus'])
+        expect(app_user).to_not(be_valid)
+        expect(app_user.errors[:scopes]).to(include("contains unsuported scopes: wadus"))
+      end
+
       it 'validates' do
         app_user = OauthAppUser.new(user: @user, oauth_app: @app)
         expect(app_user).to(be_valid)
@@ -69,6 +75,7 @@ module Carto
       end
 
       it 'grants all new scopes without duplicates' do
+        OauthAppUser::ScopesValidator.any_instance.stubs(:validate_each)
         oau = OauthAppUser.create!(user: @user, oauth_app: @app, scopes: ['allowed_1', 'allowed_2'])
 
         oau.upgrade!([])

--- a/spec/models/carto/oauth_authorization_code_spec.rb
+++ b/spec/models/carto/oauth_authorization_code_spec.rb
@@ -58,10 +58,23 @@ module Carto
       end
 
       it 'creates a new api key and blanks the code' do
-        access_token = @authorization_code.exchange!
+        access_token, refresh_token = @authorization_code.exchange!
+
         expect(Carto::OauthAuthorizationCode.exists?(@authorization_code.id)).to(be_false)
         expect(access_token.api_key).to(be)
         expect(access_token.api_key.type).to(eq('oauth'))
+        expect(refresh_token).to(be_nil)
+      end
+
+      it 'with offline scope creates a new access token and refresh token' do
+        @authorization_code.update!(scopes: ['offline'])
+
+        access_token, refresh_token = @authorization_code.exchange!
+
+        expect(Carto::OauthAuthorizationCode.exists?(@authorization_code.id)).to(be_false)
+        expect(access_token.api_key).to(be)
+        expect(access_token.api_key.type).to(eq('oauth'))
+        expect(refresh_token).to(be)
       end
     end
   end

--- a/spec/models/carto/oauth_authorization_code_spec.rb
+++ b/spec/models/carto/oauth_authorization_code_spec.rb
@@ -11,6 +11,12 @@ module Carto
         @app_user = OauthAppUser.new(user: @user, oauth_app: @app)
       end
 
+      it 'does not accept invalid scopes' do
+        authorization = OauthAuthorizationCode.new(scopes: ['wadus'])
+        expect(authorization).to_not(be_valid)
+        expect(authorization.errors[:scopes]).to(include("contains unsuported scopes: wadus"))
+      end
+
       it 'validates without redirect_uri and autogenerates code' do
         authorization = OauthAuthorizationCode.new(oauth_app_user: @app_user)
         expect(authorization).to(be_valid)

--- a/spec/models/carto/oauth_refresh_token_spec.rb
+++ b/spec/models/carto/oauth_refresh_token_spec.rb
@@ -75,10 +75,24 @@ module Carto
 
         expect(access_token.api_key).to(be)
         expect(access_token.api_key.type).to(eq('oauth'))
+        expect(access_token.scopes).to(eq(refresh_token.scopes))
 
         expect(refresh_token).to(eq(@refresh_token))
         expect(refresh_token.token).to_not(eq(prev_token))
         expect(refresh_token.updated_at).to_not(eq(prev_updated_at))
+      end
+
+      it 'creates a new access token with reduced scopes if asked to' do
+        access_token, refresh_token = @refresh_token.exchange!(requested_scopes: [])
+
+        expect(access_token.scopes).to(eq([]))
+        expect(refresh_token.scopes).to(eq(['offline']))
+      end
+
+      it 'throws an error if requesting more scopes than available' do
+        expect { @refresh_token.exchange!(requested_scopes: ['not_there']) }.to(
+          raise_error(OauthProvider::Errors::InvalidScope)
+        )
       end
     end
   end

--- a/spec/models/carto/oauth_refresh_token_spec.rb
+++ b/spec/models/carto/oauth_refresh_token_spec.rb
@@ -1,0 +1,61 @@
+# encoding: utf-8
+
+require 'spec_helper_min'
+
+module Carto
+  describe OauthRefreshToken do
+    describe '#validation' do
+      before(:all) do
+        @user = FactoryGirl.build(:carto_user)
+        @app = FactoryGirl.build(:oauth_app, user: @user)
+        @app_user = OauthAppUser.new(user: @user, oauth_app: @app)
+      end
+
+      it 'requires offline scope' do
+        refresh_token = OauthRefreshToken.new
+        expect(refresh_token).not_to(be_valid)
+        expect(refresh_token.errors[:scopes]).to(include("must contain `offline`"))
+      end
+
+      it 'validates with offline scope' do
+        refresh_token = OauthRefreshToken.new(oauth_app_user: @app_user, scopes: ['offline'])
+        expect(refresh_token).to(be_valid)
+      end
+    end
+
+    describe '#exchange!' do
+      before(:all) do
+        @user = FactoryGirl.create(:carto_user)
+        @app = FactoryGirl.create(:oauth_app, user: @user)
+        @app_user = OauthAppUser.create(user: @user, oauth_app: @app)
+      end
+
+      after(:all) do
+        @app_user.destroy
+        @user.destroy
+        @app.destroy
+      end
+
+      before(:each) do
+        @refresh_token = @app_user.oauth_refresh_tokens.create!(scopes: ['offline'])
+      end
+
+      after(:each) do
+        @refresh_token.destroy
+      end
+
+      it 'creates a new access token and regenerated the code and updated_at' do
+        prev_token = @refresh_token.token
+        prev_updated_at = @refresh_token.updated_at
+
+        access_token = @refresh_token.exchange!
+
+        expect(access_token.api_key).to(be)
+        expect(access_token.api_key.type).to(eq('oauth'))
+
+        expect(@refresh_token.token).to_not(eq(prev_token))
+        expect(@refresh_token.updated_at).to_not(eq(prev_updated_at))
+      end
+    end
+  end
+end

--- a/spec/models/carto/oauth_refresh_token_spec.rb
+++ b/spec/models/carto/oauth_refresh_token_spec.rb
@@ -17,6 +17,12 @@ module Carto
         expect(refresh_token.errors[:scopes]).to(include("must contain `offline`"))
       end
 
+      it 'does not accept invalid scopes' do
+        refresh_token = OauthRefreshToken.new(scopes: ['wadus'])
+        expect(refresh_token).to_not(be_valid)
+        expect(refresh_token.errors[:scopes]).to(include("contains unsuported scopes: wadus"))
+      end
+
       it 'validates with offline scope' do
         refresh_token = OauthRefreshToken.new(oauth_app_user: @app_user, scopes: ['offline'])
         expect(refresh_token).to(be_valid)

--- a/spec/models/carto/oauth_refresh_token_spec.rb
+++ b/spec/models/carto/oauth_refresh_token_spec.rb
@@ -71,13 +71,14 @@ module Carto
         prev_token = @refresh_token.token
         prev_updated_at = @refresh_token.updated_at
 
-        access_token = @refresh_token.exchange!
+        access_token, refresh_token = @refresh_token.exchange!
 
         expect(access_token.api_key).to(be)
         expect(access_token.api_key.type).to(eq('oauth'))
 
-        expect(@refresh_token.token).to_not(eq(prev_token))
-        expect(@refresh_token.updated_at).to_not(eq(prev_updated_at))
+        expect(refresh_token).to(eq(@refresh_token))
+        expect(refresh_token.token).to_not(eq(prev_token))
+        expect(refresh_token.updated_at).to_not(eq(prev_updated_at))
       end
     end
   end

--- a/spec/models/carto/oauth_refresh_token_spec.rb
+++ b/spec/models/carto/oauth_refresh_token_spec.rb
@@ -50,6 +50,13 @@ module Carto
         @refresh_token.destroy
       end
 
+      it 'fails if the token is expired' do
+        @refresh_token.updated_at -= 1.year
+        @refresh_token.save!
+
+        expect { @refresh_token.exchange! }.to(raise_error(OauthProvider::Errors::InvalidGrant))
+      end
+
       it 'creates a new access token and regenerated the code and updated_at' do
         prev_token = @refresh_token.token
         prev_updated_at = @refresh_token.updated_at

--- a/spec/models/carto/oauth_refresh_token_spec.rb
+++ b/spec/models/carto/oauth_refresh_token_spec.rb
@@ -57,6 +57,16 @@ module Carto
         expect { @refresh_token.exchange! }.to(raise_error(OauthProvider::Errors::InvalidGrant))
       end
 
+      it 'can exchange multiple times while it has been used in the last 6 months' do
+        @refresh_token.exchange!
+        Delorean.jump(4.months)
+        @refresh_token.exchange!
+        Delorean.jump(4.months)
+        @refresh_token.exchange!
+        Delorean.jump(7.months)
+        expect { @refresh_token.exchange! }.to(raise_error(OauthProvider::Errors::InvalidGrant))
+      end
+
       it 'creates a new access token and regenerated the code and updated_at' do
         prev_token = @refresh_token.token
         prev_updated_at = @refresh_token.updated_at

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -196,7 +196,9 @@ describe Carto::OauthProviderController do
         expect(access_token).to(be)
 
         expect(response.status).to(eq(200))
-        expect(response.body).to(eq(access_token: access_token.api_key.token, token_type: "bearer"))
+        expect(response.body[:access_token]).to(eq(access_token.api_key.token))
+        expect(response.body[:token_type]).to(eq('bearer'))
+        expect(response.body[:expires_in]).to(be_between(3595, 3600)) # Little margin for slowness
       end
     end
 
@@ -210,7 +212,9 @@ describe Carto::OauthProviderController do
         expect(access_token).to(be)
 
         expect(response.status).to(eq(200))
-        expect(response.body).to(eq(access_token: access_token.api_key.token, token_type: "bearer"))
+        expect(response.body[:access_token]).to(eq(access_token.api_key.token))
+        expect(response.body[:token_type]).to(eq('bearer'))
+        expect(response.body[:expires_in]).to(be_between(3595, 3600)) # Little margin for slowness
       end
     end
 

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -328,6 +328,22 @@ describe Carto::OauthProviderController do
           access_token = @oauth_app_user.oauth_access_tokens.reload.first
           expect(access_token).to(be)
           expect { @refresh_token.reload }.to(change { @refresh_token.token })
+          expect(access_token.scopes).to(eq(@refresh_token.scopes))
+
+          expect(response.status).to(eq(200))
+          expect(response.body[:access_token]).to(eq(access_token.api_key.token))
+          expect(response.body[:token_type]).to(eq('bearer'))
+          expect(response.body[:expires_in]).to(be_between(3595, 3600)) # Little margin for slowness
+          expect(response.body[:refresh_token]).to(eq(@refresh_token.token))
+        end
+      end
+
+      it 'with valid token and explicit scopes returns a restricted api key' do
+        post_json oauth_provider_token_url(refresh_token_payload.merge(scope: '')) do |response|
+          access_token = @oauth_app_user.oauth_access_tokens.reload.first
+          expect(access_token).to(be)
+          expect { @refresh_token.reload }.to(change { @refresh_token.token })
+          expect(access_token.scopes).to(eq([]))
 
           expect(response.status).to(eq(200))
           expect(response.body[:access_token]).to(eq(access_token.api_key.token))

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -294,6 +294,18 @@ describe Carto::OauthProviderController do
         end
       end
 
+      it 'with expired token, returns error without creating the api key' do
+        Delorean.jump 1.year
+
+        post_json oauth_provider_token_url(refresh_token_payload) do |response|
+          access_token = @oauth_app_user.oauth_access_tokens.reload.first
+          expect(access_token).to(be_nil)
+
+          expect(response.status).to(eq(400))
+          expect(response.body[:error]).to(eq('invalid_grant'))
+        end
+      end
+
       it 'with invalid code, returns error without creating the api key' do
         post_json oauth_provider_token_url(refresh_token_payload.merge(refresh_token: 'invalid')) do |response|
           access_token = @oauth_app_user.oauth_access_tokens.reload.first

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -376,7 +376,7 @@ describe Carto::OauthProviderController do
   describe '#acceptance' do
     include Capybara::DSL
 
-    it 'following the oauth flow produces a valid API Key' do
+    it 'following the oauth flow produces a valid API Key and refresh token to renew it' do
       # Since Capybara+rack passes all requests to the local server, we set a redirect URI inside localhost
       redirect_uri = "https://#{@user.username}.localhost.lan/redirect"
       @oauth_app.update!(redirect_uris: ['https://fake_uri', redirect_uri])


### PR DESCRIPTION
Closes #14208 

Implements key expiration:
- Access tokens expire after 1 hour of creation
- If you pass the `offline` scope, we generate a refresh token that can be used to get new tokens
- Refresh tokens expire after 6 months of inactivity
- Rakes to cleanup expired tokens
- A ton of tests