### PR TITLE
Fix show_trial_reminder?

### DIFF
--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -509,7 +509,9 @@ class Carto::User < ActiveRecord::Base
   end
 
   def show_trial_reminder?
-    trial_ends_at && trial_ends_at > Time.now
+    return false unless trial_ends_at
+
+    trial_ends_at > Time.now
   end
 
   def remaining_days_deletion

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -916,7 +916,9 @@ class User < Sequel::Model
   end
 
   def show_trial_reminder?
-    trial_ends_at && trial_ends_at > Time.now
+    return false unless trial_ends_at
+
+    trial_ends_at > Time.now
   end
 
   def remaining_days_deletion


### PR DESCRIPTION
[This PR](https://github.com/CartoDB/cartodb/pull/15470) caused the dashboard to show an error:

![Screenshot 2020-02-12 at 14 43 55](https://user-images.githubusercontent.com/14979109/74348977-de29fd80-4db3-11ea-8026-f49354e5e049.png)

The error raises here:
https://github.com/CartoDB/cartodb/blob/1465b27f62c8e88e67788eb8ab335665eaad5db7/lib/assets/javascripts/new-dashboard/core/trackers.js#L26

And the problem is that `show_trial_reminder?` was returning null sometimes. The fix consists in making the method to always return true or false.

To ensure it works, we have to enable track.js for Staging (in `app_config.yml`).