### PR TITLE
Fix DO subscription with NULL delivery days

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Better error reporting for BigQuery connector ([#15383](https://github.com/CartoDB/cartodb/issues/15383))
+- Fix DO subscriptions when estimated_delivery_days is NULL ([#15451](https://github.com/CartoDB/cartodb/pull/15451))
 
 4.34.0 (2020-01-28)
 -------------------

--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -136,14 +136,14 @@ module Carto
 
         def present_metadata(metadata)
           metadata[:estimated_delivery_days] = present_delivery_days(metadata[:estimated_delivery_days])
-          metadata[:subscription_list_price] = metadata[:subscription_list_price].to_f unless metadata[:subscription_list_price].nil?
+          metadata[:subscription_list_price] = metadata[:subscription_list_price]&.to_f
           metadata.slice(*METADATA_FIELDS)
         end
 
         def present_delivery_days(delivery_days)
-          return DEFAULT_DELIVERY_DAYS if delivery_days.zero? && !@user.has_feature_flag?('do-instant-licensing')
+          return DEFAULT_DELIVERY_DAYS if delivery_days&.zero? && !@user.has_feature_flag?('do-instant-licensing')
 
-          delivery_days.to_f
+          delivery_days&.to_f
         end
 
         def subscription_metadata

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -323,11 +323,11 @@ describe Carto::Api::Public::DataObservatoryController do
       end
     end
 
-    it 'returns 200 and null price with the metadata for a dataset with null price' do
+    it 'returns 200 and null values with the metadata for a dataset with null price and delivery days' do
       get_json endpoint_url(api_key: @master, id: 'carto.abc.datasetnull', type: 'dataset'), @headers do |response|
         expect(response.status).to eq(200)
         expected_response = {
-          estimated_delivery_days: 0.0,
+          estimated_delivery_days: nil,
           id: 'carto.abc.datasetnull',
           licenses: 'licenses',
           licenses_link: 'licenses_link',
@@ -379,7 +379,6 @@ describe Carto::Api::Public::DataObservatoryController do
         end
       end
     end
-
   end
 
   describe 'subscribe' do
@@ -556,7 +555,7 @@ describe Carto::Api::Public::DataObservatoryController do
                                    'rights', '{bq}', 'CARTO dataset 1');
       INSERT INTO datasets VALUES ('carto.abc.incomplete', 0.0, 100.0, 'tos', 'tos_link', 'licenses', 'licenses_link',
                                    'rights', NULL, 'Incomplete dataset');
-      INSERT INTO datasets VALUES ('carto.abc.datasetnull', 0.0, NULL, 'tos', 'tos_link', 'licenses', 'licenses_link',
+      INSERT INTO datasets VALUES ('carto.abc.datasetnull', NULL, NULL, 'tos', 'tos_link', 'licenses', 'licenses_link',
                                    'rights', '{bq}', 'CARTO dataset null');
       INSERT INTO datasets VALUES ('carto.abc.datasetzero', 0.0, 0.0, 'tos', 'tos_link', 'licenses', 'licenses_link',
                                    'rights', '{bq}', 'CARTO dataset zero');


### PR DESCRIPTION
When a dataset's metadata has no `estimated_delivery_days` (NULL), `/subscription_info` and `/subscribe`  raise an error: https://rollbar.com/carto/CartoDB/items/40907

They should work and return NULL for that field.