### PR TITLE
Hide oauth apps to Free2020 users

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Hide DataCatalog to Free 2020 users ([#15500](https://github.com/CartoDB/cartodb/pull/15500))
+- Hide Create oAuth Apps section in Connected Apps page to Free 2020 users ([#15500](https://github.com/CartoDB/cartodb/pull/15500))
 
 4.35.0 (2020-02-21)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/core/constants/accounts.js
+++ b/lib/assets/javascripts/new-dashboard/core/constants/accounts.js
@@ -10,3 +10,4 @@ export const accountsWithApiKeysLimits = [...individual, ...free2020];
 export const accountsWithApiKeysLimitsToZero = free2020;
 
 export const accountsWithDataCatalogLimits = [...free2020, ...free, ...student];
+export const accountsWithOauthAppsLimits = [...free2020, ...free, ...student];

--- a/lib/assets/javascripts/new-dashboard/pages/Apps/ConnectedApps.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Apps/ConnectedApps.vue
@@ -59,7 +59,7 @@ import AppElement from '../../components/Apps/AppElement';
 import SettingsSidebar from 'new-dashboard/components/Apps/SettingsSidebar';
 import Modal from 'new-dashboard/components/Modal';
 import { mapState } from 'vuex';
-import * as Accounts from 'new-dashboard/core/constants/accounts';
+import * as accounts from 'new-dashboard/core/constants/accounts';
 
 export default {
   name: 'ConnectedApps',
@@ -90,7 +90,7 @@ export default {
       hasConnectedApps: state => !state.connectedApps.isFetching && !!Object.keys(state.connectedApps.list).length
     }),
     showOauthApps () {
-      return !Accounts.accountsWithOauthAppsLimits.includes(this.planAccountType);
+      return !accounts.accountsWithOauthAppsLimits.includes(this.planAccountType);
     }
   },
   methods: {

--- a/lib/assets/javascripts/new-dashboard/pages/Apps/ConnectedApps.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Apps/ConnectedApps.vue
@@ -10,7 +10,7 @@
         <p v-if="hasConnectedApps" class="text is-small">{{ $t(`ConnectedAppsPage.description`) }}</p>
         <p v-else class="text is-small u-mb--96">{{ $t(`ConnectedAppsPage.emptyDescription`) }}</p>
 
-        <div v-if="!hasConnectedApps" class="u-mt--16">
+        <div v-if="!hasConnectedApps && showOauthApps" class="u-mt--16">
           <div class="connectedapps__title">
             <h2 class="text is-caption">{{ $t(`ConnectedAppsPage.emptyTipTitle`) }}</h2>
           </div>
@@ -59,6 +59,7 @@ import AppElement from '../../components/Apps/AppElement';
 import SettingsSidebar from 'new-dashboard/components/Apps/SettingsSidebar';
 import Modal from 'new-dashboard/components/Modal';
 import { mapState } from 'vuex';
+import * as Accounts from 'new-dashboard/core/constants/accounts';
 
 export default {
   name: 'ConnectedApps',
@@ -84,9 +85,13 @@ export default {
       isFetchingConnectedApps: state => state.connectedApps.isFetching,
       user: state => state.user,
       baseUrl: state => state.user.base_url,
+      planAccountType: state => state.user.account_type,
       connectedApps: state => state.connectedApps.list,
       hasConnectedApps: state => !state.connectedApps.isFetching && !!Object.keys(state.connectedApps.list).length
-    })
+    }),
+    showOauthApps () {
+      return !Accounts.accountsWithOauthAppsLimits.includes(this.planAccountType);
+    }
   },
   methods: {
     openModal (selectedApp) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.160",
+  "version": "1.0.0-assets.160-oauth-01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hide `Are you looking to create an OAuth application?` section in `Connected Apps` page to FREE, Free 2020 and students users
