### PR TITLE
[Dashboard] Drag and Drop dialog

### DIFF
--- a/lib/assets/javascripts/new-dashboard/App.vue
+++ b/lib/assets/javascripts/new-dashboard/App.vue
@@ -4,6 +4,7 @@
     <router-view/>
     <Footer/>
     <BackgroundPollingView ref="backgroundPollingView" :routeType="$route.name"/>
+    <MamufasImportView ref="mamufasImportView"/>
   </div>
 </template>
 
@@ -11,13 +12,15 @@
 import NavigationBar from 'new-dashboard/components/NavigationBar/NavigationBar';
 import Footer from 'new-dashboard/components/Footer';
 import BackgroundPollingView from './components/Backbone/BackgroundPollingView.vue';
+import MamufasImportView from './components/Backbone/MamufasImportView.vue';
 
 export default {
   name: 'App',
   components: {
     NavigationBar,
     BackgroundPollingView,
-    Footer
+    Footer,
+    MamufasImportView
   },
   computed: {
     user () {
@@ -26,9 +29,15 @@ export default {
   },
   provide () {
     const backboneViews = {};
+
     Object.defineProperty(backboneViews, 'backgroundPollingView', {
       enumerable: true,
       get: () => this.$refs.backgroundPollingView
+    });
+
+    Object.defineProperty(backboneViews, 'mamufasImportView', {
+      enumerable: true,
+      get: () => this.$refs.mamufasImportView
     });
 
     return { backboneViews };

--- a/lib/assets/javascripts/new-dashboard/components/Backbone/Dialogs/CreateDialog.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Backbone/Dialogs/CreateDialog.vue
@@ -11,6 +11,7 @@ export default {
   name: 'CreateDialog',
   props: {
     backgroundPollingView: Object,
+    mamufasImportView: Object,
     dialogType: {
       type: String,
       default: 'maps'
@@ -56,11 +57,7 @@ export default {
       });
 
       DialogView.addProperties({
-        // TODO: Update when Mamufas View is ready
-        mamufasView: {
-          enable: () => {},
-          disable: () => {}
-        }
+        mamufasView: this.$props.mamufasImportView
       });
 
       const DialogViewInstance = DialogView.openDialog(

--- a/lib/assets/javascripts/new-dashboard/components/Backbone/MamufasImportView.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Backbone/MamufasImportView.vue
@@ -1,0 +1,47 @@
+<template>
+  <div ref="injectionHTMLElement"></div>
+</template>
+
+<script>
+import MamufasImportView from 'dashboard/components/mamufas-import/mamufas-import-view';
+
+export default {
+  name: 'MamufasImportView',
+  inject: ['backboneViews'],
+  mounted () {
+    this.mamufasView = this.initView();
+  },
+  beforeDestroy () {
+    this.mamufasView.clean();
+  },
+  methods: {
+    initView () {
+      const mamufasView = new MamufasImportView({
+        el: document.body,
+        userModel: this.$cartoModels.user
+      });
+
+      mamufasView.on('dialogOpened', () => {
+        this.$cartoModels.backgroundPolling.stopPollings();
+      });
+
+      mamufasView.on('dialogClosed', () => {
+        this.$cartoModels.backgroundPolling.startPollings();
+      });
+
+      mamufasView.on('fileDropped', files => {
+        const backgroundPollingView = this.backboneViews.backgroundPollingView.getBackgroundPollingView();
+        backgroundPollingView._onDroppedFile(files);
+      });
+
+      mamufasView.enable();
+
+      return mamufasView;
+    },
+
+    getView () {
+      return this.mamufasView;
+    }
+  }
+};
+</script>

--- a/lib/assets/javascripts/new-dashboard/components/CreateButton.vue
+++ b/lib/assets/javascripts/new-dashboard/components/CreateButton.vue
@@ -22,14 +22,19 @@ export default {
       this.$modal.show({
         template: `
         <Dialog @close="$emit('close')">
-          <CreateDialog :dialogType="dialogType" :backgroundPollingView="backgroundPollingView" @close="$emit('close')"/>
+          <CreateDialog
+            :dialogType="dialogType"
+            :backgroundPollingView="backgroundPollingView"
+            :mamufasImportView="mamufasImportView"
+            @close="$emit('close')" />
         </Dialog>`,
-        props: ['dialogType', 'backgroundPollingView'],
+        props: ['dialogType', 'backgroundPollingView', 'mamufasImportView'],
         components: { Dialog, CreateDialog }
       },
       {
         dialogType: this.$props.visualizationType,
-        backgroundPollingView: this.backboneViews.backgroundPollingView.getBackgroundPollingView()
+        backgroundPollingView: this.backboneViews.backgroundPollingView.getBackgroundPollingView(),
+        mamufasImportView: this.backboneViews.mamufasImportView.getView()
       },
       {
         width: '100%',


### PR DESCRIPTION
This PR hooks Mamufas Import Dialog into New Dashboard!

### Acceptance Steps
- [ ] Check that you can import files by dragging and dropping them into New Dashboard browser window. (.carto or any other allowed filetypes).
- [ ] Check that when Create Map/Dataset Dialog is open, the dialog is not shown when dragging a file over browser's window.
- [ ] Check that drag&drop is enabled again when closing Create Dialog.