### PR TITLE
Fix CSS issues in Groups and Add groups panels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@ Development
 - Sidebar overlaps Header in profile page ([#14803](https://github.com/CartoDB/cartodb/issues/14803))
 - Remove migrated dashboard ([#14741](https://github.com/CartoDB/cartodb/pull/14741))
 - Change tag icon and spacing ([#14773](https://github.com/CartoDB/cartodb/issues/14773))
+- Fix minor CSS issues in Groups and Add groups panels ([#14786](https://github.com/CartoDB/cartodb/issues/14786))
 
 4.26.0 (2019-03-11)
 -------------------

--- a/assets/stylesheets/common/create/create_header.scss
+++ b/assets/stylesheets/common/create/create_header.scss
@@ -3,7 +3,7 @@
 
 .CreateDialog-header {
   min-height: 100px !important;
-  max-height: 100px;
+  max-height: 156px;
 }
 .CreateDialog-header.with-separator { border-bottom: 1px solid $cStructure-mainLine; }
 

--- a/assets/stylesheets/organization/organization_users_list.scss
+++ b/assets/stylesheets/organization/organization_users_list.scss
@@ -27,28 +27,21 @@ $selectedItemPaddingOnSides: $sMargin-element - 1px;
 .OrganizationList-user {
   position: relative;
   width: 100%;
+  padding: 0 $selectedItemPaddingOnSides;
+  border: 1px transparent solid;
+  border-radius: 4px;
 
   &:not(:last-child) { border-bottom: 1px solid $cStructure-softLine; }
 }
 // TODO: this is duplicated from .DatasetsList-item, can we consolidate these styles somehow?
 .OrganizationList-user.is-selectable:hover {
-  margin-top: -1px;
-  margin-right: -#{$sMargin-element};
-  margin-left: -#{$sMargin-element};
-  padding: 0 $selectedItemPaddingOnSides;
-  border: 1px $cCard-hoverBorder solid;
-  border-radius: 4px;
+  border-color: $cCard-hoverBorder;
   background-color: $cCard-hoverFill;
 }
 
 .OrganizationList-user.is-selected {
-  margin-top: -1px; // to overlap border of prev element
-  margin-right: -#{$sMargin-element};
-  margin-left: -#{$sMargin-element};
-  padding: 0 $selectedItemPaddingOnSides;
-  border: 1px $cCard-selectedBorder solid;
-  border-radius: 4px;
-  background-color: $cCard-selectedFill;
+  border-color: $cCard-hoverBorder;
+  background-color: $cCard-hoverFill;
 
   &:hover {
     border: 1px $cCard-selectedBorder solid;
@@ -102,6 +95,10 @@ $selectedItemPaddingOnSides: $sMargin-element - 1px;
 .OrganizationList-userInfoData {
   display: flex;
   flex-direction: row;
+
+  &--paragraph-icon {
+    margin-right: 5px;
+  }
 }
 
 .OrganizationList-userStats {

--- a/assets/stylesheets/organization/organization_users_list.scss
+++ b/assets/stylesheets/organization/organization_users_list.scss
@@ -97,7 +97,7 @@ $selectedItemPaddingOnSides: $sMargin-element - 1px;
   flex-direction: row;
 
   &--paragraph-icon {
-    margin-right: 5px;
+    margin-right: 4px;
   }
 }
 

--- a/assets/stylesheets/organization/organization_users_list.scss
+++ b/assets/stylesheets/organization/organization_users_list.scss
@@ -40,11 +40,11 @@ $selectedItemPaddingOnSides: $sMargin-element - 1px;
 }
 
 .OrganizationList-user.is-selected {
-  border-color: $cCard-hoverBorder;
-  background-color: $cCard-hoverFill;
+  border-color: $cCard-selectedBorder;
+  background-color: $cCard-selectedFill;
 
   &:hover {
-    border: 1px $cCard-selectedBorder solid;
+    border-color: $cCard-selectedBorder;
     background-color: $cCard-selectedFill;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.83-groups-1",
+  "version": "1.0.0-assets.83-groups-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.83",
+  "version": "1.0.0-assets.83-groups-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Add paddings to OrganizationList-user to default state so it doesn’t flicker when hovering
- Change the header max-height of the header in the dialog so that the text is not cut
- Add spacing to separate the text from the icon in maps and dataset labels

### Related issues
Check https://github.com/CartoDB/cartodb/issues/14786 for full details