### PR TITLE
Rtorre/ch57809/rui store bq and gcs user settings in redis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,11 +5,12 @@ Development
 - None yet
 
 ### Features
-- BigQuery Connector endponits for dry runs and projects/datasets/tables listings ([#15414]https://github.com/CartoDB/cartodb/pull/15414)
+- BigQuery Connector endpoints for dry runs and projects/datasets/tables listings ([#15414](https://github.com/CartoDB/cartodb/pull/15414))
 
 ### Bug fixes / enhancements
 - Better error reporting for BigQuery connector ([#15383](https://github.com/CartoDB/cartodb/issues/15383))
 - Fix DO subscriptions when estimated_delivery_days is NULL ([#15451](https://github.com/CartoDB/cartodb/pull/15451))
+- Improve management of gcloud DO settings through API keys ([#15453](https://github.com/CartoDB/cartodb/pull/15453))
 
 4.34.0 (2020-01-28)
 -------------------

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -72,6 +72,7 @@ class Superadmin::UsersController < Superadmin::SuperadminController
     @user.regenerate_api_key(user_param[:api_key]) if user_param[:api_key].present?
 
     @user.update_rate_limits(user_param[:rate_limit])
+    @user.store_gcloud_settings(user_param[:gcloud_settings])
     @user.save
     respond_with(:superadmin, @user)
   end

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -72,7 +72,7 @@ class Superadmin::UsersController < Superadmin::SuperadminController
     @user.regenerate_api_key(user_param[:api_key]) if user_param[:api_key].present?
 
     @user.update_rate_limits(user_param[:rate_limit])
-    @user.store_gcloud_settings(user_param[:gcloud_settings])
+    @user.update_gcloud_settings(user_param[:gcloud_settings])
     @user.save
     respond_with(:superadmin, @user)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ require_dependency 'carto/helpers/billing_cycle'
 require_dependency 'carto/email_cleaner'
 require_dependency 'carto/email_domain_validator'
 require_dependency 'carto/visualization'
+require_dependency 'carto/gcloud_user_settings'
 
 class User < Sequel::Model
   include CartoDB::MiniSequel
@@ -1122,6 +1123,15 @@ class User < Sequel::Model
 
   def rate_limit
     Carto::RateLimit.find(rate_limit_id) if rate_limit_id
+  end
+
+  def store_gcloud_settings(attributes)
+    settings = Carto::GCloudUserSettings.new(self, attributes)
+    if attributes.present?
+      settings.store
+    else
+      settings.remove
+    end
   end
 
   def carto_account_type

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1128,11 +1128,7 @@ class User < Sequel::Model
   def update_gcloud_settings(attributes)
     return if attributes.nil?
     settings = Carto::GCloudUserSettings.new(self, attributes)
-    if attributes.present?
-      settings.store
-    else
-      settings.remove
-    end
+    settings.update
   end
 
   def carto_account_type

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1125,7 +1125,7 @@ class User < Sequel::Model
     Carto::RateLimit.find(rate_limit_id) if rate_limit_id
   end
 
-  def store_gcloud_settings(attributes)
+  def update_gcloud_settings(attributes)
     return if attributes.nil?
     settings = Carto::GCloudUserSettings.new(self, attributes)
     if attributes.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1126,6 +1126,7 @@ class User < Sequel::Model
   end
 
   def store_gcloud_settings(attributes)
+    return if attributes.nil?
     settings = Carto::GCloudUserSettings.new(self, attributes)
     if attributes.present?
       settings.store

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -3,9 +3,6 @@ module Carto
 
     REDIS_PREFIX = 'do_settings'
 
-    STORE_ATTRIBUTES = [ :service_account, :bq_public_project,
-      :gcp_execution_project, :bq_project, :bq_dataset, :gcs_bucket ]
-
     attr_reader :service_account, :bq_public_project,
                 :gcp_execution_project, :bq_project, :bq_dataset, :gcs_bucket
 

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -28,7 +28,7 @@ module Carto
 
     def values
       hash = {}
-      STORE_ATTRIBUTES.each { |attr| hash[attr] = self.send(attr) }
+      STORE_ATTRIBUTES.each { |attr| hash[attr] = self.send(attr).to_json }
       hash
     end
 

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -13,13 +13,15 @@ module Carto
       @username = user.username
       @api_key = user.api_key
 
-      h = attributes.symbolize_keys
-      @service_account = h[:service_account]
-      @bq_public_project = h[:bq_public_project]
-      @gcp_execution_project = h[:gcp_execution_project]
-      @bq_project = h[:bq_project]
-      @bq_dataset = h[:bq_dataset]
-      @gcs_bucket = h[:gcs_bucket]
+      if attributes.present?
+        h = attributes.symbolize_keys
+        @service_account = h[:service_account]
+        @bq_public_project = h[:bq_public_project]
+        @gcp_execution_project = h[:gcp_execution_project]
+        @bq_project = h[:bq_project]
+        @bq_dataset = h[:bq_dataset]
+        @gcs_bucket = h[:gcs_bucket]
+      end
     end
 
     def store

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -1,0 +1,44 @@
+module Carto
+  class GCloudUserSettings
+
+    REDIS_PREFIX = 'do_settings'
+
+    STORE_ATTRIBUTES = [ :service_account, :bq_public_project,
+      :gcp_execution_project, :bq_project, :bq_dataset, :gcs_bucket ]
+
+    attr_reader :service_account, :bq_public_project,
+                :gcp_execution_project, :bq_project, :bq_dataset, :gcs_bucket
+
+    def initialize(user, attributes)
+      @username = user.username
+      @api_key = user.api_key
+
+      h = attributes.symbolize_keys
+      @service_account = h[:service_account]
+      @bq_public_project = h[:bq_public_project]
+      @gcp_execution_project = h[:gcp_execution_project]
+      @bq_project = h[:bq_project]
+      @bq_dataset = h[:bq_dataset]
+      @gcs_bucket = h[:gcs_bucket]
+    end
+
+    def store
+      $users_metadata.hmset(key, *values.to_a)
+    end
+
+    def values
+      hash = {}
+      STORE_ATTRIBUTES.each { |attr| hash[attr] = self.send(attr) }
+      hash
+    end
+
+    def remove
+      $users_metadata.hset key
+    end
+
+    def key
+      require 'byebug'; byebug
+      "#{REDIS_PREFIX}:#{@username}:#{@api_key}"
+    end
+  end
+end

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -27,9 +27,14 @@ module Carto
     end
 
     def values
-      hash = {}
-      STORE_ATTRIBUTES.each { |attr| hash[attr] = self.send(attr).to_json }
-      hash
+      {
+        service_account: @service_account.to_json,
+        bq_public_project: @bq_public_project,
+        gcp_execution_project: @gcp_execution_project,
+        bq_project: @bq_project,
+        bq_dataset: @bq_dataset,
+        gcs_bucket: @gcs_bucket
+      }
     end
 
     def remove

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -34,7 +34,7 @@ module Carto
     end
 
     def remove
-      $users_metadata.del key
+      $users_metadata.del(key)
     end
 
     def key

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -38,7 +38,7 @@ module Carto
     end
 
     def remove
-      $users_metadata.hset key
+      $users_metadata.del key
     end
 
     def key

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -12,6 +12,7 @@ module Carto
     def initialize(user, attributes)
       @username = user.username
       @api_key = user.api_key
+      @attributes = attributes
 
       if attributes.present?
         h = attributes.symbolize_keys
@@ -21,6 +22,14 @@ module Carto
         @bq_project = h[:bq_project]
         @bq_dataset = h[:bq_dataset]
         @gcs_bucket = h[:gcs_bucket]
+      end
+    end
+
+    def update
+      if @attributes.present?
+        store
+      else
+        remove
       end
     end
 

--- a/lib/carto/gcloud_user_settings.rb
+++ b/lib/carto/gcloud_user_settings.rb
@@ -37,7 +37,6 @@ module Carto
     end
 
     def key
-      require 'byebug'; byebug
       "#{REDIS_PREFIX}:#{@username}:#{@api_key}"
     end
   end

--- a/spec/requests/superadmin/users_spec.rb
+++ b/spec/requests/superadmin/users_spec.rb
@@ -583,7 +583,7 @@ feature "Superadmin's users API" do
       user.rate_limit.api_attributes.should eq rate_limit_custom.api_attributes
     end
 
-    it 'gcloud settings are set in redis' do
+    it 'gcloud settings are updated in redis' do
       user = FactoryGirl.create(:user)
       user.save
 
@@ -615,6 +615,16 @@ feature "Superadmin's users API" do
       redis_gcloud_settings[:bq_project].should == expected_gcloud_settings[:bq_project]
       redis_gcloud_settings[:gcs_bucket].should == expected_gcloud_settings[:gcs_bucket]
       redis_gcloud_settings[:bq_dataset].should == expected_gcloud_settings[:bq_dataset]
+
+      # Now an update without gcloud settings
+      payload = {
+        user: {
+          gcloud_settings: nil
+        }
+      }
+      put superadmin_user_url(user.id), payload.to_json, superadmin_headers
+      redis_gcloud_settings = $users_metadata.hgetall("do_settings:#{user.username}:#{user.api_key}")
+      redis_gcloud_settings.should == {}
     end
   end
 

--- a/spec/requests/superadmin/users_spec.rb
+++ b/spec/requests/superadmin/users_spec.rb
@@ -616,10 +616,29 @@ feature "Superadmin's users API" do
       redis_gcloud_settings[:gcs_bucket].should == expected_gcloud_settings[:gcs_bucket]
       redis_gcloud_settings[:bq_dataset].should == expected_gcloud_settings[:bq_dataset]
 
-      # Now an update without gcloud settings
+      # An update with nil gcloud settings
       payload = {
         user: {
           gcloud_settings: nil
+        }
+      }
+      put superadmin_user_url(user.id), payload.to_json, superadmin_headers
+      redis_gcloud_settings = $users_metadata.hgetall("do_settings:#{user.username}:#{user.api_key}")
+      redis_gcloud_settings.should == {}
+
+      # An update with empty gcloud settings
+      payload = {
+        user: {
+          gcloud_settings: {}
+        }
+      }
+      put superadmin_user_url(user.id), payload.to_json, superadmin_headers
+      redis_gcloud_settings = $users_metadata.hgetall("do_settings:#{user.username}:#{user.api_key}")
+      redis_gcloud_settings.should == {}
+
+      # An update without gcloud settings (so that it can safely be deployed without central changes)
+      payload = {
+        user: {
         }
       }
       put superadmin_user_url(user.id), payload.to_json, superadmin_headers

--- a/spec/requests/superadmin/users_spec.rb
+++ b/spec/requests/superadmin/users_spec.rb
@@ -598,6 +598,7 @@ feature "Superadmin's users API" do
             bq_public_project: 'my_public_project',
             gcp_execution_project: 'my_gcp_execution_project',
             bq_project: 'my_bq_project',
+            gcs_bucket: 'my_gcs_bucket',
             bq_dataset: 'my_bq_dataset'
           }
         }


### PR DESCRIPTION
Pretty much the design we talked about: `central -> rui -> redis <- do`.

It doesn't break much of the existing code (see limits for instance)

The plan is to make Central synchronize updates by adding `gcloud_account` to `ATTRIBUTES_FOR_CLOUD` so that it can enjoy the facilities there (with a little bit of massaging? otherwise I'll make an explicit call with the attributes we're interested in).

FTM I excluded the `instant_licensing` flag synchronization, which would complicate matters unnecessarily at this point.