### PR TITLE
Set maps and datasets filter to shared when user is viewer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Redirect viewer users to shared visualizations page, and show shared visualizations in Home ([CartoDB/support#2032](https://github.com/CartoDB/support/issues/2032))
 
 4.29.0 (2019-07-15)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/pages/Data.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Data.vue
@@ -50,6 +50,12 @@ export default {
       selectedDatasets: []
     };
   },
+  beforeMount () {
+    if (this.$store.getters['user/isViewer']) {
+      // Redirect to shared datasets page if user is viewer
+      return this.$router.replace({ name: 'datasets', params: { filter: 'shared' } });
+    }
+  },
   mounted () {
     this.stickyScrollPosition = this.getHeaderBottomPageOffset();
     this.$onScrollChange = this.onScrollChange.bind(this);

--- a/lib/assets/javascripts/new-dashboard/pages/Home/Home.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/Home.vue
@@ -40,6 +40,12 @@ export default {
     this.$store.dispatch('maps/setResultsPerPage', 6);
     this.$store.dispatch('datasets/setResultsPerPage', 6);
 
+    // If user is viewer, show shared maps and datasets
+    if (this.$store.getters['user/isViewer']) {
+      this.$store.dispatch('maps/filter', 'shared');
+      this.$store.dispatch('datasets/filter', 'shared');
+    }
+
     this.$store.dispatch('maps/fetch');
     this.$store.dispatch('datasets/fetch');
   },

--- a/lib/assets/javascripts/new-dashboard/pages/Maps.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Maps.vue
@@ -57,6 +57,12 @@ export default {
   created: function () {
     this.loadUserConfiguration();
   },
+  beforeMount () {
+    if (this.$store.getters['user/isViewer']) {
+      // Redirect to shared maps page if user is viewer
+      return this.$router.replace({ name: 'maps', params: { filter: 'shared' } });
+    }
+  },
   mounted () {
     this.stickyScrollPosition = this.getHeaderBottomPageOffset();
     this.$onScrollChange = this.onScrollChange.bind(this);


### PR DESCRIPTION
Redirect users to shared maps and shared datasets page if they are viewers, and show them the shared maps and shared datasets section in Home page.

Related to https://github.com/CartoDB/support/issues/2032.