### PR TITLE
Make GTM more resilient to table OID reuse

### DIFF
--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -88,11 +88,8 @@ module Carto
     def find_renamed_tables(cartodbfied_tables)
       user_tables = fetch_user_tables
 
-      user_table_names = user_tables.map(&:name)
-      user_table_ids = user_tables.map(&:id)
-
       cartodbfied_tables.select do |cartodbfied_table|
-        user_table_ids.include?(cartodbfied_table.id) && !user_table_names.include?(cartodbfied_table.name)
+        user_tables.any?{|t| t.name != cartodbfied_table.name && t.id == cartodbfied_table.id}
       end
     end
 
@@ -100,11 +97,8 @@ module Carto
     def find_regenerated_tables(cartodbfied_tables)
       user_tables = fetch_user_tables
 
-      user_table_names = user_tables.map(&:name)
-      user_table_ids = user_tables.map(&:id)
-
       cartodbfied_tables.select do |cartodbfied_table|
-        !user_table_ids.include?(cartodbfied_table.id) && user_table_names.include?(cartodbfied_table.name)
+        user_tables.any?{|t| t.name == cartodbfied_table.name && t.id != cartodbfied_table.id}
       end
     end
 


### PR DESCRIPTION
GTM operation assumes table OIDs are not reused.
There are a number of potential problems in that case (ambiguities between replacing, renaming tables etc)
This does not solve them but should make the code more robust in that scenario.

This is intended as a preemptive patch to some problems that we've observing (changed table privacy, missing visualizations, missing tables in scenarios with lots of sync tables) but we haven't be able to reproduce the problems and prove oid-reuse and the GTM are involved at all. Work should continue to reproduce the problem.