### PR TITLE
add table_metadata to API key

### DIFF
--- a/app/controllers/carto/api/api_key_presenter.rb
+++ b/app/controllers/carto/api/api_key_presenter.rb
@@ -28,13 +28,20 @@ module Carto
           {
             type: 'apis',
             apis: @api_key.granted_apis
-          },
-          {
-            type: 'database',
-            tables: table_permissions_for_api_key,
-            schemas: schema_permissions_for_api_key
           }
         ]
+
+        type_database = {
+          type: 'database',
+          tables: table_permissions_for_api_key,
+          schemas: schema_permissions_for_api_key
+        }
+
+        if @api_key.dataset_metadata_permissions
+          type_database['table_metadata'] = []
+        end
+
+        grants << type_database
 
         if @api_key.data_services?
           grants << {

--- a/spec/requests/carto/api/api_keys_controller_spec.rb
+++ b/spec/requests/carto/api/api_keys_controller_spec.rb
@@ -466,7 +466,8 @@ describe Carto::Api::ApiKeysController do
               'schema' => @table1.database_schema,
               :name => @table1.name,
               'permissions' => ['select']
-            ]
+            ],
+            'table_metadata' => []
           },
           {
             'type' => 'apis',
@@ -482,6 +483,7 @@ describe Carto::Api::ApiKeysController do
         get_json api_key_url(id: api_key.name), auth_params, auth_headers do |response|
           response.status.should eq 200
           response.body[:grants][1][:tables][0][:owner] = false
+          response.body[:grants][1][:table_metadata] = []
         end
         api_key.destroy
       end


### PR DESCRIPTION
We missed to return the permission if it was granted for a regular API key.