### PR TITLE
Disable analyze during import

### DIFF
--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -979,11 +979,15 @@ class Table
   end
 
   def update_table_pg_stats
-    owner.in_database.execute(%{ANALYZE #{qualified_table_name};})
+    # TODO: Reenable this with timeout/error handling.
+    # This was broken for years, and we reenabled it, imports timed out.
+    # owner.in_database.execute(%{ANALYZE #{qualified_table_name};})
   end
 
   def update_table_geom_pg_stats
-    owner.in_database.execute(%{ANALYZE #{qualified_table_name}(the_geom);})
+    # TODO: Reenable this with timeout/error handling.
+    # This was broken for years, and we reenabled it, imports timed out.
+    # owner.in_database.execute(%{ANALYZE #{qualified_table_name}(the_geom);})
   end
 
   def owner

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -2939,7 +2939,7 @@ describe Carto::Api::VisualizationsController do
           @visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: table.map_id)
         end
 
-        it 'orders descending by default' do
+        xit 'orders descending by default' do
           get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived',
                                               order: 'estimated_row_count'), {}, @headers
 
@@ -2951,7 +2951,7 @@ describe Carto::Api::VisualizationsController do
           collection[1]['id'].should eq @visualization_a.id
         end
 
-        it 'orders descending' do
+        xit 'orders descending' do
           get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count',
                                               order_direction: 'desc'), {}, @headers
 
@@ -2963,7 +2963,7 @@ describe Carto::Api::VisualizationsController do
           collection[1]['id'].should eq @visualization_a.id
         end
 
-        it 'orders ascending' do
+        xit 'orders ascending' do
           get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count',
                                               order_direction: 'asc'), {}, @headers
 


### PR DESCRIPTION
Reverts some changes in https://github.com/CartoDB/cartodb/pull/14544 that were breaking imports (https://github.com/CartoDB/support/issues/1894)