### PR TITLE
P4957 log rotation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,8 +24,8 @@ sudo make install
 ### Features
 * Add dataservices permissions in Auth API (#14263)
 * OAuth provider (WIP):
- * Add scopes for accessing dataservices
- * Add scopes for accessing user public profile
+  * Add scopes for accessing dataservices
+  * Add scopes for accessing user public profile
 
 ### Bug fixes / enhancements
 * Fix legacy functions in the data mover that doesn't process multiword type functions

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Correctly set the logger level, instead of log rotation
 
 4.21.0 (2018-09-24)
 -------------------

--- a/bump.rb
+++ b/bump.rb
@@ -87,7 +87,7 @@ def news_sections(lines)
       section_name = line[4..-1]
     elsif line != '- None yet'
       # Replace initial `-` for `*`
-      section_lines << line.sub(/^(\s)*-/, '\1*')
+      section_lines << line.sub(/^(\s*)-/, '\1*')
     end
   end
   sections << [section_name, section_lines] if section_name

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ CartoDB::Application.configure do
   # Note that we pass the desired log level to the logger's constructor;
   # assigning to `config.log_level` would have no effect here, since we have set the logger explicitly.
   config.logger = ActiveSupport::TaggedLogging.new(
-    ActiveSupport::Logger.new(Carto::Conf.new.log_file_path('production.log'), level: Logger::INFO)
+    ActiveSupport::Logger.new(Carto::Conf.new.log_file_path('production.log'))
   )
 
   config.log_level = :info

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ CartoDB::Application.configure do
   # Note that we pass the desired log level to the logger's constructor;
   # assigning to `config.log_level` would have no effect here, since we have set the logger explicitly.
   config.logger = ActiveSupport::TaggedLogging.new(
-    ActiveSupport::Logger.new(Carto::Conf.new.log_file_path('production.log'), Logger::INFO)
+    ActiveSupport::Logger.new(Carto::Conf.new.log_file_path('production.log'), level: Logger::INFO)
   )
 
   config.log_level = :info

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -25,7 +25,7 @@ CartoDB::Application.configure do
   # Note that we pass the desired log level to the logger's constructor;
   # assigning to `config.log_level` would have no effect here, since we have set the logger explicitly.
   config.logger = ActiveSupport::TaggedLogging.new(
-    ActiveSupport::Logger.new(Carto::Conf.new.log_file_path('staging.log'), level: Logger::INFO)
+    ActiveSupport::Logger.new(Carto::Conf.new.log_file_path('staging.log'))
   )
 
   config.log_level = :info

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -25,7 +25,7 @@ CartoDB::Application.configure do
   # Note that we pass the desired log level to the logger's constructor;
   # assigning to `config.log_level` would have no effect here, since we have set the logger explicitly.
   config.logger = ActiveSupport::TaggedLogging.new(
-    ActiveSupport::Logger.new(Carto::Conf.new.log_file_path('staging.log'), Logger::INFO)
+    ActiveSupport::Logger.new(Carto::Conf.new.log_file_path('staging.log'), level: Logger::INFO)
   )
 
   config.log_level = :info


### PR DESCRIPTION
https://github.com/CartoDB/cartodb-platform/issues/4957

Use the proper parameter for level. The second positional parameter is not level, but shift_age: the maximum number of old logs that will be kept. That enables automatic log rotation in Ruby side with the default size (1MB) and it did nothing to set the level. Since Logger::INFO is a constant for 1, it kept just one old log version.