### PR TITLE
[Dashboard] Dataset name doesn't change when it's updated

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Dataset name doesn't change when it's updated ([#14735](https://github.com/CartoDB/cartodb/pull/14735))
 
 4.26.0 (2019-03-11)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/store/actions/visualizations.js
+++ b/lib/assets/javascripts/new-dashboard/store/actions/visualizations.js
@@ -1,15 +1,31 @@
 export function deleteLike (context, visualization) {
   const currentLikeStatus = visualization.liked;
 
-  context.commit('updateLike', { visualizationId: visualization.id, liked: false });
+  context.dispatch('updateLike', {
+    visualizationId: visualization.id,
+    visualizationAttributes: {
+      liked: false
+    }
+  });
 
   context.rootState.client.deleteLike(visualization.id,
     function (err, _, data) {
       if (err) {
-        context.commit('updateLike', { visualizationId: visualization.id, liked: currentLikeStatus });
+        context.dispatch('updateLike', {
+          visualizationId: visualization.id,
+          visualizationAttributes: {
+            liked: currentLikeStatus
+          }
+        });
         return;
       }
-      context.commit('updateNumberLikes', { visualizationId: visualization.id, liked: data.liked });
+
+      context.dispatch('updateNumberLikes', {
+        visualizationId: visualization.id,
+        visualizationAttributes: {
+          liked: data.liked
+        }
+      });
     }
   );
 }
@@ -38,16 +54,32 @@ export function filter (context, filter) {
 export function like (context, visualization) {
   const currentLikeStatus = visualization.liked;
 
-  context.commit('updateLike', { visualizationId: visualization.id, liked: true });
+  context.dispatch('updateLike', {
+    visualizationId: visualization.id,
+    visualizationAttributes: {
+      liked: true
+    }
+  });
 
   context.rootState.client.like(visualization.id,
     function (err, _, data) {
       if (err) {
-        context.commit('updateLike', { visualizationId: visualization.id, liked: currentLikeStatus });
+        context.dispatch('updateLike', {
+          visualizationId: visualization.id,
+          visualizationAttributes: {
+            liked: currentLikeStatus
+          }
+        });
+
         return;
       }
 
-      context.commit('updateNumberLikes', { visualizationId: visualization.id, liked: data.liked });
+      context.dispatch('updateNumberLikes', {
+        visualizationId: visualization.id,
+        visualizationAttributes: {
+          liked: data.liked
+        }
+      });
     }
   );
 }
@@ -79,5 +111,16 @@ export function setURLOptions (context, options) {
 }
 
 export function updateVisualization (context, visualizationOptions) {
-  context.commit('updateVisualizationGlobally', visualizationOptions, { root: true });
+  context.commit('maps/updateVisualization', visualizationOptions, { root: true });
+  context.commit('datasets/updateVisualization', visualizationOptions, { root: true });
+  context.commit('recentContent/updateVisualization', visualizationOptions, { root: true });
+  context.commit('search/updateVisualization', visualizationOptions, { root: true });
+}
+
+export function updateLike (context, visualizationOptions) {
+  context.dispatch('updateVisualization', visualizationOptions);
+}
+
+export function updateNumberLikes (context, visualizationOptions) {
+  context.commit('updateNumberLikes', visualizationOptions);
 }

--- a/lib/assets/javascripts/new-dashboard/store/actions/visualizations.js
+++ b/lib/assets/javascripts/new-dashboard/store/actions/visualizations.js
@@ -1,7 +1,7 @@
 export function deleteLike (context, visualization) {
   const currentLikeStatus = visualization.liked;
 
-  context.dispatch('updateLike', {
+  context.dispatch('updateVisualization', {
     visualizationId: visualization.id,
     visualizationAttributes: {
       liked: false
@@ -11,7 +11,7 @@ export function deleteLike (context, visualization) {
   context.rootState.client.deleteLike(visualization.id,
     function (err, _, data) {
       if (err) {
-        context.dispatch('updateLike', {
+        context.dispatch('updateVisualization', {
           visualizationId: visualization.id,
           visualizationAttributes: {
             liked: currentLikeStatus
@@ -20,7 +20,7 @@ export function deleteLike (context, visualization) {
         return;
       }
 
-      context.dispatch('updateNumberLikes', {
+      context.commit('updateNumberLikes', {
         visualizationId: visualization.id,
         visualizationAttributes: {
           liked: data.liked
@@ -54,7 +54,7 @@ export function filter (context, filter) {
 export function like (context, visualization) {
   const currentLikeStatus = visualization.liked;
 
-  context.dispatch('updateLike', {
+  context.dispatch('updateVisualization', {
     visualizationId: visualization.id,
     visualizationAttributes: {
       liked: true
@@ -64,7 +64,7 @@ export function like (context, visualization) {
   context.rootState.client.like(visualization.id,
     function (err, _, data) {
       if (err) {
-        context.dispatch('updateLike', {
+        context.dispatch('updateVisualization', {
           visualizationId: visualization.id,
           visualizationAttributes: {
             liked: currentLikeStatus
@@ -74,7 +74,7 @@ export function like (context, visualization) {
         return;
       }
 
-      context.dispatch('updateNumberLikes', {
+      context.commit('updateNumberLikes', {
         visualizationId: visualization.id,
         visualizationAttributes: {
           liked: data.liked
@@ -115,12 +115,4 @@ export function updateVisualization (context, visualizationOptions) {
   context.commit('datasets/updateVisualization', visualizationOptions, { root: true });
   context.commit('recentContent/updateVisualization', visualizationOptions, { root: true });
   context.commit('search/updateVisualization', visualizationOptions, { root: true });
-}
-
-export function updateLike (context, visualizationOptions) {
-  context.dispatch('updateVisualization', visualizationOptions);
-}
-
-export function updateNumberLikes (context, visualizationOptions) {
-  context.commit('updateNumberLikes', visualizationOptions);
 }

--- a/lib/assets/javascripts/new-dashboard/store/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/index.js
@@ -11,8 +11,6 @@ import search from './modules/search';
 import notifications from './modules/notifications';
 import recentContent from './modules/recent-content';
 
-import { updateVisualizationGlobally } from './mutations/visualizations';
-
 Vue.use(Vuex);
 
 const storeOptions = {
@@ -20,9 +18,6 @@ const storeOptions = {
     client: new CartoNode.AuthenticatedClient()
   },
   getters: {},
-  mutations: {
-    updateVisualizationGlobally
-  },
   modules: {
     config,
     user,

--- a/lib/assets/javascripts/new-dashboard/store/modules/datasets/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/datasets/index.js
@@ -45,8 +45,6 @@ const datasets = {
     setResultsPerPage: VisualizationActions.setResultsPerPage,
     setURLOptions: VisualizationActions.setURLOptions,
     updateVisualization: VisualizationActions.updateVisualization,
-    updateLike: VisualizationActions.updateLike,
-    updateNumberLikes: VisualizationActions.updateNumberLikes,
 
     fetch (context) {
       const params = {

--- a/lib/assets/javascripts/new-dashboard/store/modules/datasets/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/datasets/index.js
@@ -33,8 +33,8 @@ const datasets = {
     setResultsPerPage: VisualizationMutations.setResultsPerPage,
     setRequestError: VisualizationMutations.setRequestError,
     setVisualizations: VisualizationMutations.setVisualizations,
-    updateLike: VisualizationMutations.updateLike,
-    updateNumberLikes: VisualizationMutations.updateNumberLikes
+    updateNumberLikes: VisualizationMutations.updateNumberLikes,
+    updateVisualization: VisualizationMutations.updateVisualization
   },
   actions: {
     deleteLike: VisualizationActions.deleteLike,
@@ -45,6 +45,8 @@ const datasets = {
     setResultsPerPage: VisualizationActions.setResultsPerPage,
     setURLOptions: VisualizationActions.setURLOptions,
     updateVisualization: VisualizationActions.updateVisualization,
+    updateLike: VisualizationActions.updateLike,
+    updateNumberLikes: VisualizationActions.updateNumberLikes,
 
     fetch (context) {
       const params = {

--- a/lib/assets/javascripts/new-dashboard/store/modules/maps/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/maps/index.js
@@ -51,8 +51,6 @@ const maps = {
     setResultsPerPage: VisualizationActions.setResultsPerPage,
     setURLOptions: VisualizationActions.setURLOptions,
     updateVisualization: VisualizationActions.updateVisualization,
-    updateLike: VisualizationActions.updateLike,
-    updateNumberLikes: VisualizationActions.updateNumberLikes,
 
     fetch (context) {
       const params = {

--- a/lib/assets/javascripts/new-dashboard/store/modules/maps/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/maps/index.js
@@ -39,8 +39,8 @@ const maps = {
     setResultsPerPage: VisualizationMutations.setResultsPerPage,
     setRequestError: VisualizationMutations.setRequestError,
     setVisualizations: VisualizationMutations.setVisualizations,
-    updateLike: VisualizationMutations.updateLike,
-    updateNumberLikes: VisualizationMutations.updateNumberLikes
+    updateNumberLikes: VisualizationMutations.updateNumberLikes,
+    updateVisualization: VisualizationMutations.updateVisualization
   },
   actions: {
     deleteLike: VisualizationActions.deleteLike,
@@ -51,6 +51,8 @@ const maps = {
     setResultsPerPage: VisualizationActions.setResultsPerPage,
     setURLOptions: VisualizationActions.setURLOptions,
     updateVisualization: VisualizationActions.updateVisualization,
+    updateLike: VisualizationActions.updateLike,
+    updateNumberLikes: VisualizationActions.updateNumberLikes,
 
     fetch (context) {
       const params = {

--- a/lib/assets/javascripts/new-dashboard/store/modules/recent-content/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/recent-content/index.js
@@ -36,8 +36,6 @@ const recentContent = {
     like: VisualizationActions.like,
     deleteLike: VisualizationActions.deleteLike,
     updateVisualization: VisualizationActions.updateVisualization,
-    updateLike: VisualizationActions.updateLike,
-    updateNumberLikes: VisualizationActions.updateNumberLikes,
 
     fetch (context) {
       context.commit('setFetchingState');

--- a/lib/assets/javascripts/new-dashboard/store/modules/recent-content/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/recent-content/index.js
@@ -23,8 +23,8 @@ const recentContent = {
   mutations: {
     setFetchingState: VisualizationMutations.setFetchingState,
     setRequestError: VisualizationMutations.setRequestError,
-    updateLike: VisualizationMutations.updateLike,
     updateNumberLikes: VisualizationMutations.updateNumberLikes,
+    updateVisualization: VisualizationMutations.updateVisualization,
 
     setRecentContent (state, recentContent) {
       state.list = toObject(recentContent.visualizations, 'id');
@@ -36,6 +36,8 @@ const recentContent = {
     like: VisualizationActions.like,
     deleteLike: VisualizationActions.deleteLike,
     updateVisualization: VisualizationActions.updateVisualization,
+    updateLike: VisualizationActions.updateLike,
+    updateNumberLikes: VisualizationActions.updateNumberLikes,
 
     fetch (context) {
       context.commit('setFetchingState');

--- a/lib/assets/javascripts/new-dashboard/store/modules/search/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/search/index.js
@@ -73,15 +73,15 @@ const search = {
 
       state.datasets.isFetching = false;
     },
-    updateLike (state, { visualizationId, liked }) {
+    updateNumberLikes () {
+      // NOOP. This method avoids action not finding mutation.
+    },
+    updateVisualization (state, { visualizationId, visualizationAttributes }) {
       const visualization = state.maps.results[visualizationId] || state.datasets.results[visualizationId];
 
       if (visualization) {
-        visualization.liked = liked;
+        Object.assign(visualization, visualizationAttributes);
       }
-    },
-    updateNumberLikes () {
-      // NOOP. This method avoids action not finding mutation.
     },
     resetState (state) {
       state.searchTerm = '';
@@ -111,6 +111,8 @@ const search = {
   actions: {
     deleteLike: VisualizationActions.deleteLike,
     like: VisualizationActions.like,
+    updateLike: VisualizationActions.updateLike,
+    updateNumberLikes: VisualizationActions.updateNumberLikes,
     doSearch (context, searchParameters) {
       context.commit('updateSearchTerm', searchParameters);
       context.commit('setFetchingState', 'maps');

--- a/lib/assets/javascripts/new-dashboard/store/modules/search/index.js
+++ b/lib/assets/javascripts/new-dashboard/store/modules/search/index.js
@@ -111,8 +111,6 @@ const search = {
   actions: {
     deleteLike: VisualizationActions.deleteLike,
     like: VisualizationActions.like,
-    updateLike: VisualizationActions.updateLike,
-    updateNumberLikes: VisualizationActions.updateNumberLikes,
     doSearch (context, searchParameters) {
       context.commit('updateSearchTerm', searchParameters);
       context.commit('setFetchingState', 'maps');

--- a/lib/assets/javascripts/new-dashboard/store/mutations/visualizations.js
+++ b/lib/assets/javascripts/new-dashboard/store/mutations/visualizations.js
@@ -45,32 +45,14 @@ export function setVisualizations (state, visualizationsData) {
   state.isFetching = false;
 }
 
-export function updateLike (state, {visualizationId, liked}) {
-  const visualization = state.list[visualizationId];
-
-  if (visualization) {
-    visualization.liked = liked;
-  }
+export function updateNumberLikes (state, {visualizationAttributes}) {
+  state.metadata.total_likes += visualizationAttributes.liked ? 1 : -1;
 }
 
-export function updateNumberLikes (state, {visualizationId, liked}) {
-  state.list[visualizationId].liked = liked;
-  state.metadata.total_likes += liked ? 1 : -1;
-}
+export function updateVisualization (state, {visualizationId, visualizationAttributes}) {
+  const isVisualizationPresent = state.list.hasOwnProperty(visualizationId);
 
-export function updateVisualizationGlobally (state, {visualizationId, visualizationAttributes}) {
-  const isVisualizationInMaps = state.maps.list.hasOwnProperty(visualizationId);
-  if (isVisualizationInMaps) {
-    Object.assign(state.maps.list[visualizationId], visualizationAttributes);
-  }
-
-  const isVisualizationInDatasets = state.datasets.list.hasOwnProperty(visualizationId);
-  if (isVisualizationInDatasets) {
-    Object.assign(state.datasets.list[visualizationId], visualizationAttributes);
-  }
-
-  const isVisualizationInRecentContent = state.recentContent.list.hasOwnProperty(visualizationId);
-  if (isVisualizationInRecentContent) {
-    Object.assign(state.recentContent.list[visualizationId], visualizationAttributes);
+  if (isVisualizationPresent) {
+    Object.assign(state.list[visualizationId], visualizationAttributes);
   }
 }

--- a/lib/assets/test/spec/new-dashboard/unit/specs/store/actions/visualizations.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/store/actions/visualizations.spec.js
@@ -1,0 +1,22 @@
+import { updateVisualization } from 'new-dashboard/store/actions/visualizations';
+import { testAction } from '../helpers';
+
+describe('store/actions/visualizations', () => {
+  it('updateVisualization', done => {
+    const payload = {
+      visualizationId: 'fake_id',
+      visualizationAttributes: {
+        liked: false
+      }
+    };
+
+    const expectedMutations = [
+      { type: 'maps/updateVisualization', payload },
+      { type: 'datasets/updateVisualization', payload },
+      { type: 'recentContent/updateVisualization', payload },
+      { type: 'search/updateVisualization', payload }
+    ];
+
+    testAction({ action: updateVisualization, payload, expectedMutations, done });
+  });
+});

--- a/lib/assets/test/spec/new-dashboard/unit/specs/store/datasets/datasets.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/store/datasets/datasets.spec.js
@@ -126,45 +126,23 @@ describe('DatasetsStore', () => {
       });
     });
 
-    it('updateLike', () => {
-      let state = {
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: false
-          }
-        }
-      };
-
-      mutations.updateLike(state, { visualizationId: 'xxxx-yyyy-zzzzz', liked: true });
-      expect(state).toEqual({
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: true
-          }
-        }
-      });
-    });
-
     it('updateNumberLikes: adds one to the total likes metadata count and changes map property liked to true', () => {
       let state = {
         metadata: {
           total_likes: 0
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: false
-          }
         }
       };
-      mutations.updateNumberLikes(state, { visualizationId: 'xxxx-yyyy-zzzzz', liked: true });
+
+      mutations.updateNumberLikes(state, {
+        visualizationId: 'xxxx-yyyy-zzzzz',
+        visualizationAttributes: {
+          liked: true
+        }
+      });
+
       expect(state).toEqual({
         metadata: {
           total_likes: 1
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: true
-          }
         }
       });
     });
@@ -173,22 +151,19 @@ describe('DatasetsStore', () => {
       let state = {
         metadata: {
           total_likes: 1
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: true
-          }
         }
       };
-      mutations.updateNumberLikes(state, { visualizationId: 'xxxx-yyyy-zzzzz', liked: false });
+
+      mutations.updateNumberLikes(state, {
+        visualizationId: 'xxxx-yyyy-zzzzz',
+        visualizationAttributes: {
+          liked: false
+        }
+      });
+
       expect(state).toEqual({
         metadata: {
           total_likes: 0
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: false
-          }
         }
       });
     });
@@ -325,9 +300,27 @@ describe('DatasetsStore', () => {
       });
       it('success', done => {
         const visualizationId = '8b2fa51d-618c-48ea-8c4c-4aa5e9a93a90';
+
+        const expectedActions = [
+          { type: 'updateVisualization',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: true
+              }
+            }
+          }
+        ];
+
         const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId, liked: true } },
-          { type: 'updateNumberLikes', payload: { visualizationId, liked: true } }
+          { type: 'updateNumberLikes',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: true
+              }
+            }
+          }
         ];
 
         const likeResponse = { id: visualizationId, liked: true };
@@ -336,15 +329,30 @@ describe('DatasetsStore', () => {
           client: { like }
         };
 
-        testAction({ action: actions.like, payload: state.list[visualizationId], state, expectedMutations, rootState, done });
+        testAction({ action: actions.like, payload: state.list[visualizationId], state, expectedActions, expectedMutations, rootState, done });
       });
 
       it('errored', done => {
         const visualizationIdErr = 'ba8b2bc3-a105-4640-b258-286fcf6f3050';
         const currentLikeStatus = state.list[visualizationIdErr].liked;
-        const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId: visualizationIdErr, liked: true } },
-          { type: 'updateLike', payload: { visualizationId: visualizationIdErr, liked: currentLikeStatus } }
+
+        const expectedActions = [
+          { type: 'updateVisualization',
+            payload: {
+              visualizationId: visualizationIdErr,
+              visualizationAttributes: {
+                liked: true
+              }
+            }
+          },
+          { type: 'updateVisualization',
+            payload: {
+              visualizationId: visualizationIdErr,
+              visualizationAttributes: {
+                liked: currentLikeStatus
+              }
+            }
+          }
         ];
 
         const likeResponse = { id: visualizationIdErr, liked: true };
@@ -354,12 +362,13 @@ describe('DatasetsStore', () => {
           client: { like }
         };
 
-        testAction({ action: actions.like, payload: state.list[visualizationIdErr], state, expectedMutations, rootState, done });
+        testAction({ action: actions.like, payload: state.list[visualizationIdErr], state, expectedActions, rootState, done });
       });
     });
 
     describe('deleteLikeDataset', () => {
       let state;
+
       beforeEach(() => {
         state = {
           list: toObject(datasets.visualizations, 'id'),
@@ -368,11 +377,29 @@ describe('DatasetsStore', () => {
           }
         };
       });
+
       it('success', done => {
         const visualizationId = 'ba8b2bc3-a105-4640-b258-286fcf6f3050';
+        const expectedActions = [
+          { type: 'updateVisualization',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: false
+              }
+            }
+          }
+        ];
+
         const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId, liked: false } },
-          { type: 'updateNumberLikes', payload: { visualizationId, liked: false } }
+          { type: 'updateNumberLikes',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: false
+              }
+            }
+          }
         ];
 
         const deleteLikeResponse = { id: visualizationId, liked: false };
@@ -381,7 +408,7 @@ describe('DatasetsStore', () => {
           client: { deleteLike }
         };
 
-        testAction({ action: actions.deleteLike, payload: state.list[visualizationId], state, expectedMutations, rootState, done });
+        testAction({ action: actions.deleteLike, payload: state.list[visualizationId], state, expectedMutations, expectedActions, rootState, done });
       });
     });
   });

--- a/lib/assets/test/spec/new-dashboard/unit/specs/store/maps/maps.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/store/maps/maps.spec.js
@@ -67,61 +67,23 @@ describe('MapsStore', () => {
       });
     });
 
-    describe('updateLike', () => {
-      it('set update liked property of a given visualization', () => {
-        let state = {
-          list: {
-            'xxxx-yyyy-zzzzz': {
-              liked: false
-            }
-          }
-        };
-
-        mutations.updateLike(state, { visualizationId: 'xxxx-yyyy-zzzzz', liked: true });
-        expect(state).toEqual({
-          list: {
-            'xxxx-yyyy-zzzzz': {
-              liked: true
-            }
-          }
-        });
-      });
-
-      it('should not throw when passing an missing visualization id', () => {
-        let state = {
-          list: {
-            'xxxx-yyyy-zzzzz': {
-              liked: false
-            }
-          }
-        };
-
-        expect(() => {
-          mutations.updateLike(state, { visualizationId: 'unknown_id', liked: true });
-        }).not.toThrow();
-      });
-    });
-
     it('updateNumberLikes: adds one to the total likes metadata count and changes map property liked to true', () => {
       let state = {
         metadata: {
           total_likes: 0
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: false
-          }
         }
       };
-      mutations.updateNumberLikes(state, { visualizationId: 'xxxx-yyyy-zzzzz', liked: true });
+
+      mutations.updateNumberLikes(state, {
+        visualizationId: 'xxxx-yyyy-zzzzz',
+        visualizationAttributes: {
+          liked: true
+        }
+      });
+
       expect(state).toEqual({
         metadata: {
           total_likes: 1
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: true
-          }
         }
       });
     });
@@ -130,22 +92,19 @@ describe('MapsStore', () => {
       let state = {
         metadata: {
           total_likes: 1
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: true
-          }
         }
       };
-      mutations.updateNumberLikes(state, { visualizationId: 'xxxx-yyyy-zzzzz', liked: false });
+
+      mutations.updateNumberLikes(state, {
+        visualizationId: 'xxxx-yyyy-zzzzz',
+        visualizationAttributes: {
+          liked: false
+        }
+      });
+
       expect(state).toEqual({
         metadata: {
           total_likes: 0
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: false
-          }
         }
       });
     });
@@ -303,9 +262,27 @@ describe('MapsStore', () => {
 
       it('success', done => {
         const visualizationId = 'e97e0001-f1c2-425e-8c9b-0fb28da59200';
+
+        const expectedActions = [
+          { type: 'updateVisualization',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: true
+              }
+            }
+          }
+        ];
+
         const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId, liked: true } },
-          { type: 'updateNumberLikes', payload: { visualizationId, liked: true } }
+          { type: 'updateNumberLikes',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: true
+              }
+            }
+          }
         ];
 
         const likeResponse = { id: visualizationId, liked: true };
@@ -314,15 +291,15 @@ describe('MapsStore', () => {
           client: { like }
         };
 
-        testAction({ action: actions.like, payload: state.list[visualizationId], state, expectedMutations, rootState, done });
+        testAction({ action: actions.like, payload: state.list[visualizationId], state, expectedMutations, expectedActions, rootState, done });
       });
 
       it('errored', done => {
         const visualizationIdErr = '8b378bf8-e74d-4187-9e57-4249db4c0f1f';
         const currentLikeStatus = state.list[visualizationIdErr].liked;
-        const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId: visualizationIdErr, liked: true } },
-          { type: 'updateLike', payload: { visualizationId: visualizationIdErr, liked: currentLikeStatus } }
+        const expectedActions = [
+          { type: 'updateVisualization', payload: { visualizationId: visualizationIdErr, visualizationAttributes: { liked: true } } },
+          { type: 'updateVisualization', payload: { visualizationId: visualizationIdErr, visualizationAttributes: { liked: currentLikeStatus } } }
         ];
 
         const likeResponse = { id: visualizationIdErr, liked: true };
@@ -332,7 +309,7 @@ describe('MapsStore', () => {
           client: { like }
         };
 
-        testAction({ action: actions.like, payload: state.list[visualizationIdErr], state, expectedMutations, rootState, done });
+        testAction({ action: actions.like, payload: state.list[visualizationIdErr], state, expectedActions, rootState, done });
       });
     });
 
@@ -345,9 +322,27 @@ describe('MapsStore', () => {
       });
       it('success', done => {
         const visualizationId = '8b378bf8-e74d-4187-9e57-4249db4c0f1f';
+
+        const expectedActions = [
+          { type: 'updateVisualization',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: false
+              }
+            }
+          }
+        ];
+
         const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId, liked: false } },
-          { type: 'updateNumberLikes', payload: { visualizationId, liked: false } }
+          { type: 'updateNumberLikes',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: false
+              }
+            }
+          }
         ];
 
         const deleteLikeResponse = { id: visualizationId, liked: false };
@@ -356,7 +351,7 @@ describe('MapsStore', () => {
           client: { deleteLike }
         };
 
-        testAction({ action: actions.deleteLike, payload: state.list[visualizationId], state, expectedMutations, rootState, done });
+        testAction({ action: actions.deleteLike, payload: state.list[visualizationId], state, expectedActions, expectedMutations, rootState, done });
       });
     });
   });

--- a/lib/assets/test/spec/new-dashboard/unit/specs/store/mutations/visualizations.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/store/mutations/visualizations.spec.js
@@ -1,0 +1,28 @@
+import { updateVisualization } from 'new-dashboard/store/mutations/visualizations';
+
+describe('store/actions/visualizations', () => {
+  it('updateVisualization', () => {
+    const state = {
+      list: {
+        visualization_id: {}
+      }
+    };
+
+    const payload = {
+      visualizationId: 'visualization_id',
+      visualizationAttributes: {
+        liked: false
+      }
+    };
+
+    updateVisualization(state, payload);
+
+    expect(state).toEqual({
+      list: {
+        visualization_id: {
+          liked: false
+        }
+      }
+    });
+  });
+});

--- a/lib/assets/test/spec/new-dashboard/unit/specs/store/recentContent/recentContent.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/store/recentContent/recentContent.spec.js
@@ -92,48 +92,23 @@ describe('RecentContentStore', () => {
       });
     });
 
-    it('updateLike', () => {
-      const state = {
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: false
-          }
-        }
-      };
-
-      mutations.updateLike(state, { visualizationId: 'xxxx-yyyy-zzzzz', liked: true });
-
-      expect(state).toEqual({
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: true
-          }
-        }
-      });
-    });
-
     it('updateNumberLikes', () => {
       const state = {
         metadata: {
           total_likes: 0
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: false
-          }
         }
       };
 
-      mutations.updateNumberLikes(state, { visualizationId: 'xxxx-yyyy-zzzzz', liked: true });
+      mutations.updateNumberLikes(state, {
+        visualizationId: 'xxxx-yyyy-zzzzz',
+        visualizationAttributes: {
+          liked: true
+        }
+      });
 
       expect(state).toEqual({
         metadata: {
           total_likes: 1
-        },
-        list: {
-          'xxxx-yyyy-zzzzz': {
-            liked: true
-          }
         }
       });
     });
@@ -151,9 +126,28 @@ describe('RecentContentStore', () => {
 
       it('success', done => {
         const visualizationId = 'e97e0001-f1c2-425e-8c9b-0fb28da59200';
+
+        const expectedActions = [
+          {
+            type: 'updateVisualization',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: true
+              }
+            }
+          }
+        ];
+
         const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId, liked: true } },
-          { type: 'updateNumberLikes', payload: { visualizationId, liked: true } }
+          { type: 'updateNumberLikes',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: true
+              }
+            }
+          }
         ];
 
         const likeResponse = { id: visualizationId, liked: true };
@@ -162,15 +156,32 @@ describe('RecentContentStore', () => {
           client: { like }
         };
 
-        testAction({ action: actions.like, payload: state.list[visualizationId], state, expectedMutations, rootState, done });
+        testAction({ action: actions.like, payload: state.list[visualizationId], state, expectedActions, expectedMutations, rootState, done });
       });
 
       it('errored', done => {
         const visualizationIdErr = 'e97e0001-f1c2-425e-8c9b-0fb28da59200';
         const currentLikeStatus = state.list[visualizationIdErr].liked;
-        const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId: visualizationIdErr, liked: true } },
-          { type: 'updateLike', payload: { visualizationId: visualizationIdErr, liked: currentLikeStatus } }
+
+        const expectedActions = [
+          {
+            type: 'updateVisualization',
+            payload: {
+              visualizationId: visualizationIdErr,
+              visualizationAttributes: {
+                liked: true
+              }
+            }
+          },
+          {
+            type: 'updateVisualization',
+            payload: {
+              visualizationId: visualizationIdErr,
+              visualizationAttributes: {
+                liked: currentLikeStatus
+              }
+            }
+          }
         ];
 
         const likeResponse = { id: visualizationIdErr, liked: true };
@@ -180,7 +191,7 @@ describe('RecentContentStore', () => {
           client: { like }
         };
 
-        testAction({ action: actions.like, payload: state.list[visualizationIdErr], state, expectedMutations, rootState, done });
+        testAction({ action: actions.like, payload: state.list[visualizationIdErr], state, expectedActions, rootState, done });
       });
     });
 
@@ -195,9 +206,29 @@ describe('RecentContentStore', () => {
 
       it('success', done => {
         const visualizationId = '8b378bf8-e74d-4187-9e57-4249db4c0f1f';
+
+        const expectedActions = [
+          {
+            type: 'updateVisualization',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: false
+              }
+            }
+          }
+        ];
+
         const expectedMutations = [
-          { type: 'updateLike', payload: { visualizationId, liked: false } },
-          { type: 'updateNumberLikes', payload: { visualizationId, liked: false } }
+          {
+            type: 'updateNumberLikes',
+            payload: {
+              visualizationId,
+              visualizationAttributes: {
+                liked: false
+              }
+            }
+          }
         ];
 
         const deleteLikeResponse = { id: visualizationId, liked: false };
@@ -206,7 +237,7 @@ describe('RecentContentStore', () => {
           client: { deleteLike }
         };
 
-        testAction({ action: actions.deleteLike, payload: state.list[visualizationId], state, expectedMutations, rootState, done });
+        testAction({ action: actions.deleteLike, payload: state.list[visualizationId], state, expectedMutations, expectedActions, rootState, done });
       });
     });
 

--- a/lib/assets/test/spec/new-dashboard/unit/specs/store/search/search.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/store/search/search.spec.js
@@ -117,29 +117,6 @@ describe('SearchStore', () => {
       });
     });
 
-    describe('updateLike', () => {
-      it('should set update liked property of a given visualization', () => {
-        const dataset = { ...datasetVisualizationsData.visualizations[0] };
-        const state = {
-          resultsPerPage: 6,
-          maps: { results: {} },
-          datasets: {
-            results: {
-              [dataset.id]: dataset
-            }
-          }
-        };
-
-        const likeData = {
-          visualizationId: '8b2fa51d-618c-48ea-8c4c-4aa5e9a93a90',
-          liked: true
-        };
-
-        searchStore.mutations.updateLike(state, likeData);
-        expect(dataset.liked).toEqual(true);
-      });
-    });
-
     describe('resetState', () => {
       it('should set results, calculate pages and revert isFetching state', () => {
         const state = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.71-testupdate",
+  "version": "1.0.0-assets.71",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.71",
+  "version": "1.0.0-assets.71-testupdate",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes a bug that maps or dataset names were not updated in the main view when the user changes it via quick actions.

This name should be updated now and whenever liking a dataset from recent content it should be updated in the sections below.

### Acceptance
- Dataset/Map name change in Search
  - Search any maps/datasets within your uploaded content using the Search bar
  - Change the name using map/dataset quick actions
  - Check that the name's been changed within the original card
Please check both cases (map and dataset)

- Like consistency in Home
  - Go to dashboard's Home Page
  - Like any map/dataset from recent content and check that it's been updated in the proper section below.


Related to #14733.