### PR TITLE
Rescue is not working due to operator precedence in Ruby 2.4.5 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- Hash now doesn't return exception when accessing a non-existent element [#14666](https://github.com/CartoDB/cartodb/pull/14666)
+- In ruby 2.4.5 looks like rescue fails for operator precendence [#14666](https://github.com/CartoDB/cartodb/pull/14666)
 
 4.25.1 (2019-02-11)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Hash now doesn't return exception when accessing a non-existent element [#14666](https://github.com/CartoDB/cartodb/pull/14666)
 
 4.25.1 (2019-02-11)
 -------------------

--- a/services/importer/lib/importer/content_guesser.rb
+++ b/services/importer/lib/importer/content_guesser.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'byebug'
 require_relative 'ip_checker'
 require_relative 'table_sampler'
 require_relative 'namedplaces_guesser'

--- a/services/importer/lib/importer/content_guesser.rb
+++ b/services/importer/lib/importer/content_guesser.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'byebug'
 require_relative 'ip_checker'
 require_relative 'table_sampler'
 require_relative 'namedplaces_guesser'
@@ -124,12 +125,12 @@ module CartoDB
         if normalizer
           sample.each do |row|
             elem = normalizer.call(row[column_name_sym])
-            frequency_table[elem] += 1 rescue frequency_table[elem] = 1
+            update_frequency_element(frequency_table, elem)
           end
         else
           sample.each do |row|
             elem = row[column_name_sym]
-            frequency_table[elem] += 1 rescue frequency_table[elem] = 1
+            update_frequency_element(frequency_table, elem)
           end
         end
         length = sample.count.to_f
@@ -205,6 +206,16 @@ module CartoDB
 
       def qualified_table_name
         %Q("#{@schema}"."#{@table_name}")
+      end
+
+      private
+
+      def update_frequency_element(frequency_table, elem)
+        if frequency_table.key?(elem)
+          frequency_table[elem] += 1
+        else
+          frequency_table[elem] = 1
+        end
       end
 
     end


### PR DESCRIPTION
Looks like the operator precedence in ruby 2.4.5 affect the way we're catching the `NoMethodError` and we're getting some errors