### PR TITLE
[Salt I] Default salt

### DIFF
--- a/db/migrate/20190517114808_add_default_salt.rb
+++ b/db/migrate/20190517114808_add_default_salt.rb
@@ -7,9 +7,15 @@ migration(
     alter_table(:users) do
       set_column_default :salt, ''
     end
+    alter_table(:user_creations) do
+      set_column_default :salt, ''
+    end
   end,
   Proc.new do
     alter_table(:users) do
+      set_column_default :salt, nil
+    end
+    alter_table(:user_creations) do
       set_column_default :salt, nil
     end
   end

--- a/db/migrate/20190517114808_add_default_salt_to_users.rb
+++ b/db/migrate/20190517114808_add_default_salt_to_users.rb
@@ -1,0 +1,16 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  Proc.new do
+    alter_table(:users) do
+      set_column_default :salt, ''
+    end
+  end,
+  Proc.new do
+    alter_table(:users) do
+      set_column_default :salt, nil
+    end
+  end
+)


### PR DESCRIPTION
Related to https://github.com/CartoDB/product/issues/291

Before removing all the appearances in the code, we need to add a default value (`''`) to the salt column in `users` and `user_creations` tables.