### PR TITLE
Upgrade dataservices api client to 0.26.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Development
 
 ### Bug fixes / enhancements
 - Setup TrackJS and Google Tag Manager in New Dashboard ([#14693](https://github.com/CartoDB/cartodb/pull/14693))
+- Update Dataservices API client default version to `0.26.2` (#14695)
 
 4.25.2 (2019-02-25)
 -------------------

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -22,7 +22,7 @@ module CartoDB
       SCHEMA_GEOCODING = 'cdb'.freeze
       SCHEMA_CDB_DATASERVICES_API = 'cdb_dataservices_client'.freeze
       SCHEMA_AGGREGATION_TABLES = 'aggregation'.freeze
-      CDB_DATASERVICES_CLIENT_VERSION = '0.26.1'.freeze
+      CDB_DATASERVICES_CLIENT_VERSION = '0.26.2'.freeze
       ODBC_FDW_VERSION = '0.3.0'.freeze
 
       def initialize(user)

--- a/carto-package.json
+++ b/carto-package.json
@@ -11,7 +11,7 @@
             "imagemagick": ">=6.9.0"
         },
         "works_with": {
-            "dataservices-api-client-extension": "0.26.1",
+            "dataservices-api-client-extension": "0.26.2",
             "carto_postgresql_ext": "0.24.1",
             "odbc_fdw": "0.2.0",
             "carto_windshaft": ">=6.2.0",


### PR DESCRIPTION
This fixes a problem with soft limits for bulk geocoding: https://github.com/CartoDB/dataservices-api/pull/543
