### PR TITLE
15231 Use the StringSanitizer to normalize column names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Add a warning to assess changes in column name normalization upon table import/sync/creation ([#15231](https://github.com/CartoDB/cartodb/issues/15231))
+- Sanitization / normalization of column names now preserves uppercase letters upon import through DB Connectors [#15231](https://github.com/CartoDB/cartodb/issues/15231)
 
 4.31.0 (2019-11-19)
 -------------------

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1342,8 +1342,8 @@ class Table
         sanitized_column_name: sanitized_column_name
       )
     end
-    if valid_column_name != column_name
-      connection.run(%Q{ALTER TABLE "#{database_schema}"."#{table_name}" RENAME COLUMN "#{column_name}" TO "#{valid_column_name}";})
+    if sanitized_column_name != column_name
+      connection.run(%Q{ALTER TABLE "#{database_schema}"."#{table_name}" RENAME COLUMN "#{column_name}" TO "#{sanitized_column_name}";})
     end
 
     valid_column_name

--- a/services/importer/lib/importer/string_sanitizer.rb
+++ b/services/importer/lib/importer/string_sanitizer.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module CartoDB
   module Importer2
     class StringSanitizer
@@ -65,6 +66,7 @@ module CartoDB
         .gsub(/-/,' ').strip
         .gsub(/ /,'-')
         .gsub(/-/,'_')
+        .gsub(/_+/,'_')
       end #sanitize
     end # StringSanitizer
   end # Importer2


### PR DESCRIPTION
This renames column names, if needed, using the `StringSanitizer`. The branch is built on top of `15231-log-traces`