### PR TITLE
Federated Tables: Quickstart guide and skeleton to continue

### DIFF
--- a/doc/developer-center/federated-tables-api/guides/01-quickstart.md
+++ b/doc/developer-center/federated-tables-api/guides/01-quickstart.md
@@ -212,13 +212,43 @@ curl -X GET "https://documentation.carto.com/api/v4/federated_servers/example_se
          "registered": false,
          "remote_schema_name": "borders",
          "remote_table_name": "pref",
-         "columns": "[{\"Name\" : \"area\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_bill\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_contents\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_pop\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_youto\", \"Type\" : \"double precision\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"gid\", \"Type\" : \"integer\"}, {\"Name\" : \"pref\", \"Type\" : \"text\"}, {\"Name\" : \"prefcode\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}]"
+         "columns": [
+            { Name: 'area', Type: 'double precision' },
+            { Name: 'area_bill', Type: 'double precision' },
+            { Name: 'area_contents', Type: 'double precision' },
+            { Name: 'area_pop', Type: 'double precision' },
+            { Name: 'area_youto', Type: 'double precision' },
+            { Name: 'cartodb_id', Type: 'integer' },
+            { Name: 'gid', Type: 'integer' },
+            { Name: 'pref', Type: 'text' },
+            { Name: 'prefcode', Type: 'integer' },
+            { Name: 'the_geom', Type: 'GEOMETRY,4326' },
+            { Name: 'the_geom_webmercator', Type: 'GEOMETRY,3857' }
+         ]
       },
       {
          "registered": false,
          "remote_schema_name": "borders",
          "remote_table_name": "world_borders",
-         "columns": "[{\"Name\" : \"area\", \"Type\" : \"integer\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"created_at\", \"Type\" : \"timestamp with time zone\"}, {\"Name\" : \"fips\", \"Type\" : \"text\"}, {\"Name\" : \"iso2\", \"Type\" : \"text\"}, {\"Name\" : \"iso3\", \"Type\" : \"text\"}, {\"Name\" : \"lat\", \"Type\" : \"double precision\"}, {\"Name\" : \"lon\", \"Type\" : \"double precision\"}, {\"Name\" : \"name\", \"Type\" : \"text\"}, {\"Name\" : \"pop2005\", \"Type\" : \"integer\"}, {\"Name\" : \"region\", \"Type\" : \"integer\"}, {\"Name\" : \"subregion\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_str\", \"Type\" : \"text\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}, {\"Name\" : \"un\", \"Type\" : \"integer\"}, {\"Name\" : \"updated_at\", \"Type\" : \"timestamp with time zone\"}]"
+         "columns": [
+            { Name: 'area', Type: 'integer' },
+            { Name: 'cartodb_id', Type: 'integer' },
+            { Name: 'created_at', Type: 'timestamp with time zone' },
+            { Name: 'fips', Type: 'text' },
+            { Name: 'iso2', Type: 'text' },
+            { Name: 'iso3', Type: 'text' },
+            { Name: 'lat', Type: 'double precision' },
+            { Name: 'lon', Type: 'double precision' },
+            { Name: 'name', Type: 'text' },
+            { Name: 'pop2005', Type: 'integer' },
+            { Name: 'region', Type: 'integer' },
+            { Name: 'subregion', Type: 'integer' },
+            { Name: 'the_geom', Type: 'GEOMETRY,4326' },
+            { Name: 'the_geom_str', Type: 'text' },
+            { Name: 'the_geom_webmercator', Type: 'GEOMETRY,3857' },
+            { Name: 'un', Type: 'integer' },
+            { Name: 'updated_at', Type: 'timestamp with time zone' }
+         ]
       }
    ],
    "_links":{
@@ -249,7 +279,19 @@ curl -X GET "https://documentation.carto.com/api/v4/federated_servers/example_se
    "registered": false,
    "remote_table_name": "pref",
    "remote_schema_name": "borders",
-   "columns": "[{\"Name\" : \"area\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_bill\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_contents\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_pop\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_youto\", \"Type\" : \"double precision\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"gid\", \"Type\" : \"integer\"}, {\"Name\" : \"pref\", \"Type\" : \"text\"}, {\"Name\" : \"prefcode\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}]"
+   "columns": [
+      { Name: 'area', Type: 'double precision' },
+      { Name: 'area_bill', Type: 'double precision' },
+      { Name: 'area_contents', Type: 'double precision' },
+      { Name: 'area_pop', Type: 'double precision' },
+      { Name: 'area_youto', Type: 'double precision' },
+      { Name: 'cartodb_id', Type: 'integer' },
+      { Name: 'gid', Type: 'integer' },
+      { Name: 'pref', Type: 'text' },
+      { Name: 'prefcode', Type: 'integer' },
+      { Name: 'the_geom', Type: 'GEOMETRY,4326' },
+      { Name: 'the_geom_webmercator', Type: 'GEOMETRY,3857' }
+   ]
 }
 ```
 
@@ -281,7 +323,25 @@ In this reponse, we can already see the `qualified_name` parameter, which can be
    "id_column_name": "cartodb_id",
    "geom_column_name": "the_geom",
    "webmercator_column_name": "the_geom_webmercator",
-   "columns": "[{\"Name\" : \"area\", \"Type\" : \"integer\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"created_at\", \"Type\" : \"timestamp with time zone\"}, {\"Name\" : \"fips\", \"Type\" : \"text\"}, {\"Name\" : \"iso2\", \"Type\" : \"text\"}, {\"Name\" : \"iso3\", \"Type\" : \"text\"}, {\"Name\" : \"lat\", \"Type\" : \"double precision\"}, {\"Name\" : \"lon\", \"Type\" : \"double precision\"}, {\"Name\" : \"name\", \"Type\" : \"text\"}, {\"Name\" : \"pop2005\", \"Type\" : \"integer\"}, {\"Name\" : \"region\", \"Type\" : \"integer\"}, {\"Name\" : \"subregion\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_str\", \"Type\" : \"text\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}, {\"Name\" : \"un\", \"Type\" : \"integer\"}, {\"Name\" : \"updated_at\", \"Type\" : \"timestamp with time zone\"}]"
+   "columns": [
+      { Name: 'area', Type: 'integer' },
+      { Name: 'cartodb_id', Type: 'integer' },
+      { Name: 'created_at', Type: 'timestamp with time zone' },
+      { Name: 'fips', Type: 'text' },
+      { Name: 'iso2', Type: 'text' },
+      { Name: 'iso3', Type: 'text' },
+      { Name: 'lat', Type: 'double precision' },
+      { Name: 'lon', Type: 'double precision' },
+      { Name: 'name', Type: 'text' },
+      { Name: 'pop2005', Type: 'integer' },
+      { Name: 'region', Type: 'integer' },
+      { Name: 'subregion', Type: 'integer' },
+      { Name: 'the_geom', Type: 'GEOMETRY,4326' },
+      { Name: 'the_geom_str', Type: 'text' },
+      { Name: 'the_geom_webmercator', Type: 'GEOMETRY,3857' },
+      { Name: 'un', Type: 'integer' },
+      { Name: 'updated_at', Type: 'timestamp with time zone' }
+   ]
 }
 ```
 
