### PR TITLE
New fields and styles for BigQuery connector UI

### DIFF
--- a/assets/stylesheets/common/create/listing/imports_options.scss
+++ b/assets/stylesheets/common/create/listing/imports_options.scss
@@ -62,6 +62,42 @@ $w: $sLayout-width;
     background-repeat: no-repeat;
     background-position: center;
   }
+
+  &__input {
+    &--long {
+      box-sizing: border-box !important;
+      width: 460px;
+    }
+  }
+
+  &__label {
+    width: 160px !important;
+
+    &--textarea {
+      padding-top: 12px;
+    }
+  }
+
+  &__CodeMirror {
+    position: relative;
+    width: 460px;
+    min-height: 150px;
+
+    .CodeMirror {
+      padding: 10px 0;
+      border-radius: 4px;
+    }
+
+    .CodeMirror-code {
+      & > div {
+        margin-bottom: 3px;
+      }
+    }
+  }
+
+  &__hint {
+    width: 460px;
+  }
 }
 
 .is-disabled .ImportOptions__overlay {

--- a/assets/stylesheets/common/create/listing/imports_options.scss
+++ b/assets/stylesheets/common/create/listing/imports_options.scss
@@ -84,8 +84,20 @@ $w: $sLayout-width;
     min-height: 150px;
 
     .CodeMirror {
+      height: 114px;
+      margin-top: 0;
       padding: 10px 0;
       border-radius: 4px;
+      background-color: rgb(43, 60, 67);
+      line-height: 13px;
+
+      pre {
+        padding-left: 14px;
+
+        &.CodeMirror-placeholder {
+          color: rgba(255, 255, 255, 0.24);
+        }
+      }
     }
 
     .CodeMirror-code {

--- a/assets/stylesheets/common/utilities/flexbox.scss
+++ b/assets/stylesheets/common/utilities/flexbox.scss
@@ -1,0 +1,2 @@
+
+@import '../../../../lib/assets/javascripts/new-dashboard/styles/helpers/_flexbox';

--- a/assets/stylesheets/common/utilities/utilities.scss
+++ b/assets/stylesheets/common/utilities/utilities.scss
@@ -1,6 +1,7 @@
-@import '../variables/mixins';
-@import '../variables/colors';
-@import '../variables/sizes';
+@import '../../variables/mixins';
+@import '../../variables/colors';
+@import '../../variables/sizes';
+@import 'flexbox';
 
 .u-transparent {
   opacity: 0;
@@ -204,3 +205,5 @@
     display: block !important;
   }
 }
+
+

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/fallbacks/import-beta-fallback.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/fallbacks/import-beta-fallback.tpl
@@ -8,7 +8,7 @@
     </button>
   <% } else if (state === "success") { %>
     <div class="SelectedImport__desc CDB-Text CDB-Size-medium u-secondaryTextColor">
-      <p><%- _t('components.modals.add-layer.imports.beta.request-sent', { brand: title }) %></p>
+      <p><%- _t('components.modals.add-layer.imports.beta.request-sent') %></p>
       <p><%= _t('components.modals.add-layer.imports.contact-soon') %></p>
     </div>
     <button class="CDB-Button CDB-Button--primary CDB-Button--medium js-back">

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/fallbacks/import-notenabled-fallback.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/fallbacks/import-notenabled-fallback.tpl
@@ -1,7 +1,7 @@
 <div class="ImportPanel-header">
   <% if (state === "idle") { %>
     <p class="SelectedImport__desc CDB-Text CDB-Size-medium u-secondaryTextColor">
-      <%- _t('components.modals.add-layer.imports.notenabled.fallback-desc', { brand: title }) %>
+      <%- _t('components.modals.add-layer.imports.notenabled.fallback-desc') %>
     </p>
     <button class="CDB-Button CDB-Button--primary CDB-Button--medium js-connectnow">
       <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase"><%- _t('components.modals.add-layer.imports.contact-us') %></span>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/fallbacks/import-notenabled-fallback.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/fallbacks/import-notenabled-fallback.tpl
@@ -8,7 +8,7 @@
     </button>
   <% } else if (state === "success") { %>
     <div class="SelectedImport__desc CDB-Text CDB-Size-medium u-secondaryTextColor">
-     <p><%- _t('components.modals.add-layer.imports.notenabled.request-sent', { brand: title }) %></p>
+     <p><%- _t('components.modals.add-layer.imports.notenabled.request-sent') %></p>
      <p><%- _t('components.modals.add-layer.imports.contact-soon') %></p>
     </div>
     <button class="CDB-Button CDB-Button--primary CDB-Button--medium js-back">

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -1,4 +1,7 @@
+var $ = require('jquery');
+var _ = require('underscore');
 var ImportDataView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-form-view');
+var CodeMirror = require('codemirror');
 
 /**
  *  Form view for BigQuery
@@ -11,12 +14,84 @@ module.exports = ImportDataView.extend({
   connector: {
     'provider': 'bigquery',
     'project': '%DATABASE%',
-    'table': '%TABLE_NAME%',
+    'import_as': '%TABLE_NAME%',
     'sql_query': '%QUERY%'
+  },
+
+  events: {
+    'keyup .js-textInput': '_onTextChanged',
+    'submit .js-form': '_onSubmitForm'
+  },
+
+  render: function () {
+    this.$el.html(this.template);
+    this._initCodeMirror();
+  },
+
+  _initCodeMirror: function () {
+    this.codeEditor = CodeMirror.fromTextArea(this.$('textarea')[0], {
+      mode: 'text/x-pgsql',
+      tabMode: 'indent',
+      tabSize: 2,
+      matchBrackets: true,
+      lineNumbers: true,
+      lineWrapping: true,
+      theme: 'material',
+      scrollbarStyle: 'simple',
+      language: 'sql',
+      addModeClass: true,
+      placeholder: 'SELECT * FROM `eternal-ship-170218.test.test`'
+    });
+    this.codeEditor.on('change', _.debounce(this._onTextChanged.bind(this), 150), this);
   },
 
   _initBinds: function () {
     this.model.bind('change:state', this._checkVisibility, this);
+  },
+
+  _onTextChanged: function () {
+    var billingProject = this.$('.js-textInput').val();
+    var query = this.codeEditor.getValue();
+    if (billingProject && query) {
+      $('.js-submit').removeClass('is-disabled');
+    } else {
+      this._hideTextError();
+      $('.js-submit').addClass('is-disabled');
+    }
+  },
+
+  _onSubmitForm: function (e) {
+    if (e) this.killEvent(e);
+
+    var query = this.codeEditor.getValue();
+
+    if (!query) {
+      this._hideTextError();
+      return;
+    }
+
+    // Change file attributes :S
+    this.trigger('urlSelected', this);
+
+    // Change model
+    var importType = this.model.get('service_name') ? 'service' : 'url';
+    debugger;
+    this.model.setUpload({
+      type: importType,
+      value: query,
+      service_item_id: query,
+      state: 'idle'
+    });
+
+    if (this.model.get('state') !== 'error') {
+      this._hideFileError();
+      this._hideTextError();
+      this.model.set('state', 'selected');
+
+      this.trigger('urlSubmitted', this);
+    } else {
+      this._showTextError();
+    }
   },
 
   _checkVisibility: function () {
@@ -49,6 +124,8 @@ module.exports = ImportDataView.extend({
         this.connector.project = catalog;
         this.connector.table = tableName;
         this.connector.sql_query = sql;
+        this.connector.billing_project = this.$('.js-textInput').val();
+        debugger;
 
         this.model.set('service_item_id', JSON.stringify(this.connector));
       } catch (e) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -53,7 +53,6 @@ module.exports = ImportDataView.extend({
     if (billingProject && query) {
       $('.js-submit').removeClass('is-disabled');
     } else {
-      this._hideTextError();
       $('.js-submit').addClass('is-disabled');
     }
   },
@@ -62,9 +61,7 @@ module.exports = ImportDataView.extend({
     if (e) this.killEvent(e);
 
     var query = this.codeEditor.getValue();
-
     if (!query) {
-      this._hideTextError();
       return;
     }
 
@@ -81,13 +78,8 @@ module.exports = ImportDataView.extend({
     });
 
     if (this.model.get('state') !== 'error') {
-      this._hideFileError();
-      this._hideTextError();
       this.model.set('state', 'selected');
-
       this.trigger('urlSubmitted', this);
-    } else {
-      this._showTextError();
     }
   },
 
@@ -98,16 +90,7 @@ module.exports = ImportDataView.extend({
     } else {
       this.hide();
     }
-    this._checkErrors(state);
     this._prepareData(state);
-  },
-
-  _checkErrors: function (state) {
-    if (state === 'error') {
-      this._showTextError();
-    } else {
-      this._hideTextError();
-    }
   },
 
   _prepareData: function (state) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -122,7 +122,7 @@ module.exports = ImportDataView.extend({
         sql = this._prepareSql(sql);
 
         this.connector.project = catalog;
-        this.connector.table = tableName;
+        this.connector.import_as = tableName;
         this.connector.sql_query = sql;
         this.connector.billing_project = this.$('.js-textInput').val();
         debugger;

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -31,16 +31,14 @@ module.exports = ImportDataView.extend({
   _initCodeMirror: function () {
     this.codeEditor = CodeMirror.fromTextArea(this.$('textarea')[0], {
       mode: 'text/x-pgsql',
-      tabMode: 'indent',
-      tabSize: 2,
-      matchBrackets: true,
-      lineNumbers: true,
-      lineWrapping: true,
       theme: 'material',
+      tabSize: 2,
+      lineWrapping: true,
+      lineNumbers: false,
       scrollbarStyle: 'simple',
-      language: 'sql',
       addModeClass: true,
-      placeholder: 'SELECT * FROM `eternal-ship-170218.test.test`'
+      matchBrackets: true,
+      placeholder: _t('components.modals.add-layer.imports.bigquery.placeholder')
     });
     this.codeEditor.on('change', _.debounce(this._onTextChanged.bind(this), 150), this);
   },
@@ -75,7 +73,6 @@ module.exports = ImportDataView.extend({
 
     // Change model
     var importType = this.model.get('service_name') ? 'service' : 'url';
-    debugger;
     this.model.setUpload({
       type: importType,
       value: query,
@@ -125,7 +122,6 @@ module.exports = ImportDataView.extend({
         this.connector.import_as = tableName;
         this.connector.sql_query = sql;
         this.connector.billing_project = this.$('.js-textInput').val();
-        debugger;
 
         this.model.set('service_item_id', JSON.stringify(this.connector));
       } catch (e) {
@@ -152,5 +148,4 @@ module.exports = ImportDataView.extend({
   _prepareSql: function (sql) {
     return sql;
   }
-
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
@@ -1,7 +1,7 @@
 <form class="Form js-form">
   <div class="Form-row u-alignCenter">
     <div class="Form-rowLabel ImportOptions__label">
-      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor">Billing Project ID</label>
+      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor"><%- _t('components.modals.add-layer.imports.bigquery.field-project-billing') %></label>
     </div>
     <div class="">
       <input type="text" class="ImportOptions__input--long Form-input CDB-Text CDB-Size-medium js-textInput">
@@ -9,20 +9,20 @@
   </div>
   <div class="Form-row u-flex__align--start">
     <div class="Form-rowLabel ImportOptions__label ImportOptions__label--textarea">
-      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor">SQL query</label>
+      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor"><%- _t('components.modals.add-layer.imports.bigquery.field-sql-query') %></label>
     </div>
     <div>
       <div class="ImportOptions__CodeMirror">
         <textarea rows="4" cols="50" class="ImportOptions__input--long Form-input Form-textarea CDB-Text CDB-Size-medium js-textarea"></textarea>
       </div>
-      <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-secondaryTextColor">If your query contains geographic data in EPSG:4326 format, name that column “the_geom” so that it’s imported correctly.</div>
+      <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-secondaryTextColor"><%- _t('components.modals.add-layer.imports.bigquery.hint') %></div>
     </div>
   </div>
   <div class="Form-row">
     <div class="Form-rowLabel ImportOptions__label ImportOptions__label--textarea"></div>
     <div class="Form-row ImportOptions__input--long u-flex__justify--end">
       <button type="submit" class="CDB-Button CDB-Button--primary is-disabled js-submit">
-        <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Run SQL query</span>
+        <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase"><%- _t('components.modals.add-layer.imports.bigquery.run') %></span>
       </button>
     </div>
   </div>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
@@ -1,20 +1,29 @@
 <form class="Form js-form">
   <div class="Form-row u-alignCenter">
-    <div class="Form-rowLabel">
-      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor">Enter a SQL query</label>
+    <div class="Form-rowLabel ImportOptions__label">
+      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor">Billing Project ID</label>
     </div>
-    <div class="Form-rowData Form-rowData--longer">
-      <input type="text" class="Form-input Form-input--longer has-submit js-textInput CDB-Text CDB-Size-medium" value="" placeholder="Paste here a valid BigQuery SQL query (this is temporary)" />
-      <button type="submit" class="CDB-Text CDB-Size-small u-upperCase u-actionTextColor Form-inputSubmit"><span>submit</span></button>
-      <div class="Form-inputError CDB-Text u-flex u-alignCenter">Error. Your SQL doesn’t look correct.</div>
+    <div class="">
+      <input type="text" class="ImportOptions__input--long Form-input CDB-Text CDB-Size-medium js-textInput">
+    </div>
+  </div>
+  <div class="Form-row u-flex__align--start">
+    <div class="Form-rowLabel ImportOptions__label ImportOptions__label--textarea">
+      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor">SQL query</label>
+    </div>
+    <div>
+      <div class="ImportOptions__CodeMirror">
+        <textarea rows="4" cols="50" class="ImportOptions__input--long Form-input Form-textarea CDB-Text CDB-Size-medium js-textarea"></textarea>
+      </div>
+      <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-secondaryTextColor">If your query contains geographic data in EPSG:4326 format, name that column “the_geom” so that it’s imported correctly.</div>
     </div>
   </div>
   <div class="Form-row">
-    <div class="Form-rowLabel"></div>
-    <div class="Form-rowData Form-rowData--longer">
-      <p class="CDB-Text CDB-Size-small u-hintTextColor Form-rowInfoText--centered Form-rowInfoText--smaller Form-rowInfoText--block">
-        Example: select * from `eternal-ship-170218.test.test`<br/>
-      </p>
+    <div class="Form-rowLabel ImportOptions__label ImportOptions__label--textarea"></div>
+    <div class="Form-row ImportOptions__input--long u-flex__justify--end">
+      <button type="submit" class="CDB-Button CDB-Button--primary is-disabled js-submit">
+        <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase">Run SQL query</span>
+      </button>
     </div>
   </div>
 </form>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-header.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-header.tpl
@@ -1,11 +1,4 @@
-<h3 class="CDB-Text CDB-Size-large u-mainTextColor u-secondaryTextColor u-bSpace--m">
-  <% if (state === 'selected') { %>
-    <%= _t('components.modals.add-layer.imports.header-import.type-selected', { brand: 'BigQuery' }) %>
-  <% } else { %>
-    <%= _t('components.modals.add-layer.imports.header-import.type-import', { brand: 'BigQuery' }) %>
-  <% } %>
-</h3>
-<p class="CDB-Text CDB-Size-medium u-altTextColor">
+<p class="CDB-Text CDB-Size-medium u-secondaryTextColor">
   <% if (state !== "selected") { %>
     <%= _t('components.modals.add-layer.imports.arcgis.import-data', { brand: 'BigQuery' }) %>
   <% } else { %>

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1352,15 +1352,22 @@
                         "fallback-desc": "Contact us to learn more about %{brand} integration",
                         "input-placeholder": "Paste your %{brand} URL here"
                     },
+                    "bigquery": {
+                        "field-project-billing": "Project Billing ID",
+                        "field-sql-query": "SQL query",
+                        "hint": "If your query contains geographic data in EPSG:4326 format, name that column “the_geom” so that it’s imported correctly.",
+                        "run": "Run SQL query",
+                        "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM mytable"
+                    },
                     "notenabled": {
                         "fallback-desc": "The %{brand} connector is not available. Please, contact us if you are interested.",
-                        "request-sent": "%{brand} activation request has been received.",
+                        "request-sent": "Your request has been received.",
                         "fallback-error": "There has been an error requesting the connector."
                     },
                     "beta": {
                         "fallback-desc": "This connector is in beta. Please, contact us if you want to give it a try.",
                         "request-access": "Request beta access",
-                        "request-sent": "%{brand} beta activation request has been received.",
+                        "request-sent": "Your request has been received.",
                         "fallback-error": "There has been an error requesting the access to the connector."
                     },
                     "feedback": {

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1360,12 +1360,12 @@
                         "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM mytable"
                     },
                     "notenabled": {
-                        "fallback-desc": "The %{brand} connector is not available. Please, contact us if you are interested.",
+                        "fallback-desc": "This connector is not currently enabled in your account. Please, contact us if you are interested.",
                         "request-sent": "Your request has been received.",
                         "fallback-error": "There has been an error requesting the connector."
                     },
                     "beta": {
-                        "fallback-desc": "This connector is in beta. Please, contact us if you want to give it a try.",
+                        "fallback-desc": "This connector is currently in beta. Please, contact us if you want to give it a try.",
                         "request-access": "Request beta access",
                         "request-sent": "Your request has been received.",
                         "fallback-error": "There has been an error requesting the access to the connector."

--- a/lib/assets/javascripts/new-dashboard/components/Code/CodeBlock.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Code/CodeBlock.vue
@@ -8,8 +8,6 @@ import 'codemirror/mode/javascript/javascript';
 import 'codemirror/mode/python/python';
 import 'codemirror/mode/shell/shell';
 import 'codemirror/mode/htmlmixed/htmlmixed';
-import 'codemirror/lib/codemirror.css';
-import 'codemirror/theme/material.css';
 
 export default {
   name: 'CodeBlock',
@@ -67,3 +65,7 @@ const defaultOptions = {
 };
 
 </script>
+
+<style lang="scss" scoped>
+  @import '../../styles/vendors/_codemirror.scss';
+</style>

--- a/lib/assets/javascripts/new-dashboard/styles/vendors/_codemirror.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/vendors/_codemirror.scss
@@ -1,0 +1,2 @@
+@import '~codemirror/lib/codemirror.css';
+@import '~codemirror/theme/material.css';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.140-grid-5",
+  "version": "1.0.0-assets.140-grid-6",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/webpack/v4/entryPoints.js
+++ b/webpack/v4/entryPoints.js
@@ -6,7 +6,7 @@ const removeDuplicated = array => Array.from(new Set(array));
 
 module.exports = {
   common_new: removeDuplicated([
-    rootDir('assets/stylesheets/common/utilities.scss'),
+    rootDir('assets/stylesheets/common/utilities/utilities.scss'),
     rootDir('assets/stylesheets/common/icon-font-specials.scss'),
     ...glob.sync(rootDir('assets/stylesheets/common/**/*.scss')),
     rootDir('node_modules/cartoassets/src/scss/entry.scss')
@@ -142,7 +142,7 @@ module.exports = {
     rootDir('assets/stylesheets/common/spinner.scss'),
     rootDir('assets/stylesheets/common/tabs.scss'),
     rootDir('assets/stylesheets/common/titles.scss'),
-    rootDir('assets/stylesheets/common/utilities.scss'),
+    rootDir('assets/stylesheets/common/utilities/utilities.scss'),
     ...glob.sync(rootDir('assets/stylesheets/common/background-polling/**/*.scss')),
     rootDir('assets/stylesheets/plugins/tipsy.scss'),
     rootDir('assets/stylesheets/common/pagination.scss'),

--- a/webpack/v4/entryPoints.js
+++ b/webpack/v4/entryPoints.js
@@ -9,7 +9,8 @@ module.exports = {
     rootDir('assets/stylesheets/common/utilities/utilities.scss'),
     rootDir('assets/stylesheets/common/icon-font-specials.scss'),
     ...glob.sync(rootDir('assets/stylesheets/common/**/*.scss')),
-    rootDir('node_modules/cartoassets/src/scss/entry.scss')
+    rootDir('node_modules/cartoassets/src/scss/entry.scss'),
+    rootDir('assets/stylesheets/editor-3/_codemirror.scss')
   ]),
 
   deep_insights_new: [


### PR DESCRIPTION
- Add a new `Billing Project ID` field, and change existing `SQL Query` input into a textarea with codemirror styles.
- Update `table` param into an `import_as` param as API has changed
- Update copies
- Change styles

### Related issue
https://github.com/CartoDB/cartodb/issues/15284