### PR TITLE
Add types parameter to /tags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Add filtering by types to /tags endpoint and use it in the new dashboard ([CartoDB/product#259](https://github.com/CartoDB/product/issues/259)))
 
 4.25.1 (2019-02-11)
 -------------------

--- a/app/controllers/carto/api/api_keys_controller.rb
+++ b/app/controllers/carto/api/api_keys_controller.rb
@@ -53,6 +53,8 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
       paged_result(
         result: result,
         total_count: api_keys.count,
+        page: page,
+        per_page: per_page,
         params: params
       ) { |params| api_keys_url(params) },
       200

--- a/app/controllers/carto/api/api_keys_controller.rb
+++ b/app/controllers/carto/api/api_keys_controller.rb
@@ -53,9 +53,7 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
       paged_result(
         result: result,
         total_count: api_keys.count,
-        page: page,
-        per_page: per_page,
-        order: order
+        params: params
       ) { |params| api_keys_url(params) },
       200
     )

--- a/app/controllers/carto/api/paged_searcher.rb
+++ b/app/controllers/carto/api/paged_searcher.rb
@@ -23,21 +23,23 @@ module Carto
         [page, per_page, order, order_direction]
       end
 
-      def paged_result(result:, total_count:, page:, per_page:, order:)
-        last_page = (total_count / per_page.to_f).ceil
+      def paged_result(result:, total_count:, params:)
+        page = params[:page].to_i
+        per_page = params[:per_page].to_f
+        last_page = (total_count / per_page).ceil
 
         metadata = {
           total: total_count,
           count: result.count,
           result: result,
           _links: {
-            first: { href: yield(page: 1, per_page: per_page, order: order) },
-            last: { href: yield(page: last_page, per_page: per_page, order: order) }
+            first: { href: yield(params.merge(page: 1)) },
+            last: { href: yield(params.merge(page: last_page)) }
           }
         }
 
-        metadata[:_links][:prev] = { href: yield(page: page - 1, per_page: per_page, order: order) } if page > 1
-        metadata[:_links][:next] = { href: yield(page: page + 1, per_page: per_page, order: order) } if last_page > page
+        metadata[:_links][:prev] = { href: yield(params.merge(page: page - 1)) } if page > 1
+        metadata[:_links][:next] = { href: yield(params.merge(page: page + 1)) } if last_page > page
         metadata
       end
 

--- a/app/controllers/carto/api/paged_searcher.rb
+++ b/app/controllers/carto/api/paged_searcher.rb
@@ -23,23 +23,22 @@ module Carto
         [page, per_page, order, order_direction]
       end
 
-      def paged_result(result:, total_count:, params:)
-        page = params[:page].to_i
-        per_page = params[:per_page].to_f
-        last_page = (total_count / per_page).ceil
+      def paged_result(result:, total_count:, page:, per_page:, params:)
+        last_page = (total_count / per_page.to_f).ceil
+        link_params = params.merge(per_page: per_page)
 
         metadata = {
           total: total_count,
           count: result.count,
           result: result,
           _links: {
-            first: { href: yield(params.merge(page: 1)) },
-            last: { href: yield(params.merge(page: last_page)) }
+            first: { href: yield(link_params.merge(page: 1)) },
+            last: { href: yield(link_params.merge(page: last_page)) }
           }
         }
 
-        metadata[:_links][:prev] = { href: yield(params.merge(page: page - 1)) } if page > 1
-        metadata[:_links][:next] = { href: yield(params.merge(page: page + 1)) } if last_page > page
+        metadata[:_links][:prev] = { href: yield(link_params.merge(page: page - 1)) } if page > 1
+        metadata[:_links][:next] = { href: yield(link_params.merge(page: page + 1)) } if last_page > page
         metadata
       end
 

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -14,8 +14,10 @@ module Carto
 
       def index
         page, per_page = page_per_page_params(default_per_page: DEFAULT_TAGS_PER_PAGE)
+        types = params.fetch(:types, "").split(',')
 
         query_builder = Carto::TagQueryBuilder.new(current_viewer.id)
+                                              .with_types(types)
         result = query_builder.build_paged(page, per_page)
         total_count = query_builder.total_count
 

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -11,6 +11,7 @@ module Carto
       before_filter :load_parameters
 
       rescue_from StandardError, with: :rescue_from_standard_error
+      rescue_from Carto::ParamCombinationInvalidError, with: :rescue_from_carto_error
 
       DEFAULT_TAGS_PER_PAGE = 6
 
@@ -21,8 +22,6 @@ module Carto
         total_count = query_builder.total_count
 
         render json: format_response(result, total_count)
-      rescue Carto::ParamCombinationInvalidError => e
-        render_jsonp({ error: e.message }, e.status)
       end
 
       private

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -41,9 +41,7 @@ module Carto
         paged_result(
           result: result,
           total_count: total_count,
-          page: @page,
-          per_page: @per_page,
-          order: nil
+          params: params
         ) { |params| api_v3_users_tags_url(params) }
       end
 

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -39,6 +39,8 @@ module Carto
         paged_result(
           result: result,
           total_count: total_count,
+          page: @page,
+          per_page: @per_page,
           params: params
         ) { |params| api_v3_users_tags_url(params) }
       end

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -11,25 +11,40 @@ module Carto
       rescue_from StandardError, with: :rescue_from_standard_error
 
       DEFAULT_TAGS_PER_PAGE = 6
+      VALID_TYPES = %w(table derived remote).freeze
 
       def index
-        page, per_page = page_per_page_params(default_per_page: DEFAULT_TAGS_PER_PAGE)
-        types = params.fetch(:types, "").split(',')
+        read_params
 
         query_builder = Carto::TagQueryBuilder.new(current_viewer.id)
-                                              .with_types(types)
-        result = query_builder.build_paged(page, per_page)
+                                              .with_types(@types)
+        result = query_builder.build_paged(@page, @per_page)
         total_count = query_builder.total_count
 
-        formatted_response = paged_result(
+        render json: format_response(result, total_count)
+      rescue Carto::ParamCombinationInvalidError => e
+        render_jsonp({ error: e.message }, e.status)
+      end
+
+      private
+
+      def read_params
+        @page, @per_page = page_per_page_params(default_per_page: DEFAULT_TAGS_PER_PAGE)
+
+        @types = params.fetch(:types, "").split(',')
+        if (@types - VALID_TYPES).present?
+          raise Carto::ParamCombinationInvalidError.new(:types, VALID_TYPES)
+        end
+      end
+
+      def format_response(result, total_count)
+        paged_result(
           result: result,
           total_count: total_count,
-          page: page,
-          per_page: per_page,
+          page: @page,
+          per_page: @per_page,
           order: nil
         ) { |params| api_v3_users_tags_url(params) }
-
-        render json: formatted_response
       end
 
     end

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -13,7 +13,6 @@ module Carto
       rescue_from StandardError, with: :rescue_from_standard_error
 
       DEFAULT_TAGS_PER_PAGE = 6
-      VALID_TYPES = %w(table derived remote).freeze
 
       def index
         query_builder = Carto::TagQueryBuilder.new(current_viewer.id)
@@ -32,8 +31,8 @@ module Carto
         @page, @per_page = page_per_page_params(default_per_page: DEFAULT_TAGS_PER_PAGE)
 
         @types = params.fetch(:types, "").split(',')
-        if (@types - VALID_TYPES).present?
-          raise Carto::ParamCombinationInvalidError.new(:types, VALID_TYPES)
+        if (@types - Carto::Visualization::VALID_TYPES).present?
+          raise Carto::ParamCombinationInvalidError.new(:types, Carto::Visualization::VALID_TYPES)
         end
       end
 

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -8,14 +8,14 @@ module Carto
 
       ssl_required
 
+      before_filter :load_parameters
+
       rescue_from StandardError, with: :rescue_from_standard_error
 
       DEFAULT_TAGS_PER_PAGE = 6
       VALID_TYPES = %w(table derived remote).freeze
 
       def index
-        read_params
-
         query_builder = Carto::TagQueryBuilder.new(current_viewer.id)
                                               .with_types(@types)
         result = query_builder.build_paged(@page, @per_page)
@@ -28,7 +28,7 @@ module Carto
 
       private
 
-      def read_params
+      def load_parameters
         @page, @per_page = page_per_page_params(default_per_page: DEFAULT_TAGS_PER_PAGE)
 
         @types = params.fetch(:types, "").split(',')

--- a/app/queries/carto/tag_query_builder.rb
+++ b/app/queries/carto/tag_query_builder.rb
@@ -5,6 +5,11 @@ require 'active_record'
 class Carto::TagQueryBuilder
 
   DEFAULT_TYPES = %w(table derived remote).freeze
+  TYPE_TRANSLATIONS = {
+    "table" => :datasets,
+    "derived" => :maps,
+    "remote" => :data_library
+  }.freeze
 
   def initialize(user_id)
     @user_id = user_id
@@ -74,22 +79,9 @@ class Carto::TagQueryBuilder
   def format_response(result)
     result.map do |row|
       types_count = @types.map { |type|
-        { translate_type(type) => row["#{type}_count"].to_i }
+        { TYPE_TRANSLATIONS.fetch(type, type) => row["#{type}_count"].to_i }
       }.inject(:merge)
       { tag: row['tag'] }.merge(types_count)
-    end
-  end
-
-  def translate_type(type)
-    case type
-    when 'table'
-      :datasets
-    when 'derived'
-      :maps
-    when 'remote'
-      :data_library
-    else
-      type
     end
   end
 

--- a/app/queries/carto/tag_query_builder.rb
+++ b/app/queries/carto/tag_query_builder.rb
@@ -37,6 +37,7 @@ class Carto::TagQueryBuilder
         count(*) FILTER(WHERE type = 'table') AS table_count
       FROM visualizations
       WHERE user_id = ?
+      AND type IN ('table', 'derived')
       GROUP BY tag
       ORDER BY COUNT(*) DESC
       LIMIT ?
@@ -51,6 +52,7 @@ class Carto::TagQueryBuilder
         SELECT LOWER(unnest(tags)) AS tag
         FROM visualizations
         WHERE user_id = ?
+        AND type IN ('table', 'derived')
       ) AS tags
     }.squish
   end

