### PR TITLE
Fix API keys list for certain table names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ sudo make install
 - Add number of employees and use case to user profile ([#14966](https://github.com/CartoDB/cartodb/pull/14966))
 
 ### Bug fixes / enhancements
+- Fix API keys page when tables had certain reserved names ([#15059](https://github.com/CartoDB/cartodb/pull/15059))
 - Stricter email domain validation ([#15030](https://github.com/CartoDB/cartodb/pull/15030))
 - Redirect viewer users to shared visualizations page, and show shared visualizations in Home ([CartoDB/support#2032](https://github.com/CartoDB/support/issues/2032))
 - Fix user presenter ([#15033](https://github.com/CartoDB/cartodb/pull/15033))

--- a/lib/assets/javascripts/dashboard/components/table-grants/table-grants-view.js
+++ b/lib/assets/javascripts/dashboard/components/table-grants/table-grants-view.js
@@ -80,9 +80,13 @@ module.exports = CoreView.extend({
     const schema = _.mapObject(tables, () => multiCheckbox);
 
     const data = _.mapObject(tables, (value, tableName) => {
-      const table = this._apiKeyModel.get('tables')[tableName] || value;
+      const apiKeyTables = this._apiKeyModel.get('tables');
 
-      return table.permissions;
+      if (apiKeyTables.hasOwnProperty(tableName) && apiKeyTables[tableName]) {
+        return apiKeyTables[tableName].permissions;
+      }
+
+      return value.permissions;
     });
 
     this._formView = new Backbone.Form({ data, schema, template: this._generateFormMarkup });


### PR DESCRIPTION
Fix: Cartodb/support#2165

As the code was before, if a dataset had the same name as any of the lower-cased array methods of JS (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Methods_2) it would crash.

CC @rubenmoya because we did this together and I'm sure he'll find it funny :joy: 