### PR TITLE
Remove CARTO logo option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ sudo make install
 ### Bug fixes / enhancements
 - Redirect viewer users to shared visualizations page, and show shared visualizations in Home ([CartoDB/support#2032](https://github.com/CartoDB/support/issues/2032))
 - Fix user presenter ([#15033](https://github.com/CartoDB/cartodb/pull/15033))
+- Remove CARTO logo option ([CartoDB/support#2091](https://github.com/CartoDB/support/issues/2091))
 
 4.29.0 (2019-07-15)
 -------------------

--- a/lib/assets/javascripts/builder/data/map-settings.js
+++ b/lib/assets/javascripts/builder/data/map-settings.js
@@ -20,7 +20,8 @@ module.exports = function (overlaysCollection, mapDefModel, userModel) {
     setting: 'logo',
     label: _t('editor.settings.preview.options.elements.logo'),
     related: 'overlays',
-    disabled: !canRemoveLogo,
+    disabled: false,
+    hidden: !canRemoveLogo,
     enabler: overlays.indexOf('logo') > 0
   },
   {

--- a/lib/assets/javascripts/builder/editor/settings/preview/preview-options-view.js
+++ b/lib/assets/javascripts/builder/editor/settings/preview/preview-options-view.js
@@ -57,7 +57,12 @@ module.exports = CoreView.extend({
   },
 
   _renderSetting: function (model) {
-    var view = new OptionsItemView({
+    const hidden = model.get('hidden');
+    if (hidden) {
+      return;
+    }
+
+    const view = new OptionsItemView({
       model: model
     });
 


### PR DESCRIPTION
This PR hides the option to remove CARTO's logo in Builder. This option was previously disabled, but we want to remove it altogether for users that don't have that permission.

Related to https://github.com/CartoDB/support/issues/2091.