@@ -311,7 +371,25 @@ curl -X PUT -H "Content-Type: application/json" "https://documentation.carto.com
    "id_column_name": "cartodb_id",
    "geom_column_name": "the_geom",
    "webmercator_column_name": "the_geom_webmercator",
-   "columns": "[{\"Name\" : \"area\", \"Type\" : \"integer\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"created_at\", \"Type\" : \"timestamp with time zone\"}, {\"Name\" : \"fips\", \"Type\" : \"text\"}, {\"Name\" : \"iso2\", \"Type\" : \"text\"}, {\"Name\" : \"iso3\", \"Type\" : \"text\"}, {\"Name\" : \"lat\", \"Type\" : \"double precision\"}, {\"Name\" : \"lon\", \"Type\" : \"double precision\"}, {\"Name\" : \"name\", \"Type\" : \"text\"}, {\"Name\" : \"pop2005\", \"Type\" : \"integer\"}, {\"Name\" : \"region\", \"Type\" : \"integer\"}, {\"Name\" : \"subregion\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_str\", \"Type\" : \"text\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}, {\"Name\" : \"un\", \"Type\" : \"integer\"}, {\"Name\" : \"updated_at\", \"Type\" : \"timestamp with time zone\"}]"
+   "columns": [
+      { Name: 'area', Type: 'integer' },
+      { Name: 'cartodb_id', Type: 'integer' },
+      { Name: 'created_at', Type: 'timestamp with time zone' },
+      { Name: 'fips', Type: 'text' },
+      { Name: 'iso2', Type: 'text' },
+      { Name: 'iso3', Type: 'text' },
+      { Name: 'lat', Type: 'double precision' },
+      { Name: 'lon', Type: 'double precision' },
+      { Name: 'name', Type: 'text' },
+      { Name: 'pop2005', Type: 'integer' },
+      { Name: 'region', Type: 'integer' },
+      { Name: 'subregion', Type: 'integer' },
+      { Name: 'the_geom', Type: 'GEOMETRY,4326' },
+      { Name: 'the_geom_str', Type: 'text' },
+      { Name: 'the_geom_webmercator', Type: 'GEOMETRY,3857' },
+      { Name: 'un', Type: 'integer' },
+      { Name: 'updated_at', Type: 'timestamp with time zone' }
+   ]
 }
 ```
 

--- a/doc/developer-center/federated-tables-api/guides/01-quickstart.md
+++ b/doc/developer-center/federated-tables-api/guides/01-quickstart.md
@@ -1,0 +1,332 @@
+## Quickstart
+
+In order to manage Federated Tables as part of the CARTO platform, we provide a RESTful Web Service to manipulate the resources that represent Federated Tables by using a uniform and predefined set of operations.
+
+For this example (and the rest of the ones illustrated here) we will be using a command-line tool known as `cURL`. For more info about this tool see [this blog post](http://quickleft.com/blog/command-line-tutorials-curl) or type `man curl` in bash.
+
+We will be using the following authentication parameters in the examples:
+
+Param | Value | Description
+--- | --- | ---
+username | `documentation` | The CARTO account username.
+api_key | `bec1667cdedaa6fd70165f5099981d0c61ec1112` | The target CARTO account [API key](https://carto.com/developers/fundamentals/authorization/#api-keys).
+
+
+### Registering a new Federated Server
+
+The Federated Server handles the information about the remote database, that is its address and authentication values so CARTO can gain access to it.
+
+We are registering a server called `example_server` that we will reuse in other examples as part of their urls.
+
+#### Call
+
+```bash
+curl -X POST -H "Content-Type: application/json" "https://documentation.carto.com/api/v4/federated_servers?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112" -d '{
+    "federated_server_name": "example_server",
+    "mode": "read-only",
+    "dbname": "geometries",
+    "host": "example.com",
+    "port": "5432",
+    "username": "remote_user",
+    "password": "remote_password"
+}'
+```
+
+#### Response
+
+```
+{
+   "federated_server_name": "example_server",
+   "mode": "read-only",
+   "dbname": "geometries",
+   "host": "example.com",
+   "port": "5432",
+   "username": "remote_user",
+   "password": "*****"
+}
+```
+
+### List all existing Federated Servers
+
+This endpoint allows you to access the information of all registered servers accesible by the caller.
+
+#### Call
+
+```bash
+curl -X GET "https://documentation.carto.com/api/v4/federated_servers?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112"
+```
+
+#### Response
+
+```
+{
+   "total": 2,
+   "count": 2,
+   "result":[
+      {
+         "federated_server_name": "example_server",
+         "mode": "read-only",
+         "dbname": "geometries",
+         "host": "example.com",
+         "port": "5432",
+         "username": "remote_user",
+         "password": "*****"
+      },
+      {
+         "federated_server_name": "test002",
+         "mode": "read-only",
+         "dbname": "wharehouse",
+         "host": "example.edu",
+         "port": "5432",
+         "username": "cartofante",
+         "password": "*****"
+      }
+   ],
+   "_links":{
+      "first":{
+         "href": "https://documentation.carto.com/api/v4/federated_servers?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112\u0026format=json\u0026page=1\u0026per_page=20"
+      },
+      "last":{
+         "href": "https://documentation.carto.com/api/v4/federated_servers?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112\u0026format=json\u0026page=1\u0026per_page=20"
+      }
+   }
+}
+```
+
+### List a single Federated Server
+
+This endpoint returns the configuration of a single server that matches the `example_server` name.
+
+#### Call
+
+```bash
+curl -X GET "https://documentation.carto.com/api/v4/federated_servers/example_server?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112"
+```
+
+#### Response
+
+```
+{
+   "federated_server_name": "example_server",
+   "mode": "read-only",
+   "dbname": "geometries",
+   "host": "example.com",
+   "port": "5432",
+   "username": "remote_user",
+   "password": "*****"
+}
+```
+
+### Modify a single Federated Server
+
+This endpoint allows the modification of an already registered server. If the server didn't already exist it will create it.
+
+#### Call
+
+```bash
+curl -X PUT -H "Content-Type: application/json" "https://documentation.carto.com/api/v4/federated_servers/example_server?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112" -d '{
+    "mode": "read-only",
+    "dbname": "geometries",
+    "host": "example.com",
+    "port": "5432",
+    "username": "new_user",
+    "password": "new_password"
+}'
+```
+
+#### Response
+
+The reponse has no extra content. The new configuration is accessible using the already mentioned endpoints.
+
+### Unregister a Federated Server
+
+This endpoint will remove a registered servers and all the tables created through it.
+
+#### Call
+
+```bash
+curl -X DELETE "https://documentation.carto.com/api/v4/federated_servers/example_server?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112"
+```
+
+#### Response
+
+The reponse has no extra content.
+
+
+### List remote schemas
+
+Once we have a server registered, we can check what information is available to us (via the provided PostgreSQL user), so first we'll list the available schemas:
+
+#### Call
+
+```bash
+curl -X GET "https://documentation.carto.com/api/v4/federated_servers/example_server/remote_schemas/?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112"
+```
+
+#### Response
+
+```
+{
+   "total": 3,
+   "count": 3,
+   "result":[
+      {
+         "remote_schema_name":"information_schema"
+      },
+      {
+         "remote_schema_name":"public"
+      },
+      {
+         "remote_schema_name":"borders"
+      }
+   ],
+   "_links":{
+      "first":{
+         "href":"https://documentation.carto.com/api/v4/federated_servers?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112\u0026federated_server_name=example_server\u0026format=json\u0026page=1\u0026per_page=20"
+      },
+      "last":{
+         "href":"https://documentation.carto.com/api/v4/federated_servers?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112\u0026federated_server_name=example_server\u0026format=json\u0026page=1\u0026per_page=20"
+      }
+   }
+}
+```
+
+### List all remote tables whitin a remote schema
+
+Once we know which schema we want to check, we can list what are the available tables and their columns so we can register them as a Federated Table. In this case we'll list the schema `borders`:
+
+#### Call
+
+```bash
+curl -X GET "https://documentation.carto.com/api/v4/federated_servers/example_server/remote_schemas/borders/remote_tables/?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112"
+```
+
+#### Response
+
+```
+{
+   "total": 2,
+   "count": 2,
+   "result":[
+      {
+         "registered": false,
+         "remote_schema_name": "borders",
+         "remote_table_name": "pref",
+         "columns": "[{\"Name\" : \"area\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_bill\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_contents\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_pop\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_youto\", \"Type\" : \"double precision\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"gid\", \"Type\" : \"integer\"}, {\"Name\" : \"pref\", \"Type\" : \"text\"}, {\"Name\" : \"prefcode\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}]"
+      },
+      {
+         "registered": false,
+         "remote_schema_name": "borders",
+         "remote_table_name": "world_borders",
+         "columns": "[{\"Name\" : \"area\", \"Type\" : \"integer\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"created_at\", \"Type\" : \"timestamp with time zone\"}, {\"Name\" : \"fips\", \"Type\" : \"text\"}, {\"Name\" : \"iso2\", \"Type\" : \"text\"}, {\"Name\" : \"iso3\", \"Type\" : \"text\"}, {\"Name\" : \"lat\", \"Type\" : \"double precision\"}, {\"Name\" : \"lon\", \"Type\" : \"double precision\"}, {\"Name\" : \"name\", \"Type\" : \"text\"}, {\"Name\" : \"pop2005\", \"Type\" : \"integer\"}, {\"Name\" : \"region\", \"Type\" : \"integer\"}, {\"Name\" : \"subregion\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_str\", \"Type\" : \"text\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}, {\"Name\" : \"un\", \"Type\" : \"integer\"}, {\"Name\" : \"updated_at\", \"Type\" : \"timestamp with time zone\"}]"
+      }
+   ],
+   "_links":{
+      "first":{
+         "href":"https://documentation.carto.com/api/v4/federated_servers/?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112\u0026federated_server_name=example_server\u0026format=json\u0026page=1\u0026per_page=20\u0026remote_schema_name=borders"
+      },
+      "last":{
+         "href":"https://documentation.carto.com/api/v4/federated_servers/?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112\u0026federated_server_name=example_server\u0026format=json\u0026page=1\u0026per_page=20\u0026remote_schema_name=borders"
+      }
+   }
+}
+```
+
+### List a single remote table
+
+If we want to see (or register with a PUT) a single remote table, we can use this endpoint:
+
+#### Call
+
+```bash
+curl -X GET "https://documentation.carto.com/api/v4/federated_servers/example_server/remote_schemas/borders/remote_tables/pref?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112"
+```
+
+#### Response
+
+```
+{
+   "registered": false,
+   "remote_table_name": "pref",
+   "remote_schema_name": "borders",
+   "columns": "[{\"Name\" : \"area\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_bill\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_contents\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_pop\", \"Type\" : \"double precision\"}, {\"Name\" : \"area_youto\", \"Type\" : \"double precision\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"gid\", \"Type\" : \"integer\"}, {\"Name\" : \"pref\", \"Type\" : \"text\"}, {\"Name\" : \"prefcode\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}]"
+}
+```
+
+### Registering a new Federated Table
+
+In the previous call we could see the tables available to register; and with this endpoint we can register one of them so it's available in the CARTO platform.
+
+#### Call
+
+```bash
+curl -X POST -H "Content-Type: application/json" "https://documentation.carto.com/api/v4/federated_servers/example_server/remote_schemas/borders/remote_tables/?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112" -d '{
+    "remote_table_name": "world_borders",
+    "id_column_name": "cartodb_id",
+    "geom_column_name": "the_geom",
+    "webmercator_column_name": "the_geom_webmercator"
+}'
+```
+
+#### Response
+
+In this reponse, we can already see the `qualified_name` parameter, which can be used whithin CARTO to use this table.
+
+```
+{
+   "registered": true,
+   "qualified_name": "cdb_fs_example_server.world_borders",
+   "remote_table_name": "world_borders",
+   "remote_schema_name": "borders",
+   "id_column_name": "cartodb_id",
+   "geom_column_name": "the_geom",
+   "webmercator_column_name": "the_geom_webmercator",
+   "columns": "[{\"Name\" : \"area\", \"Type\" : \"integer\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"created_at\", \"Type\" : \"timestamp with time zone\"}, {\"Name\" : \"fips\", \"Type\" : \"text\"}, {\"Name\" : \"iso2\", \"Type\" : \"text\"}, {\"Name\" : \"iso3\", \"Type\" : \"text\"}, {\"Name\" : \"lat\", \"Type\" : \"double precision\"}, {\"Name\" : \"lon\", \"Type\" : \"double precision\"}, {\"Name\" : \"name\", \"Type\" : \"text\"}, {\"Name\" : \"pop2005\", \"Type\" : \"integer\"}, {\"Name\" : \"region\", \"Type\" : \"integer\"}, {\"Name\" : \"subregion\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_str\", \"Type\" : \"text\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}, {\"Name\" : \"un\", \"Type\" : \"integer\"}, {\"Name\" : \"updated_at\", \"Type\" : \"timestamp with time zone\"}]"
+}
+```
+
+
+### Modify a registered Federated Table
+
+This endpoint allows the modification of an already registered table. If it wasn't already, the table will be registered.
+
+#### Call
+
+```bash
+curl -X PUT -H "Content-Type: application/json" "https://documentation.carto.com/api/v4/federated_servers/example_server/remote_schemas/borders/remote_tables/world_borders?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112" -d '{
+    "id_column_name": "cartodb_id",
+    "geom_column_name": "the_geom",
+    "webmercator_column_name": "the_geom_webmercator"
+}'
+```
+
+#### Response
+
+```
+{
+   "registered": true,
+   "qualified_name": "cdb_fs_example_server.world_borders",
+   "remote_table_name": "world_borders",
+   "remote_schema_name": "borders",
+   "id_column_name": "cartodb_id",
+   "geom_column_name": "the_geom",
+   "webmercator_column_name": "the_geom_webmercator",
+   "columns": "[{\"Name\" : \"area\", \"Type\" : \"integer\"}, {\"Name\" : \"cartodb_id\", \"Type\" : \"integer\"}, {\"Name\" : \"created_at\", \"Type\" : \"timestamp with time zone\"}, {\"Name\" : \"fips\", \"Type\" : \"text\"}, {\"Name\" : \"iso2\", \"Type\" : \"text\"}, {\"Name\" : \"iso3\", \"Type\" : \"text\"}, {\"Name\" : \"lat\", \"Type\" : \"double precision\"}, {\"Name\" : \"lon\", \"Type\" : \"double precision\"}, {\"Name\" : \"name\", \"Type\" : \"text\"}, {\"Name\" : \"pop2005\", \"Type\" : \"integer\"}, {\"Name\" : \"region\", \"Type\" : \"integer\"}, {\"Name\" : \"subregion\", \"Type\" : \"integer\"}, {\"Name\" : \"the_geom\", \"Type\" : \"GEOMETRY,4326\"}, {\"Name\" : \"the_geom_str\", \"Type\" : \"text\"}, {\"Name\" : \"the_geom_webmercator\", \"Type\" : \"GEOMETRY,3857\"}, {\"Name\" : \"un\", \"Type\" : \"integer\"}, {\"Name\" : \"updated_at\", \"Type\" : \"timestamp with time zone\"}]"
+}
+```
+
+
+### Unregister a Federated Table
+
+This endpoint will unregister a table, which means that it won't be usable inside CARTO. This will also remove any dependent objects, but it won't do any change in the remote table, which could be registered again.
+
+#### Call
+
+```bash
+curl -X DELETE -H "https://documentation.carto.com/api/v4/federated_servers/example_server/remote_schemas/borders/remote_tables/world_borders?api_key=bec1667cdedaa6fd70165f5099981d0c61ec1112"
+```
+
+#### Response
+
+The reponse has no extra content.
+```

