### PR TITLE
Remove FROM unpackaged

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Development
 - Improve management of gcloud DO settings through API keys ([#15453](https://github.com/CartoDB/cartodb/pull/15453) and [#15467](https://github.com/CartoDB/cartodb/pull/15467))
 - Add private map count to /me ([#15464](https://github.com/CartoDB/cartodb/pull/15464))
 - Fix CSV delimiter detection ([#15423](https://github.com/CartoDB/cartodb/issues/15423))
+- Remove "FROM unpackaged" from cartodb extension installation process ([#15493](https://github.com/CartoDB/cartodb/pull/15493))
 - BigQuery Connector UI enhancements ([#15393](https://github.com/CartoDB/cartodb/issues/15393))
 
 4.34.0 (2020-01-28)

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -682,7 +682,7 @@ module CartoDB
                 EXCEPTION WHEN undefined_function OR invalid_schema_name THEN
                   RAISE NOTICE 'Got % (%)', SQLERRM, SQLSTATE;
                   BEGIN
-                    CREATE EXTENSION cartodb VERSION '#{cdb_extension_target_version}' CASCADE FROM unpackaged;
+                    CREATE EXTENSION cartodb VERSION '#{cdb_extension_target_version}' CASCADE;
                   EXCEPTION WHEN undefined_table THEN
                     RAISE NOTICE 'Got % (%)', SQLERRM, SQLSTATE;
                     CREATE EXTENSION cartodb CASCADE VERSION '#{cdb_extension_target_version}';


### PR DESCRIPTION
This is hyper legacy. The purpose was to grab disparate objects out of
an extension within an extension. That predates even the
cartodb-postgresql extension and was a convenience for one or zero
developers.

The cartodb-postgresql extension make process generates "FROM
unpackage" upgrade paths just to the last version.

So removing that is simplifying our lives and getting rid of legacy.