### PR TITLE
Exclude table permissions from /viz when show_permission=false

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ sudo make install
 - Add scroll to uploaded icons page ([CartoDB/support#2073](https://github.com/CartoDB/support/issues/2073))
 - Disable the submit button in the Request Connector form when needed ([#15353](https://github.com/CartoDB/cartodb/issues/15353))
 - Fix 414 Request-URI error choosing http method based on real query ([CartoDB/support#2263](https://github.com/CartoDB/support/issues/2263))
+- Exclude table permissions from /viz with show_permission=false
 
 4.32.0 (2019-12-27)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@ sudo make install
 - Add scroll to uploaded icons page ([CartoDB/support#2073](https://github.com/CartoDB/support/issues/2073))
 - Disable the submit button in the Request Connector form when needed ([#15353](https://github.com/CartoDB/cartodb/issues/15353))
 - Fix 414 Request-URI error choosing http method based on real query ([CartoDB/support#2263](https://github.com/CartoDB/support/issues/2263))
-- Exclude table permissions from /viz with show_permission=false
+- Exclude table permissions from /viz with show_permission=false ([#15368](https://github.com/CartoDB/cartodb/pull/15368))
 
 4.32.0 (2019-12-27)
 -------------------

--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -197,7 +197,8 @@ module Carto
 
       def user_table_presentation
         Carto::Api::UserTablePresenter.new(@visualization.user_table, @current_viewer,
-                                           show_size_and_row_count: show_table_size_and_row_count)
+                                           show_size_and_row_count: show_table_size_and_row_count,
+                                           show_permission: show_permission)
                                       .with_presenter_cache(@presenter_cache).to_poro
       end
 

--- a/spec/requests/carto/api/visualizations_controller_spec.rb
+++ b/spec/requests/carto/api/visualizations_controller_spec.rb
@@ -423,6 +423,16 @@ describe Carto::Api::VisualizationsController do
       body['visualizations'][0]['dependent_visualizations_count'].should be_zero
     end
 
+    it 'exludes any kind of permissions with show_permission=false' do
+      FactoryGirl.create(:carto_user_table_with_canonical, user_id: @user_1.id)
+
+      body = response_body(type: CartoDB::Visualization::Member::TYPE_CANONICAL, show_permission: false)
+
+      body['total_entries'].should == 1
+      body['visualizations'][0]['permission'].should be_nil
+      body['visualizations'][0]['table']['permission'].should be_nil
+    end
+
     describe 'performance with many tables' do
       # The bigger the number the better the improvement, but test gets too slow
       VIZS_N = 20


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/2291

When calling to `api/v1/viz` with `show_permission=false`, it now excludes both permissions from visualizations and related tables.