### PR TITLE
[DO] Rake to purchase datasets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/requests/carto/api/public/datasets_controller_spec.rb \
 	spec/models/carto/user_migration_spec.rb \
 	spec/requests/carto/api/public/data_observatory_controller_spec.rb \
+	spec/lib/tasks/data_observatory_rake_spec.rb \
 	$(NULL)
 
 # This class must be tested isolated as pollutes namespace

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ sudo make install
 - Add CARTO Data Source Request link ([CartoDB/product#441](https://github.com/CartoDB/product/issues/441))
 - Data Observatory token endpoint ([#15097](https://github.com/CartoDB/cartodb/pull/15097))
 - Add GET MFA status to EUMAPI ([CartoDB/cartodb#15101](https://github.com/CartoDB/cartodb/issues/15101))
+- Rake task to purchase Data Observatory datasets ([CartoDB/cartodb#15076](https://github.com/CartoDB/cartodb/issues/15076))
 
 ### Bug fixes / enhancements
 - Fix API keys page when tables had certain reserved names ([#15059](https://github.com/CartoDB/cartodb/pull/15059))

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -95,6 +95,11 @@ module Cartodb
       send_request("api/users/#{username}/do_token", nil, :get, [200, 403, 404])
     end
 
+    def create_do_datasets(username:, datasets:)
+      body = { username: username, datasets: datasets }
+      send_request("api/do/datasets", body, :post, [201, 403, 404])
+    end
+
     ############################################################################
     # Organizations
 

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -1,6 +1,6 @@
 # Datasets CSV example:
-# bbva.financial_basicstats_spain_censustracts_2011_monthly_2017,bq;spanner,999,2020-09-27T08:00:00
-# mastercard.geography_usa_blockgroup_2019,bq,2000,2020-09-27T08:00:00
+# carto-do-public-data.open_data.geography_usa_state_2015,bq;spanner,999,2020-09-27T08:00:00
+# carto-do-public-data.open_data.demographics_acs_usa_cbsaclipped_2015_yearly_2015,bq,2000,2020-09-27T08:00:00
 namespace :cartodb do
   namespace :data_observatory do
     desc "Enables access to DO datasets for a user and saves the metadata in Central and Redis"

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -1,0 +1,33 @@
+# Datasets CSV example:
+# bbva.financial_basicstats_spain_censustracts_2011_monthly_2017,bq;spanner,999,2020-09-27T08:00:00
+# mastercard.geography_usa_blockgroup_2019,bq,2000,2020-09-27T08:00:00
+namespace :cartodb do
+  namespace :data_observatory do
+    desc "Enables access to DO datasets for a user and saves the metadata in Central and Redis"
+    task :purchase_datasets, [:username, :datasets_csv] => [:environment] do |_, args|
+      username = args[:username]
+      datasets_csv = args[:datasets_csv]
+      usage = 'USAGE: data_observatory:purchase_datasets["username","path/datasets.csv"]'
+      raise usage unless username.present? && datasets_csv.present?
+
+      datasets = []
+      bq_datasets = []
+      spanner_datasets = []
+      CSV.foreach(args[:datasets_csv]) do |row|
+        available_in = row[1].split(';')
+        dataset = { dataset_id: row[0], available_in: available_in, price: row[2].to_f, expires_at: Time.parse(row[3]) }
+        datasets << dataset
+        bq_datasets << dataset.slice(:dataset_id, :expires_at) if available_in.include?('bq')
+        spanner_datasets << dataset.slice(:dataset_id, :expires_at) if available_in.include?('spanner')
+      end
+
+      Cartodb::Central.new.create_do_datasets(username: username, datasets: datasets)
+
+      redis_key = "do:#{username}:datasets"
+      redis_value = ["bq", bq_datasets, "spanner", spanner_datasets]
+      $users_metadata.hmset(redis_key, redis_value)
+
+      puts 'Task finished succesfully!'
+    end
+  end
+end

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -24,7 +24,7 @@ namespace :cartodb do
       Cartodb::Central.new.create_do_datasets(username: username, datasets: datasets)
 
       redis_key = "do:#{username}:datasets"
-      redis_value = ["bq", bq_datasets, "spanner", spanner_datasets]
+      redis_value = ["bq", bq_datasets.to_json, "spanner", spanner_datasets.to_json]
       $users_metadata.hmset(redis_key, redis_value)
 
       puts 'Task finished succesfully!'

--- a/spec/lib/tasks/data_observatory_rake_spec.rb
+++ b/spec/lib/tasks/data_observatory_rake_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper_min'
+require 'rake'
+
+describe 'data_observatory.rake' do
+  before(:all) do
+    Rake.application.rake_require('tasks/data_observatory')
+    Rake::Task.define_task(:environment)
+
+    @user = FactoryGirl.create(:valid_user, username: 'fulano')
+  end
+
+  after(:all) do
+    @user.destroy
+  end
+
+  describe '#purchase_datasets' do
+    before(:each) do
+      Rake::Task['cartodb:data_observatory:purchase_datasets'].reenable
+    end
+
+    after(:each) do
+      File.unstub(:open)
+      Cartodb::Central.unstub(:new)
+      Cartodb::Central.any_instance.unstub(:create_do_datasets)
+    end
+
+    it 'throws an error if username is not provided' do
+      expect {
+        Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke
+      }.to raise_error(RuntimeError, 'USAGE: data_observatory:purchase_datasets["username","path/datasets.csv"]')
+    end
+
+    it 'throws an error if the datasets path is not provided' do
+      expect {
+        Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano')
+      }.to raise_error(RuntimeError, 'USAGE: data_observatory:purchase_datasets["username","path/datasets.csv"]')
+    end
+
+    it 'calls create_do_datasets from Central with the expected parameters' do
+      File.stubs(:open).returns(csv_example)
+      central_mock = mock
+      Cartodb::Central.stubs(:new).returns(central_mock)
+
+      expected_datasets = [
+        { dataset_id: 'dataset1', available_in: ['bq', 'spanner'], price: 100,
+          expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
+        { dataset_id: 'dataset2', available_in: ['spanner'], price: 200,
+          expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
+      ]
+      central_mock.expects(:create_do_datasets).once.with(username: 'fulano', datasets: expected_datasets)
+
+      Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano', 'datasets.csv')
+    end
+
+    it 'stores the metadata in Redis' do
+      File.stubs(:open).returns(csv_example)
+      Cartodb::Central.any_instance.stubs(:create_do_datasets)
+
+      redis_key = "do:fulano:datasets"
+      bq_datasets = [
+        { dataset_id: 'dataset1', expires_at: Time.new(2020, 9, 27, 8, 0, 0) }
+      ].to_s
+      spanner_datasets = [
+        { dataset_id: 'dataset1', expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
+        { dataset_id: 'dataset2', expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
+      ].to_s
+
+      Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano', 'datasets.csv')
+
+      $users_metadata.hmget(redis_key, 'bq').should eq [bq_datasets]
+      $users_metadata.hmget(redis_key, 'spanner').should eq [spanner_datasets]
+    end
+
+  end
+
+  def csv_example
+    CSV.generate do |csv|
+      csv << ["dataset1", "bq;spanner", "100", "2020-09-27T08:00:00"]
+      csv << ["dataset2", "spanner", "200", "2020-12-31T12:00:00"]
+    end
+  end
+
+end

--- a/spec/lib/tasks/data_observatory_rake_spec.rb
+++ b/spec/lib/tasks/data_observatory_rake_spec.rb
@@ -67,8 +67,8 @@ describe 'data_observatory.rake' do
 
       Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano', 'datasets.csv')
 
-      $users_metadata.hmget(redis_key, 'bq').should eq [bq_datasets]
-      $users_metadata.hmget(redis_key, 'spanner').should eq [spanner_datasets]
+      $users_metadata.hget(redis_key, 'bq').should eq bq_datasets
+      $users_metadata.hget(redis_key, 'spanner').should eq spanner_datasets
     end
 
   end

--- a/spec/lib/tasks/data_observatory_rake_spec.rb
+++ b/spec/lib/tasks/data_observatory_rake_spec.rb
@@ -59,11 +59,11 @@ describe 'data_observatory.rake' do
       redis_key = "do:fulano:datasets"
       bq_datasets = [
         { dataset_id: 'dataset1', expires_at: Time.new(2020, 9, 27, 8, 0, 0) }
-      ].to_s
+      ].to_json
       spanner_datasets = [
         { dataset_id: 'dataset1', expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
         { dataset_id: 'dataset2', expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
-      ].to_s
+      ].to_json
 
       Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano', 'datasets.csv')
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/15076

It calls `do/datasets` in Central (https://github.com/CartoDB/cartodb-central/pull/2578) and stores the metadata in Redis.

To use it (there's a CSV sample in the rake code):
`bundle exec rake cartodb:data_observatory:purchase_datasets["fulano","tmp/datasets.csv"]`

The result should be:
- Metadata saved in Central (`do_datasets` table) and Redis (`do:username:datasets`)
- Views created in BigQuery pointing to the right tables, with permissions to read for the user service account and with the TTL provided in the CSV