### PR TITLE
Rename analysis_updated event

### DIFF
--- a/lib/carto/tracking/events.rb
+++ b/lib/carto/tracking/events.rb
@@ -259,7 +259,7 @@ module Carto
 
       class ModifiedAnalysis < AnalysisEvent
         def pubsub_name
-          'analysis_modified'
+          'analysis_updated'
         end
       end
 


### PR DESCRIPTION
We decided to rename this event but I just missed it during the implementation.