### PR TITLE
[DO] Unsubscribe endpoint

### DIFF
--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -1,5 +1,3 @@
-# require_dependency 'carto/controller_helper'
-
 module Carto
   module Api
     module Public
@@ -12,10 +10,10 @@ module Carto
 
         before_action :load_user
         before_action :load_filters, only: [:subscriptions]
-        before_action :load_id, only: [:subscription_info, :subscribe]
+        before_action :load_id, only: [:subscription_info, :subscribe, :unsubscribe]
         before_action :load_type, only: [:subscription_info, :subscribe]
         before_action :check_api_key_permissions
-        before_action :check_licensing_enabled, only: [:subscription_info, :subscribe]
+        before_action :check_licensing_enabled, only: [:subscription_info, :subscribe, :unsubscribe]
 
         setup_default_rescues
 
@@ -61,6 +59,12 @@ module Carto
           Carto::DoLicensingService.new(@user.username).subscribe([license_info])
 
           render(json: response)
+        end
+
+        def unsubscribe
+          Carto::DoLicensingService.new(@user.username).unsubscribe(@id)
+
+          head :no_content
         end
 
         private

--- a/app/services/carto/do_licensing_service.rb
+++ b/app/services/carto/do_licensing_service.rb
@@ -11,11 +11,20 @@ module Carto
       add_to_redis(datasets)
     end
 
+    def unsubscribe(dataset_id)
+      Cartodb::Central.new.remove_do_dataset(username: @username, id: dataset_id)
+      remove_from_redis(dataset_id)
+    end
+
     private
 
     def add_to_redis(datasets)
       value = ["bq", insert_redis_value(datasets, 'bq'), "spanner", insert_redis_value(datasets, 'spanner')]
+      $users_metadata.hmset(@redis_key, value)
+    end
 
+    def remove_from_redis(dataset_id)
+      value = ["bq", remove_redis_value(dataset_id, 'bq'), "spanner", remove_redis_value(dataset_id, 'spanner')]
       $users_metadata.hmset(@redis_key, value)
     end
 
@@ -23,6 +32,11 @@ module Carto
       redis_value = JSON.parse($users_metadata.hget(@redis_key, storage) || '[]')
       new_datasets = filter_datasets(datasets, storage)
       (redis_value + new_datasets).uniq.to_json
+    end
+
+    def remove_redis_value(dataset_id, storage)
+      redis_value = JSON.parse($users_metadata.hget(@redis_key, storage) || '[]')
+      redis_value.reject { |dataset| dataset["dataset_id"] == dataset_id }.to_json
     end
 
     def filter_datasets(datasets, storage)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -590,6 +590,7 @@ CartoDB::Application.routes.draw do
         get 'token' => 'data_observatory#token', as: :api_v4_do_token
         get 'subscriptions' => 'data_observatory#subscriptions', as: :api_v4_do_subscriptions_show
         post 'subscriptions' => 'data_observatory#subscribe', as: :api_v4_do_subscriptions_create
+        delete 'subscriptions' => 'data_observatory#unsubscribe', as: :api_v4_do_subscriptions_destroy
         get 'subscription_info' => 'data_observatory#subscription_info', as: :api_v4_do_subscription_info
       end
     end

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -96,8 +96,12 @@ module Cartodb
     end
 
     def create_do_datasets(username:, datasets:)
-      body = { username: username, datasets: datasets }
-      send_request("api/do/datasets", body, :post, [201])
+      body = { datasets: datasets }
+      send_request("api/users/#{username}/do/datasets", body, :post, [201])
+    end
+
+    def remove_do_dataset(username:, id:)
+      send_request("api/users/#{username}/do/datasets/#{id}", nil, :delete, [204])
     end
 
     ############################################################################

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -21,5 +21,17 @@ namespace :cartodb do
 
       puts 'Task finished succesfully!'
     end
