### PR TITLE
Fixed varnish invalidation for http function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ Development
 - Add timeout for AR and Sequel connections (#13266)
 - Fix Feedback modal on Enter (https://github.com/CartoDB/support/issues/1804)
 - Apply code style for "Layer hidden" notification in advanced mode (#13355)
+- Fixed varnish validation for http function due a regexp problem (https://github.com/CartoDB/support/issues/1727)
 - Fix input widths (#13453)
 - Update tags style (#13756)
 - Fix sharing datasets with groups (https://github.com/CartoDB/onpremises/issues/637)

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1379,7 +1379,7 @@ module CartoDB
                   try:
                     client = GD['httplib'].HTTPConnection('#{varnish_host}', #{varnish_port}, False, timeout)
                     raw_cache_key = "t:" + GD['base64'].b64encode(GD['hashlib'].sha256('#{@user.database_name}:%s' % table_name).digest())[0:6]
-                    cache_key = re.sub(r'([\.\^\$\*\+\-\?\(\)\[\]\{\}\|])', lambda x: "\{}".format(x.group(1)), raw_cache_key)
+cache_key = raw_cache_key.replace('+', r'\+')
                     client.request('PURGE', '/key', '', {"Invalidation-Match": ('\\\\b%s\\\\b' % cache_key) })
                     response = client.getresponse()
                     assert response.status == 204

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1378,7 +1378,7 @@ module CartoDB
                   try:
                     client = GD['httplib'].HTTPConnection('#{varnish_host}', #{varnish_port}, False, timeout)
                     raw_cache_key = "t:" + GD['base64'].b64encode(GD['hashlib'].sha256('#{@user.database_name}:%s' % table_name).digest())[0:6]
-cache_key = raw_cache_key.replace('+', r'\+')
+                    cache_key = raw_cache_key.replace('+', r'\+')
                     client.request('PURGE', '/key', '', {"Invalidation-Match": ('\\\\b%s\\\\b' % cache_key) })
                     response = client.getresponse()
                     assert response.status == 204

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1365,7 +1365,6 @@ module CartoDB
             BEGIN;
             CREATE OR REPLACE FUNCTION public.cdb_invalidate_varnish(table_name text) RETURNS void AS
             $$
-                import re
                 critical = #{varnish_critical}
                 timeout = #{varnish_timeout}
                 retry = #{varnish_retry}


### PR DESCRIPTION
Related https://github.com/CartoDB/support/issues/1727

The problem comes when the surrogate key has characters that should be
escaped when used in the regexp used by Varnish to ban that key