### PR TITLE
[DO] Validate metadata before purchasing

### DIFF
--- a/app/services/carto/do_licensing_service.rb
+++ b/app/services/carto/do_licensing_service.rb
@@ -26,7 +26,7 @@ module Carto
     end
 
     def filter_datasets(datasets, storage)
-      filtered_datasets = datasets.select { |dataset| dataset[:available_in]&.include?(storage) }
+      filtered_datasets = datasets.select { |dataset| dataset[:available_in].include?(storage) }
       filtered_datasets.map do |dataset|
         { "dataset_id" => dataset[:dataset_id], "expires_at" => dataset[:expires_at].to_s }
       end

--- a/app/services/carto/do_licensing_service.rb
+++ b/app/services/carto/do_licensing_service.rb
@@ -26,7 +26,7 @@ module Carto
     end
 
     def filter_datasets(datasets, storage)
-      filtered_datasets = datasets.select { |dataset| dataset[:available_in].include?(storage) }
+      filtered_datasets = datasets.select { |dataset| dataset[:available_in]&.include?(storage) }
       filtered_datasets.map do |dataset|
         { "dataset_id" => dataset[:dataset_id], "expires_at" => dataset[:expires_at].to_s }
       end

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -351,6 +351,13 @@ describe Carto::Api::Public::DataObservatoryController do
       end
     end
 
+    it 'returns 404 if the dataset metadata is incomplete' do
+      post_json endpoint_url(api_key: @master), id: 'carto.abc.incomplete', type: 'dataset' do |response|
+        expect(response.status).to eq(404)
+        expect(response.body).to eq(errors: "Incomplete metadata found for carto.abc.incomplete", errors_cause: nil)
+      end
+    end
+
     it 'returns 200 with the dataset metadata and calls the DoLicensingService with the expected params' do
       expected_params = [{
         dataset_id: 'carto.abc.dataset1',
@@ -413,6 +420,8 @@ describe Carto::Api::Public::DataObservatoryController do
                             tos_link text, licenses text, licenses_link text, rights text, available_in text[]);
       INSERT INTO datasets VALUES ('carto.abc.dataset1', 0.0, 100.0, 'tos', 'tos_link', 'licenses', 'licenses_link',
                                    'rights', '{bq}');
+      INSERT INTO datasets VALUES ('carto.abc.incomplete', 0.0, 100.0, 'tos', 'tos_link', 'licenses', 'licenses_link',
+                                   'rights', NULL);
       CREATE TABLE geographies(id text, estimated_delivery_days numeric, subscription_list_price numeric, tos text,
                                tos_link text, licenses text, licenses_link text, rights text, available_in text[]);
       INSERT INTO geographies VALUES ('carto.abc.geography1', 3.0, 90.0, 'tos', 'tos_link', 'licenses', 'licenses_link',

--- a/spec/services/carto/do_licensing_service_spec.rb
+++ b/spec/services/carto/do_licensing_service_spec.rb
@@ -67,22 +67,6 @@ describe Carto::DoLicensingService do
       bq_datasets.count.should eq 2
       spanner_datasets.count.should eq 2
     end
-
-    it 'does not store anything in Redis if available_in is empty or nil' do
-      @central_mock.stubs(:create_do_datasets)
-
-      datasets = [
-        { dataset_id: 'dataset_nil', available_in: nil, price: 300, expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
-        { dataset_id: 'dataset_empty', available_in: [], price: 300, expires_at: Time.new(2020, 9, 27, 8, 0, 0) }
-      ]
-
-      @service.subscribe(datasets)
-
-      bq_datasets = JSON.parse($users_metadata.hget(@redis_key, 'bq'))
-      spanner_datasets = JSON.parse($users_metadata.hget(@redis_key, 'spanner'))
-      bq_datasets.count.should eq 0
-      spanner_datasets.count.should eq 0
-    end
   end
 
 end


### PR DESCRIPTION
Closes https://github.com/CartoDB/cartodb/issues/15141

Some DO datasets don't have information yet for `available_in` (it's NULL) or other required fields, and because of that the subscribe operation fails with an undescriptive error: https://rollbar.com/carto/CartoDB/items/40314

Now, if any required field is missing, it will raise a 404 error with a proper message and it will be logged in Rollbar.