### PR TITLE
Do not intercept url requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Redirect to MFA setup to logged users from dashboard AJAX calls (#14435)
+- Do not intercept marker request (#14491)
 
 4.23.1 (2018-11-26)
 -------------------

--- a/lib/assets/javascripts/builder/data/backbone/network-interceptors/interceptor.js
+++ b/lib/assets/javascripts/builder/data/backbone/network-interceptors/interceptor.js
@@ -47,6 +47,10 @@ NetworkResponseInterceptor.prototype._shouldListenToRequest = function (url) {
 };
 
 NetworkResponseInterceptor.prototype._onRequestStart = function (url, options) {
+  if (typeof url === 'string') {
+    return this._originalAjax(url);
+  }
+
   let requestOptions = !options ? url : options;
   let requestUrl = !options ? requestOptions.url : url;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.17",
+  "version": "1.0.0-assets.18",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
[Support ticket](https://github.com/CartoDB/support/issues/1855)

After merging the request interceptor, there were problems in production related to markers. They are requested using only a string and the code was not adapted to it.

I've fixed it calling directly to the ajax request when it's a string. Searching the code, it seems that it's only like that in `img-loader-view`, so we can do the exception of intercepting them in this particular case.

cc @alrocar @jesusbotella 