### PR TITLE
Fix server/user classification of odbc options

### DIFF
--- a/lib/carto/connector/providers/bigquery.rb
+++ b/lib/carto/connector/providers/bigquery.rb
@@ -82,6 +82,14 @@ module Carto
         }
       end
 
+      def server_attributes
+        %I(Driver Catalog SQLDialect OAuthMechanism ClientId ClientSecret AllowLargeResults LargeResultsDataSetId LargeResultsTempTableExpirationTime)
+      end
+
+      def user_attributes
+        %I(RefreshToken)
+      end
+
       def create_proxy_conf
         proxy = ENV['HTTP_PROXY'] || ENV['http_proxy']
         if !proxy.nil?

--- a/lib/carto/connector/providers/hive.rb
+++ b/lib/carto/connector/providers/hive.rb
@@ -46,6 +46,13 @@ module Carto
         super.reverse_merge(schema: @connection[:database] || DEFAULT_SCHEMA)
       end
 
+      def server_attributes
+        %I(Driver HOST PORT Schema)
+      end
+
+      def user_attributes
+        %I(UID PWD)
+      end
     end
   end
 end

--- a/lib/carto/connector/providers/mysql.rb
+++ b/lib/carto/connector/providers/mysql.rb
@@ -39,6 +39,14 @@ module Carto
         }
       end
 
+      def server_attributes
+        %I(Driver option prefetch no_spss can_handle_exp_pwd server port schema)
+      end
+
+      def user_attributes
+        %I(uid pwd)
+      end
+
       def non_connection_parameters
         # database acts like schema name in MySQL
         super.reverse_merge(schema: @connection[:database])

--- a/lib/carto/connector/providers/odbc.rb
+++ b/lib/carto/connector/providers/odbc.rb
@@ -211,8 +211,15 @@ module Carto
         @params.slice(*(REQUIRED_OPTIONS + OPTIONAL_OPTIONS - %I(columns connection)))
       end
 
-      SERVER_OPTIONS = %w(dsn driver host server address port database).freeze
-      USER_OPTIONS   = %w(uid pwd user username password).freeze
+      # Attributes (internal names) which will defined at fdw server level
+      def server_attributes
+        must_be_defined_in_derived_class
+      end
+
+      # Attributes (internal names) which will defined at user mapping level
+      def user_attributes
+        must_be_defined_in_derived_class
+      end
 
       def connection_options(parameters)
         # Prefix option names with "odbc_"
@@ -230,15 +237,15 @@ module Carto
       end
 
       def server_options
-        connection_options(connection_attributes.slice(*SERVER_OPTIONS)).parameters
+        connection_options(connection_attributes.slice(*server_attributes)).parameters
       end
 
       def user_options
-        connection_options(connection_attributes.slice(*USER_OPTIONS)).parameters
+        connection_options(connection_attributes.slice(*user_attributes)).parameters
       end
 
       def table_options
-        params = connection_options connection_attributes.except(*(SERVER_OPTIONS + USER_OPTIONS))
+        params = connection_options connection_attributes.except(*(server_attributes + user_attributes))
         params.merge(non_connection_parameters).parameters
       end
 

--- a/lib/carto/connector/providers/postgresql.rb
+++ b/lib/carto/connector/providers/postgresql.rb
@@ -47,6 +47,14 @@ module Carto
         # Default remote schema
         super.reverse_merge(schema: DEFAULT_SCHEMA)
       end
+
+      def server_attributes
+        %I(Driver ByteaAsLongVarBinary MaxVarcharSize BoolsAsChar Server Database Port SSLmode)
+      end
+
+      def user_attributes
+        %I(UID PWD)
+      end
     end
   end
 end

--- a/lib/carto/connector/providers/sqlserver.rb
+++ b/lib/carto/connector/providers/sqlserver.rb
@@ -41,6 +41,14 @@ module Carto
         # Default remote schema
         super.reverse_merge(schema: DEFAULT_SCHEMA)
       end
+
+      def server_attributes
+        %I(Driver AppicationIntent Server Database Port)
+      end
+
+      def user_attributes
+        %I(UID PWD)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #15180

The server/user options are now defined in each specific provider class instead of the base odbc class, because the names are provider-specific, not the generic public names. Perhaps the code would be more terse if user/table options are defined in each class instead of server/user (so that server takes all options not assigned to user or table.