### PR TITLE
Fix legends color range update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,8 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Update legends for heatmap aggregation when the colors change from the style editor (#13763)
+- Update legends for color ranges when the color list order changes
 
 4.21.0 (2018-09-24)
 -------------------

--- a/lib/assets/javascripts/builder/components/form-components/editors/sortable-list.js
+++ b/lib/assets/javascripts/builder/components/form-components/editors/sortable-list.js
@@ -39,8 +39,11 @@ Backbone.Form.editors.SortableList = Backbone.Form.editors.List.extend({
 
   _onSortableUpdate: function (event, ui) {
     var sorted = [];
-    _.each(this.items, function (item) {
-      var index = item.$el.index(this.$list);
+    var list = this.$list;
+    var items = this.items;
+
+    _.each(items, function (item) {
+      var index = item.$el.index(list.$el);
       sorted[index] = item;
     });
 

--- a/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
@@ -24,7 +24,8 @@ function _createLegendForHeatmap (layerDefModel) {
   LegendFactory.removeLegend(layerDefModel, LegendTypes.CATEGORY, function () {
     LegendFactory.removeLegend(layerDefModel, LegendTypes.TORQUE, function () {
       LegendFactory.removeLegend(layerDefModel, LegendTypes.CHOROPLETH, function () {
-        var colors = StyleHelper.getColorsFromRange(layerDefModel.styleModel);
+        var colors = StyleHelper.getColorsForLegend(layerDefModel);
+
         LegendFactory.createLegend(layerDefModel, LegendTypes.CUSTOM_CHOROPLETH, {
           title: _t('editor.legend.pixel-title'),
           colors: colors

--- a/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
+++ b/lib/assets/javascripts/builder/deep-insights-integration/legend-manager.js
@@ -24,8 +24,7 @@ function _createLegendForHeatmap (layerDefModel) {
   LegendFactory.removeLegend(layerDefModel, LegendTypes.CATEGORY, function () {
     LegendFactory.removeLegend(layerDefModel, LegendTypes.TORQUE, function () {
       LegendFactory.removeLegend(layerDefModel, LegendTypes.CHOROPLETH, function () {
-        var colors = StyleHelper.getColorsForLegend(layerDefModel);
-
+        var colors = StyleHelper.getHeatmapColors(layerDefModel);
         LegendFactory.createLegend(layerDefModel, LegendTypes.CUSTOM_CHOROPLETH, {
           title: _t('editor.legend.pixel-title'),
           colors: colors

--- a/lib/assets/javascripts/builder/helpers/parser-css.js
+++ b/lib/assets/javascripts/builder/helpers/parser-css.js
@@ -1,6 +1,6 @@
-var cdb = require('internal-carto.js');
 var carto = require('carto');
 var torque = require('torque.js');
+var Utils = require('builder/helpers/utils');
 var _ = require('underscore');
 
 var ERROR_REGEX = /.*:(\d+):(\d+)\s*(.*)/;
@@ -267,11 +267,31 @@ CartoParser.prototype = {
 
     if (opt && opt.mode === 'hex') {
       colors = _.map(colors, function (color) {
-        return cdb.Utils.rgbToHex(color[0], color[1], color[2]);
+        return Utils.rgbToHex(color[0], color[1], color[2]);
       });
     }
 
     return colors;
+  },
+
+  colorsUsedForLegend: function (opt) {
+    var method = function (self, rule) {
+      return _.map(self._colorsFromRule(rule), function (f) {
+        return f.rgb;
+      });
+    };
+
+    var colors = this._extract(method, true);
+
+    if (opt && opt.mode === 'hex') {
+      colors = _.map(colors, function (color) {
+        return Utils.rgbToHex(color[0], color[1], color[2]);
+      });
+    }
+
+    return _.map(colors, function (color) {
+      return { color: color };
+    });
   },
 
   /**

--- a/lib/assets/javascripts/builder/helpers/parser-css.js
+++ b/lib/assets/javascripts/builder/helpers/parser-css.js
@@ -258,8 +258,10 @@ CartoParser.prototype = {
   colorsUsed: function (opt) {
     // extraction method
     var method = function (self, rule) {
-      return _.map(self._colorsFromRule(rule), function (f) {
-        return f.rgb;
+      var colors = self._colorsFromRule(rule);
+
+      return _.map(colors, function (color) {
+        return color.rgb;
       });
     };
 
@@ -275,18 +277,24 @@ CartoParser.prototype = {
   },
 
   colorsUsedForLegend: function (opt) {
-    var method = function (self, rule) {
-      return _.map(self._colorsFromRule(rule), function (f) {
-        return f.rgb;
-      });
-    };
+    var rules = this.getDefaultRules();
 
-    var colors = this._extract(method, true);
+    if (rules['image-filters']) {
+      var method = function (self, rule) {
+        var imageFillRule = rules['image-filters'];
+        var colors = self._colorsFromRule(imageFillRule);
+        return _.map(colors, function (f) {
+          return f.rgb;
+        });
+      };
 
-    if (opt && opt.mode === 'hex') {
-      colors = _.map(colors, function (color) {
-        return Utils.rgbToHex(color[0], color[1], color[2]);
-      });
+      var colors = this._extract(method, true);
+
+      if (opt && opt.mode === 'hex') {
+        colors = _.map(colors, function (color) {
+          return Utils.rgbToHex(color[0], color[1], color[2]);
+        });
+      }
     }
 
     return _.map(colors, function (color) {

--- a/lib/assets/javascripts/builder/helpers/style.js
+++ b/lib/assets/javascripts/builder/helpers/style.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var ParserCSS = require('builder/helpers/parser-css');
 var LegendColorHelper = require('builder/editor/layers/layer-content-views/legend/form/legend-color-helper');
 
 module.exports = {
@@ -44,6 +45,18 @@ module.exports = {
     return color.range.map(function (v, index) {
       return { color: v };
     });
+  },
+
+  getColorsForLegend: function (layerDefinitionModel) {
+    var changed = layerDefinitionModel.styleModel && layerDefinitionModel.styleModel.hasChanged();
+
+    if (changed) {
+      return this.getColorsFromRange(layerDefinitionModel.styleModel);
+    }
+
+    var content = layerDefinitionModel.cartocssModel.get('content');
+    var parser = new ParserCSS(content);
+    return parser.colorsUsedForLegend({ mode: 'hex' });
   },
 
   getStyleCategories: function (styleModel) {

--- a/lib/assets/javascripts/builder/helpers/style.js
+++ b/lib/assets/javascripts/builder/helpers/style.js
@@ -47,7 +47,7 @@ module.exports = {
     });
   },
 
-  getColorsForLegend: function (layerDefinitionModel) {
+  getHeatmapColors: function (layerDefinitionModel) {
     var changed = layerDefinitionModel.styleModel && layerDefinitionModel.styleModel.hasChanged();
 
     if (changed) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.6",
+  "version": "1.0.0-assets.7",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes:

* Custom legend items order do not match the UI  https://github.com/CartoDB/support/issues/1761
* Heatmap legend does not update after style changes https://github.com/CartoDB/cartodb/issues/13763

*About the second issue: IMO, is quite confusing that the heatmap colors change when we change the colors in the editor, but it does not change the other parameters (such as the width, for instance) until we click on "Apply". Although his is the expected behaviour since it does not happen only for heatmaps, but for every aggregation style, I think this is not consistent*