### PR TITLE
Theme password change page with organization style

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ sudo make install
 - Fix `image_tag` function to include the assets versioning (#14266)
 - Fix broken tests due to time stubbing (#14287)
 - Remove username from Postgres roles
+- Style password change form with organization colors (#14296)
 
 4.20.2 (2018-09-10)
 -------------------

--- a/app/controllers/password_change_controller.rb
+++ b/app/controllers/password_change_controller.rb
@@ -71,6 +71,7 @@ class PasswordChangeController < ApplicationController
   def set_user
     username = params[:id].strip.downcase
     @user = User.where("email = ? OR username = ?", username, username).first
+    @organization = @user.organization
   end
 
   def set_errors


### PR DESCRIPTION
Closes #14296

It was prepared, just missing the `@organization` attribute that the `erb` uses to draw the org log and color.