### PR TITLE
Fix z-index in Quick Actions dropdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@ Development
 - Design review: update bulk actions labels and sticky table headings ([CartoDB/product#299](https://github.com/CartoDB/product/issues/299))
 - Unify modal footers ([#14769](https://github.com/CartoDB/cartodb/pull/14769))
 - Fix headers in search page and empty or initial states in dashboard([#14772](https://github.com/CartoDB/cartodb/pull/14772))
+- Fix z-index in Quick Actions dropdown ([#14780](https://github.com/CartoDB/cartodb/pull/14780))
 
 
 4.26.0 (2019-03-11)

--- a/lib/assets/javascripts/new-dashboard/components/Dropdowns/Dropdown.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Dropdowns/Dropdown.vue
@@ -35,7 +35,7 @@ export default {
 .dropdown {
   visibility: hidden;
   position: absolute;
-  z-index: 2;
+  z-index: $z-index__dropdown;
   right: 0;
   width: 316px;
   margin-top: 8px;

--- a/lib/assets/javascripts/new-dashboard/components/NavigationBar/NavigationBar.vue
+++ b/lib/assets/javascripts/new-dashboard/components/NavigationBar/NavigationBar.vue
@@ -121,7 +121,7 @@ export default {
 .navbar {
   display: flex;
   position: fixed;
-  z-index: 11;
+  z-index: $z-index__navbar;
   align-items: center;
   justify-content: space-between;
   width: 100%;

--- a/lib/assets/javascripts/new-dashboard/components/QuickActions/QuickActions.vue
+++ b/lib/assets/javascripts/new-dashboard/components/QuickActions/QuickActions.vue
@@ -79,7 +79,7 @@ export default {
 
 .quick-actions-dropdown {
   position: absolute;
-  z-index: 2;
+  z-index: $z-index__local-dropdown;
   right: 0;
   width: 260px;
   margin-top: 8px;

--- a/lib/assets/javascripts/new-dashboard/components/StickySubheader.vue
+++ b/lib/assets/javascripts/new-dashboard/components/StickySubheader.vue
@@ -24,7 +24,7 @@ export default {
 .sticky-subheader {
   display: flex;
   position: fixed;
-  z-index: 2;
+  z-index: $z-index__subheader;
   top: 0;
   left: 0;
   justify-content: center;

--- a/lib/assets/javascripts/new-dashboard/pages/Home/Home.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/Home.vue
@@ -3,8 +3,8 @@
   <Welcome />
   <RecentSection class="section" v-if="isSectionActive('RecentSection') && hasRecentContent" @sectionChange="changeSection" @contentChanged="onContentChanged"/>
   <TagsSection class="section tags-section" v-if="isSectionActive('TagsSection')" @sectionChange="changeSection"/>
-  <MapsSection class="section" @contentChanged="onContentChanged"/>
-  <DatasetsSection class="section section--noBorder" @contentChanged="onContentChanged"/>
+  <MapsSection class="section section--maps" @contentChanged="onContentChanged"/>
+  <DatasetsSection class="section section--datasets section--noBorder" @contentChanged="onContentChanged"/>
   <QuotaSection></QuotaSection>
 </section>
 </template>
@@ -72,8 +72,22 @@ export default {
 <style scoped lang="scss">
 @import 'new-dashboard/styles/variables';
 
-.page--welcome {
-  padding: 64px 0 0;
+.page {
+  &--welcome {
+    padding: 64px 0 0;
+  }
+}
+
+.section {
+  position: relative;
+
+  &--maps {
+    z-index: $z-index__stack-context--first;
+  }
+
+  &--datasets {
+    z-index: $z-index__stack-context--second;
+  }
 }
 
 .tags-section {

--- a/lib/assets/javascripts/new-dashboard/pages/Search.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Search.vue
@@ -13,8 +13,8 @@
 
     <div class="container grid">
       <div class="full-width">
-        <section class="page-section" :class="{ 'has-pagination': hasMaps && mapsNumPages > 1 }" ref="maps">
-          <div class="section-title grid-cell title is-medium">{{ $t('SearchPage.sections.maps') }}</div>
+        <section class="section section--maps" :class="{ 'has-pagination': hasMaps && mapsNumPages > 1 }" ref="maps">
+          <div class="section__title grid-cell title is-medium">{{ $t('SearchPage.sections.maps') }}</div>
             <div class="js-grid__head--sticky">
               <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky" v-if="hasMaps">
                 <CondensedMapHeader order="" orderDirection="" :isSortable="false"></CondensedMapHeader>
@@ -43,8 +43,8 @@
               @pageChange="page => onPageChange('maps', page)"></Pagination>
         </section>
 
-        <section class="page__section" ref="datasets">
-          <div class="section-title grid-cell title is-medium">{{ $t('SearchPage.sections.data') }}</div>
+        <section class="section section--datasets" ref="datasets">
+          <div class="section__title grid-cell title is-medium">{{ $t('SearchPage.sections.data') }}</div>
             <div class="js-grid__head--sticky">
               <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky" v-if="hasDatasets">
                 <DatasetListHeader order="" orderDirection="" :isSortable="false"></DatasetListHeader>
@@ -180,12 +180,27 @@ export default {
   padding-top: 192px;
 }
 
-.page-section {
+.section {
+  position: relative;
   margin-bottom: 48px;
+  padding: 0;
+  border-bottom: 0;
+
+  &--maps {
+    z-index: $z-index__stack-context--first;
+  }
+
+  &--datasets {
+    z-index: $z-index__stack-context--second;
+  }
 
   &.has-pagination,
   &:last-child {
     margin-bottom: 48px;
+  }
+
+  &__title {
+    margin-bottom: 16px;
   }
 }
 
@@ -208,10 +223,6 @@ export default {
 
 .full-width {
   width: 100%;
-}
-
-.section-title {
-  margin-bottom: 16px;
 }
 
 .grid__head--sticky {

--- a/lib/assets/javascripts/new-dashboard/styles/_grid.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/_grid.scss
@@ -46,7 +46,7 @@
 
 .grid__head--sticky {
   position: sticky;
-  z-index: 1;
+  z-index: $z-index__sticky;
   top: 0;
 }
 

--- a/lib/assets/javascripts/new-dashboard/styles/variables.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/variables.scss
@@ -1,6 +1,6 @@
 //colors
 $primary-color: #047AE6;
-$primary-color--dark: #1074b5;
+$primary-color--dark: #1074B5;
 $premium-color: #F90;
 $white: #FFF;
 $text-color: #2E3C43;
@@ -28,3 +28,15 @@ $dropdown__shadow: 0 2px 8px 0 $dropdown__shadow-color;
 
 $card__shadow-color: rgba(194, 205, 214, 0.8);
 $card__shadow: 0 8px 20px 0 $card__shadow-color;
+
+$z-index__dialog: 1000;
+$z-index__navbar: 5;
+$z-index__subheader: 4;
+$z-index__dropdown: 3;
+$z-index__sticky: 2;
+$z-index__local-dropdown: 1;
+
+// Variables to create different stacking context
+// Used in pages where you have Maps and Dataset Lists
+$z-index__stack-context--first: 2;
+$z-index__stack-context--second: 1;

--- a/lib/assets/test/spec/new-dashboard/unit/specs/pages/Search/__snapshots__/Search.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/pages/Search/__snapshots__/Search.spec.js.snap
@@ -5,8 +5,8 @@ exports[`Search.vue Rendering should render empty state correctly 1`] = `
   <stickysubheader-stub isvisible="true" class="page-subheader"><span class="title">SearchPage.title.searchTerm</span></stickysubheader-stub>
   <div class="container grid">
     <div class="full-width">
-      <section class="page-section">
-        <div class="section-title grid-cell title is-medium">SearchPage.sections.maps</div>
+      <section class="section section--maps">
+        <div class="section__title grid-cell title is-medium">SearchPage.sections.maps</div>
         <div class="js-grid__head--sticky">
           <!---->
           <!---->
@@ -18,8 +18,8 @@ exports[`Search.vue Rendering should render empty state correctly 1`] = `
         </div>
         <!---->
       </section>
-      <section class="page__section">
-        <div class="section-title grid-cell title is-medium">SearchPage.sections.data</div>
+      <section class="section section--datasets">
+        <div class="section__title grid-cell title is-medium">SearchPage.sections.data</div>
         <div class="js-grid__head--sticky">
           <!---->
           <ul class="grid-cell grid-cell--col12">
@@ -43,8 +43,8 @@ exports[`Search.vue Rendering should render fetching state correctly 1`] = `
       <span class="loading"><img svg-inline="" src="../assets/icons/common/loading.svg" class="loading__svg"></span></span></stickysubheader-stub>
   <div class="container grid">
     <div class="full-width">
-      <section class="page-section">
-        <div class="section-title grid-cell title is-medium">SearchPage.sections.maps</div>
+      <section class="section section--maps">
+        <div class="section__title grid-cell title is-medium">SearchPage.sections.maps</div>
         <div class="js-grid__head--sticky">
           <!---->
           <ul class="grid-cell grid-cell--col12">
@@ -71,8 +71,8 @@ exports[`Search.vue Rendering should render fetching state correctly 1`] = `
         </div>
         <!---->
       </section>
-      <section class="page__section">
-        <div class="section-title grid-cell title is-medium">SearchPage.sections.data</div>
+      <section class="section section--datasets">
+        <div class="section__title grid-cell title is-medium">SearchPage.sections.data</div>
         <div class="js-grid__head--sticky">
           <!---->
           <!---->
@@ -109,8 +109,8 @@ exports[`Search.vue Rendering should render search results correctly 1`] = `
   <stickysubheader-stub isvisible="true" class="page-subheader"><span class="title">SearchPage.title.searchTerm</span></stickysubheader-stub>
   <div class="container grid">
     <div class="full-width">
-      <section class="page-section has-pagination">
-        <div class="section-title grid-cell title is-medium">SearchPage.sections.maps</div>
+      <section class="section section--maps has-pagination">
+        <div class="section__title grid-cell title is-medium">SearchPage.sections.maps</div>
         <div class="js-grid__head--sticky">
           <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky">
             <condensedmapheader-stub order="" orderdirection=""></condensedmapheader-stub>
@@ -128,8 +128,8 @@ exports[`Search.vue Rendering should render search results correctly 1`] = `
         </div>
         <pagination-stub page="1" numpages="2"></pagination-stub>
       </section>
-      <section class="page__section">
-        <div class="section-title grid-cell title is-medium">SearchPage.sections.data</div>
+      <section class="section section--datasets">
+        <div class="section__title grid-cell title is-medium">SearchPage.sections.data</div>
         <div class="js-grid__head--sticky">
           <div class="grid-cell grid-cell--noMargin grid-cell--col12 grid__head--sticky">
             <datasetlistheader-stub order="" orderdirection=""></datasetlistheader-stub>


### PR DESCRIPTION
We have a little issue with z-indexes. When you have a Quick Actions dropdown open and scroll the page, you can see the dropdown above the header. This is also noticeable with the sticky headers in the tables. So we’ve done a little refactor to improve the z-index management.

![image](https://user-images.githubusercontent.com/8669176/55072591-d114fa80-508b-11e9-8d54-465088c03659.png)

### Acceptance
- Go the Home page, open a Quick Actions dropdown in Maps list and scroll the page. Check that it positions under the header of the Maps list but above the Datasets list header.
- Repeat the test in the Search results page
- Check that all dropdowns (Filters, Search suggestions, User…) are correctly positioned.

