### PR TITLE
Add db connection timeout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Scrollbar resized after notifications (#12953)
+- Add timeout for AR and Sequel connections (#13266)
 
 4.22.1 (2018-10-18)
 -------------------

--- a/app/models/carto/user_service.rb
+++ b/app/models/carto/user_service.rb
@@ -172,6 +172,8 @@ module Carto
       options[:username] = @user.database_username
       options[:password] = @user.database_password
       options[:user_schema] = @user.database_schema
+      db_config = Rails.configuration.database_configuration[Rails.env]
+      options[:connect_timeout] = db_config['connect_timeout']
       Carto::Db::Connection.connect(@user.database_host, @user.database_name, options) do |_, connection|
         if block_given?
           yield(connection)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -764,6 +764,9 @@ class User < Sequel::Model
   end
 
   def get_database(options, configuration)
+    db_config = Rails.configuration.database_configuration[Rails.env]
+    configuration[:connect_timeout] = db_config['connect_timeout']
+
     ::Sequel.connect(configuration.merge(after_connect: (proc do |conn|
       unless options[:as] == :cluster_admin
         conn.execute(%{ SET search_path TO #{db_service.build_search_path} })

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -8,6 +8,7 @@ production:
   username: postgres
   password:
   conn_validator_timeout: 900
+  connect_timeout: 2.5
   prepared_statements: false
 
 staging:
@@ -20,6 +21,7 @@ staging:
   username: postgres
   password:
   conn_validator_timeout: 900
+  connect_timeout: 2.5
   prepared_statements: false
 
 development:
@@ -32,6 +34,7 @@ development:
   username: postgres
   password:
   conn_validator_timeout: 900
+  connect_timeout: 2.5
   pool: 50
   prepared_statements: false
 
@@ -45,5 +48,6 @@ test:
   username: postgres
   password:
   conn_validator_timeout: -1
+  connect_timeout: -1
   prepared_statements: false
 

--- a/lib/carto/db/connection.rb
+++ b/lib/carto/db/connection.rb
@@ -88,7 +88,8 @@ module Carto
             password: base_config['password'],
             database: db_name,
             port:     base_config['port'],
-            encoding: base_config['encoding'].nil? ? 'unicode' : base_config['encoding']
+            encoding: base_config['encoding'].nil? ? 'unicode' : base_config['encoding'],
+            connect_timeout: options[:connect_timeout]
           }
 
           case options[:as]

--- a/spec/models/carto/user_service_spec.rb
+++ b/spec/models/carto/user_service_spec.rb
@@ -16,101 +16,118 @@ describe Carto::UserService do
     @user.destroy
   end
 
-  it "Tests in_database() settimeout option" do
-    custom_timeout = 123456
-    expected_returned_custom_timeout = { statement_timeout: "#{custom_timeout}ms" }
+  describe "#in_database" do
+    it "initializes the connection with the expected options" do
+      carto_user = Carto::User.find(@user.id)
+      default_opts = {
+        username: carto_user.database_username,
+        password: carto_user.database_password,
+        user_schema: carto_user.database_schema,
+        connect_timeout: -1
+      }
+      expected_params = [carto_user.database_host, carto_user.database_name, default_opts]
 
-    @returned_timeout = nil
-    @default_timeout = nil
-    @returned_timeout_new = nil
-    @default_timeout_new = nil
+      Carto::Db::Connection.expects(:connect).with(*expected_params)
 
-    @user.in_database do |db|
-      @default_timeout = db[%{SHOW statement_timeout}].first
+      carto_user.in_database
     end
 
-    @user.in_database(statement_timeout: custom_timeout) do |db|
-      @returned_timeout = db[%{SHOW statement_timeout}].first
+    it "sets statement timeout option" do
+      custom_timeout = 123456
+      expected_returned_custom_timeout = { statement_timeout: "#{custom_timeout}ms" }
+
+      @returned_timeout = nil
+      @default_timeout = nil
+      @returned_timeout_new = nil
+      @default_timeout_new = nil
+
+      @user.in_database do |db|
+        @default_timeout = db[%{SHOW statement_timeout}].first
+      end
+
+      @user.in_database(statement_timeout: custom_timeout) do |db|
+        @returned_timeout = db[%{SHOW statement_timeout}].first
+      end
+
+      @returned_timeout.should eq expected_returned_custom_timeout
+      @default_timeout.should_not eq @returned_timeout
+
+      @user.in_database do |db|
+        @default_timeout.should eq db[%{SHOW statement_timeout}].first
+      end
+
+      # Now test with CARTO user
+      carto_user = Carto::User.find(@user.id)
+
+      carto_user.in_database do |db|
+        @default_timeout_new = db.execute(%{SHOW statement_timeout}).first
+      end
+
+      carto_user.in_database(statement_timeout: custom_timeout) do |db|
+        @returned_timeout_new = db.execute(%{SHOW statement_timeout}).first
+      end
+
+      @returned_timeout_new.symbolize_keys!
+      @default_timeout_new .symbolize_keys!
+
+      @returned_timeout_new.should eq expected_returned_custom_timeout
+      @default_timeout_new.should_not eq @returned_timeout_new
+
+      carto_user.in_database do |db|
+        @default_timeout_new.should eq db.execute(%{SHOW statement_timeout}).first.symbolize_keys
+      end
+
+      @default_timeout_new .symbolize_keys!
+
+      @returned_timeout_new.should eq @returned_timeout
+      @default_timeout_new.should eq @default_timeout
     end
 
-    @returned_timeout.should eq expected_returned_custom_timeout
-    @default_timeout.should_not eq @returned_timeout
+    it "sets search_path correctly" do
+      expected_returned_normal_search_path = { search_path: "#{@user.database_schema}, cartodb, cdb_dataservices_client, public" }
 
-    @user.in_database do |db|
-      @default_timeout.should eq db[%{SHOW statement_timeout}].first
+      @normal_search_path = nil
+      @normal_search_path_new = nil
+      @user.in_database do |db|
+        @normal_search_path = db[%{SHOW search_path}].first
+      end
+      @normal_search_path.should eq expected_returned_normal_search_path
+
+      carto_user = Carto::User.find(@user.id)
+
+      carto_user.in_database do |db|
+        @normal_search_path_new = db.execute(%{SHOW search_path}).first
+      end
+      @normal_search_path_new.symbolize_keys!
+      @normal_search_path_new.should eq expected_returned_normal_search_path
+
+      @normal_search_path_new.should eq @normal_search_path
     end
 
-    # Now test with CARTO user
-    carto_user = Carto::User.find(@user.id)
-
-    carto_user.in_database do |db|
-      @default_timeout_new = db.execute(%{SHOW statement_timeout}).first
-    end
-
-    carto_user.in_database(statement_timeout: custom_timeout) do |db|
-      @returned_timeout_new = db.execute(%{SHOW statement_timeout}).first
-    end
-
-    @returned_timeout_new.symbolize_keys!
-    @default_timeout_new .symbolize_keys!
-
-    @returned_timeout_new.should eq expected_returned_custom_timeout
-    @default_timeout_new.should_not eq @returned_timeout_new
-
-    carto_user.in_database do |db|
-      @default_timeout_new.should eq db.execute(%{SHOW statement_timeout}).first.symbolize_keys
-    end
-
-    @default_timeout_new .symbolize_keys!
-
-    @returned_timeout_new.should eq @returned_timeout
-    @default_timeout_new.should eq @default_timeout
-  end
-
-  it "Tests search_path correctly set" do
-    expected_returned_normal_search_path = { search_path: "#{@user.database_schema}, cartodb, cdb_dataservices_client, public" }
-
-    @normal_search_path = nil
-    @normal_search_path_new = nil
-    @user.in_database do |db|
-      @normal_search_path = db[%{SHOW search_path}].first
-    end
-    @normal_search_path.should eq expected_returned_normal_search_path
-
-    carto_user = Carto::User.find(@user.id)
-
-    carto_user.in_database do |db|
-      @normal_search_path_new = db.execute(%{SHOW search_path}).first
-    end
-    @normal_search_path_new.symbolize_keys!
-    @normal_search_path_new.should eq expected_returned_normal_search_path
-
-    @normal_search_path_new.should eq @normal_search_path
-  end
-
-  it "tests in_database() with superadmin only operations" do
-    carto_user = Carto::User.find(@user.id)
-    expect {
-      @user.in_database do |conn|
+    it "only allows superadmin operations to the expected roles" do
+      carto_user = Carto::User.find(@user.id)
+      expect {
+        @user.in_database do |conn|
+          conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
+        end
+      }.to raise_exception(Sequel::DatabaseError, /permission denied to set parameter "log_statement_stats"/)
+      expect {
+        carto_user.in_database do |conn|
+          conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
+        end
+      }.to raise_exception(ActiveRecord::StatementInvalid, /permission denied to set parameter "log_statement_stats"/)
+      @user.in_database(as: :superuser) do |conn|
         conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
       end
-    }.to raise_exception(Sequel::DatabaseError, /permission denied to set parameter "log_statement_stats"/)
-    expect {
-      carto_user.in_database do |conn|
+      carto_user.in_database(as: :superuser) do |conn|
         conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
       end
-    }.to raise_exception(ActiveRecord::StatementInvalid, /permission denied to set parameter "log_statement_stats"/)
-    @user.in_database(as: :superuser) do |conn|
-      conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
-    end
-    carto_user.in_database(as: :superuser) do |conn|
-      conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
-    end
-    @user.in_database(as: :cluster_admin) do |conn|
-      conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
-    end
-    carto_user.in_database(as: :cluster_admin) do |conn|
-      conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
+      @user.in_database(as: :cluster_admin) do |conn|
+        conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
+      end
+      carto_user.in_database(as: :cluster_admin) do |conn|
+        conn.execute(%{SELECT set_config('log_statement_stats', 'off', false)})
+      end
     end
   end
 end


### PR DESCRIPTION
Fix for https://github.com/CartoDB/cartodb/issues/13266

We currently have 2 ways to connect to the user database, depending on the model:
- Old User uses Sequel, which has a [20s timeout by default](https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc#postgres) 
- Carto::User uses AR, which throws a timeout after 2 minutes or so.

In production we already have the `connect_timeout` configuration in database.yml set to 2.5s, but unused for user databases, and Tonino thinks it's a good value for this.

So the fix is to take that `connect_timeout` and initialize with it both Sequel and AR connections.