### PR TITLE
Add scroll to uploaded icons page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 
 ### Bug fixes / enhancements
 - Fix /embed_map for kuviz ([#15360](https://github.com/CartoDB/cartodb/pull/15360))
+- Add scroll to uploaded icons page ([CartoDB/support#2073](https://github.com/CartoDB/support/issues/2073))
 
 4.32.0 (2019-12-27)
 -------------------

--- a/lib/assets/javascripts/builder/components/input-color/assets-picker/assets-view.js
+++ b/lib/assets/javascripts/builder/components/input-color/assets-picker/assets-view.js
@@ -264,14 +264,18 @@ module.exports = CoreView.extend({
   },
 
   _createYourUploadsView: function () {
-    var view = new UserAssetsView({
-      model: this.model,
-      selectedAsset: this._selectedAsset,
-      title: _t('components.modals.add-asset.your-uploads'),
-      organizationAssetCollection: this._organizationAssetCollection,
-      userAssetCollection: this._userAssetCollection,
-      userModel: this._userModel
-    }).bind(this);
+    var view = new ScrollView({
+      createContentView: function () {
+        return new UserAssetsView({
+          model: this.model,
+          selectedAsset: this._selectedAsset,
+          title: _t('components.modals.add-asset.your-uploads'),
+          organizationAssetCollection: this._organizationAssetCollection,
+          userAssetCollection: this._userAssetCollection,
+          userModel: this._userModel
+        });
+      }.bind(this)
+    });
 
     this._userAssetsView = view;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.146-scroll-1",
+  "version": "1.0.0-assets.146",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.146",
+  "version": "1.0.0-assets.146-scroll-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Related issue
https://github.com/CartoDB/support/issues/2073

## Acceptance
(This can be done in staging cloud)

### Prepare

1. Open a Builder map with a point layer
2. Open the style menu of the point layer
3. Click on the icon IMG of the point color section the the style menu of the point layer
4. Click on Show full collections
5. Click on Upload file tab
6. Upload multiple icons

### Test
1. Click on Upload file tab

- [x] Check that a scrollbar appears when there are enough icons uploaded