### PR TITLE
Fix scroll issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ Development
 - Bulk actions in datasets and maps revised and fixed ([#14700](https://github.com/CartoDB/cartodb/pull/14700))
 - Fix .carto not creating a map in old dashboard ([#14713](https://github.com/CartoDB/cartodb/pull/14713))
 - Reorder Quick actions menu ([CartoDB/product#282](https://github.com/CartoDB/product/issues/282))
+- Scroll fixes ([#14704](https://github.com/CartoDB/cartodb/issues/14704), [#14703](https://github.com/CartoDB/cartodb/issues/14703))
 
 4.25.2 (2019-02-25)
 -------------------

--- a/assets/stylesheets/common/create/create_listing.scss
+++ b/assets/stylesheets/common/create/create_listing.scss
@@ -15,13 +15,14 @@
   width: 940px;
   margin: 0 auto;
   padding: 30px 0;
+
+  &:empty {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 }
 
 .DatasetsPaginator .Pagination {
   justify-content: flex-end;
 }
 
-//Fix Pagination for add layer modal
-.Tab-paneContent .DatasetsPaginator {
-  margin: 0 auto 95px;
-}

--- a/assets/stylesheets/common/dialog.scss
+++ b/assets/stylesheets/common/dialog.scss
@@ -80,6 +80,7 @@ body.is-inDialog {
   position: fixed;
   bottom: 0;
   width: 100%;
+  background: $cStructure-grayBkg;
 }
 
 .Dialog-content.is-newContent {
@@ -113,8 +114,11 @@ body.is-inDialog {
 }
 
 .Dialog-body.Dialog-body--create {
+  $createDialog-footerInner-height: 72px;
+  $createDialog-footerInner-padding: 16px;
   position: relative;
   width: 100%;
+  margin-bottom: calc(#{$createDialog-footerInner-height} + 2*#{$createDialog-footerInner-padding});
   overflow: auto;
 }
 

--- a/assets/stylesheets/common/dialog.scss
+++ b/assets/stylesheets/common/dialog.scss
@@ -118,7 +118,7 @@ body.is-inDialog {
   $createDialog-footerInner-padding: 16px;
   position: relative;
   width: 100%;
-  margin-bottom: calc(#{$createDialog-footerInner-height} + 2*#{$createDialog-footerInner-padding});
+  margin-bottom: $createDialog-footerInner-height + 2 * $createDialog-footerInner-padding;
   overflow: auto;
 }
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/datasets/datasets-pagination-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/datasets/datasets-pagination-view.js
@@ -31,7 +31,10 @@ module.exports = CoreView.extend({
 
   render: function () {
     this.clearSubViews();
-    this.$el.append(this.paginationView.render().el);
+    this.$el.html('');
+    if (this.model.shouldBeVisible()) {
+      this.$el.append(this.paginationView.render().el);
+    }
     return this;
   },
 

--- a/lib/assets/javascripts/dashboard/data/visualizations-collection.js
+++ b/lib/assets/javascripts/dashboard/data/visualizations-collection.js
@@ -134,5 +134,7 @@ module.exports = Backbone.Collection.extend({
     return this[attribute] || 0;
   },
 
-  getDefaultParam: function (param) {}
+  getDefaultParam: function (param) {
+    return this.options.get(param);
+  }
 });

--- a/lib/assets/javascripts/new-dashboard/components/Backbone/Dialog.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Backbone/Dialog.vue
@@ -17,6 +17,12 @@ export default {
     close () {
       this.$emit('close');
     }
+  },
+  beforeMount() {
+    document.body.classList.add('u-overflow-hidden');
+  },
+  beforeDestroy() {
+    document.body.classList.remove('u-overflow-hidden');
   }
 };
 </script>

--- a/lib/assets/javascripts/new-dashboard/components/Backbone/Dialog.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Backbone/Dialog.vue
@@ -18,10 +18,10 @@ export default {
       this.$emit('close');
     }
   },
-  beforeMount() {
+  beforeMount () {
     document.body.classList.add('u-overflow-hidden');
   },
-  beforeDestroy() {
+  beforeDestroy () {
     document.body.classList.remove('u-overflow-hidden');
   }
 };

--- a/lib/assets/javascripts/new-dashboard/styles/_utilities.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/_utilities.scss
@@ -32,3 +32,7 @@
   opacity: .5;
   pointer-events: none;
 }
+
+.u-overflow-hidden {
+  overflow: hidden;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.67",
+  "version": "1.0.0-assets.67-scroll-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The footer has a position: fixed and therefore, the container is behind the footer. To respect that space and avoid overlapping I have placed a margin-bottom to the container with the same footer height.

Besides, I avoid the main scroll to appear when opening a modal.

Also, I fixed pagination that wasn't appearing when it should.

### Acceptance
Having more than 20 datasets, click “New map” button and check:
- That main scroll doesn’t appear.
- That the footer doesn’t overlap the dataset container.
- The pagination appears.

### Related Issue
https://github.com/CartoDB/cartodb/issues/14704, https://github.com/CartoDB/cartodb/issues/14703