### PR TITLE
Hide like button if the user is not logged in

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Hide like button if the user is not logged in (https://github.com/CartoDB/cartodb/issues/13098)
 
 4.20.0 (2018-08-13)
 -------------------

--- a/lib/assets/javascripts/dashboard/components/likes/like-view.js
+++ b/lib/assets/javascripts/dashboard/components/likes/like-view.js
@@ -15,6 +15,8 @@ module.exports = CoreView.extend({
   },
 
   render: function () {
+    if (!this.model.get('likeable')) return;
+
     this.$el.html(
       template({
         likes: this.model.get('likes'),

--- a/lib/assets/javascripts/dashboard/views/public-profile/feed-view.js
+++ b/lib/assets/javascripts/dashboard/views/public-profile/feed-view.js
@@ -203,7 +203,8 @@ module.exports = CoreView.extend({
         geomType: geomType,
         account_host: this._config.get('account_host'),
         base_url: this._config.get('url_prefix'),
-        updated: moment(item.get('updated_at')).fromNow()
+        updated: moment(item.get('updated_at')).fromNow(),
+        showLikeButton: this._userLoggedIn()
       });
 
       this.$('.js-items').append(el);
@@ -218,7 +219,9 @@ module.exports = CoreView.extend({
         this._renderStaticMap(item, $item);
       }
 
-      this._initLike(item, $item.find('.js-like'));
+      if (this._userLoggedIn()) {
+        this._initLike(item, $item.find('.js-like'));
+      }
     }, this);
   },
 
@@ -288,6 +291,10 @@ module.exports = CoreView.extend({
     });
 
     likeView.render();
+  },
+
+  _userLoggedIn: function () {
+    return this._authenticatedUser && !!this._authenticatedUser.get('username');
   },
 
   _fetchLike: function (model, url) {

--- a/lib/assets/javascripts/dashboard/views/public-profile/user-feed/dataset-item.tpl
+++ b/lib/assets/javascripts/dashboard/views/public-profile/user-feed/dataset-item.tpl
@@ -30,13 +30,15 @@
                 </div>
               </div>
             </div>
-            <div class="MapCard-contentFooterDetails--right">
-              <a href="#/like" class="LikesIndicator js-like is-likeable" data-vis-id="<%- vis.id %>">
-                <i class="CDB-Text CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon "></i>
-                <span class="CDB-Text CDB-Size-medium LikesIndicator-count"><%- vis.likes %></span>
-                <span class="CDB-Text CDB-Size-medium LikesIndicator-label">like<%- vis.likes !== 1 ? 's' : '' %></span>
-              </a>
-            </div>
+            <% if (showLikeButton) { %>
+              <div class="MapCard-contentFooterDetails--right">
+                <a href="#/like" class="LikesIndicator js-like is-likeable" data-vis-id="<%- vis.id %>">
+                  <i class="CDB-Text CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon "></i>
+                  <span class="CDB-Text CDB-Size-medium LikesIndicator-count"><%- vis.likes %></span>
+                  <span class="CDB-Text CDB-Size-medium LikesIndicator-label">like<%- vis.likes !== 1 ? 's' : '' %></span>
+                </a>
+              </div>
+            <% } %>
           </div>
         </div>
       </div>

--- a/lib/assets/javascripts/dashboard/views/public-profile/user-feed/map-item.tpl
+++ b/lib/assets/javascripts/dashboard/views/public-profile/user-feed/map-item.tpl
@@ -24,15 +24,15 @@
             <%- updated %>
           </div>
         </div>
-
-        <div class="MapCard-contentFooterDetails--right">
-          <a href="#/like" class="LikesIndicator js-like is-likeable" data-vis-id="<%- vis.id %>">
-            <i class="CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon"></i>
-            <span class="CDB-Text CDB-Size-medium LikesIndicator-count"><%- vis.likes %></span>
-            <span class="CDB-Text CDB-Size-medium LikesIndicator-label">like<%- vis.likes !== 1 ? 's' : '' %></span>
-          </a>
-        </div>
-
+        <% if (showLikeButton) { %>
+          <div class="MapCard-contentFooterDetails--right">
+            <a href="#/like" class="LikesIndicator js-like is-likeable" data-vis-id="<%- vis.id %>">
+              <i class="CDB-IconFont CDB-IconFont-heartFill LikesIndicator-icon"></i>
+              <span class="CDB-Text CDB-Size-medium LikesIndicator-count"><%- vis.likes %></span>
+              <span class="CDB-Text CDB-Size-medium LikesIndicator-label">like<%- vis.likes !== 1 ? 's' : '' %></span>
+            </a>
+          </div>
+        <% } %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/13098

### Description
This PR hides the like button in the user public profile if the user visiting the page is not logged in.

### Acceptance
Create a user with some public maps and datasets

With the user logged in visit the user public page:
- [x] The maps/datasets should have a like button

Log out and visit the public page:
- [x] The maps/datasets should not have the a button
