### PR TITLE
Add noindex for Organization login page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@ sudo make install
 * Limit private maps by quota ([#15412](https://github.com/CartoDB/cartodb/pull/15412))
 
 ### Bug fixes / enhancements
+* Add noindex meta to organization login page ([#15117](https://github.com/CartoDB/cartodb/issues/15117))
 * Prevent sync starvation ([#15398](https://github.com/CartoDB/cartodb/issues/15398))
 * Fix misplaced footer in Dialogs ([#15418](https://github.com/CartoDB/cartodb/pull/15418))
 * Remove directo connections debug trace ([#15274](https://github.com/CartoDB/cartodb/pull/15274))

--- a/app/views/layouts/frontend.html.erb
+++ b/app/views/layouts/frontend.html.erb
@@ -6,6 +6,7 @@
   <title><%= "#{yield(:title)} — " if content_for?(:title) %>CARTO</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="<%= content_for?(:title) ? yield(:title) : "Create dynamic maps, analyze and build location-aware and geospatial applications with your data using the power of PostGIS in the cloud." %>">
+  <%= yield(:robots) if content_for?(:robots) %>
   <%= favicon_link_tag "favicons/favicon.ico" %>
   <%= stylesheet_link_tag "sessions" %>
   <%= yield :css %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,9 @@
 <% if @organization %>
   <% content_for :title do %><%= @organization.name %><% end %>
+
+  <% content_for :robots do %>
+    <meta name="robots" content="noindex">
+  <% end %>
 <% end %>
 
 <% content_for :js do %>


### PR DESCRIPTION
Following the change of allowing public signup/login pages to be indexed, here's the change to avoid indexing organization pages in search engines.

https://github.com/CartoDB/cartodb/issues/15117