--- a/app/queries/carto/tag_query_builder.rb
+++ b/app/queries/carto/tag_query_builder.rb
@@ -4,14 +4,22 @@ require 'active_record'
 
 class Carto::TagQueryBuilder
 
+  DEFAULT_TYPES = %w(table derived remote).freeze
+
   def initialize(user_id)
     @user_id = user_id
+    @types = DEFAULT_TYPES
+  end
+
+  def with_types(types)
+    @types = types if types.present?
+    self
   end
 
   def build_paged(page, per_page)
     limit = per_page.to_i
     offset = (page.to_i - 1) * per_page.to_i
-    query = ActiveRecord::Base.send(:sanitize_sql_array, [select_sql, @user_id, limit, offset])
+    query = ActiveRecord::Base.send(:sanitize_sql_array, [select_sql, @user_id, @types, limit, offset])
 
     connection = ActiveRecord::Base.connection
     result = connection.exec_query(query)
@@ -20,7 +28,7 @@ class Carto::TagQueryBuilder
   end
 
   def total_count
-    query = ActiveRecord::Base.send(:sanitize_sql_array, [count_sql, @user_id])
+    query = ActiveRecord::Base.send(:sanitize_sql_array, [count_sql, @user_id, @types])
 
     connection = ActiveRecord::Base.connection
     result = connection.exec_query(query)
