### PR TITLE
Change tag icon and spacing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@ Development
 - Fix wrong link to Dashboard Help Center articule ([#14799](https://github.com/CartoDB/cartodb/issues/14799))
 - Sidebar overlaps Header in profile page ([#14803](https://github.com/CartoDB/cartodb/issues/14803))
 - Remove migrated dashboard ([#14741](https://github.com/CartoDB/cartodb/pull/14741))
+- Change tag icon and spacing ([#14773](https://github.com/CartoDB/cartodb/issues/14773))
 
 4.26.0 (2019-03-11)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/assets/icons/common/tag.svg
+++ b/lib/assets/javascripts/new-dashboard/assets/icons/common/tag.svg
@@ -1,4 +1,4 @@
-<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
   <g transform="matrix(-1 0 0 1 12 0)" fill="#6F757B" fill-rule="evenodd">
     <path d="M7 11.67a.58.58 0 0 1-.41-.17L.17 5.08A.58.58 0 0 1 0 4.67V.58C0 .26.26 0 .58 0h4.09c.15 0 .3.06.4.17L11.5 6.6c.22.23.22.6 0 .82L7.4 11.5a.58.58 0 0 1-.41.17zM1.17 4.43L7 10.26 10.26 7 4.43 1.17H1.17v3.26z" fill-rule="nonzero"/>
     <circle cx="2.92" cy="2.92" r="1.17"/>

--- a/lib/assets/javascripts/new-dashboard/assets/icons/maps/tag.svg
+++ b/lib/assets/javascripts/new-dashboard/assets/icons/maps/tag.svg
@@ -1,6 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(.5 .5)" fill="#2E3C43" fill-rule="evenodd">
-    <path d="M9 15a.75.75 0 0 1-.53-.22L.22 6.53A.75.75 0 0 1 0 6V.75C0 .34.34 0 .75 0H6c.2 0 .39.08.53.22l8.25 8.25c.3.3.3.77 0 1.06l-5.25 5.25A.75.75 0 0 1 9 15zM1.5 5.69l7.5 7.5L13.19 9l-7.5-7.5H1.5v4.19z" fill-rule="nonzero"/>
-    <circle cx="3.75" cy="3.75" r="1.5"/>
-  </g>
-</svg>

--- a/lib/assets/javascripts/new-dashboard/assets/icons/section-title/tags.svg
+++ b/lib/assets/javascripts/new-dashboard/assets/icons/section-title/tags.svg
@@ -1,5 +1,5 @@
 <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
-  <g fill="#2E3C43" fill-rule="evenodd">
+  <g transform="matrix(-1 0 0 1 20 0)" fill="#2E3C43" fill-rule="evenodd">
     <path d="M12 20a.997.997 0 0 1-.707-.293l-11-11A.996.996 0 0 1 0 8V1a1 1 0 0 1 1-1h7c.266 0 .52.105.707.293l11 11a.999.999 0 0 1 0 1.414l-7 7A.997.997 0 0 1 12 20zM2 7.586l10 10L17.586 12l-10-10H2v5.586z" fill-rule="nonzero"/>
     <circle cx="5" cy="5" r="2"/>
   </g>

--- a/lib/assets/javascripts/new-dashboard/assets/icons/sections/recent-content/tags.svg
+++ b/lib/assets/javascripts/new-dashboard/assets/icons/sections/recent-content/tags.svg
@@ -1,5 +1,5 @@
 <svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
-  <g fill="#036FE2" fill-rule="evenodd">
+  <g transform="matrix(-1 0 0 1 20 0)" fill="#036FE2" fill-rule="evenodd">
     <path d="M12 20a.997.997 0 0 1-.707-.293l-11-11A.996.996 0 0 1 0 8V1a1 1 0 0 1 1-1h7c.266 0 .52.105.707.293l11 11a.999.999 0 0 1 0 1.414l-7 7A.997.997 0 0 1 12 20zM2 7.586l10 10L17.586 12l-10-10H2v5.586z" fill-rule="nonzero"/>
     <circle cx="5" cy="5" r="2"/>
   </g>

--- a/lib/assets/javascripts/new-dashboard/components/Dataset/DatasetCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Dataset/DatasetCard.vue
@@ -34,7 +34,7 @@
         </div>
         <div class="row-metadataContainer" v-if="hasTags || isSharedWithMe || isSharedWithColleagues">
           <div class="row-metadata" v-if="hasTags" @mouseover="mouseOverChildElement" @mouseleave="mouseOutChildElement">
-            <img class="icon-metadata" svg-inline src="../../assets/icons/common/tag.svg">
+            <img class="icon-metadata" src="../../assets/icons/common/tag.svg" width="14" height="14">
             <ul v-if="tagsChars <= maxTagChars" class="tag-list">
               <li v-for="(tag, index) in dataset.tags" :key="tag">
                 <router-link :to="{ name: 'tagSearch', params: { tag } }" class="text is-small is-txtSoftGrey tag-list__tag">{{ tag }}</router-link><span class="text is-small is-txtSoftGrey" v-if="!isLastTag(index)">,&nbsp;</span>
@@ -483,7 +483,7 @@ export default {
 
     .icon-metadata {
       margin-right: 4px;
-      transform: translate(0, 1px);
+      transform: translate(0, 2px);
     }
 
     li {

--- a/lib/assets/javascripts/new-dashboard/components/MapCard/CondensedMapCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapCard/CondensedMapCard.vue
@@ -39,7 +39,7 @@
 
         <div class="metadata" v-if="hasTags || isSharedWithMe || isSharedWithColleagues">
           <div class="metadata__element" v-if="hasTags" @mouseover="mouseOverChildElement" @mouseleave="mouseOutChildElement">
-            <img class="metadata__icon" svg-inline src="../../assets/icons/common/tag.svg">
+            <img class="metadata__icon" src="../../assets/icons/common/tag.svg" width="14" height="14">
 
             <ul class="metadata__tags" v-if="tagsChars <= maxTagsChars">
               <li v-for="(tag, index) in visualization.tags" :key="tag">

--- a/lib/assets/javascripts/new-dashboard/components/MapCard/CondensedMapCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapCard/CondensedMapCard.vue
@@ -309,7 +309,7 @@ export default {
 
       .metadata__icon {
         margin-right: 4px;
-        transform: translate(0, 1px);
+        transform: translate(0, 2px);
       }
 
       li {

--- a/lib/assets/javascripts/new-dashboard/components/MapCard/SimpleMapCard.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapCard/SimpleMapCard.vue
@@ -76,7 +76,7 @@
         </li>
 
         <li class="card-metadataItem text is-caption" v-if="sectionsToShow.tags">
-          <span class="icon"><img inline-svg src="../../assets/icons/maps/tag.svg"></span>
+          <span class="icon"><img class="icon__tags" svg-inline src="../../assets/icons/common/tag.svg"></span>
 
           <ul class="card-tags" v-if="tagsChars <= maxTagsChars">
             <li v-for="(tag, index) in visualization.tags" :key="tag">
@@ -391,6 +391,15 @@ export default {
     &.icon--sharedBy {
       border-radius: 2px;
       background-size: contain;
+    }
+
+    .icon__tags {
+      width: 16px;
+      height: 16px;
+
+      g {
+        fill: $text-color;
+      }
     }
   }
 }

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/Dataset/__snapshots__/DatasetCard.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/Dataset/__snapshots__/DatasetCard.spec.js.snap
@@ -186,7 +186,7 @@ exports[`DatasetCard.vue should render multiple tags 1`] = `
         </h3> <span class="card-favorite"><img svg-inline="" src="../../assets/icons/common/favorite.svg"></span>
       </div>
       <div class="row-metadataContainer">
-        <div class="row-metadata"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon-metadata">
+        <div class="row-metadata"><img src="../../assets/icons/common/tag.svg" width="14" height="14" class="icon-metadata">
           <!---->
           <featuresdropdown-stub list="Hi,Hello,CARTO Rules,Just one more tag here" feature="tag" linkroute="tagSearch"><span class="tag-list__more-tags text is-small is-txtSoftGrey">4 DatasetCard.tags</span></featuresdropdown-stub>
         </div>
@@ -279,7 +279,7 @@ exports[`DatasetCard.vue should render tags 1`] = `
         </h3> <span class="card-favorite"><img svg-inline="" src="../../assets/icons/common/favorite.svg"></span>
       </div>
       <div class="row-metadataContainer">
-        <div class="row-metadata"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon-metadata">
+        <div class="row-metadata"><img src="../../assets/icons/common/tag.svg" width="14" height="14" class="icon-metadata">
           <ul class="tag-list">
             <li>
               <router-link to="[object Object]" class="text is-small is-txtSoftGrey tag-list__tag">Hi</router-link><span class="text is-small is-txtSoftGrey">,&nbsp;</span>

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/MapCard/__snapshots__/CondensedMapCard.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/MapCard/__snapshots__/CondensedMapCard.spec.js.snap
@@ -312,7 +312,7 @@ exports[`MapCard.vue should render description and tag dropdown 1`] = `
         </h3> <span class="cell__favorite"><img svg-inline="" src="../../assets/icons/common/favorite.svg"></span>
       </div>
       <div class="metadata">
-        <div class="metadata__element"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="metadata__icon">
+        <div class="metadata__element"><img src="../../assets/icons/common/tag.svg" width="14" height="14" class="metadata__icon">
           <!---->
           <featuresdropdown-stub list="Hi,Hello,CARTO Rules,Shows dropdown" feature="tag" linkroute="tagSearch"><span class="metadata__tags-count text is-small is-txtSoftGrey">4 DatasetCard.tags</span></featuresdropdown-stub>
         </div>
@@ -356,7 +356,7 @@ exports[`MapCard.vue should render description and tags 1`] = `
         </h3> <span class="cell__favorite"><img svg-inline="" src="../../assets/icons/common/favorite.svg"></span>
       </div>
       <div class="metadata">
-        <div class="metadata__element"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="metadata__icon">
+        <div class="metadata__element"><img src="../../assets/icons/common/tag.svg" width="14" height="14" class="metadata__icon">
           <ul class="metadata__tags">
             <li>
               <router-link to="[object Object]" class="text is-small is-txtSoftGrey metadata__tag">Hi</router-link><span class="text is-small is-txtSoftGrey">,&nbsp;</span>

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/MapCard/__snapshots__/SimpleMapCard.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/MapCard/__snapshots__/SimpleMapCard.spec.js.snap
@@ -22,7 +22,7 @@ exports[`MapCard.vue Events should receive and process correctly the event when 
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>
@@ -55,7 +55,7 @@ exports[`MapCard.vue Events should receive and process correctly the event when 
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>
@@ -88,7 +88,7 @@ exports[`MapCard.vue Methods should close quick actions 1`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>
@@ -121,7 +121,7 @@ exports[`MapCard.vue Methods should open quick actions 1`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>
@@ -155,7 +155,7 @@ exports[`MapCard.vue Methods should show thumbnail error 1`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>
@@ -188,7 +188,7 @@ exports[`MapCard.vue Methods should toggle mouse hover 1`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>
@@ -221,7 +221,7 @@ exports[`MapCard.vue Methods should toggle mouse hover 2`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>
@@ -254,7 +254,7 @@ exports[`MapCard.vue should render correct contents 1`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>
@@ -287,7 +287,7 @@ exports[`MapCard.vue should render description and tag dropdown 1`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <!---->
         <featuresdropdown-stub list="Hi,Hello,CARTO Rules,Shows dropdown" feature="tag" linkroute="tagSearch"><span class="feature-text text is-caption is-txtGrey">4 MapCard.tags</span></featuresdropdown-stub>
       </li>
@@ -318,7 +318,7 @@ exports[`MapCard.vue should render description and tags 1`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li>
             <router-link to="[object Object]" class="card-tags__tag">Hi</router-link><span>, </span>
@@ -361,7 +361,7 @@ exports[`MapCard.vue should show the map is shared 1`] = `
       <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/calendar.svg"></span>
         <p>MapCard.lastUpdate</p>
       </li>
-      <li class="card-metadataItem text is-caption"><span class="icon"><img inline-svg="" src="../../assets/icons/maps/tag.svg"></span>
+      <li class="card-metadataItem text is-caption"><span class="icon"><img svg-inline="" src="../../assets/icons/common/tag.svg" class="icon__tags"></span>
         <ul class="card-tags">
           <li><span>MapCard.noTags</span></li>
         </ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.83-tags-1",
+  "version": "1.0.0-assets.83-tags-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.83",
+  "version": "1.0.0-assets.83-tags-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.83-tags-3",
+  "version": "1.0.0-assets.83",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.83-tags-2",
+  "version": "1.0.0-assets.83-tags-3",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We have unified all the tag icons so all are right oriented, and have proper spacing and alignment:
- `View your tags` button
- `Your tags` title
- Condensed maps cards
- Regular maps cards
- Dataset cards

### Related issue
https://github.com/CartoDB/cartodb/issues/14773