### PR TITLE
Fix empty navigation for non engine users in API keys page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ Development
 - Minor copy edit in final step of Builder Onboarding
 - Filter API keys by type (#14904)
 - Change API keys page layout ([#14907](https://github.com/CartoDB/cartodb/pull/14907))
+- Fix empty navigation for non engine users in API keys page ([#14916](https://github.com/CartoDB/cartodb/pull/14916))
 
 4.26.1 (2019-05-06)
 -------------------

--- a/app/views/admin/client_applications/api_key.html.erb
+++ b/app/views/admin/client_applications/api_key.html.erb
@@ -11,10 +11,7 @@
     var dashboardNotifications = <%= safe_js_object @dashboard_notifications.to_json %>;
     var organization_notifications = <%= safe_js_object @organization_notifications.to_json %>;
   </script>
-
-  <% if @has_engine_enabled %>
-    <%= javascript_include_tag 'common', 'common_vendor', 'api_keys_new' %>
-  <% end %>
+  <%= javascript_include_tag 'common', 'common_vendor', 'api_keys_new' %>
 <% end %>
 
 <%= content_for(:css) do %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.96",
+  "version": "1.0.0-assets.96-nonengine",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.96-nonengine",
+  "version": "1.0.0-assets.96",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
#14915 

Acceptance to be done by:

- [x] Log as a non engine user
- [x] Check that navigation bar shows properly
- [x] Check that user dropdown works ok
- [x] Check that search box works ok
<img width="1219" alt="Screen Shot 2019-05-28 at 14 41 05" src="https://user-images.githubusercontent.com/26403479/58478571-b415aa00-8156-11e9-9d61-73c14ee41385.png">