### PR TITLE
Change Header CSS display to block

### DIFF
--- a/lib/assets/javascripts/new-dashboard/components/Wizard/Header.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Wizard/Header.vue
@@ -43,11 +43,8 @@ $bullet__border-color: #D3E6FA;
 $transition__timing-function: cubic-bezier(0.4, 0.01, 0.165, 0.99);
 
 .header {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding-top: 2.406em;
+  display: block;
+  padding-top: 2.375em;
   background: $white;
 }
 
@@ -58,12 +55,12 @@ $transition__timing-function: cubic-bezier(0.4, 0.01, 0.165, 0.99);
 .breadcrumbs {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 1em;
+  margin-bottom: 1.5em;
 
   &__item {
     position: relative;
     width: 100%;
-    height: 46px;
+    height: 36px;
 
     &:not(:last-child) {
       border-top: $timeline__border-width solid $primary-color;
@@ -136,7 +133,7 @@ $transition__timing-function: cubic-bezier(0.4, 0.01, 0.165, 0.99);
 
   &__text {
     position: absolute;
-    top: 30px;
+    top: 24px;
     transform: translateX(-50%);
     color: $text-color;
     font-size: 0.75em;


### PR DESCRIPTION
We have an issue in Safari and in some Chrome versions with the header being too narrow
<img width="959" alt="header" src="https://user-images.githubusercontent.com/8669176/55628455-0bc81280-57b1-11e9-8e3e-28b24e9c3249.png">

This is how the Header should look like:
![header-fixed](https://user-images.githubusercontent.com/8669176/55628632-85600080-57b1-11e9-9de1-1e962ca8cc91.png)

We have fixed this by simply not using flexbox in the `.header` div because, anyway, is was no necessary. We also change spacing and heights a little bit according to design.
