### PR TITLE
[DO] List purchased datasets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ sudo make install
 - Data Observatory token endpoint ([#15097](https://github.com/CartoDB/cartodb/pull/15097))
 - Add GET MFA status to EUMAPI ([CartoDB/cartodb#15101](https://github.com/CartoDB/cartodb/issues/15101))
 - Rake task to purchase Data Observatory datasets ([CartoDB/cartodb#15076](https://github.com/CartoDB/cartodb/issues/15076))
+- Endpoint to list purchased Data Observatory datasets ([CartoDB/cartodb#15119](https://github.com/CartoDB/cartodb/issues/15119))
 
 ### Bug fixes / enhancements
 - Fix API keys page when tables had certain reserved names ([#15059](https://github.com/CartoDB/cartodb/pull/15059))

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@ sudo make install
   - Track OauthApp and OauthAppUser events in Segment ([#15055](https://github.com/CartoDB/cartodb/pull/15055))
   - Update Auth API swagger spec to include schemas and table_metadata grants ([#14998](https://github.com/CartoDB/cartodb/issues/14998))
   - Allow developers to manage their OAuth apps in the dashboard ([#15031](https://github.com/CartoDB/cartodb/pull/15031))
-  - Scope for data_observatory_token ([#15089](https://github.com/CartoDB/cartodb/pull/15089))
+  - Scope for data_observatory_v2 ([CartoDB/cartodb#15119](https://github.com/CartoDB/cartodb/issues/15119))
 - Add number of employees and use case to user profile ([#14966](https://github.com/CartoDB/cartodb/pull/14966))
 - Add CARTO Data Source Request link ([CartoDB/product#441](https://github.com/CartoDB/product/issues/441))
 - Data Observatory token endpoint ([#15097](https://github.com/CartoDB/cartodb/pull/15097))

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@ sudo make install
   - Track OauthApp and OauthAppUser events in Segment ([#15055](https://github.com/CartoDB/cartodb/pull/15055))
   - Update Auth API swagger spec to include schemas and table_metadata grants ([#14998](https://github.com/CartoDB/cartodb/issues/14998))
   - Allow developers to manage their OAuth apps in the dashboard ([#15031](https://github.com/CartoDB/cartodb/pull/15031))
-  - Scope for data_observatory_v2 ([CartoDB/cartodb#15119](https://github.com/CartoDB/cartodb/issues/15119))
+  - Scope to access DO API ([CartoDB/cartodb#15119](https://github.com/CartoDB/cartodb/issues/15119))
 - Add number of employees and use case to user profile ([#14966](https://github.com/CartoDB/cartodb/pull/14966))
 - Add CARTO Data Source Request link ([CartoDB/product#441](https://github.com/CartoDB/product/issues/441))
 - Data Observatory token endpoint ([#15097](https://github.com/CartoDB/cartodb/pull/15097))

--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -29,7 +29,7 @@ module Carto
 
         def check_permissions
           api_key = Carto::ApiKey.find_by_token(params["api_key"])
-          raise UnauthorizedError unless api_key&.master? || api_key&.data_observatory_token_permissions?
+          raise UnauthorizedError unless api_key&.master? || api_key&.data_observatory_permissions?
         end
 
       end

--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -5,20 +5,31 @@ module Carto
     module Public
       class DataObservatoryController < Carto::Api::Public::ApplicationController
         include Carto::ControllerHelper
+        include Carto::Api::PagedSearcher
         extend Carto::DefaultRescueFroms
 
         ssl_required
 
         before_action :load_user
+        before_action :load_order, only: [:datasets]
         before_action :check_permissions
 
         setup_default_rescues
 
         respond_to :json
 
+        BIGQUERY_KEY = 'bq'.freeze
+        VALID_ORDER_PARAMS = %i(id table dataset project).freeze
+
         def token
           response = Cartodb::Central.new.get_do_token(@user.username)
           render(json: response)
+        end
+
+        def datasets
+          available_datasets = bq_datasets.select { |dataset| Time.parse(dataset['expires_at']) > Time.now }
+          response = present_datasets(available_datasets)
+          render(json: { datasets: response })
         end
 
         private
@@ -27,9 +38,31 @@ module Carto
           @user = Carto::User.find(current_viewer.id)
         end
 
+        def load_order
+          _, _, @order, @direction = page_per_page_order_params(
+            VALID_ORDER_PARAMS, default_order: 'id', default_order_direction: 'asc'
+          )
+        end
+
         def check_permissions
           api_key = Carto::ApiKey.find_by_token(params["api_key"])
           raise UnauthorizedError unless api_key&.master? || api_key&.data_observatory_permissions?
+        end
+
+        def bq_datasets
+          redis_key = "do:#{@user.username}:datasets"
+          redis_value = $users_metadata.hget(redis_key, BIGQUERY_KEY) || '[]'
+          JSON.parse(redis_value)
+        end
+
+        def present_datasets(datasets)
+          enriched_datasets = datasets.map do |dataset|
+            dataset_id = dataset['dataset_id']
+            project, dataset, table = dataset_id.split('.')
+            { project: project, dataset: dataset, table: table, id: dataset_id }
+          end
+          ordered_datasets = enriched_datasets.sort_by { |dataset| dataset[@order] }
+          @direction == :asc ? ordered_datasets : ordered_datasets.reverse
         end
 
       end

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -35,7 +35,7 @@ module Carto
 
     API_SQL       = 'sql'.freeze
     API_MAPS      = 'maps'.freeze
-    API_DO        = 'data_observatory_v2'.freeze
+    API_DO        = 'do'.freeze
 
     GRANTS_ALL_APIS = { type: "apis", apis: [API_SQL, API_MAPS] }.freeze
     GRANTS_ALL_DATA_SERVICES = {

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -37,7 +37,7 @@ module Carto
     API_MAPS      = 'maps'.freeze
     API_DO        = 'data_observatory_v2'.freeze
 
-    GRANTS_ALL_APIS = { type: "apis", apis: [API_SQL, API_MAPS, API_DO] }.freeze
+    GRANTS_ALL_APIS = { type: "apis", apis: [API_SQL, API_MAPS] }.freeze
     GRANTS_ALL_DATA_SERVICES = {
       type: 'dataservices',
       services: ['geocoding', 'routing', 'isolines', 'observatory']

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -35,8 +35,9 @@ module Carto
 
     API_SQL       = 'sql'.freeze
     API_MAPS      = 'maps'.freeze
+    API_DO        = 'data_observatory_v2'.freeze
 
-    GRANTS_ALL_APIS = { type: "apis", apis: [API_SQL, API_MAPS] }.freeze
+    GRANTS_ALL_APIS = { type: "apis", apis: [API_SQL, API_MAPS, API_DO] }.freeze
     GRANTS_ALL_DATA_SERVICES = {
       type: 'dataservices',
       services: ['geocoding', 'routing', 'isolines', 'observatory']
@@ -56,8 +57,6 @@ module Carto
                           "ELSE 0 END DESC".freeze
 
     CDB_CONF_KEY_PREFIX = 'api_keys_'.freeze
-
-    DATA_OBSERVATORY_TOKEN_GRANT = 'data_observatory_token'.freeze
 
     self.inheritance_column = :_type
 
@@ -197,8 +196,8 @@ module Carto
       @dataset_metadata_permissions ||= process_dataset_metadata_permissions
     end
 
-    def data_observatory_token_permissions?
-      process_user_data_grants&.include?(DATA_OBSERVATORY_TOKEN_GRANT)
+    def data_observatory_permissions?
+      granted_apis&.include?(API_DO)
     end
 
     def table_permissions_from_db

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -588,6 +588,7 @@ CartoDB::Application.routes.draw do
 
       scope 'do' do
         get 'token' => 'data_observatory#token', as: :api_v4_do_token
+        get 'datasets' => 'data_observatory#datasets', as: :api_v4_do_datasets
       end
     end
 

--- a/lib/carto/oauth_provider/scopes/apis_scope.rb
+++ b/lib/carto/oauth_provider/scopes/apis_scope.rb
@@ -1,0 +1,16 @@
+module Carto
+  module OauthProvider
+    module Scopes
+      class ApisScope < DefaultScope
+        def initialize(service, description)
+          super('apis', service, CATEGORY_APIS, description)
+          @grant_key = :apis
+        end
+
+        def add_to_api_key_grants(grants, _user = nil)
+          super(grants)
+        end
+      end
+    end
+  end
+end

--- a/lib/carto/oauth_provider/scopes/scopes.rb
+++ b/lib/carto/oauth_provider/scopes/scopes.rb
@@ -32,7 +32,7 @@ module Carto
         DataservicesScope.new('routing', 'Routing').freeze,
         DataservicesScope.new('observatory', 'Data Observatory').freeze,
 
-        ApisScope.new('data_observatory_v2', 'Data Observatory API').freeze,
+        ApisScope.new('do', 'Data Observatory API').freeze,
 
         UserScope.new('profile', 'User profile (avatar, name, org. owner)').freeze,
         DatasetsMetadataScope.new('Table names').freeze

--- a/lib/carto/oauth_provider/scopes/scopes.rb
+++ b/lib/carto/oauth_provider/scopes/scopes.rb
@@ -1,6 +1,7 @@
 require_relative './category'
 require_relative './scope'
 require_relative './default_scope'
+require_relative './apis_scope'
 require_relative './dataservices_scope'
 require_relative './datasets_scope'
 require_relative './datasets_metadata_scope'
@@ -20,6 +21,7 @@ module Carto
       CATEGORY_DATASETS = Category.new('Access to your datasets')
       CATEGORY_SCHEMA = Category.new('Create tables')
       CATEGORY_DATASETS_METADATA = Category.new('List your datasets')
+      CATEGORY_APIS = Category.new('Access to CARTO APIs')
 
       SCOPES = [
         Scope.new(SCOPE_DEFAULT, CATEGORY_USER, 'Username and organization name').freeze,
@@ -30,8 +32,9 @@ module Carto
         DataservicesScope.new('routing', 'Routing').freeze,
         DataservicesScope.new('observatory', 'Data Observatory').freeze,
 
+        ApisScope.new('data_observatory_v2', 'Data Observatory API').freeze,
+
         UserScope.new('profile', 'User profile (avatar, name, org. owner)').freeze,
-        UserScope.new('data_observatory_token', 'User token for Data Observatory').freeze,
         DatasetsMetadataScope.new('Table names').freeze
       ].freeze
 

--- a/lib/formats/carto/api_key/grants.json
+++ b/lib/formats/carto/api_key/grants.json
@@ -23,7 +23,7 @@
           "enum": [
             "sql",
             "maps",
-            "data_observatory_v2"
+            "do"
           ]
         }
       },

--- a/lib/formats/carto/api_key/grants.json
+++ b/lib/formats/carto/api_key/grants.json
@@ -22,7 +22,8 @@
           "type": "string",
           "enum": [
             "sql",
-            "maps"
+            "maps",
+            "data_observatory_v2"
           ]
         }
       },
@@ -108,8 +109,7 @@
         "items": {
           "type": "string",
           "enum": [
-            "profile",
-            "data_observatory_token"
+            "profile"
           ]
         }
       },

--- a/spec/lib/carto/oauth_provider/scopes/scopes_spec.rb
+++ b/spec/lib/carto/oauth_provider/scopes/scopes_spec.rb
@@ -332,11 +332,11 @@ describe Carto::OauthProvider::Scopes do
 
   describe Carto::OauthProvider::Scopes::ApisScope do
     describe '#add_to_api_key_grants' do
-      it 'adds apis scope with data_observatory_v2 subset' do
-        scope = Carto::OauthProvider::Scopes::ApisScope.new('data_observatory_v2', 'Data Observatory API')
+      it 'adds apis scope with do subset' do
+        scope = Carto::OauthProvider::Scopes::ApisScope.new('do', 'Data Observatory API')
         grants = [{ type: 'apis', apis: [] }]
         scope.add_to_api_key_grants(grants, nil)
-        expect(grants).to(eq([{ type: 'apis', apis: ['data_observatory_v2'] }]))
+        expect(grants).to(eq([{ type: 'apis', apis: ['do'] }]))
       end
     end
   end
@@ -634,7 +634,7 @@ describe Carto::OauthProvider::Scopes do
     end
 
     it 'shows Data Observatory API permission' do
-      scope = ["apis:data_observatory_v2"]
+      scope = ["apis:do"]
       expected = [
         {
           description: "User and personal data",

--- a/spec/lib/carto/oauth_provider/scopes/scopes_spec.rb
+++ b/spec/lib/carto/oauth_provider/scopes/scopes_spec.rb
@@ -327,12 +327,16 @@ describe Carto::OauthProvider::Scopes do
         scope.add_to_api_key_grants(grants, nil)
         expect(grants).to(eq([{ type: 'apis', apis: [] }, { type: 'user', data: ['profile'] }]))
       end
+    end
+  end
 
-      it 'adds user scope with data_observatory_token subset' do
-        scope = Carto::OauthProvider::Scopes::UserScope.new('data_observatory_token', 'DO token')
+  describe Carto::OauthProvider::Scopes::ApisScope do
+    describe '#add_to_api_key_grants' do
+      it 'adds apis scope with data_observatory_v2 subset' do
+        scope = Carto::OauthProvider::Scopes::ApisScope.new('data_observatory_v2', 'Data Observatory API')
         grants = [{ type: 'apis', apis: [] }]
         scope.add_to_api_key_grants(grants, nil)
-        expect(grants).to(eq([{ type: 'apis', apis: [] }, { type: 'user', data: ['data_observatory_token'] }]))
+        expect(grants).to(eq([{ type: 'apis', apis: ['data_observatory_v2'] }]))
       end
     end
   end
@@ -629,14 +633,18 @@ describe Carto::OauthProvider::Scopes do
       expect(scopes_by_category).to(eq(expected))
     end
 
-    it 'shows user service account permission' do
-      scope = ["user:data_observatory_token"]
+    it 'shows Data Observatory API permission' do
+      scope = ["apis:data_observatory_v2"]
       expected = [
         {
           description: "User and personal data",
           icon: nil,
-          scopes: [{ description: "Username and organization name", new: true },
-                   { description: "User token for Data Observatory", new: true }]
+          scopes: [{ description: "Username and organization name", new: true }]
+        },
+        {
+          description: "Access to CARTO APIs",
+          icon: nil,
+          scopes: [{ description: "Data Observatory API", new: true }]
         }
       ]
 

--- a/spec/models/carto/api_key_spec.rb
+++ b/spec/models/carto/api_key_spec.rb
@@ -455,10 +455,10 @@ describe Carto::ApiKey do
         }.to_not raise_error
       end
 
-      it 'validates data_observatory_v2 API grant' do
+      it 'validates do API grant' do
         apis_grants = {
           type: "apis",
-          apis: ["data_observatory_v2"]
+          apis: ["do"]
         }
         expect {
           @carto_user1.api_keys.create_regular_key!(name: 'x', grants: [apis_grants])
@@ -842,17 +842,17 @@ describe Carto::ApiKey do
     end
 
     describe '#data_observatory_permissions?' do
-      it 'returns true when it has the data_observatory_v2 api grant' do
+      it 'returns true when it has the do api grant' do
         apis_grants = {
           type: "apis",
-          apis: ["data_observatory_v2"]
+          apis: ["do"]
         }
         api_key = @carto_user1.api_keys.create_regular_key!(name: 'x', grants: [apis_grants])
 
         expect(api_key.data_observatory_permissions?).to eq true
       end
 
-      it 'returns false when it does not have the data_observatory_v2 api grant' do
+      it 'returns false when it does not have the do api grant' do
         apis_grants = {
           type: "apis",
           apis: ["sql"]

--- a/spec/models/carto/api_key_spec.rb
+++ b/spec/models/carto/api_key_spec.rb
@@ -455,14 +455,13 @@ describe Carto::ApiKey do
         }.to_not raise_error
       end
 
-      it 'validates data_observatory_token grant' do
-        user_grants = {
-          type: "user",
-          data: ["data_observatory_token"]
+      it 'validates data_observatory_v2 API grant' do
+        apis_grants = {
+          type: "apis",
+          apis: ["data_observatory_v2"]
         }
-        grants = [apis_grant, user_grants]
         expect {
-          @carto_user1.api_keys.create_regular_key!(name: 'x', grants: grants)
+          @carto_user1.api_keys.create_regular_key!(name: 'x', grants: [apis_grants])
         }.to_not raise_error
       end
 
@@ -839,6 +838,28 @@ describe Carto::ApiKey do
       it 'filters all if nil type' do
         api_keys = @carto_user1.api_keys.by_type(nil)
         api_keys.count.should eq 2
+      end
+    end
+
+    describe '#data_observatory_permissions?' do
+      it 'returns true when it has the data_observatory_v2 api grant' do
+        apis_grants = {
+          type: "apis",
+          apis: ["data_observatory_v2"]
+        }
+        api_key = @carto_user1.api_keys.create_regular_key!(name: 'x', grants: [apis_grants])
+
+        expect(api_key.data_observatory_permissions?).to eq true
+      end
+
+      it 'returns false when it does not have the data_observatory_v2 api grant' do
+        apis_grants = {
+          type: "apis",
+          apis: ["sql"]
+        }
+        api_key = @carto_user1.api_keys.create_regular_key!(name: 'x', grants: [apis_grants])
+
+        expect(api_key.data_observatory_permissions?).to eq false
       end
     end
   end

--- a/spec/models/carto/oauth_access_token_spec.rb
+++ b/spec/models/carto/oauth_access_token_spec.rb
@@ -239,11 +239,11 @@ module Carto
           [
             {
               type: 'apis',
-              apis: ['data_observatory_v2']
+              apis: ['do']
             }
           ]
 
-        access_token = OauthAccessToken.create!(oauth_app_user: @app_user, scopes: ['apis:data_observatory_v2'])
+        access_token = OauthAccessToken.create!(oauth_app_user: @app_user, scopes: ['apis:do'])
 
         expect(access_token.api_key.type).to(eq('oauth'))
         expect(access_token.api_key.grants).to(eq(expected_grants))

--- a/spec/models/carto/oauth_access_token_spec.rb
+++ b/spec/models/carto/oauth_access_token_spec.rb
@@ -239,15 +239,11 @@ module Carto
           [
             {
               type: 'apis',
-              apis: []
-            },
-            {
-              type: 'user',
-              data: ['data_observatory_token']
+              apis: ['data_observatory_v2']
             }
           ]
 
-        access_token = OauthAccessToken.create!(oauth_app_user: @app_user, scopes: ['user:data_observatory_token'])
+        access_token = OauthAccessToken.create!(oauth_app_user: @app_user, scopes: ['apis:data_observatory_v2'])
 
         expect(access_token.api_key.type).to(eq('oauth'))
         expect(access_token.api_key.grants).to(eq(expected_grants))

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -13,55 +13,169 @@ describe Carto::Api::Public::DataObservatoryController do
     @headers = { 'CONTENT_TYPE' => 'application/json' }
   end
 
-  describe 'token' do
-    before(:each) do
-      host! "#{@user1.username}.localhost.lan"
-    end
+  before(:each) do
+    host! "#{@user1.username}.localhost.lan"
+  end
 
-    it 'returns 401 if there is no API key' do
-      get_json api_v4_do_token_url, @headers do |response|
-        expect(response.status).to eq(401)
-      end
-    end
-
+  shared_examples 'an endpoint validating a DO API key' do
     it 'returns 401 if the API key is wrong' do
-      get_json api_v4_do_token_url(api_key: 'wrong'), @headers do |response|
+      get_json endpoint_url(api_key: 'wrong'), @headers do |response|
         expect(response.status).to eq(401)
       end
     end
 
     it 'returns 403 when using a regular API key without DO grant' do
-      get_json api_v4_do_token_url(api_key: @not_granted_token), @headers do |response|
+      get_json endpoint_url(api_key: @not_granted_token), @headers do |response|
         expect(response.status).to eq(403)
       end
     end
+  end
+
+  def endpoint_url(params = {})
+    send(@url_helper, params)
+  end
+
+  describe 'token' do
+    before(:all) do
+      @url_helper = 'api_v4_do_token_url'
+      @expected_body = [{ 'access_token' => 'tokenuco' }]
+    end
+
+    after(:each) do
+      Cartodb::Central.any_instance.unstub(:get_do_token)
+    end
+
+    it_behaves_like 'an endpoint validating a DO API key'
+
+    it 'calls Central to request the token' do
+      Cartodb::Central.any_instance.expects(:get_do_token).with(@user1.username).once.returns(@expected_body.to_json)
+
+      get_json api_v4_do_token_url(api_key: @master), @headers
+    end
 
     it 'returns 200 with an access token when using the master API key' do
-      expected_body = [{ "access_token" => 'tokenuco' }]
-      Cartodb::Central.any_instance.expects(:get_do_token).with(@user1.username).once.returns(expected_body.to_json)
+      Cartodb::Central.any_instance.stubs(:get_do_token).returns(@expected_body.to_json)
 
       get_json api_v4_do_token_url(api_key: @master), @headers do |response|
         expect(response.status).to eq(200)
-        expect(response.body).to eq expected_body
+        expect(response.body).to eq @expected_body
       end
     end
 
-    it 'returns 200 with an access token when using a regular API key with DO grant' do
-      expected_body = [{ "access_token" => 'tokenuco' }]
-      Cartodb::Central.any_instance.expects(:get_do_token).with(@user1.username).once.returns(expected_body.to_json)
+    it 'returns 200 when using a regular API key with DO grant' do
+      Cartodb::Central.any_instance.stubs(:get_do_token).returns(@expected_body.to_json)
 
       get_json api_v4_do_token_url(api_key: @granted_token), @headers do |response|
         expect(response.status).to eq(200)
-        expect(response.body).to eq expected_body
       end
     end
 
     it 'returns 500 if the central call fails' do
       central_error = CentralCommunicationFailure.new('boom')
-      Cartodb::Central.any_instance.expects(:get_do_token).with(@user1.username).once.raises(central_error)
+      Cartodb::Central.any_instance.stubs(:get_do_token).raises(central_error)
 
       get_json api_v4_do_token_url(api_key: @master), @headers do |response|
         expect(response.status).to eq(500)
+      end
+    end
+  end
+
+  describe 'datasets' do
+    before(:all) do
+      @url_helper = 'api_v4_do_datasets_url'
+
+      next_year = Time.now + 1.year
+      dataset1 = { dataset_id: 'carto.zzz.table1', expires_at: next_year }
+      dataset2 = { dataset_id: 'carto.abc.table2', expires_at: next_year }
+      dataset3 = { dataset_id: 'opendata.tal.table3', expires_at: next_year }
+      dataset4 = { dataset_id: 'carto.abc.expired', expires_at: Time.now - 1.day }
+      bq_datasets = [dataset1, dataset2, dataset3, dataset4]
+      @redis_key = "do:#{@user1.username}:datasets"
+      $users_metadata.hset(@redis_key, 'bq', bq_datasets.to_json)
+    end
+
+    after(:all) do
+      $users_metadata.del(@redis_key)
+    end
+
+    it_behaves_like 'an endpoint validating a DO API key'
+
+    it 'returns 200 with the non expired datasets when using the master API key' do
+      get_json api_v4_do_datasets_url(api_key: @master), @headers do |response|
+        expect(response.status).to eq(200)
+        datasets = response.body[:datasets]
+        expect(datasets.count).to eq 3
+        expect(datasets.first).to eq(project: 'carto', dataset: 'abc', table: 'table2', id: 'carto.abc.table2')
+      end
+    end
+
+    it 'returns 200 when using a regular API key with DO grant' do
+      get_json api_v4_do_datasets_url(api_key: @granted_token), @headers do |response|
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'returns 200 with an empty array if the user does not have datasets' do
+      host! "#{@user2.username}.localhost.lan"
+
+      get_json api_v4_do_datasets_url(api_key: @user2.api_key), @headers do |response|
+        expect(response.status).to eq(200)
+        datasets = response.body[:datasets]
+        expect(datasets.count).to eq 0
+      end
+    end
+
+    context 'ordering' do
+      it 'orders by id ascending by default' do
+        get_json api_v4_do_datasets_url(api_key: @master), @headers do |response|
+          expect(response.status).to eq(200)
+          datasets = response.body[:datasets]
+          expect(datasets.count).to eq 3
+          expect(datasets[0][:id]).to eq 'carto.abc.table2'
+          expect(datasets[1][:id]).to eq 'carto.zzz.table1'
+        end
+      end
+
+      it 'orders by id descending' do
+        get_json api_v4_do_datasets_url(api_key: @master, order_direction: 'desc'), @headers do |response|
+          expect(response.status).to eq(200)
+          datasets = response.body[:datasets]
+          expect(datasets.count).to eq 3
+          expect(datasets[0][:id]).to eq 'opendata.tal.table3'
+          expect(datasets[1][:id]).to eq 'carto.zzz.table1'
+        end
+      end
+
+      it 'orders by project descending' do
+        params = { api_key: @master, order: 'project', order_direction: 'desc' }
+        get_json api_v4_do_datasets_url(params), @headers do |response|
+          expect(response.status).to eq(200)
+          datasets = response.body[:datasets]
+          expect(datasets.count).to eq 3
+          expect(datasets[0][:id]).to eq 'opendata.tal.table3'
+        end
+      end
+
+      it 'orders by dataset ascending' do
+        params = { api_key: @master, order: 'dataset', order_direction: 'asc' }
+        get_json api_v4_do_datasets_url(params), @headers do |response|
+          expect(response.status).to eq(200)
+          datasets = response.body[:datasets]
+          expect(datasets.count).to eq 3
+          expect(datasets[0][:id]).to eq 'carto.abc.table2'
+          expect(datasets[1][:id]).to eq 'opendata.tal.table3'
+        end
+      end
+
+      it 'orders by table descending' do
+        params = { api_key: @master, order: 'table', order_direction: 'desc' }
+        get_json api_v4_do_datasets_url(params), @headers do |response|
+          expect(response.status).to eq(200)
+          datasets = response.body[:datasets]
+          expect(datasets.count).to eq 3
+          expect(datasets[0][:id]).to eq 'opendata.tal.table3'
+          expect(datasets[1][:id]).to eq 'carto.abc.table2'
+        end
       end
     end
   end

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -8,7 +8,7 @@ describe Carto::Api::Public::DataObservatoryController do
   before(:all) do
     @master = @user1.api_key
     @not_granted_token = @user1.api_keys.create_regular_key!(name: 'not_do', grants: [{ type: 'apis', apis: [] }]).token
-    do_grants = [{ type: 'apis', apis: [] }, { type: 'user', data: ['data_observatory_token'] }]
+    do_grants = [{ type: 'apis', apis: ['data_observatory_v2'] }]
     @granted_token = @user1.api_keys.create_regular_key!(name: 'do', grants: do_grants).token
     @headers = { 'CONTENT_TYPE' => 'application/json' }
   end

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -8,7 +8,7 @@ describe Carto::Api::Public::DataObservatoryController do
   before(:all) do
     @master = @user1.api_key
     @not_granted_token = @user1.api_keys.create_regular_key!(name: 'not_do', grants: [{ type: 'apis', apis: [] }]).token
-    do_grants = [{ type: 'apis', apis: ['data_observatory_v2'] }]
+    do_grants = [{ type: 'apis', apis: ['do'] }]
     @granted_token = @user1.api_keys.create_regular_key!(name: 'do', grants: do_grants).token
     @headers = { 'CONTENT_TYPE' => 'application/json' }
   end


### PR DESCRIPTION
Closes: https://github.com/CartoDB/cartodb/issues/15119

Added `api/v4/do/datasets` endpoint, which returns:
```
{
  "datasets": [
    {
      "project": "carto",
      "dataset": "public",
      "table": "demographics",
      "id": "carto.public.demographics"
    },
    ...
  ]
}
```

It allows ordering by any of the fields (id, table, dataset, project).

I've also changed the API key grant required for this new endpoint and the `token` one. It now requires `apis: ['do']` instead of `data_observatory_token` under user data. And the OAuth scope changes from `user:data_observatory_token` to `apis:do`.