### PR TITLE
Radio button alignment and search suggestions unnecessary request fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@ Development
 - Add sql_query parameter on database connector sync examples([#14781](https://github.com/CartoDB/cartodb/pull/14781))
 - Fix layer interface does not appear ([CartoDB/product#1988](https://github.com/CartoDB/product/issues/1988))
 - Fix z-index in Quick Actions dropdown ([#14780](https://github.com/CartoDB/cartodb/pull/14780))
+- Fix extra API call in global search ([#14774](https://github.com/CartoDB/cartodb/issues/14774))
+- Fix Radio buttons not being displayed correctly in connect dataset modal ([#14776](https://github.com/CartoDB/cartodb/issues/14776))
 
 4.26.0 (2019-03-11)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/components/Backbone/Dialogs/CreateDialog.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Backbone/Dialogs/CreateDialog.vue
@@ -81,6 +81,8 @@ export default {
 <style lang="scss">
 .Dialog {
   .CreateDialog--new-dashboard {
+    // We set content-box because it seems like
+    // older content was laid out that way
     .Dialog-footer,
     .ImportOptions {
       box-sizing: content-box;
@@ -88,6 +90,11 @@ export default {
       * {
         box-sizing: content-box;
       }
+    }
+
+    // Reset style for radio button
+    .RadioButton-input {
+      box-sizing: border-box;
     }
   }
 }

--- a/lib/assets/javascripts/new-dashboard/components/Search/Suggestions/SearchSuggestions.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Search/Suggestions/SearchSuggestions.vue
@@ -98,6 +98,10 @@ export default {
   },
   methods: {
     fetchSuggestions () {
+      if (!this.query) {
+        return;
+      }
+
       this.client.getVisualization('',
         this.queryParameters,
 

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/Search/Suggestions/SearchSuggestions.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/Search/Suggestions/SearchSuggestions.spec.js
@@ -116,10 +116,6 @@ describe('SearchSuggestions.vue', () => {
   describe('Methods', () => {
     describe('fetchSuggestions', () => {
       it('should not request suggestions if query is empty', () => {
-
-      });
-
-      it('should set search results via API', () => {
         const getVisualizationSpy = jest.fn();
 
         const searchSuggestions = createSearchSuggestions({
@@ -139,6 +135,33 @@ describe('SearchSuggestions.vue', () => {
 
         expect(searchSuggestions.vm.searchResults).toEqual([]);
         expect(getVisualizationSpy).not.toHaveBeenCalled();
+      });
+
+      it('should set search results via API', () => {
+        const getVisualizationSpy = jest.fn((vizUrl, params, callback) => {
+          callback(null, null, visualizationData);
+        });
+
+        const queryParameters = {
+          per_page: 4,
+          q: 'Query text',
+          types: 'derived,table'
+        };
+
+        const searchSuggestions = createSearchSuggestions({
+          data () {
+            return {
+              isFetching: true,
+              searchResults: [],
+              client: { getVisualization: getVisualizationSpy }
+            };
+          }
+        });
+
+        searchSuggestions.vm.fetchSuggestions();
+
+        expect(searchSuggestions.vm.searchResults).toEqual(visualizationData);
+        expect(getVisualizationSpy).toHaveBeenCalledWith('', queryParameters, expect.any(Function));
       });
 
       it('should not set search results via API if request is errored', () => {

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/Search/Suggestions/SearchSuggestions.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/Search/Suggestions/SearchSuggestions.spec.js
@@ -115,19 +115,17 @@ describe('SearchSuggestions.vue', () => {
 
   describe('Methods', () => {
     describe('fetchSuggestions', () => {
-      it('should set search results via API', () => {
-        const getVisualizationSpy = jest.fn((vizUrl, params, callback) => {
-          callback(null, null, visualizationData);
-        });
+      it('should not request suggestions if query is empty', () => {
 
-        const queryParameters = {
-          per_page: 4,
-          q: 'Query text',
-          types: 'derived,table'
-        };
+      });
+
+      it('should set search results via API', () => {
+        const getVisualizationSpy = jest.fn();
 
         const searchSuggestions = createSearchSuggestions({
-
+          propsData: {
+            query: ''
+          },
           data () {
             return {
               isFetching: true,
@@ -139,8 +137,8 @@ describe('SearchSuggestions.vue', () => {
 
         searchSuggestions.vm.fetchSuggestions();
 
-        expect(searchSuggestions.vm.searchResults).toEqual(visualizationData);
-        expect(getVisualizationSpy).toHaveBeenCalledWith('', queryParameters, expect.any(Function));
+        expect(searchSuggestions.vm.searchResults).toEqual([]);
+        expect(getVisualizationSpy).not.toHaveBeenCalled();
       });
 
       it('should not set search results via API if request is errored', () => {


### PR DESCRIPTION
This PR fixes the alignment of the checked state in the radio buttons, as well as an unnecessary request made by the search suggestions when query was empty.

Related to #14774 and #14776 