### PR TITLE
disabling ghost tables event trigger during migrations

### DIFF
--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -631,6 +631,7 @@ module CartoDB
         cdb_schema = superuser_user_pg_conn.query("SELECT nspname FROM pg_catalog.pg_namespace where nspname = 'cdb'")
         superuser_user_pg_conn.query("CREATE SCHEMA cdb") if cdb_schema.count == 0
         superuser_user_pg_conn.query("CREATE EXTENSION IF NOT EXISTS cartodb WITH SCHEMA cartodb")
+        superuser_user_pg_conn.query("SELECT CDB_DisableGhostTablesTrigger()")
       rescue PG::Error => e
         @logger.error "Error: Cannot setup DB"
         raise e


### PR DESCRIPTION
Solves https://github.com/CartoDB/cartodb-postgresql/issues/368 and unblock some migrations

After some different approaches, I think this one is best and simpler:
- disabling the trigger after database creation
- the trigger will be reenabled (if the user has the FF and the configuration) in `configure_database` method after pg_restore finish  