### PR TITLE
[DO] Licensing API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/models/carto/user_migration_spec.rb \
 	spec/requests/carto/api/public/data_observatory_controller_spec.rb \
 	spec/lib/tasks/data_observatory_rake_spec.rb \
+	spec/services/carto/do_licensing_service_spec.rb \
 	$(NULL)
 
 # This class must be tested isolated as pollutes namespace

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,7 +28,7 @@ sudo make install
 - Data Observatory token endpoint ([#15097](https://github.com/CartoDB/cartodb/pull/15097))
 - Add GET MFA status to EUMAPI ([CartoDB/cartodb#15101](https://github.com/CartoDB/cartodb/issues/15101))
 - Rake task to purchase Data Observatory datasets ([CartoDB/cartodb#15076](https://github.com/CartoDB/cartodb/issues/15076))
-- Endpoint to list purchased Data Observatory datasets ([CartoDB/cartodb#15119](https://github.com/CartoDB/cartodb/issues/15119))
+- Data Observatory licensing API ([#15136](https://github.com/CartoDB/cartodb/pull/15136))
 - Remove Hubspot tracking from cartodb. All the tracking will be managed from Google Tag Manager ([#15128](https://github.com/CartoDB/cartodb/pull/15128))
 
 ### Bug fixes / enhancements

--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -11,25 +11,55 @@ module Carto
         ssl_required
 
         before_action :load_user
-        before_action :load_order, only: [:datasets]
-        before_action :check_permissions
+        before_action :load_filters, only: [:subscriptions]
+        before_action :load_id, only: [:subscription_info, :subscribe]
+        before_action :load_type, only: [:subscription_info]
+        before_action :check_api_key_permissions
+        before_action :check_organization, only: [:subscription_info, :subscribe]
 
         setup_default_rescues
 
         respond_to :json
 
         BIGQUERY_KEY = 'bq'.freeze
-        VALID_ORDER_PARAMS = %i(id table dataset project).freeze
+        VALID_TYPES = %w(dataset geography).freeze
+        DATASET_REGEX = /[\w\-]+\.[\w\-]+\.[\w\-]+/.freeze
+        VALID_ORDER_PARAMS = %i(id table dataset project type).freeze
+        METADATA_FIELDS = %i(id estimated_delivery_days subscription_list_price tos tos_link licenses licenses_link
+                             rights).freeze
 
         def token
           response = Cartodb::Central.new.get_do_token(@user.username)
           render(json: response)
         end
 
-        def datasets
-          available_datasets = bq_datasets.select { |dataset| Time.parse(dataset['expires_at']) > Time.now }
-          response = present_datasets(available_datasets)
-          render(json: { datasets: response })
+        def subscriptions
+          available_subscriptions = bq_subscriptions.select { |dataset| Time.parse(dataset['expires_at']) > Time.now }
+          response = present_subscriptions(available_subscriptions)
+          render(json: { subscriptions: response })
+        end
+
+        def subscription_info
+          response = subscription_metadata.slice(*METADATA_FIELDS)
+
+          render(json: response)
+        end
+
+        def subscribe
+          metadata = subscription_metadata
+          response = metadata.slice(*METADATA_FIELDS)
+
+          return render(json: response) unless metadata[:estimated_delivery_days] == "0"
+
+          license_info = {
+            dataset_id: dataset[:id],
+            available_in: dataset[:available_in],
+            price: dataset[:subscription_list_price],
+            expires_at: Time.now + 1.year
+          }
+          Carto::DoLicensingService.new(username).subscribe([license_info])
+
+          render(json: response)
         end
 
         private
@@ -38,33 +68,70 @@ module Carto
           @user = Carto::User.find(current_viewer.id)
         end
 
-        def load_order
+        def load_filters
           _, _, @order, @direction = page_per_page_order_params(
             VALID_ORDER_PARAMS, default_order: 'id', default_order_direction: 'asc'
           )
+          load_type(required: false)
         end
 
-        def check_permissions
+        def load_id
+          @id = params[:id]
+          raise 'id must be in the format project.schema.table' unless @id =~ DATASET_REGEX
+        end
+
+        def load_type(required: true)
+          @type = params[:type]
+          return if @type.nil? && !required
+
+          raise "type must be 'dataset' or 'geography'" unless VALID_TYPES.include?(@type)
+        end
+
+        def check_api_key_permissions
           api_key = Carto::ApiKey.find_by_token(params["api_key"])
           raise UnauthorizedError unless api_key&.master? || api_key&.data_observatory_permissions?
         end
 
-        def bq_datasets
+        def check_organization
+          raise UnauthorizedError unless @user.organization&.name == 'team'
+        end
+
+        def bq_subscriptions
           redis_key = "do:#{@user.username}:datasets"
           redis_value = $users_metadata.hget(redis_key, BIGQUERY_KEY) || '[]'
           JSON.parse(redis_value)
         end
 
-        def present_datasets(datasets)
-          enriched_datasets = datasets.map do |dataset|
-            dataset_id = dataset['dataset_id']
-            project, dataset, table = dataset_id.split('.')
-            { project: project, dataset: dataset, table: table, id: dataset_id }
+        def present_subscriptions(subscriptions)
+          enriched_subscriptions = subscriptions.map do |subscription|
+            qualified_id = subscription['dataset_id']
+            project, dataset, table = qualified_id.split('.')
+            # FIXME: better save the type in Redis or look for it in the metadata tables
+            type = table.starts_with?('geography') ? 'geography' : 'dataset'
+            { project: project, dataset: dataset, table: table, id: qualified_id, type: type }
           end
-          ordered_datasets = enriched_datasets.sort_by { |dataset| dataset[@order] }
-          @direction == :asc ? ordered_datasets : ordered_datasets.reverse
+          enriched_subscriptions.select! { |subscription| subscription[:type] == @type } if @type
+          ordered_subscriptions = enriched_subscriptions.sort_by { |subscription| subscription[@order] }
+          @direction == :asc ? ordered_subscriptions : ordered_subscriptions.reverse
         end
 
+        def subscription_metadata
+          metadata_user = User.where(username: 'do-metadata').first
+          raise 'No Data Observatory metadata found' unless metadata_user
+
+          query = "SELECT * FROM #{metadata_table} WHERE id = '#{@id}'"
+          result = metadata_user.in_database[query].first
+          raise "No metadata found for #{@id}" unless result
+
+          result
+        end
+
+        def metadata_table
+          case @type
+          when 'dataset' then 'datasets'
+          when 'geography' then 'geographies'
+          end
+        end
       end
     end
   end

--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -26,7 +26,7 @@ module Carto
         DATASET_REGEX = /[\w\-]+\.[\w\-]+\.[\w\-]+/.freeze
         VALID_ORDER_PARAMS = %i(id table dataset project type).freeze
         METADATA_FIELDS = %i(id estimated_delivery_days subscription_list_price tos tos_link licenses licenses_link
-                             rights).freeze
+                             rights type).freeze
         TABLES_BY_TYPE = { 'dataset' => 'datasets', 'geography' => 'geographies' }.freeze
 
         def token
@@ -120,7 +120,7 @@ module Carto
           metadata_user = ::User.where(username: 'do-metadata').first
           raise Carto::LoadError.new('No Data Observatory metadata found') unless metadata_user
 
-          query = "SELECT * FROM #{TABLES_BY_TYPE[@type]} WHERE id = '#{@id}'"
+          query = "SELECT *, '#{@type}' as type FROM #{TABLES_BY_TYPE[@type]} WHERE id = '#{@id}'"
           result = metadata_user.in_database[query].first
           raise Carto::LoadError.new("No metadata found for #{@id}") unless result
 

--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -27,6 +27,7 @@ module Carto
         VALID_ORDER_PARAMS = %i(id table dataset project type).freeze
         METADATA_FIELDS = %i(id estimated_delivery_days subscription_list_price tos tos_link licenses licenses_link
                              rights).freeze
+        TABLES_BY_TYPE = { 'dataset' => 'datasets', 'geography' => 'geographies' }.freeze
 
         def token
           response = Cartodb::Central.new.get_do_token(@user.username)
@@ -119,18 +120,11 @@ module Carto
           metadata_user = ::User.where(username: 'do-metadata').first
           raise Carto::LoadError.new('No Data Observatory metadata found') unless metadata_user
 
-          query = "SELECT * FROM #{metadata_table} WHERE id = '#{@id}'"
+          query = "SELECT * FROM #{TABLES_BY_TYPE[@type]} WHERE id = '#{@id}'"
           result = metadata_user.in_database[query].first
           raise Carto::LoadError.new("No metadata found for #{@id}") unless result
 
           result
-        end
-
-        def metadata_table
-          case @type
-          when 'dataset' then 'datasets'
-          when 'geography' then 'geographies'
-          end
         end
       end
     end

--- a/app/services/carto/do_licensing_service.rb
+++ b/app/services/carto/do_licensing_service.rb
@@ -6,19 +6,20 @@ module Carto
       @redis_key = "do:#{@username}:datasets"
     end
 
-    def purchase(datasets)
+    def subscribe(datasets)
       Cartodb::Central.new.create_do_datasets(username: @username, datasets: datasets)
-      update_redis(datasets)
+      add_to_redis(datasets)
     end
 
     private
 
-    def update_redis(datasets)
-      value = ["bq", merge_redis_value(datasets, 'bq'), "spanner", merge_redis_value(datasets, 'spanner')]
+    def add_to_redis(datasets)
+      value = ["bq", insert_redis_value(datasets, 'bq'), "spanner", insert_redis_value(datasets, 'spanner')]
+
       $users_metadata.hmset(@redis_key, value)
     end
 
-    def merge_redis_value(datasets, storage)
+    def insert_redis_value(datasets, storage)
       redis_value = JSON.parse($users_metadata.hget(@redis_key, storage) || '[]')
       new_datasets = filter_datasets(datasets, storage)
       (redis_value + new_datasets).uniq.to_json

--- a/app/services/carto/do_licensing_service.rb
+++ b/app/services/carto/do_licensing_service.rb
@@ -1,0 +1,27 @@
+module Carto
+  class DoLicensingService
+
+    def initialize(username)
+      @username = username
+    end
+
+    def purchase(datasets)
+      Cartodb::Central.new.create_do_datasets(username: @username, datasets: datasets)
+
+      bq_datasets = filter_datasets(datasets, 'bq')
+      spanner_datasets = filter_datasets(datasets, 'spanner')
+      redis_key = "do:#{@username}:datasets"
+      redis_value = ["bq", bq_datasets.to_json, "spanner", spanner_datasets.to_json]
+      # TODO: merge values, not replace
+      $users_metadata.hmset(redis_key, redis_value)
+    end
+
+    private
+
+    def filter_datasets(datasets, storage)
+      filtered_datasets = datasets.select { |dataset| dataset[:available_in].include?(storage) }
+      filtered_datasets.map { |dataset| dataset.slice(:dataset_id, :expires_at) }
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -588,7 +588,9 @@ CartoDB::Application.routes.draw do
 
       scope 'do' do
         get 'token' => 'data_observatory#token', as: :api_v4_do_token
-        get 'datasets' => 'data_observatory#datasets', as: :api_v4_do_datasets
+        get 'subscriptions' => 'data_observatory#subscriptions', as: :api_v4_do_subscriptions_show
+        post 'subscriptions' => 'data_observatory#subscribe', as: :api_v4_do_subscriptions_create
+        get 'subscription_info' => 'data_observatory#subscription_info', as: :api_v4_do_subscription_info
       end
     end
 

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -97,7 +97,7 @@ module Cartodb
 
     def create_do_datasets(username:, datasets:)
       body = { username: username, datasets: datasets }
-      send_request("api/do/datasets", body, :post, [201, 403, 404])
+      send_request("api/do/datasets", body, :post, [201])
     end
 
     ############################################################################

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -11,21 +11,13 @@ namespace :cartodb do
       raise usage unless username.present? && datasets_csv.present?
 
       datasets = []
-      bq_datasets = []
-      spanner_datasets = []
       CSV.foreach(args[:datasets_csv]) do |row|
         available_in = row[1].split(';')
         dataset = { dataset_id: row[0], available_in: available_in, price: row[2].to_f, expires_at: Time.parse(row[3]) }
         datasets << dataset
-        bq_datasets << dataset.slice(:dataset_id, :expires_at) if available_in.include?('bq')
-        spanner_datasets << dataset.slice(:dataset_id, :expires_at) if available_in.include?('spanner')
       end
 
-      Cartodb::Central.new.create_do_datasets(username: username, datasets: datasets)
-
-      redis_key = "do:#{username}:datasets"
-      redis_value = ["bq", bq_datasets.to_json, "spanner", spanner_datasets.to_json]
-      $users_metadata.hmset(redis_key, redis_value)
+      Carto::DoLicensingService.new(username).purchase(datasets)
 
       puts 'Task finished succesfully!'
     end

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -17,7 +17,7 @@ namespace :cartodb do
         datasets << dataset
       end
 
-      Carto::DoLicensingService.new(username).purchase(datasets)
+      Carto::DoLicensingService.new(username).subscribe(datasets)
 
       puts 'Task finished succesfully!'
     end

--- a/spec/lib/tasks/data_observatory_rake_spec.rb
+++ b/spec/lib/tasks/data_observatory_rake_spec.rb
@@ -36,41 +36,20 @@ describe 'data_observatory.rake' do
       }.to raise_error(RuntimeError, 'USAGE: data_observatory:purchase_datasets["username","path/datasets.csv"]')
     end
 
-    it 'calls create_do_datasets from Central with the expected parameters' do
+    it 'calls purchase from Carto::DoLicensingService with the expected parameters' do
       File.stubs(:open).returns(csv_example)
-      central_mock = mock
-      Cartodb::Central.stubs(:new).returns(central_mock)
-
       expected_datasets = [
         { dataset_id: 'dataset1', available_in: ['bq', 'spanner'], price: 100,
           expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
         { dataset_id: 'dataset2', available_in: ['spanner'], price: 200,
           expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
       ]
-      central_mock.expects(:create_do_datasets).once.with(username: 'fulano', datasets: expected_datasets)
+      service_mock = mock
+      service_mock.expects(:purchase).once.with(expected_datasets)
+      Carto::DoLicensingService.expects(:new).once.with('fulano').returns(service_mock)
 
       Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano', 'datasets.csv')
     end
-
-    it 'stores the metadata in Redis' do
-      File.stubs(:open).returns(csv_example)
-      Cartodb::Central.any_instance.stubs(:create_do_datasets)
-
-      redis_key = "do:fulano:datasets"
-      bq_datasets = [
-        { dataset_id: 'dataset1', expires_at: Time.new(2020, 9, 27, 8, 0, 0) }
-      ].to_json
-      spanner_datasets = [
-        { dataset_id: 'dataset1', expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
-        { dataset_id: 'dataset2', expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
-      ].to_json
-
-      Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano', 'datasets.csv')
-
-      $users_metadata.hget(redis_key, 'bq').should eq bq_datasets
-      $users_metadata.hget(redis_key, 'spanner').should eq spanner_datasets
-    end
-
   end
 
   def csv_example

--- a/spec/lib/tasks/data_observatory_rake_spec.rb
+++ b/spec/lib/tasks/data_observatory_rake_spec.rb
@@ -36,16 +36,16 @@ describe 'data_observatory.rake' do
       }.to raise_error(RuntimeError, 'USAGE: data_observatory:purchase_datasets["username","path/datasets.csv"]')
     end
 
-    it 'calls purchase from Carto::DoLicensingService with the expected parameters' do
+    it 'calls subscribe from Carto::DoLicensingService with the expected parameters' do
       File.stubs(:open).returns(csv_example)
       expected_datasets = [
-        { dataset_id: 'dataset1', available_in: ['bq', 'spanner'], price: 100,
+        { dataset_id: 'dataset1', available_in: ['bq', 'spanner'], price: 100.0,
           expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
-        { dataset_id: 'dataset2', available_in: ['spanner'], price: 200,
+        { dataset_id: 'dataset2', available_in: ['spanner'], price: 200.0,
           expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
       ]
       service_mock = mock
-      service_mock.expects(:purchase).once.with(expected_datasets)
+      service_mock.expects(:subscribe).once.with(expected_datasets)
       Carto::DoLicensingService.expects(:new).once.with('fulano').returns(service_mock)
 
       Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano', 'datasets.csv')

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -86,9 +86,9 @@ describe Carto::Api::Public::DataObservatoryController do
     end
   end
 
-  describe 'datasets' do
+  describe 'subscriptions' do
     before(:all) do
-      @url_helper = 'api_v4_do_datasets_url'
+      @url_helper = 'api_v4_do_subscriptions_show_url'
 
       next_year = Time.now + 1.year
       dataset1 = { dataset_id: 'carto.zzz.table1', expires_at: next_year }
@@ -106,12 +106,13 @@ describe Carto::Api::Public::DataObservatoryController do
 
     it_behaves_like 'an endpoint validating a DO API key'
 
-    it 'returns 200 with the non expired datasets' do
+    it 'returns 200 with the non expired subscriptions' do
+      expected_dataset = { project: 'carto', dataset: 'abc', table: 'table2', id: 'carto.abc.table2', type: 'dataset' }
       get_json endpoint_url(api_key: @master), @headers do |response|
         expect(response.status).to eq(200)
-        datasets = response.body[:datasets]
+        datasets = response.body[:subscriptions]
         expect(datasets.count).to eq 3
-        expect(datasets.first).to eq(project: 'carto', dataset: 'abc', table: 'table2', id: 'carto.abc.table2')
+        expect(datasets.first).to eq expected_dataset
       end
     end
 
@@ -120,7 +121,7 @@ describe Carto::Api::Public::DataObservatoryController do
 
       get_json endpoint_url(api_key: @user2.api_key), @headers do |response|
         expect(response.status).to eq(200)
-        datasets = response.body[:datasets]
+        datasets = response.body[:subscriptions]
         expect(datasets.count).to eq 0
       end
     end
@@ -143,7 +144,7 @@ describe Carto::Api::Public::DataObservatoryController do
       it 'orders by id ascending by default' do
         get_json endpoint_url(api_key: @master), @headers do |response|
           expect(response.status).to eq(200)
-          datasets = response.body[:datasets]
+          datasets = response.body[:subscriptions]
           expect(datasets.count).to eq 3
           expect(datasets[0][:id]).to eq 'carto.abc.table2'
           expect(datasets[1][:id]).to eq 'carto.zzz.table1'
@@ -153,7 +154,7 @@ describe Carto::Api::Public::DataObservatoryController do
       it 'orders by id descending' do
         get_json endpoint_url(api_key: @master, order_direction: 'desc'), @headers do |response|
           expect(response.status).to eq(200)
-          datasets = response.body[:datasets]
+          datasets = response.body[:subscriptions]
           expect(datasets.count).to eq 3
           expect(datasets[0][:id]).to eq 'opendata.tal.table3'
           expect(datasets[1][:id]).to eq 'carto.zzz.table1'
@@ -164,7 +165,7 @@ describe Carto::Api::Public::DataObservatoryController do
         params = { api_key: @master, order: 'project', order_direction: 'desc' }
         get_json endpoint_url(params), @headers do |response|
           expect(response.status).to eq(200)
-          datasets = response.body[:datasets]
+          datasets = response.body[:subscriptions]
           expect(datasets.count).to eq 3
           expect(datasets[0][:id]).to eq 'opendata.tal.table3'
         end
@@ -174,7 +175,7 @@ describe Carto::Api::Public::DataObservatoryController do
         params = { api_key: @master, order: 'dataset', order_direction: 'asc' }
         get_json endpoint_url(params), @headers do |response|
           expect(response.status).to eq(200)
-          datasets = response.body[:datasets]
+          datasets = response.body[:subscriptions]
           expect(datasets.count).to eq 3
           expect(datasets[0][:id]).to eq 'carto.abc.table2'
           expect(datasets[1][:id]).to eq 'opendata.tal.table3'
@@ -185,7 +186,7 @@ describe Carto::Api::Public::DataObservatoryController do
         params = { api_key: @master, order: 'table', order_direction: 'desc' }
         get_json endpoint_url(params), @headers do |response|
           expect(response.status).to eq(200)
-          datasets = response.body[:datasets]
+          datasets = response.body[:subscriptions]
           expect(datasets.count).to eq 3
           expect(datasets[0][:id]).to eq 'opendata.tal.table3'
           expect(datasets[1][:id]).to eq 'carto.abc.table2'

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -273,7 +273,8 @@ describe Carto::Api::Public::DataObservatoryController do
           rights: 'rights',
           subscription_list_price: '100.0',
           tos: 'tos',
-          tos_link: 'tos_link'
+          tos_link: 'tos_link',
+          type: 'dataset'
         }
         expect(response.body).to eq expected_response
       end
@@ -290,7 +291,8 @@ describe Carto::Api::Public::DataObservatoryController do
           rights: 'rights',
           subscription_list_price: '90.0',
           tos: 'tos',
-          tos_link: 'tos_link'
+          tos_link: 'tos_link',
+          type: 'geography'
         }
         expect(response.body).to eq expected_response
       end
@@ -372,7 +374,8 @@ describe Carto::Api::Public::DataObservatoryController do
             rights: 'rights',
             subscription_list_price: '100.0',
             tos: 'tos',
-            tos_link: 'tos_link'
+            tos_link: 'tos_link',
+            type: 'dataset'
           }
           expect(response.body).to eq expected_response
         end
@@ -393,7 +396,8 @@ describe Carto::Api::Public::DataObservatoryController do
             rights: 'rights',
             subscription_list_price: '90.0',
             tos: 'tos',
-            tos_link: 'tos_link'
+            tos_link: 'tos_link',
+            type: 'geography'
           }
           expect(response.body).to eq expected_response
         end

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper_min'
 require 'support/helpers'
+require 'helpers/feature_flag_helper'
 
 describe Carto::Api::Public::DataObservatoryController do
   include_context 'users helper'
   include HelperMethods
+  include FeatureFlagHelper
 
   before(:all) do
     @master = @user1.api_key
@@ -11,6 +13,14 @@ describe Carto::Api::Public::DataObservatoryController do
     do_grants = [{ type: 'apis', apis: ['do'] }]
     @granted_token = @user1.api_keys.create_regular_key!(name: 'do', grants: do_grants).token
     @headers = { 'CONTENT_TYPE' => 'application/json' }
+    populate_do_metadata
+    @feature_flag = FactoryGirl.create(:feature_flag, name: 'do-licensing', restricted: true)
+    Carto::FeatureFlagsUser.create(user_id: @user1.id, feature_flag_id: @feature_flag.id)
+  end
+
+  after(:all) do
+    Carto::User.find_by_username('do-metadata').destroy
+    @feature_flag.destroy
   end
 
   before(:each) do
@@ -18,26 +28,30 @@ describe Carto::Api::Public::DataObservatoryController do
   end
 
   shared_examples 'an endpoint validating a DO API key' do
+    before(:all) do
+      @params ||= {}
+    end
+
     it 'returns 401 if the API key is wrong' do
-      get_json endpoint_url(api_key: 'wrong'), @headers do |response|
+      get_json endpoint_url(@params.merge(api_key: 'wrong')), @headers do |response|
         expect(response.status).to eq(401)
       end
     end
 
     it 'returns 403 when using a regular API key without DO grant' do
-      get_json endpoint_url(api_key: @not_granted_token), @headers do |response|
+      get_json endpoint_url(@params.merge(api_key: @not_granted_token)), @headers do |response|
         expect(response.status).to eq(403)
       end
     end
 
     it 'returns 200 when using the master API key' do
-      get_json endpoint_url(api_key: @master), @headers do |response|
+      get_json endpoint_url(@params.merge(api_key: @master)), @headers do |response|
         expect(response.status).to eq(200)
       end
     end
 
     it 'returns 200 when using a regular API key with DO grant' do
-      get_json endpoint_url(api_key: @granted_token), @headers do |response|
+      get_json endpoint_url(@params.merge(api_key: @granted_token)), @headers do |response|
         expect(response.status).to eq(200)
       end
     end
@@ -193,5 +207,213 @@ describe Carto::Api::Public::DataObservatoryController do
         end
       end
     end
+  end
+
+  describe 'subscription_info' do
+    before(:all) do
+      @url_helper = 'api_v4_do_subscription_info_url'
+      @params = { id: 'carto.abc.dataset1', type: 'dataset' }
+    end
+
+    it_behaves_like 'an endpoint validating a DO API key'
+
+    it 'returns 400 if the id param is not valid' do
+      get_json endpoint_url(api_key: @master, id: 'wrong'), @headers do |response|
+        expect(response.status).to eq(400)
+        expect(response.body).to eq(errors: "Wrong 'id' parameter value.", errors_cause: nil)
+      end
+    end
+
+    it 'returns 400 if the type param is not valid' do
+      get_json endpoint_url(api_key: @master, id: 'carto.abc.dataset1', type: 'wrong'), @headers do |response|
+        expect(response.status).to eq(400)
+        expected_response = {
+          errors: "Wrong 'type' parameter value. Valid values are one of dataset, geography",
+          errors_cause: nil
+        }
+        expect(response.body).to eq expected_response
+      end
+    end
+
+    it 'returns 403 if the feature flag is not enabled for the user' do
+      with_feature_flag @user1, 'do-licensing', false do
+        get_json endpoint_url(api_key: @master, id: 'carto.abc.dataset1', type: 'dataset'), @headers do |response|
+          expect(response.status).to eq(403)
+          expect(response.body).to eq(errors: "DO licensing not enabled", errors_cause: nil)
+        end
+      end
+    end
+
+    it 'returns 404 if the metadata user does not exist' do
+      Carto::User.find_by_username('do-metadata').destroy
+
+      get_json endpoint_url(api_key: @master, id: 'carto.abc.dataset1', type: 'dataset'), @headers do |response|
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(errors: 'No Data Observatory metadata found', errors_cause: nil)
+      end
+
+      populate_do_metadata
+    end
+
+    it 'returns 404 if the dataset metadata does not exist' do
+      get_json endpoint_url(api_key: @master, id: 'carto.abc.inexistent', type: 'dataset'), @headers do |response|
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(errors: 'No metadata found for carto.abc.inexistent', errors_cause: nil)
+      end
+    end
+
+    it 'returns 200 with the metadata for a dataset' do
+      get_json endpoint_url(api_key: @master, id: 'carto.abc.dataset1', type: 'dataset'), @headers do |response|
+        expect(response.status).to eq(200)
+        expected_response = {
+          estimated_delivery_days: '0.0',
+          id: 'carto.abc.dataset1',
+          licenses: 'licenses',
+          licenses_link: 'licenses_link',
+          rights: 'rights',
+          subscription_list_price: '100.0',
+          tos: 'tos',
+          tos_link: 'tos_link'
+        }
+        expect(response.body).to eq expected_response
+      end
+    end
+
+    it 'returns 200 with the metadata for a geography' do
+      get_json endpoint_url(api_key: @master, id: 'carto.abc.geography1', type: 'geography'), @headers do |response|
+        expect(response.status).to eq(200)
+        expected_response = {
+          estimated_delivery_days: '3.0',
+          id: 'carto.abc.geography1',
+          licenses: 'licenses',
+          licenses_link: 'licenses_link',
+          rights: 'rights',
+          subscription_list_price: '90.0',
+          tos: 'tos',
+          tos_link: 'tos_link'
+        }
+        expect(response.body).to eq expected_response
+      end
+    end
+
+  end
+
+  describe 'subscribe' do
+    before(:all) do
+      @url_helper = 'api_v4_do_subscriptions_create_url'
+      @payload = { id: 'carto.abc.dataset1', type: 'dataset' }
+    end
+
+    it 'returns 400 if the id param is not valid' do
+      post_json endpoint_url(api_key: @master), id: 'wrong' do |response|
+        expect(response.status).to eq(400)
+        expect(response.body).to eq(errors: "Wrong 'id' parameter value.", errors_cause: nil)
+      end
+    end
+
+    it 'returns 400 if the type param is not valid' do
+      post_json endpoint_url(api_key: @master), id: 'carto.abc.dataset1', type: 'wrong' do |response|
+        expect(response.status).to eq(400)
+        expected_response = {
+          errors: "Wrong 'type' parameter value. Valid values are one of dataset, geography",
+          errors_cause: nil
+        }
+        expect(response.body).to eq expected_response
+      end
+    end
+
+    it 'returns 403 if the feature flag is not enabled for the user' do
+      with_feature_flag @user1, 'do-licensing', false do
+        post_json endpoint_url(api_key: @master), @payload do |response|
+          expect(response.status).to eq(403)
+          expect(response.body).to eq(errors: "DO licensing not enabled", errors_cause: nil)
+        end
+      end
+    end
+
+    it 'returns 404 if the metadata user does not exist' do
+      Carto::User.find_by_username('do-metadata').destroy
+
+      post_json endpoint_url(api_key: @master), @payload do |response|
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(errors: "No Data Observatory metadata found", errors_cause: nil)
+      end
+
+      populate_do_metadata
+    end
+
+    it 'returns 404 if the dataset metadata does not exist' do
+      post_json endpoint_url(api_key: @master), id: 'carto.abc.inexistent', type: 'dataset' do |response|
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(errors: "No metadata found for carto.abc.inexistent", errors_cause: nil)
+      end
+    end
+
+    it 'returns 200 with the dataset metadata and calls the DoLicensingService with the expected params' do
+      expected_params = [{
+        dataset_id: 'carto.abc.dataset1',
+        available_in: ['bq'],
+        price: 100.0,
+        expires_at: Time.parse('2019/01/01 00:00:00')
+      }]
+
+      mock_service = mock
+      mock_service.expects(:subscribe).with(expected_params).once
+      Carto::DoLicensingService.expects(:new).with(@user1.username).once.returns(mock_service)
+
+      Delorean.time_travel_to '2018/01/01 00:00:00' do
+        post_json endpoint_url(api_key: @master), @payload do |response|
+          expect(response.status).to eq(200)
+          expected_response = {
+            estimated_delivery_days: '0.0',
+            id: 'carto.abc.dataset1',
+            licenses: 'licenses',
+            licenses_link: 'licenses_link',
+            rights: 'rights',
+            subscription_list_price: '100.0',
+            tos: 'tos',
+            tos_link: 'tos_link'
+          }
+          expect(response.body).to eq expected_response
+        end
+      end
+    end
+
+    it 'returns 200 with the dataset metadata without calling DoLicensingService when the delivery time is not 0' do
+      Carto::DoLicensingService.expects(:new).never
+
+      Delorean.time_travel_to '2018/01/01 00:00:00' do
+        post_json endpoint_url(api_key: @master), id: 'carto.abc.geography1', type: 'geography' do |response|
+          expect(response.status).to eq(200)
+          expected_response = {
+            estimated_delivery_days: '3.0',
+            id: 'carto.abc.geography1',
+            licenses: 'licenses',
+            licenses_link: 'licenses_link',
+            rights: 'rights',
+            subscription_list_price: '90.0',
+            tos: 'tos',
+            tos_link: 'tos_link'
+          }
+          expect(response.body).to eq expected_response
+        end
+      end
+    end
+
+  end
+
+  def populate_do_metadata
+    metadata_user = FactoryGirl.create(:user, username: 'do-metadata')
+    db_seed = %{
+      CREATE TABLE datasets(id text, estimated_delivery_days numeric, subscription_list_price numeric, tos text,
+                            tos_link text, licenses text, licenses_link text, rights text, available_in text[]);
+      INSERT INTO datasets VALUES ('carto.abc.dataset1', 0.0, 100.0, 'tos', 'tos_link', 'licenses', 'licenses_link',
+                                   'rights', '{bq}');
+      CREATE TABLE geographies(id text, estimated_delivery_days numeric, subscription_list_price numeric, tos text,
+                               tos_link text, licenses text, licenses_link text, rights text, available_in text[]);
+      INSERT INTO geographies VALUES ('carto.abc.geography1', 3.0, 90.0, 'tos', 'tos_link', 'licenses', 'licenses_link',
+                                      'rights', '{bq}');
+    }
+    metadata_user.in_database.run(db_seed)
   end
 end

--- a/spec/services/carto/do_licensing_service_spec.rb
+++ b/spec/services/carto/do_licensing_service_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper_min'
+
+describe Carto::DoLicensingService do
+
+  before(:all) do
+    @user = FactoryGirl.create(:valid_user, username: 'fulano')
+    @service = Carto::DoLicensingService.new('fulano')
+    @datasets = [
+      { dataset_id: 'dataset1', available_in: ['bq', 'spanner'], price: 100,
+        expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
+      { dataset_id: 'dataset2', available_in: ['spanner'], price: 200,
+        expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
+    ]
+  end
+
+  after(:all) do
+    @user.destroy
+  end
+
+  describe '#purchase' do
+    before(:each) do
+      @central_mock = mock
+      Cartodb::Central.stubs(:new).returns(@central_mock)
+    end
+
+    after(:each) do
+      Cartodb::Central.unstub(:new)
+    end
+
+    it 'calls create_do_datasets from Central with the expected parameters' do
+      @central_mock.expects(:create_do_datasets).once.with(username: 'fulano', datasets: @datasets)
+
+      @service.purchase(@datasets)
+    end
+
+    it 'stores the metadata in Redis' do
+      @central_mock.stubs(:create_do_datasets)
+      redis_key = "do:fulano:datasets"
+      bq_datasets = [
+        { dataset_id: 'dataset1', expires_at: Time.new(2020, 9, 27, 8, 0, 0) }
+      ].to_json
+      spanner_datasets = [
+        { dataset_id: 'dataset1', expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
+        { dataset_id: 'dataset2', expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
+      ].to_json
+
+      @service.purchase(@datasets)
+
+      $users_metadata.hget(redis_key, 'bq').should eq bq_datasets
+      $users_metadata.hget(redis_key, 'spanner').should eq spanner_datasets
+    end
+  end
+
+end

--- a/spec/services/carto/do_licensing_service_spec.rb
+++ b/spec/services/carto/do_licensing_service_spec.rb
@@ -18,7 +18,7 @@ describe Carto::DoLicensingService do
     @user.destroy
   end
 
-  describe '#purchase' do
+  describe '#subscribe' do
     before(:each) do
       @central_mock = mock
       Cartodb::Central.stubs(:new).returns(@central_mock)
@@ -31,7 +31,7 @@ describe Carto::DoLicensingService do
     it 'calls create_do_datasets from Central with the expected parameters' do
       @central_mock.expects(:create_do_datasets).once.with(username: 'fulano', datasets: @datasets)
 
-      @service.purchase(@datasets)
+      @service.subscribe(@datasets)
     end
 
     it 'stores the metadata in Redis' do
@@ -45,7 +45,7 @@ describe Carto::DoLicensingService do
         { dataset_id: 'dataset2', expires_at: '2020-12-31 12:00:00 +0000' }
       ].to_json
 
-      @service.purchase(@datasets)
+      @service.subscribe(@datasets)
 
       $users_metadata.hget(@redis_key, 'bq').should eq bq_datasets
       $users_metadata.hget(@redis_key, 'spanner').should eq spanner_datasets
@@ -59,8 +59,8 @@ describe Carto::DoLicensingService do
           expires_at: '2020-09-27 08:00:00 +0000' }
       ]
 
-      @service.purchase(@datasets)
-      @service.purchase(more_datasets)
+      @service.subscribe(@datasets)
+      @service.subscribe(more_datasets)
 
       bq_datasets = JSON.parse($users_metadata.hget(@redis_key, 'bq'))
       spanner_datasets = JSON.parse($users_metadata.hget(@redis_key, 'spanner'))


### PR DESCRIPTION
Related to https://github.com/CartoDB/data-observatory/issues/144, https://github.com/CartoDB/data-observatory/issues/212, https://github.com/CartoDB/cartoframes/issues/1079

- Renamed `/do/datasets` to `/do/subscriptions`
- Added GET `/do/subscription_info` to get metadata from a dataset
- Added POST `/do/subscriptions` to enable a subscription in case of delivery time = 0 (in another case we should send an email, but we do nothing for now)
- Refactored licensing logic to a service (used now from the data_observatory.rake and the new POST endpoint)
- The new endpoints require the feature flag `do-licensing`

**GET /do/subscriptions**

Params
- type: 'dataset' / 'geography' (optional)
- order: 'project' / 'dataset' / 'table' / 'id' / 'type' (optional)
- order_direction: 'asc' / 'desc' (optional)

Response
 ```
{
  "subscriptions": [
    {
      "project": "carto",
      "dataset": "bbva",
      "table": "financial_spain_2019",
      "id": "carto.bbva.financial_spain_2019",
      "type": "dataset"
    },
    ...
  ]
}
```

**GET /do/subscription_info**

Params
- id: string
- type: 'dataset' / 'geography'

Response
 ```
    {
      "id": "",
      "estimated_delivery_days": 0,
      "subscription_list_price": 0,
      "tos": "",
      "tos_link": "",
      "licenses": "",
      "licenses_link": "",
      "rights": "",
      "type": ""
    }
```

**POST /do/subscriptions**

Params
- id: string
- type: 'dataset' / 'geography'

Response
 ```
    {
      "id": "",
      "estimated_delivery_days": 0,
      "subscription_list_price": 0,
      "tos": "",
      "tos_link": "",
      "licenses": "",
      "licenses_link": "",
      "rights": "",
      "type": ""
    }
```