### PR TITLE
Allow to visit shared+locked datsets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,8 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancement
-* Don't show "- Rows" instead of 0 if the dataset has been updated recently ()
+* Add link to `datasets/shared/locked` (https://github.com/CartoDB/cartodb/issues/14188)
+* Don't show "- Rows" instead of 0 if the dataset has been updated recently (https://github.com/CartoDB/cartodb/pull/14228)
 * Fix panning and interactivity in Safari (https://github.com/CartoDB/cartodb/issues/14115)
 * Add a warning when the user is about to delete multiple analyses at once (https://github.com/CartoDB/cartodb/pull/14222)
 * Fix problems when searching datasets for API Keys management (https://github.com/CartoDB/support/issues/1678)

--- a/lib/assets/javascripts/dashboard/common/router-dashboard.js
+++ b/lib/assets/javascripts/dashboard/common/router-dashboard.js
@@ -78,6 +78,13 @@ module.exports = RouterBase.extend({
     'datasets/locked/:page': '_changeRouteToDatasets',
     'datasets/locked/:page?:q': '_changeRouteToDatasets',
 
+    // Shared locked datasets
+    'datasets/shared/locked': '_changeRouteToDatasets',
+    'datasets/shared/locked/': '_changeRouteToDatasets',
+    'datasets/shared/locked?:q': '_changeRouteToDatasets',
+    'datasets/shared/locked/:page': '_changeRouteToDatasets',
+    'datasets/shared/locked/:page?:q': '_changeRouteToDatasets',
+
     // Library datasets
     'datasets/library': '_changeRouteToDatasets',
     'datasets/library/': '_changeRouteToDatasets',

--- a/lib/assets/javascripts/dashboard/views/dashboard/content-controller/content-footer/content-footer-view.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/content-controller/content-footer/content-footer-view.js
@@ -110,7 +110,7 @@ module.exports = CoreView.extend({
     const baseUrl = this.router.currentDashboardUrl();
     let path = [];
 
-    if (routerModel.get('shared')) path.push('shared');
+    if (routerModel.get('shared') !== 'no') path.push('shared');
     if (!routerModel.get('locked')) path.push('locked');
 
     return baseUrl.urlToPath(path.join('/'));

--- a/lib/assets/javascripts/dashboard/views/dashboard/content-controller/content-footer/content-footer-view.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/content-controller/content-footer/content-footer-view.js
@@ -87,12 +87,12 @@ module.exports = CoreView.extend({
       let html = '';
 
       const rModel = this.router.model;
-      const currentUrl = this.router.currentDashboardUrl();
+
       const totalCount = this.filterShortcutVis.total_entries;
       const templateData = {
         totalCount,
         pluralizedContents: this._pluralizedContentType(totalCount),
-        url: rModel.get('locked') ? currentUrl : currentUrl.lockedItems()
+        url: this._getUrl()
       };
 
       if (rModel.get('locked')) {
@@ -103,6 +103,17 @@ module.exports = CoreView.extend({
 
       this.$(`#${filterShortcutId}`).html(html);
     };
+  },
+
+  _getUrl: function () {
+    const routerModel = this.router.model;
+    const baseUrl = this.router.currentDashboardUrl();
+    let path = [];
+
+    if (routerModel.get('shared')) path.push('shared');
+    if (!routerModel.get('locked')) path.push('locked');
+
+    return baseUrl.urlToPath(path.join('/'));
   },
 
   _pluralizedContentType: function (totalCount) {
@@ -116,16 +127,15 @@ module.exports = CoreView.extend({
   },
 
   _isLockInfoNeeded: function () {
-    return this.router.model.get('shared') === 'no' &&
-      !this.router.model.get('library') &&
-      !this.router.model.isSearching();
+    const routerModel = this.router.model;
+    return !routerModel.get('library') && !routerModel.isSearching();
   },
 
   _updateFilterShortcut: function () {
     if (this._isLockInfoNeeded()) {
       this.filterShortcutVis.options.set({
         locked: !this.router.model.get('locked'),
-        shared: 'no',
+        shared: this.router.model.get('shared'),
         page: 1,
         per_page: 1,
         only_liked: this.router.model.get('liked'),

--- a/lib/assets/javascripts/dashboard/views/dashboard/content-controller/content-footer/non-locked-template.tpl
+++ b/lib/assets/javascripts/dashboard/views/dashboard/content-controller/content-footer/non-locked-template.tpl
@@ -1,1 +1,2 @@
+<i class="CDB-IconFont CDB-IconFont-unlock ContentFooter-lockedIcon"></i>
 <a href="<%- url %>" class="CDB-Text CDB-Size-medium">Show your <%- totalCount %> non-locked <%- pluralizedContents %></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.71",
+  "version": "4.12.71-14188",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.70",
+  "version": "4.12.70-14188",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.70-14188",
+  "version": "4.12.70-14188.2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.71-14188",
+  "version": "4.12.71",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/14188

### Description
This PR allows the user to visit the `/datasets/shared/locked` url

### Acceptance
You'll need a user with shared and shared+locked maps.
- Visit the datasets page
- Click on the `Shared with you` tab
  - [x] Check there is a link to the shared+locked datasets
- Click that link
  - [x] Check you can see the shared+locked datasets
  - [x] Check the URL is `/datasets/shared/locked`
  - [x] Chec there is a link to the shared datasets