### PR TITLE
Use plpython3u for PG12+

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@ sudo make install
 - Exclude table permissions from /viz with show_permission=false ([#15368](https://github.com/CartoDB/cartodb/pull/15368))
 - Add default delivery days for data observatory metadata ([#15362](https://github.com/CartoDB/cartodb/pull/15362))
 - Add required tips parameter to fix street geocoding in advanced mode ([CartoDB/support#2265](https://github.com/CartoDB/support/issues/2265))
+- Use plpython3u for PG12+ ([#15228](https://github.com/CartoDB/cartodb/pull/15228))
+
 
 4.32.0 (2019-12-27)
 -------------------

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -27,6 +27,8 @@ module CartoDB
         raise "User nil" unless user
         @user = user
         @queries = CartoDB::UserModule::DBQueries.new(@user)
+        @pgversion = nil
+        @plpythonu = nil
       end
 
       def queries
@@ -36,6 +38,8 @@ module CartoDB
       # This method is used both upon user creation and by the UserMover
       # All methods called inside should allow to be executed multiple times without errors
       def configure_database
+        set_pgversion
+
         set_database_search_path
 
         grant_user_in_database
@@ -190,12 +194,8 @@ module CartoDB
               db.run("SET statement_timeout TO '#{statement_timeout}';")
             end
 
-            db.run('CREATE EXTENSION plpythonu FROM unpackaged') unless db.fetch(%{
-                SELECT count(*) FROM pg_extension WHERE extname='plpythonu'
-              }).first[:count] > 0
-            db.run('CREATE EXTENSION postgis FROM unpackaged') unless db.fetch(%{
-                SELECT count(*) FROM pg_extension WHERE extname='postgis'
-              }).first[:count] > 0
+            db.run("CREATE EXTENSION IF NOT EXISTS #{@plpythonu}")
+            db.run("CREATE EXTENSION IF NOT EXISTS postgis")
 
             unless statement_timeout.nil?
               db.run("SET statement_timeout TO '#{old_timeout}';")
@@ -251,6 +251,17 @@ module CartoDB
       def self.build_search_path(user_schema, quote_user_schema = true)
         quote_char = quote_user_schema ? "\"" : ""
         "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_CDB_DATASERVICES_API}, #{SCHEMA_PUBLIC}"
+      end
+
+      def set_pgversion
+        @user.in_database(as: :superuser) do |database|
+          @pgversion = database.fetch("select current_setting('server_version_num') as version").first[:version].to_i
+        end
+        if @pgversion >= 120000
+          @plpythonu = "plpython3u"
+        else
+          @plpythonu = "plpythonu"
+        end
       end
 
       def set_database_search_path
@@ -674,10 +685,10 @@ module CartoDB
                 EXCEPTION WHEN undefined_function OR invalid_schema_name THEN
                   RAISE NOTICE 'Got % (%)', SQLERRM, SQLSTATE;
                   BEGIN
-                    CREATE EXTENSION cartodb VERSION '#{cdb_extension_target_version}' FROM unpackaged;
+                    CREATE EXTENSION cartodb VERSION '#{cdb_extension_target_version}' CASCADE FROM unpackaged;
                   EXCEPTION WHEN undefined_table THEN
                     RAISE NOTICE 'Got % (%)', SQLERRM, SQLSTATE;
-                    CREATE EXTENSION cartodb VERSION '#{cdb_extension_target_version}';
+                    CREATE EXTENSION cartodb CASCADE VERSION '#{cdb_extension_target_version}';
                     RETURN;
                   END;
                   RETURN;
@@ -1036,9 +1047,7 @@ module CartoDB
       end
 
       def get_drop_functions_sql(database, schema_name, aggregated: false)
-        pg_version = database.fetch("select current_setting('server_version_num') as version").first[:version].to_i
-
-        if pg_version >= 110000
+        if @pgversion >= 110000
           agg_join_clause = "pg_proc.prokind #{aggregated ? ' = ' : ' <> '} 'a'"
         else
           agg_join_clause = "pg_proc.proisagg = #{aggregated ? 'TRUE' : 'FALSE'}"
@@ -1076,10 +1085,12 @@ module CartoDB
 
       # Add plpythonu pl handler
       def add_python
+        set_pgversion
+
         @user.in_database(
           as: :superuser,
           no_cartodb_in_schema: true
-        ).run("CREATE OR REPLACE PROCEDURAL LANGUAGE 'plpythonu' HANDLER plpython_call_handler;")
+        ).run("CREATE EXTENSION IF NOT EXISTS #{@plpythonu};")
       end
 
       # Needed because in some cases it might not exist and failure ends transaction
@@ -1486,7 +1497,7 @@ module CartoDB
                       break
                     retry -= 1 # try reconnecting
             $$
-            LANGUAGE 'plpythonu' VOLATILE;
+            LANGUAGE '#{@plpythonu}' VOLATILE;
             REVOKE ALL ON FUNCTION public.cdb_invalidate_varnish(TEXT) FROM PUBLIC;
             COMMIT;
         TRIGGER
@@ -1535,7 +1546,7 @@ module CartoDB
                       break
                     retry -= 1 # try reconnecting
             $$
-            LANGUAGE 'plpythonu' VOLATILE;
+            LANGUAGE '#{@plpythonu}' VOLATILE;
             REVOKE ALL ON FUNCTION public.cdb_invalidate_varnish(TEXT) FROM PUBLIC;
             COMMIT;
           TRIGGER
@@ -1629,7 +1640,7 @@ module CartoDB
                   syslog.syslog(syslog.LOG_INFO, "invalidation: %s" % json.dumps(invalidation_result))
 
             $$
-            LANGUAGE 'plpythonu' VOLATILE;
+            LANGUAGE '#{@plpythonu}' VOLATILE;
             REVOKE ALL ON FUNCTION public.cdb_invalidate_varnish(TEXT) FROM PUBLIC;
             COMMIT;
           TRIGGER

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1047,6 +1047,8 @@ module CartoDB
       end
 
       def get_drop_functions_sql(database, schema_name, aggregated: false)
+        set_pgversion
+
         if @pgversion >= 110000
           agg_join_clause = "pg_proc.prokind #{aggregated ? ' = ' : ' <> '} 'a'"
         else

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -622,9 +622,7 @@ module CartoDB
       end
 
       def setup_db(_dbname)
-        ['postgis'].each do |extension|
-          superuser_user_pg_conn.query("CREATE EXTENSION IF NOT EXISTS #{extension}")
-        end
+        superuser_user_pg_conn.query("CREATE EXTENSION IF NOT EXISTS postgis")
         cartodb_schema = superuser_user_pg_conn.query("SELECT nspname FROM pg_catalog.pg_namespace where nspname = 'cartodb'")
         superuser_user_pg_conn.query("CREATE SCHEMA cartodb") if cartodb_schema.count == 0
         cdb_importer_schema = superuser_user_pg_conn.query("SELECT nspname FROM pg_catalog.pg_namespace where nspname = 'cdb_importer'")

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -622,7 +622,7 @@ module CartoDB
       end
 
       def setup_db(_dbname)
-        ['plpythonu', 'postgis'].each do |extension|
+        ['postgis'].each do |extension|
           superuser_user_pg_conn.query("CREATE EXTENSION IF NOT EXISTS #{extension}")
         end
         cartodb_schema = superuser_user_pg_conn.query("SELECT nspname FROM pg_catalog.pg_namespace where nspname = 'cartodb'")
@@ -631,7 +631,7 @@ module CartoDB
         superuser_user_pg_conn.query("CREATE SCHEMA cdb_importer") if cdb_importer_schema.count == 0
         cdb_schema = superuser_user_pg_conn.query("SELECT nspname FROM pg_catalog.pg_namespace where nspname = 'cdb'")
         superuser_user_pg_conn.query("CREATE SCHEMA cdb") if cdb_schema.count == 0
-        superuser_user_pg_conn.query("CREATE EXTENSION IF NOT EXISTS cartodb WITH SCHEMA cartodb")
+        superuser_user_pg_conn.query("CREATE EXTENSION IF NOT EXISTS cartodb WITH SCHEMA cartodb CASCADE")
         superuser_user_pg_conn.query("SELECT CDB_DisableGhostTablesTrigger()")
       rescue PG::Error => e
         @logger.error "Error: Cannot setup DB"


### PR DESCRIPTION
Use python3 (plpython3u) on new databases when created against PG12. Migrations from pg11 + python2 are not supported.