### PR TITLE
Fix views without Trackjs config

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Development
 ### Bug fixes / enhancements
 - Update user industries options with the allowed values from Hubspot ([#14959](https://github.com/CartoDB/cartodb/pull/14959))
 - New Superadmin API to get user activity stats ([CartoDB/cartodb-central#2455](https://github.com/CartoDB/cartodb-central/issues/2455))
+- Do not require trackjs config ([#14979](https://github.com/CartoDB/cartodb/pull/14979))
 
 4.27.0 (2019-06-17)
 -------------------

--- a/app/views/admin/visualizations/embed_map.html.erb
+++ b/app/views/admin/visualizations/embed_map.html.erb
@@ -43,7 +43,7 @@
 <% end %>
 
 <%= content_for(:js) do %>
-  <%= insert_trackjs('embeds', Cartodb.config[:trackjs].try(:[], 'frequency')) %>
+  <%= insert_trackjs('embeds', Cartodb.get_config(:trackjs, 'frequency')) %>
   <%= render :partial => 'admin/visualizations/public/embed_map_inline_js' %>
   <%= insert_google_analytics('embeds', true) %>
 <% end %>

--- a/app/views/admin/visualizations/embed_map.html.erb
+++ b/app/views/admin/visualizations/embed_map.html.erb
@@ -43,7 +43,7 @@
 <% end %>
 
 <%= content_for(:js) do %>
-  <%= insert_trackjs('embeds', Cartodb.config[:trackjs]['frequency']) %>
+  <%= insert_trackjs('embeds', Cartodb.config[:trackjs].try(:[], 'frequency')) %>
   <%= render :partial => 'admin/visualizations/public/embed_map_inline_js' %>
   <%= insert_google_analytics('embeds', true) %>
 <% end %>

--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -299,7 +299,7 @@
 
 
 <%= content_for(:js) do %>
-  <%= insert_trackjs('embeds', Cartodb.config[:trackjs]['frequency']) %>
+  <%= insert_trackjs('embeds', Cartodb.config[:trackjs].try(:[], 'frequency')) %>
 
   <% if @visualization.map.provider == 'googlemaps' %>
     <%= insert_google_maps(@google_maps_query_string) %>

--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -299,7 +299,7 @@
 
 
 <%= content_for(:js) do %>
-  <%= insert_trackjs('embeds', Cartodb.config[:trackjs].try(:[], 'frequency')) %>
+  <%= insert_trackjs('embeds', Cartodb.get_config(:trackjs, 'frequency')) %>
 
   <% if @visualization.map.provider == 'googlemaps' %>
     <%= insert_google_maps(@google_maps_query_string) %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 
 <%= content_for(:js) do %>
-  <%= insert_trackjs('builder-embeds', Cartodb.config[:trackjs].try(:[], 'frequency')) %>
+  <%= insert_trackjs('builder-embeds', Cartodb.get_config(:trackjs, 'frequency')) %>
 
   <% if @vizjson[:map_provider] == 'googlemaps' && @google_maps_qs.present? %>
     <%= insert_google_maps(@google_maps_qs) %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -25,7 +25,7 @@
 <% end %>
 
 <%= content_for(:js) do %>
-  <%= insert_trackjs('builder-embeds', Cartodb.config[:trackjs]['frequency']) %>
+  <%= insert_trackjs('builder-embeds', Cartodb.config[:trackjs].try(:[], 'frequency')) %>
 
   <% if @vizjson[:map_provider] == 'googlemaps' && @google_maps_qs.present? %>
     <%= insert_google_maps(@google_maps_qs) %>

--- a/app/views/layouts/application_password_layout.html.erb
+++ b/app/views/layouts/application_password_layout.html.erb
@@ -30,7 +30,7 @@
       </div>
     </div>
 
-    <%= insert_trackjs('embeds', Cartodb.config[:trackjs].try(:[], 'frequency')) %>
+    <%= insert_trackjs('embeds', Cartodb.get_config(:trackjs, 'frequency')) %>
     <%= insert_google_analytics('embeds', true) %>
     <%= insert_hubspot() %>
   </body>

--- a/app/views/layouts/application_password_layout.html.erb
+++ b/app/views/layouts/application_password_layout.html.erb
@@ -30,7 +30,7 @@
       </div>
     </div>
 
-    <%= insert_trackjs('embeds', Cartodb.config[:trackjs]['frequency']) %>
+    <%= insert_trackjs('embeds', Cartodb.config[:trackjs].try(:[], 'frequency')) %>
     <%= insert_google_analytics('embeds', true) %>
     <%= insert_hubspot() %>
   </body>


### PR DESCRIPTION
Avoid some views to break when there is no `trackjs` config in `app_config.yml`