### PR TITLE
Ghost tables visualization_backups migration STEP 2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@ Development
 - None yet
 
 ### Features
-- None yet
+* Visualizations backup revamp [#14698](https://github.com/CartoDB/cartodb/issues/14698)
+  * `visualization_backups` table migration step 2 [#14747](https://github.com/CartoDB/cartodb/pull/14747)
 
 ### Bug fixes / enhancements
 - Remove locked maps from total_likes and total_shared counts [#14727](https://github.com/CartoDB/cartodb/pull/14727)

--- a/app/models/carto/visualization_backup.rb
+++ b/app/models/carto/visualization_backup.rb
@@ -5,15 +5,16 @@ require 'active_record'
 module Carto
   class VisualizationBackup < ActiveRecord::Base
 
-    # @param String username
-    # @param Uuid visualization
-    # @param String export_vizjson
-    # @param DateTime created_at (Self-generated)
+    # @param Uuid id
+    # @param Uuid user_id
+    # @param Uuid visualization_id
+    # @param DateTime created_at (CURRENT_TIMESTAMP)
+    # @param String type
+    # @param String export
 
-    # Allow mass-setting upon .new
-    attr_accessible :username, :visualization, :export_vizjson
+    attr_accessible :id, :user_id, :visualization_id, :type, :export
 
-    validates :username, :visualization, :export_vizjson, presence: true
+    validates :user_id, :visualization_id, :type, :export, presence: true
 
   end
 end

--- a/db/migrate/20190314144818_revamp_visualization_backup_2.rb
+++ b/db/migrate/20190314144818_revamp_visualization_backup_2.rb
@@ -1,0 +1,19 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  Proc.new do
+    create_table :visualization_backups do
+      Uuid      :id,                primary_key: true, default: Sequel.lit('uuid_generate_v4()')
+      foreign_key :user_id, :users, type: :uuid, null: false, on_delete: :cascade
+      Uuid      :visualization_id,  null: false
+      DateTime  :created_at,        default: Sequel::CURRENT_TIMESTAMP
+      String    :type,              null: false
+      json      :export,            null: false
+    end
+  end,
+  Proc.new do
+    drop_table :visualization_backups
+  end
+)

--- a/db/migrate/20190314144818_revamp_visualization_backup_2.rb
+++ b/db/migrate/20190314144818_revamp_visualization_backup_2.rb
@@ -4,6 +4,7 @@ include Carto::Db::MigrationHelper
 
 migration(
   Proc.new do
+    drop_table :visualization_backups
     create_table :visualization_backups do
       Uuid      :id,                primary_key: true, default: Sequel.lit('uuid_generate_v4()')
       foreign_key :user_id, :users, type: :uuid, null: false, on_delete: :cascade


### PR DESCRIPTION
Step 2 of the migration related to #14698 

Step 1: https://github.com/CartoDB/cartodb/pull/14744

