### PR TITLE
Use presenter cache for related tables, saves a query to retrieve the user db size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Makes dashboard listing go faster (user db size cache issue, #14165)
 
 4.24.0 (2019-01-16)
 -------------------

--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -219,7 +219,7 @@ module Carto
                   end
 
         related.map do |table|
-          Carto::Api::UserTablePresenter.new(table, @current_viewer).to_poro
+          Carto::Api::UserTablePresenter.new(table, @current_viewer).with_presenter_cache(@presenter_cache).to_poro
         end
       end
 


### PR DESCRIPTION
I was investigating the possible performance of using tags for folders and I realized that this small change makes the visualization listing goes 700% faster (made-up number). Anyway, it saves a lot of time.

Related to https://github.com/CartoDB/cartodb/issues/14615

cc @ethervoid 