### PR TITLE
Add or clean massively notifications using rake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/lib/tasks/layers_rake_spec.rb \
 	spec/lib/tasks/fix_unique_legends_spec.rb \
 	spec/lib/tasks/oauth_rake_spec.rb \
+	spec/lib/tasks/user_rake_spec.rb \
 	spec/models/carto/username_proposer_spec.rb \
 	spec/services/carto/overquota_users_service_spec.rb \
 	spec/services/visualization/common_data_service_spec.rb \

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -128,4 +128,27 @@ namespace :user do
       end
     end
   end
+
+  namespace :notifications do
+    desc 'Add a text in the notification field for users filtered by field'
+    task :add_by_field, [:filter_field, :filter_value, :notification] => [:environment] do |task, args|
+      allowed_fields = ['database_host']
+      raise "Filter field and value are needed" if args[:filter_field].nil? || args[:filter_value].nil?
+      raise "Unknown field #{args[:filter_field]} for filtering. Allowed fields are #{allowed_fields.join(',')}" unless allowed_fields.include?(args[:filter_field])
+      raise "Notification not provided. Please include it" if args[:notification].nil?
+      sql = "UPDATE users SET notification = '%s' WHERE %s = '%s'"
+      query = ActiveRecord::Base.send(:sanitize_sql_array, [sql, args[:notification], args[:filter_field], args[:filter_value]])
+      ActiveRecord::Base.connection.execute(query)
+    end
+
+    desc 'Clean notification for users filtered by field'
+    task :clean_by_field, [:filter_field, :filter_value] => [:environment] do |task, args|
+      allowed_fields = ['database_host']
+      raise "Filter field and value are needed" if args[:filter_field].nil? || args[:filter_value].nil?
+      raise "Unknown field #{args[:filter_field]} for filtering. Allowed fields are #{allowed_fields.join(',')}" unless allowed_fields.include?(args[:filter_field])
+      sql = "UPDATE users SET notification = NULL WHERE %s = '%s'"
+      query = ActiveRecord::Base.send(:sanitize_sql_array, [sql, args[:filter_field], args[:filter_value]])
+      ActiveRecord::Base.connection.execute(query)
+    end
+  end
 end

--- a/spec/lib/tasks/user_rake_spec.rb
+++ b/spec/lib/tasks/user_rake_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper_min'
+require 'rake'
+
+describe 'user' do
+  before :all do
+    Rake.application.rake_require "tasks/user"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'notifications:add_by_field' do
+    it "should not accept wrong or incomplete input" do
+      expect {
+        Rake::Task["user:notifications:add_by_field"].reenable
+        Rake.application.invoke_task "user:notifications:add_by_field"
+      }.to raise_error(RuntimeError, "Filter field and value are needed")
+
+      expect {
+        Rake::Task["user:notifications:add_by_field"].reenable
+        Rake.application.invoke_task "user:notifications:add_by_field[database_host]"
+      }.to raise_error(RuntimeError, "Filter field and value are needed")
+
+      expect {
+        Rake::Task["user:notifications:add_by_field"].reenable
+        Rake.application.invoke_task "user:notifications:add_by_field[database_host,localhost]"
+      }.to raise_error(RuntimeError, "Notification not provided. Please include it")
+
+      expect {
+        Rake::Task["user:notifications:add_by_field"].reenable
+        Rake.application.invoke_task "user:notifications:add_by_field[unknown_field,localhost,test notification!]"
+      }.to raise_error(RuntimeError, "Unknown field unknown_field for filtering. Allowed fields are database_host")
+    end
+
+    it "should change the notification field for the users with localhost database" do
+      user = FactoryGirl.create(:valid_user)
+      user.database_host = "localhost"
+      user.save
+
+      user2 = FactoryGirl.create(:valid_user)
+      user2.database_host = "127.0.0.1"
+      user2.save
+
+      Rake::Task["user:notifications:add_by_field"].reenable
+      Rake.application.invoke_task "user:notifications:add_by_field[database_host,localhost,test notification!]"
+
+      user.reload.notification.should eql 'test notification!'
+      user2.reload.notification.should be_nil
+
+      user.destroy
+      user2.destroy
+    end
+  end
+
+  describe 'notifications:clean_by_field' do
+    it "should not accept wrong or incomplete input" do
+      expect {
+        Rake::Task["user:notifications:clean_by_field"].reenable
+        Rake.application.invoke_task "user:notifications:clean_by_field"
+      }.to raise_error(RuntimeError, "Filter field and value are needed")
+
+      expect {
+        Rake::Task["user:notifications:clean_by_field"].reenable
+        Rake.application.invoke_task "user:notifications:clean_by_field[database_host]"
+      }.to raise_error(RuntimeError, "Filter field and value are needed")
+
+      expect {
+        Rake::Task["user:notifications:clean_by_field"].reenable
+        Rake.application.invoke_task "user:notifications:clean_by_field[unknown_field,localhost]"
+      }.to raise_error(RuntimeError, "Unknown field unknown_field for filtering. Allowed fields are database_host")
+    end
+
+    it "should clean the notification field for the users with localhost database" do
+      user = FactoryGirl.create(:valid_user)
+      user.database_host = "localhost"
+      user.notification = 'test notification!'
+      user.save
+
+      user2 = FactoryGirl.create(:valid_user)
+      user2.database_host = "127.0.0.1"
+      user2.notification = 'test notification!'
+      user2.save
+
+      Rake::Task["user:notifications:clean_by_field"].reenable
+      Rake.application.invoke_task "user:notifications:clean_by_field[database_host,localhost]"
+
+      user.reload.notification.should be_nil
+      user2.reload.notification.should eql 'test notification!'
+
+      user.destroy
+      user2.destroy
+    end
+  end
+end


### PR DESCRIPTION
Related https://github.com/CartoDB/cartodb-platform/issues/5505

Rake to add a maintenance text in the notifications field filtering by a
field.

Instead of using the model, we're going to use raw SQL to perform the
update in the cartodb metadata database because we dont need to progress
this change to central.