### PR TITLE
Only consider geometry validity an error if it breaks ogr2ogr

### DIFF
--- a/services/importer/lib/importer/ogr2ogr.rb
+++ b/services/importer/lib/importer/ogr2ogr.rb
@@ -99,7 +99,7 @@ module CartoDB
       end
 
       def geometry_validity_error?
-        command_output =~ /Invalid number of points in LinearRing/i
+        exit_code != 0 && command_output =~ /Invalid number of points in LinearRing/i
       end
 
       def encoding_error?


### PR DESCRIPTION
Possible fix for https://github.com/CartoDB/support/issues/1869