### PR TITLE
Fix visualization URL when username has hyphens

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ Development
 - Fix Cancel button not working in metadata edition view ([CartoDB/product#232](https://github.com/CartoDB/product/issues/232)))
 - Show latest maps/datasets within Recent Content in Home ([product#207](https://github.com/CartoDB/product/issues/207))
 - Usability Fixes for New Dashboard ([#14565](https://github.com/CartoDB/cartodb/issues/14565))
+- Fix visualization URL with hyphens in /viz ([product#229](https://github.com/CartoDB/product/issues/229))
 
 4.25.0 (2019-01-28)
 -------------------

--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -240,8 +240,9 @@ module Carto
 
       def url
         if @visualization.canonical?
+          dataset_name = @visualization.qualified_name(@current_viewer).tr('"', '')
           CartoDB.url(@context, 'public_tables_show_bis',
-                      params: { id: @visualization.qualified_name(@current_viewer) },
+                      params: { id: dataset_name },
                       user: @current_viewer)
         else
           CartoDB.url(@context, 'public_visualizations_show_map',


### PR DESCRIPTION
Closes https://github.com/CartoDB/product/issues/229

To generate the URL, the presenter is using `sql_safe_database_schema` method from User, which adds the quotes when it contains a hyphen. The solution was to remove them in the presenter, where they are not needed.