--- a/doc/developer-center/federated-tables-api/guides/02-general-concepts.md
+++ b/doc/developer-center/federated-tables-api/guides/02-general-concepts.md
@@ -1,0 +1,16 @@
+## General Concepts
+
+The following concepts are the same for every endpoint in the API except when it is noted explicitly.
+
+
+### Auth
+
+Manipulating data on a CARTO account requires prior authentication using a unique identifier as a password. For the import API, a special identifier known as the API Key is used as a proof of authentication for each user account to authorize access to its data.
+
+To execute an authorized request, `api_key=YOURAPIKEY` should be added to the request URL. This parameter can be also passed as a POST parameter. We **strongly advise** using HTTPS when you are performing requests that include your `api_key`.
+
+---
+
+### Errors
+
+Errors are reported using standard HTTP codes....

--- a/doc/developer-center/federated-tables-api/guides/02-general-concepts.md
+++ b/doc/developer-center/federated-tables-api/guides/02-general-concepts.md
@@ -5,7 +5,7 @@ The following concepts are the same for every endpoint in the API except when it
 
 ### Auth
 
-Manipulating data on a CARTO account requires prior authentication using a unique identifier as a password. For the import API, a special identifier known as the API Key is used as a proof of authentication for each user account to authorize access to its data.
+Manipulating data on a CARTO account requires prior authentication using a unique identifier as a password. For the federated tables API, a special identifier known as the API Key is used as a proof of authentication for each user account to authorize access to its data.
 
 To execute an authorized request, `api_key=YOURAPIKEY` should be added to the request URL. This parameter can be also passed as a POST parameter. We **strongly advise** using HTTPS when you are performing requests that include your `api_key`.
 

