### PR TITLE
[DO] Fix number format in Licensing API

### DIFF
--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -41,14 +41,14 @@ module Carto
         end
 
         def subscription_info
-          response = subscription_metadata.slice(*METADATA_FIELDS)
+          response = present_metadata(subscription_metadata)
 
           render(json: response)
         end
 
         def subscribe
           metadata = subscription_metadata
-          response = metadata.slice(*METADATA_FIELDS)
+          response = present_metadata(subscription_metadata)
 
           return render(json: response) if metadata[:estimated_delivery_days].positive?
 
@@ -114,6 +114,12 @@ module Carto
           enriched_subscriptions.select! { |subscription| subscription[:type] == @type } if @type
           ordered_subscriptions = enriched_subscriptions.sort_by { |subscription| subscription[@order] }
           @direction == :asc ? ordered_subscriptions : ordered_subscriptions.reverse
+        end
+
+        def present_metadata(metadata)
+          metadata[:estimated_delivery_days] = metadata[:estimated_delivery_days].to_f
+          metadata[:subscription_list_price] = metadata[:subscription_list_price].to_f
+          metadata.slice(*METADATA_FIELDS)
         end
 
         def subscription_metadata

--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -48,7 +48,7 @@ module Carto
 
         def subscribe
           metadata = subscription_metadata
-          response = present_metadata(subscription_metadata)
+          response = present_metadata(metadata)
 
           return render(json: response) if metadata[:estimated_delivery_days].positive?
 

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -266,12 +266,12 @@ describe Carto::Api::Public::DataObservatoryController do
       get_json endpoint_url(api_key: @master, id: 'carto.abc.dataset1', type: 'dataset'), @headers do |response|
         expect(response.status).to eq(200)
         expected_response = {
-          estimated_delivery_days: '0.0',
+          estimated_delivery_days: 0.0,
           id: 'carto.abc.dataset1',
           licenses: 'licenses',
           licenses_link: 'licenses_link',
           rights: 'rights',
-          subscription_list_price: '100.0',
+          subscription_list_price: 100.0,
           tos: 'tos',
           tos_link: 'tos_link',
           type: 'dataset'
@@ -284,12 +284,12 @@ describe Carto::Api::Public::DataObservatoryController do
       get_json endpoint_url(api_key: @master, id: 'carto.abc.geography1', type: 'geography'), @headers do |response|
         expect(response.status).to eq(200)
         expected_response = {
-          estimated_delivery_days: '3.0',
+          estimated_delivery_days: 3.0,
           id: 'carto.abc.geography1',
           licenses: 'licenses',
           licenses_link: 'licenses_link',
           rights: 'rights',
-          subscription_list_price: '90.0',
+          subscription_list_price: 90.0,
           tos: 'tos',
           tos_link: 'tos_link',
           type: 'geography'
@@ -367,12 +367,12 @@ describe Carto::Api::Public::DataObservatoryController do
         post_json endpoint_url(api_key: @master), @payload do |response|
           expect(response.status).to eq(200)
           expected_response = {
-            estimated_delivery_days: '0.0',
+            estimated_delivery_days: 0.0,
             id: 'carto.abc.dataset1',
             licenses: 'licenses',
             licenses_link: 'licenses_link',
             rights: 'rights',
-            subscription_list_price: '100.0',
+            subscription_list_price: 100.0,
             tos: 'tos',
             tos_link: 'tos_link',
             type: 'dataset'
@@ -389,12 +389,12 @@ describe Carto::Api::Public::DataObservatoryController do
         post_json endpoint_url(api_key: @master), id: 'carto.abc.geography1', type: 'geography' do |response|
           expect(response.status).to eq(200)
           expected_response = {
-            estimated_delivery_days: '3.0',
+            estimated_delivery_days: 3.0,
             id: 'carto.abc.geography1',
             licenses: 'licenses',
             licenses_link: 'licenses_link',
             rights: 'rights',
-            subscription_list_price: '90.0',
+            subscription_list_price: 90.0,
             tos: 'tos',
             tos_link: 'tos_link',
             type: 'geography'


### PR DESCRIPTION
The API was returning `estimated_delivery_days` and `subscription_list_price` as strings, but they should be decimals.

The problem is that they are BigDecimals and [as_json converts it to string](https://apidock.com/rails/BigDecimal/as_json), so I'm converting them to float before.