### PR TITLE
[OAuth] Add developer center links to OAuth apps texts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@ sudo make install
 - Fix disabled privacy button in Builder when there are no other public maps ([CartoDB/support#2163](https://github.com/CartoDB/support/issues/2163))
 - Include password confirmation in the delete mobile app modal ([CartoDB/support#2155](https://github.com/CartoDB/support/issues/2155))([#15061](https://github.com/CartoDB/cartodb/pull/15061))
 - The type of the tables_id column of user_tables has changed from integer to oid ([#15068](https://github.com/CartoDB/cartodb/issues/15068))
+- Add developer center links to OAuth apps texts ([#15081](https://github.com/CartoDB/cartodb/pull/15081))
 
 4.29.0 (2019-07-15)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
+++ b/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
@@ -652,7 +652,7 @@
   },
   "OAuthAppsPage": {
     "title": "Apps",
-    "description": "Build your app allowing users to authenticate through CARTO to share specific data with your app. You can read more in our <a href=''>developer documentation</a>.",
+    "description": "Build your app allowing users to authenticate through CARTO to share specific data with your app. You can read more in our <a href='https://carto.com/developers/fundamentals/oauth-apps/' target='_blank'>developer documentation</a>.",
 
     "emptyDescription": "Want to build something that integrates with and extends CARTO?",
     "newAppButton": "New OAuth App",
@@ -695,7 +695,7 @@
       "clientSecret": "Client Secret:",
       "clientSecretWarning": "Client secret must be kept secret",
       "clientSecretButton": "Reset client secret",
-      "clientSecretDesc": "OAuth apps can use OAuth credentials to identify users. Learn more about identifying users by reading our <a href''>integration developer documentation.</a>",
+      "clientSecretDesc": "OAuth apps can use OAuth credentials to identify users. Learn more about identifying users by reading our <a href'https://carto.com/developers/fundamentals/oauth-apps/#oauth-flow' target='_blank'>integration developer documentation.</a>",
       "appInformationTitle": "App Information",
       "deleteAppButton": "Delete my app"
     }


### PR DESCRIPTION
Add missing links from developer center new documentation in OAuth Apps pages:
- https://carto.com/developers/fundamentals/oauth-apps
- https://carto.com/developers/fundamentals/oauth-apps/#oauth-flow