### PR TITLE
Fix for users with likes order applied

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Development
 ### Bug fixes / enhancements
 - Add filtering by types to /tags endpoint and use it in the new dashboard ([CartoDB/product#259](https://github.com/CartoDB/product/issues/259)))
 - In ruby 2.4.5 looks like rescue fails for operator precendence [#14666](https://github.com/CartoDB/cartodb/pull/14666)
+- Fix users that had sort by likes stored [#14668](https://github.com/CartoDB/cartodb/pull/14668)
 
 4.25.1 (2019-02-11)
 -------------------

--- a/lib/assets/javascripts/dashboard/dashboard.js
+++ b/lib/assets/javascripts/dashboard/dashboard.js
@@ -205,6 +205,6 @@ function resetOrderWhenLikesIsApplied () {
   const dashboardOrder = localStorageInstance.get('dashboard.order');
 
   if (dashboardOrder === 'likes') {
-    localStorageInstance.set({'dashboard.order': 'mapviews'});
+    localStorageInstance.set({'dashboard.order': 'updated_at'});
   }
 }

--- a/lib/assets/javascripts/dashboard/dashboard.js
+++ b/lib/assets/javascripts/dashboard/dashboard.js
@@ -12,6 +12,7 @@ const polyglot = new Polyglot({
 
 window._t = polyglot.t.bind(polyglot);
 
+const LocalStorage = require('dashboard/helpers/local-storage');
 const ConfigModel = require('dashboard/data/config-model');
 const UserModel = require('dashboard/data/user-model');
 const CreateDialog = require('dashboard/views/dashboard/dialogs/create-dialog/dialog-view');
@@ -61,6 +62,8 @@ function dataLoaded (data) {
   const organizationNotifications = data.organization_notifications;
   const isJustLoggedIn = data.isJustLoggedIn;
   const isFirstTimeViewingDashboard = data.isFirstTimeViewingDashboard;
+
+  resetOrderWhenLikesIsApplied();
 
   const configModel = new ConfigModel(
     _.extend(
@@ -195,4 +198,13 @@ if (window.CartoConfig.data) {
       dataLoaded(data);
     }
   });
+}
+
+function resetOrderWhenLikesIsApplied () {
+  const localStorageInstance = new LocalStorage();
+  const dashboardOrder = localStorageInstance.get('dashboard.order');
+
+  if (dashboardOrder === 'likes') {
+    localStorageInstance.set({'dashboard.order': 'mapviews'});
+  }
 }


### PR DESCRIPTION
This PR fixes broken dashboard for users that had the likes order applied before the release which removed them altogether.