### PR TITLE
[Dashboard] Change lock copy in modal

### DIFF
--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-lock/change-lock.tpl
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-lock/change-lock.tpl
@@ -10,9 +10,17 @@
   </h3>
   <p class="CDB-Text CDB-Size-medium u-altTextColor">
     <% if (areLocked) { %>
-      Unlocking <%- thisOrTheseStr %> <%- contentTypePluralized %> will show <%- itOrThemStr %> on the dashboard again.
+      <%- _t('components.modals.change-lock.description.locked', {
+          thisOrTheseStr: thisOrTheseStr,
+          contentTypePluralized: contentTypePluralized,
+          itOrThemStr: itOrThemStr
+        }) %>
     <% } else { %>
-      Locking <%- thisOrTheseStr %> <%- contentTypePluralized %> will hide <%- itOrThemStr %> from the dashboard. Reveal <%- itOrThemStr %> using the header menu or the bottom link.
+      <%- _t('components.modals.change-lock.description.unlocked', {
+        thisOrTheseStr: thisOrTheseStr,
+        contentTypePluralized: contentTypePluralized,
+        itOrThemStr: itOrThemStr
+      }) %>
     <% } %>
   </p>
 </div>

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1419,6 +1419,12 @@
           "confirm": "Confirm",
           "cancel": "Cancel"
         }
+      },
+      "change-lock": {
+        "description": {
+          "locked": "Unlocking %{thisOrTheseStr} %{contentTypePluralized} will show %{itOrThemStr} on the dashboard again.",
+          "unlocked": "Locking %{thisOrTheseStr} %{contentTypePluralized} will hide %{itOrThemStr} from the dashboard. Reveal %{itOrThemStr} using the header menu or the bottom link."
+        }
       }
     },
     "error": {

--- a/lib/assets/javascripts/new-dashboard/i18n/backbone-i18n.js
+++ b/lib/assets/javascripts/new-dashboard/i18n/backbone-i18n.js
@@ -1,3 +1,5 @@
+import deepObjectExtend from 'new-dashboard/utils/deep-object-extend';
+
 var ACTIVE_LOCALE = 'en';
 if (ACTIVE_LOCALE !== 'en') {
   require('moment/locale/' + ACTIVE_LOCALE);
@@ -5,6 +7,10 @@ if (ACTIVE_LOCALE !== 'en') {
 
 var Locale = require('locale/index');
 var Polyglot = require('node-polyglot');
+
+// Override original translation strings
+const overrideTranslationStrings = require('./locales/en.overrides.json');
+Locale.en = deepObjectExtend(Locale.en, overrideTranslationStrings);
 
 var polyglot = new Polyglot({
   locale: ACTIVE_LOCALE, // Needed for pluralize behaviour

--- a/lib/assets/javascripts/new-dashboard/i18n/locales/en.overrides.json
+++ b/lib/assets/javascripts/new-dashboard/i18n/locales/en.overrides.json
@@ -1,0 +1,11 @@
+{
+  "components": {
+    "modals": {
+      "change-lock": {
+        "description": {
+          "unlocked": "Locking %{thisOrTheseStr} %{contentTypePluralized} will hide %{itOrThemStr} from this list. You can see %{itOrThemStr} using the “Locked” filter."
+        }
+      }
+    }
+  }
+}

--- a/lib/assets/javascripts/new-dashboard/utils/deep-object-extend.js
+++ b/lib/assets/javascripts/new-dashboard/utils/deep-object-extend.js
@@ -1,0 +1,23 @@
+// Copied from https://stackoverflow.com/questions/38345937/object-assign-vs-extend/42740894#42740894
+
+function isObject (item) {
+  return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+export default function deepObjectExtend (target, ...sources) {
+  if (!sources.length) return target;
+  const source = sources.shift();
+
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        deepObjectExtend(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+
+  return deepObjectExtend(target, ...sources);
+}


### PR DESCRIPTION
This PR changes copy in Lock modal for new dashboard. The copy will only change in the New Dashboard, but it will remain the same in the old one.

### Acceptance steps
- [ ] Open the lock modal with one map selected and see that the copy is correct.
- [ ] Open the lock modal selecting more than one map and see that the copy is correct.
- [ ] Open the lock modal in the **old dashboard** with one map selected and see that the copy is correct.
- [ ] Open the lock modal in the **old dashboard** selecting more than one map and see that the copy is correct.