### PR TITLE
Include password confirmation in the delete mobile app modal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ sudo make install
 - Fix user presenter ([#15033](https://github.com/CartoDB/cartodb/pull/15033))
 - Remove CARTO logo option ([CartoDB/support#2091](https://github.com/CartoDB/support/issues/2091))
 - Change embeds attribution character ([#14914](https://github.com/CartoDB/cartodb/issues/14914))
+- Include password confirmation in the delete mobile app modal ([CartoDB/support#2155](https://github.com/CartoDB/support/issues/2155))
 
 4.29.0 (2019-07-15)
 -------------------

--- a/lib/assets/javascripts/dashboard/views/mobile-apps/delete-mobile-app/delete-mobile-app-view.js
+++ b/lib/assets/javascripts/dashboard/views/mobile-apps/delete-mobile-app/delete-mobile-app-view.js
@@ -1,4 +1,5 @@
 const CoreView = require('backbone/core-view');
+const PasswordValidatedForm = require('dashboard/helpers/password-validated-form');
 const template = require('./delete-mobile-app.tpl');
 const checkAndBuildOpts = require('builder/helpers/required-opts');
 
@@ -27,6 +28,10 @@ module.exports = CoreView.extend({
         authenticityToken: this._authenticityToken
       })
     );
+
+    PasswordValidatedForm.bindEventTo('.js-form', {
+      passwordConfirmationNeeded: true
+    });
   },
 
   _close: function () {

--- a/lib/assets/javascripts/dashboard/views/mobile-apps/delete-mobile-app/delete-mobile-app-view.js
+++ b/lib/assets/javascripts/dashboard/views/mobile-apps/delete-mobile-app/delete-mobile-app-view.js
@@ -1,5 +1,4 @@
 const CoreView = require('backbone/core-view');
-const PasswordValidatedForm = require('dashboard/helpers/password-validated-form');
 const template = require('./delete-mobile-app.tpl');
 const checkAndBuildOpts = require('builder/helpers/required-opts');
 
@@ -12,7 +11,7 @@ const REQUIRED_OPTS = [
 module.exports = CoreView.extend({
   events: {
     'submit .js-form': '_close',
-    'click .cancel': '_close'
+    'click .js-cancel': '_close'
   },
 
   initialize: function (options) {
@@ -28,10 +27,6 @@ module.exports = CoreView.extend({
         authenticityToken: this._authenticityToken
       })
     );
-
-    PasswordValidatedForm.bindEventTo('.js-form', {
-      passwordConfirmationNeeded: true
-    });
   },
 
   _close: function () {

--- a/lib/assets/javascripts/dashboard/views/mobile-apps/delete-mobile-app/delete-mobile-app.tpl
+++ b/lib/assets/javascripts/dashboard/views/mobile-apps/delete-mobile-app/delete-mobile-app.tpl
@@ -11,11 +11,22 @@
     <p class="Dialog-headerText">Remember, once you delete it there is no going back</p>
   </div>
 
+  <div class="CDB-Text Dialog-body">
+    <div class="Form-row Form-row--centered has-label">
+      <div class="Form-rowLabel">
+        <label class="Form-label">Your password</label>
+      </div>
+      <div class="Form-rowData">
+        <input type="password" id="deletion_password_confirmation" name="password_confirmation" class="CDB-InputText CDB-Text Form-input Form-input--long" value=""/>
+      </div>
+    </div>
+  </div>
+
   <div class="Dialog-footer u-inner">
-    <button type="button" class="CDB-Button CDB-Button--secondary cancel">
+    <button type="button" class="CDB-Button CDB-Button--secondary js-cancel">
       <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Cancel</span>
     </button>
-    <button type="submit" class="CDB-Button CDB-Button--error js-ok js-save">
+    <button type="submit" class="CDB-Button CDB-Button--error js-save">
       <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Delete this application</span>
     </button>
   </div>

--- a/lib/assets/javascripts/dashboard/views/mobile-apps/delete-mobile-app/delete-mobile-app.tpl
+++ b/lib/assets/javascripts/dashboard/views/mobile-apps/delete-mobile-app/delete-mobile-app.tpl
@@ -15,7 +15,7 @@
     <button type="button" class="CDB-Button CDB-Button--secondary cancel">
       <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Cancel</span>
     </button>
-    <button type="submit" class="CDB-Button CDB-Button--error js-ok">
+    <button type="submit" class="CDB-Button CDB-Button--error js-ok js-save">
       <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Delete this application</span>
     </button>
   </div>


### PR DESCRIPTION
Include password confirmation in the `delete mobile app` modal

### Related issue
https://github.com/CartoDB/support/issues/2155