### PR TITLE
Remove options from empty layers' contextual menu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancement
+* Remove options from empty layers' contextual menu (#13451)
 * Use input instead of select for `job_profile` (https://github.com/CartoDB/cartodb/pull/14227)
 * Don't show "- Rows" instead of 0 if the dataset has been updated recently ()
 * Fix panning and interactivity in Safari (https://github.com/CartoDB/cartodb/issues/14115)

--- a/lib/assets/javascripts/builder/editor/layers/layer-views/data-layer-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-views/data-layer-view.js
@@ -356,16 +356,22 @@ module.exports = CoreView.extend({
         action: function () {
           this._inlineEditor.edit();
         }.bind(this)
-      }, {
-        label: _t('editor.layers.options.export'),
-        val: 'export-data',
-        action: this._exportLayer.bind(this)
-      },
-      {
-        label: _t('editor.layers.options.center-map'),
-        val: 'center-map',
-        action: this._centerMap.bind(this)
       }]);
+
+      if (!this._viewState.get('isLayerEmpty')) {
+        menuItems = menuItems.concat([
+          {
+            label: _t('editor.layers.options.export'),
+            val: 'export-data',
+            action: this._exportLayer.bind(this)
+          },
+          {
+            label: _t('editor.layers.options.center-map'),
+            val: 'center-map',
+            action: this._centerMap.bind(this)
+          }
+        ]);
+      }
     }
 
     if (this.model.canBeDeletedByUser()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.71",
+  "version": "4.12.71-13451",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13451

### Acceptance
Create a map with an empty layer and click in the layer contextual menu (the three dots)
  - [x] Check that the `Export data` option is not there
  - [x] Check that the `Center map in layer` option is not there

Add a geometry to that layer
  - [x] Check that the `Export data` option is there
  - [x] Check that the `Center map in layer` option is there