+
+    desc "Removes access to a DO dataset for a user and updates the metadata in Central and Redis"
+    task :remove_purchase, [:username, :dataset_id] => [:environment] do |_, args|
+      username = args[:username]
+      dataset_id = args[:dataset_id]
+      usage = 'USAGE: data_observatory:remove_purchase["username","project.schema.table"]'
+      raise usage unless username.present? && dataset_id.present?
+
+      Carto::DoLicensingService.new(username).unsubscribe(dataset_id)
+
+      puts 'Task finished succesfully!'
+    end
   end
 end

--- a/spec/lib/tasks/data_observatory_rake_spec.rb
+++ b/spec/lib/tasks/data_observatory_rake_spec.rb
@@ -20,8 +20,6 @@ describe 'data_observatory.rake' do
 
     after(:each) do
       File.unstub(:open)
-      Cartodb::Central.unstub(:new)
-      Cartodb::Central.any_instance.unstub(:create_do_datasets)
     end
 
     it 'throws an error if username is not provided' do
@@ -49,6 +47,32 @@ describe 'data_observatory.rake' do
       Carto::DoLicensingService.expects(:new).once.with('fulano').returns(service_mock)
 
       Rake::Task['cartodb:data_observatory:purchase_datasets'].invoke('fulano', 'datasets.csv')
+    end
+  end
+
+  describe '#remove_purchase' do
+    before(:each) do
+      Rake::Task['cartodb:data_observatory:remove_purchase'].reenable
+    end
+
+    it 'throws an error if username is not provided' do
+      expect {
+        Rake::Task['cartodb:data_observatory:remove_purchase'].invoke
+      }.to raise_error(RuntimeError, 'USAGE: data_observatory:remove_purchase["username","project.schema.table"]')
+    end
+
+    it 'throws an error if dataset_id is not provided' do
+      expect {
+        Rake::Task['cartodb:data_observatory:remove_purchase'].invoke('fulano')
+      }.to raise_error(RuntimeError, 'USAGE: data_observatory:remove_purchase["username","project.schema.table"]')
+    end
+
+    it 'calls unsubscribe from Carto::DoLicensingService with the expected parameters' do
+      service_mock = mock
+      service_mock.expects(:unsubscribe).once.with('carto.abc.dataset')
+      Carto::DoLicensingService.expects(:new).once.with('fulano').returns(service_mock)
+
+      Rake::Task['cartodb:data_observatory:remove_purchase'].invoke('fulano', 'carto.abc.dataset')
     end
   end
 

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -406,6 +406,39 @@ describe Carto::Api::Public::DataObservatoryController do
 
   end
 
