### PR TITLE
Protected maps through public map endpoint now ask for password

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Development
   - UI improvements (#14389)
 
 ### Bug fixes / enhancements
+- Protected maps now asks for password even if it goes through `public_map` endpoint (#14420)
 - Sync new password resets fields with central (#14333)
 
 4.22.2 (2018-11-05)

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -219,7 +219,6 @@ class Admin::VisualizationsController < Admin::AdminController
       return(show_organization_public_map)
     end
 
-
     # Legacy redirect, now all public pages also with org. name
     if eligible_for_redirect?(@visualization.user)
       # INFO: here we only want the presenter to rewrite the url of @visualization.user namespacing it like 'schema.id',
@@ -229,6 +228,7 @@ class Admin::VisualizationsController < Admin::AdminController
                                                                 'public_visualizations_public_map') and return
     end
 
+    return(public_map_protected) if @visualization.password_protected?
 
     if @visualization.can_be_cached?
       response.headers['X-Cache-Channel'] = "#{@visualization.varnish_key}:vizjson"
@@ -342,7 +342,7 @@ class Admin::VisualizationsController < Admin::AdminController
     unless @visualization.password_valid?(submitted_password)
       flash[:placeholder] = '*' * (submitted_password ? submitted_password.size : DEFAULT_PLACEHOLDER_CHARS)
       flash[:error] = "Invalid password"
-      return(embed_protected)
+      return(public_map_protected)
     end
 
     response.headers['X-Cache-Channel'] = "#{@visualization.varnish_key}:vizjson"


### PR DESCRIPTION
Related https://github.com/CartoDB/support/issues/1832

- [x] Protected maps now are redirected to ask for a password when goes through `public_map` endpoint
- [x] Org maps are doing the same
- [x] Embed maps work as intended