### PR TITLE
Fix concurrent acceptance specs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@ Development
 * Update some old vulnerable dependencies (#14368)
 * Fix shrinkwrap generation through a carto.js release (https://github.com/CartoDB/cartodb/pull/14369)
 * Revert tag style, add color to privacy modal (#13756)
+* Fix parallel execution of some acceptance specs (#14391)
 
 4.22.1 (2018-10-18)
 -------------------

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -1,6 +1,5 @@
 # coding: UTF-8
 
-require_relative '../acceptance_helper'
 require_relative '../spec_helper_min'
 
 feature "Forgot password" do
@@ -11,7 +10,6 @@ feature "Forgot password" do
   end
 
   before(:each) do
-    Capybara.current_driver = :rack_test
     visit login_path
     click_link 'Forgot?'
     fill_in 'email', with: @user.email


### PR DESCRIPTION
Closes #14391

I've just removed the requirement of an acceptance_helper which was unnecessarily changing the capybara driver to Selenium.