### PR TITLE
Add empty tips to CodeMirrorView because it is required

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ sudo make install
 - Disable the submit button in the Request Connector form when needed ([#15353](https://github.com/CartoDB/cartodb/issues/15353))
 - Fix 414 Request-URI error choosing http method based on real query ([CartoDB/support#2263](https://github.com/CartoDB/support/issues/2263))
 - Exclude table permissions from /viz with show_permission=false ([#15368](https://github.com/CartoDB/cartodb/pull/15368))
+- Add required tips parameter to fix street geocoding in advanced mode ([CartoDB/support#2265](https://github.com/CartoDB/support/issues/2265))
 
 4.32.0 (2019-12-27)
 -------------------

--- a/lib/assets/javascripts/builder/components/form-components/editors/code-editor.js
+++ b/lib/assets/javascripts/builder/components/form-components/editors/code-editor.js
@@ -45,7 +45,8 @@ Backbone.Form.editors.CodeEditor = Backbone.Form.editors.TextArea.extend({
       autocompleteChars: 2,
       autocompletePrefix: '{{',
       autocompleteSuffix: '}}',
-      placeholder: this.options.placeholder
+      placeholder: this.options.placeholder,
+      tips: []
     });
     this.codeMirrorView.bind('codeChanged', function () {
       this.trigger('change', this.codeMirrorView.getContent());

--- a/lib/assets/test/spec/builder/components/code-mirror/code-editor.spec.js
+++ b/lib/assets/test/spec/builder/components/code-mirror/code-editor.spec.js
@@ -1,8 +1,6 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
-var CodeMirrorView = require('builder/components/code-mirror/code-mirror-view');
 var FactoryHints = require('builder/editor/editor-hints/factory-hints');
-// var CodeEditor = require('builder/components/form-components/editors/code-editor');
 
 describe('components/code-mirror/code-editor', function () {
   var view;

--- a/lib/assets/test/spec/builder/components/code-mirror/code-editor.spec.js
+++ b/lib/assets/test/spec/builder/components/code-mirror/code-editor.spec.js
@@ -1,0 +1,49 @@
+var _ = require('underscore');
+var Backbone = require('backbone');
+var CodeMirrorView = require('builder/components/code-mirror/code-mirror-view');
+var FactoryHints = require('builder/editor/editor-hints/factory-hints');
+// var CodeEditor = require('builder/components/form-components/editors/code-editor');
+
+describe('components/code-mirror/code-editor', function () {
+  var view;
+
+  beforeEach(function () {
+    view = new Backbone.Form.editors.CodeEditor({
+      className: 'className',
+      key: 'key',
+      model: new Backbone.Model(),
+      schema: {}
+    });
+  });
+
+  it('should render properly', function () {
+    spyOn(view, '_initViews');
+    view.render();
+    expect(view._initViews).toHaveBeenCalled();
+  });
+
+  it('should create CodeMirrorView with required properties', function () {
+    view._codemirrorModel = new Backbone.Model({
+      content: '',
+      readonly: false,
+      lineNumbers: false
+    });
+
+    FactoryHints.init({
+      tokens: '',
+      tableName: false,
+      columnsName: false
+    });
+
+    view._initViews();
+    var props = [
+      'model',
+      '_placeholder',
+      '_tips'
+    ];
+
+    props.forEach(function (prop) {
+      expect(_.has(view.codeMirrorView, prop)).toBeTruthy();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.147-analysis-1",
+  "version": "1.0.0-assets.147",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.147",
+  "version": "1.0.0-assets.147-analysis-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add required tips parameter when creating a new CodeMirrorView instance to fix street geocoding in advanced mode.

### Related issue
https://github.com/CartoDB/support/issues/2265