### PR TITLE
Add objectid as eligible id column by our content guesser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Include objectid column from GDB files to be used as ID column when the content guesser is activated [#14965](https://github.com/CartoDB/cartodb/pull/14965)
 
 4.27.1 (2019-06-20)
 -------------------

--- a/services/importer/lib/importer/content_guesser.rb
+++ b/services/importer/lib/importer/content_guesser.rb
@@ -14,7 +14,7 @@ module CartoDB
       COUNTRIES_COLUMN = 'name_'
       COUNTRIES_QUERY = "SELECT #{COUNTRIES_COLUMN} FROM admin0_synonyms"
       DEFAULT_MINIMUM_ENTROPY = 0.9
-      ID_COLUMNS = ['ogc_fid', 'gid', 'cartodb_id']
+      ID_COLUMNS = ['ogc_fid', 'gid', 'cartodb_id', 'objectid'].freeze
 
       attr_reader :country_name_normalizer
 

--- a/services/importer/spec/unit/content_guesser_spec.rb
+++ b/services/importer/spec/unit/content_guesser_spec.rb
@@ -199,20 +199,32 @@ describe CartoDB::Importer2::ContentGuesser do
     it 'should return a column name known to be sequential and with index' do
       db = mock
       list_of_columns = [
-        {:column_name=>"data", :data_type=>"string"},
-        {:column_name=>"ogc_fid", :data_type=>"integer"},
-        {:column_name=>"more_data", :data_type=>"string"},
+        { column_name: "data", data_type: "string" },
+        { column_name: "ogc_fid", data_type: "integer" },
+        { column_name: "more_data", data_type: "string" }
       ]
       db.expects(:[]).once.returns(list_of_columns)
       guesser = CartoDB::Importer2::ContentGuesser.new db, nil, nil, nil
       guesser.id_column.should eq 'ogc_fid'
     end
 
+    it "should use objectid in case the file is a gdb one" do
+      db = mock
+      list_of_columns = [
+        { column_name: "data", data_type: "string" },
+        { column_name: "objectid", data_type: "integer" },
+        { column_name: "more_data", data_type: "string" }
+      ]
+      db.expects(:[]).once.returns(list_of_columns)
+      guesser = CartoDB::Importer2::ContentGuesser.new db, nil, nil, nil
+      guesser.id_column.should eq 'objectid'
+    end
+
     it "should raise an exception if there's no suitable id column" do
       db = mock
       list_of_columns = [
-        {:column_name=>"data", :data_type=>"string"},
-        {:column_name=>"more_data", :data_type=>"string"},
+        { column_name: "data", data_type: "string" },
+        { column_name: "more_data", data_type: "string" }
       ]
       db.expects(:[]).once.returns(list_of_columns)
       guesser = CartoDB::Importer2::ContentGuesser.new db, nil, nil, nil


### PR DESCRIPTION
Related https://github.com/CartoDB/support/issues/2077

We have some whitelisted columns the prevails after ogr2ogr imports the file: ogc_fid, gid and cartodb_id but when we included GDB files in our catalog we didn't include its own column objectid.

Objectid is the id column for that type of files and is taken by ogr2ogr as the id column so in the fix I've made, we now include it as ID column and we use it as our cartodb_id when the content guesser is activated