### PR TITLE
Add badge for first onboarding visitors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@ Development
 - Change tag icon and spacing ([#14773](https://github.com/CartoDB/cartodb/issues/14773))
 - Dashboard onboarding: Timeline animation and bug fixes ([#14789](https://github.com/CartoDB/cartodb/pull/14789))
 - Fix minor CSS issues in Groups and Add groups panels ([#14786](https://github.com/CartoDB/cartodb/issues/14786))
+- Add badge for first onboarding visitors [#14831](https://github.com/CartoDB/cartodb/pull/14831)
 
 4.26.0 (2019-03-11)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/components/Onboarding/OnboardingButton.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Onboarding/OnboardingButton.vue
@@ -19,7 +19,7 @@ export default {
   data () {
     return {
       hasVisitedOnboarding: false
-    }
+    };
   },
   mounted () {
     this.hasVisitedOnboarding = this.setHasVisitedOnboarding();
@@ -33,7 +33,7 @@ export default {
       if (localStorage.hasOwnProperty('hasVisitedOnboarding')) {
         return JSON.parse(window.localStorage.getItem('hasVisitedOnboarding'));
       } else {
-        return false
+        return false;
       }
     },
     updateHasVisitedOnboarding (visited) {

--- a/lib/assets/javascripts/new-dashboard/components/Onboarding/OnboardingButton.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Onboarding/OnboardingButton.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     class="button"
-    :class="[isFirstTimeViewingDashboard ? 'button--cta' : 'button--ghost']"
+    :class="[{'not-visited': !(hasVisitedOnboarding || isFirstTimeViewingDashboard)}, isFirstTimeViewingDashboard ? 'button--cta' : 'button--ghost']"
     @click="openOnboarding()">
     {{ $t('Wizards.Distributor.cta') }}
   </button>
@@ -16,10 +16,48 @@ export default {
       default: false
     }
   },
+  data () {
+    return {
+      hasVisitedOnboarding: false
+    }
+  },
+  mounted () {
+    this.hasVisitedOnboarding = this.setHasVisitedOnboarding();
+  },
   methods: {
     openOnboarding () {
+      this.updateHasVisitedOnboarding(true);
       this.$router.push({ name: 'onboarding' });
+    },
+    setHasVisitedOnboarding () {
+      if (localStorage.hasOwnProperty('hasVisitedOnboarding')) {
+        return JSON.parse(window.localStorage.getItem('hasVisitedOnboarding'));
+      } else {
+        return false
+      }
+    },
+    updateHasVisitedOnboarding (visited) {
+      this.hasVisitedOnboarding = visited;
+      localStorage.hasVisitedOnboarding = JSON.stringify(visited);
     }
   }
 };
 </script>
+<style scoped lang="scss">
+@import 'new-dashboard/styles/variables';
+
+button.button--ghost {
+  position: relative;
+
+  &.not-visited::after {
+    content: '';
+    position: absolute;
+    top: -4px;
+    right: -12px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: $onboarding-notification;
+  }
+}
+</style>

--- a/lib/assets/javascripts/new-dashboard/components/Onboarding/distributor/Selector.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Onboarding/distributor/Selector.vue
@@ -103,7 +103,9 @@ export default {
     }
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
+    outline: none;
     background-color: $softblue;
     box-shadow: $card__shadow;
 

--- a/lib/assets/javascripts/new-dashboard/components/Onboarding/distributor/Selector.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Onboarding/distributor/Selector.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="selector" tabindex="0">
-    <h3 class="title is-body is-medium u-mb--8" :class="iconClass">
-      {{ this.title }}
-    </h3>
+    <div>
+      <h3 class="selector__title title is-body is-medium u-mb--8" :class="iconClass">
+        {{ this.title }}
+      </h3>
 
-    <p class="text is-caption">{{ this.text }}</p>
+      <p class="text is-caption">{{ this.text }}</p>
+    </div>
 
     <ul class="selector__tags">
       <li class="selector__tags-item title" v-for="tag in tags" :key="tag">{{ tag }}</li>
@@ -41,6 +43,9 @@ export default {
 @import 'new-dashboard/styles/variables';
 
 .selector {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   max-width: 460px;
   height: 340px;
   padding: 1.5em;
@@ -86,8 +91,6 @@ export default {
   }
 
   &__tags {
-    margin-top: 66px;
-
     &-item {
       display: inline-block;
       margin-top: 8px;
@@ -104,7 +107,7 @@ export default {
     background-color: $softblue;
     box-shadow: $card__shadow;
 
-    > .title {
+    .selector__title {
       color: $primary-color;
       text-decoration: underline;
     }

--- a/lib/assets/javascripts/new-dashboard/components/Onboarding/distributor/Selector.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Onboarding/distributor/Selector.vue
@@ -4,7 +4,7 @@
       {{ this.title }}
     </h3>
 
-    <p class="is-caption">{{ this.text }}</p>
+    <p class="text is-caption">{{ this.text }}</p>
 
     <ul class="selector__tags">
       <li class="selector__tags-item title" v-for="tag in tags" :key="tag">{{ tag }}</li>
@@ -97,6 +97,16 @@ export default {
       border-radius: 3px;
       font-size: 10px;
       text-transform: uppercase;
+    }
+  }
+
+  &:hover {
+    background-color: $softblue;
+    box-shadow: $card__shadow;
+
+    > .title {
+      color: $primary-color;
+      text-decoration: underline;
     }
   }
 }

--- a/lib/assets/javascripts/new-dashboard/components/Onboarding/distributor/Selector.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Onboarding/distributor/Selector.vue
@@ -97,7 +97,7 @@ export default {
       margin-right: 8px;
       padding: 6px 16px;
       border: 1px solid $onboarding-tags__border-color;
-      border-radius: 3px;
+      border-radius: 18px;
       font-size: 10px;
       text-transform: uppercase;
     }

--- a/lib/assets/javascripts/new-dashboard/components/Onboarding/tutorials/Builder/DatasetCard_21.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Onboarding/tutorials/Builder/DatasetCard_21.vue
@@ -39,7 +39,7 @@ export default {
     margin-right: 16px;
     border-radius: 2px;
     background-color: #F2F6F9;
-    background-image: url(/assets/1.0.0-assets.dashboard-onboarding-11/images/dots.svg);
+    background-image: url(../../../../assets/icons/datasets/data-types/dots.svg);
     background-repeat: no-repeat;
     background-position: center;
     background-size: 18px;

--- a/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/WelcomeCompact.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/WelcomeCompact.vue
@@ -73,7 +73,7 @@ export default {
   }
 
   .button--ghost {
-    margin-right: 36px;
+    margin-right: 48px;
     padding: 0;
     background: none;
     color: #047AE6;

--- a/lib/assets/javascripts/new-dashboard/styles/variables.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/variables.scss
@@ -47,6 +47,7 @@ $onboarding__bg-color: #F9F9F9;
 $onboarding-tags__border-color: #34444C;
 $onboarding-congrats__height: 445px;
 $onboarding-congrats__bg-color: rgba(203, 228, 255, 0.3);
+$onboarding-notification: #FEE600;
 $z-index__dialog: 1000;
 $z-index__navbar: 5;
 $z-index__subheader: 4;

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/OnboardingButton.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/OnboardingButton.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount } from '@vue/test-utils';
 import OnboardingButton from 'new-dashboard/components/Onboarding/OnboardingButton';
 
 const $t = key => key;
@@ -6,6 +6,9 @@ const $t = key => key;
 describe('OnboardingButton.vue', () => {
   it('should render properly', () => {
     const onboardingButton = shallowMount(OnboardingButton, {
+      propsData: {
+        isFirstTimeViewingDashboard: false
+      },
       mocks: { $t }
     });
 
@@ -23,6 +26,23 @@ describe('OnboardingButton.vue', () => {
     expect(onboardingButton).toMatchSnapshot();
   });
 
+  it('should not contain not-visited class after opening onboarding', () => {
+    const $router = {
+      push: jest.fn()
+    };
+
+    const onboardingButton = shallowMount(OnboardingButton, {
+      propsData: {
+        isFirstTimeViewingDashboard: false
+      },
+      mocks: { $t, $router }
+    });
+
+    onboardingButton.vm.openOnboarding();
+
+    expect(onboardingButton).toMatchSnapshot();
+  });
+
   describe('Methods', () => {
     it('should call router.push when opening onboarding', () => {
       const $router = {
@@ -36,6 +56,22 @@ describe('OnboardingButton.vue', () => {
       onboardingButton.vm.openOnboarding();
 
       expect($router.push).toHaveBeenCalledWith({ name: 'onboarding' });
+    });
+
+    it('should call updateHasVisitedOnboarding with true when opening onboarding', () => {
+      const $router = {
+        push: jest.fn()
+      };
+      const updateHasVisitedOnboarding = jest.fn();
+
+      const onboardingButton = shallowMount(OnboardingButton, {
+        mocks: { $t, $router },
+        methods: { updateHasVisitedOnboarding }
+      });
+
+      onboardingButton.vm.openOnboarding();
+
+      expect(updateHasVisitedOnboarding).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/OnboardingButton.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/OnboardingButton.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount, mount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import OnboardingButton from 'new-dashboard/components/Onboarding/OnboardingButton';
 
 const $t = key => key;

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/__snapshots__/OnboardingButton.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/__snapshots__/OnboardingButton.spec.js.snap
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OnboardingButton.vue should render properly 1`] = `
+exports[`OnboardingButton.vue should not contain not-visited class after opening onboarding 1`] = `
 <button class="button button--ghost">
+  Wizards.Distributor.cta
+</button>
+`;
+
+exports[`OnboardingButton.vue should render properly 1`] = `
+<button class="button not-visited button--ghost">
   Wizards.Distributor.cta
 </button>
 `;

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/distributor/__snapshots__/Selector.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/distributor/__snapshots__/Selector.spec.js.snap
@@ -2,10 +2,12 @@
 
 exports[`Selector.vue should render properly 1`] = `
 <div tabindex="0" class="selector">
-  <h3 class="title is-body is-medium u-mb--8">
-    JavaScript Tutorial
-  </h3>
-  <p class="text is-caption">This a fake description</p>
+  <div>
+    <h3 class="selector__title title is-body is-medium u-mb--8">
+      JavaScript Tutorial
+    </h3>
+    <p class="text is-caption">This a fake description</p>
+  </div>
   <ul class="selector__tags">
     <li class="selector__tags-item title">Fake tag</li>
     <li class="selector__tags-item title">More fake tag</li>

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/distributor/__snapshots__/Selector.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/Onboarding/distributor/__snapshots__/Selector.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Selector.vue should render properly 1`] = `
   <h3 class="title is-body is-medium u-mb--8">
     JavaScript Tutorial
   </h3>
-  <p class="is-caption">This a fake description</p>
+  <p class="text is-caption">This a fake description</p>
   <ul class="selector__tags">
     <li class="selector__tags-item title">Fake tag</li>
     <li class="selector__tags-item title">More fake tag</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.87-ob-visited",
+  "version": "1.0.0-assets.87",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.87",
+  "version": "1.0.0-assets.87-ob-visited",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.87-onboarding-visited",
+  "version": "1.0.0-assets.87",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.87",
+  "version": "1.0.0-assets.87-onboarding-visited",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add badge for **first Onboarding visitors** (removed once the onboarding wizard has been opened):

<img width="827" alt="Screen Shot 2019-04-17 at 13 40 34" src="https://user-images.githubusercontent.com/26403479/56287054-aca4bf00-611b-11e9-8ae1-0888fc008bbd.png">


> 

This PR includes as well:
- Fix hover in Selectors card
- Fix icon path in fake Dataset card of Builder tutorial
- Increase border radius in selector tags to avoid button confusion