### PR TITLE
Send all allowed params from the viz API to the viz presenter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@ sudo make install
 - Unlock Connectors UI ([CartoDB/support#2318](https://github.com/CartoDB/support/issues/2318))
 - Destroy users with OAuth access tokens ([CartoDB/support#2301](https://github.com/CartoDB/support/issues/2301))
 - Add element to track GTM events in Connectors UI ([#15340](https://github.com/CartoDB/cartodb/issues/15340))
+- Better control of visualization presenter parameters ([CartoDB/support#2291](https://github.com/CartoDB/support/issues/2291))
 
 4.31.0 (2019-11-19)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 
 ### Bug fixes / enhancements
 - Fix /embed_map for kuviz ([#15360](https://github.com/CartoDB/cartodb/pull/15360))
+- Avoid extra calls when counting number of likes of each visualization ([#15349](https://github.com/CartoDB/cartodb/pull/15349))
 
 4.32.0 (2019-12-27)
 -------------------

--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -6,6 +6,12 @@ module Carto
   module Api
     class VisualizationPresenter
 
+      ALLOWED_PARAMS = [:related, :related_canonical_visualizations, :show_user,
+                        :show_stats, :show_table, :show_liked,
+                        :show_permission, :show_synchronization, :show_uses_builder_features,
+                        :show_table_size_and_row_count, :show_auth_tokens, :show_user_basemaps,
+                        :password, :with_dependent_visualizations].freeze
+
       def initialize(visualization, current_viewer, context,
                      related: true, related_canonical_visualizations: false, show_user: false,
                      show_stats: true, show_table: true, show_liked: true,
@@ -31,7 +37,7 @@ module Carto
         @password = password
         @with_dependent_visualizations = with_dependent_visualizations
 
-        @presenter_cache = Carto::Api::PresenterCache.new
+        @presenter_cache ||= Carto::Api::PresenterCache.new
       end
 
       def with_presenter_cache(presenter_cache)

--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -37,7 +37,7 @@ module Carto
         @password = password
         @with_dependent_visualizations = with_dependent_visualizations
 
-        @presenter_cache ||= Carto::Api::PresenterCache.new
+        @presenter_cache = Carto::Api::PresenterCache.new
       end
 
       def with_presenter_cache(presenter_cache)

--- a/app/controllers/carto/api/visualization_searcher.rb
+++ b/app/controllers/carto/api/visualization_searcher.rb
@@ -98,13 +98,13 @@ module Carto
 
       def presenter_options_from_hash(params)
         options = {}
-        options[:show_stats] = false if params[:show_stats].to_s == 'false'
-        options[:show_table] = false if params[:show_table].to_s == 'false'
-        options[:show_permission] = false if params[:show_permission].to_s == 'false'
-        options[:show_uses_builder_features] = false if params[:show_uses_builder_features].to_s == 'false'
-        options[:show_synchronization] = false if params[:show_synchronization].to_s == 'false'
-        options[:show_table_size_and_row_count] = false if params[:show_table_size_and_row_count].to_s == 'false'
+
+        params.each { |k, v| options[k.to_sym] = false if params[k].to_s == 'false' }
+
         options[:with_dependent_visualizations] = params[:with_dependent_visualizations].to_i
+
+        invalid_keys = options.keys - Carto::Api::VisualizationPresenter::ALLOWED_PARAMS
+        options.except!(*invalid_keys)
         options
       end
 

--- a/app/controllers/carto/api/visualization_searcher.rb
+++ b/app/controllers/carto/api/visualization_searcher.rb
@@ -103,9 +103,7 @@ module Carto
 
         options[:with_dependent_visualizations] = params[:with_dependent_visualizations].to_i
 
-        invalid_keys = options.keys - Carto::Api::VisualizationPresenter::ALLOWED_PARAMS
-        options.except!(*invalid_keys)
-        options
+        options.slice(*Carto::Api::VisualizationPresenter::ALLOWED_PARAMS)
       end
 
       private


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/2291

I checked we were counting the number of `likes` for every visualization because it wasn't taking into account the `show_likes=false` parameters. At the same time I improved a little bit the method to build the options for the VisualizationPresenter which in the end turns out it's not just a presenter but it does queries to the database 🤷‍♂ 