### PR TITLE
Hide DataCatalog to Free2020 users

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,15 +5,10 @@ Development
 - None yet
 
 ### Features
-- None yet
+- New Free 2020 Plan, Dashboard and Builder changes ([#15497](https://github.com/CartoDB/cartodb/pull/15497))
 
 ### Bug fixes / enhancements
-- New Free Plan (Dashboard): Update metrics section in homepage ([#15435](https://github.com/CartoDB/cartodb/issues/15435))
-- New Free Plan (Dashboard): Update welcome section ([#15434](https://github.com/CartoDB/cartodb/issues/15434))
-- New Free Plan (Dashboard): Update custom API keys section in settings ([#15440](https://github.com/CartoDB/cartodb/issues/15440))
-- New Free Plan (Dashboard): Update change privacy and duplicate options ([#15441](https://github.com/CartoDB/cartodb/issues/15441))
-- New Free Plan (Dashboard): Update limits counter and warnings in maps section ([#15436](https://github.com/CartoDB/cartodb/issues/15436))
-- New Free Plan (Dashboard): Update limits counter and warnings in datasets section ([#15439](https://github.com/CartoDB/cartodb/issues/15439))
+- Hide DataCatalog to Free 2020 users ([#15500](https://github.com/CartoDB/cartodb/pull/15500))
 
 4.35.0 (2020-02-21)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
@@ -117,7 +117,7 @@ import EmptyState from 'new-dashboard/components/States/EmptyState';
 import CreateButton from 'new-dashboard/components/CreateButton';
 import DatasetBulkActions from 'new-dashboard/components/BulkActions/DatasetBulkActions.vue';
 import { shiftClick } from 'new-dashboard/utils/shift-click.service.js';
-import * as Accounts from 'new-dashboard/core/constants/accounts';
+import * as accounts from 'new-dashboard/core/constants/accounts';
 
 export default {
   name: 'DatasetsList',
@@ -224,7 +224,7 @@ export default {
       return this.$router.currentRoute.name === 'home';
     },
     hasSecondaryNavbar () {
-      return !Accounts.accountsWithDataCatalogLimits.includes(this.planAccountType);
+      return !accounts.accountsWithDataCatalogLimits.includes(this.planAccountType);
     }
   },
   methods: {

--- a/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
+++ b/lib/assets/javascripts/new-dashboard/components/DatasetsList.vue
@@ -67,6 +67,7 @@
         :class="{
           'has-user-notification': isNotificationVisible,
           'in-home': isInHomePage,
+          'no-secondary-navbar': !hasSecondaryNavbar
         }">
 
       <DatasetListHeader :order="appliedOrder" :orderDirection="appliedOrderDirection" @changeOrder="applyOrder"></DatasetListHeader>
@@ -116,6 +117,7 @@ import EmptyState from 'new-dashboard/components/States/EmptyState';
 import CreateButton from 'new-dashboard/components/CreateButton';
 import DatasetBulkActions from 'new-dashboard/components/BulkActions/DatasetBulkActions.vue';
 import { shiftClick } from 'new-dashboard/utils/shift-click.service.js';
+import * as Accounts from 'new-dashboard/core/constants/accounts';
 
 export default {
   name: 'DatasetsList',
@@ -166,7 +168,8 @@ export default {
       totalUserEntries: state => state.datasets.metadata.total_user_entries,
       totalShared: state => state.datasets.metadata.total_shared,
       isFirstTimeViewingDashboard: state => state.config.isFirstTimeViewingDashboard,
-      upgradeUrl: state => state.config.upgrade_url
+      upgradeUrl: state => state.config.upgrade_url,
+      planAccountType: state => state.user.account_type
     }),
     ...mapGetters({
       datasetsCount: 'user/datasetsCount',
@@ -219,6 +222,9 @@ export default {
     },
     isInHomePage () {
       return this.$router.currentRoute.name === 'home';
+    },
+    hasSecondaryNavbar () {
+      return !Accounts.accountsWithDataCatalogLimits.includes(this.planAccountType);
     }
   },
   methods: {
@@ -289,14 +295,16 @@ export default {
 .grid__head--sticky {
   top: $header__height + $subheader__height;
 
-  &.in-home {
+  &.in-home,
+  &.no-secondary-navbar {
     top: $header__height;
   }
 
   &.has-user-notification {
     top: $header__height + $subheader__height + $notification-warning__height;
 
-    &.in-home {
+    &.in-home,
+    &.no-secondary-navbar {
       top: $header__height + $notification-warning__height;
     }
   }

--- a/lib/assets/javascripts/new-dashboard/core/constants/accounts.js
+++ b/lib/assets/javascripts/new-dashboard/core/constants/accounts.js
@@ -6,3 +6,5 @@ export const accountsWithPublicMapLimits = [...individual, ...free2020];
 export const accountsWithPrivateMapsLimits = free2020;
 export const accountsWithApiKeysLimits = [...individual, ...free2020];
 export const accountsWithApiKeysLimitsToZero = free2020;
+
+export const accountsWithDataCatalogLimits = free2020;

--- a/lib/assets/javascripts/new-dashboard/core/constants/accounts.js
+++ b/lib/assets/javascripts/new-dashboard/core/constants/accounts.js
@@ -1,5 +1,7 @@
 export const individual = ['Individual', 'Annual Individual'];
 export const free2020 = ['Free 2020'];
+export const free = ['FREE'];
+export const student = ['CARTO for the Classroom - Annual', 'CARTO for students - Annual'];
 
 export const accountsWithTableLimits = [...individual, ...free2020];
 export const accountsWithPublicMapLimits = [...individual, ...free2020];
@@ -7,4 +9,4 @@ export const accountsWithPrivateMapsLimits = free2020;
 export const accountsWithApiKeysLimits = [...individual, ...free2020];
 export const accountsWithApiKeysLimitsToZero = free2020;
 
-export const accountsWithDataCatalogLimits = free2020;
+export const accountsWithDataCatalogLimits = [...free2020, ...free, ...student];

--- a/lib/assets/javascripts/new-dashboard/pages/Data/Data.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Data/Data.vue
@@ -1,6 +1,6 @@
 <template>
   <Page class="page--data">
-    <SecondaryNavigation>
+    <SecondaryNavigation v-if="showDataCatalog">
       <div class="tabs">
         <router-link :to="{ name: 'datasets' }" class="tabs__item title is-small" exact active-class="is-active" :class="{'is-active': isDatasetPage }">
           <span>{{ $t('DataPage.tabs.yourDatasets') }}</span>
@@ -15,9 +15,11 @@
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import Page from 'new-dashboard/components/Page';
 import SecondaryNavigation from 'new-dashboard/components/SecondaryNavigation';
 import { isAllowed } from 'new-dashboard/core/configuration/filters';
+import * as Accounts from 'new-dashboard/core/constants/accounts';
 
 export default {
   name: 'DataPage',
@@ -26,8 +28,14 @@ export default {
     SecondaryNavigation
   },
   computed: {
+    ...mapState({
+      planAccountType: state => state.user.account_type
+    }),
     isDatasetPage () {
       return isAllowed(this.$route.params.filter);
+    },
+    showDataCatalog () {
+      return !Accounts.accountsWithDataCatalogLimits.includes(this.planAccountType);
     }
   }
 };

--- a/lib/assets/javascripts/new-dashboard/pages/Data/Data.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Data/Data.vue
@@ -19,7 +19,7 @@ import { mapState } from 'vuex';
 import Page from 'new-dashboard/components/Page';
 import SecondaryNavigation from 'new-dashboard/components/SecondaryNavigation';
 import { isAllowed } from 'new-dashboard/core/configuration/filters';
-import * as Accounts from 'new-dashboard/core/constants/accounts';
+import * as accounts from 'new-dashboard/core/constants/accounts';
 
 export default {
   name: 'DataPage',
@@ -35,7 +35,7 @@ export default {
       return isAllowed(this.$route.params.filter);
     },
     showDataCatalog () {
-      return !Accounts.accountsWithDataCatalogLimits.includes(this.planAccountType);
+      return !accounts.accountsWithDataCatalogLimits.includes(this.planAccountType);
     }
   }
 };

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/DatasetList.spec.js
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/DatasetList.spec.js
@@ -160,6 +160,9 @@ describe('DatasetsList.vue', () => {
           },
           config: {
             isFirstTimeViewingDashboard: false
+          },
+          user: {
+            account_type: 'account_type'
           }
         });
         const datasetsList = createDatasetsList(store);
@@ -186,6 +189,9 @@ describe('DatasetsList.vue', () => {
           },
           config: {
             isFirstTimeViewingDashboard: true
+          },
+          user: {
+            account_type: 'account_type'
           }
         });
         const datasetsList = createDatasetsList(store);
@@ -208,6 +214,9 @@ describe('DatasetsList.vue', () => {
           },
           config: {
             isFirstTimeViewingDashboard: false
+          },
+          user: {
+            account_type: 'account_type'
           }
         });
         const datasetsList = createDatasetsList(store);
@@ -230,6 +239,9 @@ describe('DatasetsList.vue', () => {
           },
           config: {
             isFirstTimeViewingDashboard: true
+          },
+          user: {
+            account_type: 'account_type'
           }
         });
         const datasetsList = createDatasetsList(store);
@@ -255,6 +267,9 @@ function createStore (customStoreData) {
     },
     config: {
       isFirstTimeViewingDashboard: false
+    },
+    user: {
+      account_type: 'account_type'
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.160-data-01",
+  "version": "1.0.0-assets.160-data-02",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.160-data-02",
+  "version": "1.0.0-assets.160",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.160",
+  "version": "1.0.0-assets.160-data-01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hide the secondary navbar appearing in Datasets page so now we don't offer the Data Catalog to Free 2020 users. There is also a CSS fix for the sticky header to appear properly.