### PR TITLE
Faster ordering by likes in /viz

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,20 +5,21 @@ Development
 - None yet
 
 ### Features
-- Multiple ordering for /viz endpoint ([#14372](https://github.com/CartoDB/cartodb/issues/14372))
-- Ordering by favorited for /viz endpoint ([#14372](https://github.com/CartoDB/cartodb/issues/14372))
-- /viz endpoint supports ordering by :name and specifying an `order_direction` (#14316)
 - /viz endpoint supports ordering by :estimated_row_count and :privacy ([#14320](https://github.com/CartoDB/cartodb/issues/14320))
+- /viz endpoint supports multiple ordering ([#14372](https://github.com/CartoDB/cartodb/issues/14372))
+- /viz endpoint supports ordering by :favorited ([#14372](https://github.com/CartoDB/cartodb/issues/14372))
+- /viz endpoint includes dependent visualizations and supports ordering by it ([#14424](https://github.com/CartoDB/cartodb/issues/14424))
+- /viz endpoint orders search results by relevance ([#14325](https://github.com/CartoDB/cartodb/issues/14325))
 - Send org_admin parameter to central (#14483)
-- Multiple ordering for /viz endpoint ([#14372](https://github.com/CartoDB/cartodb/issues/14372))
-- Ordering by favorited for /viz endpoint ([#14372](https://github.com/CartoDB/cartodb/issues/14372))
 - Add support for Node.js 10 and npm 6 (#14501).
 - Password validation against common passwords & usernames (#14522)
 - New Welcome module for New Dashboard (#14527)
 
 ### Bug fixes / enhancements
 - Changed the Interal Engine public name for Enterprise engine to avoid issues with the clients (#14538)
+- Improved performance in /viz endpoint when ordering by dependent visualizations ([#14508](https://github.com/CartoDB/cartodb/issues/14508))
 - Revert favorited ordering for Datasets in New Dashboard (#14552)
+- Fix visualization ordering by favorited with dependent visualizations (#14555)[https://github.com/CartoDB/cartodb/issues/14555]
 
 4.23.4 (2018-12-18)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ Development
 - Improved performance in /viz endpoint when ordering by dependent visualizations ([#14508](https://github.com/CartoDB/cartodb/issues/14508))
 - Revert favorited ordering for Datasets in New Dashboard (#14552)
 - Fix visualization ordering by favorited with dependent visualizations (#14555)[https://github.com/CartoDB/cartodb/issues/14555]
+- Improved performance in /viz endpoint when ordering by likes ([#14508](https://github.com/CartoDB/cartodb/issues/14508))
 
 4.23.4 (2018-12-18)
 -------------------

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -77,7 +77,6 @@ class Admin::PagesController < Admin::AdminController
       end
 
       visualizations = public_builder(user_id: @viewed_user.id).with_prefetch_user(true).build
-
     end
 
     @urls = visualizations.map { |vis|

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -60,7 +60,6 @@ module Carto
 
       VALID_ORDER_PARAMS = %i(name updated_at size mapviews likes favorited estimated_row_count privacy
                               dependent_visualizations).freeze
-      VALID_ORDER_COMBINATIONS = %i(name updated_at favorited privacy).freeze
 
       def show
         presenter = VisualizationPresenter.new(
@@ -83,7 +82,9 @@ module Carto
       end
 
       def index
-        opts = { valid_order_combinations: VALID_ORDER_COMBINATIONS }
+        offdatabase_orders = Carto::VisualizationQueryOrderer::SUPPORTED_OFFDATABASE_ORDERS.map(&:to_sym)
+        valid_order_combinations = VALID_ORDER_PARAMS - offdatabase_orders
+        opts = { valid_order_combinations: valid_order_combinations }
         page, per_page, order, order_direction = page_per_page_order_params(VALID_ORDER_PARAMS, opts)
         _, total_types = get_types_parameters
 

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -229,6 +229,7 @@ class Carto::VisualizationQueryBuilder
     query = query.includes(@include_associations)
     query = query.eager_load(@eager_load_associations)
     query = with_favorited(query)
+    query = with_likes(query)
     with_dependent_visualization_count(query)
   end
 
@@ -237,6 +238,12 @@ class Carto::VisualizationQueryBuilder
     raise 'Cannot order by favorited if no user is provided' unless @current_user_id
 
     Carto::VisualizationQueryIncluder.new(query).include_favorited(@current_user_id)
+  end
+
+  def with_likes(query)
+    return query unless @order && @order.include?("likes")
+
+    Carto::VisualizationQueryIncluder.new(query).include_likes_count(@filtering_params)
   end
 
   def with_dependent_visualization_count(query)

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -29,9 +29,7 @@ class Carto::VisualizationQueryBuilder
   def initialize
     @include_associations = []
     @eager_load_associations = []
-    @exclude_synced_external_sources = false
-    @exclude_imported_remote_visualizations = false
-    @excluded_kinds = []
+    @filtering_params = {}
   end
 
   def with_id_or_name(id_or_name)
@@ -45,62 +43,63 @@ class Carto::VisualizationQueryBuilder
   end
 
   def with_id(id)
-    @id = id
+    @filtering_params[:id] = id
     self
   end
 
   def with_excluded_ids(ids)
-    @excluded_ids = ids
+    @filtering_params[:excluded_ids] = ids
     self
   end
 
   def without_synced_external_sources
-    @exclude_synced_external_sources = true
+    @filtering_params[:exclude_synced_external_sources] = true
     self
   end
 
   def without_imported_remote_visualizations
-    @exclude_imported_remote_visualizations = true
+    @filtering_params[:exclude_imported_remote_visualizations] = true
     self
   end
 
   def without_raster
-    @excluded_kinds << Carto::Visualization::KIND_RASTER
+    @filtering_params[:excluded_kinds] ||= []
+    @filtering_params[:excluded_kinds] << Carto::Visualization::KIND_RASTER
     self
   end
 
   def with_name(name)
-    @name = name
+    @filtering_params[:name] = name
     self
   end
 
   def with_user_id(user_id)
-    @user_id = user_id
+    @filtering_params[:user_id] = user_id
     self
   end
 
   def with_user_id_not(user_id)
-    @user_id_not = user_id
+    @filtering_params[:user_id_not] = user_id
     self
   end
 
   def with_privacy(privacy)
-    @privacy = privacy
+    @filtering_params[:privacy] = privacy
     self
   end
 
   def with_liked_by_user_id(user_id)
-    @liked_by_user_id = user_id
+    @filtering_params[:liked_by_user_id] = user_id
     self
   end
 
   def with_shared_with_user_id(user_id)
-    @shared_with_user_id = user_id
+    @filtering_params[:shared_with_user_id] = user_id
     self
   end
 
   def with_owned_by_or_shared_with_user_id(user_id)
-    @owned_by_or_shared_with_user_id = user_id
+    @filtering_params[:owned_by_or_shared_with_user_id] = user_id
     self
   end
 
@@ -118,7 +117,7 @@ class Carto::VisualizationQueryBuilder
   end
 
   def with_prefetch_dependent_visualizations
-    inner_visualization = { visualization: { map: { layers: :layers_user_tables } } }
+    inner_visualization = { visualization: { map: { layers: :layers_user_tables }, permission: :owner } }
     nested_association = { map: { user_table: { layers: { maps: inner_visualization } } } }
     with_eager_load_of(nested_association)
   end
@@ -138,23 +137,14 @@ class Carto::VisualizationQueryBuilder
   end
 
   def with_type(type)
-    # Clear always the other "types holder"
-    @types = nil
-
-    @type = type == nil || type == '' ? nil : type
+    @filtering_params[:type] = type
     self
   end
 
-  def with_types(types)
-    # Clear always the other "types holder"
-    @type = nil
-
-    @types = types
-    self
-  end
+  alias with_types with_type
 
   def with_locked(locked)
-    @locked = locked
+    @filtering_params[:locked] = locked
     self
   end
 
@@ -169,206 +159,45 @@ class Carto::VisualizationQueryBuilder
   end
 
   def with_partial_match(tainted_search_pattern)
-    @tainted_search_pattern = tainted_search_pattern
+    @filtering_params[:tainted_search_pattern] = tainted_search_pattern
     self
   end
 
   def with_tags(tags)
-    @tags = tags
+    @filtering_params[:tags] = tags
     self
   end
 
   def with_bounding_box(bounding_box)
-    @bounding_box = bounding_box
+    @filtering_params[:bounding_box] = bounding_box
     self
   end
 
   def with_display_name
-    @only_with_display_name = true
+    @filtering_params[:only_with_display_name] = true
     self
   end
 
   def with_organization_id(organization_id)
-    @organization_id = organization_id
+    @filtering_params[:organization_id] = organization_id
     self
   end
 
   # Published: see `Carto::Visualization#published?`
   def with_published
-    @only_published = true
+    @filtering_params[:only_published] = true
     self
   end
 
   def with_version(version)
-    @version = version
+    @filtering_params[:version] = version
     self
   end
 
   def build
     query = Carto::Visualization.all
-
-    if @name && !(@id || @user_id || @organization_id || @owned_by_or_shared_with_user_id || @shared_with_user_id)
-      CartoDB::Logger.error(message: "VQB query by name without user_id nor org_id")
-      raise 'VQB query by name without user_id nor org_id'
-    end
-
-    if @id
-      query = query.where(id: @id)
-    end
-
-    if @excluded_ids && !@excluded_ids.empty?
-      query = query.where('visualizations.id not in (?)', @excluded_ids)
-    end
-
-    if @name
-      query = query.where(name: @name)
-    end
-
-    if @user_id
-      query = query.where(user_id: @user_id)
-    end
-
-    if @user_id_not
-      query = query.where('visualizations.user_id != ?', @user_id_not)
-    end
-
-    if @privacy
-      query = query.where(privacy: @privacy)
-    end
-
-    if @liked_by_user_id
-      query = query
-              .joins(:likes)
-              .where(likes: { actor: @liked_by_user_id })
-    end
-
-    if @shared_with_user_id
-      # The problem here is to manage to generate a query that Postgres will correctly optimize. The problem is that the
-      # optimizer seems to have problem determining the best plan when there are many JOINS, such as when VQB is called
-      # with many prefetch options, e.g: from visualizations index.
-      # This is hacky but works, without a performance hit. Other approaches:
-      # - Use a WHERE visualization.id IN (SELECT entity_id...).
-      #     psql does a very bad query plan on this, but only when adding the `LEFT OUTER JOIN synchronizations`
-      # - Use a CTE (WITH shared_vizs AS (SELECT entity_id ...) SELECT FROM visualizations JOIN shared_vizs)
-      #     This generates a nice query plan, but I was unable to generate this with ActiveRecord
-      # - Create a view for shared_entities grouped by entity_id, and then create a fake model to join to the
-      #     view instead of the table. Should work, but adds a view just to cover for a failure in Rails
-      # - Use `GROUP BY visualizations.id, synchronizations.id ...`
-      #     For some reason, Rails generates a wrong result when combining `group` with `count`
-      # - Use a JOIN `query.joins("JOIN (#{shared_vizs.to_sql} ...)")`
-      #     Rails insists in putting custom SQL joins at the end, and psql fails at optimizing. This would work
-      #     if this JOIN was written as the first JOIN in the query. psql uses order to inform the optimizer.
-      #     This is precisely what this hacks achieves, by tricking the `FROM` part of the query
-      # Context: https://github.com/CartoDB/cartodb/issues/13970
-      user = Carto::User.where(id: @shared_with_user_id).first
-      shared_vizs = Carto::SharedEntity.where(recipient_id: recipient_ids(user)).select(:entity_id).uniq
-      query = query.from([Arel::Nodes::SqlLiteral.new("
-        visualizations
-        JOIN
-          (#{shared_vizs.to_sql}) shared_ent
-        ON
-          visualizations.id = shared_ent.entity_id")])
-    end
-
-    if @owned_by_or_shared_with_user_id
-      # TODO: sql strings are suboptimal and compromise compositability, but
-      # I haven't found a better way to do this OR in Rails
-      shared_with_viz_ids = ::Carto::VisualizationQueryBuilder.new.with_shared_with_user_id(
-        @owned_by_or_shared_with_user_id).build.uniq.pluck('visualizations.id')
-      if shared_with_viz_ids.empty?
-        query = query.where(' "visualizations"."user_id" = (?)', @owned_by_or_shared_with_user_id)
-      else
-        query = query.where(' ("visualizations"."user_id" = (?) or "visualizations"."id" in (?))',
-                            @owned_by_or_shared_with_user_id, shared_with_viz_ids)
-      end
-    end
-
-    if @exclude_synced_external_sources
-      query = query.joins(%{
-                            LEFT JOIN external_sources es
-                              ON es.visualization_id = visualizations.id
-                          })
-                   .joins(%{
-                            LEFT JOIN external_data_imports edi
-                              ON edi.external_source_id = es.id
-                              AND (SELECT state FROM data_imports WHERE id = edi.data_import_id) <> 'failure'
-                              #{exclude_only_synchronized}
-                          })
-                   .where("edi.id IS NULL")
-    end
-
-    if @exclude_imported_remote_visualizations
-      # Right now only common-data public visualizations have display name setted so
-      # the data-library visualizations have it too. So if we want to filter legacy remote
-      # visualizations without display_name, we have to to this way.
-      # We take into account other types and exclude from the display_name because the search
-      # of datasets, for example, make a query with multiples types (table, remote) and we don't
-      # want to filter the table ones
-      query = query.where('("visualizations"."type" <> \'remote\' OR "visualizations"."type" = \'remote\' AND "visualizations"."display_name" IS NOT NULL)')
-    end
-
-    @excluded_kinds.each do |kind|
-      query = query.where("\"visualizations\".\"kind\" != '#{kind}'")
-    end
-
-    if @type
-      query = query.where(type: @type)
-    end
-
-    if @types
-      query = query.where(type: @types)
-    end
-
-    if !@locked.nil?
-      query = query.where(locked: @locked)
-    end
-
-    if @tainted_search_pattern
-      query = Carto::VisualizationQuerySearcher.new(query).search(@tainted_search_pattern)
-    end
-
-    if @tags
-      @tags.each(&:downcase!)
-      query = query.where("array_to_string(visualizations.tags, ', ') ILIKE '%' || array_to_string(ARRAY[?]::text[], ', ') || '%'", @tags)
-    end
-
-    if @bounding_box
-      bbox_sql = Carto::BoundingBoxUtils.to_polygon(
-        @bounding_box[:minx], @bounding_box[:miny], @bounding_box[:maxx], @bounding_box[:maxy]
-      )
-      query = query.where("visualizations.bbox is not null AND visualizations.bbox && #{bbox_sql}")
-    end
-
-    if @only_with_display_name
-      query = query.where("display_name is not null")
-    end
-
-    if @organization_id
-      query = query.joins(:user).where(users: { organization_id: @organization_id })
-    end
-
-    if @version
-      query = query.where(version: @version)
-    end
-
-    if @only_published
-      # "Published" is only required for builder maps
-      # This SQL check should match Ruby `Carto::Visualization#published?` definition
-      query = query.where(%{
-            visualizations.privacy <> '#{Carto::Visualization::PRIVACY_PRIVATE}'
-        and (
-               ((visualizations.version <> #{Carto::Visualization::VERSION_BUILDER}) or (visualizations.version is null))
-            or
-               visualizations.type <> '#{Carto::Visualization::TYPE_DERIVED}'
-            or
-               (exists (select 1 from mapcaps mc_pub where visualizations.id = mc_pub.visualization_id limit 1))
-            )
-      })
-    end
-
-    query = query.includes(@include_associations)
-    query = query.eager_load(@eager_load_associations)
-
+    query = Carto::VisualizationQueryFilterer.new(query).filter(@filtering_params)
+    query = with_associations(query)
     order_query(query)
   end
 
@@ -382,7 +211,8 @@ class Carto::VisualizationQueryBuilder
     # Search has its own ordering criteria
     return query if @tainted_search_pattern
 
-    Carto::VisualizationQueryOrderer.new(query: query, user_id: @current_user_id).order(@order, @direction)
+    orderer = Carto::VisualizationQueryOrderer.new(query)
+    orderer.order(@order, @direction)
   end
 
   def with_include_of(association)
@@ -395,16 +225,24 @@ class Carto::VisualizationQueryBuilder
     self
   end
 
-  def recipient_ids(user)
-    [ user.id, user.organization_id ].compact + groups_ids(user)
+  def with_associations(query)
+    query = query.includes(@include_associations)
+    query = query.eager_load(@eager_load_associations)
+    query = with_favorited(query)
+    with_dependent_visualization_count(query)
   end
 
-  def groups_ids(user)
-    user.groups.nil? ? [] : user.groups.collect(&:id)
+  def with_favorited(query)
+    return query unless @order && @order.include?("favorited")
+    raise 'Cannot order by favorited if no user is provided' unless @current_user_id
+
+    Carto::VisualizationQueryIncluder.new(query).include_favorited(@current_user_id)
   end
 
-  def exclude_only_synchronized
-    "AND edi.synchronization_id IS NOT NULL" unless @exclude_imported_remote_visualizations
+  def with_dependent_visualization_count(query)
+    return query unless @order && @order.include?("dependent_visualizations")
+
+    Carto::VisualizationQueryIncluder.new(query).include_dependent_visualization_count(@filtering_params)
   end
 
 end

--- a/app/queries/carto/visualization_query_filterer.rb
+++ b/app/queries/carto/visualization_query_filterer.rb
@@ -1,0 +1,174 @@
+# encoding: UTF-8
+
+require 'active_record'
+
+class Carto::VisualizationQueryFilterer
+
+  REGULAR_FILTERS = %i(id name user_id privacy type version locked).freeze
+
+  def initialize(query)
+    @query = query
+  end
+
+  def filter(params = {})
+    query = @query
+
+    if params[:name] &&
+       !(params[:id] || params[:user_id] || params[:organization_id] || params[:owned_by_or_shared_with_user_id] ||
+         params[:shared_with_user_id])
+      CartoDB::Logger.error(message: "VQB query by name without user_id nor org_id")
+      raise 'VQB query by name without user_id nor org_id'
+    end
+
+    query = query.where(params.slice(*REGULAR_FILTERS).compact)
+
+    if params[:excluded_ids]
+      query = query.where('visualizations.id not in (?)', params[:excluded_ids])
+    end
+
+    if params[:user_id_not]
+      query = query.where('visualizations.user_id != ?', params[:user_id_not])
+    end
+
+    if params[:liked_by_user_id]
+      query = query
+              .joins(:likes)
+              .where(likes: { actor: params[:liked_by_user_id] })
+    end
+
+    if params[:shared_with_user_id]
+      # The problem here is to manage to generate a query that Postgres will correctly optimize. The problem is that the
+      # optimizer seems to have problem determining the best plan when there are many JOINS, such as when VQB is called
+      # with many prefetch options, e.g: from visualizations index.
+      # This is hacky but works, without a performance hit. Other approaches:
+      # - Use a WHERE visualization.id IN (SELECT entity_id...).
+      #     psql does a very bad query plan on this, but only when adding the `LEFT OUTER JOIN synchronizations`
+      # - Use a CTE (WITH shared_vizs AS (SELECT entity_id ...) SELECT FROM visualizations JOIN shared_vizs)
+      #     This generates a nice query plan, but I was unable to generate this with ActiveRecord
+      # - Create a view for shared_entities grouped by entity_id, and then create a fake model to join to the
+      #     view instead of the table. Should work, but adds a view just to cover for a failure in Rails
+      # - Use `GROUP BY visualizations.id, synchronizations.id ...`
+      #     For some reason, Rails generates a wrong result when combining `group` with `count`
+      # - Use a JOIN `query.joins("JOIN (#{shared_vizs.to_sql} ...)")`
+      #     Rails insists in putting custom SQL joins at the end, and psql fails at optimizing. This would work
+      #     if this JOIN was written as the first JOIN in the query. psql uses order to inform the optimizer.
+      #     This is precisely what this hacks achieves, by tricking the `FROM` part of the query
+      # Context: https://github.com/CartoDB/cartodb/issues/13970
+      user = Carto::User.where(id: params[:shared_with_user_id]).first
+      shared_vizs = Carto::SharedEntity.where(recipient_id: recipient_ids(user)).select(:entity_id).uniq
+      query = query.from([Arel::Nodes::SqlLiteral.new("
+        visualizations
+        JOIN
+          (#{shared_vizs.to_sql}) shared_ent
+        ON
+          visualizations.id = shared_ent.entity_id")])
+    end
+
+    if params[:owned_by_or_shared_with_user_id]
+      # TODO: sql strings are suboptimal and compromise compositability, but
+      # I haven't found a better way to do this OR in Rails
+      shared_with_viz_ids = ::Carto::VisualizationQueryBuilder.new.with_shared_with_user_id(
+        params[:owned_by_or_shared_with_user_id]).build.uniq.pluck('visualizations.id')
+      query = if shared_with_viz_ids.empty?
+                query.where(' "visualizations"."user_id" = (?)', params[:owned_by_or_shared_with_user_id])
+              else
+                query = query.where(' ("visualizations"."user_id" = (?) or "visualizations"."id" in (?))',
+                                    params[:owned_by_or_shared_with_user_id], shared_with_viz_ids)
+              end
+    end
+
+    if params[:exclude_synced_external_sources]
+      query = query.joins(%{
+                            LEFT JOIN external_sources es
+                              ON es.visualization_id = visualizations.id
+                          })
+                   .joins(%{
+                            LEFT JOIN external_data_imports edi
+                              ON edi.external_source_id = es.id
+                              AND (SELECT state FROM data_imports WHERE id = edi.data_import_id) <> 'failure'
+                              #{exclude_only_synchronized(params[:exclude_imported_remote_visualizations])}
+                          })
+                   .where("edi.id IS NULL")
+    end
+
+    if params[:exclude_imported_remote_visualizations]
+      # Right now only common-data public visualizations have display name setted so
+      # the data-library visualizations have it too. So if we want to filter legacy remote
+      # visualizations without display_name, we have to to this way.
+      # We take into account other types and exclude from the display_name because the search
+      # of datasets, for example, make a query with multiples types (table, remote) and we don't
+      # want to filter the table ones
+      query = query.where(
+        %{
+          "visualizations"."type" <> 'remote' OR
+            ("visualizations"."type" = 'remote' AND "visualizations"."display_name" IS NOT NULL)
+        }.squish
+      )
+    end
+
+    if params[:excluded_kinds]
+      params[:excluded_kinds].each do |kind|
+        query = query.where("\"visualizations\".\"kind\" != '#{kind}'")
+      end
+    end
+
+    if params[:tainted_search_pattern]
+      query = Carto::VisualizationQuerySearcher.new(query).search(params[:tainted_search_pattern])
+    end
+
+    if params[:tags]
+      params[:tags].each(&:downcase!)
+      query = query.where(
+        "array_to_string(visualizations.tags, ', ') ILIKE '%' || array_to_string(ARRAY[?]::text[], ', ') || '%'",
+        params[:tags]
+      )
+    end
+
+    if params[:bounding_box]
+      bbox_sql = Carto::BoundingBoxUtils.to_polygon(
+        params[:bounding_box][:minx], params[:bounding_box][:miny],
+        params[:bounding_box][:maxx], params[:bounding_box][:maxy]
+      )
+      query = query.where("visualizations.bbox IS NOT NULL AND visualizations.bbox && #{bbox_sql}")
+    end
+
+    if params[:only_with_display_name]
+      query = query.where("display_name IS NOT NULL")
+    end
+
+    if params[:organization_id]
+      query = query.joins(:user).where(users: { organization_id: params[:organization_id] })
+    end
+
+    if params[:only_published]
+      # "Published" is only required for builder maps
+      # This SQL check should match Ruby `Carto::Visualization#published?` definition
+      query = query.where(
+        %{
+          visualizations.privacy <> '#{Carto::Visualization::PRIVACY_PRIVATE}'
+            AND ((visualizations.version <> #{Carto::Visualization::VERSION_BUILDER} OR visualizations.version IS NULL)
+              OR visualizations.type <> '#{Carto::Visualization::TYPE_DERIVED}'
+              OR EXISTS (SELECT 1 FROM mapcaps mc_pub WHERE visualizations.id = mc_pub.visualization_id LIMIT 1)
+            )
+        }.squish
+      )
+    end
+
+    query
+  end
+
+  private
+
+  def exclude_only_synchronized(exclude_imported_remote_visualizations)
+    "AND edi.synchronization_id IS NOT NULL" unless exclude_imported_remote_visualizations
+  end
+
+  def recipient_ids(user)
+    [user.id, user.organization_id].compact + groups_ids(user)
+  end
+
+  def groups_ids(user)
+    user.groups.nil? ? [] : user.groups.map(&:id)
+  end
+
+end

--- a/app/queries/carto/visualization_query_includer.rb
+++ b/app/queries/carto/visualization_query_includer.rb
@@ -1,0 +1,54 @@
+# encoding: UTF-8
+
+require 'active_record'
+
+class Carto::VisualizationQueryIncluder
+
+  def initialize(query)
+    @query = query
+  end
+
+  def include_dependent_visualization_count(params = {})
+    join_sql = "LEFT OUTER JOIN (#{dependencies_query(params)}) AS dependencies ON dependencies.id = visualizations.id"
+    @query.joins(join_sql)
+  end
+
+  def include_favorited(user_id)
+    @query.joins(
+      %{
+        LEFT JOIN likes
+          ON "likes"."subject" = "visualizations"."id"
+          AND "likes"."actor" = #{ActiveRecord::Base::sanitize(user_id)}
+      }.squish
+    )
+  end
+
+  private
+
+  def dependencies_query(params)
+    select_count = 'count(distinct(visualizations.id, dependency_visualizations.id)) as dependent_visualization_count'
+    query = Carto::Visualization.select(:id, select_count)
+                                .joins(dependency_joins)
+                                .where(dependency_visualizations: { type: 'derived' })
+                                .group(:id)
+    filtered_query = Carto::VisualizationQueryFilterer.new(query).filter(params)
+    filtered_query.to_sql
+  end
+
+  def dependency_joins
+    %{
+      INNER JOIN "maps" "dependency_maps" ON "dependency_maps"."id" = "visualizations"."map_id"
+      INNER JOIN "user_tables" "dependency_user_tables" ON "dependency_user_tables"."map_id" = "dependency_maps"."id"
+      INNER JOIN "layers_user_tables" "dependency_layers_user_tables"
+        ON "dependency_layers_user_tables"."user_table_id" = "dependency_user_tables"."id"
+      INNER JOIN "layers" "dependency_layers"
+        ON "dependency_layers"."id" = "dependency_layers_user_tables"."layer_id"
+      INNER JOIN "layers_maps" "dependency_layers_maps"
+        ON "dependency_layers_maps"."layer_id" = "dependency_layers"."id"
+      INNER JOIN "maps" "dependency_maps_2" ON "dependency_maps_2"."id" = "dependency_layers_maps"."map_id"
+      INNER JOIN "visualizations" "dependency_visualizations"
+        ON "dependency_visualizations"."map_id" = "dependency_maps_2"."id"
+    }.squish
+  end
+
+end

--- a/app/queries/carto/visualization_query_orderer.rb
+++ b/app/queries/carto/visualization_query_orderer.rb
@@ -5,12 +5,14 @@ require 'active_record'
 class Carto::VisualizationQueryOrderer
 
   DEFAULT_ORDER_DIRECTION = 'asc'.freeze
-  SUPPORTED_OFFDATABASE_ORDERS = %w(size mapviews likes estimated_row_count dependent_visualizations).freeze
+  SUPPORTED_OFFDATABASE_ORDERS = %w(size mapviews likes estimated_row_count).freeze
   VISUALIZATION_TABLE_ORDERS = %w(name updated_at privacy).freeze
 
-  def initialize(query:, user_id: nil)
+  DEPENDENT_VISUALIZATIONS_ORDER_CLAUSE = "coalesce(dependent_visualization_count, 0)".freeze
+  FAVORITED_ORDER_CLAUSE = "(likes.actor IS NOT NULL)".freeze
+
+  def initialize(query)
     @query = query
-    @user_id = user_id
   end
 
   def order(order, direction = "")
@@ -19,7 +21,7 @@ class Carto::VisualizationQueryOrderer
     prepare_order_params(order, direction)
 
     if offdatabase_orders.empty?
-      query_with_favorited_if_needed.order(database_orders)
+      @query.order(database_orders)
     else
       Carto::OffdatabaseQueryAdapter.new(@query, offdatabase_orders)
     end
@@ -34,6 +36,8 @@ class Carto::VisualizationQueryOrderer
 
     orders.each_with_index do |order, index|
       order = "visualizations.#{order}" if VISUALIZATION_TABLE_ORDERS.include?(order)
+      order = DEPENDENT_VISUALIZATIONS_ORDER_CLAUSE if order == "dependent_visualizations"
+      order = FAVORITED_ORDER_CLAUSE if order == "favorited"
       @order_hash[order] = directions[index] || directions[0] || DEFAULT_ORDER_DIRECTION
     end
     @order_hash
@@ -46,20 +50,6 @@ class Carto::VisualizationQueryOrderer
 
   def offdatabase_orders
     @order_hash.slice(*SUPPORTED_OFFDATABASE_ORDERS)
-  end
-
-  def query_with_favorited_if_needed
-    return @query unless @order_hash.include?("favorited")
-    raise 'Cannot order by favorited if no user is provided' unless @user_id
-
-    @query.select('(likes.actor IS NOT NULL) AS favorited')
-          .joins(
-            %{
-              LEFT JOIN likes
-                ON "likes"."subject" = "visualizations"."id"
-                AND "likes"."actor" = #{ActiveRecord::Base::sanitize(@user_id)}
-            }.squish
-          )
   end
 
 end

--- a/app/queries/carto/visualization_query_orderer.rb
+++ b/app/queries/carto/visualization_query_orderer.rb
@@ -5,10 +5,11 @@ require 'active_record'
 class Carto::VisualizationQueryOrderer
 
   DEFAULT_ORDER_DIRECTION = 'asc'.freeze
-  SUPPORTED_OFFDATABASE_ORDERS = %w(size mapviews likes estimated_row_count).freeze
+  SUPPORTED_OFFDATABASE_ORDERS = %w(size mapviews estimated_row_count).freeze
   VISUALIZATION_TABLE_ORDERS = %w(name updated_at privacy).freeze
 
   DEPENDENT_VISUALIZATIONS_ORDER_CLAUSE = "coalesce(dependent_visualization_count, 0)".freeze
+  LIKES_ORDER_CLAUSE = "coalesce(likes_count, 0)".freeze
   FAVORITED_ORDER_CLAUSE = "(likes.actor IS NOT NULL)".freeze
 
   def initialize(query)
@@ -38,6 +39,7 @@ class Carto::VisualizationQueryOrderer
       order = "visualizations.#{order}" if VISUALIZATION_TABLE_ORDERS.include?(order)
       order = DEPENDENT_VISUALIZATIONS_ORDER_CLAUSE if order == "dependent_visualizations"
       order = FAVORITED_ORDER_CLAUSE if order == "favorited"
+      order = LIKES_ORDER_CLAUSE if order == "likes"
       @order_hash[order] = directions[index] || directions[0] || DEFAULT_ORDER_DIRECTION
     end
     @order_hash

--- a/spec/queries/carto/visualization_query_orderer_spec.rb
+++ b/spec/queries/carto/visualization_query_orderer_spec.rb
@@ -5,14 +5,16 @@ require_relative '../../spec_helper_min'
 describe Carto::VisualizationQueryOrderer do
   before(:all) do
     @user = FactoryGirl.create(:carto_user)
-    @visualization_a = FactoryGirl.create(:derived_visualization, user_id: @user.id, name: 'Visualization A')
+    @visualization_a = FactoryGirl.create(:derived_visualization, user_id: @user.id, name: 'Visualization A',
+                                                                  privacy: Carto::Visualization::PRIVACY_PUBLIC)
     Delorean.jump(1.day)
-    @visualization_b = FactoryGirl.create(:derived_visualization, user_id: @user.id, name: 'Visualization B')
+    @visualization_b = FactoryGirl.create(:derived_visualization, user_id: @user.id, name: 'Visualization B',
+                                                                  privacy: Carto::Visualization::PRIVACY_LINK)
     @visualization_b.add_like_from(@user.id)
     Delorean.back_to_the_present
 
     query = Carto::Visualization.all.select("visualizations.*").where(user_id: @user.id)
-    @orderer = Carto::VisualizationQueryOrderer.new(query: query, user_id: @user.id)
+    @orderer = Carto::VisualizationQueryOrderer.new(query)
   end
 
   after(:all) do
@@ -59,22 +61,6 @@ describe Carto::VisualizationQueryOrderer do
     end
   end
 
-  context 'by favorited' do
-    it 'orders ascending' do
-      result = @orderer.order('favorited', 'asc')
-
-      expect(result.size).to eql 2
-      expect(result.first.name).to eql @visualization_a.name
-    end
-
-    it 'orders descending' do
-      result = @orderer.order('favorited', 'desc')
-
-      expect(result.size).to eql 2
-      expect(result.first.name).to eql @visualization_b.name
-    end
-  end
-
   context 'by likes' do
     it 'orders ascending' do
       result = @orderer.order('likes', 'asc')
@@ -91,11 +77,27 @@ describe Carto::VisualizationQueryOrderer do
     end
   end
 
+  context 'by privacy' do
+    it 'orders ascending' do
+      result = @orderer.order('privacy', 'asc')
+
+      expect(result.size).to eql 2
+      expect(result.first.name).to eql @visualization_b.name
+    end
+
+    it 'orders descending' do
+      result = @orderer.order('privacy', 'desc')
+
+      expect(result.size).to eql 2
+      expect(result.first.name).to eql @visualization_a.name
+    end
+  end
+
   context 'multiple ordering' do
     before(:each) do
       Delorean.jump(2.days)
-      @visualization_c = FactoryGirl.create(:derived_visualization, user_id: @user.id, name: 'Visualization C')
-      @visualization_c.add_like_from(@user.id)
+      @visualization_c = FactoryGirl.create(:derived_visualization, user_id: @user.id, name: 'Visualization C',
+                                                                    privacy: Carto::Visualization::PRIVACY_LINK)
       Delorean.back_to_the_present
     end
 
@@ -103,36 +105,36 @@ describe Carto::VisualizationQueryOrderer do
       @visualization_c.delete
     end
 
-    it 'orders by favorited desc + updated_at desc' do
-      result = @orderer.order('favorited,updated_at', 'desc,desc')
+    it 'orders by privacy desc + updated_at desc' do
+      result = @orderer.order('privacy,updated_at', 'desc,desc')
 
       expect(result.size).to eql 3
-      expect(result.first.name).to eql @visualization_c.name
-      expect(result.second.name).to eql @visualization_b.name
-    end
-
-    it 'orders by favorited desc + updated_at asc' do
-      result = @orderer.order('favorited,updated_at', 'desc,asc')
-
-      expect(result.size).to eql 3
-      expect(result.first.name).to eql @visualization_b.name
+      expect(result.first.name).to eql @visualization_a.name
       expect(result.second.name).to eql @visualization_c.name
     end
 
-    it 'orders by favorited + name without direction (default direction = asc)' do
-      result = @orderer.order('favorited,name')
+    it 'orders by privacy desc + updated_at asc' do
+      result = @orderer.order('privacy,updated_at', 'desc,asc')
 
       expect(result.size).to eql 3
       expect(result.first.name).to eql @visualization_a.name
       expect(result.second.name).to eql @visualization_b.name
     end
 
-    it 'orders by favorited desc + name without direction (it takes the first direction)' do
-      result = @orderer.order('favorited,name', 'desc')
+    it 'orders by privacy + name without direction (default direction = asc)' do
+      result = @orderer.order('privacy,name')
 
       expect(result.size).to eql 3
-      expect(result.first.name).to eql @visualization_c.name
-      expect(result.second.name).to eql @visualization_b.name
+      expect(result.first.name).to eql @visualization_b.name
+      expect(result.second.name).to eql @visualization_c.name
+    end
+
+    it 'orders by privacy desc + name without direction (it takes the first direction)' do
+      result = @orderer.order('privacy,name', 'desc')
+
+      expect(result.size).to eql 3
+      expect(result.first.name).to eql @visualization_a.name
+      expect(result.second.name).to eql @visualization_c.name
     end
   end
 end

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -2931,6 +2931,25 @@ describe Carto::Api::VisualizationsController do
         collection[1]['id'].should eq visualization_b.id
       end
 
+      it 'orders by likes' do
+        other_user = FactoryGirl.create(:valid_user)
+        visualization_a = FactoryGirl.create(:carto_visualization, user_id: @user.id).store
+        visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id).store
+        visualization_a.add_like_from(other_user.id)
+
+        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', with_dependent_visualizations: 10,
+                                            order: 'likes', order_direction: 'desc'), {}, @headers
+
+        last_response.status.should == 200
+        response = JSON.parse(last_response.body)
+        collection = response.fetch('visualizations')
+        collection.length.should eq 2
+        collection[0]['id'].should eq visualization_a.id
+        collection[1]['id'].should eq visualization_b.id
+
+        other_user.destroy
+      end
+
       it 'orders by size' do
         vis1 = factory(@user, locked: true, type: 'remote', display_name: 'visu1')
         post api_v1_visualizations_create_url(api_key: @user.api_key), vis1.to_json, @headers

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -2826,7 +2826,7 @@ describe Carto::Api::VisualizationsController do
       end
 
       it 'does not return the dependent visualizations if with_dependent_visualizations = 0' do
-        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'table', order: 'dependent_visualizations',
+        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'table',
                                             with_dependent_visualizations: 0), {}, @headers
 
         last_response.status.should == 200
@@ -2838,7 +2838,7 @@ describe Carto::Api::VisualizationsController do
       end
 
       it 'returns the 2 most recent dependent visualizations when with_dependent_visualizations = 2' do
-        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'table', order: 'dependent_visualizations',
+        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'table',
                                             with_dependent_visualizations: 2), {}, @headers
 
         last_response.status.should == 200
@@ -2855,6 +2855,7 @@ describe Carto::Api::VisualizationsController do
     end
 
     context 'ordering' do
+
       it 'returns the expected status' do
         get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: ''), {}, @headers
         last_response.status.should == 200
@@ -2919,7 +2920,7 @@ describe Carto::Api::VisualizationsController do
         visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id).store
         visualization_a.add_like_from(@user.id)
 
-        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived',
+        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', with_dependent_visualizations: 10,
                                             order: 'favorited', order_direction: 'desc'), {}, @headers
 
         last_response.status.should == 200
@@ -2930,149 +2931,104 @@ describe Carto::Api::VisualizationsController do
         collection[1]['id'].should eq visualization_b.id
       end
 
-      context 'by estimated row count' do
-        before(:each) do
-          @visualization_a = FactoryGirl.create(:carto_visualization, user_id: @user.id)
-          table = FactoryGirl.create(:table, user_id: @user.id)
-          table.insert_row!(name: 'name1')
-          table.update_table_pg_stats
-          @visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: table.map_id)
-        end
+      it 'orders by size' do
+        vis1 = factory(@user, locked: true, type: 'remote', display_name: 'visu1')
+        post api_v1_visualizations_create_url(api_key: @user.api_key), vis1.to_json, @headers
+        vis1_id = JSON.parse(last_response.body).fetch('id')
+        Carto::ExternalSource.new(
+          visualization_id: vis1_id,
+          import_url: 'http://www.fake.com',
+          rows_counted: 1,
+          size: 100
+        ).save
 
-        xit 'orders descending by default' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived',
-                                              order: 'estimated_row_count'), {}, @headers
+        vis2 = factory(@user, locked: true, type: 'remote', display_name: 'visu2')
+        post api_v1_visualizations_create_url(api_key: @user.api_key), vis2.to_json, @headers
+        vis2_id = JSON.parse(last_response.body).fetch('id')
+        Carto::ExternalSource.new(
+          visualization_id: vis2_id,
+          import_url: 'http://www.fake.com',
+          rows_counted: 1,
+          size: 200
+        ).save
 
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_b.id
-          collection[1]['id'].should eq @visualization_a.id
-        end
+        vis3 = factory(@user, locked: true, type: 'remote', display_name: 'visu3')
+        post api_v1_visualizations_create_url(api_key: @user.api_key), vis3.to_json, @headers
+        vis3_id = JSON.parse(last_response.body).fetch('id')
+        Carto::ExternalSource.new(
+          visualization_id: vis3_id,
+          import_url: 'http://www.fake.com',
+          rows_counted: 1, size: 10
+        ).save
 
-        xit 'orders descending' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count',
-                                              order_direction: 'desc'), {}, @headers
-
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_b.id
-          collection[1]['id'].should eq @visualization_a.id
-        end
-
-        xit 'orders ascending' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count',
-                                              order_direction: 'asc'), {}, @headers
-
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_a.id
-          collection[1]['id'].should eq @visualization_b.id
-        end
+        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'remote', order: 'size'), {}, @headers
+        last_response.status.should == 200
+        response    = JSON.parse(last_response.body)
+        collection  = response.fetch('visualizations')
+        collection.length.should eq 3
+        collection[0]['id'].should == vis2_id
+        collection[1]['id'].should == vis1_id
+        collection[2]['id'].should == vis3_id
       end
 
-      context 'by privacy' do
-        before(:each) do
-          link_privacy = Carto::Visualization::PRIVACY_LINK
-          public_privacy = Carto::Visualization::PRIVACY_PUBLIC
-          @visualization_a = FactoryGirl.create(:carto_visualization, user_id: @user.id, privacy: link_privacy).store
-          @visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id, privacy: public_privacy).store
-        end
+      xit 'orders by estimated row count' do
+        visualization_a = FactoryGirl.create(:carto_visualization, user_id: @user.id)
+        table = FactoryGirl.create(:table, user_id: @user.id)
+        table.insert_row!(name: 'name1')
+        table.update_table_pg_stats
+        visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id, map_id: table.map_id)
 
-        it 'orders descending by default' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived',
-                                              order: 'privacy'), {}, @headers
+        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'estimated_row_count',
+                                            order_direction: 'desc'), {}, @headers
 
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_b.id
-          collection[1]['id'].should eq @visualization_a.id
-        end
-
-        it 'orders descending' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'privacy',
-                                              order_direction: 'desc'), {}, @headers
-
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_b.id
-          collection[1]['id'].should eq @visualization_a.id
-        end
-
-        it 'orders ascending' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'privacy',
-                                              order_direction: 'asc'), {}, @headers
-
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_a.id
-          collection[1]['id'].should eq @visualization_b.id
-        end
+        last_response.status.should == 200
+        response = JSON.parse(last_response.body)
+        collection = response.fetch('visualizations')
+        collection.length.should eq 2
+        collection[0]['id'].should eq visualization_b.id
+        collection[1]['id'].should eq visualization_a.id
       end
 
-      context 'by dependent visualizations' do
-        before(:each) do
-          table_a = create_random_table(@user)
-          @visualization_a = table_a.table_visualization
-          dependent_visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id)
-          dependent_visualization.map = FactoryGirl.create(:carto_map, user_id: @user.id)
-          dependent_visualization.save!
-          layer = FactoryGirl.build(:carto_layer)
-          layer.options[:table_name] = table_a.name
-          layer.save!
-          dependent_visualization.layers << layer
-          table_b = create_random_table(@user)
-          @visualization_b = table_b.table_visualization
-        end
+      it 'orders by privacy' do
+        link_privacy = Carto::Visualization::PRIVACY_LINK
+        public_privacy = Carto::Visualization::PRIVACY_PUBLIC
+        visualization_a = FactoryGirl.create(:carto_visualization, user_id: @user.id, privacy: link_privacy).store
+        visualization_b = FactoryGirl.create(:carto_visualization, user_id: @user.id, privacy: public_privacy).store
 
-        it 'orders descending by default' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'table', order: 'dependent_visualizations',
-                                              with_dependent_visualizations: true), {}, @headers
+        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'derived', order: 'privacy',
+                                            order_direction: 'desc'), {}, @headers
 
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_a.id
-          collection[1]['id'].should eq @visualization_b.id
-        end
+        last_response.status.should == 200
+        response = JSON.parse(last_response.body)
+        collection = response.fetch('visualizations')
+        collection.length.should eq 2
+        collection[0]['id'].should eq visualization_b.id
+        collection[1]['id'].should eq visualization_a.id
+      end
 
-        it 'orders descending' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'table', order: 'dependent_visualizations',
-                                              with_dependent_visualizations: true,
-                                              order_direction: 'desc'), {}, @headers
+      it 'orders by dependent visualizations' do
+        table_a = create_random_table(@user)
+        visualization_a = table_a.table_visualization
+        dependent_visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id)
+        dependent_visualization.map = FactoryGirl.create(:carto_map, user_id: @user.id)
+        dependent_visualization.save!
+        layer = FactoryGirl.build(:carto_layer)
+        layer.options[:table_name] = table_a.name
+        layer.save!
+        dependent_visualization.layers << layer
+        table_b = create_random_table(@user)
+        visualization_b = table_b.table_visualization
 
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_a.id
-          collection[1]['id'].should eq @visualization_b.id
-        end
+        get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'table', order: 'dependent_visualizations',
+                                            with_dependent_visualizations: 10,
+                                            order_direction: 'desc'), {}, @headers
 
-        it 'orders ascending' do
-          get api_v1_visualizations_index_url(api_key: @user.api_key, types: 'table', order: 'dependent_visualizations',
-                                              with_dependent_visualizations: true,
-                                              order_direction: 'asc'), {}, @headers
-
-          last_response.status.should == 200
-          response = JSON.parse(last_response.body)
-          collection = response.fetch('visualizations')
-          collection.length.should eq 2
-          collection[0]['id'].should eq @visualization_b.id
-          collection[1]['id'].should eq @visualization_a.id
-        end
+        last_response.status.should == 200
+        response = JSON.parse(last_response.body)
+        collection = response.fetch('visualizations')
+        collection.length.should eq 2
+        collection[0]['id'].should eq visualization_a.id
+        collection[1]['id'].should eq visualization_b.id
       end
 
       context 'by search rank' do


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb/issues/14508

To order visualizations by `likes` we are currently using `OffdatabaseQueryAdapter`, which generates N+1 queries to get the number of likes of each visualization. Now, the likes count is retrieved in a subquery (similar to the approach with dependent visualizations), so it's ordered by SQL, which is faster for large results.