--- a/doc/developer-center/federated-tables-api/guides/03-using-federated-tables.md
+++ b/doc/developer-center/federated-tables-api/guides/03-using-federated-tables.md
@@ -1,0 +1,6 @@
+
+Explain how to use the output of a Federated Table in:
+- SQL API
+- Tiler API
+
+Explain how caching works when a Federated Table is used in the different systems

--- a/doc/developer-center/federated-tables-api/reference/swagger.yaml
+++ b/doc/developer-center/federated-tables-api/reference/swagger.yaml
@@ -1,0 +1,1 @@
+This should be a swagger file :D

--- a/doc/developer-center/federated-tables-api/support/01-support-options.md
+++ b/doc/developer-center/federated-tables-api/support/01-support-options.md
@@ -1,0 +1,36 @@
+## Support Options
+
+Feeling stuck? There are many ways to find help.
+
+* Ask a question on [GIS StackExchange](https://gis.stackexchange.com/questions/tagged/carto) using the `CARTO` tag.
+* [Report an issue](https://github.com/CartoDB/cartodb/issues) in Github.
+* Engine Plan customers have additional access to enterprise-level support through CARTO's support representatives.
+
+If you just want to describe an issue or share an idea, just <a class="typeform-share" href="https://cartohq.typeform.com/to/mH6RRl" data-mode="popup" target="_blank"> send your feedback</a>
+
+### Issues on Github
+
+If you think you may have found a bug, or if you have a feature request that you would like to share with the Import API team, please [open an issue](https://github.com/CartoDB/cartodb/issues/new). 
+
+Before opening an issue, review the [contributing guidelines](https://github.com/CartoDB/cartodb/blob/master/CONTRIBUTING.md).
+
+
+### Community support on GIS Stack Exchange
+
+GIS Stack Exchange is the most popular community in the geospatial industry. This is a collaboratively-edited question and answer site for geospatial programmers and technicians. It is a fantastic resource for asking technical questions about developing and maintaining your application.
+
+
+When posting a new question, please consider the following:
+
+* Read the GIS Stack Exchange [help](https://gis.stackexchange.com/help) and [how to ask](https://gis.stackexchange.com/help/how-to-ask) pages for guidelines and tips about posting questions.
+* Be very clear about your question in the subject. A clear explanation helps those trying to answer your question, as well as those who may be looking for information in the future.
+* Be informative in your post. Details, code snippets, logs, screenshots, etc. help others to understand your problem.
+* Use code that demonstrates the problem. It is very hard to debug errors without sample code to reproduce the problem.
+
+### Engine Plan Customers
+
+Engine Plan customers have additional support options beyond general community support. As per your account Terms of Service, you have access to enterprise-level support through CARTO's support representatives available at [enterprise-support@carto.com](mailto:enterprise-support@carto.com)
+
+In order to speed up the resolution of your issue, provide as much information as possible (even if it is a link from community support). This allows our engineers to investigate your problem as soon as possible.
+
+If you are not yet CARTO customer, browse our [plans & pricing](https://carto.com/pricing/) and find the right plan for you.

--- a/doc/developer-center/federated-tables-api/support/01-support-options.md
+++ b/doc/developer-center/federated-tables-api/support/01-support-options.md
@@ -10,7 +10,7 @@ If you just want to describe an issue or share an idea, just <a class="typeform-
 
 ### Issues on Github
 
-If you think you may have found a bug, or if you have a feature request that you would like to share with the Import API team, please [open an issue](https://github.com/CartoDB/cartodb/issues/new). 
+If you think you may have found a bug, or if you have a feature request that you would like to share with the Federated Tables API team, please [open an issue](https://github.com/CartoDB/cartodb/issues/new). 
 
 Before opening an issue, review the [contributing guidelines](https://github.com/CartoDB/cartodb/blob/master/CONTRIBUTING.md).
 

--- a/doc/developer-center/federated-tables-api/support/02-contribute.md
+++ b/doc/developer-center/federated-tables-api/support/02-contribute.md
@@ -1,0 +1,36 @@
+## Contribute
+
+CARTO platform is an open-source ecosystem. You can read about the [fundamentals]({{site.fundamental_docs}}/components/) of CARTO architecture and its components.
+We are more than happy to receive your contributions to the code and the documentation as well.
+
+## Filling a ticket
+
+If you want to open a new issue in our repository, please follow these instructions:
+
+1. Descriptive title.
+2. Write a good description, it always helps.
+3. Specify the steps to reproduce the problem.
+4. Try to add an example showing the problem.
+
+## Contributing code
+
+Best part of open source, collaborate in Import API code!. We like hearing from you, so if you have any bug fixed, or a new feature ready to be merged, those are the steps you should follow:
+
+1. Fork the repository.
+2. Create a new branch in your forked repository.
+3. Commit your changes. Add new tests if it is necessary.
+4. Open a pull request.
+5. Any of the maintainers will take a look.
+6. If everything works, it will merged and released \o/.
+
+If you want more detailed information, this [GitHub guide](https://guides.github.com/activities/contributing-to-open-source/) is a must.
+
+## Completing documentation
+
+Import API documentation is located in ```docs/```. That folder is the content that appears in the [Developer Center](http://carto.com/developers/import-api/). Just follow the instructions described in [contributing code](#contributing-code) and after accepting your pull request, we will make it appear online :).
+
+**Tip:** A convenient, easy way of proposing changes in documentation is by using the GitHub editor directly on the web. You can easily create a branch with your changes and make a PR from there.
+
+## Submitting contributions
+
+You will need to sign a Contributor License Agreement (CLA) before making a submission. [Learn more here](https://carto.com/contributions).

--- a/doc/developer-center/federated-tables-api/support/02-contribute.md
+++ b/doc/developer-center/federated-tables-api/support/02-contribute.md
@@ -27,7 +27,7 @@ If you want more detailed information, this [GitHub guide](https://guides.github
 
 ## Completing documentation
 
-Import API documentation is located in ```docs/```. That folder is the content that appears in the [Developer Center](http://carto.com/developers/import-api/). Just follow the instructions described in [contributing code](#contributing-code) and after accepting your pull request, we will make it appear online :).
+Federated Tables API documentation is located in ```docs/```. That folder is the content that appears in the [Developer Center](http://carto.com/developers/federated-tables-api/). Just follow the instructions described in [contributing code](#contributing-code) and after accepting your pull request, we will make it appear online :).
 
 **Tip:** A convenient, easy way of proposing changes in documentation is by using the GitHub editor directly on the web. You can easily create a branch with your changes and make a PR from there.
 

--- a/doc/developer-center/federated-tables-api/support/02-contribute.md
+++ b/doc/developer-center/federated-tables-api/support/02-contribute.md
@@ -14,7 +14,7 @@ If you want to open a new issue in our repository, please follow these instructi
 
 ## Contributing code
 
-Best part of open source, collaborate in Import API code!. We like hearing from you, so if you have any bug fixed, or a new feature ready to be merged, those are the steps you should follow:
+Best part of open source, collaborate in Federated Tables API code!. We like hearing from you, so if you have any bug fixed, or a new feature ready to be merged, those are the steps you should follow:
 
 1. Fork the repository.
 2. Create a new branch in your forked repository.


### PR DESCRIPTION
Adds a quickstart guide and a skeleton to add the following files:
- guides/02-general-concepts.md: Some general concepts. Missing explaining how errors are reported.
- guides/03-using-federated-tables.md: Explain how to use the registered tables in the APIS, i.e. use `qualified_name`.
- reference/swagger.yaml: The full reference, with error codes and all that jazz.

These 3 files should contain something useful before making them public :smile: 