### PR TITLE
changing st_text definition

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Chaging test related to deprecated st_text function [#14865](https://github.com/CartoDB/cartodb/pull/14865)
 
 4.26.1 (2019-05-06)
 -------------------

--- a/spec/models/carto/user_migration_spec.rb
+++ b/spec/models/carto/user_migration_spec.rb
@@ -589,6 +589,10 @@ describe 'UserMigration' do
       DummyTester.new.remove_line?(line4).should be false
       line5 = '541; 1259 735510 FOREIGN TABLE aggregation agg_admin1 postgres'
       DummyTester.new.remove_line?(line5).should be false
+      line6 = "242; 1255 148122 FUNCTION org00000001-admin st_text(boolean) test_cartodb_user_0711adbd-17fc-482d-babf-82b935f8b65e\n"
+      DummyTester.new.remove_line?(line6).should be true
+      line7 = '5003; 0 0 ACL org00000001-admin FUNCTION "st_text"(boolean) test_cartodb_user_0711adbd-17fc-482d-babf-82b935f8b65e'
+      DummyTester.new.remove_line?(line7).should be true
     end
 
     it 'skips importing legacy functions using fixture' do
@@ -677,7 +681,7 @@ describe 'UserMigration' do
       it 'should not import acl over deprecated functions' do
         user1 = @carto_organization.users.first
         user2 = @carto_organization.users.last
-        user1.in_database.execute('CREATE OR REPLACE FUNCTION st_text(b boolean) RETURNS INT AS $$
+        user1.in_database.execute('CREATE OR REPLACE FUNCTION st_text(boolean) RETURNS INT AS $$
         BEGIN
           RETURN 1;
         END;

--- a/spec/models/carto/user_migration_spec.rb
+++ b/spec/models/carto/user_migration_spec.rb
@@ -589,9 +589,9 @@ describe 'UserMigration' do
       DummyTester.new.remove_line?(line4).should be false
       line5 = '541; 1259 735510 FOREIGN TABLE aggregation agg_admin1 postgres'
       DummyTester.new.remove_line?(line5).should be false
-      line6 = "242; 1255 148122 FUNCTION org00000001-admin st_text(boolean) test_cartodb_user_0711adbd-17fc-482d-babf-82b935f8b65e\n"
+      line6 = '242; 1255 148122 FUNCTION org00000001-admin st_text(boolean)'
       DummyTester.new.remove_line?(line6).should be true
-      line7 = '5003; 0 0 ACL org00000001-admin FUNCTION "st_text"(boolean) test_cartodb_user_0711adbd-17fc-482d-babf-82b935f8b65e'
+      line7 = '5003; 0 0 ACL org000001-admin FUNCTION "st_text"(boolean)'
       DummyTester.new.remove_line?(line7).should be true
     end
 


### PR DESCRIPTION
Solves https://github.com/CartoDB/cartodb/issues/14855

The function was created without parameter name (only type), so I have done the same in the test which creates the function. I think the regex and the migrations works fine with this change, so I have followed the easy path.