@@ -32,17 +40,23 @@ class Carto::TagQueryBuilder
 
   def select_sql
     %{
-      SELECT LOWER(unnest(tags)) AS tag,
-        count(*) FILTER(WHERE type = 'derived') AS derived_count,
-        count(*) FILTER(WHERE type = 'table') AS table_count
+      SELECT LOWER(unnest(tags)) AS tag, #{count_by_type_sql}
       FROM visualizations
       WHERE user_id = ?
-      AND type IN ('table', 'derived')
+      AND type IN (?)
       GROUP BY tag
       ORDER BY COUNT(*) DESC
       LIMIT ?
       OFFSET ?
     }.squish
+  end
+
+  def count_by_type_sql
+    queries = @types.map do |type|
+      count_query = "count(*) FILTER(WHERE type = ?) AS #{type}_count"
+      ActiveRecord::Base.send(:sanitize_sql_array, [count_query, type])
+    end
+    queries.join(",")
   end
 
   def count_sql
@@ -52,18 +66,30 @@ class Carto::TagQueryBuilder
         SELECT LOWER(unnest(tags)) AS tag
         FROM visualizations
         WHERE user_id = ?
-        AND type IN ('table', 'derived')
+        AND type IN (?)
       ) AS tags
     }.squish
   end
 
   def format_response(result)
     result.map do |row|
