### PR TITLE
Disable the submit button in the Request Connector form when needed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ sudo make install
 
 ### Bug fixes / enhancements
 - Fix /embed_map for kuviz ([#15360](https://github.com/CartoDB/cartodb/pull/15360))
+- Disable the submit button in the Request Connector form when needed ([#15353](https://github.com/CartoDB/cartodb/issues/15353))
 
 4.32.0 (2019-12-27)
 -------------------

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/imports-selector/import-other-button-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/imports-selector/import-other-button-view.js
@@ -41,7 +41,7 @@ module.exports = CoreView.extend({
   _onKeyup: function () {
     var hasValue = this.$('.js-input').val();
 
-    (hasValue ? this._enaableSubmit() : this._disableSubmit());
+    (hasValue ? this._enableSubmit() : this._disableSubmit());
   },
 
   _onOk: function () {
@@ -81,7 +81,7 @@ module.exports = CoreView.extend({
     this.$('.js-submit').addClass('is-disabled');
   },
 
-  _enaableSubmit: function () {
+  _enableSubmit: function () {
     this.$('.js-submit').removeAttr('disabled');
     this.$('.js-submit').removeClass('is-disabled');
   }

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/imports-selector/import-other-button-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/imports-selector/import-other-button-view.js
@@ -40,7 +40,10 @@ module.exports = CoreView.extend({
 
   _onKeyup: function () {
     var hasValue = this.$('.js-input').val();
-    this.$('.js-submit').toggleClass('is-disabled', !hasValue);
+    var submitButton = this.$('.js-submit');
+
+    (hasValue ? submitButton.removeAttr('disabled') : submitButton.attr('disabled', 'disabled'));
+    submitButton.toggleClass('is-disabled', !hasValue);
   },
 
   _onOk: function () {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/imports-selector/import-other-button-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/imports-selector/import-other-button-view.js
@@ -40,10 +40,8 @@ module.exports = CoreView.extend({
 
   _onKeyup: function () {
     var hasValue = this.$('.js-input').val();
-    var submitButton = this.$('.js-submit');
 
-    (hasValue ? submitButton.removeAttr('disabled') : submitButton.attr('disabled', 'disabled'));
-    submitButton.toggleClass('is-disabled', !hasValue);
+    (hasValue ? this._enaableSubmit() : this._disableSubmit());
   },
 
   _onOk: function () {
@@ -67,6 +65,7 @@ module.exports = CoreView.extend({
         self._hasError = false;
         self._goToStep(4);
         self._resetInput();
+        self._disableSubmit();
       },
       function () {
         self._hasError = true;
@@ -75,5 +74,15 @@ module.exports = CoreView.extend({
 
   _resetInput: function () {
     this.$('.js-input').val('');
+  },
+
+  _disableSubmit: function () {
+    this.$('.js-submit').attr('disabled', 'disabled');
+    this.$('.js-submit').addClass('is-disabled');
+  },
+
+  _enaableSubmit: function () {
+    this.$('.js-submit').removeAttr('disabled');
+    this.$('.js-submit').removeClass('is-disabled');
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/imports-selector/import-other-button.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/imports-selector/import-other-button.tpl
@@ -6,7 +6,10 @@
   <li class="ImportOther__step2 js-step js-step2">
     <span><%- _t('components.modals.add-layer.imports.other.type') %></span>
     <input type="text" class="ImportOther__input js-input" required value=""/>
-    <button type="submit" class="ImportOther__inputSubmit js-submit is-disabled CDB-Text CDB-Size-small u-actionTextColor u-upperCase">
+    <button
+      type="submit"
+      disabled
+      class="ImportOther__inputSubmit js-submit is-disabled CDB-Text CDB-Size-small u-actionTextColor u-upperCase">
       <span><%- _t('components.modals.add-layer.imports.other.submit') %></span>
     </button>
     <div class="ImportOther__inputError"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.146-connectors-disable",
+  "version": "1.0.0-assets.146-connectors-disable-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.146",
+  "version": "1.0.0-assets.146-connectors-disable",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.146-connectors-disable-2",
+  "version": "1.0.0-assets.146",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Related issue
https://github.com/CartoDB/cartodb/issues/15353

## Acceptance
(This can be done in staging cloud)

1. Click on New dataset button
2. In Connect tab, click on Request connector. A new form will appear. 
3. Inspect the form via DevTools. 
- [x] Check the submit button is really disabled and has `is-disabled` CSS class
4. Fill in the input text
- [x] Check the submit button is enabled and hasn't `is-disabled` CSS class
5. Clear the input text
- [x] Check the submit button is really disabled and has `is-disabled` CSS class
6. Fill in the input text
7. Send the request
8. Click on Ok, got it and click on Request connector.
- [x] Check the submit button is really disabled and has `is-disabled` CSS class