### PR TITLE
timestamp is not required

### DIFF
--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -320,7 +320,7 @@ module Carto
 
         include Carto::Tracking::Validators::User
 
-        required_properties :user_id, :app_id, :app_name, :timestamp
+        required_properties :user_id, :app_id, :app_name
       end
 
       class CreatedOauthApp < OauthAppEvent; end


### PR DESCRIPTION
Closes #15086 

We made a rake to insert past events with the proper creation timestamp, but then we removed the timestamp from the actual events since it's not needed.

I'm removing the `timestamp`  attribute as required in this PR.