### PR TITLE
Fix mapcards sizing

### DIFF
--- a/lib/assets/javascripts/new-dashboard/components/MapCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapCard.vue
@@ -251,7 +251,7 @@ export default {
 
 .card-metadataItem {
   display: flex;
-  margin-bottom: 4px;
+  margin-bottom: 8px;
 
   a {
     color: $text-color;

--- a/lib/assets/javascripts/new-dashboard/components/MapCardFake.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapCardFake.vue
@@ -39,7 +39,7 @@ export default {
 .text-placeholder {
   width: 100%;
   height: 24px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   background-color: $softblue;
 
   &.text-placeholder--double {


### PR DESCRIPTION
The Map Card component and the Map Card Fake component didn't have the same sizes. Now it's fixed and should always have the same height