### PR TITLE
Fix master testing: ensure to undo time stubs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Fix legacy functions in the data mover that doesn't process multiword type functions
+- Fix broken tests due to time stubbing (#14287)
 
 4.20.2 (2018-09-10)
 -------------------

--- a/spec/lib/tasks/oauth_rake_spec.rb
+++ b/spec/lib/tasks/oauth_rake_spec.rb
@@ -18,6 +18,7 @@ describe 'oauth.rake' do
 
   after(:each) do
     @oauth_app_user.reload.destroy!
+    Delorean.back_to_the_present
   end
 
   after(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,10 @@ RSpec.configure do |config|
   config.include HelperMethods
   config.include NamedMapsHelper
 
+  config.after(:each) do
+    Delorean.back_to_the_present
+  end
+
   unless ENV['PARALLEL']
     config.before(:suite) do
       CartoDB::RedisTest.up

--- a/spec/spec_helper_min.rb
+++ b/spec/spec_helper_min.rb
@@ -22,6 +22,10 @@ RSpec.configure do |config|
   config.include SpecHelperHelpers
   config.include NamedMapsHelper
 
+  config.after(:each) do
+    Delorean.back_to_the_present
+  end
+
   unless ENV['PARALLEL']
     config.before(:suite) do
       CartoDB::RedisTest.up


### PR DESCRIPTION
Fixes #14251 

Running master testing with this branch -> https://ci.cartodb.net/user/javitonino/my-views/view/Builder/job/CartoDB-master-testing/1589/console :green_apple: (no further acceptance needed)

Fixes the errors in testing:
```
07:36:10   1) Carto::Superadmin::OrganizationsController#usage returns Twitter imports
07:36:10      Failure/Error: tweets.find { |h| h[:date] == formatted_date }[:value].should eq st1.retrieved_items + st2.retrieved_items
07:36:10      NoMethodError:
07:36:10        undefined method `[]' for nil:NilClass
07:36:10      # ./spec/requests/carto/superadmin/organizations_controller_spec.rb:247:in `block (4 levels) in <top (required)>'
07:36:10      # ./spec/support/helpers.rb:43:in `get_json'
07:36:10      # ./spec/requests/carto/superadmin/organizations_controller_spec.rb:244:in `block (3 levels) in <top (required)>'
07:36:10 
07:36:10   2) Carto::Superadmin::UsersController#usage returns Twitter imports
07:36:10      Failure/Error: tweets.find { |h| h[:date] == formatted_date }[:value].should eq st.retrieved_items
07:36:10      NoMethodError:
07:36:10        undefined method `[]' for nil:NilClass
07:36:10      # ./spec/requests/carto/superadmin/users_controller_spec.rb:246:in `block (4 levels) in <top (required)>'
07:36:10      # ./spec/support/helpers.rb:43:in `get_json'
07:36:10      # ./spec/requests/carto/superadmin/users_controller_spec.rb:243:in `block (3 levels) in <top (required)>'
```

Some tests (in this case OAuth) were leaving the time stubbed. Delorean does not automatically unstub. I decided to add this to the global helpers as well, as a fallback.