### PR TITLE
Add Feature Flags capability to Static pages

### DIFF
--- a/lib/assets/javascripts/dashboard/statics/static.js
+++ b/lib/assets/javascripts/dashboard/statics/static.js
@@ -28,7 +28,35 @@ window.CartoConfig = window.CartoConfig || {};
     spinnerEl.parentNode.classList.add('is-hidden');
   };
 
-  var addAssets = function () {
+  var getEndpointFeatureFlags = function (staticConfig) {
+    var featureFlagsData = window.StaticConfig.feature_flags;
+
+    if (!featureFlagsData) {
+      return [];
+    }
+
+    return Object.keys(featureFlagsData);
+  };
+
+  var getAssetsToLoad = function (userData) {
+    var endpointFeatureFlags = getEndpointFeatureFlags(window.StaticConfig);
+    var userFeatureFlags = userData.feature_flags;
+
+    var featureFlagToUse = endpointFeatureFlags.filter(function (featureFlag) {
+      return userFeatureFlags.indexOf(featureFlag) !== -1;
+    })[0];
+
+    if (featureFlagToUse) {
+      return window.StaticConfig.feature_flags[featureFlagToUse];
+    }
+
+    return {
+      stylesheets: window.StaticConfig.stylesheets,
+      scripts: window.StaticConfig.scripts
+    };
+  };
+
+  var addAssets = function (options) {
     (function (w, d, a, favicon, stylesheets, scripts, l, h, s, t) {
       var googleMapsQueryString = w.CartoConfig.vizdata
         ? w.CartoConfig.vizdata.user.google_maps_query_string
@@ -73,7 +101,7 @@ window.CartoConfig = window.CartoConfig || {};
         s.src = a + src;
         t.parentNode.insertBefore(s, t);
       });
-    })(window, document, assetsUrl, '/favicons/favicon.ico', window.StaticConfig.stylesheets, window.StaticConfig.scripts);
+    })(window, document, assetsUrl, '/favicons/favicon.ico', options.stylesheets, options.scripts);
   };
 
   var getUserConfig = function (visualizationError) {
@@ -95,7 +123,12 @@ window.CartoConfig = window.CartoConfig || {};
       window.CartoConfig.data = data;
       assetsUrl = AssetsVersionHelper.getAssetsUrl(version);
       addSpinner();
-      addAssets();
+
+      var assets = getAssetsToLoad(userData);
+      addAssets({
+        stylesheets: assets.stylesheets,
+        scripts: assets.scripts
+      });
     });
   };
 

--- a/lib/assets/javascripts/dashboard/statics/static.js
+++ b/lib/assets/javascripts/dashboard/statics/static.js
@@ -28,8 +28,8 @@ window.CartoConfig = window.CartoConfig || {};
     spinnerEl.parentNode.classList.add('is-hidden');
   };
 
-  var getEndpointFeatureFlags = function (staticConfig) {
-    var featureFlagsData = window.StaticConfig.feature_flags;
+  var getEntryPointFeatureFlags = function (staticConfig) {
+    var featureFlagsData = staticConfig.feature_flags;
 
     if (!featureFlagsData) {
       return [];
@@ -39,10 +39,10 @@ window.CartoConfig = window.CartoConfig || {};
   };
 
   var getAssetsToLoad = function (userData) {
-    var endpointFeatureFlags = getEndpointFeatureFlags(window.StaticConfig);
+    var entryPointFeatureFlags = getEntryPointFeatureFlags(window.StaticConfig);
     var userFeatureFlags = userData.feature_flags;
 
-    var featureFlagToUse = endpointFeatureFlags.filter(function (featureFlag) {
+    var featureFlagToUse = entryPointFeatureFlags.filter(function (featureFlag) {
       return userFeatureFlags.indexOf(featureFlag) !== -1;
     })[0];
 


### PR DESCRIPTION
Until now, we didn't have the possibility of loading different scripts/stylesheets depending on a user's feature flag. Due to new dashboard implementation, we need to allow this behaviour. So here it is.

The static script will load assets matching endpoint's feature flags against the ones defined in the user profile.

The feature flag endpoint specification is:

```js
{endpoint}: {
    page: '{endpoint}',
    stylesheets: [
      // Stylesheets
    ],
    scripts: [
      // Scripts
    ],
    feature_flags: {
      '{feature_flag_name}': {
        stylesheets: [
          // Feature flag stylesheets
        ],
        scripts: [
          // Feature flag scripts
        ]
      }
    }
},
```

Related to https://github.com/CartoDB/cartodb/issues/14311