+  describe 'unsubscribe' do
+    before(:all) do
+      @url_helper = 'api_v4_do_subscriptions_destroy_url'
+      @params = { api_key: @master, id: 'carto.abc.dataset1' }
+    end
+
+    it 'returns 400 if the id param is not valid' do
+      delete_json endpoint_url(@params.merge(id: 'wrong')) do |response|
+        expect(response.status).to eq(400)
+        expect(response.body).to eq(errors: "Wrong 'id' parameter value.", errors_cause: nil)
+      end
+    end
+
+    it 'returns 403 if the feature flag is not enabled for the user' do
+      with_feature_flag @user1, 'do-licensing', false do
+        delete_json endpoint_url(@params) do |response|
+          expect(response.status).to eq(403)
+          expect(response.body).to eq(errors: "DO licensing not enabled", errors_cause: nil)
+        end
+      end
+    end
+
+    it 'returns 204 calls the DoLicensingService with the expected params' do
+      mock_service = mock
+      mock_service.expects(:unsubscribe).with('carto.abc.dataset1').once
+      Carto::DoLicensingService.expects(:new).with(@user1.username).once.returns(mock_service)
+
+      delete_json endpoint_url(@params) do |response|
+        expect(response.status).to eq(204)
+      end
+    end
+  end
+
   def populate_do_metadata
     metadata_user = FactoryGirl.create(:user, username: 'do-metadata')
     db_seed = %{

--- a/spec/services/carto/do_licensing_service_spec.rb
+++ b/spec/services/carto/do_licensing_service_spec.rb
@@ -6,16 +6,21 @@ describe Carto::DoLicensingService do
     @user = FactoryGirl.create(:valid_user, username: 'fulano')
     @redis_key = "do:fulano:datasets"
     @service = Carto::DoLicensingService.new('fulano')
+    @dataset_id = 'carto.abc.dataset1'
     @datasets = [
-      { dataset_id: 'dataset1', available_in: ['bq', 'spanner'], price: 100,
+      { dataset_id: @dataset_id, available_in: ['bq', 'spanner'], price: 100,
         expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
-      { dataset_id: 'dataset2', available_in: ['spanner'], price: 200,
+      { dataset_id: 'carto.abc.dataset2', available_in: ['spanner'], price: 200,
         expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
     ]
   end
 
   after(:all) do
     @user.destroy
+  end
+
+  after(:each) do
+    $users_metadata.del(@redis_key)
   end
 
   describe '#subscribe' do
@@ -38,11 +43,11 @@ describe Carto::DoLicensingService do
       @central_mock.stubs(:create_do_datasets)
 
       bq_datasets = [
-        { dataset_id: 'dataset1', expires_at: '2020-09-27 08:00:00 +0000' }
+        { dataset_id: 'carto.abc.dataset1', expires_at: '2020-09-27 08:00:00 +0000' }
       ].to_json
       spanner_datasets = [
-        { dataset_id: 'dataset1', expires_at: '2020-09-27 08:00:00 +0000' },
-        { dataset_id: 'dataset2', expires_at: '2020-12-31 12:00:00 +0000' }
+        { dataset_id: 'carto.abc.dataset1', expires_at: '2020-09-27 08:00:00 +0000' },
+        { dataset_id: 'carto.abc.dataset2', expires_at: '2020-12-31 12:00:00 +0000' }
       ].to_json
 
       @service.subscribe(@datasets)
@@ -55,7 +60,7 @@ describe Carto::DoLicensingService do
       @central_mock.stubs(:create_do_datasets)
 
       more_datasets = [
-        { dataset_id: 'dataset3', available_in: ['bq'], price: 300,
+        { dataset_id: 'carto.abc.dataset3', available_in: ['bq'], price: 300,
           expires_at: '2020-09-27 08:00:00 +0000' }
       ]
 
@@ -66,6 +71,39 @@ describe Carto::DoLicensingService do
       spanner_datasets = JSON.parse($users_metadata.hget(@redis_key, 'spanner'))
       bq_datasets.count.should eq 2
       spanner_datasets.count.should eq 2
+    end
+  end
+
+  describe '#unsubscribe' do
+    before(:each) do
+      @central_mock = mock
+      Cartodb::Central.stubs(:new).returns(@central_mock)
+    end
+
+    after(:each) do
+      Cartodb::Central.unstub(:new)
+    end
+
+    it 'calls remove_do_dataset from Central with the expected parameters' do
+      @central_mock.expects(:remove_do_dataset).once.with(username: 'fulano', id: @dataset_id)
+
+      @service.unsubscribe(@dataset_id)
+    end
+
+    it 'removes the metadata from Redis' do
+      @central_mock.stubs(:create_do_datasets)
+      @central_mock.stubs(:remove_do_dataset)
+
+      bq_datasets = [].to_json
+      spanner_datasets = [
+        { dataset_id: 'carto.abc.dataset2', expires_at: '2020-12-31 12:00:00 +0000' }
+      ].to_json
+
+      @service.subscribe(@datasets)
+      @service.unsubscribe(@dataset_id)
+
+      $users_metadata.hget(@redis_key, 'bq').should eq bq_datasets
+      $users_metadata.hget(@redis_key, 'spanner').should eq spanner_datasets
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/data-observatory/issues/254

DELETE endpoint: `api/v4/do/subscriptions?api_key=X&id=project.schema.table`
Rake task: `bundle exec rake cartodb:data_observatory:remove_purchase["gonzalor","project.schema.table"]`

:warning: **Deploy along with https://github.com/CartoDB/cartodb-central/pull/2581**