### PR TITLE
Fix remaining trial days calculation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Development
 - Better error reporting for BigQuery connector ([#15383](https://github.com/CartoDB/cartodb/issues/15383))
 - Fix DO subscriptions when estimated_delivery_days is NULL ([#15451](https://github.com/CartoDB/cartodb/pull/15451))
 - Improve management of gcloud DO settings through API keys ([#15453](https://github.com/CartoDB/cartodb/pull/15453))
+- Fix remaining trial days calculation ([#15470](https://github.com/CartoDB/cartodb/pull/15470))
 
 4.34.0 (2020-01-28)
 -------------------

--- a/app/controllers/carto/api/user_presenter.rb
+++ b/app/controllers/carto/api/user_presenter.rb
@@ -209,7 +209,7 @@ module Carto
           },
           trial_ends_at: @user.trial_ends_at,
           upgraded_at: @user.upgraded_at,
-          show_trial_reminder: @user.trial_ends_at.present?,
+          show_trial_reminder: @user.show_trial_reminder?,
           show_upgraded_message: (@user.account_type.downcase != 'free' && @user.upgraded_at && @user.upgraded_at + 15.days > Date.today ? true : false),
           actions: {
             private_tables: @user.private_tables_enabled,

--- a/app/models/carto/account_type.rb
+++ b/app/models/carto/account_type.rb
@@ -1,6 +1,15 @@
 module Carto
   class AccountType < ActiveRecord::Base
 
+    FREE = 'FREE'.freeze
+    PERSONAL30 = 'PERSONAL30'.freeze
+    INDIVIDUAL = 'Individual'.freeze
+
+    TRIAL_PLANS = [PERSONAL30, INDIVIDUAL].freeze
+    TRIAL_DAYS = { PERSONAL30 => 30, INDIVIDUAL => 14 }.freeze
+
+    FULLSTORY_SUPPORTED_PLANS = [FREE, PERSONAL30, INDIVIDUAL].freeze
+
     belongs_to :rate_limit, dependent: :destroy
 
     def soft_geocoding_limit?(user)

--- a/app/models/carto/account_type.rb
+++ b/app/models/carto/account_type.rb
@@ -5,8 +5,8 @@ module Carto
     PERSONAL30 = 'PERSONAL30'.freeze
     INDIVIDUAL = 'Individual'.freeze
 
-    TRIAL_PLANS = [PERSONAL30, INDIVIDUAL].freeze
-    TRIAL_DAYS = { PERSONAL30 => 30, INDIVIDUAL => 14 }.freeze
+    TRIAL_PLANS = [INDIVIDUAL].freeze
+    TRIAL_DAYS = { INDIVIDUAL => 14 }.freeze
 
     FULLSTORY_SUPPORTED_PLANS = [FREE, PERSONAL30, INDIVIDUAL].freeze
 

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -785,7 +785,8 @@ class Carto::User < ActiveRecord::Base
   end
 
   def remaining_trial_days
-    return 0 unless trial_ends_at
+    return 0 if trial_ends_at.nil? || trial_ends_at < Time.now
+
     ((trial_ends_at - Time.now) / 1.day).round
   end
 

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -33,12 +33,6 @@ class Carto::User < ActiveRecord::Base
   # conditions and the Privacy policy was included in the Signup page.
   # See https://github.com/CartoDB/cartodb-central/commit/3627da19f071c8fdd1604ddc03fb21ab8a6dff9f
   FULLSTORY_ENABLED_MIN_DATE = Date.new(2017, 1, 1)
-  FULLSTORY_SUPPORTED_PLANS = ['FREE', 'PERSONAL30', 'Individual'].freeze
-
-  MAGELLAN_TRIAL_DAYS = 15
-  PERSONAL30_TRIAL_DAYS = 30
-  INDIVIDUAL_TRIAL_DAYS = 14
-  TRIAL_PLANS = ['personal30', 'individual'].freeze
 
   # INFO: select filter is done for security and performance reasons. Add new columns if needed.
   DEFAULT_SELECT = "users.email, users.username, users.admin, users.organization_id, users.id, users.avatar_url," \
@@ -499,14 +493,22 @@ class Carto::User < ActiveRecord::Base
     !soft_mapzen_routing_limit?
   end
   alias_method :hard_mapzen_routing_limit, :hard_mapzen_routing_limit?
+
   def trial_ends_at
-    if account_type.to_s.casecmp('magellan').zero? && upgraded_at && upgraded_at + 15.days > Date.today
-      upgraded_at + MAGELLAN_TRIAL_DAYS.days
-    elsif account_type.to_s.casecmp('personal30').zero?
-      created_at + PERSONAL30_TRIAL_DAYS.days
-    elsif account_type.to_s.casecmp('individual').zero?
-      created_at + INDIVIDUAL_TRIAL_DAYS.days
-    end
+    return nil unless Carto::AccountType::TRIAL_PLANS.include?(account_type)
+
+    trial_days = Carto::AccountType::TRIAL_DAYS[account_type].days
+    created_at + trial_days
+  end
+
+  def remaining_trial_days
+    return 0 if trial_ends_at.nil? || trial_ends_at < Time.now
+
+    ((trial_ends_at - Time.now) / 1.day).ceil
+  end
+
+  def show_trial_reminder?
+    trial_ends_at && trial_ends_at > Time.now
   end
 
   def remaining_days_deletion
@@ -742,7 +744,7 @@ class Carto::User < ActiveRecord::Base
   end
 
   def fullstory_enabled?
-    FULLSTORY_SUPPORTED_PLANS.include?(account_type) && created_at > FULLSTORY_ENABLED_MIN_DATE
+    Carto::AccountType::FULLSTORY_SUPPORTED_PLANS.include?(account_type) && created_at > FULLSTORY_ENABLED_MIN_DATE
   end
 
   def password_expired?
@@ -782,16 +784,6 @@ class Carto::User < ActiveRecord::Base
     else
       MULTIFACTOR_AUTHENTICATION_DISABLED
     end
-  end
-
-  def remaining_trial_days
-    return 0 if trial_ends_at.nil? || trial_ends_at < Time.now
-
-    ((trial_ends_at - Time.now) / 1.day).round
-  end
-
-  def trial_user?
-    TRIAL_PLANS.include?(account_type.to_s.downcase)
   end
 
   def get_database_roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1948,7 +1948,8 @@ class User < Sequel::Model
   end
 
   def remaining_trial_days
-    return 0 unless trial_ends_at
+    return 0 if trial_ends_at.nil? || trial_ends_at < Time.now
+
     ((trial_ends_at - Time.now) / 1.day).round
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,7 +60,6 @@ class User < Sequel::Model
   # conditions and the Privacy policy was included in the Signup page.
   # See https://github.com/CartoDB/cartodb-central/commit/3627da19f071c8fdd1604ddc03fb21ab8a6dff9f
   FULLSTORY_ENABLED_MIN_DATE = Date.new(2017, 1, 1)
-  FULLSTORY_SUPPORTED_PLANS = ['FREE', 'PERSONAL30', 'Individual'].freeze
 
   self.strict_param_setting = false
 
@@ -116,11 +115,6 @@ class User < Sequel::Model
   OBS_SNAPSHOT_BLOCK_SIZE = 1000
   OBS_GENERAL_BLOCK_SIZE = 1000
   MAPZEN_ROUTING_BLOCK_SIZE = 1000
-
-  MAGELLAN_TRIAL_DAYS = 15
-  PERSONAL30_TRIAL_DAYS = 30
-  INDIVIDUAL_TRIAL_DAYS = 14
-  TRIAL_PLANS = ['personal30', 'individual'].freeze
 
   DEFAULT_GEOCODING_QUOTA = 0
   DEFAULT_HERE_ISOLINES_QUOTA = 0
@@ -909,13 +903,20 @@ class User < Sequel::Model
   end
 
   def trial_ends_at
-    if account_type.to_s.casecmp('magellan').zero? && upgraded_at && upgraded_at + MAGELLAN_TRIAL_DAYS.days > Date.today
-      upgraded_at + MAGELLAN_TRIAL_DAYS.days
-    elsif account_type.to_s.casecmp('personal30').zero?
-      created_at + PERSONAL30_TRIAL_DAYS.days
-    elsif account_type.to_s.casecmp('individual').zero?
-      created_at + INDIVIDUAL_TRIAL_DAYS.days
-    end
+    return nil unless Carto::AccountType::TRIAL_PLANS.include?(account_type)
+
+    trial_days = Carto::AccountType::TRIAL_DAYS[account_type].days
+    created_at + trial_days
+  end
+
+  def remaining_trial_days
+    return 0 if trial_ends_at.nil? || trial_ends_at < Time.now
+
+    ((trial_ends_at - Time.now) / 1.day).ceil
+  end
+
+  def show_trial_reminder?
+    trial_ends_at && trial_ends_at > Time.now
   end
 
   def remaining_days_deletion
@@ -1913,7 +1914,7 @@ class User < Sequel::Model
   end
 
   def fullstory_enabled?
-    FULLSTORY_SUPPORTED_PLANS.include?(account_type) && created_at > FULLSTORY_ENABLED_MIN_DATE
+    Carto::AccountType::FULLSTORY_SUPPORTED_PLANS.include?(account_type) && created_at > FULLSTORY_ENABLED_MIN_DATE
   end
 
   def password_expired?
@@ -1945,16 +1946,6 @@ class User < Sequel::Model
     else
       MULTIFACTOR_AUTHENTICATION_DISABLED
     end
-  end
-
-  def remaining_trial_days
-    return 0 if trial_ends_at.nil? || trial_ends_at < Time.now
-
-    ((trial_ends_at - Time.now) / 1.day).round
-  end
-
-  def trial_user?
-    TRIAL_PLANS.include?(account_type.to_s.downcase)
   end
 
   def get_database_roles

--- a/app/models/user/user_decorator.rb
+++ b/app/models/user/user_decorator.rb
@@ -120,7 +120,7 @@ module CartoDB
         layers: layers.map(&:public_values),
         trial_ends_at: trial_ends_at,
         upgraded_at: upgraded_at,
-        show_trial_reminder: trial_ends_at.present?,
+        show_trial_reminder: show_trial_reminder?,
         show_upgraded_message: (account_type.downcase != 'free' && upgraded_at && upgraded_at + 15.days > Date.today ? true : false),
         actions: {
           private_tables: private_tables_enabled,

--- a/app/views/admin/shared/_trial_notification.html.erb
+++ b/app/views/admin/shared/_trial_notification.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.trial_user? %>
+<% if current_user.show_trial_reminder? %>
   <div class="CDB-Text FlashMessage FlashMessage--main">
     <div class="u-inner">
       <div class="FlashMessage FlashMessage-info FlashMessage--main u-flex u-justifyCenter u-alignCenter">

--- a/lib/assets/javascripts/dashboard/views/account/account-main-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-main-view.js
@@ -8,8 +8,6 @@ const FlashMessageModel = require('dashboard/data/flash-message-model');
 const FlashMessageView = require('dashboard/components/flash-message/flash-message-view');
 var moment = require('moment');
 
-const TRIAL_ACCOUNTS = ['PERSONAL30', 'Individual'];
-
 const REQUIRED_OPTS = [
   'userModel',
   'configModel',
@@ -26,9 +24,8 @@ module.exports = CoreView.extend({
 
   _initViews: function () {
     const $app = this.$('#app');
-    const accountType = this._userModel.get('account_type');
 
-    if (TRIAL_ACCOUNTS.indexOf(accountType) > -1) {
+    if (this._userModel.get('show_trial_reminder') === true) {
       const trialEndsAt = moment(this._userModel.get('trial_ends_at'));
       const now = moment();
       const trialNotificationView = new TrialNotificationView({

--- a/lib/assets/javascripts/dashboard/views/account/account-main-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-main-view.js
@@ -31,7 +31,7 @@ module.exports = CoreView.extend({
       const trialNotificationView = new TrialNotificationView({
         userModel: this._userModel,
         upgradeUrl: this._configModel.get('upgrade_url'),
-        trialDays: Math.round(trialEndsAt.diff(now, 'days', true))
+        trialDays: Math.ceil(trialEndsAt.diff(now, 'days', true))
       });
       $app.append(trialNotificationView.render().el);
       this.addView(trialNotificationView);

--- a/lib/assets/javascripts/dashboard/views/profile/profile-main-view.js
+++ b/lib/assets/javascripts/dashboard/views/profile/profile-main-view.js
@@ -8,8 +8,6 @@ const FlashMessageView = require('dashboard/components/flash-message/flash-messa
 const checkAndBuildOpts = require('builder/helpers/required-opts');
 var moment = require('moment');
 
-const TRIAL_ACCOUNTS = ['PERSONAL30', 'Individual'];
-
 const REQUIRED_OPTS = [
   'userModel',
   'configModel',
@@ -27,9 +25,8 @@ module.exports = CoreView.extend({
 
   _initViews: function () {
     const $app = this.$('#app');
-    const accountType = this._userModel.get('account_type');
 
-    if (TRIAL_ACCOUNTS.indexOf(accountType) > -1) {
+    if (this._userModel.get('show_trial_reminder') === true) {
       const trialEndsAt = moment(this._userModel.get('trial_ends_at'));
       const now = moment();
       const trialNotificationView = new TrialNotificationView({

--- a/lib/assets/javascripts/dashboard/views/profile/profile-main-view.js
+++ b/lib/assets/javascripts/dashboard/views/profile/profile-main-view.js
@@ -32,7 +32,7 @@ module.exports = CoreView.extend({
       const trialNotificationView = new TrialNotificationView({
         userModel: this._userModel,
         upgradeUrl: this._configModel.get('upgrade_url'),
-        trialDays: Math.round(trialEndsAt.diff(now, 'days', true))
+        trialDays: Math.ceil(trialEndsAt.diff(now, 'days', true))
       });
       $app.append(trialNotificationView.render().el);
       this.addView(trialNotificationView);

--- a/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
+++ b/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
@@ -236,7 +236,7 @@
         "contactOrganizationAdmin": "Contact the admin",
         "manageOrganization": "Manage my organization"
       },
-      "trialMessage": "{date} left in your trial.&nbsp;",
+      "trialMessage": "{date} days left in your trial.&nbsp;",
       "notificationsButton": "Go to Notifications",
       "learnMoreButton": "Learn More",
       "actions": {

--- a/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
@@ -2,7 +2,7 @@
   <section class="welcome-section">
     <WelcomeFirst v-if="isFirst" :name="name" :userType="userType"></WelcomeFirst>
     <WelcomeCompact v-if="!isFirst" :name="name" :userType="userType">
-      <template v-if="trialEndDate">
+      <template v-if="showTrialReminder">
         <span v-html="trialTimeLeft" class="title is-small"></span>
         <a class="title is-small" :href="accountUpgradeURL" v-if="accountUpgradeURL">
           {{ $t('HomePage.WelcomeSection.subscribeNow') }}
@@ -32,6 +32,7 @@ export default {
       isFirst: state => state.config.isFirstTimeViewingDashboard,
       accountUpgradeURL: state => state.config.upgrade_url,
       trialEndDate: state => state.user.trial_ends_at,
+      showTrialReminder: state => state.user.show_trial_reminder,      
       user: state => state.user,
       name: state => state.user.name || state.user.username,
       organization: state => state.user.organization,

--- a/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
@@ -14,7 +14,7 @@
 
 <script>
 import { mapState } from 'vuex';
-import distanceInWordsStrict from 'date-fns/distance_in_words_strict';
+import moment from 'moment';
 import WelcomeCompact from './WelcomeCompact';
 import WelcomeFirst from './WelcomeFirst';
 import WelcomeBasic from './WelcomeBasic';
@@ -39,7 +39,10 @@ export default {
       notifications: state => state.user.organizationNotifications
     }),
     trialTimeLeft () {
-      return this.$t(`HomePage.WelcomeSection.trialMessage`, { date: distanceInWordsStrict(this.trialEndDate, new Date(), { partialMethod: 'round' }) });
+      const endDate = moment(this.trialEndDate);
+      const now = moment();
+      const days = Math.ceil(endDate.diff(now, 'days', true));
+      return this.$t(`HomePage.WelcomeSection.trialMessage`, { date: days });
     },
     userType () {
       if (this.isOrganizationAdmin()) {

--- a/lib/assets/test/spec/dashboard/views/account/account-main-view.spec.js
+++ b/lib/assets/test/spec/dashboard/views/account/account-main-view.spec.js
@@ -49,12 +49,13 @@ describe('dashboard/views/account/account-main-view', function () {
       expect(_.size(view._subviews)).toBe(4);
     });
 
-    it('should show the trial notification if the user\'s account is Individual', function () {
+    it('should show the trial notification if the user\'s show_trial_reminder: true', function () {
       userModel = new UserModel({
         username: 'pepe',
         base_url: 'http://pepe.carto.com',
         email: 'pepe@carto.com',
         account_type: 'Individual',
+        show_trial_reminder: true,
         id: 1,
         api_key: 'hello-apikey'
       });

--- a/lib/assets/test/spec/dashboard/views/profile/profile-main-view.spec.js
+++ b/lib/assets/test/spec/dashboard/views/profile/profile-main-view.spec.js
@@ -59,9 +59,10 @@ describe('dashboard/views/profile/profile-main-view', function () {
       expect(_.size(view._subviews)).toBe(4);
     });
 
-    it('should show the trial notification if the user\'s account is Individual', function () {
+    it('should show the trial notification if the user\'s show_trial_reminder is true', function () {
       view = createViewFn({
-        account_type: 'Individual'
+        account_type: 'Individual',
+        show_trial_reminder: true
       });
 
       expect(_.size(view._subviews)).toBe(5);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.157.1",
+  "version": "1.0.0-assets.157.2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.157",
+  "version": "1.0.0-assets.157.1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/spec/models/carto/user_spec.rb
+++ b/spec/models/carto/user_spec.rb
@@ -14,6 +14,10 @@ describe Carto::User do
     def create_user
       FactoryGirl.create(:carto_user)
     end
+
+    def build_user
+      FactoryGirl.build(:carto_user)
+    end
   end
 
   describe '#needs_password_confirmation?' do

--- a/spec/models/user_part_plans_and_services_spec.rb
+++ b/spec/models/user_part_plans_and_services_spec.rb
@@ -29,24 +29,6 @@ describe User do
     Delorean.back_to_the_present
   end
 
-  it "should calculate the trial end date" do
-    @user.stubs(:upgraded_at).returns(nil)
-    @user.trial_ends_at.should be_nil
-    @user.stubs(:upgraded_at).returns(Time.now - 5.days)
-    @user.stubs(:account_type).returns('CORONELLI')
-    @user.trial_ends_at.should be_nil
-    @user.stubs(:account_type).returns('MAGELLAN')
-    @user.trial_ends_at.should_not be_nil
-    @user.stubs(:upgraded_at).returns(nil)
-    @user.trial_ends_at.should be_nil
-    @user.stubs(:upgraded_at).returns(Time.now - (::User::MAGELLAN_TRIAL_DAYS - 1).days)
-    @user.trial_ends_at.should_not be_nil
-    @user.stubs(:account_type).returns('PERSONAL30')
-    @user.trial_ends_at.should_not be_nil
-    @user.stubs(:account_type).returns('Individual')
-    @user.trial_ends_at.should_not be_nil
-  end
-
   it "should update remaining quotas when adding or removing tables" do
     initial_quota = @user2.remaining_quota
 

--- a/spec/models/user_part_refactored_behaviour_spec.rb
+++ b/spec/models/user_part_refactored_behaviour_spec.rb
@@ -15,5 +15,9 @@ describe 'refactored behaviour' do
     def create_user
       FactoryGirl.create(:valid_user)
     end
+
+    def build_user
+      FactoryGirl.build(:valid_user)
+    end
   end
 end

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -1042,4 +1042,20 @@ shared_examples_for "user models" do
       result.should be_true
     end
   end
+
+  describe '#remaining_trial_days' do
+    before(:all) do
+      @user = create_user
+    end
+
+    after(:each) do
+      @user.unstub(:trial_ends_at)
+    end
+
+    it 'returns 0 if trial_ends_at is in the past' do
+      @user.stubs(trial_ends_at: Time.now - 2.days)
+
+      @user.remaining_trial_days.should eq 0
+    end
+  end
 end

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -1055,24 +1055,24 @@ shared_examples_for "user models" do
     end
 
     it 'returns 0 the trial has ended' do
-      @user.account_type = 'PERSONAL30'
+      @user.account_type = 'Individual'
       @user.created_at = Time.now - 2.months
 
       expect(@user.remaining_trial_days).to eq 0
     end
 
     it 'returns the remaining number of trial days of the plan' do
-      @user.account_type = 'PERSONAL30'
-      @user.created_at = Time.now - 10.days
+      @user.account_type = 'Individual'
+      @user.created_at = Time.now - 4.days
 
-      expect(@user.remaining_trial_days).to eq 20
+      expect(@user.remaining_trial_days).to eq 10
     end
 
     it 'rounds up the remaining days' do
-      @user.account_type = 'PERSONAL30'
+      @user.account_type = 'Individual'
       @user.created_at = Time.now - 28.hours
 
-      expect(@user.remaining_trial_days).to eq 29
+      expect(@user.remaining_trial_days).to eq 13
     end
   end
 
@@ -1088,14 +1088,14 @@ shared_examples_for "user models" do
     end
 
     it 'returns false if the account has an expired trial' do
-      @user.account_type = 'PERSONAL30'
+      @user.account_type = 'Individual'
       @user.created_at = Time.now - 2.months
 
       expect(@user.show_trial_reminder?).to be_false
     end
 
     it 'returns true if the account has an active trial' do
-      @user.account_type = 'PERSONAL30'
+      @user.account_type = 'Individual'
       @user.created_at = Time.now - 1.day
 
       expect(@user.show_trial_reminder?).to be_true

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -1043,6 +1043,26 @@ shared_examples_for "user models" do
     end
   end
 
+  describe '#trial_ends_at' do
+    before(:each) do
+      @user = build_user
+    end
+
+    it 'returns nil if the account does not have a trial' do
+      @user.account_type = 'CORONELLI'
+
+      expect(@user.trial_ends_at).to be_nil
+    end
+
+    it 'returns the expected date for trial accounts' do
+      @user.account_type = 'Individual'
+      @user.created_at = Time.parse('2020-02-01 10:00:00')
+      expected_date = Time.parse('2020-02-15 10:00:00')
+
+      expect(@user.trial_ends_at).to eql expected_date
+    end
+  end
+
   describe '#remaining_trial_days' do
     before(:each) do
       @user = build_user

--- a/spec/models/user_shared_examples.rb
+++ b/spec/models/user_shared_examples.rb
@@ -1044,18 +1044,61 @@ shared_examples_for "user models" do
   end
 
   describe '#remaining_trial_days' do
-    before(:all) do
-      @user = create_user
+    before(:each) do
+      @user = build_user
     end
 
-    after(:each) do
-      @user.unstub(:trial_ends_at)
+    it 'returns 0 if the plan has no trial' do
+      @user.account_type = 'FREE'
+
+      expect(@user.remaining_trial_days).to eq 0
     end
 
-    it 'returns 0 if trial_ends_at is in the past' do
-      @user.stubs(trial_ends_at: Time.now - 2.days)
+    it 'returns 0 the trial has ended' do
+      @user.account_type = 'PERSONAL30'
+      @user.created_at = Time.now - 2.months
 
-      @user.remaining_trial_days.should eq 0
+      expect(@user.remaining_trial_days).to eq 0
+    end
+
+    it 'returns the remaining number of trial days of the plan' do
+      @user.account_type = 'PERSONAL30'
+      @user.created_at = Time.now - 10.days
+
+      expect(@user.remaining_trial_days).to eq 20
+    end
+
+    it 'rounds up the remaining days' do
+      @user.account_type = 'PERSONAL30'
+      @user.created_at = Time.now - 28.hours
+
+      expect(@user.remaining_trial_days).to eq 29
+    end
+  end
+
+  describe '#show_trial_reminder?' do
+    before(:each) do
+      @user = build_user
+    end
+
+    it 'returns false if the account does not have a trial' do
+      @user.account_type = 'FREE'
+
+      expect(@user.show_trial_reminder?).to be_false
+    end
+
+    it 'returns false if the account has an expired trial' do
+      @user.account_type = 'PERSONAL30'
+      @user.created_at = Time.now - 2.months
+
+      expect(@user.show_trial_reminder?).to be_false
+    end
+
+    it 'returns true if the account has an active trial' do
+      @user.account_type = 'PERSONAL30'
+      @user.created_at = Time.now - 1.day
+
+      expect(@user.show_trial_reminder?).to be_true
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/1997

- Do not show the banner with the trial reminder the supposed end date is over
 (the account should be locked or paying in that case)
- Keep `remaining_trial_days` as 0 when the trial ends (it was showing negative numbers)
- Round up the remaining days as we do in Central in order to be consistent with the billing page
- Small refactor and removed old MAGELLAN/PERSONAL30 logic, as we don't have any active trials with those plans
