### PR TITLE
Fix lots of requests triggered in datasets view

### DIFF
--- a/lib/assets/javascripts/dashboard/views/dashboard/content-controller/content-controller-view.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/content-controller/content-controller-view.js
@@ -251,11 +251,11 @@ module.exports = CoreView.extend({
     this._showBlocks(activeViews);
   },
 
-  _onDataChange: function () {
+  _onDataChange: _.debounce(function () {
     // Fetch collection again to check if current
     // view has suffered a change
     this.collection.fetch();
-  },
+  }, 100),
 
   _onDataError: function (e) {
     this._hideBlocks();


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/14190

### Description
This PR fixes a problem with the datasets tab triggering a lot of requests, we were calling `fetch` everytime an item is added/removed from the collection, so if the user had 20 datasets we called 20 times the fetch method.

### Acceptance
With a user with multiple datasets visit the `/datasets` view.
- [ ] Check there are no cancelled requests