### PR TITLE
Change header margin bottom in cards

### DIFF
--- a/lib/assets/javascripts/new-dashboard/components/Dataset/DatasetListHeader.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Dataset/DatasetListHeader.vue
@@ -131,7 +131,7 @@ export default {
   display: flex;
   align-items: center;
   width: 100%;
-  margin-bottom: 0;
+  margin-bottom: 1px;
   padding: 14px;
   overflow: hidden;
   border-bottom: 1px solid $softblue;

--- a/lib/assets/javascripts/new-dashboard/components/MapCard/CondensedMapHeader.vue
+++ b/lib/assets/javascripts/new-dashboard/components/MapCard/CondensedMapHeader.vue
@@ -111,7 +111,7 @@ export default {
   display: flex;
   align-items: center;
   width: 100%;
-  margin-bottom: 0;
+  margin-bottom: 1px;
   padding: 14px;
   overflow: hidden;
   border-bottom: 1px solid $softblue;


### PR DESCRIPTION
When selecting datasets or map cards in condensed views, the upper border in the first row is hidden below the header. Added a margin-bottom to the header to leave space for the border to show up.