### PR TITLE
Improve embeds controller tests

### DIFF
--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -66,23 +66,23 @@ describe Carto::Builder::Public::EmbedsController do
     end
 
     it 'displays published layers, not ("live") visualization layers' do
-      @map, @table, @table_visualization, @visualization = create_full_builder_vis(@carto_user)
-      Carto::Mapcap.create!(visualization_id: @visualization.id)
+      map, table, table_visualization, visualization = create_full_builder_vis(@carto_user)
+      Carto::Mapcap.create!(visualization_id: visualization.id)
 
-      layer = @visualization.layers[1]
+      layer = visualization.layers[1]
       old_tile_style = layer.options['tile_style']
 
       new_layer_style = '#layer { marker-width: 7; }'
       layer.options['tile_style'] = new_layer_style
       layer.save
 
-      get builder_visualization_public_embed_url(visualization_id: @visualization.id)
+      get builder_visualization_public_embed_url(visualization_id: visualization.id)
 
       response.status.should == 200
       response.body.should_not include(new_layer_style)
       response.body.should include(old_tile_style)
 
-      destroy_full_visualization(@map, @table, @table_visualization, @visualization)
+      destroy_full_visualization(map, table, table_visualization, visualization)
     end
 
     it 'embeds visualizations' do
@@ -103,18 +103,18 @@ describe Carto::Builder::Public::EmbedsController do
 
     describe 'connectivity issues' do
       it 'does not need connection to the user db' do
-        @map, @table, @table_visualization, @visualization = create_full_builder_vis(@carto_user)
-        Carto::Mapcap.create!(visualization_id: @visualization.id)
+        map, table, table_visualization, visualization = create_full_builder_vis(@carto_user)
+        Carto::Mapcap.create!(visualization_id: visualization.id)
 
-        @actual_database_name = @visualization.user.database_name
-        @visualization.user.update_attribute(:database_name, 'wadus')
+        actual_database_name = visualization.user.database_name
+        visualization.user.update_attribute(:database_name, 'wadus')
 
         CartoDB::Logger.expects(:warning).never
-        get builder_visualization_public_embed_url(visualization_id: @visualization.id)
+        get builder_visualization_public_embed_url(visualization_id: visualization.id)
         response.status.should == 200
 
-        @visualization.user.update_attribute(:database_name, @actual_database_name)
-        destroy_full_visualization(@map, @table, @table_visualization, @visualization)
+        visualization.user.update_attribute(:database_name, actual_database_name)
+        destroy_full_visualization(map, table, table_visualization, visualization)
       end
     end
 
@@ -359,7 +359,6 @@ describe Carto::Builder::Public::EmbedsController do
       unpublished_visualization = FactoryGirl.create(:carto_visualization, user: @carto_user, map_id: @map.id, version: 3, privacy: Carto::Visualization::PRIVACY_PROTECTED)
       unpublished_visualization.published?.should be_false
 
-
       post builder_visualization_public_embed_protected_url(visualization_id: unpublished_visualization.id, password: TEST_PASSWORD)
 
       response.body.include?('Invalid password').should be false
@@ -375,7 +374,6 @@ describe Carto::Builder::Public::EmbedsController do
       Carto::Mapcap.create!(visualization_id: published_visualization.id)
       published_visualization.published?.should be_true
 
-
       post builder_visualization_public_embed_protected_url(visualization_id: published_visualization.id, password: TEST_PASSWORD)
 
       response.status.should == 200
@@ -389,7 +387,6 @@ describe Carto::Builder::Public::EmbedsController do
       @visualization.privacy = Carto::Visualization::PRIVACY_PROTECTED
       @visualization.save
 
-
       post builder_visualization_public_embed_protected_url(visualization_id: @visualization.id, password: "${TEST_PASSWORD}NO!")
 
       response.body.include?('Invalid password').should be true
@@ -400,7 +397,6 @@ describe Carto::Builder::Public::EmbedsController do
       stub_passwords(TEST_PASSWORD)
       @visualization.privacy = Carto::Visualization::PRIVACY_PROTECTED
       @visualization.save
-
 
       post builder_visualization_public_embed_protected_url(visualization_id: @visualization.id, password: TEST_PASSWORD)
 
@@ -413,7 +409,6 @@ describe Carto::Builder::Public::EmbedsController do
       stub_passwords(TEST_PASSWORD)
       @visualization.privacy = Carto::Visualization::PRIVACY_PROTECTED
       @visualization.save
-
 
       post builder_visualization_public_embed_protected_url(visualization_id: @visualization.id, password: TEST_PASSWORD)
 


### PR DESCRIPTION
Some tests were overriding an instance variable (`@map`) that could cause an error depending on the execution order.