### PR TITLE
[Dashboard] Fix quick actions dropdown in maps and datasets card

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ Development
 - In ruby 2.4.5 looks like rescue fails for operator precendence [#14666](https://github.com/CartoDB/cartodb/pull/14666)
 - Fix users that had sort by likes stored [#14668](https://github.com/CartoDB/cartodb/pull/14668)
 - Relocate styles to the New Dashboard folder [#14672](https://github.com/CartoDB/cartodb/pull/14672)
+- Fix quick actions dropdown in maps and datasets card - Dashboard
 
 4.25.1 (2019-02-11)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/components/QuickActions/QuickActions.vue
+++ b/lib/assets/javascripts/new-dashboard/components/QuickActions/QuickActions.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="quick-actions">
+  <div class="quick-actions" v-click-outside="closeDropdown">
     <a href="javascript:void(0)" class="quick-actions-select" @click="toggleDropdown" :class="{'is-active': isOpen }">
       <img svg-inline src="new-dashboard/assets/icons/common/options.svg">
     </a>
-    <div class="quick-actions-dropdown" :class="{'is-active' : isOpen}" v-if="isOpen" v-click-outside="closeDropdown" @click="killEvent">
+    <div class="quick-actions-dropdown" :class="{'is-active' : isOpen}" v-if="isOpen" @click="killEvent">
       <h6 class="quick-actions-title text is-semibold is-xsmall is-txtSoftGrey">{{ $t(`QuickActions.title`) }}</h6>
       <ul>
         <li v-for="action in actions" :key="action.name" v-if="!action.shouldBeHidden">


### PR DESCRIPTION
Quick actions dropdown does not show open after clicking in three dots symbol due to click-outside directive closing again the dropdown.