### PR TITLE
Reflect last cartodb-postgres extension version at carto-package.json

### DIFF
--- a/carto-package.json
+++ b/carto-package.json
@@ -12,7 +12,7 @@
         },
         "works_with": {
             "dataservices-api-client-extension": "0.28.0",
-            "carto_postgresql_ext": "0.33.0",
+            "carto_postgresql_ext": "0.35.0",
             "odbc_fdw": "0.4.0",
             "carto_windshaft": ">=6.2.0",
             "carto_sql_api": ">=2.1.0",


### PR DESCRIPTION
Last cartodb-postgres extension update didn't include the change at carto-package.json: https://github.com/CartoDB/cartodb/commit/0357a72ef9a377705ac5f96ff2a26c00d4071e63

Can we retag v4.33.0, please?