### PR TITLE
Use a SVG for the plus icon

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ This release introduces a new API Key system. In order to migrate existing users
 * Support FileGeodatabase format uploads (https://github.com/CartoDB/cartodb/issues/10730)
 
 ### Bug fixes / enhancement
+* Use a SVG icon instead of a simple `+` sign in the `Add {layer|analysis|widget}` buttons. (https://github.com/CartoDB/cartodb/issues/#14234)
 * Use input instead of select for `job_profile` (https://github.com/CartoDB/cartodb/pull/14227)
 * Don't show "- Rows" instead of 0 if the dataset has been updated recently ()
 * Fix panning and interactivity in Safari (https://github.com/CartoDB/cartodb/issues/14115)

--- a/lib/assets/javascripts/builder/components/icon/templates/plus.tpl
+++ b/lib/assets/javascripts/builder/components/icon/templates/plus.tpl
@@ -1,0 +1,3 @@
+<svg width="12px" height="12px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#1785FB" d="M8,8 L8,1 L9,1 L9,8 L16,8 L16,9 L9,9 L9,16 L8,16 L8,9 L1,9 L1,8 L8,8 Z" />
+</svg>

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-content-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-content-view.js
@@ -3,6 +3,7 @@ var checkAndBuildOpts = require('builder/helpers/required-opts');
 var ScrollView = require('builder/components/scroll/scroll-view');
 var ViewFactory = require('builder/components/view-factory');
 var TipsyTooltipView = require('builder/components/tipsy-tooltip-view');
+var IconView = require('builder/components/icon/icon-view');
 var analysisPlaceholderTemplate = require('builder/editor/layers/layer-content-views/analyses/analyses-placeholder.tpl');
 var analysisSQLErrorTemplate = require('builder/editor/layers/layer-content-views/analyses/analyses-sql-error.tpl');
 var AnalysisFormView = require('builder/editor/layers/layer-content-views/analyses/analysis-form-view');
@@ -93,6 +94,13 @@ module.exports = CoreView.extend({
       this._renderScrollableListView(formModel);
       this._renderControlsView(formModel);
     }
+
+    var plusIcon = new IconView({
+      placeholder: this.$el.find('.js-plus-icon'),
+      icon: 'plus'
+    });
+    plusIcon.render();
+    this.addView(plusIcon);
   },
 
   _toggleOverlay: function () {

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-placeholder.tpl
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-placeholder.tpl
@@ -1,5 +1,6 @@
-<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--xl js-add-analysis">
-  + <%- _t('editor.layers.analysis-form.add-analysis.label') %>
+<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--xl u-flex u-justifyCenter u-alignCenter js-add-analysis">
+  <span class="js-plus-icon u-flex u-justifyCenter u-alignCenter u-rSpace--m"></span>
+  <%- _t('editor.layers.analysis-form.add-analysis.label') %>
 </button>
 
 <h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor"><%- _t('editor.layers.analysis-form.placeholder-text') %></h2>

--- a/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-workflow-list.tpl
+++ b/lib/assets/javascripts/builder/editor/layers/layer-content-views/analyses/analyses-workflow-list.tpl
@@ -1,5 +1,7 @@
-<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase js-add-analysis" data-layer-id="<%- layerId %>">
-  <span class="CDB-Size-big">+</span> <%- _t('editor.layers.analysis-form.add-analysis.label') %>
+<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--xl u-flex u-justifyCenter u-alignCenter js-add-analysis" data-layer-id="<%- layerId %>">
+  <span class="js-plus-icon u-flex u-justifyCenter u-alignCenter u-rSpace--m"></span>
+  <%- _t('editor.layers.analysis-form.add-analysis.label') %>
 </button>
+
 
 <ul class="VerticalRadioList u-tSpace js-analyes"></ul>

--- a/lib/assets/javascripts/builder/editor/layers/layers-view.js
+++ b/lib/assets/javascripts/builder/editor/layers/layers-view.js
@@ -4,6 +4,7 @@ var CoreView = require('backbone/core-view');
 var Notifier = require('builder/components/notifier/notifier');
 var template = require('./layers.tpl');
 var LayerViewFactory = require('./layer-view-factory');
+var IconView = require('builder/components/icon/icon-view');
 var checkAndBuildOpts = require('builder/helpers/required-opts');
 var TipsyTooltipView = require('builder/components/tipsy-tooltip-view');
 var AddLayerView = require('builder/components/modals/add-layer/add-layer-view');
@@ -84,6 +85,13 @@ module.exports = CoreView.extend({
       offset: 8
     });
     this.addView(tooltip);
+
+    var plusIcon = new IconView({
+      placeholder: this.$el.find('.js-plus-icon'),
+      icon: 'plus'
+    });
+    plusIcon.render();
+    this.addView(plusIcon);
   },
 
   _addLayer: function () {

--- a/lib/assets/javascripts/builder/editor/layers/layers.tpl
+++ b/lib/assets/javascripts/builder/editor/layers/layers.tpl
@@ -1,5 +1,6 @@
-<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--m js-add">
-  + <%- _t('editor.layers.add-layer.label') %>
+<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--xl u-flex u-justifyCenter u-alignCenter js-add">
+  <span class="js-plus-icon u-flex u-justifyCenter u-alignCenter u-rSpace--m"></span>
+  <%- _t('editor.layers.add-layer.label') %>
 </button>
 <ul class="Editor-ListLayer js-layers"></ul>
 <ul class="Editor-ListLayer js-basemaps"></ul>

--- a/lib/assets/javascripts/builder/editor/widgets/widgets-placeholder.tpl
+++ b/lib/assets/javascripts/builder/editor/widgets/widgets-placeholder.tpl
@@ -1,4 +1,5 @@
 <h2 class="CDB-Text CDB-Size-huge is-light u-secondaryTextColor u-bSpace--xl"><%- _t('editor.widgets.widgets-form.placeholder-text') %></h2>
-<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase js-add">
-  + <%- _t('editor.widgets.add-widget.label') %>
+<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-flex u-justifyCenter u-alignCenter js-add">
+  <span class="js-plus-icon u-flex u-justifyCenter u-alignCenter u-rSpace--m"></span>
+  <%- _t('editor.widgets.add-widget.label') %>
 </button>

--- a/lib/assets/javascripts/builder/editor/widgets/widgets-view.js
+++ b/lib/assets/javascripts/builder/editor/widgets/widgets-view.js
@@ -3,6 +3,7 @@ var $ = require('jquery');
 var Backbone = require('backbone');
 var CoreView = require('backbone/core-view');
 var EditorWidgetView = require('./widget-view');
+var IconView = require('builder/components/icon/icon-view');
 var template = require('./widgets-view.tpl');
 var widgetPlaceholderTemplate = require('./widgets-placeholder.tpl');
 var widgetsErrorTemplate = require('./widgets-content-error.tpl');
@@ -88,11 +89,22 @@ module.exports = CoreView.extend({
       _.each(this._widgetDefinitionsCollection.sortBy('order'), this._addWidgetItem, this);
       this._initSortable();
       this._addTooltip();
+      this._renderPlusIcon();
       return;
     }
 
     this.$el.append(widgetPlaceholderTemplate());
     this._addTooltip();
+    this._renderPlusIcon();
+  },
+
+  _renderPlusIcon: function () {
+    var plusIcon = new IconView({
+      placeholder: this.$el.find('.js-plus-icon'),
+      icon: 'plus'
+    });
+    plusIcon.render();
+    this.addView(plusIcon);
   },
 
   _initBinds: function () {

--- a/lib/assets/javascripts/builder/editor/widgets/widgets-view.tpl
+++ b/lib/assets/javascripts/builder/editor/widgets/widgets-view.tpl
@@ -1,4 +1,5 @@
-<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--m js-add">
-   + <%- _t('editor.widgets.add-widget.label') %>
+<button class="CDB-Button CDB-Button--dashed CDB-Button--wide CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase u-bSpace--m u-flex u-justifyCenter u-alignCenter js-add">
+  <span class="js-plus-icon u-flex u-justifyCenter u-alignCenter u-rSpace--m"></span>
+  <%- _t('editor.widgets.add-widget.label') %>
 </button>
 <ul class="BlockList js-widgets"></ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "4.12.71",
+  "version": "4.12.71-13536",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13536

### Description
This PR uses a SVG icon instead of a simple `+` sign in the `Add {layer|analysis|widget}` button.

### Acceptance
Layers view
- [x] The plus icon in the `Add layer` button is an SVG

Analysis view
- [x] When there are no analyses, the plus icon in the `Add analysis` button is an SVG
- [x] When there are analyses, the plus icon in the `Add analysis` button is an SVG

Widgets view
- [x] When there are no widgets, the plus icon in the `Add widget` button is an SVG
- [x] When there are widgets, the plus icon in the `Add widget` button is an SVG