### PR TITLE
BigQuery connector UI improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ Development
 - Improve management of gcloud DO settings through API keys ([#15453](https://github.com/CartoDB/cartodb/pull/15453))
 - Add private map count to /me ([#15464](https://github.com/CartoDB/cartodb/pull/15464))
 - Fix CSV delimiter detection ([#15423](https://github.com/CartoDB/cartodb/issues/15423))
+- BigQuery Connector UI enhancements ([#15393](https://github.com/CartoDB/cartodb/issues/15393))
 
 4.34.0 (2020-01-28)
 -------------------

--- a/assets/stylesheets/common/create/listing/import_panel.scss
+++ b/assets/stylesheets/common/create/listing/import_panel.scss
@@ -44,9 +44,8 @@ $w: 780px;
 
 .ImportPanel-headerButton {
   position: absolute;
-  top: 50%;
+  top: 28px;
   left: 0;
-  margin-top: -20px;
 }
 .ImportPanel-headerLink { margin-top: 30px; }
 

--- a/assets/stylesheets/common/create/listing/import_selected_dataset.scss
+++ b/assets/stylesheets/common/create/listing/import_selected_dataset.scss
@@ -9,7 +9,7 @@ $br: 4px;
 .DatasetSelected {
   width: $w;
   margin: 0 0 0 -20px;
-  border: 1px solid #BBD7F2;
+  border: 1px solid #1785FB;
   border-radius: $br;
   background: #FFF;
 }
@@ -25,10 +25,10 @@ $br: 4px;
   width: 38px;
   min-width: 38px;
   height: 38px;
-  border: 1px solid #199BDB;
+  border: 1px solid #1785FB;
   border-radius: 4px;
-  color: #419CDB;
-  font-size: $sFontSize-smallUpperCase;
+  color: #1785FB;
+  font-size: $sFontSize-large;
   line-height: 38px;
   text-align: center;
   text-transform: uppercase;

--- a/assets/stylesheets/common/create/listing/imports_options.scss
+++ b/assets/stylesheets/common/create/listing/imports_options.scss
@@ -138,7 +138,7 @@ $w: $sLayout-width;
   }
 
   &__feedback {
-    padding-top: 75px;
+    padding-top: 60px;
     text-align: center;
   }
 }

--- a/assets/stylesheets/common/create/listing/imports_options.scss
+++ b/assets/stylesheets/common/create/listing/imports_options.scss
@@ -66,11 +66,12 @@ $w: $sLayout-width;
   &__input {
     &--long {
       box-sizing: border-box !important;
-      width: 460px;
+      width: 540px;
     }
   }
 
   &__label {
+    max-width: 100px;
     padding-top: 12px;
   }
 
@@ -92,23 +93,23 @@ $w: $sLayout-width;
 
   &__input-error {
     margin-top: -4px;
-    padding: 0 12px;
+    padding: 10px 12px;
     border: 1px solid $cHighlight-negative;
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
     background: #FFF4F4;
     color: $cHighlight-negative;
-    font-size: $sFontSize-normal;
-    line-height: 38px;
+    font-size: 12px;
+    line-height: 16px;
   }
 
   &__CodeMirror {
     position: relative;
-    width: 460px;
+    width: 540px;
 
     .CodeMirror {
       position: relative;
-      height: 114px;
+      height: 150px;
       margin-top: 0;
       margin-bottom: 0;
       padding: 10px 0;
@@ -133,7 +134,7 @@ $w: $sLayout-width;
   }
 
   &__hint {
-    width: 460px;
+    width: 540px;
   }
 
   &__feedback {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-arcgis/import-arcgis-header.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-arcgis/import-arcgis-header.tpl
@@ -13,7 +13,8 @@
   <% } %>
 </p>
 <% if (state === "selected") { %>
-  <button class="NavButton NavButton--back ImportPanel-headerButton js-back">
-    <i class="CDB-IconFont CDB-IconFont-arrowPrev"></i>
+  <button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+    <i class="CDB-IconFont is-semibold CDB-IconFont-arrowPrev u-mr--4"></i>
+    <span><%= _t('components.modals.add-layer.imports.header-import.go-back') %></span>
   </button>
 <% } %>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project-model.js
@@ -1,0 +1,26 @@
+const Backbone = require('backbone');
+const checkAndBuildOpts = require('builder/helpers/required-opts');
+
+const REQUIRED_OPTS = [
+  'configModel'
+];
+
+module.exports = Backbone.Model.extend({
+  defaults: {
+    projects: []
+  },
+
+  url: function () {
+    var version = this._configModel.urlVersion('connectors');
+    var baseUrl = this._configModel.get('base_url');
+    return baseUrl + '/api/' + version + '/connectors/bigquery/projects';
+  },
+
+  parse: function (response, options) {
+    this.set('projects', response);
+  },
+
+  initialize: function (attrs, opts) {
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+  }
+});

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project-model.js
@@ -11,8 +11,8 @@ module.exports = Backbone.Model.extend({
   },
 
   url: function () {
-    var version = this._configModel.urlVersion('connectors');
-    var baseUrl = this._configModel.get('base_url');
+    const version = this._configModel.urlVersion('connectors');
+    const baseUrl = this._configModel.get('base_url');
     return baseUrl + '/api/' + version + '/connectors/bigquery/projects';
   },
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project-view.js
@@ -1,0 +1,54 @@
+const CoreView = require('backbone/core-view');
+const BillingProjectModel = require('./billing-project-model');
+const template = require('./billing-project.tpl');
+const checkAndBuildOpts = require('builder/helpers/required-opts');
+
+const REQUIRED_OPTS = [
+  'configModel'
+];
+
+module.exports = CoreView.extend({
+
+  initialize: function (opts) {
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+
+    this._initModels();
+  },
+
+  render: function () {
+    this.$el.html(
+      template({
+        options: this.model.get('projects')
+      })
+    );
+
+    this._initSelect();
+    return this;
+  },
+
+  _initModels: function () {
+    const self = this;
+    this.model = new BillingProjectModel({}, {
+      configModel: this._configModel
+    });
+
+    this.model.bind('change:loaded', this.render, this);
+    this.model.fetch({
+      complete: function () {
+        self.model.set('loaded', true);
+      }
+    });
+  },
+
+  _initSelect: function () {
+    const self = this;
+    const billingProjectSelect = this.$el.find('select')[0];
+
+    this.localStorageName = 'carto.bigQuery.billingProject';
+
+    billingProjectSelect.value = localStorage.getItem(this.localStorageName);
+    billingProjectSelect.onchange = function () {
+      localStorage.setItem(self.localStorageName, this.value);
+    };
+  }
+});

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project-view.js
@@ -9,6 +9,8 @@ const REQUIRED_OPTS = [
 
 module.exports = CoreView.extend({
 
+  _LOCAL_STORAGE_KEY: 'carto.bigQuery.billingProject',
+
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
 
@@ -44,11 +46,9 @@ module.exports = CoreView.extend({
     const self = this;
     const billingProjectSelect = this.$el.find('select')[0];
 
-    this.localStorageName = 'carto.bigQuery.billingProject';
-
-    billingProjectSelect.value = localStorage.getItem(this.localStorageName);
+    billingProjectSelect.value = localStorage.getItem(this._LOCAL_STORAGE_KEY);
     billingProjectSelect.onchange = function () {
-      localStorage.setItem(self.localStorageName, this.value);
+      localStorage.setItem(self._LOCAL_STORAGE_KEY, this.value);
     };
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project.tpl
@@ -1,0 +1,6 @@
+<select name="billing-project" class="ImportOptions__input--long Form-inputField Form-inputField--withLabel CDB-Text CDB-Size-medium">
+  <option value=""></option>
+  <% options.forEach(function (option) { %>
+    <option value="<%- option.id %>"><%- option.friendly_name %></option>
+  <% }); %>
+</select>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/billing-project.tpl
@@ -1,4 +1,4 @@
-<select name="billing-project" class="ImportOptions__input--long Form-inputField Form-inputField--withLabel CDB-Text CDB-Size-medium">
+<select class="ImportOptions__input--long Form-inputField Form-inputField--withLabel CDB-Text CDB-Size-medium js-select">
   <option value=""></option>
   <% options.forEach(function (option) { %>
     <option value="<%- option.id %>"><%- option.friendly_name %></option>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -1,7 +1,15 @@
-var $ = require('jquery');
-var _ = require('underscore');
-var ImportDataView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-form-view');
-var CodeMirror = require('codemirror');
+const $ = require('jquery');
+const _ = require('underscore');
+const ImportDataFormView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-form-view');
+const BillingProjectView = require('./billing-project-view');
+const CodeMirror = require('codemirror');
+const checkAndBuildOpts = require('builder/helpers/required-opts');
+const template = require('./import-bigquery-form.tpl');
+
+const REQUIRED_OPTS = [
+  'userModel',
+  'configModel'
+];
 
 /**
  *  Form view for BigQuery
@@ -9,7 +17,7 @@ var CodeMirror = require('codemirror');
  *
  */
 
-module.exports = ImportDataView.extend({
+module.exports = ImportDataFormView.extend({
 
   connector: {
     'provider': 'bigquery',
@@ -23,6 +31,14 @@ module.exports = ImportDataView.extend({
     'submit .js-form': '_onSubmitForm'
   },
 
+  initialize: function (opts) {
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+    this.template = template;
+
+    this._initBinds();
+    this._checkVisibility();
+  },
+
   render: function () {
     this.$el.html(
       this.template({
@@ -30,12 +46,22 @@ module.exports = ImportDataView.extend({
         errorMessage: this.model.get('errorMessage')
       })
     );
+    this._initViews();
     this._initCodeMirror();
 
     if (this.formFields) {
       this.$el.find('.js-textInput')[0].value = this.formFields.billingProject;
       this.codeEditor.setValue(this.formFields.sqlQuery);
     }
+  },
+
+  _initViews: function () {
+    const billingProjectView = new BillingProjectView({
+      el: this.$('.ImportOptions__select'),
+      configModel: this._configModel
+    });
+    billingProjectView.render();
+    this.addView(billingProjectView);
   },
 
   _initCodeMirror: function () {
@@ -58,8 +84,8 @@ module.exports = ImportDataView.extend({
   },
 
   _onTextChanged: function () {
-    var billingProject = this.$('.js-textInput').val();
-    var query = this.codeEditor.getValue();
+    const billingProject = this.$('.js-textInput').val();
+    const query = this.codeEditor.getValue();
     if (billingProject && query) {
       $('.js-submit').removeClass('is-disabled');
     } else {
@@ -70,7 +96,7 @@ module.exports = ImportDataView.extend({
   _onSubmitForm: function (e) {
     if (e) this.killEvent(e);
 
-    var query = this.codeEditor.getValue();
+    const query = this.codeEditor.getValue();
     if (!query) {
       return;
     }
@@ -84,7 +110,7 @@ module.exports = ImportDataView.extend({
     this.trigger('urlSelected', this);
 
     // Change model
-    var importType = this.model.get('service_name') ? 'service' : 'url';
+    const importType = this.model.get('service_name') ? 'service' : 'url';
     this.model.setUpload({
       type: importType,
       value: query,
@@ -99,7 +125,7 @@ module.exports = ImportDataView.extend({
   },
 
   _checkVisibility: function () {
-    var state = this.model.get('state');
+    const state = this.model.get('state');
     if (state === 'list') {
       this.show();
     } else {
@@ -111,9 +137,9 @@ module.exports = ImportDataView.extend({
   _prepareData: function (state) {
     if (state === 'selected') {
       try {
-        var sql = this.model.get('service_item_id');
-        var catalog = this._extractCatalog(sql);
-        var tableName = this._extractTableName(sql);
+        let sql = this.model.get('service_item_id');
+        const catalog = this._extractCatalog(sql);
+        const tableName = this._extractTableName(sql);
         sql = this._prepareSql(sql);
 
         this.connector.project = catalog;
@@ -139,13 +165,13 @@ module.exports = ImportDataView.extend({
   },
 
   _extractCatalog: function (sql) {
-    var parts = this._preprocessSql(sql).split(' from ');
+    const parts = this._preprocessSql(sql).split(' from ');
     return parts[1].split('.')[0];
   },
 
   _extractTableName: function (sql) {
-    var parts = this._preprocessSql(sql).split(' from ');
-    var table = parts[1].split(' ')[0];
+    const parts = this._preprocessSql(sql).split(' from ');
+    const table = parts[1].split(' ')[0];
     return table.split('.').join('_');
   },
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -1,5 +1,6 @@
 const $ = require('jquery');
 const _ = require('underscore');
+const CartoNode = require('carto-node');
 const ImportDataFormView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-form-view');
 const BillingProjectView = require('./billing-project-view');
 const CodeMirror = require('codemirror');
@@ -27,7 +28,6 @@ module.exports = ImportDataFormView.extend({
   },
 
   events: {
-    'keyup .js-textInput': '_onTextChanged',
     'submit .js-form': '_onSubmitForm'
   },
 
@@ -50,7 +50,7 @@ module.exports = ImportDataFormView.extend({
     this._initCodeMirror();
 
     if (this.formFields) {
-      this.$el.find('.js-textInput')[0].value = this.formFields.billingProject;
+      this.$el.find('.js-select')[0].value = this.formFields.billingProject;
       this.codeEditor.setValue(this.formFields.sqlQuery);
     }
   },
@@ -84,7 +84,7 @@ module.exports = ImportDataFormView.extend({
   },
 
   _onTextChanged: function () {
-    const billingProject = this.$('.js-textInput').val();
+    const billingProject = this.$('.js-select').val();
     const query = this.codeEditor.getValue();
     if (billingProject && query) {
       $('.js-submit').removeClass('is-disabled');
@@ -102,7 +102,7 @@ module.exports = ImportDataFormView.extend({
     }
 
     this.formFields = {
-      billingProject: this.$('.js-textInput').val(),
+      billingProject: this.$('.js-select').val(),
       sqlQuery: query
     };
 
@@ -118,10 +118,28 @@ module.exports = ImportDataFormView.extend({
       state: 'idle'
     });
 
-    if (this.model.get('state') !== 'error') {
-      this.model.set('state', 'selected');
-      this.trigger('urlSubmitted', this);
-    }
+    const client = new CartoNode.AuthenticatedClient();
+    const params = {
+      billing_project: this.formFields.billingProject,
+      sql_query: this.formFields.sqlQuery
+    };
+
+    client.dryRun(params, (errors, _response, data) => {
+      if (errors) {
+        this.model.set('errorMessage', _t('components.modals.add-layer.imports.database.sql-error'));
+        this.model.set('state', 'list');
+        this.model.setUpload({
+          value: '',
+          service_item_id: ''
+        });
+        this.render();
+      } else if (data && data.total_bytes_processed) {
+        if (this.model.get('state') !== 'error') {
+          this.model.set('state', 'selected');
+          this.trigger('urlSubmitted', this);
+        }
+      }
+    });
   },
 
   _checkVisibility: function () {
@@ -145,7 +163,7 @@ module.exports = ImportDataFormView.extend({
         this.connector.project = catalog;
         this.connector.import_as = tableName;
         this.connector.sql_query = sql;
-        this.connector.billing_project = this.$('.js-textInput').val();
+        this.connector.billing_project = this.$('.js-select').val();
 
         this.model.set('service_item_id', JSON.stringify(this.connector));
       } catch (e) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -44,7 +44,7 @@ module.exports = ImportDataFormView.extend({
     this.$el.html(
       this.template({
         state: this.model.get('state'),
-        errorMessage: this.model.get('errorMessage')
+        errorMessages: this.model.get('errorMessages')
       })
     );
     this._initViews();
@@ -118,15 +118,15 @@ module.exports = ImportDataFormView.extend({
       importAs: this.$('.js-textInput').val()
     };
 
-    const client = new CartoNode.AuthenticatedClient();
+    const dbConnectorsClient = new CartoNode.AuthenticatedClient().dbConnectors();
     const params = {
       billing_project: this.formFields.billingProject,
       sql_query: this.formFields.sqlQuery.replace(/\n/g, ' ')
     };
 
-    client.dryRun(params, (errors, _response, data) => {
+    dbConnectorsClient.dryRun(params, (errors, _response, data) => {
       if (errors) {
-        this._handleErrors();
+        this._handleErrors(data);
       } else if (data && data.total_bytes_processed) {
         this._prepareUploadModel(query);
         this._updateUploadModel();
@@ -168,13 +168,26 @@ module.exports = ImportDataFormView.extend({
     }
   },
 
-  _handleErrors: function () {
-    this.model.set('errorMessage', _t('components.modals.add-layer.imports.database.sql-error'));
+  _handleErrors: function (data) {
+    let errorMessages = [];
+    if (data.responseJSON && data.responseJSON.errors) {
+      errorMessages.push(_t('components.modals.add-layer.imports.database.sql-error'));
+      errorMessages.push(this._getPrintableError(data.responseJSON.errors));
+    } else {
+      errorMessages.push(_t('components.modals.add-layer.imports.database.general-error'));
+    }
+    this.model.set('errorMessages', errorMessages);
     this.model.set('state', 'list');
     this.model.setUpload({
       value: '',
       service_item_id: ''
     });
     this.render();
+  },
+
+  _getPrintableError: function (error) {
+    const partialError = error.replace('Error connecting to provider bigquery: ', '');
+    const colonIndex = partialError.indexOf(':');
+    return partialError.substring(colonIndex + 2, partialError.length);
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -6,6 +6,7 @@ const BillingProjectView = require('./billing-project-view');
 const CodeMirror = require('codemirror');
 const checkAndBuildOpts = require('builder/helpers/required-opts');
 const template = require('./import-bigquery-form.tpl');
+const commonForm = require('builder/components/modals/add-layer/content/imports/import-database/import-database-common');
 
 const REQUIRED_OPTS = [
   'userModel',
@@ -28,6 +29,7 @@ module.exports = ImportDataFormView.extend({
   },
 
   events: {
+    'keyup .js-textInput': '_onTextChanged',
     'submit .js-form': '_onSubmitForm'
   },
 
@@ -52,6 +54,7 @@ module.exports = ImportDataFormView.extend({
     if (this.formFields) {
       this.$el.find('.js-select')[0].value = this.formFields.billingProject;
       this.codeEditor.setValue(this.formFields.sqlQuery);
+      this.$el.find('.js-textInput')[0].value = this.formFields.importAs;
     }
   },
 
@@ -93,13 +96,13 @@ module.exports = ImportDataFormView.extend({
   },
 
   _onTextChanged: function () {
-    const billingProject = this.$('.js-select').val();
-    const query = this.codeEditor.getValue();
-    if (billingProject && query) {
-      $('.js-submit').removeClass('is-disabled');
-    } else {
-      $('.js-submit').addClass('is-disabled');
-    }
+    (this._isFormFilled() ? commonForm.enableButton(this.$('.js-submit')) : commonForm.disableButton(this.$('.js-submit')));
+  },
+
+  _isFormFilled: function () {
+    return this.$('.js-select').val() !== '' &&
+           this.codeEditor.getValue() !== '' &&
+           this.$('.js-textInput').val() !== '';
   },
 
   _onSubmitForm: function (e) {
@@ -112,13 +115,14 @@ module.exports = ImportDataFormView.extend({
 
     this.formFields = {
       billingProject: this.$('.js-select').val(),
-      sqlQuery: query
+      sqlQuery: query,
+      importAs: this.$('.js-textInput').val()
     };
 
     const client = new CartoNode.AuthenticatedClient();
     const params = {
       billing_project: this.formFields.billingProject,
-      sql_query: this.formFields.sqlQuery
+      sql_query: this.formFields.sqlQuery.replace(/\n/g, ' ')
     };
 
     client.dryRun(params, (errors, _response, data) => {
@@ -126,23 +130,17 @@ module.exports = ImportDataFormView.extend({
         this._handleErrors();
       } else if (data && data.total_bytes_processed) {
         this._prepareUploadModel(query);
-        this._saveFormData();
+        this._updateUploadModel();
         this._goSelectDataset();
       }
     });
   },
 
-  _saveFormData: function () {
+  _updateUploadModel: function () {
     try {
-      let sql = this.model.get('service_item_id');
-      const catalog = this._extractCatalog(sql);
-      const tableName = this._extractTableName(sql);
-      sql = this._prepareSql(sql);
-
-      this.connector.project = catalog;
-      this.connector.import_as = tableName;
-      this.connector.sql_query = sql;
-      this.connector.billing_project = this.$('.js-select').val();
+      this.connector.billing_project = this.formFields.billingProject;
+      this.connector.import_as = this.formFields.importAs;
+      this.connector.sql_query = this.formFields.sqlQuery.replace(/\n/g, ' ');
 
       this.model.set('service_item_id', JSON.stringify(this.connector));
     } catch (e) {
@@ -179,24 +177,5 @@ module.exports = ImportDataFormView.extend({
       service_item_id: ''
     });
     this.render();
-  },
-
-  _preprocessSql: function (sql) {
-    return sql.toLowerCase().split('`').join('');
-  },
-
-  _extractCatalog: function (sql) {
-    const parts = this._preprocessSql(sql).split(' from ');
-    return parts[1].split('.')[0];
-  },
-
-  _extractTableName: function (sql) {
-    const parts = this._preprocessSql(sql).split(' from ');
-    const table = parts[1].split(' ')[0];
-    return table.split('.').join('_');
-  },
-
-  _prepareSql: function (sql) {
-    return sql;
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -83,6 +83,7 @@ module.exports = ImportDataFormView.extend({
 
   _initBinds: function () {
     this.model.bind('change:state', this._checkVisibility, this);
+    this.model.bind('change:errorMessages', this.render, this);
   },
 
   _checkVisibility: function () {
@@ -176,13 +177,12 @@ module.exports = ImportDataFormView.extend({
     } else {
       errorMessages.push(_t('components.modals.add-layer.imports.database.general-error'));
     }
-    this.model.set('errorMessages', errorMessages);
     this.model.set('state', 'list');
     this.model.setUpload({
       value: '',
       service_item_id: ''
     });
-    this.render();
+    this.model.set('errorMessages', errorMessages);
   },
 
   _getPrintableError: function (error) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -83,6 +83,15 @@ module.exports = ImportDataFormView.extend({
     this.model.bind('change:state', this._checkVisibility, this);
   },
 
+  _checkVisibility: function () {
+    const state = this.model.get('state');
+    if (state === 'list') {
+      this.show();
+    } else {
+      this.hide();
+    }
+  },
+
   _onTextChanged: function () {
     const billingProject = this.$('.js-select').val();
     const query = this.codeEditor.getValue();
@@ -106,6 +115,42 @@ module.exports = ImportDataFormView.extend({
       sqlQuery: query
     };
 
+    const client = new CartoNode.AuthenticatedClient();
+    const params = {
+      billing_project: this.formFields.billingProject,
+      sql_query: this.formFields.sqlQuery
+    };
+
+    client.dryRun(params, (errors, _response, data) => {
+      if (errors) {
+        this._handleErrors();
+      } else if (data && data.total_bytes_processed) {
+        this._prepareUploadModel(query);
+        this._saveFormData();
+        this._goSelectDataset();
+      }
+    });
+  },
+
+  _saveFormData: function () {
+    try {
+      let sql = this.model.get('service_item_id');
+      const catalog = this._extractCatalog(sql);
+      const tableName = this._extractTableName(sql);
+      sql = this._prepareSql(sql);
+
+      this.connector.project = catalog;
+      this.connector.import_as = tableName;
+      this.connector.sql_query = sql;
+      this.connector.billing_project = this.$('.js-select').val();
+
+      this.model.set('service_item_id', JSON.stringify(this.connector));
+    } catch (e) {
+      this._handleErrors();
+    }
+  },
+
+  _prepareUploadModel: function (query) {
     // Change file attributes :S
     this.trigger('urlSelected', this);
 
@@ -117,65 +162,23 @@ module.exports = ImportDataFormView.extend({
       service_item_id: query,
       state: 'idle'
     });
+  },
 
-    const client = new CartoNode.AuthenticatedClient();
-    const params = {
-      billing_project: this.formFields.billingProject,
-      sql_query: this.formFields.sqlQuery
-    };
+  _goSelectDataset: function () {
+    if (this.model.get('state') !== 'error') {
+      this.model.set('state', 'selected');
+      this.trigger('urlSubmitted', this);
+    }
+  },
 
-    client.dryRun(params, (errors, _response, data) => {
-      if (errors) {
-        this.model.set('errorMessage', _t('components.modals.add-layer.imports.database.sql-error'));
-        this.model.set('state', 'list');
-        this.model.setUpload({
-          value: '',
-          service_item_id: ''
-        });
-        this.render();
-      } else if (data && data.total_bytes_processed) {
-        if (this.model.get('state') !== 'error') {
-          this.model.set('state', 'selected');
-          this.trigger('urlSubmitted', this);
-        }
-      }
+  _handleErrors: function () {
+    this.model.set('errorMessage', _t('components.modals.add-layer.imports.database.sql-error'));
+    this.model.set('state', 'list');
+    this.model.setUpload({
+      value: '',
+      service_item_id: ''
     });
-  },
-
-  _checkVisibility: function () {
-    const state = this.model.get('state');
-    if (state === 'list') {
-      this.show();
-    } else {
-      this.hide();
-    }
-    this._prepareData(state);
-  },
-
-  _prepareData: function (state) {
-    if (state === 'selected') {
-      try {
-        let sql = this.model.get('service_item_id');
-        const catalog = this._extractCatalog(sql);
-        const tableName = this._extractTableName(sql);
-        sql = this._prepareSql(sql);
-
-        this.connector.project = catalog;
-        this.connector.import_as = tableName;
-        this.connector.sql_query = sql;
-        this.connector.billing_project = this.$('.js-select').val();
-
-        this.model.set('service_item_id', JSON.stringify(this.connector));
-      } catch (e) {
-        this.model.set('errorMessage', _t('components.modals.add-layer.imports.database.sql-error'));
-        this.model.set('state', 'list');
-        this.model.setUpload({
-          value: '',
-          service_item_id: ''
-        });
-        this.render();
-      }
-    }
+    this.render();
   },
 
   _preprocessSql: function (sql) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -1,4 +1,3 @@
-const $ = require('jquery');
 const _ = require('underscore');
 const CartoNode = require('carto-node');
 const ImportDataFormView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-form-view');

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
@@ -3,8 +3,8 @@
     <div class="Form-rowLabel ImportOptions__label">
       <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor"><%- _t('components.modals.add-layer.imports.bigquery.field-billing-project') %></label>
     </div>
-    <div class="">
-      <input type="text" class="ImportOptions__input--long Form-input CDB-Text CDB-Size-medium js-textInput">
+    <div>
+      <div class="ImportOptions__select"></div>
       <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-altTextColor u-mt--8"><%= _t('components.modals.add-layer.imports.bigquery.billing-project-hint') %></div>
     </div>
   </div>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
@@ -24,6 +24,15 @@
       <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-altTextColor u-mt--8"><%- _t('components.modals.add-layer.imports.database.sql-hint') %></div>
     </div>
   </div>
+  <div class="Form-row u-flex__align--start">
+    <div class="Form-rowLabel ImportOptions__label">
+      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor"><%- _t('components.modals.add-layer.imports.bigquery.import-as-field') %></label>
+    </div>
+    <div>
+      <input type="text" class="ImportOptions__input--long Form-input CDB-Text CDB-Size-medium js-textInput" value="" />
+      <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-altTextColor u-mt--8"><%= _t('components.modals.add-layer.imports.bigquery.import-as-hint') %></div>
+    </div>
+  </div>
   <div class="Form-row">
     <div class="Form-rowLabel ImportOptions__label"></div>
     <div class="Form-row ImportOptions__input--long u-flex__justify--end">

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
@@ -28,11 +28,11 @@
   </div>
   <div class="Form-row u-flex__align--start">
     <div class="Form-rowLabel ImportOptions__label">
-      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor"><%- _t('components.modals.add-layer.imports.bigquery.import-as-field') %></label>
+      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor"><%- _t('components.modals.add-layer.imports.database.import-as-field') %></label>
     </div>
     <div>
       <input type="text" class="ImportOptions__input--long Form-input CDB-Text CDB-Size-medium js-textInput" value="" />
-      <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-altTextColor u-mt--8"><%= _t('components.modals.add-layer.imports.bigquery.import-as-hint') %></div>
+      <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-altTextColor u-mt--8"><%= _t('components.modals.add-layer.imports.database.import-as-hint') %></div>
     </div>
   </div>
   <div class="Form-row">

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
@@ -15,9 +15,11 @@
     <div>
       <div class="ImportOptions__CodeMirror">
         <textarea rows="4" cols="50" class="ImportOptions__input--long Form-input Form-textarea CDB-Text CDB-Size-medium js-textarea"></textarea>
-        <% if (errorMessage) { %>
+        <% if (errorMessages) { %>
           <div class="ImportOptions__input-error CDB-Text">
-            <%- errorMessage %>
+            <% errorMessages.forEach(function (errorMessage) { %>
+              <p><%- errorMessage %></p>
+            <% }); %>
           </div>
         <% } %>
       </div>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-header-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-header-view.js
@@ -1,0 +1,17 @@
+const ImportDataHeaderView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-header-view');
+
+/**
+ *  BigQuery header view
+ *
+ */
+
+module.exports = ImportDataHeaderView.extend({
+  events: {
+    'click .js-back': '_goToPreviusStep'
+  },
+
+  _goToPreviusStep: function () {
+    this.model.set('state', 'list');
+    this.model.set('service_name', 'connector');
+  }
+});

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-header-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-header-view.js
@@ -7,10 +7,10 @@ const ImportDataHeaderView = require('builder/components/modals/add-layer/conten
 
 module.exports = ImportDataHeaderView.extend({
   events: {
-    'click .js-back': '_goToPreviusStep'
+    'click .js-back': '_goToPreviousStep'
   },
 
-  _goToPreviusStep: function () {
+  _goToPreviousStep: function () {
     this.model.set('state', 'list');
     this.model.set('service_name', 'connector');
   }

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-header.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-header.tpl
@@ -9,7 +9,8 @@
   <% } %>
 </p>
 <% if (state === "selected") { %>
-  <button class="NavButton NavButton--back ImportPanel-headerButton js-back">
-    <i class="CDB-IconFont CDB-IconFont-arrowPrev"></i>
+  <button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+    <i class="CDB-IconFont is-semibold CDB-IconFont-arrowPrev u-mr--4"></i>
+    <span><%= _t('components.modals.add-layer.imports.header-import.go-back') %></span>
   </button>
 <% } %>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-selected-dataset-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-selected-dataset-view.js
@@ -1,6 +1,5 @@
-var Utils = require('builder/helpers/utils');
-var SelectedDatasetView = require('builder/components/modals/add-layer/content/imports/import-selected-dataset-view');
-var template = require('builder/components/modals/add-layer/content/imports/import-selected-dataset.tpl');
+const SelectedDatasetView = require('builder/components/modals/add-layer/content/imports/import-selected-dataset-view');
+const template = require('builder/components/modals/add-layer/content/imports/import-selected-dataset.tpl');
 
 /**
  *  Selected BigQuery dataset
@@ -9,17 +8,13 @@ var template = require('builder/components/modals/add-layer/content/imports/impo
 
 module.exports = SelectedDatasetView.extend({
   render: function () {
-    var title = this.options.fileAttrs.title && this.model.get('value')[this.options.fileAttrs.title] || this.model.get('value');
-    var description = this._genDescription();
-    var ext = this.options.fileAttrs.ext ? Utils.getFileExtension(title) : 'sql';
+    const title = this.model.get('value');
+    const description = this._genDescription();
+    const ext = 'sql';
 
-    if (this.options.fileAttrs.ext) {
-      title = title && title.replace('.' + ext, '');
-    }
-
-    var upgradeUrl = window.upgrade_url;
-    var userCanSync = this._userModel.isActionEnabled('sync_tables');
-    var customInstall = this._configModel.get('cartodb_com_hosted');
+    const upgradeUrl = window.upgrade_url;
+    const userCanSync = this._userModel.isActionEnabled('sync_tables');
+    const customInstall = this._configModel.get('cartodb_com_hosted');
 
     this.$el.html(
       template({

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-selected-dataset-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-selected-dataset-view.js
@@ -11,8 +11,7 @@ module.exports = SelectedDatasetView.extend({
     const title = this.model.get('value');
     const description = this._genDescription();
     const ext = 'sql';
-
-    const upgradeUrl = window.upgrade_url;
+    const upgradeUrl = this._configModel.get('upgrade_url');
     const userCanSync = this._userModel.isActionEnabled('sync_tables');
     const customInstall = this._configModel.get('cartodb_com_hosted');
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-selected-dataset-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-selected-dataset-view.js
@@ -11,7 +11,7 @@ module.exports = SelectedDatasetView.extend({
   render: function () {
     var title = this.options.fileAttrs.title && this.model.get('value')[this.options.fileAttrs.title] || this.model.get('value');
     var description = this._genDescription();
-    var ext = this.options.fileAttrs.ext ? Utils.getFileExtension(title) : '';
+    var ext = this.options.fileAttrs.ext ? Utils.getFileExtension(title) : 'sql';
 
     if (this.options.fileAttrs.ext) {
       title = title && title.replace('.' + ext, '');

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
@@ -1,7 +1,6 @@
 var HeaderView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-header-view');
 var ImportDataView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-view');
 var headerTemplate = require('./import-bigquery-header.tpl');
-var formTemplate = require('./import-bigquery-form.tpl');
 var template = require('./import-bigquery.tpl');
 var UploadModel = require('builder/data/upload-model');
 
@@ -126,8 +125,8 @@ module.exports = ImportDataView.extend({
     var formView = new FormView({
       el: this.$('.ImportPanel-form'),
       userModel: this._userModel,
+      configModel: this._configModel,
       model: this.model,
-      template: formTemplate,
       fileEnabled: this.options.fileEnabled
     });
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
@@ -1,4 +1,4 @@
-var HeaderView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-header-view');
+var HeaderView = require('./import-bigquery-header-view');
 var ImportDataView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-view');
 var headerTemplate = require('./import-bigquery-header.tpl');
 var template = require('./import-bigquery.tpl');

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
@@ -1,14 +1,14 @@
-var HeaderView = require('./import-bigquery-header-view');
-var ImportDataView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-view');
-var headerTemplate = require('./import-bigquery-header.tpl');
-var template = require('./import-bigquery.tpl');
-var UploadModel = require('builder/data/upload-model');
+const HeaderView = require('./import-bigquery-header-view');
+const ImportDataView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-view');
+const headerTemplate = require('./import-bigquery-header.tpl');
+const template = require('./import-bigquery.tpl');
+const UploadModel = require('builder/data/upload-model');
 
-var FormView = require('./import-bigquery-form-view');
-var SelectedDataset = require('./import-bigquery-selected-dataset-view');
-var ServiceTokenModel = require('../import-service/import-service-token-model');
-var ServiceOauthModel = require('../import-service/import-service-oauth-model');
-var ServiceLoaderView = require('../import-service/import-service-loader-view');
+const FormView = require('./import-bigquery-form-view');
+const SelectedDataset = require('./import-bigquery-selected-dataset-view');
+const ServiceTokenModel = require('../import-service/import-service-token-model');
+const ServiceOauthModel = require('../import-service/import-service-oauth-model');
+const ServiceLoaderView = require('../import-service/import-service-loader-view');
 
 /**
  *  Import BigQuery panel
@@ -87,7 +87,7 @@ module.exports = ImportDataView.extend({
 
   _initViews: function () {
     // Data header
-    var headerView = new HeaderView({
+    const headerView = new HeaderView({
       el: this.$('.ImportPanel-header'),
       model: this.model,
       userModel: this._userModel,
@@ -100,7 +100,7 @@ module.exports = ImportDataView.extend({
     this.addView(headerView);
 
     // Loader
-    var loader = new ServiceLoaderView({
+    const loader = new ServiceLoaderView({
       el: this.$('.ServiceLoader'),
       model: this.model,
       serviceTokenModel: this._serviceTokenModel,
@@ -110,7 +110,7 @@ module.exports = ImportDataView.extend({
     this.addView(loader);
 
     // Dataset selected
-    var selected = new SelectedDataset({
+    const selected = new SelectedDataset({
       el: this.$('.DatasetSelected'),
       userModel: this._userModel,
       model: this.model,
@@ -122,7 +122,7 @@ module.exports = ImportDataView.extend({
     this.addView(selected);
 
     // Data Form
-    var formView = new FormView({
+    const formView = new FormView({
       el: this.$('.ImportPanel-form'),
       userModel: this._userModel,
       configModel: this._configModel,
@@ -145,9 +145,9 @@ module.exports = ImportDataView.extend({
   },
 
   _checkConnection: function () {
-    var version = this._configModel.urlVersion('connectors');
-    var baseUrl = this._configModel.get('base_url');
-    var self = this;
+    const version = this._configModel.urlVersion('connectors');
+    const baseUrl = this._configModel.get('base_url');
+    const self = this;
 
     fetch(baseUrl + '/api/' + version + '/connectors/bigquery/connect/')
       .then(function (response) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-data/import-data-header.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-data/import-data-header.tpl
@@ -25,7 +25,8 @@
   <% } %>
 </p>
 <% if (state === "selected") { %>
-  <button class="NavButton NavButton--back ImportPanel-headerButton js-back">
-    <i class="CDB-IconFont CDB-IconFont-arrowPrev"></i>
+  <button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+    <i class="CDB-IconFont is-semibold CDB-IconFont-arrowPrev u-mr--4"></i>
+    <span><%= _t('components.modals.add-layer.imports.header-import.go-back') %></span>
   </button>
 <% } %>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-connect-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-connect-form-view.js
@@ -105,8 +105,8 @@ module.exports = CoreView.extend({
   _checkConnection: function (params) {
     this._resetErrorMessage();
 
-    const client = new CartoNode.AuthenticatedClient();
-    client.checkDBConnectorsConnection(this._service, params, (errors, _response, data) => {
+    const dbConnectorsClient = new CartoNode.AuthenticatedClient().dbConnectors();
+    dbConnectorsClient.checkConnection(this._service, params, (errors, _response, data) => {
       if (errors) {
         this._checkConnectionError(data);
       } else if (data && data.connected) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-header-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-header-view.js
@@ -8,7 +8,7 @@ const ImportDataHeaderView = require('builder/components/modals/add-layer/conten
 module.exports = ImportDataHeaderView.extend({
 
   events: {
-    'click .js-back': '_goToPreviusStep'
+    'click .js-back': '_goToPreviousStep'
   },
 
   render: function () {
@@ -36,7 +36,7 @@ module.exports = ImportDataHeaderView.extend({
     }
   },
 
-  _goToPreviusStep: function () {
+  _goToPreviousStep: function () {
     this.model.set('state', 'connected');
     this.model.set('service_name', 'connector');
   }

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-header-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-header-view.js
@@ -7,6 +7,10 @@ const ImportDataHeaderView = require('builder/components/modals/add-layer/conten
 
 module.exports = ImportDataHeaderView.extend({
 
+  events: {
+    'click .js-back': '_goToPreviusStep'
+  },
+
   render: function () {
     var acceptSync = this.options.acceptSync && this._userModel.get('actions') && this._userModel.isActionEnabled('sync_tables') && this.model.get('type') !== 'file';
 
@@ -30,5 +34,10 @@ module.exports = ImportDataHeaderView.extend({
     } else {
       this.hide();
     }
+  },
+
+  _goToPreviusStep: function () {
+    this.model.set('state', 'connected');
+    this.model.set('service_name', 'connector');
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-header.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-header.tpl
@@ -5,3 +5,9 @@
     <%- _t('components.modals.add-layer.imports.header-import.sync-options') %>
   <% } %>
 </p>
+<% if (state === "selected") { %>
+  <button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+    <i class="CDB-IconFont is-semibold CDB-IconFont-arrowPrev u-mr--4"></i>
+    <span><%= _t('components.modals.add-layer.imports.header-import.go-back') %></span>
+  </button>
+<% } %>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -1,12 +1,13 @@
 const _ = require('underscore');
-const ImportDataView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-form-view');
+const ImportDataFormView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-form-view');
 const template = require('./import-database-query-form.tpl');
 const CodeMirror = require('codemirror');
 const common = require('./import-database-common');
 
-module.exports = ImportDataView.extend({
+module.exports = ImportDataFormView.extend({
 
   events: {
+    'keyup .js-textInput': '_onTextChanged',
     'submit .js-form': '_onSubmitForm'
   },
 
@@ -21,8 +22,9 @@ module.exports = ImportDataView.extend({
 
     this._initCodeMirror();
 
-    if (this.sqlQuery) {
-      this.codeEditor.setValue(this.sqlQuery);
+    if (this.formFields) {
+      this.codeEditor.setValue(this.formFields.sqlQuery);
+      this.$el.find('.js-textInput')[0].value = this.formFields.importAs;
     }
     return this;
   },
@@ -47,21 +49,44 @@ module.exports = ImportDataView.extend({
     this.model.bind('change:errorMessage', this.render, this);
   },
 
+  _checkVisibility: function () {
+    const state = this.model.get('state');
+    if (state === 'connected') {
+      this.show();
+    } else {
+      this.hide();
+    }
+  },
+
   _onTextChanged: function () {
-    const query = this.codeEditor.getValue();
-    (query ? common.enableButton(this.$('.js-submit')) : common.disableButton(this.$('.js-submit')));
+    (this._isFormFilled() ? common.enableButton(this.$('.js-submit')) : common.disableButton(this.$('.js-submit')));
+  },
+
+  _isFormFilled: function () {
+    return this.codeEditor.getValue() !== '' &&
+           this.$('.js-textInput').val() !== '';
   },
 
   _onSubmitForm: function (e) {
     if (e) this.killEvent(e);
 
-    const query = this.codeEditor.getValue().replace(/\n/g, ' ');
+    const query = this.codeEditor.getValue();
     if (!query) {
       return;
     }
 
-    this.sqlQuery = query;
+    this.formFields = {
+      sqlQuery: query,
+      importAs: this.$('.js-textInput').val()
+    };
 
+    this._prepareUploadModel(query);
+    this._updateUploadModel();
+    this._goSelectDataset();
+  },
+
+  _prepareUploadModel: function (query) {
+    // Change file attributes :S
     this.trigger('urlSelected', this);
 
     // Change model
@@ -72,48 +97,32 @@ module.exports = ImportDataView.extend({
       service_item_id: query,
       state: 'idle'
     });
+  },
 
+  _updateUploadModel: function () {
+    try {
+      const connector = {
+        provider: this.options.service,
+        connection: this.model.connection,
+        sql_query: this.formFields.sqlQuery.replace(/\n/g, ' '),
+        import_as: this.formFields.importAs
+      };
+
+      this.model.set('service_item_id', JSON.stringify(connector));
+    } catch (e) {
+      this.model.set('state', 'connected');
+      this.model.setUpload({
+        value: '',
+        service_item_id: ''
+      });
+      this.model.set('errorMessage', _t('components.modals.add-layer.imports.database.sql-error'));
+    }
+  },
+
+  _goSelectDataset: function () {
     if (this.model.get('state') !== 'error') {
       this.model.set('state', 'selected');
       this.trigger('urlSubmitted', this);
     }
-  },
-
-  _checkVisibility: function () {
-    const state = this.model.get('state');
-    if (state === 'connected') {
-      this.show();
-    } else {
-      this.hide();
-    }
-    this._prepareData(state);
-  },
-
-  _prepareData: function (state) {
-    if (state === 'selected') {
-      try {
-        const connector = {
-          provider: this.options.service,
-          connection: this.model.connection,
-          sql_query: this.model.get('service_item_id'),
-          import_as: this._extractTableName(this.model.get('service_item_id'))
-        };
-
-        this.model.set('service_item_id', JSON.stringify(connector));
-      } catch (e) {
-        this.model.set('state', 'connected');
-        this.model.setUpload({
-          value: '',
-          service_item_id: ''
-        });
-        this.model.set('errorMessage', _t('components.modals.add-layer.imports.database.sql-error'));
-      }
-    }
-  },
-
-  _extractTableName: function (sql) {
-    const parts = sql.split(' from ');
-    const table = parts[1].split(' ')[0];
-    return table.split('.').join('_');
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form.tpl
@@ -15,6 +15,15 @@
       <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-altTextColor u-mt--8"><%- _t('components.modals.add-layer.imports.database.sql-hint') %></div>
     </div>
   </div>
+  <div class="Form-row u-flex__align--start">
+    <div class="Form-rowLabel ImportOptions__label">
+      <label class="Form-label CDB-Text CDB-Size-medium u-mainTextColor"><%- _t('components.modals.add-layer.imports.database.import-as-field') %></label>
+    </div>
+    <div>
+      <input type="text" class="ImportOptions__input--long Form-input CDB-Text CDB-Size-medium js-textInput" value="" />
+      <div class="ImportOptions__hint CDB-Text CDB-Size-medium u-altTextColor u-mt--8"><%= _t('components.modals.add-layer.imports.database.import-as-hint') %></div>
+    </div>
+  </div>
   <div class="Form-row">
     <div class="Form-rowLabel ImportOptions__label"></div>
     <div class="Form-row ImportOptions__input--long u-flex__justify--end">

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-selected-dataset-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-selected-dataset-view.js
@@ -1,4 +1,3 @@
-const Utils = require('builder/helpers/utils');
 const SelectedDatasetView = require('builder/components/modals/add-layer/content/imports/import-selected-dataset-view');
 const template = require('builder/components/modals/add-layer/content/imports/import-selected-dataset.tpl');
 
@@ -9,13 +8,9 @@ const template = require('builder/components/modals/add-layer/content/imports/im
 
 module.exports = SelectedDatasetView.extend({
   render: function () {
-    let title = this.options.fileAttrs.title && this.model.get('value')[this.options.fileAttrs.title] || this.model.get('value');
+    const title = this.model.get('value');
     const description = this._genDescription();
-    const ext = this.options.fileAttrs.ext ? Utils.getFileExtension(title) : 'sql';
-
-    if (this.options.fileAttrs.ext) {
-      title = title && title.replace('.' + ext, '');
-    }
+    const ext = 'sql';
 
     const upgradeUrl = window.upgrade_url;
     const userCanSync = this._userModel.isActionEnabled('sync_tables');

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-selected-dataset-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-selected-dataset-view.js
@@ -11,8 +11,7 @@ module.exports = SelectedDatasetView.extend({
     const title = this.model.get('value');
     const description = this._genDescription();
     const ext = 'sql';
-
-    const upgradeUrl = window.upgrade_url;
+    const upgradeUrl = this._configModel.get('upgrade_url');
     const userCanSync = this._userModel.isActionEnabled('sync_tables');
     const customInstall = this._configModel.get('cartodb_com_hosted');
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-mailchimp/import-data-header-mailchimp.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-mailchimp/import-data-header-mailchimp.tpl
@@ -27,7 +27,7 @@
     <% } %>
   </p>
   <% if (state === "selected") { %>
-    <<button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+    <button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
       <i class="CDB-IconFont is-semibold CDB-IconFont-arrowPrev u-mr--4"></i>
       <span><%= _t('components.modals.add-layer.imports.header-import.go-back') %></span>
     </button>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-mailchimp/import-data-header-mailchimp.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-mailchimp/import-data-header-mailchimp.tpl
@@ -27,8 +27,9 @@
     <% } %>
   </p>
   <% if (state === "selected") { %>
-    <button class="NavButton NavButton--back ImportPanel-headerButton js-back">
-      <i class="CDB-IconFont CDB-IconFont-arrowPrev"></i>
+    <<button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+      <i class="CDB-IconFont is-semibold CDB-IconFont-arrowPrev u-mr--4"></i>
+      <span><%= _t('components.modals.add-layer.imports.header-import.go-back') %></span>
     </button>
   <% } %>
 <% } %>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-salesforce/import-data-header-salesforce.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-salesforce/import-data-header-salesforce.tpl
@@ -17,7 +17,8 @@
   <% } %>
 </p>
 <% if (state === "selected") { %>
-  <button class="NavButton NavButton--back ImportPanel-headerButton js-back">
-    <i class="CDB-IconFont CDB-IconFont-arrowPrev"></i>
+  <button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+    <i class="CDB-IconFont is-semibold CDB-IconFont-arrowPrev u-mr--4"></i>
+    <span><%= _t('components.modals.add-layer.imports.header-import.go-back') %></span>
   </button>
 <% } %>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-service/import-service-header.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-service/import-service-header.tpl
@@ -42,8 +42,9 @@
     <% } %>
   </p>
   <% if (state === "selected" && items > 1) { %>
-    <button class="CDB-Size-large ImportPanel-headerButton js-back">
-      <i class="CDB-IconFont CDB-IconFont-arrowPrev u-actionTextColor"></i>
+    <button class="ImportPanel-headerButton CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+      <i class="CDB-IconFont is-semibold CDB-IconFont-arrowPrev u-mr--4"></i>
+      <span><%= _t('components.modals.add-layer.imports.header-import.go-back') %></span>
     </button>
   <% } %>
 <% } %>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/selected-import/selected-import-header.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/selected-import/selected-import-header.tpl
@@ -1,6 +1,7 @@
 <div class="SelectedImport__header CDB-Text CDB-Size-large u-mainTextColor">
-  <button class="SelectedImport__back CDB-Size-large js-back">
-    <i class="CDB-IconFont CDB-IconFont-arrowPrev u-actionTextColor"></i>
+  <button class="SelectedImport__back CDB-Text is-semibold u-upperCase CDB-Size-medium u-actionTextColor js-back">
+    <i class="CDB-IconFont CDB-IconFont-arrowPrev is-semibold u-mr--4"></i>
+    <span><%= _t('components.modals.add-layer.imports.go-connectors') %></span>
   </button>
   <div class="u-flex">
     <img class="SelectedImport__icon" src="<%= __ASSETS_PATH__ %>/images/layout/connectors/<%= name %>.svg" alt="<%= _t('components.modals.add-layer.imports.header-alt', { brand: cdb.core.sanitize.html(title)}) %>">

--- a/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
+++ b/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
@@ -201,6 +201,16 @@ class AuthenticatedClient extends PublicClient {
 
     return this.get([URIParts, uriParams], callback);
   }
+
+  dryRun (data, callback) {
+    const URIParts = ['api/v1/connectors/bigquery/dryrun'];
+    const opts = {
+      data: JSON.stringify(data),
+      dataType: 'json'
+    };
+
+    return this.post(URIParts, opts, callback);
+  }
 }
 
 module.exports = AuthenticatedClient;

--- a/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
+++ b/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
@@ -195,21 +195,27 @@ class AuthenticatedClient extends PublicClient {
     return this.post(CONFIG_PATH, opts, callback);
   }
 
-  checkDBConnectorsConnection (service, params, callback) {
-    const URIParts = [`api/v1/connectors/${service}/connect`];
-    const uriParams = this.paramsToURI(params);
+  dbConnectors () {
+    const self = this;
 
-    return this.get([URIParts, uriParams], callback);
-  }
+    return {
+      checkConnection: function (service, params, callback) {
+        const URIParts = [`api/v1/connectors/${service}/connect`];
+        const uriParams = self.paramsToURI(params);
 
-  dryRun (data, callback) {
-    const URIParts = ['api/v1/connectors/bigquery/dryrun'];
-    const opts = {
-      data: JSON.stringify(data),
-      dataType: 'json'
+        return self.get([URIParts, uriParams], callback);
+      },
+
+      dryRun: function (data, callback) {
+        const URIParts = ['api/v1/connectors/bigquery/dryrun'];
+        const opts = {
+          data: JSON.stringify(data),
+          dataType: 'json'
+        };
+
+        return self.post(URIParts, opts, callback);
+      }
     };
-
-    return this.post(URIParts, opts, callback);
   }
 }
 

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1359,9 +1359,7 @@
                     "bigquery": {
                         "field-billing-project": "Billing Project ID",
                         "billing-project-hint": "Project ID for the Google Cloud project that will run the queries and be charged for the expenses. Example: my-project-identifier. More info <a href='https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_project' target='_blank'>here</a>.",
-                        "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM project.dataset.table",
-                        "import-as-field": "CARTO Dataset",
-                        "import-as-hint": "Name of the new Dataset that will be created in your CARTO Dashboard with the imported data."
+                        "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM project.dataset.table"
                     },
                     "database": {
                         "title": "Enter your %{brand} credentials",
@@ -1382,6 +1380,8 @@
                         "field-sql-query": "SQL query",
                         "sql-hint": "If your query contains geographic data in EPSG:4326 format, name that column with an accepted name so that it’s imported correctly: “the_geom”, “geom“, “geometry“...",
                         "sql-error": "There has been an error parsing your query",
+                        "import-as-field": "CARTO Dataset",
+                        "import-as-hint": "Name of the new Dataset that will be created in your CARTO Dashboard with the imported data.",
                         "run": "Run SQL query",
                         "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM table",
                         "sidebar-connect": {

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1235,6 +1235,7 @@
                 "imports": {
                     "header": "Connect with %{brand}",
                     "header-alt": "%{brand} connector logo",
+                    "go-connectors": "Connectors",
                     "ask-for-demo": "ask for demo",
                     "contact-us": "Contact us",
                     "loading": "Sending request",
@@ -1276,7 +1277,8 @@
                         "type-import": "%{brand} import",
                         "upload-file-url": "Upload a file or a URL |||| Upload a URL",
                         "import-data": "Import your data from a %{brand} instance",
-                        "sync-options": "Sync options only available for a layer"
+                        "sync-options": "Sync options only available for a layer",
+                        "go-back": "Back"
                     },
                     "service-import": {
                         "and": "and",

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1357,7 +1357,9 @@
                     "bigquery": {
                         "field-billing-project": "Billing Project ID",
                         "billing-project-hint": "Project ID for the Google Cloud project that will run the queries and be charged for the expenses. Example: my-project-identifier. More info <a href='https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_project' target='_blank'>here</a>.",
-                        "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM project.dataset.table"
+                        "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM project.dataset.table",
+                        "import-as-field": "CARTO Dataset name",
+                        "import-as-hint": "Name of the new Dataset in your CARTO Dashboard with the imported data."
                     },
                     "database": {
                         "title": "Enter your %{brand} credentials",

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1360,8 +1360,8 @@
                         "field-billing-project": "Billing Project ID",
                         "billing-project-hint": "Project ID for the Google Cloud project that will run the queries and be charged for the expenses. Example: my-project-identifier. More info <a href='https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_project' target='_blank'>here</a>.",
                         "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM project.dataset.table",
-                        "import-as-field": "CARTO Dataset name",
-                        "import-as-hint": "Name of the new Dataset in your CARTO Dashboard with the imported data."
+                        "import-as-field": "CARTO Dataset",
+                        "import-as-hint": "Name of the new Dataset that will be created in your CARTO Dashboard with the imported data."
                     },
                     "database": {
                         "title": "Enter your %{brand} credentials",

--- a/lib/assets/test/spec/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.spec.js
@@ -41,6 +41,7 @@ describe('components/modals/add-layer/content/imports/import-database/import-dat
   describe('_onTextChanged', function () {
     beforeEach(function () {
       this.view.codeEditor.setValue('select * from mytable');
+      this.view.$('.js-textInput')[0].value = 'dbtable';
       this.view._onTextChanged();
     });
 
@@ -62,6 +63,7 @@ describe('components/modals/add-layer/content/imports/import-database/import-dat
   describe('_onSubmitForm', function () {
     beforeEach(function () {
       this.view.codeEditor.setValue('select * from mytable');
+      this.view.$('.js-textInput')[0].value = 'dbtable';
     });
 
     it('should get the entered query in CodeMirror', function () {
@@ -99,7 +101,7 @@ describe('components/modals/add-layer/content/imports/import-database/import-dat
     });
   });
 
-  describe('_prepareData', function () {
+  describe('_updateUploadModel', function () {
     const connection = {
       server: 'localhost',
       port: '1234',
@@ -108,20 +110,27 @@ describe('components/modals/add-layer/content/imports/import-database/import-dat
       password: 'password'
     };
 
+    const formFields = {
+      sqlQuery: 'select * from mytable',
+      importAs: 'dbtable'
+    };
+
     beforeEach(function () {
+      this.view.formFields = formFields;
       this.view.model.connection = connection;
       this.view.model.set('service_item_id', 'select * from mytable');
     });
 
     it('should update model service_item_id with correct params', function () {
+      console.log(this.view.model.connection);
       const connector = {
         provider: 'postgres',
         connection: connection,
-        sql_query: 'select * from mytable',
-        import_as: 'mytable'
+        sql_query: formFields.sqlQuery,
+        import_as: formFields.importAs
       };
 
-      this.view._prepareData('selected');
+      this.view._updateUploadModel();
       expect(this.view.model.get('service_item_id')).toEqual(JSON.stringify(connector));
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.158",
+  "version": "1.0.0-assets.159",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.157-bq-1",
+  "version": "1.0.0-assets.157-bq-2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.157",
+  "version": "1.0.0-assets.157-bq-1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.158",
+  "version": "1.0.0-assets.159",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR includes:
- New `Billing Project` dropdown with client's projects instead of a plain text input. Using browser's local storage to save/load last selected option.
- Dry run: There is a new endpoint that detects permission errors (or other errors like invalid SQL syntax, non-existent tables or columns, etc.) by performing a dry run execution of the query. So when the user clicks `Run query` button, this dry run is executed and possible errors are rendered.
- There is a new `CARTO Dataset` field to set the `import_as` param instead of parsing the query and trying to get it from there. 
- Fix the `Back` button so it goes to previous screen in BQ, and add it to DB connectors. Also changed the styles of other existing back buttons to keep the design cohesive.
- `Connectors` button: Added a small label to clarify where that button redirects.
- Other CSS improvements, such as bigger SQL query editor and other styles.

### Related issue
https://github.com/CartoDB/cartodb/issues/15393