### PR TITLE
Fix db:create rake

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ Development
 - New Dashboard documentation ([#14712](https://github.com/CartoDB/cartodb/pull/14712))
 - Bolt now can: retry with timeout, execute a rerun function for retry. The importer now uses bolt
   for the register phase in order to avoid multiple ghost table calls in the future[#14736](https://github.com/CartoDB/cartodb/pull/14736)
+- Fix `db:create` rake (#14766)
 - Design review changes ([CartoDB/product#272](https://github.com/CartoDB/product/issues/272))
 - Invite User menu missing go back icon ([#14739](https://github.com/CartoDB/cartodb/issues/14739))
 - Fix error when duplicating shared dataset in dashboard ([#14750](https://github.com/CartoDB/cartodb/issues/14750))

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,7 @@ rake_tasks.delete('default')
 
 # Remove ActiveRecord tasks and replace with Sequel versions
 rake_tasks.select { |k, _| k.starts_with?('sequel') }.each { |k, v| rake_tasks[k.sub('sequel:', 'db:')] = v }
+rake_tasks.select { |k, _| k.starts_with?('cartodb:db') }.each { |k, v| rake_tasks[k.sub('cartodb:db:', 'db:')] = v }
 
 if Rails.env.test?
   namespace :spec do

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -1,4 +1,19 @@
 namespace :cartodb do
+  namespace :db do
+    task :create, [:env] do |_t, args|
+      # When the db:create task runs, there is no prior database. Since we use models in our initializers, we need to
+      # skip the :environment dependency or Sequel will error out when trying to load the schema for the model table.
+      # This task overrides the default Sequel task, loading the bare minimum (db config) instead of all initializers
+      args.with_defaults(:env => Rails.env)
+
+      config = SequelRails::Configuration.for(Rails.root, Carto::Conf.new.db_config)
+
+      unless SequelRails::Storage.create_environment(config.environment_for(args.env))
+        abort "Could not create database for #{args.env}."
+      end
+    end
+  end
+
   namespace :test do
     task :prepare do
       if (ENV['RAILS_ENV'] == "test")

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -4,7 +4,7 @@ namespace :cartodb do
       # When the db:create task runs, there is no prior database. Since we use models in our initializers, we need to
       # skip the :environment dependency or Sequel will error out when trying to load the schema for the model table.
       # This task overrides the default Sequel task, loading the bare minimum (db config) instead of all initializers
-      args.with_defaults(:env => Rails.env)
+      args.with_defaults(env: Rails.env)
 
       config = SequelRails::Configuration.for(Rails.root, Carto::Conf.new.db_config)
 


### PR DESCRIPTION
Fixes #14766 

@gonzaloriestra can you check it out since you reported the problem first?

Before the latest upgrade to Sequel 4 this was not a problem because Sequel did not crash when loading the model if the DB was not connected/did not exist.

Proper solution is to remove all Sequel model usage from the initializers, but that started to get complicated quickly, due to things like `warden` needing the User model.