### PR TITLE
Fix schema name in create API key permission

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@ sudo make install
 - Fix disabled privacy button in Builder when there are no other public maps ([CartoDB/support#2163](https://github.com/CartoDB/support/issues/2163))
 - Include password confirmation in the delete mobile app modal ([CartoDB/support#2155](https://github.com/CartoDB/support/issues/2155))([#15061](https://github.com/CartoDB/cartodb/pull/15061))
 - The type of the tables_id column of user_tables has changed from integer to oid ([#15068](https://github.com/CartoDB/cartodb/issues/15068))
+- Fix schema name in create API key permission ([#15082](https://github.com/CartoDB/cartodb/pull/15082))
 
 4.29.0 (2019-07-15)
 -------------------

--- a/lib/assets/javascripts/dashboard/data/api-key-model.js
+++ b/lib/assets/javascripts/dashboard/data/api-key-model.js
@@ -149,8 +149,8 @@ module.exports = Backbone.Model.extend({
 
   _parseDatabaseSchemas: function (grants) {
     const schemas = _.find(grants, grant => grant.type === GRANT_TYPES.DATABASE).schemas;
-    const shcema = _.find(schemas, schema => schema.name === this.schemaName);
-    return !!(shcema && shcema.permissions && shcema.permissions.indexOf('create') > -1);
+    const schema = _.find(schemas, schema => schema.name === this.schemaName);
+    return !!(schema && schema.permissions && schema.permissions.indexOf('create') > -1);
   },
 
   _arrayToObj: function (arr) {

--- a/lib/assets/javascripts/dashboard/data/api-key-model.js
+++ b/lib/assets/javascripts/dashboard/data/api-key-model.js
@@ -34,6 +34,7 @@ module.exports = Backbone.Model.extend({
 
   initialize: function (attributes, options) {
     checkAndBuildOpts(options, REQUIRED_OPTS, this);
+    this.schemaName = this._userModel.isInsideOrg() ? this._userModel.get('username') : 'public';
   },
 
   regenerate: function () {
@@ -107,7 +108,7 @@ module.exports = Backbone.Model.extend({
 
     if (this.get('datasets').create) {
       schemas.push({
-        name: 'public',
+        name: this.schemaName,
         permissions: ['create']
       });
     }
@@ -148,8 +149,8 @@ module.exports = Backbone.Model.extend({
 
   _parseDatabaseSchemas: function (grants) {
     const schemas = _.find(grants, grant => grant.type === GRANT_TYPES.DATABASE).schemas;
-    const publicSchema = _.find(schemas, schema => schema.name === 'public');
-    return !!(publicSchema && publicSchema.permissions && publicSchema.permissions.indexOf('create') > -1);
+    const shcema = _.find(schemas, schema => schema.name === this.schemaName);
+    return !!(shcema && shcema.permissions && shcema.permissions.indexOf('create') > -1);
   },
 
   _arrayToObj: function (arr) {

--- a/lib/assets/javascripts/dashboard/data/api-key-model.js
+++ b/lib/assets/javascripts/dashboard/data/api-key-model.js
@@ -34,7 +34,6 @@ module.exports = Backbone.Model.extend({
 
   initialize: function (attributes, options) {
     checkAndBuildOpts(options, REQUIRED_OPTS, this);
-    this.schemaName = this._userModel.isInsideOrg() ? this._userModel.get('username') : 'public';
   },
 
   regenerate: function () {
@@ -47,13 +46,14 @@ module.exports = Backbone.Model.extend({
     return this.sync(null, this, options);
   },
 
-  parse: function (data) {
+  parse: function (data, options) {
+    const schemaName = options.userModel.getSchema();
     const { grants, ...attrs } = data;
     const apis = this._parseApiGrants(grants);
     const tables = this._parseTableGrants(grants);
 
     const datasets = {
-      create: this._parseDatabaseSchemas(grants),
+      create: this._parseDatabaseSchemas(grants, schemaName),
       listing: this._parseDatabaseGrants(grants)
     };
 
@@ -108,7 +108,7 @@ module.exports = Backbone.Model.extend({
 
     if (this.get('datasets').create) {
       schemas.push({
-        name: this.schemaName,
+        name: this._userModel.getSchema(),
         permissions: ['create']
       });
     }
@@ -147,9 +147,9 @@ module.exports = Backbone.Model.extend({
     return !!_.find(grants, grant => grant.type === GRANT_TYPES.DATABASE).table_metadata;
   },
 
-  _parseDatabaseSchemas: function (grants) {
+  _parseDatabaseSchemas: function (grants, schemaName) {
     const schemas = _.find(grants, grant => grant.type === GRANT_TYPES.DATABASE).schemas;
-    const schema = _.find(schemas, schema => schema.name === this.schemaName);
+    const schema = _.find(schemas, schema => schema.name === schemaName);
     return !!(schema && schema.permissions && schema.permissions.indexOf('create') > -1);
   },
 

--- a/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/api-keys/api-keys-form-view.js
@@ -254,7 +254,8 @@ module.exports = CoreView.extend({
       error: (model, request) => {
         this._handleServerErrors(request.responseText);
         saveButton.removeClass('is-loading');
-      }
+      },
+      userModel: this._userModel
     });
   },
 

--- a/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
+++ b/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
@@ -652,7 +652,7 @@
   },
   "OAuthAppsPage": {
     "title": "Apps",
-    "description": "Build your app allowing users to authenticate through CARTO to share specific data with your app. You can read more in our <a href=''>developer documentation</a>.",
+    "description":  "Build your app allowing users to authenticate through CARTO to share specific data with your app. You can read more in our <a href='https://carto.com/developers/fundamentals/oauth-apps/' target='_blank'>developer documentation</a>.",
 
     "emptyDescription": "Want to build something that integrates with and extends CARTO?",
     "newAppButton": "New OAuth App",
@@ -695,7 +695,7 @@
       "clientSecret": "Client Secret:",
       "clientSecretWarning": "Client secret must be kept secret",
       "clientSecretButton": "Reset client secret",
-      "clientSecretDesc": "OAuth apps can use OAuth credentials to identify users. Learn more about identifying users by reading our <a href''>integration developer documentation.</a>",
+      "clientSecretDesc": "OAuth apps can use OAuth credentials to identify users. Learn more about identifying users by reading our <a href'https://carto.com/developers/fundamentals/oauth-apps/#oauth-flow' target='_blank'>integration developer documentation.</a>",
       "appInformationTitle": "App Information",
       "deleteAppButton": "Delete my app"
     }

--- a/lib/assets/test/spec/dashboard/data/api-key-model.spec.js
+++ b/lib/assets/test/spec/dashboard/data/api-key-model.spec.js
@@ -100,7 +100,12 @@ describe('dashboard/data/api-key-model', function () {
 
   describe('.parse', function () {
     it('should parse data properly', function () {
-      const parsed = model.parse(apiData);
+      const options = {
+        userModel: {
+          getSchema: () => 'public'
+        }
+      };
+      const parsed = model.parse(apiData, options);
       expect(parsed).toEqual(parsedData);
     });
   });
@@ -243,8 +248,9 @@ describe('dashboard/data/api-key-model', function () {
         type: 'database',
         schemas: [{ name: 'public', permissions: ['create'] }]
       }];
+      const schemaName = 'public';
 
-      const parsedDatabaseSchemas = model._parseDatabaseSchemas(tableGrants);
+      const parsedDatabaseSchemas = model._parseDatabaseSchemas(tableGrants, schemaName);
 
       expect(parsedDatabaseSchemas).toBe(true);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.118",
+  "version": "1.0.0-assets.118-fixcreate",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.118-fixcreate-2",
+  "version": "1.0.0-assets.118-fixcreate-3",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.118-fixcreate-3",
+  "version": "1.0.0-assets.118",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.118-fixcreate",
+  "version": "1.0.0-assets.118-fixcreate-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix schema name for API Keys **CREATE** permission:

- For regular users schema name is `"public"`
- For organizations users schema name is the username -> Fixed in this PR

In addition to that:
Add missing links from developer center new documentation in OAuth Apps pages
* https://carto.com/developers/fundamentals/oauth-apps
* https://carto.com/developers/fundamentals/oauth-apps/#oauth-flow