### PR TITLE
Parse json columns

### DIFF
--- a/app/services/carto/federated_tables_service.rb
+++ b/app/services/carto/federated_tables_service.rb
@@ -82,9 +82,13 @@ module Carto
 
     def list_remote_tables(federated_server_name, remote_schema_name, pagination)
       pagination[:offset] = (pagination[:page] - 1) * pagination[:per_page]
-      @user_db_connection[
+      remote_tables = @user_db_connection[
         select_remote_tables_query(federated_server_name, remote_schema_name, pagination)
       ].all
+      remote_tables.each do |remote_table|
+        remote_table[:columns] = JSON.parse(remote_table[:columns], symbolize_names: true)
+      end
+      return remote_tables
     end
 
     def count_remote_tables(federated_server_name, remote_schema_name)
@@ -103,13 +107,17 @@ module Carto
     end
 
     def get_remote_table(federated_server_name:, remote_schema_name:, remote_table_name:)
-      @user_db_connection[
+      remote_table = @user_db_connection[
         get_remote_table_query(
           federated_server_name: federated_server_name,
           remote_schema_name: remote_schema_name,
           remote_table_name: remote_table_name
         )
       ].first
+      unless remote_table.nil?
+        remote_table[:columns] = JSON.parse(remote_table[:columns], symbolize_names: true)
+      end
+      return remote_table
     end
 
     def update_table(attributes)

--- a/spec/requests/carto/api/public/federated_tables_controller_spec.rb
+++ b/spec/requests/carto/api/public/federated_tables_controller_spec.rb
@@ -793,7 +793,11 @@ describe Carto::Api::Public::FederatedTablesController do
         expect(found[:registered]).to eq(false)
         expect(found[:remote_schema_name]).to eq(@remote_schema_name)
         expect(found[:remote_table_name]).to eq(@remote_table_name)
-        expect(found[:columns]).to eq('[{"Name" : "geom", "Type" : "GEOMETRY,0"}, {"Name" : "geom_webmercator", "Type" : "GEOMETRY,0"}, {"Name" : "id", "Type" : "integer"}]')
+        expect(found[:columns]).to eq([
+          {:Name=>"geom", :Type=>"GEOMETRY,0"},
+          {:Name=>"geom_webmercator", :Type=>"GEOMETRY,0"},
+          {:Name=>"id", :Type=>"integer"}
+        ])
 
         expect(found.include?(:qualified_name)).to eq(false)
         expect(found.include?(:id_column_name)).to eq(false)
@@ -869,7 +873,11 @@ describe Carto::Api::Public::FederatedTablesController do
         expect(response.body[:remote_table_name]).to eq(@payload_register_table[:remote_table_name])
         expect(response.body[:registered]).to eq(true)
         expect(response.body[:qualified_name]).to eq("cdb_fs_#{@federated_server_name}.#{@remote_geo_table_name}")
-        expect(response.body[:columns]).to eq('[{"Name" : "geom", "Type" : "GEOMETRY,0"}, {"Name" : "geom_webmercator", "Type" : "GEOMETRY,0"}, {"Name" : "id", "Type" : "integer"}]')
+        expect(response.body[:columns]).to eq([
+          {:Name=>"geom", :Type=>"GEOMETRY,0"},
+          {:Name=>"geom_webmercator", :Type=>"GEOMETRY,0"},
+          {:Name=>"id", :Type=>"integer"}
+        ])
         expect(response.body[:id_column_name]).to eq('id')
         expect(response.body[:geom_column_name]).to eq('geom')
         expect(response.body[:webmercator_column_name]).to eq('geom_webmercator')
@@ -889,7 +897,7 @@ describe Carto::Api::Public::FederatedTablesController do
         expect(response.body[:remote_table_name]).to eq(@remote_no_geo_table_name)
         expect(response.body[:registered]).to eq(true)
         expect(response.body[:qualified_name]).to eq("cdb_fs_#{@federated_server_name}.#{@remote_no_geo_table_name}")
-        expect(response.body[:columns]).to eq('[{"Name" : "id", "Type" : "integer"}, {"Name" : "value", "Type" : "double precision"}]')
+        expect(response.body[:columns]).to eq([{:Name=>"id", :Type=>"integer"}, {:Name=>"value", :Type=>"double precision"}])
         expect(response.body[:id_column_name]).to eq('id')
         expect(response.body[:geom_column_name]).to eq('')
         expect(response.body[:webmercator_column_name]).to eq('')
@@ -927,7 +935,11 @@ describe Carto::Api::Public::FederatedTablesController do
         expect(response.body[:remote_table_name]).to eq(payload_register_table[:remote_table_name])
         expect(response.body[:registered]).to eq(true)
         expect(response.body[:qualified_name]).to eq("cdb_fs_#{@federated_server_name}.#{@remote_geo_table_name}")
-        expect(response.body[:columns]).to eq('[{"Name" : "geom", "Type" : "GEOMETRY,0"}, {"Name" : "geom_webmercator", "Type" : "GEOMETRY,0"}, {"Name" : "id", "Type" : "integer"}]')
+        expect(response.body[:columns]).to eq([
+          {:Name=>"geom", :Type=>"GEOMETRY,0"},
+          {:Name=>"geom_webmercator", :Type=>"GEOMETRY,0"},
+          {:Name=>"id", :Type=>"integer"}
+        ])
         expect(response.body[:id_column_name]).to eq('id')
         expect(response.body[:geom_column_name]).to eq('geom')
         expect(response.body[:webmercator_column_name]).to eq('geom')
@@ -949,7 +961,11 @@ describe Carto::Api::Public::FederatedTablesController do
         expect(response.body[:remote_table_name]).to eq(payload_register_table[:remote_table_name])
         expect(response.body[:registered]).to eq(true)
         expect(response.body[:qualified_name]).to eq("cdb_fs_#{@federated_server_name}.#{@remote_geo_table_name}")
-        expect(response.body[:columns]).to eq('[{"Name" : "geom", "Type" : "GEOMETRY,0"}, {"Name" : "geom_webmercator", "Type" : "GEOMETRY,0"}, {"Name" : "id", "Type" : "integer"}]')
+        expect(response.body[:columns]).to eq([
+          {:Name=>"geom", :Type=>"GEOMETRY,0"},
+          {:Name=>"geom_webmercator", :Type=>"GEOMETRY,0"},
+          {:Name=>"id", :Type=>"integer"}
+        ])
         expect(response.body[:id_column_name]).to eq('id')
         expect(response.body[:geom_column_name]).to eq('geom_webmercator')
         expect(response.body[:webmercator_column_name]).to eq('geom_webmercator')
@@ -1119,6 +1135,7 @@ describe Carto::Api::Public::FederatedTablesController do
     it 'returns 404 when there is not a remote schema with the provided name' do
       params = { federated_server_name: @federated_server_name, remote_schema_name: 'wadus', remote_table_name: @remote_table_name, api_key: @user1.api_key }
       get_json api_v4_federated_servers_get_table_url(params) do |response|
+        puts response.body
         expect(response.status).to eq(404)
       end
     end

--- a/spec/services/carto/federated_tables_service_spec.rb
+++ b/spec/services/carto/federated_tables_service_spec.rb
@@ -306,14 +306,18 @@ describe Carto::FederatedTablesService do
                 pagination = { page: 1, per_page: 10, order: 'remote_table_name', direction: 'asc' }
                 remote_tables = @service.list_remote_tables(@federated_server_name, @remote_schema_name, pagination)
                 expect(remote_tables).to include(
-                    :registered => false,
-                    :qualified_name => nil,
-                    :remote_schema_name => @remote_schema_name,
-                    :remote_table_name => @remote_table_name,
-                    :id_column_name => nil,
+                    :registered=>false,
+                    :qualified_name=>nil,
+                    :remote_table_name=>@remote_table_name,
+                    :remote_schema_name=>@remote_schema_name,
+                    :id_column_name=>nil,
                     :geom_column_name=>nil,
-                    :webmercator_column_name => nil,
-                    :columns => '[{"Name" : "geom", "Type" : "GEOMETRY,0"}, {"Name" : "geom_webmercator", "Type" : "GEOMETRY,0"}, {"Name" : "id", "Type" : "integer"}]'
+                    :webmercator_column_name=>nil,
+                    :columns=>[
+                        {:Name=>"geom", :Type=>"GEOMETRY,0"},
+                        {:Name=>"geom_webmercator", :Type=>"GEOMETRY,0"},
+                        {:Name=>"id", :Type=>"integer"}
+                    ]
                 )
             end
 
@@ -330,7 +334,11 @@ describe Carto::FederatedTablesService do
                     :id_column_name=> "id",
                     :geom_column_name=>"geom",
                     :webmercator_column_name=> "geom_webmercator",
-                    :columns => '[{"Name" : "geom", "Type" : "GEOMETRY,0"}, {"Name" : "geom_webmercator", "Type" : "GEOMETRY,0"}, {"Name" : "id", "Type" : "integer"}]'
+                    :columns => [
+                        {:Name=>"geom", :Type=>"GEOMETRY,0"},
+                        {:Name=>"geom_webmercator", :Type=>"GEOMETRY,0"},
+                        {:Name=>"id", :Type=>"integer"}
+                    ]
                 )
             end
 


### PR DESCRIPTION
In order to get full json responses:

```
$ curl -X GET -H "Content-Type: application/json" "https://cartofante-ft.carto-staging.com/api/v4/federated_servers/test001/remote_schemas/public/remote_tables/?api_key=d4f87*****6f59b"  | python -m 'json.tool'
{
    "total": 1,
    "count": 1,
    "result": [
        {
            "registered": true,
            "qualified_name": "cdb_fs_test001.populated_places_remote",
            "remote_table_name": "populated_places",
            "remote_schema_name": "public",
            "id_column_name": "id",
            "geom_column_name": "the_geom",
            "webmercator_column_name": "the_geom",
            "columns": [
                {
                    "Name": "country",
                    "Type": "text"
                },
                {
                    "Name": "id",
                    "Type": "integer"
                },
                {
                    "Name": "latitude",
                    "Type": "double precision"
                },
                {
                    "Name": "longitude",
                    "Type": "double precision"
                },
                {
                    "Name": "name",
                    "Type": "text"
                },
                {
                    "Name": "pop_max",
                    "Type": "integer"
                },
                {
                    "Name": "pop_min",
                    "Type": "integer"
                },
                {
                    "Name": "the_geom",
                    "Type": "GEOMETRY,4326"
                }
            ]
        }
    ],
    "_links": {
        "first": {
            "href": "https://cartofante-ft.carto-staging.com/api/v4/federated_servers?api_key=d4f87c90115492cbaade4a3ab06f04af2896f59b&federated_server_name=test001&format=json&page=1&per_page=20&remote_schema_name=public"
        },
        "last": {
            "href": "https://cartofante-ft.carto-staging.com/api/v4/federated_servers?api_key=d4f87c90115492cbaade4a3ab06f04af2896f59b&federated_server_name=test001&format=json&page=1&per_page=20&remote_schema_name=public"
        }
    }
}
```

```
$ curl -X GET -H "Content-Type: application/json" "https://cartofante-ft.carto-staging.com/api/v4/federated_servers/test001/remote_schemas/public/remote_tables/populated_places?api_key=d4f87*****6f59b"  | python -m 'json.tool'
{
    "registered": true,
    "qualified_name": "cdb_fs_test001.populated_places_remote",
    "remote_table_name": "populated_places",
    "remote_schema_name": "public",
    "id_column_name": "id",
    "geom_column_name": "the_geom",
    "webmercator_column_name": "the_geom",
    "columns": [
        {
            "Name": "country",
            "Type": "text"
        },
        {
            "Name": "id",
            "Type": "integer"
        },
        {
            "Name": "latitude",
            "Type": "double precision"
        },
        {
            "Name": "longitude",
            "Type": "double precision"
        },
        {
            "Name": "name",
            "Type": "text"
        },
        {
            "Name": "pop_max",
            "Type": "integer"
        },
        {
            "Name": "pop_min",
            "Type": "integer"
        },
        {
            "Name": "the_geom",
            "Type": "GEOMETRY,4326"
        }
    ]
}
```