### PR TITLE
Fix welcome module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ Development
 - Changed the Interal Engine public name for Enterprise engine to avoid issues with the clients (#14538)
 - Revert favorited ordering for Datasets in New Dashboard (#14552)
 - Rake to fix batch geocoder multypolygon type mismatch (dataservices-api#538)
+- Fixes bug that didn't showed properly the New Dashboard's welcome module [#14570](https://github.com/CartoDB/cartodb/pull/14570)
 
 4.23.4 (2018-12-18)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
@@ -69,9 +69,13 @@ export default {
     isInTrial () {
       return Boolean(this.trialEndDate);
     },
+    isFreeUser () {
+      const freeUser = ['free'];
+      return freeUser.includes(this.$store.state.user.account_type);
+    },
     isProUser () {
       const noProUsers = ['internal', 'partner', 'ambassador', 'free'];
-      return noProUsers.includes(this.user.account_type);
+      return noProUsers.includes(this.$store.state.user.account_type);
     },
     isOrganizationAdmin () {
       if (!this.isOrganizationUser()) {

--- a/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
@@ -34,6 +34,7 @@ export default {
       isFirst: state => state.config.isFirstTimeViewingDashboard,
       accountUpdateURL: state => state.config.accountUpdateURL,
       trialEndDate: state => state.user.trial_ends_at,
+      user: state => state.user,
       username: state => state.user.username,
       organization: state => state.user.organization,
       notifications: state => state.user.organizationNotifications
@@ -71,18 +72,18 @@ export default {
     },
     isFreeUser () {
       const freeUser = ['free'];
-      return freeUser.includes(this.$store.state.user.account_type);
+      return freeUser.includes(this.user.account_type);
     },
     isProUser () {
       const noProUsers = ['internal', 'partner', 'ambassador', 'free'];
-      return noProUsers.includes(this.$store.state.user.account_type);
+      return noProUsers.includes(this.user.account_type);
     },
     isOrganizationAdmin () {
       if (!this.isOrganizationUser()) {
         return false;
       }
 
-      return isOrganizationAdmin(this.$store.state.user.organization, this.$store.state.user);
+      return isOrganizationAdmin(this.user.organization, this.user);
     },
     isOrganizationUser () {
       return Boolean(this.organization);


### PR DESCRIPTION
The welcome module failed for users that were not in a organizaition. There was two errors:

.- isProUser method called to this.user, which didn't exist. We added it as a computed property to fix the issue.
.- isFreeUser methods didn't exist. Now it's created returning true if the user is free