-      {
-        tag: row['tag'],
-        maps: row['derived_count'].to_i,
-        datasets: row['table_count'].to_i
-      }
+      types_count = @types.map { |type|
+        { translate_type(type) => row["#{type}_count"].to_i }
+      }.inject(:merge)
+      { tag: row['tag'] }.merge(types_count)
+    end
+  end
+
+  def translate_type(type)
+    case type
+    when 'table'
+      :datasets
+    when 'derived'
+      :maps
+    when 'remote'
+      :data_library
+    else
+      type
     end
   end
 

--- a/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
+++ b/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
@@ -83,7 +83,7 @@ class AuthenticatedClient extends PublicClient {
     const URLParameters = {
       page: options.page || 1,
       per_page: options.perPage || 6,
-      types: 'derived,table'
+      types: options.types || 'derived,table'
     };
 
     const queryOptions = {

--- a/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
+++ b/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
@@ -82,7 +82,8 @@ class AuthenticatedClient extends PublicClient {
     const URIParts = ['api/v3/tags'];
     const URLParameters = {
       page: options.page || 1,
-      per_page: options.perPage || 6
+      per_page: options.perPage || 6,
+      types: 'derived,table'
     };
 
     const queryOptions = {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.45",
+  "version": "1.0.0-assets.47",
   "dependencies": {
     "@babel/polyfill": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.45",
+  "version": "1.0.0-assets.47",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/spec/queries/carto/tag_query_builder_spec.rb
+++ b/spec/queries/carto/tag_query_builder_spec.rb
@@ -46,6 +46,14 @@ describe Carto::TagQueryBuilder do
       result.should eql []
     end
 
+    it 'ignores tags from remote visualizations' do
+      FactoryGirl.create(:carto_visualization, type: 'remote', user_id: @user1.id, tags: ["user1"])
+
+      result = @builder.build_paged(1, 10)
+
+      result.should eql []
+    end
+
     it 'returns the tags in lowercase and merges tags with different letter case' do
       FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["USER1"])
       FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["uSeR1"])

--- a/spec/queries/carto/tag_query_builder_spec.rb
+++ b/spec/queries/carto/tag_query_builder_spec.rb
@@ -46,31 +46,24 @@ describe Carto::TagQueryBuilder do
       result.should eql []
     end
 
-    it 'ignores tags from remote visualizations' do
-      FactoryGirl.create(:carto_visualization, type: 'remote', user_id: @user1.id, tags: ["user1"])
-
-      result = @builder.build_paged(1, 10)
-
-      result.should eql []
-    end
-
     it 'returns the tags in lowercase and merges tags with different letter case' do
       FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["USER1"])
       FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["uSeR1"])
-      expected_result = [{ tag: "user1", maps: 2, datasets: 0 }]
+      expected_result = [{ tag: "user1", maps: 2, datasets: 0, data_library: 0 }]
 
       result = @builder.build_paged(1, 10)
 
       result.should eql expected_result
     end
 
-    it 'returns the right count of single tags for maps and datasets' do
+    it 'returns the right count of single tags for any type' do
       FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["user1"])
       FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["dataset"])
       FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["user1"])
+      FactoryGirl.create(:carto_visualization, type: 'remote', user_id: @user1.id, tags: ["user1"])
       expected_result = [
-        { tag: "user1", maps: 1, datasets: 1 },
-        { tag: "dataset", maps: 0, datasets: 1 }
+        { tag: "user1", maps: 1, datasets: 1, data_library: 1 },
+        { tag: "dataset", maps: 0, datasets: 1, data_library: 0 }
       ]
 
       result = @builder.build_paged(1, 10)
@@ -78,12 +71,39 @@ describe Carto::TagQueryBuilder do
       result.should eql expected_result
     end
 
-    it 'returns the right count of multiple tags for maps and datasets' do
+    it 'allows to filter by one type' do
+      FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["dataset"])
+      FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["map"])
+      FactoryGirl.create(:carto_visualization, type: 'remote', user_id: @user1.id, tags: ["remote"])
+      expected_result = [{ tag: "map", maps: 1 }]
+
+      builder = Carto::TagQueryBuilder.new(@user1.id).with_types(["derived"])
+      result = builder.build_paged(1, 10)
+
+      result.should eql expected_result
+    end
+
+    it 'allows to filter by 2 types' do
+      FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["dataset"])
+      FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["map"])
+      FactoryGirl.create(:carto_visualization, type: 'remote', user_id: @user1.id, tags: ["remote"])
+      expected_result = [
+        { tag: "map", maps: 1, data_library: 0 },
+        { tag: "remote", maps: 0, data_library: 1 }
+      ]
+
+      builder = Carto::TagQueryBuilder.new(@user1.id).with_types(["derived", "remote"])
+      result = builder.build_paged(1, 10)
+
+      result.should eql expected_result
+    end
+
+    it 'returns the right count when having multiple tags' do
       FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["user1", "dataset"])
       FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["dataset"])
       expected_result = [
-        { tag: "dataset", maps: 0, datasets: 2 },
-        { tag: "user1", maps: 0, datasets: 1 }
+        { tag: "dataset", maps: 0, datasets: 2, data_library: 0 },
+        { tag: "user1", maps: 0, datasets: 1, data_library: 0 }
       ]
 
       result = @builder.build_paged(1, 10)
