### PR TITLE
Enable HTTP mode for Varnish invalidation by default

### DIFF
--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -169,6 +169,7 @@ defaults: &defaults
     critical: false
     host: '127.0.0.1'
     port: 6082
+    http_port: 6081
     purge_command: 'purge'
     retries: 5
     timeout: 5


### PR DESCRIPTION
Varnish invalidation is disabled with TIS and HTTP modes in `app_config.yml.sample`, so it's using TELNET by default:
https://github.com/CartoDB/cartodb/blob/0571992000b481257005d82aa47ccf3da6534090/app/models/user/db_service.rb#L1003-L1011

I'm adding the required configuration to use HTTP, which is more reliable.