### PR TITLE
Fix uncaught exception when there is no fill or stroke by default in layer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@ Development
 - Disable 'New dataset' options when no available/remaining storage quota ([#14762](https://github.com/CartoDB/cartodb/pull/14762))
 - Footer and pagination fix in create and share dialogs [#14765](https://github.com/CartoDB/cartodb/pull/14765)
 - Design review: update bulk actions labels and sticky table headings ([CartoDB/product#299](https://github.com/CartoDB/product/issues/299))
+- Fix layer interface does not appear ([CartoDB/product#1988](https://github.com/CartoDB/product/issues/1988))
 
 
 4.26.0 (2019-03-11)

--- a/lib/assets/javascripts/builder/editor/style/style-form/style-properties-form/style-shape-properties-form-model.js
+++ b/lib/assets/javascripts/builder/editor/style/style-form/style-properties-form/style-shape-properties-form-model.js
@@ -22,10 +22,10 @@ module.exports = StyleFormDefaultModel.extend({
 
     var fields = {
       style: response.style,
-      fillSize: response.fill.size,
-      fillColor: response.fill.color,
-      strokeSize: response.stroke.size,
-      strokeColor: response.stroke.color,
+      fillSize: response.fill && response.fill.size,
+      fillColor: response.fill && response.fill.color,
+      strokeSize: response.stroke && response.stroke.size,
+      strokeColor: response.stroke && response.stroke.color,
       blending: response.blending
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.78",
+  "version": "1.0.0-assets.78-cartocssproblem-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.78-cartocssproblem-1",
+  "version": "1.0.0-assets.78-cartocssproblem-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes the issue that a client has when reentering a layer that has a malformed CartoCSS.

Related to https://github.com/CartoDB/support/issues/1988