### PR TITLE
Fix disabled privacy button when there are no other public maps.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ sudo make install
 - Fix user presenter ([#15033](https://github.com/CartoDB/cartodb/pull/15033))
 - Remove CARTO logo option ([CartoDB/support#2091](https://github.com/CartoDB/support/issues/2091))
 - Change embeds attribution character ([#14914](https://github.com/CartoDB/cartodb/issues/14914))
+- Fix disabled privacy button in Builder when there are no other public maps ([CartoDB/support#2163](https://github.com/CartoDB/support/issues/2163))
 
 4.29.0 (2019-07-15)
 -------------------

--- a/lib/assets/javascripts/builder/data/user-model.js
+++ b/lib/assets/javascripts/builder/data/user-model.js
@@ -91,15 +91,17 @@ var UserModel = Backbone.Model.extend({
 
   hasRemainingPublicMaps: function () {
     if (this.isPro2019User()) {
-      return !(!this.getTotalPublicMapsCount() || this.getTotalPublicMapsCount() >= this.get('public_map_quota'));
+      return this.get('public_map_quota') > this.getTotalPublicMapsCount();
     }
     return true;
   },
 
   getTotalPublicMapsCount: function () {
-    return this.get('public_privacy_map_count') +
-      this.get('password_privacy_map_count') +
-      this.get('link_privacy_map_count');
+    var totalPublicPrivacyMapsCount = this.get('public_privacy_map_count') || 0;
+    var totalPasswordPrivacyMapsCount = this.get('password_privacy_map_count') || 0;
+    var totalLinkPrivacyMapsCount = this.get('link_privacy_map_count') || 0;
+
+    return totalPublicPrivacyMapsCount + totalPasswordPrivacyMapsCount + totalLinkPrivacyMapsCount;
   },
 
   canCreateTwitterDataset: function () {

--- a/lib/assets/test/spec/builder/components/privacy-dropdown/privacy-dropdown-view.spec.js
+++ b/lib/assets/test/spec/builder/components/privacy-dropdown/privacy-dropdown-view.spec.js
@@ -108,16 +108,6 @@ describe('components/privacy-dropdown/privacy-dropdown-view', function () {
     });
 
     it('should render properly', function () {
-      visDefinitionModel = new VisDefinitionModel({
-        name: 'Foo Map',
-        privacy: 'PRIVATE',
-        updated_at: '2016-06-21T15:30:06+00:00',
-        type: 'derived',
-        permission: {}
-      }, {
-        configModel: configModel
-      });
-
       userModel = new UserModel({
         username: 'pepe',
         account_type: 'Professional',
@@ -132,14 +122,7 @@ describe('components/privacy-dropdown/privacy-dropdown-view', function () {
         configModel: configModel
       });
 
-      view = new PrivacyDropdown({
-        privacyCollection: collection,
-        visDefinitionModel: visDefinitionModel,
-        userModel: userModel,
-        configModel: configModel,
-        mapcapsCollection: mapcapsCollection,
-        isOwner: true
-      });
+      view = createPrivacyDropdown(userModel);
 
       view.render();
       view.$el.appendTo(document.body);
@@ -151,7 +134,57 @@ describe('components/privacy-dropdown/privacy-dropdown-view', function () {
       expect(view.$('.js-content').children().length).toBe(0); // empty initially
     });
 
+    it('should render properly and be active if there are no other public maps', function () {
+      userModel = new UserModel({
+        username: 'pepe',
+        account_type: 'Professional',
+        public_map_quota: 10,
+        public_privacy_map_count: 0,
+        password_privacy_map_count: 0,
+        link_privacy_map_count: 0,
+        actions: {
+          private_tables: true
+        }
+      }, {
+        configModel: configModel
+      });
+
+      view = createPrivacyDropdown(userModel);
+
+      view.render();
+      view.$el.appendTo(document.body);
+
+      expect(view.$('.Privacy-dropdownTrigger').length).toBe(1);
+      expect(view.$('.Privacy-dropdownTrigger').text()).toContain('PRIVATE');
+      expect(view.$('.Privacy-dropdownTrigger').hasClass('is-disabled')).toBe(false);
+    });
+
     it('should render properly and be disabled if user is out of public maps quota', function () {
+      userModel = new UserModel({
+        username: 'pepe',
+        account_type: 'Professional',
+        public_map_quota: 10,
+        public_privacy_map_count: 3,
+        password_privacy_map_count: 2,
+        link_privacy_map_count: 5,
+        actions: {
+          private_tables: true
+        }
+      }, {
+        configModel: configModel
+      });
+
+      view = createPrivacyDropdown(userModel);
+
+      view.render();
+      view.$el.appendTo(document.body);
+
+      expect(view.$('.Privacy-dropdownTrigger').length).toBe(1);
+      expect(view.$('.Privacy-dropdownTrigger').text()).toContain('PRIVATE');
+      expect(view.$('.Privacy-dropdownTrigger').hasClass('is-disabled')).toBe(true);
+    });
+
+    function createPrivacyDropdown (customUserModel) {
       visDefinitionModel = new VisDefinitionModel({
         name: 'Foo Map',
         privacy: 'PRIVATE',
@@ -179,19 +212,14 @@ describe('components/privacy-dropdown/privacy-dropdown-view', function () {
       view = new PrivacyDropdown({
         privacyCollection: collection,
         visDefinitionModel: visDefinitionModel,
-        userModel: userModel,
+        userModel: customUserModel || userModel,
         configModel: configModel,
         mapcapsCollection: mapcapsCollection,
         isOwner: true
       });
 
-      view.render();
-      view.$el.appendTo(document.body);
-
-      expect(view.$('.Privacy-dropdownTrigger').length).toBe(1);
-      expect(view.$('.Privacy-dropdownTrigger').text()).toContain('PRIVATE');
-      expect(view.$('.Privacy-dropdownTrigger').hasClass('is-disabled')).toBe(true);
-    });
+      return view;
+    }
   });
 
   describe('if is not the owner', function () {


### PR DESCRIPTION
This PR fixes the issue that there is no way to change map privacy from Builder when you don’t have any other public map.

## Related issues
https://github.com/CartoDB/support/issues/2163

## Acceptance
- With a Pro plan user create a new map. It should be able to change map privacy from Builder to Public.
- Create 9 more public maps
- Create another map. It shouldn't be able to change map privacy from Builder to Public.