### PR TITLE
Re-order Quick actions menu

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ Development
 - Adapt current dashboard's request interceptor ([#14489](https://github.com/CartoDB/cartodb/issues/14489))
 - Bulk actions in datasets and maps revised and fixed ([#14700](https://github.com/CartoDB/cartodb/pull/14700))
 - Fix .carto not creating a map in old dashboard ([#14713](https://github.com/CartoDB/cartodb/pull/14713))
+- Reorder Quick actions menu ([CartoDB/product#282](https://github.com/CartoDB/product/issues/282))
 
 4.25.2 (2019-02-25)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/components/QuickActions/DatasetQuickActions.vue
+++ b/lib/assets/javascripts/new-dashboard/components/QuickActions/DatasetQuickActions.vue
@@ -34,11 +34,11 @@ export default {
       return {
         mine: [
           { name: this.$t('QuickActions.createMap'), event: 'createMap' },
-          { name: this.$t('QuickActions.duplicate'), event: 'duplicateDataset' },
-          { name: this.$t('QuickActions.share'), event: 'shareVisualization', shouldBeHidden: !this.isUserInsideOrganization },
           { name: this.$t('QuickActions.editInfo'), event: 'editInfo' },
           { name: this.$t('QuickActions.manageTags'), event: 'manageTags' },
           { name: this.$t('QuickActions.changePrivacy'), event: 'changePrivacy' },
+          { name: this.$t('QuickActions.share'), event: 'shareVisualization', shouldBeHidden: !this.isUserInsideOrganization },
+          { name: this.$t('QuickActions.duplicate'), event: 'duplicateDataset' },
           { name: this.$t('QuickActions.lock'), event: 'lockDataset' },
           { name: this.$t('QuickActions.delete'), event: 'deleteDataset', isDestructive: true }
         ],

--- a/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
+++ b/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
@@ -23,10 +23,10 @@
   },
   "QuickActions": {
     "title": "Quick actions",
-    "editInfo": "Edit Name & description",
-    "manageTags": "Manage Tags",
+    "editInfo": "Edit name & description",
+    "manageTags": "Manage tags",
     "createMap": "Create map",
-    "changePrivacy": "Change Privacy",
+    "changePrivacy": "Change privacy",
     "share": "Share with colleagues",
     "duplicate": "Duplicate",
     "lock": "Lock",

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/QuickActions/__snapshots__/DatasetQuickActions.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/QuickActions/__snapshots__/DatasetQuickActions.spec.js.snap
@@ -18,11 +18,11 @@ exports[`DatasetQuickAction.vue should render open dropdown with all actions for
     <h6 class="quick-actions-title text is-semibold is-xsmall is-txtSoftGrey">QuickActions.title</h6>
     <ul>
       <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.createMap</a></li>
-      <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.duplicate</a></li>
-      <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.share</a></li>
       <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.editInfo</a></li>
       <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.manageTags</a></li>
       <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.changePrivacy</a></li>
+      <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.share</a></li>
+      <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.duplicate</a></li>
       <li><a href="#" class="action text is-caption is-txtPrimary">QuickActions.lock</a></li>
       <li><a href="#" class="action text is-caption is-txtAlert">QuickActions.delete</a></li>
     </ul>


### PR DESCRIPTION
Just reordered Quick action menus to keep them consistent, lowercasing them. In Datasets the first option is Create map as it's the most relevant.

### Acceptance
Make sure Quick actions menu in datasets appears in the following order:
1. Create map
2. Edit name & description
3. Manage tags
4. Change privacy
5. Share with colleagues
6. Duplicate
7. Lock
8. Delete

### Related Issue
https://github.com/CartoDB/product/issues/282