### PR TITLE
Footer and pagination fix in create and share dialogs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Development
 - Fix error when duplicating shared dataset in dashboard ([#14750](https://github.com/CartoDB/cartodb/issues/14750))
 - Set results per page to 6 in maps and datasets for Home Page ([#14756](https://github.com/CartoDB/cartodb/pull/14756))
 - Display shared with colleagues list in map and dataset card ([#14748](https://github.com/CartoDB/cartodb/pull/14748))
+- Footer and pagination fix in create and share dialogs [#14765](https://github.com/CartoDB/cartodb/pull/14765)
 
 
 4.26.0 (2019-03-11)

--- a/assets/stylesheets/common/pagination.scss
+++ b/assets/stylesheets/common/pagination.scss
@@ -23,7 +23,7 @@
 
 .Pagination--searchShare {
   z-index: 5;
-  bottom: 50px;
+  bottom: 30px;
 }
 
 .Pagination-label {

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/create-dialog/dialog-view.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/create-dialog/dialog-view.js
@@ -158,7 +158,11 @@ const CreateDialogView = CoreView.extend({
     paneModel.set('selected', true);
 
     if (paneModelName === 'loading' || paneModelName === 'creatingFromScratch' || paneModelName === 'importFailed') {
-      this._footerView.hide();
+      var hiddenStyle = {
+        visibility: 'hidden',
+        opacity: '0'
+      };
+      this._footerView.$el.css(hiddenStyle);
       this._navigationView.hide();
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.76",
+  "version": "1.0.0-assets.76-dialog-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Acceptance
- Check that Create Map dialog displays correctly, with a uniform background color.
- Check that pagination in Share dialog is aligned with other elements in the footer