### PR TITLE
Minor css improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@ sudo make install
 - The type of the tables_id column of user_tables has changed from integer to oid ([#15068](https://github.com/CartoDB/cartodb/issues/15068))
 - Revamp link to DB connectors feedback ([#1614](https://github.com/CartoDB/design/issues/1614))
 - Fix schema name in create API key permission ([#15082](https://github.com/CartoDB/cartodb/pull/15082))
+- Minor CSS fixes in Mobile Apps page ([#15090](https://github.com/CartoDB/cartodb/pull/15090))
 
 4.29.0 (2019-07-15)
 -------------------

--- a/app/views/admin/shared/_api_keys_subheader.erb
+++ b/app/views/admin/shared/_api_keys_subheader.erb
@@ -1,6 +1,6 @@
 <%- if Cartodb::Central.sync_data_with_cartodb_central? && current_user.mobile_sdk_enabled? %>
 
-    <div class="Filters is-relative js-org-subheader Filters--margin-fix">
+    <div class="Filters is-relative js-org-subheader Filters__margin-fix">
     <div class="Filters-inner">
       <span class="Filters-separator"></span>
       <div class="Filters-row">

--- a/app/views/admin/shared/_org_subheader.html.erb
+++ b/app/views/admin/shared/_org_subheader.html.erb
@@ -1,4 +1,4 @@
-<div class="Filters is-relative js-org-subheader Filters--margin-fix">
+<div class="Filters is-relative js-org-subheader Filters__margin-fix">
   <div class="Filters-inner">
     <span class="Filters-separator"></span>
     <div class="Filters-row">

--- a/app/views/carto/admin/mobile_apps/index.html.erb
+++ b/app/views/carto/admin/mobile_apps/index.html.erb
@@ -23,7 +23,6 @@
 
   <div class="CDB-Text FormAccount-Content">
     <%= render :partial => 'admin/shared/api_keys_subheader' %>
-    <div class="Filters-separator"></div>
 
     <%= render :partial => 'carto/admin/mobile_apps/mobile_plan_info' %>
 

--- a/app/views/carto/admin/mobile_apps/index.html.erb
+++ b/app/views/carto/admin/mobile_apps/index.html.erb
@@ -15,6 +15,7 @@
 <% end %>
 
 <%= render :partial => 'shared/flash_message' %>
+<%= render :partial => 'admin/shared/trial_notification' %>
 
 <div class="FormAccount-Section u-inner">
 

--- a/app/views/carto/admin/mobile_apps/new.html.erb
+++ b/app/views/carto/admin/mobile_apps/new.html.erb
@@ -21,7 +21,7 @@
 
   <div class="CDB-Text FormAccount-Content">
 
-    <div class="Filters is-relative">
+    <div class="Filters is-relative Filters__margin-fix">
       <div class="Filters-inner">
         <span class="Filters-separator"></span>
         <div class="Filters-row">
@@ -32,7 +32,7 @@
               </a>
             </li>
             <li class="Filters-typeItem">
-              <div class="FormAccount-title">
+              <div class="u-iblock">
                 <p class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">New application</p>
               </div>
             </li>

--- a/app/views/carto/admin/mobile_apps/new.html.erb
+++ b/app/views/carto/admin/mobile_apps/new.html.erb
@@ -27,7 +27,7 @@
         <div class="Filters-row">
           <ul class="Filters-group">
             <li class="u-flex u-alignCenter">
-              <a href="<%= current_user_url('mobile_apps') %>" class="u-actionTextColor u-flex u-alignCenter">
+              <a href="<%= current_user_url('mobile_apps') %>" class="u-actionTextColor u-flex u-alignCenter Filters-typeLink">
                 <i class="CDB-IconFont CDB-IconFont-arrowPrev u-rSpace--xl"></i>
               </a>
             </li>

--- a/app/views/carto/admin/mobile_apps/new.html.erb
+++ b/app/views/carto/admin/mobile_apps/new.html.erb
@@ -14,6 +14,7 @@
 <% end %>
 
 <%= render :partial => 'shared/flash_message' %>
+<%= render :partial => 'admin/shared/trial_notification' %>
 
 <div class="FormAccount-Section u-inner">
   <%= render :partial => 'admin/shared/pages_subheader' %>

--- a/app/views/carto/admin/mobile_apps/show.html.erb
+++ b/app/views/carto/admin/mobile_apps/show.html.erb
@@ -18,6 +18,7 @@
 <% end %>
 
 <%= render :partial => 'shared/flash_message' %>
+<%= render :partial => 'admin/shared/trial_notification' %>
 
 <div class="FormAccount-Section u-inner">
   <%= render :partial => 'admin/shared/pages_subheader' %>

--- a/assets/stylesheets/common/filters.scss
+++ b/assets/stylesheets/common/filters.scss
@@ -428,7 +428,7 @@ a.Filters-cleanSearch {
   font-size: 6px;
 }
 
-.Filters--margin-fix {
+.Filters__margin-fix {
   margin-top: -28px;
 }
 

--- a/lib/assets/javascripts/new-dashboard/components/CreateButton.vue
+++ b/lib/assets/javascripts/new-dashboard/components/CreateButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="button button--small is-primary" @click="openCreateModal" :class="{'u-is-disabled': disabled}">
+  <button class="button is-primary" @click="openCreateModal" :class="{'u-is-disabled': disabled}">
     <slot />
   </button>
 </template>

--- a/lib/assets/javascripts/new-dashboard/styles/bundles/header.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/bundles/header.scss
@@ -4,10 +4,6 @@
 @import "../helpers/colors";
 @import "../helpers/utilities";
 
-.FlashMessage-container {
-  padding-top: 64px;
-}
-
 .navbar-placeholder {
   display: flex;
   position: fixed;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.121-improvments-1",
+  "version": "1.0.0-assets.121-improvments-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.121",
+  "version": "1.0.0-assets.121-improvments-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.121-improvments-2",
+  "version": "1.0.0-assets.121",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR solves minor styling issues:
- In the dashboard, CreateButton styles that were appearing too small and texts in uppercase
- Banners spacing, at least, in Mobile Apps page. When adding a new app there was a 64px white space between the menu and the error banner
- Also in Mobile Apps page: 
    - Add trial banners 
    - Remove an overlapping separator
    - New Application title spacing