### PR TITLE
Order by rows and privacy in Visualizations API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Development
   - Admin management (#14347)
 - Change password functionality for Carto Gears (#14351)
 - /viz endpoint supports ordering by :name and specifying an `order_direction` (#14316)
+- /viz endpoint supports ordering by :estimated_row_count and :privacy ([#14320](https://github.com/CartoDB/cartodb/issues/14320))
 
 ### Bug fixes / enhancements
 - Protected maps now asks for password even if it goes through `public_map` endpoint (#14420)

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -60,7 +60,7 @@ module Carto
       rescue_from Carto::UUIDParameterFormatError, with: :rescue_from_carto_error
       rescue_from Carto::ProtectedVisualizationLoadError, with: :rescue_from_protected_visualization_load_error
 
-      VALID_ORDER_PARAMS = [:name, :updated_at, :size, :mapviews, :likes].freeze
+      VALID_ORDER_PARAMS = %i(name updated_at size mapviews likes estimated_row_count privacy).freeze
 
       def show
         presenter = VisualizationPresenter.new(

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -979,11 +979,11 @@ class Table
   end
 
   def update_table_pg_stats
-    owner.in_database[%Q{ANALYZE #{qualified_table_name};}]
+    owner.in_database.execute(%{ANALYZE #{qualified_table_name};})
   end
 
   def update_table_geom_pg_stats
-    owner.in_database[%Q{ANALYZE #{qualified_table_name}(the_geom);}]
+    owner.in_database.execute(%{ANALYZE #{qualified_table_name}(the_geom);})
   end
 
   def owner

--- a/app/queries/carto/offdatabase_query_adapter.rb
+++ b/app/queries/carto/offdatabase_query_adapter.rb
@@ -55,7 +55,7 @@ module Carto
       all = @query.all
       @order_by_asc_or_desc_by_attribute.each do |attribute, asc_or_desc|
         # Cache attribute type
-        is_array = all.present? && all.first.send(attribute).respond_to?(:count)
+        is_array = all.present? && all.first.send(attribute).respond_to?(:each)
         all = all.sort do |x, y|
           x_attribute = is_array ? x.send(attribute).count : x.send(attribute)
           y_attribute = is_array ? y.send(attribute).count : y.send(attribute)

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -10,7 +10,7 @@ require_dependency 'carto/uuidhelper'
 class Carto::VisualizationQueryBuilder
   include Carto::UUIDHelper
 
-  SUPPORTED_OFFDATABASE_ORDERS = [ 'mapviews', 'likes', 'size' ]
+  SUPPORTED_OFFDATABASE_ORDERS = %w(mapviews likes size estimated_row_count privacy).freeze
 
   def self.user_public_tables(user)
     self.user_public(user).with_type(Carto::Visualization::TYPE_CANONICAL)

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -2883,6 +2883,96 @@ describe Carto::Api::VisualizationsController do
         end
       end
 
+      context 'by estimated row count' do
+        before(:each) do
+          @visualization_a = FactoryGirl.create(:carto_visualization, user_id: @user.id)
+          table = FactoryGirl.create(:table, user_id: @user.id)
+          table.insert_row!(:name => 'name1')
+          table.update_table_pg_stats
+          @visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: table.map_id)
+        end
+
+        it 'orders descending by default' do
+          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count'), {}, @headers
+
+          last_response.status.should == 200
+          response = JSON.parse(last_response.body)
+          collection = response.fetch('visualizations')
+          collection.length.should eq 2
+          collection[0]['id'].should eq @visualization_b.id
+          collection[1]['id'].should eq @visualization_a.id
+        end
+
+        it 'orders descending' do
+          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count',
+                                              order_direction: 'desc'), {}, @headers
+
+          last_response.status.should == 200
+          response = JSON.parse(last_response.body)
+          collection = response.fetch('visualizations')
+          collection.length.should eq 2
+          collection[0]['id'].should eq @visualization_b.id
+          collection[1]['id'].should eq @visualization_a.id
+        end
+
+        it 'orders ascending' do
+          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count',
+                                              order_direction: 'asc'), {}, @headers
+
+          last_response.status.should == 200
+          response = JSON.parse(last_response.body)
+          collection = response.fetch('visualizations')
+          collection.length.should eq 2
+          collection[0]['id'].should eq @visualization_a.id
+          collection[1]['id'].should eq @visualization_b.id
+        end
+      end
+
+      context 'by privacy' do
+        before(:each) do
+          link_privacy = Carto::Visualization::PRIVACY_LINK
+          public_privacy = Carto::Visualization::PRIVACY_PUBLIC
+          @visualization_a = FactoryGirl.create(:carto_visualization, user_id: @user.id, privacy: link_privacy).store
+          @visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id, privacy: public_privacy).store
+        end
+
+        it 'orders descending by default' do
+          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived',
+                                              order: 'privacy'), {}, @headers
+
+          last_response.status.should == 200
+          response = JSON.parse(last_response.body)
+          collection = response.fetch('visualizations')
+          collection.length.should eq 2
+          collection[0]['id'].should eq @visualization_b.id
+          collection[1]['id'].should eq @visualization_a.id
+        end
+
+        it 'orders descending' do
+          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'privacy',
+                                              order_direction: 'desc'), {}, @headers
+
+          last_response.status.should == 200
+          response = JSON.parse(last_response.body)
+          collection = response.fetch('visualizations')
+          collection.length.should eq 2
+          collection[0]['id'].should eq @visualization_b.id
+          collection[1]['id'].should eq @visualization_a.id
+        end
+
+        it 'orders ascending' do
+          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'privacy',
+                                              order_direction: 'asc'), {}, @headers
+
+          last_response.status.should == 200
+          response = JSON.parse(last_response.body)
+          collection = response.fetch('visualizations')
+          collection.length.should eq 2
+          collection[0]['id'].should eq @visualization_a.id
+          collection[1]['id'].should eq @visualization_b.id
+        end
+      end
+
       context 'error handling' do
         before(:each) do
           @valid_order = 'updated_at'

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -2887,13 +2887,14 @@ describe Carto::Api::VisualizationsController do
         before(:each) do
           @visualization_a = FactoryGirl.create(:carto_visualization, user_id: @user.id)
           table = FactoryGirl.create(:table, user_id: @user.id)
-          table.insert_row!(:name => 'name1')
+          table.insert_row!(name: 'name1')
           table.update_table_pg_stats
           @visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: table.map_id)
         end
 
         it 'orders descending by default' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count'), {}, @headers
+          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived',
+                                              order: 'estimated_row_count'), {}, @headers
 
           last_response.status.should == 200
           response = JSON.parse(last_response.body)


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/14320

Added new keys to `order` parameter in Visualizations API (`api/v1/viz`): 
- `estimated_row_count`
- `privacy`

The other allowed keys are: `name`, `updated_at`, `size`, `mapviews` and `likes`.

All of them can be used with `order_direction=asc`, `order_direction=desc` or nothing (descending by default).