### PR TITLE
With the change to Rails 4.x we need to make some tweaks to the OAuth login

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -124,6 +124,7 @@ sudo make install
 * Fail fast instead of locking dashboard / user data size calculation on table deletion (#12829)
 * Update odbc_fdw extension to `0.3.0`
 * Triggering ghost tables and common data when visiting the dashboard (#14010)
+* Fix OAuth login for the organizations
 * Now you can limit the amount of memory used by ogr2ogr adding the `memory_limit` option in bytes to the ogr2ogr section of the `app_config.yml`
 
 ### Internals

--- a/app/controllers/carto/oauth_login_controller.rb
+++ b/app/controllers/carto/oauth_login_controller.rb
@@ -48,7 +48,7 @@ module Carto
       @organization_name = state[:organization_name]
       @invitation_token = state[:invitation_token]
 
-      return render_403 unless params[:code] && state[:csrf] == form_authenticity_token
+      return render_403 unless params[:code] && valid_authenticity_token?(state[:csrf])
     end
 
     def initialize_github_config

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -106,8 +106,8 @@ Warden::Strategies.add(:oauth) do
   end
 
   def authenticate!
-    fail! unless params[:oauth_api]
-    oauth_api = params[:oauth_api]
+    fail! unless env[:oauth_api]
+    oauth_api = env[:oauth_api]
     user = oauth_api.user
     if user && oauth_api.config.valid_method_for?(user)
       trigger_login_event(user)


### PR DESCRIPTION
Related: https://github.com/CartoDB/support/issues/1699
- Use the valid_authenticity_token? method to compare csrf and
form_authenticity_token instead of use a simple equal as before
- Use the env variable to pass the OAuth API object instead of params