### PR TITLE
FServer: Return username when listing servers

### DIFF
--- a/app/controllers/carto/api/public/federated_tables_controller.rb
+++ b/app/controllers/carto/api/public/federated_tables_controller.rb
@@ -59,10 +59,6 @@ module Carto
 
         def register_federated_server
           federated_server = @service.register_server(@federated_server_attributes)
-          @service.grant_access_to_federated_server(
-            federated_server_name: federated_server[:federated_server_name],
-            db_role: @user.database_username
-          )
           response.headers['Content-Location'] = "#{request.path}/#{federated_server[:federated_server_name]}"
           render_jsonp(federated_server, 201)
         rescue Sequel::DatabaseError => exception
@@ -90,10 +86,6 @@ module Carto
         end
 
         def unregister_federated_server
-          @service.revoke_access_to_federated_server(
-            federated_server_name: params[:federated_server_name],
-            db_role: @user.database_username
-          )
           @service.unregister_server(federated_server_name: params[:federated_server_name])
           render_jsonp({}, 204)
         rescue Sequel::DatabaseError => exception

--- a/app/services/carto/federated_tables_service.rb
+++ b/app/services/carto/federated_tables_service.rb
@@ -21,6 +21,10 @@ module Carto
 
     def register_server(attributes)
       @superuser_db_connection[register_federated_server_query(attributes)].first
+      grant_access_to_federated_server(
+        federated_server_name: attributes[:federated_server_name],
+        db_role: @user.database_username
+       )
       get_server(federated_server_name: attributes[:federated_server_name])
     end
 

--- a/spec/requests/carto/api/public/federated_tables_controller_spec.rb
+++ b/spec/requests/carto/api/public/federated_tables_controller_spec.rb
@@ -467,7 +467,7 @@ describe Carto::Api::Public::FederatedTablesController do
         expect(response.body[:dbname]).to eq(new_db_name)
         expect(response.body[:host]).to eq(new_host)
         expect(response.body[:port]).to eq(new_port)
-        # We don't check for username or password since they aren't returned for db users (only to superadmin)
+        expect(response.body[:username]).to eq(new_username)
       end
 
       # Return it to previous values

--- a/spec/services/carto/federated_tables_service_spec.rb
+++ b/spec/services/carto/federated_tables_service_spec.rb
@@ -279,16 +279,6 @@ describe Carto::FederatedTablesService do
                 expect(remote_schemas).to include(:remote_schema_name => "public")
             end
 
-            it 'should raise "Not enough permissions" error when listing remote schemas of a federated server' do
-                @federated_server_name = "fs_009_from_#{@user1.username}_to_remote"
-                create_federated_server(federated_server_name: @federated_server_name)
-                pagination = { page: 1, per_page: 10, order: 'remote_schema_name', direction: 'asc' }
-
-                expect {
-                    @service.list_remote_schemas(@federated_server_name, pagination)
-                }.to raise_error(Sequel::DatabaseError, /Not enough permissions to access the server/)
-            end
-
             it 'should raise "Server [...] does not exist" error when listing remote schemas of a non registered federated server' do
                 nonregistered_federated_server_name = "fs_999_from_#{@user1.username}_to_remote"
                 pagination = { page: 1, per_page: 10, order: 'remote_schema_name', direction: 'asc' }


### PR DESCRIPTION
- Updates sql submodule so it returns the username when the requester has permissions over the server.
- Moves the grant to the controller so it's done before listing the newly created server. This also avoids a bug where if a user created a server via PUT it wouldn't have permissions to use it.
- Removes the calls to revoke access when unregistering a server as it should be done automatically by the extension.