### PR TITLE
Fix Nokogiri upgrade

### DIFF
--- a/gears/carto_gears_api/Gemfile.lock
+++ b/gears/carto_gears_api/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     carto_gears_api (0.0.6)
       pg (= 0.20.0)
       rails (= 4.2.11)
+      sprockets (= 3.7.2)
       values (= 1.8.0)
 
 GEM
@@ -107,7 +108,7 @@ GEM
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
       rspec-mocks (~> 2.12.0)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -131,4 +132,4 @@ DEPENDENCIES
   rspec-rails (= 2.12.0)
 
 BUNDLED WITH
-   1.14.6
+   1.17.3

--- a/gears/carto_gears_api/carto_gears_api.gemspec
+++ b/gears/carto_gears_api/carto_gears_api.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "4.2.11"
-  s.add_dependency 'values', '1.8.0'
   s.add_dependency 'pg', '0.20.0'
+  s.add_dependency "rails", "4.2.11"
+  s.add_dependency 'sprockets', '3.7.2'
+  s.add_dependency 'values', '1.8.0'
 end


### PR DESCRIPTION
[Dependabot upgraded Nokogiri](https://github.com/CartoDB/cartodb/pull/15200 ) and it caused Sprockets to upgrade from 3.7.2 to 4.0.0, but [that version requires ruby 2.5](https://rubygems.org/gems/sprockets/versions/4.0.0).

So I'm locking Sprockets to 3.7.2.
