### PR TITLE
 Update pending notifications badge when checking out notifications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Development
 - Fix users that had sort by likes stored [#14668](https://github.com/CartoDB/cartodb/pull/14668)
 - Relocate styles to the New Dashboard folder [#14672](https://github.com/CartoDB/cartodb/pull/14672)
 - Fix quick actions dropdown in maps and datasets card - Dashboard
+- Update pending notifications badge when checking out notifications in the New Dashboard
 
 4.25.1 (2019-02-11)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/App.vue
+++ b/lib/assets/javascripts/new-dashboard/App.vue
@@ -37,6 +37,7 @@ export default {
       return this.$store.state.user.base_url;
     },
     notificationsCount () {
+      console.log('notificationsCount', this.$store.state.user.organizationNotifications);
       return this.$store.state.user.organizationNotifications.length;
     },
     isFirstTimeInDashboard () {

--- a/lib/assets/javascripts/new-dashboard/App.vue
+++ b/lib/assets/javascripts/new-dashboard/App.vue
@@ -37,7 +37,6 @@ export default {
       return this.$store.state.user.base_url;
     },
     notificationsCount () {
-      console.log('notificationsCount', this.$store.state.user.organizationNotifications);
       return this.$store.state.user.organizationNotifications.length;
     },
     isFirstTimeInDashboard () {

--- a/lib/assets/javascripts/new-dashboard/pages/Notifications.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Notifications.vue
@@ -58,6 +58,9 @@ export default {
     isFetching () {
       return this.$store.state.notifications.isFetching;
     }
+  },
+  mounted: function() {
+    this.$store.dispatch('user/emptyOrganizationNotifications', this.$store);
   }
 };
 </script>

--- a/lib/assets/javascripts/new-dashboard/pages/Notifications.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Notifications.vue
@@ -59,7 +59,7 @@ export default {
       return this.$store.state.notifications.isFetching;
     }
   },
-  mounted: function() {
+  mounted: function () {
     this.$store.dispatch('user/resetOrganizationNotifications');
   }
 };

--- a/lib/assets/javascripts/new-dashboard/pages/Notifications.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Notifications.vue
@@ -60,7 +60,7 @@ export default {
     }
   },
   mounted: function() {
-    this.$store.dispatch('user/emptyOrganizationNotifications', this.$store);
+    this.$store.dispatch('user/resetOrganizationNotifications');
   }
 };
 </script>

--- a/lib/assets/javascripts/new-dashboard/store/modules/user/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/user/index.js
@@ -18,6 +18,9 @@ const user = {
   mutations: {
     setUserData (state, userData) {
       Object.assign(state, userData);
+    },
+    setOrganizationNotifications (state, organizationNotifications) {
+      state.organizationNotifications = organizationNotifications;
     }
   },
   actions: {
@@ -29,6 +32,11 @@ const user = {
 
         context.commit('setUserData', data.user_data);
       });
+    }, 
+    emptyOrganizationNotifications(context) {
+      const organizationNotifications = [...context.rootState.user.organizationNotifications];
+      organizationNotifications.length = 0;
+      context.commit('setOrganizationNotifications', organizationNotifications);
     }
   }
 };

--- a/lib/assets/javascripts/new-dashboard/store/modules/user/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/user/index.js
@@ -32,11 +32,9 @@ const user = {
 
         context.commit('setUserData', data.user_data);
       });
-    }, 
-    emptyOrganizationNotifications(context) {
-      const organizationNotifications = [...context.rootState.user.organizationNotifications];
-      organizationNotifications.length = 0;
-      context.commit('setOrganizationNotifications', organizationNotifications);
+    },
+    resetOrganizationNotifications (context) {
+      context.commit('setOrganizationNotifications', []);
     }
   }
 };

--- a/lib/assets/test/spec/new-dashboard/unit/specs/pages/mocks.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/pages/mocks.js
@@ -1,5 +1,5 @@
 export const fakeStore = {
-  dispatch: () => {},
+  dispatch: jest.fn(),
   state: {
     user: {
       base_url: 'fake_base_url',

--- a/lib/assets/test/spec/new-dashboard/unit/specs/pages/notifications.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/pages/notifications.spec.js
@@ -1,5 +1,5 @@
 import { fakeStore } from './mocks';
-import { mount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import fakeNotifications from '../fixtures/notifications';
 import NotificationsPage from 'new-dashboard/pages/Notifications';
 import LoadingState from 'new-dashboard/components/States/LoadingState';
@@ -22,6 +22,19 @@ describe('NotificationsPage.vue', () => {
       expect(notificationsPageWrapper.vm.emptyState).toBeFalsy();
       expect(notificationsPageWrapper.vm.emptyStateText).toBe('fake_i18n_string');
       expect($tSpy).toHaveBeenCalledWith('NotificationsPage.emptyState');
+    });
+  });
+
+  describe('mounted method', () => {
+    it('should dispatch user/resetOrganizationNotifications action when page is loaded', () => {
+      notificationsPageWrapper = shallowMount(NotificationsPage, {
+        mocks: {
+          $store: fakeStore,
+          $t: () => {}
+        }
+      });
+
+      expect(fakeStore.dispatch).toHaveBeenCalledWith('user/resetOrganizationNotifications');
     });
   });
 

--- a/lib/assets/test/spec/new-dashboard/unit/specs/store/user/user.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/store/user/user.spec.js
@@ -41,7 +41,7 @@ describe('UserStore', () => {
 
       expect(state).toEqual({
         organizationNotifications: []
-      })
+      });
     });
   });
 

--- a/lib/assets/test/spec/new-dashboard/unit/specs/store/user/user.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/store/user/user.spec.js
@@ -27,6 +27,22 @@ describe('UserStore', () => {
         website: 'https://carto.com'
       });
     });
+
+    it('setOrganizationNotifications', () => {
+      const state = {
+        organizationNotifications: [{
+          id: '3cbd8ee6-8f08-40c6-b58d-e49cb712c9e4',
+          icon: 'alert',
+          received_at: '2019-02-19T09:41:29.646Z'
+        }]
+      };
+
+      mutations.setOrganizationNotifications(state, []);
+
+      expect(state).toEqual({
+        organizationNotifications: []
+      })
+    });
   });
 
   describe('actions', () => {
@@ -50,6 +66,13 @@ describe('UserStore', () => {
         ];
         testAction({ action: actions.updateData, state, expectedMutations, done });
       });
+    });
+
+    it('resetOrganizationNotifications: should reset organization notifications', done => {
+      const expectedMutations = [
+        { type: 'setOrganizationNotifications', payload: [] }
+      ];
+      testAction({ action: actions.resetOrganizationNotifications, expectedMutations, done });
     });
   });
 });


### PR DESCRIPTION
When the Notifications page is mounted, reset the organization notifications as the user is already checking them.

### Acceptance
1. Go to Your organization/Notifications
2. Send some notifications
3. Go to Notifications page and check that the notifications green icon on the avatar disappears when the page is loaded.

### Related Issue
https://github.com/CartoDB/cartodb/issues/14678