### PR TITLE
Rake to purge broken visualizations without user table associated

### DIFF
--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -234,7 +234,7 @@ namespace :cartodb do
     end
 
     def inconsistent_table?(viz)
-      (viz.table? && viz.related_tables.empty?)
+      (viz.user_table? && viz.related_tables.empty?)
     end
 
     def delete_with_confirmation(viz)

--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -234,7 +234,7 @@ namespace :cartodb do
     end
 
     def inconsistent_table?(viz)
-      (viz.user_table? && viz.related_tables.empty?)
+      (viz.user_table.nil? && viz.related_tables.empty?)
     end
 
     def delete_with_confirmation(viz)

--- a/lib/tasks/viz_maintenance.rake
+++ b/lib/tasks/viz_maintenance.rake
@@ -26,7 +26,7 @@ namespace :cartodb do
         if inconsistent_table?(viz)
           puts "Deleting viz --> User: #{viz.user.username} | Viz id: #{viz.id}"
           begin
-            viz.destroy
+            viz.destroy!
           rescue => e
             puts "Error deleting viz #{viz.id}: #{e}"
           end


### PR DESCRIPTION
Related #13928 

We have almost 90k visualization without user_table and we need to remove them