### PR TITLE
Add locked count to Visualizations endpoint

### DIFF
--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -512,7 +512,7 @@ module Carto
       def calculate_totals(total_types)
         # Prefetching at counts removes duplicates
         {
-          total_user_entries: VisualizationQueryBuilder.new.with_types(total_types).with_locked(false)
+          total_user_entries: VisualizationQueryBuilder.new.with_types(total_types)
                                                        .with_user_id(current_user.id).build.count,
           total_locked: VisualizationQueryBuilder.new.with_types(total_types).with_locked(true).build.count,
           total_likes: VisualizationQueryBuilder.new.with_types(total_types).with_liked_by_user_id(current_user.id)

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -514,7 +514,8 @@ module Carto
         {
           total_user_entries: VisualizationQueryBuilder.new.with_types(total_types)
                                                        .with_user_id(current_user.id).build.count,
-          total_locked: VisualizationQueryBuilder.new.with_types(total_types).with_locked(true).build.count,
+          total_locked: VisualizationQueryBuilder.new.with_types(total_types)
+                                                 .with_user_id(current_user.id).with_locked(true).build.count,
           total_likes: VisualizationQueryBuilder.new.with_types(total_types).with_liked_by_user_id(current_user.id)
                                                 .build.count,
           total_shared: VisualizationQueryBuilder.new.with_types(total_types).with_shared_with_user_id(current_user.id)

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -84,7 +84,7 @@ module Carto
 
       def index
         page, per_page, order, order_direction = page_per_page_order_params(VALID_ORDER_PARAMS)
-        types, total_types = get_types_parameters
+        _, total_types = get_types_parameters
         vqb = query_builder_with_filter_from_hash(params)
 
         presenter_cache = Carto::Api::PresenterCache.new
@@ -102,12 +102,7 @@ module Carto
           total_entries: vqb.build.count
         }
         if current_user && (params[:load_totals].to_s != 'false')
-          # Prefetching at counts removes duplicates
-          response.merge!({
-            total_user_entries: VisualizationQueryBuilder.new.with_types(total_types).with_user_id(current_user.id).build.count,
-            total_likes: VisualizationQueryBuilder.new.with_types(total_types).with_liked_by_user_id(current_user.id).build.count,
-            total_shared: VisualizationQueryBuilder.new.with_types(total_types).with_shared_with_user_id(current_user.id).with_user_id_not(current_user.id).with_prefetch_table.build.count
-          })
+          response.merge!(calculate_totals(total_types))
         end
         render_jsonp(response)
       rescue CartoDB::BoundingBoxError => e
@@ -116,7 +111,7 @@ module Carto
         render_jsonp({ error: e.message }, e.status)
       rescue Carto::OrderDirectionParamInvalidError => e
         render_jsonp({ error: e.message }, e.status)
-      rescue => e
+      rescue StandardError => e
         CartoDB::Logger.error(exception: e)
         render_jsonp({ error: e.message }, 500)
       end
@@ -512,6 +507,19 @@ module Carto
           CartoDB.notify_exception(e, {user:current_user})
           return true
         end
+      end
+
+      def calculate_totals(total_types)
+        # Prefetching at counts removes duplicates
+        {
+          total_user_entries: VisualizationQueryBuilder.new.with_types(total_types).with_locked(false)
+                                                       .with_user_id(current_user.id).build.count,
+          total_locked: VisualizationQueryBuilder.new.with_types(total_types).with_locked(true).build.count,
+          total_likes: VisualizationQueryBuilder.new.with_types(total_types).with_liked_by_user_id(current_user.id)
+                                                .build.count,
+          total_shared: VisualizationQueryBuilder.new.with_types(total_types).with_shared_with_user_id(current_user.id)
+                                                 .with_user_id_not(current_user.id).with_prefetch_table.build.count
+        }
       end
     end
   end

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -378,7 +378,10 @@ describe Carto::Api::VisualizationsController do
     end
 
     it 'returns locked count' do
+      FactoryGirl.build(:derived_visualization, user_id: @user_1.id, locked: false).store
       FactoryGirl.build(:derived_visualization, user_id: @user_1.id, locked: true).store
+      user2 = FactoryGirl.create(:valid_user)
+      FactoryGirl.build(:derived_visualization, user_id: user2.id, locked: true).store
 
       response_body(type: CartoDB::Visualization::Member::TYPE_DERIVED)['total_locked'].should == 1
     end

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -328,7 +328,15 @@ describe Carto::Api::VisualizationsController do
     end
 
     it 'returns success, empty response for empty user' do
-      response_body.should == { 'visualizations' => [], 'total_entries' => 0, 'total_user_entries' => 0, 'total_likes' => 0, 'total_shared' => 0}
+      expected_response = {
+        'visualizations' => [],
+        'total_entries' => 0,
+        'total_user_entries' => 0,
+        'total_likes' => 0,
+        'total_shared' => 0,
+        'total_locked' => 0
+      }
+      response_body.should == expected_response
     end
 
     it 'returns valid information for a user with one table' do
@@ -359,6 +367,7 @@ describe Carto::Api::VisualizationsController do
       response['total_user_entries'].should eq 1
       response['total_likes'].should eq 0
       response['total_shared'].should eq 0
+      response['total_locked'].should eq 0
     end
 
     it 'returns liked count' do
@@ -366,6 +375,12 @@ describe Carto::Api::VisualizationsController do
       vis.add_like_from(@user_1.id)
 
       response_body(type: CartoDB::Visualization::Member::TYPE_DERIVED)['total_likes'].should == 1
+    end
+
+    it 'returns locked count' do
+      FactoryGirl.build(:derived_visualization, user_id: @user_1.id, locked: true).store
+
+      response_body(type: CartoDB::Visualization::Member::TYPE_DERIVED)['total_locked'].should == 1
     end
 
     it 'does a partial match search' do
@@ -950,6 +965,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 1
         body['total_likes'].should eq 0
         body['total_shared'].should eq 0
+        body['total_locked'].should eq 0
         vis = body['visualizations'].first
         vis['id'].should eq u1_t_1_id
 
@@ -959,6 +975,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 1
         body['total_likes'].should eq 0
         body['total_shared'].should eq 0
+        body['total_locked'].should eq 0
         vis = body['visualizations'].first
         vis['id'].should eq u1_vis_1_id
 
@@ -979,6 +996,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 2
         body['total_likes'].should eq 0
         body['total_shared'].should eq 1
+        body['total_locked'].should eq 0
 
         # Share u2 vis2 with u1
         put api_v1_permissions_update_url(user_domain: @org_user_2.username, api_key: @org_user_2.api_key, id: u2_vis_2_perm_id),
@@ -997,6 +1015,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 3
         body['total_likes'].should eq 0
         body['total_shared'].should eq 2
+        body['total_locked'].should eq 0
 
         post api_v1_visualizations_add_like_url(user_domain: @org_user_1.username, id: u1_vis_1_id, api_key: @org_user_1.api_key)
 
@@ -1006,6 +1025,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 3
         body['total_likes'].should eq 1
         body['total_shared'].should eq 2
+        body['total_locked'].should eq 0
 
         # Multiple likes to same vis shouldn't increment total as is per vis
         post api_v1_visualizations_add_like_url(user_domain: @org_user_1.username, id: u1_vis_1_id, api_key: @org_user_1.api_key)
@@ -1016,6 +1036,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 3
         body['total_likes'].should eq 1
         body['total_shared'].should eq 2
+        body['total_locked'].should eq 0
 
 
         # Share u2 table1 with org
@@ -1034,6 +1055,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 2
         body['total_likes'].should eq 0
         body['total_shared'].should eq 1
+        body['total_locked'].should eq 0
 
         # Share u2 table2 with org
         put api_v1_permissions_update_url(user_domain:@org_user_2.username, api_key: @org_user_2.api_key, id: u2_t_2_perm_id),
@@ -1051,6 +1073,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 3
         body['total_likes'].should eq 0
         body['total_shared'].should eq 2
+        body['total_locked'].should eq 0
         body['visualizations'][0]['table']['name'].should == "\"#{@org_user_2.database_schema}\".#{u2_t_2.name}"
 
         post api_v1_visualizations_add_like_url(user_domain: @org_user_1.username, id: u1_t_1_id, api_key: @org_user_1.api_key)
@@ -1061,6 +1084,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 3
         body['total_likes'].should eq 1
         body['total_shared'].should eq 2
+        body['total_locked'].should eq 0
 
         # Multiple likes to same table shouldn't increment total as is per vis
         post api_v1_visualizations_add_like_url(user_domain: @org_user_1.username, id: u1_t_1_id, api_key: @org_user_2.api_key)
@@ -1071,6 +1095,7 @@ describe Carto::Api::VisualizationsController do
         body['total_entries'].should eq 3
         body['total_likes'].should eq 1
         body['total_shared'].should eq 2
+        body['total_locked'].should eq 0
       end
 
     end


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/14482

The /viz endpoint now returns a new property `total_locked` with the count of locked datasets:
```
{
  "visualizations": [...],
  "total_entries": 3,
  "total_user_entries": 3,
  "total_locked": 1,
  "total_likes": 0,
  "total_shared": 0
}
```