### PR TITLE
Tag search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,11 +6,12 @@ Development
   suitable random key by using `bundle exec rake secret`
 
 ### Features
-* Visualizations backup revamp [#14698](https://github.com/CartoDB/cartodb/issues/14698)
-  * Remove `VisualizationsExportService` [#14744](https://github.com/CartoDB/cartodb/pull/14744)
-  * `visualization_backups` table Migration [#14749](https://github.com/CartoDB/cartodb/pull/14749)
-  * New visualizations backup [#14745](https://github.com/CartoDB/cartodb/pull/14745)
-  * Restore visualizations from new backup [#14764](https://github.com/CartoDB/cartodb/pull/14764)
+- Visualizations backup revamp [#14698](https://github.com/CartoDB/cartodb/issues/14698)
+  - Remove `VisualizationsExportService` [#14744](https://github.com/CartoDB/cartodb/pull/14744)
+  - `visualization_backups` table Migration [#14749](https://github.com/CartoDB/cartodb/pull/14749)
+  - New visualizations backup [#14745](https://github.com/CartoDB/cartodb/pull/14745)
+  - Restore visualizations from new backup [#14764](https://github.com/CartoDB/cartodb/pull/14764)
+- Tag search [#14777](https://github.com/CartoDB/cartodb/pull/14777)
 
 ### Bug fixes / enhancements
 - Add link to Help Center to invitation emails

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -28,7 +28,7 @@ module Carto
       def tag_query_builder
         query_builder = Carto::TagQueryBuilder.new
                                               .with_types(@types)
-                                              .with_search_pattern(@pattern)
+                                              .with_partial_match(@pattern)
 
         return query_builder.with_owned_by_or_shared_with_user_id(current_viewer.id) if @include_shared
         query_builder.with_owned_by_user_id(current_viewer.id)

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -14,7 +14,6 @@ module Carto
       rescue_from Carto::ParamCombinationInvalidError, with: :rescue_from_carto_error
 
       DEFAULT_TAGS_PER_PAGE = 6
-      FILTER_SHARED_YES = 'yes'.freeze
 
       def index
         query_builder = tag_query_builder
@@ -39,7 +38,7 @@ module Carto
         @page, @per_page = page_per_page_params(default_per_page: DEFAULT_TAGS_PER_PAGE)
 
         @pattern = params[:q]
-        @include_shared = params[:shared] == FILTER_SHARED_YES
+        @include_shared = params[:include_shared] == 'true'
 
         @types = params.fetch(:types, "").split(',')
         if (@types - Carto::Visualization::VALID_TYPES).present?

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -18,6 +18,7 @@ module Carto
       def index
         query_builder = Carto::TagQueryBuilder.new(current_viewer.id)
                                               .with_types(@types)
+                                              .with_search_pattern(@pattern)
         result = query_builder.build_paged(@page, @per_page)
         total_count = query_builder.total_count
 
@@ -28,6 +29,8 @@ module Carto
 
       def load_parameters
         @page, @per_page = page_per_page_params(default_per_page: DEFAULT_TAGS_PER_PAGE)
+
+        @pattern = params[:q]
 
         @types = params.fetch(:types, "").split(',')
         if (@types - Carto::Visualization::VALID_TYPES).present?

--- a/app/controllers/carto/api/tags_controller.rb
+++ b/app/controllers/carto/api/tags_controller.rb
@@ -14,11 +14,10 @@ module Carto
       rescue_from Carto::ParamCombinationInvalidError, with: :rescue_from_carto_error
 
       DEFAULT_TAGS_PER_PAGE = 6
+      FILTER_SHARED_YES = 'yes'.freeze
 
       def index
-        query_builder = Carto::TagQueryBuilder.new(current_viewer.id)
-                                              .with_types(@types)
-                                              .with_search_pattern(@pattern)
+        query_builder = tag_query_builder
         result = query_builder.build_paged(@page, @per_page)
         total_count = query_builder.total_count
 
@@ -27,10 +26,20 @@ module Carto
 
       private
 
+      def tag_query_builder
+        query_builder = Carto::TagQueryBuilder.new
+                                              .with_types(@types)
+                                              .with_search_pattern(@pattern)
+
+        return query_builder.with_owned_by_or_shared_with_user_id(current_viewer.id) if @include_shared
+        query_builder.with_owned_by_user_id(current_viewer.id)
+      end
+
       def load_parameters
         @page, @per_page = page_per_page_params(default_per_page: DEFAULT_TAGS_PER_PAGE)
 
         @pattern = params[:q]
+        @include_shared = params[:shared] == FILTER_SHARED_YES
 
         @types = params.fetch(:types, "").split(',')
         if (@types - Carto::Visualization::VALID_TYPES).present?

--- a/app/queries/carto/tag_query_builder.rb
+++ b/app/queries/carto/tag_query_builder.rb
@@ -34,7 +34,7 @@ class Carto::TagQueryBuilder
     self
   end
 
-  def with_search_pattern(pattern)
+  def with_partial_match(pattern)
     return self unless pattern.present?
     clean_pattern = escape_characters_from_pattern(pattern)
     @pattern = clean_pattern.split(' ').map { |word| "%#{word}%" }

--- a/app/queries/carto/tag_query_builder.rb
+++ b/app/queries/carto/tag_query_builder.rb
@@ -13,9 +13,20 @@ class Carto::TagQueryBuilder
     "remote" => :data_library
   }.freeze
 
-  def initialize(user_id)
-    @user_id = user_id
+  def initialize
     @types = DEFAULT_TYPES
+  end
+
+  def with_owned_by_user_id(user_id)
+    @owner_id = user_id
+    @user_id = nil
+    self
+  end
+
+  def with_owned_by_or_shared_with_user_id(user_id)
+    @user_id = user_id
+    @owner_id = nil
+    self
   end
 
   def with_types(types)
@@ -26,78 +37,67 @@ class Carto::TagQueryBuilder
   def with_search_pattern(pattern)
     return self unless pattern.present?
     clean_pattern = escape_characters_from_pattern(pattern)
-    @pattern = clean_pattern.downcase.split(' ').map { |word| "%#{word}%" }
+    @pattern = clean_pattern.split(' ').map { |word| "%#{word}%" }
     self
   end
 
-  def escape_characters_from_pattern(pattern)
-    pattern.chars.map { |c| PATTERN_ESCAPE_CHARS.include?(c) ? "\\" + c : c }.join
+  def build
+    build_base_visualization_query
+      .select(select_sql)
+      .where('array_length(tags, 1) > 0')
+      .group('tag')
+      .order('total DESC')
   end
 
   def build_paged(page, per_page)
-    limit = per_page.to_i
     offset = (page.to_i - 1) * per_page.to_i
-    sql_array = [select_sql, @user_id, @types, limit, offset, @pattern].compact
-    query = ActiveRecord::Base.send(:sanitize_sql_array, sql_array)
-    p query
-
-    connection = ActiveRecord::Base.connection
-    result = connection.exec_query(query)
-
+    limit = per_page.to_i
+    query = filter_query(query: build, offset: offset, limit: limit)
+    result = run_query(query)
     format_response(result)
   end
 
   def total_count
-    query = ActiveRecord::Base.send(:sanitize_sql_array, [count_sql, @user_id, @types, @pattern].compact)
-
-    connection = ActiveRecord::Base.connection
-    result = connection.exec_query(query)
-
-    result.cast_values.first
+    query = filter_query(query: build, count: true)
+    result = run_query(query)
+    result.first["count"].to_i
   end
 
   private
 
+  def build_base_visualization_query
+    query = Carto::VisualizationQueryBuilder.new
+    query.with_user_id(@owner_id) if @owner_id
+    query.with_owned_by_or_shared_with_user_id(@user_id) if @user_id
+    query.with_types(@types) if @types
+    query.build
+  end
+
   def select_sql
-    %{
-      SELECT *
-      FROM (
-        SELECT LOWER(unnest(tags)) AS tag, #{count_by_type_sql}
-        FROM visualizations
-        WHERE user_id = ?
-        AND type IN (?)
-        GROUP BY tag
-        ORDER BY COUNT(*) DESC
-        LIMIT ?
-        OFFSET ?
-      ) AS tags
-      #{search_filter}
+    "lower(unnest(tags)) AS tag, #{counts_sql}, count(*) as total"
+  end
+
+  def counts_sql
+    @types.map { |type|
+      "sum(CASE type WHEN '#{type}' THEN 1 ELSE 0 END) AS #{type}_count"
+    }.join(', ')
+  end
+
+  def filter_query(query:, count: false, limit: nil, offset: nil)
+    select_clause = count ? "COUNT(tag)" : "*"
+    where_clause = "WHERE tag ILIKE ANY (array[?])" if @pattern
+    limit_clause = "LIMIT ?" if limit
+    offset_clause = "OFFSET ?" if offset
+    filter_sql =  %{
+      SELECT #{select_clause} FROM (#{query.to_sql}) AS tags #{where_clause} #{limit_clause} #{offset_clause}
     }.squish
+
+    ActiveRecord::Base.send(:sanitize_sql_array, [filter_sql, @pattern, limit, offset].compact)
   end
 
-  def count_by_type_sql
-    queries = @types.map do |type|
-      count_query = "count(*) FILTER(WHERE type = ?) AS #{type}_count"
-      ActiveRecord::Base.send(:sanitize_sql_array, [count_query, type])
-    end
-    queries.join(",")
-  end
-
-  def search_filter
-    "WHERE tag ilike any (array[?])" if @pattern
-  end
-
-  def count_sql
-    %{
-      SELECT COUNT(DISTINCT(tag))
-      FROM (
-        SELECT LOWER(unnest(tags)) AS tag
-        FROM visualizations
-        WHERE user_id = ?
-        AND type IN (?)
-      ) AS tags
-      #{search_filter}
-    }.squish
+  def run_query(query)
+    connection = ActiveRecord::Base.connection
+    connection.exec_query(query)
   end
 
   def format_response(result)
@@ -107,6 +107,10 @@ class Carto::TagQueryBuilder
       }.inject(:merge)
       { tag: row['tag'] }.merge(types_count)
     end
+  end
+
+  def escape_characters_from_pattern(pattern)
+    pattern.chars.map { |c| PATTERN_ESCAPE_CHARS.include?(c) ? "\\" + c : c }.join
   end
 
 end

--- a/spec/queries/carto/tag_query_builder_spec.rb
+++ b/spec/queries/carto/tag_query_builder_spec.rb
@@ -200,6 +200,16 @@ describe Carto::TagQueryBuilder do
 
         result.should =~ expected_result
       end
+
+      it 'finds tags with problematic characters' do
+        FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["50%"])
+        expected_result = [{ tag: "50%", datasets: 1, maps: 0, data_library: 0 }]
+
+        builder = Carto::TagQueryBuilder.new(@user1.id).with_search_pattern('%')
+        result = builder.build_paged(1, 10)
+
+        result.should =~ expected_result
+      end
     end
   end
 

--- a/spec/queries/carto/tag_query_builder_spec.rb
+++ b/spec/queries/carto/tag_query_builder_spec.rb
@@ -163,7 +163,7 @@ describe Carto::TagQueryBuilder do
       it 'finds tags with the exact word' do
         expected_result = [{ tag: "tag2", datasets: 1, maps: 0, data_library: 0 }]
 
-        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_search_pattern('tag2')
+        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_partial_match('tag2')
         result = builder.build_paged(1, 10)
 
         result.should =~ expected_result
@@ -175,7 +175,7 @@ describe Carto::TagQueryBuilder do
           { tag: "tag2", datasets: 1, maps: 0, data_library: 0 }
         ]
 
-        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_search_pattern('tag')
+        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_partial_match('tag')
         result = builder.build_paged(1, 10)
 
         result.should =~ expected_result
@@ -187,7 +187,7 @@ describe Carto::TagQueryBuilder do
           { tag: "several words", datasets: 0, maps: 1, data_library: 0 }
         ]
 
-        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_search_pattern('tag2 not-found word')
+        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_partial_match('tag2 not-found word')
         result = builder.build_paged(1, 10)
         result.should =~ expected_result
       end
@@ -195,7 +195,7 @@ describe Carto::TagQueryBuilder do
       it 'is not case sensitive' do
         expected_result = [{ tag: "tag1", datasets: 2, maps: 0, data_library: 0 }]
 
-        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_search_pattern('TAG1')
+        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_partial_match('TAG1')
         result = builder.build_paged(1, 10)
 
         result.should =~ expected_result
@@ -205,7 +205,7 @@ describe Carto::TagQueryBuilder do
         FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["50%"])
         expected_result = [{ tag: "50%", datasets: 1, maps: 0, data_library: 0 }]
 
-        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_search_pattern('%')
+        builder = Carto::TagQueryBuilder.new.with_owned_by_user_id(@user1.id).with_partial_match('%')
         result = builder.build_paged(1, 10)
 
         result.should =~ expected_result

--- a/spec/requests/carto/api/tags_controller_spec.rb
+++ b/spec/requests/carto/api/tags_controller_spec.rb
@@ -5,15 +5,31 @@ require 'support/helpers'
 require_relative '../../../../app/controllers/carto/api/tags_controller'
 
 describe Carto::Api::TagsController do
-  include_context 'user helper'
+  include_context 'users helper'
   include HelperMethods
 
   before(:all) do
-    @params = { user_domain: @user.username, api_key: @user.api_key, types: "derived,table" }
+    @params = { user_domain: @user1.username, api_key: @user1.api_key, types: "derived,table" }
     @headers = { 'CONTENT_TYPE' => 'application/json' }
   end
 
   describe 'index' do
+    before(:each) do
+      FactoryGirl.create(:derived_visualization, user_id: @user1.id, tags: ["owned-tag"])
+
+      table = create_random_table(@user2)
+      shared_visualization = table.table_visualization
+      shared_visualization.tags = ["shared-tag"]
+      shared_visualization.save
+      shared_entity = CartoDB::SharedEntity.new(
+        recipient_id:   @user1.id,
+        recipient_type: CartoDB::SharedEntity::RECIPIENT_TYPE_USER,
+        entity_id:      shared_visualization.id,
+        entity_type:    CartoDB::SharedEntity::ENTITY_TYPE_VISUALIZATION
+      )
+      shared_entity.save
+    end
+
     it 'returns 401 if there is no authenticated user' do
       get_json api_v3_users_tags_url, @headers do |response|
         expect(response.status).to eq(401)
@@ -27,9 +43,8 @@ describe Carto::Api::TagsController do
       end
     end
 
-    it 'returns a 200 response with the current user tags' do
-      FactoryGirl.create(:derived_visualization, user_id: @user.id, tags: ["etiqueta"])
-      expected_tags = [{ tag: "etiqueta", maps: 1, datasets: 0 }]
+    it 'returns a 200 response with the tags owned by the current user' do
+      expected_tags = [{ tag: "owned-tag", maps: 1, datasets: 0 }]
 
       get_json api_v3_users_tags_url(@params), @headers do |response|
         expect(response.status).to eq(200)
@@ -39,11 +54,25 @@ describe Carto::Api::TagsController do
       end
     end
 
+    it 'returns a 200 response with the tags owned or shared by the current user' do
+      expected_tags = [
+        { tag: "owned-tag", maps: 1, datasets: 0 },
+        { tag: "shared-tag", maps: 0, datasets: 1 }
+      ]
+      shared_params = @params.merge(shared: "yes")
+
+      get_json api_v3_users_tags_url(shared_params), @headers do |response|
+        expect(response.status).to eq(200)
+        expect(response.body[:result]).to eq expected_tags
+        expect(response.body[:total]).to eq 2
+        expect(response.body[:count]).to eq 2
+      end
+    end
+
     it 'returns a 200 response with filtered tags' do
-      FactoryGirl.create(:derived_visualization, user_id: @user.id, tags: ["etiqueta"])
-      FactoryGirl.create(:table_visualization, user_id: @user.id, tags: ["otra"])
+      FactoryGirl.create(:table_visualization, user_id: @user1.id, tags: ["otra"])
       expected_tags = [{ tag: "otra", maps: 0, datasets: 1 }]
-      search_params = @params.merge(q: 'otra')
+      search_params = @params.merge(q: "otra")
 
       get_json api_v3_users_tags_url(search_params), @headers do |response|
         expect(response.status).to eq(200)

--- a/spec/requests/carto/api/tags_controller_spec.rb
+++ b/spec/requests/carto/api/tags_controller_spec.rb
@@ -38,5 +38,19 @@ describe Carto::Api::TagsController do
         expect(response.body[:count]).to eq 1
       end
     end
+
+    it 'returns a 200 response with filtered tags' do
+      FactoryGirl.create(:derived_visualization, user_id: @user.id, tags: ["etiqueta"])
+      FactoryGirl.create(:table_visualization, user_id: @user.id, tags: ["otra"])
+      expected_tags = [{ tag: "otra", maps: 0, datasets: 1 }]
+      search_params = @params.merge(q: 'otra')
+
+      get_json api_v3_users_tags_url(search_params), @headers do |response|
+        expect(response.status).to eq(200)
+        expect(response.body[:result]).to eq expected_tags
+        expect(response.body[:total]).to eq 1
+        expect(response.body[:count]).to eq 1
+      end
+    end
   end
 end

--- a/spec/requests/carto/api/tags_controller_spec.rb
+++ b/spec/requests/carto/api/tags_controller_spec.rb
@@ -59,7 +59,7 @@ describe Carto::Api::TagsController do
         { tag: "owned-tag", maps: 1, datasets: 0 },
         { tag: "shared-tag", maps: 0, datasets: 1 }
       ]
-      shared_params = @params.merge(shared: "yes")
+      shared_params = @params.merge(include_shared: "true")
 
       get_json api_v3_users_tags_url(shared_params), @headers do |response|
         expect(response.status).to eq(200)


### PR DESCRIPTION
Related to https://github.com/CartoDB/product/issues/243

Add search parameter to tags controller to filter them: `api/v3/tags?q=madrid`. It allows partial search and multiple words.

Acceptance:
- [x] Tags view from home tab in the dashboard works as before
- [x] It allows to search tags by adding `?q=whatever`
- [x] It allows to show/search tags from shared visualizations by adding `?include_shared=true`