### PR TITLE
Avoid that cis of different pg version cancel each other

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,6 @@
 # Compass configuration, used by cartodb UI grunt task.
 # Require any additional compass plugins here.
 
-
 # Set this to the root of your project when deployed:
 http_path = "/"
 css_dir = "dist/css"

--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,7 @@
 # Compass configuration, used by cartodb UI grunt task.
 # Require any additional compass plugins here.
 
+
 # Set this to the root of your project when deployed:
 http_path = "/"
 css_dir = "dist/css"

--- a/script/ci/cloudbuild-pg11.yaml
+++ b/script/ci/cloudbuild-pg11.yaml
@@ -5,7 +5,7 @@ steps:
   entrypoint: /bin/bash
   args:
   - '-c'
-  - 'gcloud builds list --ongoing --filter="substitutions.BRANCH_NAME=${BRANCH_NAME} AND substitutions.REPO_NAME=cartodb AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
+  - 'gcloud builds list --ongoing --filter="buildTriggerId=7c2750ed-7d87-4d94-9f60-de53b2e64c61 AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
 
 - name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash

--- a/script/ci/cloudbuild-pg12.yaml
+++ b/script/ci/cloudbuild-pg12.yaml
@@ -5,7 +5,7 @@ steps:
   entrypoint: /bin/bash
   args:
   - '-c'
-  - 'gcloud builds list --ongoing --filter="substitutions.BRANCH_NAME=${BRANCH_NAME} AND substitutions.REPO_NAME=cartodb AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
+  - 'gcloud builds list --ongoing --filter="buildTriggerId=51a5fed6-3b1c-4b53-aa4c-9855ccb3f510 AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
 
 - name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash


### PR DESCRIPTION
After enabling postgres 12 tests in parallel with postgres 11, the mechanism to cancel ci for the previous push started to cancel the job with the other postgres version