### PR TITLE
Choose http method based on real query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ sudo make install
 - Fix /embed_map for kuviz ([#15360](https://github.com/CartoDB/cartodb/pull/15360))
 - Add scroll to uploaded icons page ([CartoDB/support#2073](https://github.com/CartoDB/support/issues/2073))
 - Disable the submit button in the Request Connector form when needed ([#15353](https://github.com/CartoDB/cartodb/issues/15353))
+- Fix 414 Request-URI error choosing http method based on real query ([CartoDB/support#2263](https://github.com/CartoDB/support/issues/2263))
 
 4.32.0 (2019-12-27)
 -------------------

--- a/lib/assets/javascripts/builder/data/query-rows-collection.js
+++ b/lib/assets/javascripts/builder/data/query-rows-collection.js
@@ -183,10 +183,8 @@ module.exports = Backbone.Collection.extend({
     });
   },
 
-  _httpMethod: function () {
-    return this._querySchemaModel.get('query').length > MAX_GET_LENGTH
-      ? 'POST'
-      : 'GET';
+  _httpMethod: function (query) {
+    return query.length > MAX_GET_LENGTH ? 'POST' : 'GET';
   },
 
   _incrementRepeatedError: function () {
@@ -208,6 +206,7 @@ module.exports = Backbone.Collection.extend({
     this.statusModel.set('status', STATUS.fetching);
 
     var excludeColumns = (opts.data && opts.data.exclude) || [];
+    var query = this._getWrappedSQL(excludeColumns);
 
     opts = opts || {};
     opts.data = _.extend(
@@ -216,11 +215,11 @@ module.exports = Backbone.Collection.extend({
       opts.data && _.omit(opts.data, 'exclude') || {},
       {
         api_key: this._configModel.get('api_key'),
-        q: this._getWrappedSQL(excludeColumns)
+        q: query
       }
     );
 
-    opts.method = this._httpMethod();
+    opts.method = this._httpMethod(query);
     var errorCallback = opts.error;
     opts.error = function (coll, resp) {
       if (previousStatus === STATUS.unavailable) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.146",
+  "version": "1.0.0-assets.146-http-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.146-http-1",
+  "version": "1.0.0-assets.146",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The request method was being decided based on `this._querySchemaModel.get('query')` length, but it should be decided based on `this._getWrappedSQL(excludeColumns)`, which is the final query sent to the SQL API. Having a wrong request method caused a `414 Request-URI Too Large` error. 

### Related issues
https://github.com/CartoDB/support/issues/2263
https://github.com/CartoDB/cartodb/issues/15085

## Acceptance

1. Upload the .carto file linked in the [issue](https://github.com/CartoDB/support/issues/2263)
2. Select data view
3. Open the dataset
- [x] Check that the DevTool console is clean and data loads properly