### PR TITLE
Fix Unp tmp dir with capital letters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Development
 - Show new footer in settings and private user pages ([#14342](https://github.com/CartoDB/cartodb/issues/14342))
 - Format quota numbers with separators in Home Page ([#14680](https://github.com/CartoDB/cartodb/pull/14680))
 - Number of favorites in filter dropdown does not update when fav/unfav items in new Dashboard [CartoDB/product#256](https://github.com/CartoDB/product/issues/265)
+- Fix for importer, which did not work when configuring the temp directory (`unp_temporal_folder`) to a path containing capital letters [#14688](https://github.com/CartoDB/cartodb/pull/14688)
 - Fix Drag&Drop behaviour from Home Page ([#14682](https://github.com/CartoDB/cartodb/pull/14682))
 
 4.25.1 (2019-02-11)

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -174,7 +174,6 @@ module CartoDB
           .gsub(/'/, '')
           .gsub(/"/, '')
           .gsub(/&/, '')
-          .downcase
           .gsub(/\.txt/, '.csv')
           .gsub(/\.tsv/, '.csv')
       end

--- a/services/importer/lib/importer/unp.rb
+++ b/services/importer/lib/importer/unp.rb
@@ -160,9 +160,10 @@ module CartoDB
         filename.force_encoding("UTF-8").valid_encoding?
       end
 
-      def normalize(filename)
-        normalized = underscore(filename)
-        rename(filename, normalized)
+      def normalize(path)
+        dir, filename = File.split(path)
+        normalized = File.join(dir, underscore(filename))
+        rename(path, normalized)
         normalized
       end
 
@@ -174,6 +175,7 @@ module CartoDB
           .gsub(/'/, '')
           .gsub(/"/, '')
           .gsub(/&/, '')
+          .downcase
           .gsub(/\.txt/, '.csv')
           .gsub(/\.tsv/, '.csv')
       end

--- a/services/importer/spec/fixtures/Name_With_Capitals.csv
+++ b/services/importer/spec/fixtures/Name_With_Capitals.csv
@@ -1,0 +1,3 @@
+column,column,third
+1,2,3
+4,5,6

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -35,6 +35,21 @@ describe Unp do
       FileUtils.rm_rf(unp.temporary_directory)
     end
 
+    it 'can deal with filenames with capital letters (compressed file)' do
+      zip_file = file_factory(filename: 'TestShape.zip')
+      unp = Unp.new
+
+      unp.run(zip_file)
+
+      # NOTE: the input zip file contains file names capitalized, e.g:
+      # Bryansk_stores_for_test_point.shp This test is added to make
+      # sure of backwards compatibility with other pieces of the
+      # importer. Observe the uncompressed file is "normalized" and
+      # thus downcased.
+      Dir.entries(unp.temporary_directory).should include('bryansk_stores_for_test_point.shp')
+      FileUtils.rm_rf(unp.temporary_directory)
+    end
+
     it 'extracts the contents of a GPKG file' do
       zipfile   = file_factory(filename: 'geopackage.zip')
       unp       = Unp.new

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -9,7 +9,7 @@ include CartoDB::Importer2
 describe Unp do
   describe '#run' do
     it 'extracts the contents of the file' do
-      zipfile   = zipfile_factory
+      zipfile   = file_factory
       unp       = Unp.new
 
       unp.run(zipfile)
@@ -18,7 +18,7 @@ describe Unp do
     end
 
     it 'extracts the contents of a carto file (see #11954)' do
-      zipfile   = zipfile_factory(filename: 'this_is_a_zip_file.carto')
+      zipfile   = file_factory(filename: 'this_is_a_zip_file.carto')
       unp       = Unp.new
 
       unp.run(zipfile)
@@ -27,7 +27,7 @@ describe Unp do
     end
 
     it 'lets an uncompressed file pass through and store it in a tmp dir with uppercase chars' do
-      uncompressed_file = zipfile_factory(filename: 'duplicated_column_name.csv')
+      uncompressed_file = file_factory(filename: 'duplicated_column_name.csv')
       unp = Unp.new({ 'unp_temporal_folder' => '/tmp/IMPORTS' })
 
       unp.run(uncompressed_file)
@@ -36,7 +36,7 @@ describe Unp do
     end
 
     it 'extracts the contents of a GPKG file' do
-      zipfile   = zipfile_factory(filename: 'geopackage.zip')
+      zipfile   = file_factory(filename: 'geopackage.zip')
       unp       = Unp.new
 
       unp.run(zipfile)
@@ -47,7 +47,7 @@ describe Unp do
     end
 
     it 'extracts the contents of a FGDB file' do
-      zipfile   = zipfile_factory(filename: 'filegeodatabase.zip')
+      zipfile   = file_factory(filename: 'filegeodatabase.zip')
       unp       = Unp.new
 
       unp.run(zipfile)
@@ -58,7 +58,7 @@ describe Unp do
     end
 
     it 'extracts the contents of a FGDB file' do
-      zipfile   = zipfile_factory(filename: 'filegeodatabase.gdb.zip')
+      zipfile   = file_factory(filename: 'filegeodatabase.gdb.zip')
       unp       = Unp.new
 
       unp.run(zipfile)
@@ -69,7 +69,7 @@ describe Unp do
     end
 
     it 'extracts the contents of a carto file with rar in the name (see #11954)' do
-      zipfile   = zipfile_factory(filename: 'this_is_not_a_rar_file.carto')
+      zipfile   = file_factory(filename: 'this_is_not_a_rar_file.carto')
       unp       = Unp.new
 
       unp.run(zipfile)
@@ -78,7 +78,7 @@ describe Unp do
     end
 
     it 'populates a list of source files' do
-      zipfile   = zipfile_factory
+      zipfile   = file_factory
       unp       = Unp.new
 
       unp.source_files.should be_empty
@@ -90,7 +90,7 @@ describe Unp do
       unp       = Unp.new
 
       unp.source_files.should be_empty
-      unp.run(zipfile_factory)
+      unp.run(file_factory)
       unp.source_files.length.should eq 2
     end
   end
@@ -100,7 +100,7 @@ describe Unp do
       unp       = Unp.new
 
       unp.source_files.should be_empty
-      unp.without_unpacking(zipfile_factory)
+      unp.without_unpacking(file_factory)
       unp.source_files.size.should eq 1
     end
 
@@ -151,7 +151,7 @@ describe Unp do
   describe '#extract' do
     it 'generates a temporary directory' do
       dir       = '/var/tmp/bogus'
-      zipfile   = zipfile_factory(dir)
+      zipfile   = file_factory(dir)
       unp       = Unp.new.extract(zipfile)
 
       File.directory?(unp.temporary_directory).should eq true
@@ -161,7 +161,7 @@ describe Unp do
 
     it 'extracts the contents of the file into the temporary directory' do
       dir       = '/var/tmp/bogus'
-      zipfile   = zipfile_factory(dir)
+      zipfile   = file_factory(dir)
       unp       = Unp.new.extract(zipfile)
 
       (Dir.entries(unp.temporary_directory).size > 2).should eq true
@@ -319,7 +319,7 @@ describe Unp do
     end
   end
 
-  def zipfile_factory(dir = '/var/tmp/bogus', filename: 'bogus.zip')
+  def file_factory(dir = '/var/tmp/bogus', filename: 'bogus.zip')
     zipfile = "#{dir}/#{filename}"
 
     FileUtils.rm(zipfile) if File.exists?(zipfile)

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -26,6 +26,15 @@ describe Unp do
       FileUtils.rm_rf(unp.temporary_directory)
     end
 
+    it 'lets an uncompressed file pass through and store it in a tmp dir with uppercase chars' do
+      uncompressed_file = zipfile_factory(filename: 'duplicated_column_name.csv')
+      unp = Unp.new({ 'unp_temporal_folder' => '/tmp/IMPORTS' })
+
+      unp.run(uncompressed_file)
+      Dir.entries(unp.temporary_directory).should include('duplicated_column_name.csv')
+      FileUtils.rm_rf(unp.temporary_directory)
+    end
+
     it 'extracts the contents of a GPKG file' do
       zipfile   = zipfile_factory(filename: 'geopackage.zip')
       unp       = Unp.new

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -28,7 +28,7 @@ describe Unp do
 
     it 'lets an uncompressed file pass through and store it in a tmp dir with uppercase chars' do
       uncompressed_file = file_factory(filename: 'duplicated_column_name.csv')
-      unp = Unp.new({ 'unp_temporal_folder' => '/tmp/IMPORTS' })
+      unp = Unp.new('unp_temporal_folder' => '/tmp/IMPORTS')
 
       unp.run(uncompressed_file)
       Dir.entries(unp.temporary_directory).should include('duplicated_column_name.csv')

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -50,6 +50,20 @@ describe Unp do
       FileUtils.rm_rf(unp.temporary_directory)
     end
 
+    it 'can deal with filenames with capital letters (uncompressed file)' do
+      uncompressed_file = file_factory(filename: 'Name_With_Capitals.csv')
+      unp = Unp.new
+
+      unp.run(uncompressed_file)
+
+      # NOTE: the input is a file name capitalized. This test is added
+      # to make sure of backwards compatibility with other pieces of
+      # the importer. Observe the output file name is "normalized" and
+      # thus downcased.
+      Dir.entries(unp.temporary_directory).should include('name_with_capitals.csv')
+      FileUtils.rm_rf(unp.temporary_directory)
+    end
+
     it 'extracts the contents of a GPKG file' do
       zipfile   = file_factory(filename: 'geopackage.zip')
       unp       = Unp.new


### PR DESCRIPTION
The problem is that the `.downcase` call through `normalize->underscore`is downcasing the full path, including the directory and the file name.

Later on, it tries to retrieve the file from a different path, and the file is not there.

This fixes it by normalizing just the filename (and not the full path), which is then expected to not have capitals or especial characters in some other parts of the importer (table names are taken from file names).