### PR TITLE
[DNM] Poc prevent schema locks

### DIFF
--- a/app/models/carto/user_service.rb
+++ b/app/models/carto/user_service.rb
@@ -111,6 +111,7 @@ module Carto
         in_database(as: :superuser) do |user_database|
           user_database.transaction do
             user_database.execute(%{SET LOCAL lock_timeout = '1s'})
+            user_database.execute(%{SET LOCAL statement_timeout = '5s'})
             user_database.execute(%{SELECT cartodb.#{user_data_size_function}}).first['cdb_userdatasize'].to_i
           end
         end

--- a/app/models/carto/user_service.rb
+++ b/app/models/carto/user_service.rb
@@ -127,7 +127,7 @@ module Carto
           end
         rescue => ee
           CartoDB.report_exception(ee, "Failed to get user db size, retrying...", user: @user)
-          raise ee
+          #raise ee
         end
         retry unless attempts > 1
         CartoDB.notify_exception(e, user: @user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1413,8 +1413,8 @@ class User < Sequel::Model
                                                           : "CDB_UserDataSize('#{self.database_schema}')"
       in_database(as: :superuser) do |user_database|
         user_database.transaction do
-          user_database.fetch(%{SET LOCAL lock_timeout = '1s'})
-          user_database.fetch(%{SET LOCAL statement_timeout = '5s'})
+          user_database.execute(%{SET LOCAL lock_timeout = '1s'})
+          user_database.execute(%{SET LOCAL statement_timeout = '1s'})
           user_database.fetch(%{SELECT cartodb.#{user_data_size_function}}).first[:cdb_userdatasize]
         end
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1414,6 +1414,7 @@ class User < Sequel::Model
       in_database(as: :superuser) do |user_database|
         user_database.transaction do
           user_database.fetch(%{SET LOCAL lock_timeout = '1s'})
+          user_database.fetch(%{SET LOCAL statement_timeout = '5s'})
           user_database.fetch(%{SELECT cartodb.#{user_data_size_function}}).first[:cdb_userdatasize]
         end
       end


### PR DESCRIPTION

PoC: Avoid locks on table schema changes in long transactions

Warning: this is experimental code and shall no be merged without
further review and adjustments.

What it does:

- It sets pretty arbitrary statement_timout and lock_timeout here and
  there (not clear from code and traces what it does in the event of
  timeouts)

- It avoids table schema reloads as much as possible.