### PR TITLE
Fix headers in search page and empty or initial states

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@ Development
 - Disable 'New dataset' options when no available/remaining storage quota ([#14762](https://github.com/CartoDB/cartodb/pull/14762))
 - Footer and pagination fix in create and share dialogs [#14765](https://github.com/CartoDB/cartodb/pull/14765)
 - Design review: update bulk actions labels and sticky table headings ([CartoDB/product#299](https://github.com/CartoDB/product/issues/299))
+- Fix headers in search page and empty or initial states in dashboard([#14772](https://github.com/CartoDB/cartodb/pull/14772))
 
 
 4.26.0 (2019-03-11)

--- a/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
@@ -163,8 +163,7 @@ export default {
         this.totalUserEntries <= 0;
     },
     emptyState () {
-      return ((!this.isFirstTimeViewingDashboard || this.hasSharedDatasets)
-        || this.isFirstTimeViewerAfterAction) &&
+      return ((!this.isFirstTimeViewingDashboard || this.hasSharedDatasets) || this.isFirstTimeViewerAfterAction) &&
         !this.isFetchingDatasets &&
         !this.currentEntriesCount;
     },

--- a/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
@@ -153,7 +153,7 @@ export default {
       return Object.keys(this.datasets).length === this.selectedDatasets.length;
     },
     shouldShowHeader () {
-      return !this.emptyState && !this.initialState;
+      return !this.emptyState && !this.initialState && this.currentEntriesCount > 0;
     },
     initialState () {
       return this.isFirstTimeViewingDashboard &&
@@ -163,13 +163,18 @@ export default {
         this.totalUserEntries <= 0;
     },
     emptyState () {
-      return (!this.isFirstTimeViewingDashboard || this.hasSharedDatasets) &&
+      return ((!this.isFirstTimeViewingDashboard || this.hasSharedDatasets) ||
+        this.isFirstTimeViewerAfterAction) &&
         !this.isFetchingDatasets &&
         !this.currentEntriesCount;
     },
     emptyStateText () {
       const route = this.$router.resolve({name: 'datasets', params: { filter: 'shared' }});
       return this.hasSharedDatasets ? this.$t('DataPage.emptyCase.onlyShared', { path: route.href }) : this.$t('DataPage.emptyCase.default', { path: route.href });
+    },
+    isFirstTimeViewerAfterAction () {
+      //First time viewing dashboard but user has performed any action such as drag and dropping a dataset (no page refreshing)
+      return this.isFirstTimeViewingDashboard && this.currentEntriesCount <= 0 && !this.hasFilterApplied('mine');
     },
     hasSharedDatasets () {
       return this.totalShared > 0;

--- a/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
@@ -163,8 +163,8 @@ export default {
         this.totalUserEntries <= 0;
     },
     emptyState () {
-      return ((!this.isFirstTimeViewingDashboard || this.hasSharedDatasets) ||
-        this.isFirstTimeViewerAfterAction) &&
+      return ((!this.isFirstTimeViewingDashboard || this.hasSharedDatasets)
+        || this.isFirstTimeViewerAfterAction) &&
         !this.isFetchingDatasets &&
         !this.currentEntriesCount;
     },
@@ -173,7 +173,7 @@ export default {
       return this.hasSharedDatasets ? this.$t('DataPage.emptyCase.onlyShared', { path: route.href }) : this.$t('DataPage.emptyCase.default', { path: route.href });
     },
     isFirstTimeViewerAfterAction () {
-      //First time viewing dashboard but user has performed any action such as drag and dropping a dataset (no page refreshing)
+      // First time viewing dashboard but user has performed any action such as drag and dropping a dataset (no page refreshing)
       return this.isFirstTimeViewingDashboard && this.currentEntriesCount <= 0 && !this.hasFilterApplied('mine');
     },
     hasSharedDatasets () {

--- a/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
@@ -153,7 +153,7 @@ export default {
       return Object.keys(this.datasets).length === this.selectedDatasets.length;
     },
     shouldShowHeader () {
-      return !this.emptyState && !this.initialState && !this.isFirstTimeViewingDashboard;
+      return !this.emptyState && !this.initialState;
     },
     initialState () {
       return this.isFirstTimeViewingDashboard &&

--- a/lib/assets/javascripts/new-dashboard/components/MapsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapsList.vue
@@ -165,7 +165,8 @@ export default {
         this.totalUserEntries <= 0;
     },
     emptyState () {
-      return (!this.isFirstTimeViewingDashboard || this.hasSharedMaps) &&
+      return ((!this.isFirstTimeViewingDashboard || this.hasSharedDatasets) ||
+        this.isFirstTimeViewerAfterAction) &&
         !this.isFetchingMaps &&
         !this.currentEntriesCount;
     },
@@ -175,6 +176,10 @@ export default {
       return this.hasSharedMaps
         ? this.$t('MapsPage.emptyCase.onlyShared', { path: route.href })
         : this.$t('MapsPage.emptyCase.default', { path: route.href });
+    },
+    isFirstTimeViewerAfterAction () {
+      //First time viewing dashboard but user has performed any action such as drag and dropping a dataset (no page refreshing)
+      return this.isFirstTimeViewingDashboard && this.currentEntriesCount <= 0 && !this.hasFilterApplied('mine');
     },
     hasSharedMaps () {
       return this.totalShared > 0;

--- a/lib/assets/javascripts/new-dashboard/components/MapsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapsList.vue
@@ -165,7 +165,7 @@ export default {
         this.totalUserEntries <= 0;
     },
     emptyState () {
-      return ((!this.isFirstTimeViewingDashboard || this.hasSharedDatasets) ||
+      return ((!this.isFirstTimeViewingDashboard || this.hasSharedMaps) ||
         this.isFirstTimeViewerAfterAction) &&
         !this.isFetchingMaps &&
         !this.currentEntriesCount;
@@ -178,7 +178,7 @@ export default {
         : this.$t('MapsPage.emptyCase.default', { path: route.href });
     },
     isFirstTimeViewerAfterAction () {
-      //First time viewing dashboard but user has performed any action such as drag and dropping a dataset (no page refreshing)
+      // First time viewing dashboard but user has performed any action such as drag and dropping a dataset (no page refreshing)
       return this.isFirstTimeViewingDashboard && this.currentEntriesCount <= 0 && !this.hasFilterApplied('mine');
     },
     hasSharedMaps () {

--- a/lib/assets/javascripts/new-dashboard/components/MapsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapsList.vue
@@ -165,8 +165,7 @@ export default {
         this.totalUserEntries <= 0;
     },
     emptyState () {
-      return ((!this.isFirstTimeViewingDashboard || this.hasSharedMaps) ||
-        this.isFirstTimeViewerAfterAction) &&
+      return ((!this.isFirstTimeViewingDashboard || this.hasSharedMaps) || this.isFirstTimeViewerAfterAction) &&
         !this.isFetchingMaps &&
         !this.currentEntriesCount;
     },

--- a/lib/assets/javascripts/new-dashboard/components/MapsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapsList.vue
@@ -186,7 +186,7 @@ export default {
       return this.canChangeViewMode && !this.initialState && !this.emptyState && !this.selectedMaps.length;
     },
     shouldShowListHeader () {
-      return this.isCondensed && !this.emptyState && !this.initialState && !this.isFirstTimeViewingDashboard;
+      return this.isCondensed && !this.emptyState && !this.initialState;
     },
     isViewer () {
       return this.$store.getters['user/isViewer'];

--- a/lib/assets/javascripts/new-dashboard/pages/Search.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Search.vue
@@ -16,7 +16,7 @@
         <section class="page-section" :class="{ 'has-pagination': hasMaps && mapsNumPages > 1 }" ref="maps">
           <div class="section-title grid-cell title is-medium">{{ $t('SearchPage.sections.maps') }}</div>
             <div class="js-grid__head--sticky">
-              <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky">
+              <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky" v-if="hasMaps">
                 <CondensedMapHeader order="" orderDirection="" :isSortable="false"></CondensedMapHeader>
               </div>
 
@@ -46,7 +46,7 @@
         <section class="page__section" ref="datasets">
           <div class="section-title grid-cell title is-medium">{{ $t('SearchPage.sections.data') }}</div>
             <div class="js-grid__head--sticky">
-              <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky">
+              <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky" v-if="hasDatasets">
                 <DatasetListHeader order="" orderDirection="" :isSortable="false"></DatasetListHeader>
               </div>
 

--- a/lib/assets/test/spec/new-dashboard/unit/specs/pages/Search/__snapshots__/Search.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/pages/Search/__snapshots__/Search.spec.js.snap
@@ -8,9 +8,7 @@ exports[`Search.vue Rendering should render empty state correctly 1`] = `
       <section class="page-section">
         <div class="section-title grid-cell title is-medium">SearchPage.sections.maps</div>
         <div class="js-grid__head--sticky">
-          <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky">
-            <condensedmapheader-stub order="" orderdirection=""></condensedmapheader-stub>
-          </div>
+          <!---->
           <!---->
           <ul class="grid-cell grid-cell--col12">
             <div class="is-caption text maps--empty">
@@ -23,9 +21,7 @@ exports[`Search.vue Rendering should render empty state correctly 1`] = `
       <section class="page__section">
         <div class="section-title grid-cell title is-medium">SearchPage.sections.data</div>
         <div class="js-grid__head--sticky">
-          <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky">
-            <datasetlistheader-stub order="" orderdirection=""></datasetlistheader-stub>
-          </div>
+          <!---->
           <ul class="grid-cell grid-cell--col12">
             <div class="is-caption text">
               SearchPage.emptyText.datasets
@@ -50,9 +46,7 @@ exports[`Search.vue Rendering should render fetching state correctly 1`] = `
       <section class="page-section">
         <div class="section-title grid-cell title is-medium">SearchPage.sections.maps</div>
         <div class="js-grid__head--sticky">
-          <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky">
-            <condensedmapheader-stub order="" orderdirection=""></condensedmapheader-stub>
-          </div>
+          <!---->
           <ul class="grid-cell grid-cell--col12">
             <li class="search-item">
               <mapcardfake-stub condensed="true" class="search-item"></mapcardfake-stub>
@@ -80,9 +74,7 @@ exports[`Search.vue Rendering should render fetching state correctly 1`] = `
       <section class="page__section">
         <div class="section-title grid-cell title is-medium">SearchPage.sections.data</div>
         <div class="js-grid__head--sticky">
-          <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky">
-            <datasetlistheader-stub order="" orderdirection=""></datasetlistheader-stub>
-          </div>
+          <!---->
           <!---->
           <ul class="grid-cell grid-cell--col12">
             <li class="search-item">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.78-headers3",
+  "version": "1.0.0-assets.78",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.78-headers",
+  "version": "1.0.0-assets.78-headers2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.78",
+  "version": "1.0.0-assets.78-headers",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.78-headers2",
+  "version": "1.0.0-assets.78-headers3",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:

- [x] When there are no results in search page -> list headers must be hidden since the list is empty
<img width="1148" alt="Screen Shot 2019-03-25 at 16 13 58" src="https://user-images.githubusercontent.com/26403479/54931311-0947fc00-4f19-11e9-9c24-8c9604c7956d.png">

- [x] Initial state (First time viewer): when datasets are drag&dropped in homepage, they appear on the list but the list headers are missing -> Headers must be visible when the first dataset is uploaded.
<img width="1202" alt="Screen Shot 2019-03-25 at 16 15 38" src="https://user-images.githubusercontent.com/26403479/54931446-4c09d400-4f19-11e9-98a9-fb531033a277.png">
