### PR TITLE
[Dashboard] Fix typo in dashboard search suggestions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Development
 - Enable search box geocoder provider selection ([#14622](https://github.com/CartoDB/cartodb/pull/14622))
 - New Lockout page for New Dashboard ([#14589](https://github.com/CartoDB/cartodb/issues/14589))
 - Fix organization invitation styles ([#14629](https://github.com/CartoDB/cartodb/issues/14629))
+- Fix typo in new dashboard search suggestions ([#14632](https://github.com/CartoDB/cartodb/pull/14632))
 
 4.24.0 (2019-01-16)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/components/Search/Suggestions/SearchSuggestions.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Search/Suggestions/SearchSuggestions.vue
@@ -11,7 +11,7 @@
           {{ query }} <span v-if="!isFetching">- {{ searchResults.total_entries }} results</span>
         </router-link>
       </li>
-      <li v-for="(visualization, index) in searchResults.visualizations" :key="visualization.id" :class="{'suggestions--active': activeSuggestionIndex === index + 1}"  @mouseover="udpateActiveSuggestion(index + 1)">
+      <li v-for="(visualization, index) in searchResults.visualizations" :key="visualization.id" :class="{'suggestions--active': activeSuggestionIndex === index + 1}"  @mouseover="updateActiveSuggestion(index + 1)">
         <SearchSuggestionsItem :item="visualization" @itemClick="onPageChange"/>
       </li>
     </ul>


### PR DESCRIPTION
Hover on dashboard search suggestions wasn't working properly due to typo in `updateActiveSuggestion` method.