### PR TITLE
Shorten message to fit in one line

### DIFF
--- a/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
+++ b/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
@@ -211,7 +211,7 @@
     "WelcomeSection": {
       "greeting" : "Hello, {name}",
       "firstTime": {
-        "message": "Welcome to your new dashboard! Take a look around and play with it or learn more about it <a class='welcome-first__link' href='https://carto.com/help/getting-started/new-dashboard' target='_blank'>here</a>.",
+        "message": "Welcome to your new dashboard! We hope you like it. You can learn more about it <a class='welcome-first__link' href='https://carto.com/help/getting-started/new-dashboard' target='_blank'>here</a>.",
         "planMessage": {
           "free": "Remember that you're currently on the FREE plan.",
           "30day": "Remember that you're currently on the 30-day personal trial.",


### PR DESCRIPTION
This message looks a bit weird because it's split in two lines:

![image](https://user-images.githubusercontent.com/390398/53414208-7e81e900-39ce-11e9-9d7b-53cf0b182831.png)

This PR shortens that message so that it fits in one line.