### PR TITLE
Query for api keys in the index endpoint returns them weighted

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
   - Add new design for OAuth consent screen (#14237)
 
 ### Bug fixes / enhancements
+- Api keys endpoint maintains the following order: master, default and regular (https://github.com/CartoDB/cartodb/pull/14257)
 - Fix tooltips not hiding in size & color controls in mobile (https://github.com/CartoDB/cartodb/issues/14098)
 
 4.20.1 (2018-08-24)

--- a/app/controllers/carto/api/api_keys_controller.rb
+++ b/app/controllers/carto/api/api_keys_controller.rb
@@ -43,7 +43,7 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
   def index
     page, per_page, order = page_per_page_order_params(VALID_ORDER_PARAMS)
 
-    api_keys = Carto::User.find(current_user.id).api_keys.user_visible.order(Carto::ApiKey.query_order_by_type_weighted)
+    api_keys = Carto::User.find(current_user.id).api_keys.user_visible.order_weighted_by_type
     api_keys = request_api_key.master? ? api_keys : api_keys.where(id: request_api_key.id)
     filtered_api_keys = Carto::PagedModel.paged_association(api_keys, page, per_page, order)
 

--- a/app/controllers/carto/api/api_keys_controller.rb
+++ b/app/controllers/carto/api/api_keys_controller.rb
@@ -43,7 +43,7 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
   def index
     page, per_page, order = page_per_page_order_params(VALID_ORDER_PARAMS)
 
-    api_keys = Carto::User.find(current_viewer.id).api_keys.user_visible
+    api_keys = Carto::User.find(current_user.id).api_keys.user_visible.order(Carto::ApiKey.query_order_by_type_weighted)
     api_keys = request_api_key.master? ? api_keys : api_keys.where(id: request_api_key.id)
     filtered_api_keys = Carto::PagedModel.paged_association(api_keys, page, per_page, order)
 

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -52,6 +52,11 @@ module Carto
 
     TOKEN_DEFAULT_PUBLIC = 'default_public'.freeze
 
+    WEIGHTED_ORDER = "CASE WHEN type = '#{TYPE_MASTER}' THEN 3 " \
+                     "WHEN type = '#{TYPE_DEFAULT_PUBLIC}' THEN 2 " \
+                     "WHEN type = '#{TYPE_REGULAR}' THEN 1 " \
+                     "ELSE 0 END DESC".freeze
+
     self.inheritance_column = :_type
 
     belongs_to :user
@@ -145,6 +150,10 @@ module Carto
         user_id: api_key_hash[:user_id],
         skip_role_setup: true
       )
+    end
+
+    def self.query_order_by_type_weighted
+      WEIGHTED_ORDER
     end
 
     def granted_apis

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -52,10 +52,10 @@ module Carto
 
     TOKEN_DEFAULT_PUBLIC = 'default_public'.freeze
 
-    WEIGHTED_ORDER = "CASE WHEN type = '#{TYPE_MASTER}' THEN 3 " \
-                     "WHEN type = '#{TYPE_DEFAULT_PUBLIC}' THEN 2 " \
-                     "WHEN type = '#{TYPE_REGULAR}' THEN 1 " \
-                     "ELSE 0 END DESC".freeze
+    TYPE_WEIGHTED_ORDER = "CASE WHEN type = '#{TYPE_MASTER}' THEN 3 " \
+                          "WHEN type = '#{TYPE_DEFAULT_PUBLIC}' THEN 2 " \
+                          "WHEN type = '#{TYPE_REGULAR}' THEN 1 " \
+                          "ELSE 0 END DESC".freeze
 
     self.inheritance_column = :_type
 
@@ -90,6 +90,7 @@ module Carto
     scope :default_public, -> { where(type: TYPE_DEFAULT_PUBLIC) }
     scope :regular, -> { where(type: TYPE_REGULAR) }
     scope :user_visible, -> { where(type: [TYPE_MASTER, TYPE_DEFAULT_PUBLIC, TYPE_REGULAR]) }
+    scope :order_weighted_by_type, -> { order(TYPE_WEIGHTED_ORDER) }
 
     attr_accessor :skip_role_setup
 
@@ -150,10 +151,6 @@ module Carto
         user_id: api_key_hash[:user_id],
         skip_role_setup: true
       )
-    end
-
-    def self.query_order_by_type_weighted
-      WEIGHTED_ORDER
     end
 
     def granted_apis

--- a/spec/requests/carto/api/api_keys_controller_spec.rb
+++ b/spec/requests/carto/api/api_keys_controller_spec.rb
@@ -484,6 +484,26 @@ describe Carto::Api::ApiKeysController do
         end
       end
 
+      it 'should come master first, default type second and then regular' do
+        auth_user(@carto_user_index)
+        get_json api_keys_url, auth_params.merge(per_page: 20), auth_headers do |response|
+          response.body[:result][0][:type].should eq 'master'
+          response.body[:result][1][:type].should eq 'default'
+          response.body[:result][2][:type].should eq 'regular'
+        end
+
+        master_key = @apikeys.select { |key| key.type == 'master' }.first
+        master_key.updated_at = Time.now
+        master_key.save
+
+        get_json api_keys_url, auth_params.merge(per_page: 20), auth_headers do |response|
+          response.body[:result][0][:type].should eq 'master'
+          response.body[:result][1][:type].should eq 'default'
+          response.body[:result][2][:type].should eq 'regular'
+        end
+
+      end
+
       it 'paginates correctly' do
         auth_user(@carto_user_index)
         get_json api_keys_url, auth_params.merge(per_page: 2), auth_headers do |response|


### PR DESCRIPTION
Related https://github.com/CartoDB/support/issues/1714
Now we return the api keys ordered by type and every type has a weight.
First we get the master one, then the default and finally the regular
ones