### PR TITLE
Fix spec_helper_min

### DIFF
--- a/spec/spec_helper_min.rb
+++ b/spec/spec_helper_min.rb
@@ -18,6 +18,10 @@ require 'rspec/rails'
 
 Resque.inline = true
 
+# host_validation is set to support `example.com` emails in specs
+# in production we do check for the existance of mx records associated to the domain
+EmailAddress::Config.configure(local_format: :conventional, host_validation: :syntax)
+
 RSpec.configure do |config|
   config.include SpecHelperHelpers
   config.include NamedMapsHelper


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/pull/15030

Support invalid email domains when using spec_helper_min.

The CI probably works because spec_helper adds this configuration before, but it fails if you run only one test using spec_helper_min.