### PR TITLE
Update carto-package.json

### DIFF
--- a/carto-package.json
+++ b/carto-package.json
@@ -2,9 +2,9 @@
     "name": "carto_builder",
     "current_version": {
         "requires": {
-            "gdal": "2.2.2",
+            "gdal": ">=2.2.0 <2.4.0",
             "ruby": ">=2.4.0 <2.5.0",
-            "nodejs": "6.9.2",
+            "nodejs": ">=10.3.0 <11.0.0",
             "python": "~2.7.0",
             "unp": ">=2.0.0",
             "zip": ">=3.0.0",


### PR DESCRIPTION
- Update `gdal` required version to `>=2.2.0 <2.4.0`, we are running it with 2.2.2 but we are also running the tests against 2.3.2 in the Postgres 11 CI so this version is supported.
- Update `nodejs` required version to `>=10.3.0 <11.0.0` to match the current requirement of Node.js 10 and npm 6.
