### PR TITLE
[WIP] Incremental table syncing PoC

### DIFF
--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -66,7 +66,11 @@ module CartoDB
       def overwrite(table_name, result, geo_type)
         return false unless runner.remote_data_updated?
 
-        qualified_result_table_name = %{"#{result.schema}"."#{result.table_name}"}
+        # NOTE for some reason the import table is already moved to
+        # the user schema. My guess is that this is more a convenience
+        # than anything and that it can interfere with Ghost Tables
+        # and datasets in the Dashboard
+        qualified_result_table_name = %{"#{user.database_schema}"."#{result.table_name}"}
         skip_columns = '{the_geom, the_geom_webmercator}'
 
         database.transaction do

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -205,6 +205,10 @@ module CartoDB
         qualified_table_name = "\"#{schema_name}\".#{table_name}"
 
         user.db_service.in_database_direct_connection(statement_timeout: STATEMENT_TIMEOUT) do |user_database|
+
+          # For consistency with regular imports, also eases testing
+          Table.sanitize_columns(table_name, {database_schema: schema_name, connection: user_database})
+
           # When tables are created using ogr2ogr they are added a ogc_fid or gid primary key
           # In that case:
           #  - If cartodb_id already exists, remove ogc_fid

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -227,6 +227,9 @@ class Table
       # ensure unique name, also ensures self.name can override any imported table name
       uniname = get_valid_name(name ? name : migrate_existing_table) unless uniname
 
+      # Make sure column names are sanitized. Make it consistently.
+      self.class.sanitize_columns(uniname, {database_schema: owner.database_schema, connection: owner.in_database})
+
       # with table #{uniname} table created now run migrator to CartoDBify
       hash_in = ::SequelRails.configuration.environment_for(Rails.env).merge(
         'host' => owner.database_host,

--- a/lib/importer/lib/cartodb-migrator/migrator.rb
+++ b/lib/importer/lib/cartodb-migrator/migrator.rb
@@ -43,12 +43,8 @@ module CartoDB
     end
 
     def migrate!
-      # # Check if the file had data, if not rise an error because probably something went wrong
-
-      # Sanitize column names where needed
-      column_names = @db_connection.schema(@current_name, {:schema => @target_schema}).map{ |s| s[0].to_s }
-
-      sanitize(column_names)
+      # Already done by Table#sanitize_columns in app/models/table.rb
+      #sanitize_columns!
 
       # Rename our table
       if @current_name != @suggested_name
@@ -80,6 +76,13 @@ module CartoDB
         puts str
       end
     end
+
+    # Sanitize column names where needed
+    def sanitize_columns!
+      column_names = @db_connection.schema(@current_name, {:schema => @target_schema}).map{ |s| s[0].to_s }
+      sanitize(column_names)
+    end
+
 
     def sanitize(column_names)
       columns_to_sanitize = column_names.select do |column_name|

--- a/spec/models/synchronization/member_spec.rb
+++ b/spec/models/synchronization/member_spec.rb
@@ -149,7 +149,7 @@ describe Synchronization::Member do
         @user1.reload
       end
 
-      it 'fails to overwrite tables with views' do
+      it 'now works with tables with views' do
         url = 'https://wadus.com/guess_country.csv'
 
         path = fake_data_path('guess_country.csv')
@@ -170,8 +170,7 @@ describe Synchronization::Member do
         @user2.in_database.execute('CREATE VIEW wadus AS SELECT * FROM guess_country')
 
         member.run
-        expect(member.state).to eq 'failure'
-        expect(member.error_code).to eq 2013
+        expect(member.state).to eq 'success'
       end
 
       it 'should sync files with missing ogc_fid' do

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8
+# coding: utf-8
 
 # NOTE that these tests are very sensitive to precisce versions of GDAL (1.9.0)
 # 747 # Table post import processing tests should add a point the_geom column after importing a CSV
@@ -1240,7 +1240,7 @@ describe Table do
 
         table = create_table(user_table: UserTable[data_import.table_id], user_id: @user.id)
         table.should_not be_nil, "Import failure: #{data_import.log}"
-        update_data = {:upo___nombre_partido=>"PSOEE"}
+        update_data = {:upo_nombre_partido=>"PSOEE"}
         id = 5
 
         lambda {
@@ -1248,7 +1248,7 @@ describe Table do
         }.should_not raise_error
 
         res = table.sequel.where(:cartodb_id => 5).first
-        res[:upo___nombre_partido].should == "PSOEE"
+        res[:upo_nombre_partido].should == "PSOEE"
       end
 
       it "should be able to insert data in rows with column names with multiple underscores" do
@@ -1260,14 +1260,14 @@ describe Table do
         table.should_not be_nil, "Import failure: #{data_import.log}"
 
         pk = nil
-        insert_data = {:upo___nombre_partido=>"PSOEE"}
+        insert_data = {:upo_nombre_partido=>"PSOEE"}
 
         lambda {
           pk = table.insert_row!(insert_data)
         }.should_not raise_error
 
         res = table.sequel.where(:cartodb_id => pk).first
-        res[:upo___nombre_partido].should == "PSOEE"
+        res[:upo_nombre_partido].should == "PSOEE"
       end
 
       # No longer used, now we automatically rename reserved word columns


### PR DESCRIPTION
This is a PoC using the `CDB_TableSync` function, which synchronizes tables incrementally. See https://github.com/CartoDB/cartodb-postgresql/pull/355 for details.

The main difference with respect to the old syncing mechanism is that there's no table replacement, so there are two main benefits:
- extra columns added after initial syncing (e.g: the_geom) are not lost in the process.
- it's easier to deal with metadata, there's no oid nor Ghost Tables dark magic required to mend the swap.
- meant to be more efficient for incremental changes vs locking and swapping big tables.

There are a few known issues / trade offs:
- A unique ID is required for the incremental syncing process. Whether a good one is picked or not depends upon having an explicit `cartodb_id` or accuracy of type guessing + `CDB_CartodbfyTable` identifying a suitable one.
- It does not behave well with schema changes, particularly when new columns are added to the source or when types of old ones change.