### PR TITLE
Fix datasets table header width in edge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Development
 - Update user industries options with the allowed values from Hubspot ([#15265](https://github.com/CartoDB/cartodb/pull/15265))
 - ArcGIS connector: Stop skipping ids on failure.
 - Adapt python scripts python3 syntax.
+- Column options display bug ([#15325](https://github.com/CartoDB/cartodb/pull/15325))
 
 4.31.0 (2019-11-19)
 -------------------

--- a/assets/stylesheets/editor-3/_table.scss
+++ b/assets/stylesheets/editor-3/_table.scss
@@ -85,7 +85,7 @@ $tableBorderColor: $cSecondaryLine;
 
 .Table-headItemName {
   box-sizing: border-box;
-  width: 180px; // ie11
+  width: 100%;
   height: auto;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
https://github.com/CartoDB/support/issues/2292

Tested in browserstack (local testing):
- In Windows 10 - Edge 18
- In Windows 10 - IE 11
- In Windows 7 - IE 11

Locally:
- MacOS Catalina 10.15.1 - Chrome Version 78.0.3904.108 
- MacOS Catalina 10.15.1 - Safari Version 13.0.3
(Removed the comment about IE11 in the css property due to the tests done)
