### PR TITLE
Fixes sync starvation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ sudo make install
 * Limit private maps by quota ([#15412](https://github.com/CartoDB/cartodb/pull/15412))
 
 ### Bug fixes / enhancements
+* Prevent sync starvation ([#15398](https://github.com/CartoDB/cartodb/issues/15398))
 * Fix misplaced footer in Dialogs ([#15418](https://github.com/CartoDB/cartodb/pull/15418))
 * Remove directo connections debug trace ([#15274](https://github.com/CartoDB/cartodb/pull/15274))
 * New versioned sanitization of column names ([#15326](https://github.com/CartoDB/cartodb/issues/15326))

--- a/services/synchronizer/lib/synchronizer/collection.rb
+++ b/services/synchronizer/lib/synchronizer/collection.rb
@@ -60,6 +60,7 @@ module CartoDB
                   OR (r.state = '#{CartoDB::Synchronization::Member::STATE_FAILURE}'
                       AND r.retried_times < #{CartoDB::Synchronization::Member::MAX_RETRIES})
                 )
+              ORDER BY ran_at
             ))
           end
           success = true


### PR DESCRIPTION
Adding `ORDER BY rant_at` when fetching and enqueuing pending synchronizations in order to prevent starvation.

Fixes #15398 