### PR TITLE
Bolt and importer changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@ Development
 - Change Builder Feedback Form ([#14708](https://github.com/CartoDB/cartodb/issues/14708))
 - Dataset name doesn't change when it's updated ([#14735](https://github.com/CartoDB/cartodb/pull/14735))
 - New Dashboard documentation ([#14712](https://github.com/CartoDB/cartodb/pull/14712))
+- Bolt now can: retry with timeout, execute a rerun function for retry. The importer now uses bolt
+  for the register phase in order to avoid multiple ghost table calls in the future[#14736](https://github.com/CartoDB/cartodb/pull/14736)
 
 4.26.0 (2019-03-11)
 -------------------

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -64,7 +64,7 @@ module CartoDB
           log('Proceeding to register')
           bolt = Carto::Bolt.new("#{user.username}:#{Carto::Bolt::MUTEX_REDIS_KEY}",
                                  ttl_ms: Carto::Bolt::MUTEX_TTL_MS)
-          bolt.run_locked(force_block_execution=true) {
+          bolt.run_locked(force_block_execution: true) {
             results.select(&:success?).each { |result|
               register(result)
             }

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -62,9 +62,9 @@ module CartoDB
           }
         else
           log('Proceeding to register')
-          bolt = Carto::Bolt.new("#{user.username}:#{Carto::GhostTablesManager::MUTEX_REDIS_KEY}",
-                                 ttl_ms: Carto::GhostTablesManager::MUTEX_TTL_MS)
-          rerun_func = lambda { Carto::GhostTablesManager.new(user.id).sync }
+          gtm = Carto::GhostTablesManager.new(user.id)
+          bolt = gtm.get_bolt
+          rerun_func = lambda { gtm.sync }
           bolt.run_locked(attempts: 10, timeout: 30000, rerun_func: rerun_func) do
             results.select(&:success?).each do |result|
               register(result)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -62,16 +62,16 @@ module CartoDB
           }
         else
           log('Proceeding to register')
-          bolt = Carto::Bolt.new("#{user.username}:#{Carto::Bolt::MUTEX_REDIS_KEY}",
-                                 ttl_ms: Carto::Bolt::MUTEX_TTL_MS)
-          bolt.run_locked(force_block_execution: true) {
-            results.select(&:success?).each { |result|
+          bolt = Carto::Bolt.new("#{user.username}:#{Carto::GhostTablesManager::MUTEX_REDIS_KEY}",
+                                 ttl_ms: Carto::GhostTablesManager::MUTEX_TTL_MS)
+          bolt.run_locked(force_block_execution: true) do
+            results.select(&:success?).each do |result|
               register(result)
-            }
-          }
-          results.select(&:success?).each { |result|
+            end
+          end
+          results.select(&:success?).each do |result|
             create_overviews(result)
-          }
+          end
 
           create_visualization if data_import.create_visualization
         end

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -62,8 +62,12 @@ module CartoDB
           }
         else
           log('Proceeding to register')
-          results.select(&:success?).each { |result|
-            register(result)
+          bolt = Carto::Bolt.new("#{user.username}:#{Carto::Bolt::MUTEX_REDIS_KEY}",
+                                 ttl_ms: Carto::Bolt::MUTEX_TTL_MS)
+          bolt.run_locked(force_block_execution=true) {
+            results.select(&:success?).each { |result|
+              register(result)
+            }
           }
           results.select(&:success?).each { |result|
             create_overviews(result)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -83,7 +83,9 @@ module CartoDB
         # In case we couldnt acquire bolt we want to continue with the import work so we register the
         # results anyway
         unless lock_acquired
-          CartoDB::Logger.warning(message: "Couldn't acquire bolt to register. Registering without bolt")
+          CartoDB::Logger.warning(message: "Couldn't acquire bolt to register. Registering without bolt",
+                                  user: user,
+                                  import_id: @data_import_id)
           results.select(&:success?).each do |result|
             register(result)
           end

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -62,22 +62,32 @@ module CartoDB
           }
         else
           log('Proceeding to register')
-          gtm = Carto::GhostTablesManager.new(user.id)
-          bolt = gtm.get_bolt
-          rerun_func = lambda { gtm.sync }
-          bolt.run_locked(attempts: 10, timeout: 30000, rerun_func: rerun_func) do
-            results.select(&:success?).each do |result|
-              register(result)
-            end
-          end
-          results.select(&:success?).each do |result|
+          register_results(results)
+          results.select(&:success?).each { |result|
             create_overviews(result)
-          end
-
+          }
           create_visualization if data_import.create_visualization
         end
-
         self
+      end
+
+      def register_results(results)
+        gtm = Carto::GhostTablesManager.new(user.id)
+        bolt = gtm.get_bolt
+        rerun_func = lambda { gtm.send(:sync) }
+        lock_acquired = bolt.run_locked(attempts: 10, timeout: 30000, rerun_func: rerun_func) do
+          results.select(&:success?).each do |result|
+            register(result)
+          end
+        end
+        # In case we couldnt acquire bolt we want to continue with the import work so we register the
+        # results anyway
+        unless lock_acquired
+          CartoDB::Logger.warning(message: "Couldn't acquire bolt to register. Registering without bolt")
+          results.select(&:success?).each do |result|
+            register(result)
+          end
+        end
       end
 
       def register(result)

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -15,15 +15,15 @@ module Carto
 
     def run_locked(attempts: DEFAULT_RETRY_ATTEMPTS,
                    timeout: DEFAULT_RETRY_TIMEOUT,
-                   rerun_func: lambda {})
+                   rerun_func: nil)
       raise 'no code block given' unless block_given?
-      raise 'no proc/lambda give as rerun_func' unless is_proc?(rerun_func)
+      raise 'no proc/lambda passed as rerun_func' if rerun_func.present? && !is_proc?(rerun_func)
 
       is_locked = acquire_lock(attempts, timeout)
 
       begin
         is_locked ? yield : set_rerun_after_finish
-        try_to_rerun(rerun_func) if is_locked
+        try_to_rerun(rerun_func) if is_locked && rerun_func.present?
         !!is_locked
       ensure
         unlock if is_locked
@@ -59,7 +59,7 @@ module Carto
     end
 
     def is_proc?(proc)
-      proc && proc.respond_to?(:call)
+      proc.respond_to?(:call)
     end
 
     def unlock

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -5,7 +5,7 @@ module Carto
     DEFAULT_REDIS_OBJECT = $users_metadata
     DEFAULT_TTL_MS = 10000
     DEFAULT_RETRY_ATTEMPTS = 1
-    DEFAULT_RETRY_TIMEOUT = 10000 #in_ms
+    DEFAULT_RETRY_TIMEOUT = 10000 # in_ms
 
     def initialize(bolt_key, redis_object: DEFAULT_REDIS_OBJECT, ttl_ms: DEFAULT_TTL_MS)
       @bolt_key = add_namespace_to_key(bolt_key)
@@ -17,7 +17,7 @@ module Carto
                    timeout: DEFAULT_RETRY_TIMEOUT,
                    rerun_func: nil)
       raise 'no code block given' unless block_given?
-      raise 'no proc/lambda passed as rerun_func' if rerun_func.present? && !is_proc?(rerun_func)
+      raise 'no proc/lambda passed as rerun_func' if rerun_func.present? && !proc?(rerun_func)
 
       is_locked = acquire_lock(attempts, timeout)
 
@@ -35,9 +35,9 @@ module Carto
     def acquire_lock(attempts, timeout)
       current_attempt = 1
       is_locked = false
-      while current_attempt <= attempts do
+      while current_attempt <= attempts
         is_locked = get_lock
-        if (is_locked || current_attempt == attempts)
+        if is_locked || current_attempt == attempts
           break
         else
           sleep((timeout / 1000.0).second)
@@ -58,7 +58,7 @@ module Carto
       end
     end
 
-    def is_proc?(proc)
+    def proc?(proc)
       proc.respond_to?(:call)
     end
 
@@ -70,7 +70,7 @@ module Carto
         CartoDB.notify_error('Removed bolt key was duplicated', bolt_key: @bolt_key, amount: removed_keys)
       end
 
-      removed_keys > 0 ? true : false
+      removed_keys > 0
     end
 
     def get_lock

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -45,6 +45,7 @@ module Carto
           current_attempt += 1
         end
       end
+      CartoDB::Logger.warning(message: "Couldn't acquire bolt and finish the task") unless is_locked && current_attempt < attempts
       is_locked
     end
 

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -11,7 +11,7 @@ module Carto
       @ttl_ms = ttl_ms
     end
 
-    def run_locked(force_block_execution=false, retriable = false)
+    def run_locked(force_block_execution: false, retriable: false)
       raise 'no code block given' unless block_given?
 
       is_locked = get_lock()

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -14,11 +14,11 @@ module Carto
     def run_locked(force_block_execution: false, retriable: false)
       raise 'no code block given' unless block_given?
 
-      is_locked = get_lock()
+      is_locked = get_lock
 
       begin
         loop do
-          yield if (is_locked || force_block_execution)
+          yield if is_locked || force_block_execution
           set_retry_after_finish(is_locked)
           break unless retriable && retry?
         end

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -36,8 +36,8 @@ module Carto
     def acquire_lock(attempts, timeout)
       current_attempt = 1
       is_locked = false
-      loop do
-        is_locked = get_lock()
+      while current_attempt <= attempts do
+        is_locked = get_lock
         if (is_locked || current_attempt == attempts)
           break
         else

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -4,6 +4,8 @@ module Carto
   class Bolt
     DEFAULT_REDIS_OBJECT = $users_metadata
     DEFAULT_TTL_MS = 10000
+    DEFAULT_RETRY_ATTEMPTS = 1
+    DEFAULT_RETRY_TIMEOUT = 10000 #in_ms
 
     def initialize(bolt_key, redis_object: DEFAULT_REDIS_OBJECT, ttl_ms: DEFAULT_TTL_MS)
       @bolt_key = add_namespace_to_key(bolt_key)
@@ -11,17 +13,18 @@ module Carto
       @ttl_ms = ttl_ms
     end
 
-    def run_locked(force_block_execution: false, retriable: false)
+    def run_locked(attempts: DEFAULT_RETRY_ATTEMPTS,
+                   timeout: DEFAULT_RETRY_TIMEOUT,
+                   rerun_func: lambda {})
       raise 'no code block given' unless block_given?
+      raise 'no proc/lambda give as rerun_func' unless is_proc?(rerun_func)
 
-      is_locked = get_lock
+      is_locked = acquire_lock(attempts, timeout)
 
       begin
-        loop do
-          yield if is_locked || force_block_execution
-          set_retry_after_finish(is_locked)
-          break unless retriable && retry?
-        end
+        yield if is_locked
+        set_retry_after_finish unless is_locked
+        rerun_func.call if is_locked && retry?
         !!is_locked
       ensure
         unlock if is_locked
@@ -30,8 +33,26 @@ module Carto
 
     private
 
+    def acquire_lock(attempts, timeout)
+      current_attempt = 1
+      is_locked = false
+      loop do
+        is_locked = get_lock()
+        if (is_locked || current_attempt == attempts)
+          break
+        else
+          sleep((timeout / 1000.0).second)
+          current_attempt += 1
+        end
+      end
+      is_locked
+    end
+
+    def is_proc?(proc)
+      proc && proc.respond_to?(:call)
+    end
+
     def unlock
-      @redis_object.del("#{@bolt_key}:retry")
       removed_keys = @redis_object.del(@bolt_key)
 
       # This may happen due to Redis failure. Highly unlikely, still nice to know.
@@ -46,12 +67,12 @@ module Carto
       @redis_object.set(@bolt_key, true, px: @ttl_ms, nx: true)
     end
 
-    def set_retry_after_finish(is_locked)
-      @redis_object.set("#{@bolt_key}:retry", true, px: @ttl_ms, nx: true) unless is_locked
+    def set_retry_after_finish
+      @redis_object.set("#{@bolt_key}:retry", true, px: @ttl_ms, nx: true)
     end
 
     def retry?
-      @redis_object.set("#{@bolt_key}:retry", true, px: @ttl_ms, nx: true)
+      @redis_object.del("#{@bolt_key}:retry") > 0
     end
 
     def add_namespace_to_key(key)

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -17,7 +17,7 @@ module Carto
       is_locked = get_lock()
 
       begin
-        while true
+        loop do
           yield if (is_locked || force_block_execution)
           set_retry_after_finish(is_locked)
           break unless retriable && retry?

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -37,11 +37,11 @@ module Carto
     private
 
     def acquire_lock(attempts, timeout)
-      attempts.times do
+      attempts.times do |index|
         lock_acquired = get_lock
         # With only 1 attempt, the default value, we dont sleep
         # even if false
-        if lock_acquired || attempts == 1
+        if lock_acquired || (attempts == index + 1)
           return lock_acquired
         end
         sleep((timeout / 1000.0).second)

--- a/lib/carto/bolt.rb
+++ b/lib/carto/bolt.rb
@@ -53,6 +53,7 @@ module Carto
     def try_to_rerun(rerun_func)
       return unless rerun_func.present?
       while retry?
+        refresh_lock_timeout
         rerun_func.call
       end
     end
@@ -78,6 +79,10 @@ module Carto
 
     def set_rerun_after_finish
       @redis_object.set("#{@bolt_key}:retry", true, px: @ttl_ms, nx: true)
+    end
+
+    def refresh_lock_timeout
+      @redis_object.pexpire(@bolt_key, @ttl_ms)
     end
 
     def retry?

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -56,7 +56,7 @@ module Carto
     def sync_user_tables_with_db
       bolt = Carto::Bolt.new("#{user.username}:#{MUTEX_REDIS_KEY}", ttl_ms: MUTEX_TTL_MS)
 
-      got_locked = bolt.run_locked(retriable=true) { sync }
+      got_locked = bolt.run_locked(retriable: true) { sync }
 
       CartoDB::Logger.info(message: 'Ghost table race condition avoided', user: user) unless got_locked
     end

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -56,7 +56,7 @@ module Carto
     def sync_user_tables_with_db
       bolt = Carto::Bolt.new("#{user.username}:#{MUTEX_REDIS_KEY}", ttl_ms: MUTEX_TTL_MS)
 
-      got_locked = bolt.run_locked(retriable: true) { sync }
+      got_locked = bolt.run_locked(rerun_func: {sync} ) { sync }
 
       CartoDB::Logger.info(message: 'Ghost table race condition avoided', user: user) unless got_locked
     end

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -56,7 +56,7 @@ module Carto
     def sync_user_tables_with_db
       bolt = Carto::Bolt.new("#{user.username}:#{MUTEX_REDIS_KEY}", ttl_ms: MUTEX_TTL_MS)
 
-      got_locked = bolt.run_locked { sync }
+      got_locked = bolt.run_locked(retriable=true) { sync }
 
       CartoDB::Logger.info(message: 'Ghost table race condition avoided', user: user) unless got_locked
     end

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -227,7 +227,7 @@ module Carto
       new_table.keep_user_database_table = true
 
       new_table.save
-    rescue => exception
+    rescue StandardError => exception
       CartoDB::Logger.error(message: 'Ghost tables: Error creating UserTable',
                             exception: exception,
                             user: user,
@@ -248,7 +248,7 @@ module Carto
       user_table_vis.name = name
 
       user_table_vis.store
-    rescue => exception
+    rescue StandardError => exception
       CartoDB::Logger.error(message: 'Ghost tables: Error renaming Visualization',
                             exception: exception,
                             user: user,
@@ -269,7 +269,7 @@ module Carto
       table_to_drop = ::Table.new(user_table: user_table_to_drop)
       table_to_drop.keep_user_database_table = true
       table_to_drop.destroy
-    rescue => exception
+    rescue StandardError => exception
       CartoDB::Logger.error(message: 'Ghost tables: Error dropping Table',
                             exception: exception,
                             user: user,
@@ -288,7 +288,7 @@ module Carto
 
       user_table_to_regenerate.table_id = id
       user_table_to_regenerate.save
-    rescue => exception
+    rescue StandardError => exception
       CartoDB::Logger.error(message: 'Ghost tables: Error syncing table_id for UserTable',
                             exception: exception,
                             user: user,

--- a/spec/lib/carto/bolt_spec.rb
+++ b/spec/lib/carto/bolt_spec.rb
@@ -94,6 +94,12 @@ module Carto
       main.join
     end
 
+    it 'should raise error if rerun_func is not a lambda' do
+      expect {
+        @bolt.run_locked(rerun_func: "lala") {}.should_raise
+      }.to raise_error('no proc/lambda passed as rerun_func')
+    end
+
 
     it 'should expire a lock after ttl_ms' do
       ttl_ms = 200

--- a/spec/lib/carto/bolt_spec.rb
+++ b/spec/lib/carto/bolt_spec.rb
@@ -34,7 +34,7 @@ module Carto
       end
       thr = Thread.new do
         flag = false
-        Carto::Bolt.new('manolo_bolt_locked').run_locked(attempts: 5, timeout: 1000) { flag=true }
+        Carto::Bolt.new('manolo_bolt_locked').run_locked(attempts: 5, timeout: 1000) { flag = true }
         flag.should be_true
       end
       thr.join
@@ -49,9 +49,7 @@ module Carto
       end
       thr = Thread.new do
         flag = false
-        Carto::Bolt.new('manolo_bolt_locked').run_locked(attempts: 5, timeout: 1) do
-         flag=true
-        end
+        Carto::Bolt.new('manolo_bolt_locked').run_locked(attempts: 5, timeout: 1) { flag = true }
         flag.should be_false
       end
       thr.join
@@ -61,7 +59,7 @@ module Carto
     it 'should retry an execution when other process tries to acquire bolt and has retriable flag set' do
       main = Thread.new do
         flag = 0
-        @bolt.run_locked(rerun_func: lambda {flag += 1}) {
+        @bolt.run_locked(rerun_func: lambda { flag += 1 }) {
           flag += 1
           sleep(1)
         }.should be_true
@@ -77,17 +75,20 @@ module Carto
     it 'should execute once the rerun_func part despite of the number of calls to acquire the lock' do
       main = Thread.new do
         flag = 0
-        @bolt.run_locked(rerun_func: lambda { sleep(1); flag += 1}) {
+        rerun_func = lambda do
+          sleep(1)
+          flag += 1
+        end
+        @bolt.run_locked(rerun_func: rerun_func) {
           flag += 1
           sleep(1)
         }.should be_true
         flag.should > 2
       end
-      threads = []
-      (1..5).each do
+      5.times do
         t = Thread.new do
-          Carto::Bolt.new('manolo_bolt_locked').run_locked {};
-          sleep(1.0/4.0)
+          Carto::Bolt.new('manolo_bolt_locked').run_locked {}
+          sleep(1.0 / 4.0)
         end
         t.join
       end
@@ -99,7 +100,6 @@ module Carto
         @bolt.run_locked(rerun_func: "lala") {}.should_raise
       }.to raise_error('no proc/lambda passed as rerun_func')
     end
-
 
     it 'should expire a lock after ttl_ms' do
       ttl_ms = 200

--- a/spec/lib/carto/bolt_spec.rb
+++ b/spec/lib/carto/bolt_spec.rb
@@ -29,9 +29,10 @@ module Carto
     it 'should wait for execution if we pass attempts parameters' do
       main = Thread.new do
         @bolt.run_locked {
-          sleep(0.1)
+          sleep(2)
         }.should be_true
       end
+      sleep(0.5)
       thr = Thread.new do
         flag = false
         Carto::Bolt.new('manolo_bolt_locked').run_locked(attempts: 5, timeout: 1000) { flag = true }
@@ -44,9 +45,10 @@ module Carto
     it 'should wait for execution and exit without complete it if timeout and retries reach the limit' do
       main = Thread.new do
         @bolt.run_locked {
-          sleep(1)
+          sleep(2)
         }.should be_true
       end
+      sleep(0.5)
       thr = Thread.new do
         flag = false
         Carto::Bolt.new('manolo_bolt_locked').run_locked(attempts: 5, timeout: 1) { flag = true }
@@ -61,10 +63,11 @@ module Carto
         flag = 0
         @bolt.run_locked(rerun_func: lambda { flag += 1 }) {
           flag += 1
-          sleep(1)
+          sleep(2)
         }.should be_true
         flag.should eq(2)
       end
+      sleep(0.5)
       thr = Thread.new do
         Carto::Bolt.new('manolo_bolt_locked').run_locked {}.should be_false
       end
@@ -81,11 +84,12 @@ module Carto
         end
         @bolt.run_locked(rerun_func: rerun_func) {
           flag += 1
-          sleep(1)
+          sleep(2)
         }.should be_true
         flag.should > 2
       end
-      6.times do
+      sleep(0.5)
+      20.times do
         t = Thread.new do
           Carto::Bolt.new('manolo_bolt_locked').run_locked {}
           sleep(0.25)

--- a/spec/lib/carto/bolt_spec.rb
+++ b/spec/lib/carto/bolt_spec.rb
@@ -44,7 +44,7 @@ module Carto
     it 'should wait for execution and exit without complete it if timeout and retries reach the limit' do
       main = Thread.new do
         @bolt.run_locked {
-          sleep(0.1)
+          sleep(1)
         }.should be_true
       end
       thr = Thread.new do
@@ -61,7 +61,7 @@ module Carto
         flag = 0
         @bolt.run_locked(rerun_func: lambda { flag += 1 }) {
           flag += 1
-          sleep(0.1)
+          sleep(1)
         }.should be_true
         flag.should eq(2)
       end
@@ -76,19 +76,19 @@ module Carto
       main = Thread.new do
         flag = 0
         rerun_func = lambda do
-          sleep(0.1)
+          sleep(1)
           flag += 1
         end
         @bolt.run_locked(rerun_func: rerun_func) {
           flag += 1
-          sleep(0.1)
+          sleep(1)
         }.should be_true
         flag.should > 2
       end
       6.times do
         t = Thread.new do
           Carto::Bolt.new('manolo_bolt_locked').run_locked {}
-          sleep(0.025)
+          sleep(0.25)
         end
         t.join
       end

--- a/spec/lib/carto/bolt_spec.rb
+++ b/spec/lib/carto/bolt_spec.rb
@@ -29,7 +29,7 @@ module Carto
     it 'should wait for execution if we pass attempts parameters' do
       main = Thread.new do
         @bolt.run_locked {
-          sleep(1.0 / 10.0)
+          sleep(0.1)
         }.should be_true
       end
       thr = Thread.new do
@@ -44,7 +44,7 @@ module Carto
     it 'should wait for execution and exit without complete it if timeout and retries reach the limit' do
       main = Thread.new do
         @bolt.run_locked {
-          sleep(1.0 / 10.0)
+          sleep(0.1)
         }.should be_true
       end
       thr = Thread.new do
@@ -61,7 +61,7 @@ module Carto
         flag = 0
         @bolt.run_locked(rerun_func: lambda { flag += 1 }) {
           flag += 1
-          sleep(1.0 / 10.0)
+          sleep(0.1)
         }.should be_true
         flag.should eq(2)
       end
@@ -76,19 +76,19 @@ module Carto
       main = Thread.new do
         flag = 0
         rerun_func = lambda do
-          sleep(1.0 / 10.0)
+          sleep(0.1)
           flag += 1
         end
         @bolt.run_locked(rerun_func: rerun_func) {
           flag += 1
-          sleep(1.0 / 10.0)
+          sleep(0.1)
         }.should be_true
         flag.should > 2
       end
       6.times do
         t = Thread.new do
           Carto::Bolt.new('manolo_bolt_locked').run_locked {}
-          sleep(1.0 / 40.0)
+          sleep(0.025)
         end
         t.join
       end

--- a/spec/lib/carto/bolt_spec.rb
+++ b/spec/lib/carto/bolt_spec.rb
@@ -29,7 +29,7 @@ module Carto
     it 'should wait for execution if we pass attempts parameters' do
       main = Thread.new do
         @bolt.run_locked {
-          sleep(1)
+          sleep(1.0 / 10.0)
         }.should be_true
       end
       thr = Thread.new do
@@ -44,7 +44,7 @@ module Carto
     it 'should wait for execution and exit without complete it if timeout and retries reach the limit' do
       main = Thread.new do
         @bolt.run_locked {
-          sleep(1)
+          sleep(1.0 / 10.0)
         }.should be_true
       end
       thr = Thread.new do
@@ -61,7 +61,7 @@ module Carto
         flag = 0
         @bolt.run_locked(rerun_func: lambda { flag += 1 }) {
           flag += 1
-          sleep(1)
+          sleep(1.0 / 10.0)
         }.should be_true
         flag.should eq(2)
       end
@@ -76,19 +76,19 @@ module Carto
       main = Thread.new do
         flag = 0
         rerun_func = lambda do
-          sleep(1)
+          sleep(1.0 / 10.0)
           flag += 1
         end
         @bolt.run_locked(rerun_func: rerun_func) {
           flag += 1
-          sleep(1)
+          sleep(1.0 / 10.0)
         }.should be_true
         flag.should > 2
       end
-      5.times do
+      6.times do
         t = Thread.new do
           Carto::Bolt.new('manolo_bolt_locked').run_locked {}
-          sleep(1.0 / 4.0)
+          sleep(1.0 / 40.0)
         end
         t.join
       end

--- a/spec/lib/carto/ghost_tables_manager_spec.rb
+++ b/spec/lib/carto/ghost_tables_manager_spec.rb
@@ -269,5 +269,44 @@ module Carto
       ::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTablesByUsername.perform(@user.username)
     end
 
+    it 'should call the rerun_func and execute sync twice becuase other worker tried to get the lock' do
+      @user.tables.count.should eq 0
+      @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_true
+      main = Thread.new do
+        run_in_user_database(%{
+          CREATE TABLE manoloescobar ("description" text);
+          SELECT * FROM CDB_CartodbfyTable('manoloescobar');
+        })
+        rerun_func = lambda do
+          Carto::GhostTablesManager.new(@user.id).send(:sync)
+        end
+        gtm = Carto::GhostTablesManager.new(@user.id)
+        gtm.get_bolt.run_locked(rerun_func: rerun_func) do
+          sleep(1)
+          Carto::GhostTablesManager.new(@user.id).send(:sync)
+        end
+      end
+      thr = Thread.new do
+        run_in_user_database(%{
+          CREATE TABLE manoloescobar2 ("description" text);
+          SELECT * FROM CDB_CartodbfyTable('manoloescobar2');
+        })
+        Carto::GhostTablesManager.new(@user.id).get_bolt.run_locked {}
+      end
+      thr.join
+      main.join
+      @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_true
+      @user.tables.count.should eq 2
+
+      run_in_user_database(%{
+        DROP TABLE manoloescobar;
+        DROP TABLE manoloescobar2;
+      })
+
+      @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_false
+      @ghost_tables_manager.link_ghost_tables_synchronously
+      @user.tables.count.should eq 0
+      @ghost_tables_manager.instance_eval { user_tables_synced_with_db? }.should be_true
+    end
   end
 end


### PR DESCRIPTION
Closes #14720 #14725 

- Bolt now can retry its code block if needed
- Register part of importer now is under Bolt to avoid Ghost tables to be executed until it finishes
- Bolt now let the block be executed even if was not possible to acquire the lock