### PR TITLE
Reassign ownership after destroying an OAuth API key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - Add quick link to copy dataset name ([CartoDB/product#391](https://github.com/CartoDB/product/issues/391))
 
 ### Bug fixes / enhancements
-- None yet
+- Reassign ownership after destroying an OAuth API key ([#15162](https://github.com/CartoDB/cartodb/pull/15162))
 
 4.30.0 (2019-10-18)
 -------------------

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -554,8 +554,6 @@ module Carto
     end
 
     def reassign_owner
-      # The other type of keys are reassigned in oauth_app_user for example
-      return unless regular?
       db_run("REASSIGN OWNED BY \"#{db_role}\" TO \"#{user.database_username}\";")
     end
 


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/15159

The reassignment was being only applied to regular API keys, but we should also do it for the ones from OAuth. 

There was a comment saying that `The other type of keys are reassigned in oauth_app_user for example`, but in OauthAppUser only the datasets and ownership roles were being reassigned.