### PR TITLE
Avoid warnings when running test in parallel with an empty environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
+- Avoid warnings when running test in parallel with an empty environment
 - Improve concurrent Ghost Tables syncs handling ([#15272](https://github.com/CartoDB/cartodb/pull/15272))
 - Fix consent screen in OAuth apps without user ([#15247](https://github.com/CartoDB/cartodb/pull/15247))
 

--- a/script/ci/cleaner.sh
+++ b/script/ci/cleaner.sh
@@ -11,6 +11,7 @@ sed -e 's/\s\+/\n/g' parallel_tests/databases.log > parallel_tests/databases_new
 
 while read -r line
 do
+  [ -z "$line" ] && continue
   psql -U postgres -t -c "drop database $line" >> parallel_tests/cleaner.log
 done < parallel_tests/databases_new.log
 
@@ -24,6 +25,7 @@ sed -e 's/\s\+/\n/g' parallel_tests/user_databases.log > parallel_tests/user_dat
 
 while read -r line
 do
+  [ -z "$line" ] && continue
   psql -U postgres -t -c "drop database \"$line\"" >> parallel_tests/cleaner.log
 done < parallel_tests/user_databases_new.log
 
@@ -39,13 +41,14 @@ sed -e 's/\s\+/\n/g' parallel_tests/user_databases.log > parallel_tests/user_dat
 
 while read -r line
 do
+  [ -z "$line" ] && continue
   psql -U postgres -t -c "drop database \"$line\"" >> parallel_tests/cleaner.log
 done < parallel_tests/user_databases_new.log
 
 # Cleanup
-rm parallel_tests/databases.log
-rm parallel_tests/databases_new.log
-rm parallel_tests/user_databases.log
-rm parallel_tests/users_databases_new.log
+rm -f parallel_tests/databases.log
+rm -f parallel_tests/databases_new.log
+rm -f parallel_tests/user_databases.log
+rm -f parallel_tests/users_databases_new.log
 
 echo "# Cleaner finished"


### PR DESCRIPTION
Gets rid of warnings like:
```
ERROR:  zero-length delimited identifier at or near """"
LINE 1: drop database ""
                      ^
rm: cannot remove 'parallel_tests/users_databases_new.log': No such file or directory
ERROR:  zero-length delimited identifier at or near """"
LINE 1: drop database ""
                      ^
rm: cannot remove 'parallel_tests/users_databases_new.log': No such file or directory
```