### PR TITLE
Fix api key and overviews

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Sync new password resets fields with central (#14333)
+- Do not concatenate the schema if it's already defined while fetching overview tables #14414
 
 4.22.2 (2018-11-05)
 -------------------

--- a/app/services/carto/table_and_friends.rb
+++ b/app/services/carto/table_and_friends.rb
@@ -1,6 +1,6 @@
 module Carto
   # A dataset may be comprised of additional tables other than the main table
-  # For example, if overviews have been creetaed for the dataset.
+  # For example, if overviews have been created for the dataset.
   # This is a utility to apply changes (e.g. privilege modifications) to all
   # the tables than comprise the dataset.
   module TableAndFriends

--- a/app/services/carto/table_and_friends.rb
+++ b/app/services/carto/table_and_friends.rb
@@ -9,7 +9,7 @@ module Carto
       block[schema, table_name, qualified_name]
       overviews_service = Carto::OverviewsService.new(db_connection)
       overviews_service.overview_tables(qualified_name).each do |overview_table|
-        table, schema = Table.table_and_schema(overview_table)
+        table, _ = Table.table_and_schema(overview_table)
         block[schema, table, qualified_table_name(schema, table)]
       end
       # TODO: should we apply also to raster overview tables?

--- a/app/services/carto/table_and_friends.rb
+++ b/app/services/carto/table_and_friends.rb
@@ -9,7 +9,8 @@ module Carto
       block[schema, table_name, qualified_name]
       overviews_service = Carto::OverviewsService.new(db_connection)
       overviews_service.overview_tables(qualified_name).each do |overview_table|
-        block[schema, overview_table, qualified_table_name(schema, overview_table)]
+        table, schema = Table.table_and_schema(overview_table)
+        block[schema, table, qualified_table_name(schema, table)]
       end
       # TODO: should we apply also to raster overview tables?
       # To do so we could use SupportTables class and modify it to make #tables public.

--- a/spec/connectors/importer_overviews_spec.rb
+++ b/spec/connectors/importer_overviews_spec.rb
@@ -465,7 +465,7 @@ describe CartoDB::Importer2::Overviews do
   end
 
   it 'given user in organization overviews are granted api key privileges as for base table ' do
-    # Import two tables with overviews for @user
+    # Import two tables with overviews for @org_user_1
     table1 = ov_tables1 = nil
     table2 = ov_tables2 = nil
     user = @org_user_1


### PR DESCRIPTION
From https://github.com/CartoDB/support/issues/1829

This PR fixes double schema concatenation in method 'qualified_table_name'