### PR TITLE
[DO] Explicit errors from Central in Licensing API

### DIFF
--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -97,6 +97,10 @@ module Carto
           raise UnauthorizedError.new('DO licensing not enabled') unless @user.has_feature_flag?('do-licensing')
         end
 
+        def rescue_from_central_error(exception)
+          render_jsonp({ errors: exception.errors }, 500)
+        end
+
         def bq_subscriptions
           redis_key = "do:#{@user.username}:datasets"
           redis_value = $users_metadata.hget(redis_key, BIGQUERY_KEY) || '[]'

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -92,7 +92,7 @@ module Cartodb
     end
 
     def get_do_token(username)
-      send_request("api/users/#{username}/do_token", nil, :get, [200, 403, 404])
+      send_request("api/users/#{username}/do_token", nil, :get, [200])
     end
 
     def create_do_datasets(username:, datasets:)

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -90,12 +90,14 @@ describe Carto::Api::Public::DataObservatoryController do
       end
     end
 
-    it 'returns 500 if the central call fails' do
-      central_error = CentralCommunicationFailure.new('boom')
+    it 'returns 500 with an explicit message if the central call fails' do
+      central_response = OpenStruct.new(code: 500, body: { errors: ['boom'] }.to_json)
+      central_error = CartoDB::CentralCommunicationFailure.new(central_response)
       Cartodb::Central.any_instance.stubs(:get_do_token).raises(central_error)
 
       get_json endpoint_url(api_key: @master), @headers do |response|
         expect(response.status).to eq(500)
+        expect(response.body).to eq(errors: ["boom"])
       end
     end
   end
@@ -348,6 +350,17 @@ describe Carto::Api::Public::DataObservatoryController do
       post_json endpoint_url(api_key: @master), id: 'carto.abc.inexistent', type: 'dataset' do |response|
         expect(response.status).to eq(404)
         expect(response.body).to eq(errors: "No metadata found for carto.abc.inexistent", errors_cause: nil)
+      end
+    end
+
+    it 'returns 500 with an explicit message if the central call fails' do
+      central_response = OpenStruct.new(code: 500, body: { errors: ['boom'] }.to_json)
+      central_error = CartoDB::CentralCommunicationFailure.new(central_response)
+      Carto::DoLicensingService.expects(:new).with(@user1.username).once.raises(central_error)
+
+      post_json endpoint_url(api_key: @master), @payload do |response|
+        expect(response.status).to eq(500)
+        expect(response.body).to eq(errors: ["boom"])
       end
     end
 


### PR DESCRIPTION
When calling `GET /do/token` or `POST /do/subscription`, if Central raises a 422 error (with a message like `The user does not have Data Observatory enabled`), we were hiding that message and showing one generic: `Error while updating data in Central`. But for this API it's useful to know the details.