### PR TITLE
First bug

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -27,7 +27,7 @@ class SignupController < ApplicationController
   def create
     account_creator = CartoDB::UserAccountCreator.new(Carto::UserCreation::CREATED_VIA_ORG_SIGNUP).
                       with_organization(@organization, viewer: invitation.try(:viewer)).
-                      with_invitation_token( params[:invitation_token] )
+                      with_invitation_token(params[:invitation_token])
 
     raise "Organization doesn't allow user + password authentication" if user_password_signup? && !@organization.auth_username_password_enabled
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -27,7 +27,7 @@ class SignupController < ApplicationController
   def create
     account_creator = CartoDB::UserAccountCreator.new(Carto::UserCreation::CREATED_VIA_ORG_SIGNUP).
                       with_organization(@organization, viewer: invitation.try(:viewer)).
-                      with_invitation_token(params[:invitation_token])
+                      with_invitation_token(params[:user][:invitation_token])
 
     raise "Organization doesn't allow user + password authentication" if user_password_signup? && !@organization.auth_username_password_enabled
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -27,7 +27,7 @@ class SignupController < ApplicationController
   def create
     account_creator = CartoDB::UserAccountCreator.new(Carto::UserCreation::CREATED_VIA_ORG_SIGNUP).
                       with_organization(@organization, viewer: invitation.try(:viewer)).
-                      with_invitation_token(params[:user][:invitation_token])
+                      with_invitation_token( params[:invitation_token] )
 
     raise "Organization doesn't allow user + password authentication" if user_password_signup? && !@organization.auth_username_password_enabled
 
@@ -195,7 +195,7 @@ class SignupController < ApplicationController
     email = (params[:user] && params[:user][:email]) || params[:email]
     token = params[:invitation_token]
     return unless email && token
-    invitations = Carto::Invitation.query_with_valid_email(email).where(organization_id: @organization.id).all
+    invitations = Carto::Invitation.query_with_unused_email(email).where(organization_id: @organization.id).all
     @invitation = invitations.find { |i| i.token(email) == token }
   end
 end

--- a/app/models/carto/user_creation.rb
+++ b/app/models/carto/user_creation.rb
@@ -163,6 +163,7 @@ class Carto::UserCreation < ActiveRecord::Base
 
   def pertinent_invitation
     @pertinent_invitation ||= select_valid_invitation_token(Carto::Invitation.query_with_unused_email(email).all)
+
   end
 
   private
@@ -264,11 +265,9 @@ class Carto::UserCreation < ActiveRecord::Base
   end
 
   def use_invitation
-    return unless invitation_token
-    invitation = pertinent_invitation
-    return unless invitation
-
-    invitation.use(email, invitation_token)
+    Carto::Invitation.query_with_valid_email(email).each do |invitation|
+      invitation.use(email, invitation.token(email))
+    end
   end
 
   def promote_user

--- a/spec/requests/signup_controller_spec.rb
+++ b/spec/requests/signup_controller_spec.rb
@@ -144,6 +144,70 @@ describe SignupController do
       get signup_url(invitation_token: invitation.token('wadus@wad.us'), email: 'wadus@wad.us')
       response.status.should == 200
     end
+
+    context 'an invited user' do
+      let(:fake_organization) { FactoryGirl.create(:organization_with_users, whitelisted_email_domains: []) }
+      let(:owner) { Carto::User.find(fake_organization.owner.id) }
+      let(:email) { 'new_user_invited@carto.com' }
+      let!(:invitation) { Carto::Invitation.create_new(owner, [email], 'Welcome!', true) }
+      let(:invitation_token) { invitation.token(email) }
+
+      before do
+        fake_organization.default_quota_in_bytes = DEFAULT_QUOTA_IN_BYTES
+        fake_organization.whitelisted_email_domains = ['carto.com']      
+        fake_organization.auth_username_password_enabled = true
+        fake_organization.seats = 99
+        fake_organization.viewer_seats = 99
+        fake_organization.save
+        host! "#{fake_organization.name}.localhost.lan"
+      end
+
+      context 'signup' do
+        before do
+          get signup_url(invitation_token: invitation_token, email: email)
+        end
+
+        it { expect(response.status).to eql 200 }
+
+        context 'when there is more than one invitation token' do
+          let!(:invitation2) { Carto::Invitation.create_new(owner, [email], 'Welcome!', true) }
+          let(:invitation_token) { invitation2.token(email) }
+
+          it { expect(response.status).to eql 200 }
+        end
+      end
+     
+      context '#create' do
+        let(:email) { 'new_user_valid@carto.com' }
+        let(:username) { 'inviteduser' }
+        let(:password) { '2{Patrañas}' }
+  
+        before :each do
+          host! "#{fake_organization.name}.localhost.lan"
+          post signup_organization_user_url(user_domain: fake_organization.name, user: { username: username, email: email, password: password, invitation_token: invitation_token })
+        end
+
+        it { expect(response.body).to include "Your account is being created" }
+
+        context 'when invitation token is wrong' do
+          let(:email) { 'new_user_wrong@carto.com' }
+          let(:username) { 'inviteduser2' }
+          let(:invitation_token) { 'wrong' }
+
+          it { expect(response.body).to include "Fake token" }
+        end
+
+        context 'when user has more than one invitation token' do
+          let(:email) { 'new_user_multiple@carto.com' }
+          let(:username) { 'multipleuser' }
+          let!(:invitation2) { Carto::Invitation.create_new(owner, [email], 'Welcome!', true) }
+          let!(:other_invitation) { Carto::Invitation.create_new(owner, [email], 'Welcome!', true) }
+          let(:invitation_token) { other_invitation.token(email) }
+
+          it { expect(response.body).to_not include "Fake token" }
+        end
+      end
+    end
   end
 
   describe 'user creation' do

--- a/spec/requests/signup_controller_spec.rb
+++ b/spec/requests/signup_controller_spec.rb
@@ -432,7 +432,7 @@ describe SignupController do
       last_user_creation = Carto::UserCreation.order('created_at desc').limit(1).first
       @organization.whitelisted_email_domains.should_not include(last_user_creation.email)
       last_user_creation.organization_id.should == @organization.id
-      # last_user_creation.requires_validation_email?.should == false
+      last_user_creation.requires_validation_email?.should == false
       invitation.reload
       invitation.used_emails.should include(invited_email)
     end


### PR DESCRIPTION

What this PR does:

* Makes the check in the signup new controller action instead of doing it in the create.
* Check that the email has not being used previously with other user.
* When user has been created it invalidates all tokens for this email, not just the current one.
* I've grouped all my tests together in a single _context_ to be easier to read in the diff.

### Suggestions

In the new signup action if invitation is wrong we redirect the user to a 404 page.  I think in that case we should present a message indicating the issue and hiding the form.  In general redirecting to a 404 page if some params are missing or wrong is not a good UX.  

It would be good to have an InvitationService object that takes care of all the invitation logic.  Right now both the signup controller and the user_creation model know too much about invitations.

Also the naming can be improved: _pertinent_invitation_ is not very descriptive of what it does.