### PR TITLE
Fixes error that didn't counted properly the number of selected items

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ Development
 - Changed the Interal Engine public name for Enterprise engine to avoid issues with the clients (#14538)
 - Revert favorited ordering for Datasets in New Dashboard (#14552)
 - Rake to fix batch geocoder multypolygon type mismatch (dataservices-api#538)
+- Fixed bug that counted incorrectly the number of datasets/maps selected [#14571](https://github.com/CartoDB/cartodb/pull/14571)
 
 4.23.4 (2018-12-18)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ Development
 - Changed the Interal Engine public name for Enterprise engine to avoid issues with the clients (#14538)
 - Revert favorited ordering for Datasets in New Dashboard (#14552)
 - Rake to fix batch geocoder multypolygon type mismatch (dataservices-api#538)
-- Fixed bug that counted incorrectly the number of datasets/maps selected [#14571](https://github.com/CartoDB/cartodb/pull/14571)
+- Fixed bug that counted incorrectly the number of datasets/maps selected [#14571](https://github.com/CartoDB/cartodb/pull/14571) in New Dashboard
 - Fix dataset button in homepage new dashboard ([#14558](https://github.com/CartoDB/cartodb/issues/14558))
 
 4.23.4 (2018-12-18)

--- a/lib/assets/javascripts/new-dashboard/components/Dataset/DatasetCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Dataset/DatasetCard.vue
@@ -6,13 +6,14 @@
        'dataset-row--quick-actions-open': areQuickActionsOpen,
        'dataset-row--no-hover': !activeHover,
        'dataset-row--can-hover': canHover
-     }">
+     }"
+     @click="onClick">
     <div class="dataset-cell cell--start">
       <div class="row-dataType">
           <div class="icon--dataType" :class="`icon--${dataType}`"></div>
       </div>
       <span class="checkbox row-checkbox" @mouseover="mouseOverChildElement" @mouseleave="mouseOutChildElement">
-        <input class="checkbox-input" :checked="isSelected" @click.prevent="toggleSelection" type="checkBox">
+        <input class="checkbox-input" :checked="isSelected" @click.stop="toggleSelection" type="checkBox">
         <span class="checkbox-decoration">
           <img svg-inline src="../../assets/icons/common/checkbox.svg">
         </span>
@@ -212,7 +213,13 @@ export default {
     ...mapActions({
       likeDataset: 'datasets/like',
       deleteLikeDataset: 'datasets/deleteLike'
-    })
+    }),
+    onClick (event) {
+      if (this.$props.selectMode) {
+        event.preventDefault();
+        this.toggleSelection();
+      }
+    }
   }
 };
 </script>

--- a/lib/assets/javascripts/new-dashboard/components/Dataset/DatasetCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Dataset/DatasetCard.vue
@@ -6,8 +6,7 @@
        'dataset-row--quick-actions-open': areQuickActionsOpen,
        'dataset-row--no-hover': !activeHover,
        'dataset-row--can-hover': canHover
-     }"
-     @click="onClick">
+     }">
     <div class="dataset-cell cell--start">
       <div class="row-dataType">
           <div class="icon--dataType" :class="`icon--${dataType}`"></div>
@@ -213,13 +212,7 @@ export default {
     ...mapActions({
       likeDataset: 'datasets/like',
       deleteLikeDataset: 'datasets/deleteLike'
-    }),
-    onClick (event) {
-      if (this.$props.selectMode) {
-        event.preventDefault();
-        this.toggleSelection();
-      }
-    }
+    })
   }
 };
 </script>

--- a/lib/assets/javascripts/new-dashboard/components/MapCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapCard.vue
@@ -6,8 +6,7 @@
        'card--child-hover': !activeHover,
        'card--quick-actions-open': areQuickActionsOpen,
        'card--can-hover': canHover
-     }"
-    @click="onClick">
+     }">
     <div class="card-media" :class="{'has-error': isThumbnailErrored}">
       <img :src="mapThumbnailUrl" @error="onThumbnailError" v-if="!isThumbnailErrored"/>
       <div class="MapCard-error" v-if="isThumbnailErrored"></div>
@@ -199,13 +198,7 @@ export default {
     ...mapActions({
       likeMap: 'maps/like',
       deleteMapLike: 'maps/deleteLike'
-    }),
-    onClick (event) {
-      if (this.$props.selectMode) {
-        event.preventDefault();
-        this.toggleSelection();
-      }
-    }
+    })
   }
 };
 </script>

--- a/lib/assets/javascripts/new-dashboard/components/MapCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapCard.vue
@@ -6,14 +6,15 @@
        'card--child-hover': !activeHover,
        'card--quick-actions-open': areQuickActionsOpen,
        'card--can-hover': canHover
-     }">
+     }"
+    @click="onClick">
     <div class="card-media" :class="{'has-error': isThumbnailErrored}">
       <img :src="mapThumbnailUrl" @error="onThumbnailError" v-if="!isThumbnailErrored"/>
       <div class="MapCard-error" v-if="isThumbnailErrored"></div>
     </div>
 
     <span class="checkbox card-select" v-if="!isShared" @mouseover="mouseOverChildElement" @mouseleave="mouseOutChildElement">
-      <input class="checkbox-input" :checked="isSelected" @click.prevent="toggleSelection" type="checkBox">
+      <input class="checkbox-input" :checked="isSelected" @click.stop="toggleSelection" type="checkBox">
       <span class="checkbox-decoration">
         <img svg-inline src="../assets/icons/common/checkbox.svg">
       </span>
@@ -198,7 +199,13 @@ export default {
     ...mapActions({
       likeMap: 'maps/like',
       deleteMapLike: 'maps/deleteLike'
-    })
+    }),
+    onClick (event) {
+      if (this.$props.selectMode) {
+        event.preventDefault();
+        this.toggleSelection();
+      }
+    }
   }
 };
 </script>


### PR DESCRIPTION
When one item was selected (either map or dataset) it emitted the event twice, making it to count incorrectly the number of selected items.