### PR TITLE
Limit regular API keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Development
 
 ### Features
 - Add notification warning to display user notifications when necessary [#14859](https://github.com/CartoDB/cartodb/issues/14859)
+- Limit regular api keys ([#14863](https://github.com/CartoDB/cartodb/issues/14863))
 
 ### Bug fixes / enhancements
 - Improve caching management when table permissions change ([CartoDB/cartodb-management#5218](https://github.com/CartoDB/cartodb-management/issues/5218))

--- a/app/controllers/carto/api/api_keys_controller.rb
+++ b/app/controllers/carto/api/api_keys_controller.rb
@@ -17,6 +17,7 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
   rescue_from Carto::LoadError, with: :rescue_from_carto_error
   rescue_from Carto::UnprocesableEntityError, with: :rescue_from_carto_error
   rescue_from Carto::UnauthorizedError, with: :rescue_from_carto_error
+  rescue_from Carto::CartoError, with: :rescue_from_carto_error
 
   VALID_ORDER_PARAMS = [:type, :name, :updated_at].freeze
 
@@ -26,6 +27,8 @@ class Carto::Api::ApiKeysController < ::Api::ApplicationController
     render_jsonp(Carto::Api::ApiKeyPresenter.new(api_key).to_poro, 201)
   rescue ActiveRecord::RecordInvalid => e
     raise Carto::UnprocesableEntityError.new(e.message)
+  rescue CartoDB::QuotaExceeded => e
+    raise Carto::CartoError.new(e.message, 403)
   end
 
   def destroy

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -143,6 +143,9 @@ module Carto
     end
 
     def self.create_regular_key!(user: Carto::User.find(scope_attributes['user_id']), name:, grants:)
+      over_regular_quota = CartoDB::QuotaChecker.new(user).will_be_over_regular_api_key_quota?
+      raise CartoDB::QuotaExceeded.new('You have reached your regular API keys quota') if over_regular_quota
+
       create!(
         user: user,
         type: TYPE_REGULAR,

--- a/app/models/quota_checker.rb
+++ b/app/models/quota_checker.rb
@@ -4,21 +4,32 @@ module CartoDB
   class QuotaChecker
     def initialize(user)
       @user = user
-    end 
+    end
 
     def will_be_over_table_quota?(number_of_new_tables)
       return false unless user.remaining_table_quota
+
       number_of_new_tables.to_i > user.remaining_table_quota.to_i
     end
 
     def over_table_quota?
       return false unless user.remaining_table_quota
+
       user.tables.count > user.table_quota.to_i
+    end
+
+    def will_be_over_regular_api_key_quota?
+      return false unless user.regular_api_key_quota
+
+      regular_api_key_count >= user.regular_api_key_quota
     end
 
     private
 
-    attr_reader :user
-  end # QuotaChecker
-end # CartoDB
+    def regular_api_key_count
+      user.api_keys.select { |api_key| api_key.type == Carto::ApiKey::TYPE_REGULAR }.count
+    end
 
+    attr_reader :user
+  end
+end

--- a/spec/models/carto/api_key_spec.rb
+++ b/spec/models/carto/api_key_spec.rb
@@ -342,7 +342,7 @@ describe Carto::ApiKey do
 
         it 'raises an exception when creating a regular key' do
           grants = [database_grant(@table1.database_schema, @table1.name), apis_grant]
-  
+
           expect {
             @carto_user1.api_keys.create_regular_key!(name: 'full', grants: grants)
           }.to raise_exception(CartoDB::QuotaExceeded, /regular API keys quota/)

--- a/spec/models/carto/api_key_spec.rb
+++ b/spec/models/carto/api_key_spec.rb
@@ -328,6 +328,26 @@ describe Carto::ApiKey do
           @carto_user1.api_keys.create_regular_key!(name: 'x', grants: two_apis_grant)
         }.to raise_exception(ActiveRecord::RecordInvalid, /Grants only one user section is allowed/)
       end
+
+      context 'without enough regular api key quota' do
+        before(:all) do
+          @carto_user1.regular_api_key_quota = 0
+          @carto_user1.save
+        end
+
+        after(:all) do
+          @carto_user1.regular_api_key_quota = be_nil
+          @carto_user1.save
+        end
+
+        it 'raises an exception when creating a regular key' do
+          grants = [database_grant(@table1.database_schema, @table1.name), apis_grant]
+  
+          expect {
+            @carto_user1.api_keys.create_regular_key!(name: 'full', grants: grants)
+          }.to raise_exception(CartoDB::QuotaExceeded, /regular API keys quota/)
+        end
+      end
     end
 
     describe '#table_permission_from_db' do

--- a/spec/requests/carto/api/api_keys_controller_spec.rb
+++ b/spec/requests/carto/api/api_keys_controller_spec.rb
@@ -344,6 +344,26 @@ describe Carto::Api::ApiKeysController do
 
         Carto::ApiKey.where(name: 'wadus').each(&:destroy)
       end
+
+      context 'without enough regular api key quota' do
+        before(:all) do
+          @carto_user.regular_api_key_quota = 0
+          @carto_user.save
+        end
+
+        after(:all) do
+          @carto_user.regular_api_key_quota = be_nil
+          @carto_user.save
+        end
+
+        it 'fails creating a regular key' do
+          auth_user(@carto_user)
+          post_json api_keys_url, auth_params.merge(create_payload), auth_headers do |response|
+            response.status.should eq 403
+            response.body[:errors].should match /regular API keys quota/
+          end
+        end
+      end
     end
 
     describe '#destroy' do


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/14863

`/api_keys` endpoint now returns a 403 error when creating a new regular API key and there is not enough quota. The frontend already shows the proper message.