@@ -96,9 +116,9 @@ describe Carto::TagQueryBuilder do
       FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["dataset", "user1"])
       FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["map", "user1"])
       expected_result = [
-        { tag: "user1", maps: 1, datasets: 2 },
-        { tag: "dataset", maps: 0, datasets: 2 },
-        { tag: "map", maps: 1, datasets: 0 }
+        { tag: "user1", maps: 1, datasets: 2, data_library: 0 },
+        { tag: "dataset", maps: 0, datasets: 2, data_library: 0 },
+        { tag: "map", maps: 1, datasets: 0, data_library: 0 }
       ]
 
       result = @builder.build_paged(1, 10)
@@ -115,8 +135,8 @@ describe Carto::TagQueryBuilder do
 
       it 'returns the expected result for the first page' do
         expected_result = [
-          { tag: "tag1", maps: 1, datasets: 2 },
-          { tag: "tag2", maps: 1, datasets: 1 }
+          { tag: "tag1", maps: 1, datasets: 2, data_library: 0 },
+          { tag: "tag2", maps: 1, datasets: 1, data_library: 0 }
         ]
 
         result = @builder.build_paged(1, 2)
@@ -125,7 +145,7 @@ describe Carto::TagQueryBuilder do
       end
 
       it 'returns the expected result for the last page' do
-        expected_result = [{ tag: "tag3", maps: 1, datasets: 0 }]
+        expected_result = [{ tag: "tag3", maps: 1, datasets: 0, data_library: 0 }]
 
         result = @builder.build_paged(2, 2)
 

--- a/spec/requests/carto/api/tags_controller_spec.rb
+++ b/spec/requests/carto/api/tags_controller_spec.rb
@@ -9,7 +9,7 @@ describe Carto::Api::TagsController do
   include HelperMethods
 
   before(:all) do
-    @params = { user_domain: @user.username, api_key: @user.api_key }
+    @params = { user_domain: @user.username, api_key: @user.api_key, types: "derived,table" }
     @headers = { 'CONTENT_TYPE' => 'application/json' }
   end
 
@@ -20,9 +20,16 @@ describe Carto::Api::TagsController do
       end
     end
 
+    it 'raises a 400 error if types parameter is not valid' do
+      params = @params.merge(types: "table,wrong")
+      get_json api_v3_users_tags_url(params), @headers do |response|
+        expect(response.status).to eq(400)
+      end
+    end
+
     it 'returns a 200 response with the current user tags' do
       FactoryGirl.create(:derived_visualization, user_id: @user.id, tags: ["etiqueta"])
-      expected_tags = [{ tag: "etiqueta", maps: 1, datasets: 0, data_library: 0 }]
+      expected_tags = [{ tag: "etiqueta", maps: 1, datasets: 0 }]
 
       get_json api_v3_users_tags_url(@params), @headers do |response|
         expect(response.status).to eq(200)

--- a/spec/requests/carto/api/tags_controller_spec.rb
+++ b/spec/requests/carto/api/tags_controller_spec.rb
@@ -22,7 +22,7 @@ describe Carto::Api::TagsController do
 
     it 'returns a 200 response with the current user tags' do
       FactoryGirl.create(:derived_visualization, user_id: @user.id, tags: ["etiqueta"])
-      expected_tags = [{ tag: "etiqueta", maps: 1, datasets: 0 }]
+      expected_tags = [{ tag: "etiqueta", maps: 1, datasets: 0, data_library: 0 }]
 
       get_json api_v3_users_tags_url(@params), @headers do |response|
         expect(response.status).to eq(200)


### PR DESCRIPTION
Closes https://github.com/CartoDB/product/issues/259

I've added a parameter to filter the types and used it in the new dashboard to only show tags from maps and datasets.