### PR TITLE
Fix pagination in visualization API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Disable user multifactor auths on skip ([#14447](https://github.com/CartoDB/cartodb/issues/14447))
+- Fix pagination in visualization API when ordering by size ([#14476](https://github.com/CartoDB/cartodb/issues/14476))
 
 4.23.0 (2018-11-19)
 -------------------

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -390,7 +390,7 @@ class Carto::Visualization < ActiveRecord::Base
   alias :can_view_private_info? :has_read_permission?
 
   def estimated_row_count
-    table_service.nil? ? nil : table_service.estimated_row_count
+    user_table.try(:row_count)
   end
 
   def actual_row_count

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -394,7 +394,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def actual_row_count
-    table_service.nil? ? nil : table_service.actual_row_count
+    user_table.try(:actual_row_count)
   end
 
   def license_info

--- a/app/queries/carto/offdatabase_query_adapter.rb
+++ b/app/queries/carto/offdatabase_query_adapter.rb
@@ -64,11 +64,7 @@ module Carto
           asc_or_desc == :asc ? x_attribute <=> y_attribute : y_attribute <=> x_attribute
         end
       end
-      all[@offset, size(all)]
-    end
-
-    def size(array)
-      @limit.nil? ? array.count : @limit
+      all[@offset, @limit.nil? ? all.count : @limit]
     end
 
   end

--- a/app/queries/carto/offdatabase_query_adapter.rb
+++ b/app/queries/carto/offdatabase_query_adapter.rb
@@ -64,11 +64,11 @@ module Carto
           asc_or_desc == :asc ? x_attribute <=> y_attribute : y_attribute <=> x_attribute
         end
       end
-      all[@offset, last_index(all)]
+      all[@offset, size(all)]
     end
 
-    def last_index(array)
-      @limit.nil? ? array.count : (@offset + @limit)
+    def size(array)
+      @limit.nil? ? array.count : @limit
     end
 
   end

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -121,7 +121,7 @@ describe Carto::Visualization do
   describe '#estimated_row_count and #actual_row_count' do
 
     it 'should query Table estimated an actual row count methods' do
-      ::Table.any_instance.stubs(:estimated_row_count).returns(999)
+      ::Table.any_instance.stubs(:row_count_and_size).returns(row_count: 999)
       ::Table.any_instance.stubs(:actual_row_count).returns(1000)
       table = create_table(name: 'table1', user_id: @user.id)
       vis = Carto::Visualization.find(table.table_visualization.id)

--- a/spec/models/visualization/relator_spec.rb
+++ b/spec/models/visualization/relator_spec.rb
@@ -37,9 +37,9 @@ describe Visualization::Relator do
   describe '#estimated_row_count and #actual_row_count' do
 
     it 'should query Table estimated an actual row count methods' do
-      ::Table.any_instance.stubs(:estimated_row_count).returns(999)
+      ::Table.any_instance.stubs(:row_count_and_size).returns(row_count: 999)
       ::Table.any_instance.stubs(:actual_row_count).returns(1000)
-      table = create_table({:name => 'table1', :user_id => @user.id})
+      table = create_table(name: 'table1', user_id: @user.id)
       vis = table.table_visualization
       vis.estimated_row_count.should == 999
       vis.actual_row_count.should == 1000

--- a/spec/queries/carto/visualization_query_builder_spec.rb
+++ b/spec/queries/carto/visualization_query_builder_spec.rb
@@ -380,6 +380,32 @@ describe Carto::VisualizationQueryBuilder do
     expect { @vqb.with_id_or_name(nil) }.to raise_error
   end
 
+  it 'paginates correctly when ordering by size' do
+    table1 = create_random_table(@user1)
+    table2 = create_random_table(@user1)
+    table3 = create_random_table(@user1)
+
+    mocked_vis1 = Carto::Visualization.where(id: table1.table_visualization.id).first
+    mocked_vis2 = Carto::Visualization.where(id: table2.table_visualization.id).first
+    mocked_vis3 = Carto::Visualization.where(id: table3.table_visualization.id).first
+
+    mocked_vis1.stubs(:size).returns(200)
+    mocked_vis2.stubs(:size).returns(1)
+    mocked_vis3.stubs(:size).returns(600)
+
+    # Careful to not do anything else on this spec after this size assertions
+    Carto::Visualization::ActiveRecord_Relation.any_instance.stubs(:all).returns(
+      [mocked_vis3, mocked_vis1, mocked_vis2]
+    )
+
+    page = 2
+    per_page = 1
+    ids = @vqb.with_type(Carto::Visualization::TYPE_CANONICAL).with_order('size', :desc)
+              .build_paged(page, per_page).map(&:id)
+
+    ids.should == [table1.table_visualization.id]
+  end
+
   describe '#with_published' do
     it 'is implied by public search, so querying public filters public, unpublished' do
       map, table, table_visualization, visualization = create_full_visualization(@carto_user1, visualization_attributes: { version: 3, privacy: Carto::Visualization::PRIVACY_PUBLIC })


### PR DESCRIPTION
Closes #14476 

The problem was that the square brackets operator for an array does not receive the last index as the second parameter, but the length: https://ruby-doc.org/core-2.2.0/Array.html#method-i-5B-5D

Also, the way to get the row_count (estimated and actual) from Visualization has been changed to use memoization in order to improve performance in visualizations controller.