### PR TITLE
Change user_tables table_id type to oid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ sudo make install
 - Change embeds attribution character ([#14914](https://github.com/CartoDB/cartodb/issues/14914))
 - Fix disabled privacy button in Builder when there are no other public maps ([CartoDB/support#2163](https://github.com/CartoDB/support/issues/2163))
 - Include password confirmation in the delete mobile app modal ([CartoDB/support#2155](https://github.com/CartoDB/support/issues/2155))([#15061](https://github.com/CartoDB/cartodb/pull/15061))
+- The type of the tables_id column of user_tables has changed from integer to oid ([#15068](https://github.com/CartoDB/cartodb/issues/15068))
 
 4.29.0 (2019-07-15)
 -------------------

--- a/db/migrate/20190822115827_chage_user_tables_oid.rb
+++ b/db/migrate/20190822115827_chage_user_tables_oid.rb
@@ -1,0 +1,16 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  Proc.new do
+    alter_table :user_tables do
+      set_column_type :table_id, :oid
+    end
+  end,
+  Proc.new do
+    alter_table :user_tables do
+      set_column_type :table_id, Integer
+    end
+  end
+)


### PR DESCRIPTION
Fixes #15068
PostgreSQL table OIDs are 32-bit unsigned integers, we used to have 32-bit signed integers for tables_id