### PR TITLE
Fix brittle test: sort triggers before comparison #15268

### DIFF
--- a/spec/models/user_organization_spec.rb
+++ b/spec/models/user_organization_spec.rb
@@ -83,9 +83,9 @@ describe UserOrganization do
       @owner.reload
 
       triggers_after = @owner.db_service.triggers
-      triggers_after.map { |t| [t.database_name, t.table_name, t.trigger_name] }.sort \
-        .should == \
-      triggers_before.map { |t| [t.database_name, t.table_name, t.trigger_name] }.sort
+      triggers_after.map { |t| [t.database_name, t.table_name, t.trigger_name] } \
+        .should =~ \
+      triggers_before.map { |t| [t.database_name, t.table_name, t.trigger_name] }
 
       @owner.db_service.triggers('public').should be_empty
     end

--- a/spec/models/user_organization_spec.rb
+++ b/spec/models/user_organization_spec.rb
@@ -83,7 +83,9 @@ describe UserOrganization do
       @owner.reload
 
       triggers_after = @owner.db_service.triggers
-      triggers_after.map { |t| [t.database_name, t.table_name, t.trigger_name] } .should == triggers_before.map { |t| [t.database_name, t.table_name, t.trigger_name] }
+      triggers_after.map { |t| [t.database_name, t.table_name, t.trigger_name] }.sort \
+        .should == \
+      triggers_before.map { |t| [t.database_name, t.table_name, t.trigger_name] }.sort
 
       @owner.db_service.triggers('public').should be_empty
     end


### PR DESCRIPTION
Ordering of triggers is not guaranteed after a migration, because the underneath queries do not enforce the ordering.

This fixes it by sorting them before comparing the list of triggers.