### PR TITLE
Update footer links based on account types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Development
 ### Bug fixes / enhancements
 - Hide DataCatalog to Free 2020 users ([#15500](https://github.com/CartoDB/cartodb/pull/15500))
 - Hide Create oAuth Apps section in Connected Apps page to Free 2020 users ([#15500](https://github.com/CartoDB/cartodb/pull/15500))
+- Update footer links based on account types ([#15502](https://github.com/CartoDB/cartodb/pull/15502))
 
 4.35.0 (2020-02-21)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/components/Footer.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Footer.vue
@@ -29,12 +29,6 @@
         </a>
         <a href="mailto:support@carto.com" class="footer-link" v-if="isIndividualUser">
           <h4 class="title-link title is-caption is-txtGrey">
-            {{ $t(`Footer.TechSupport.title`) }}<span class="chevron"><img svg-inline src="../assets/icons/common/chevron.svg"/></span>
-          </h4>
-          <p class="description-link text is-small is-txtSoftGrey">{{ $t(`Footer.TechSupport.description`) }}</p>
-        </a>
-        <a href="mailto:support@carto.com" class="footer-link" v-if="isIndividualUser">
-          <h4 class="title-link title is-caption is-txtGrey">
             {{ $t(`Footer.DedicatedSupport.title`) }}<span class="chevron"><img svg-inline src="../assets/icons/common/chevron.svg"/></span>
           </h4>
           <p class="description-link text is-small is-txtSoftGrey">{{ $t(`Footer.DedicatedSupport.description`) }}</p>
@@ -73,7 +67,7 @@ export default {
     },
 
     isIndividualUser () {
-      const noIndividualUsers = ['internal', 'partner', 'ambassador', 'free', 'free 2020', 'carto for students - anual'];
+      const noIndividualUsers = ['internal', 'partner', 'ambassador', 'free', 'free 2020', 'carto for students - annual', 'carto for the classroom - annual'];
       return !(noIndividualUsers.includes(this.userAccountType) || this.user.organization || this.isFreeUser);
     },
 

--- a/lib/assets/javascripts/new-dashboard/components/Footer.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Footer.vue
@@ -27,7 +27,7 @@
           </h4>
           <p class="description-link text is-small is-txtSoftGrey">{{ $t(`Footer.GISStackExchange.description`) }}</p>
         </a>
-        <a href="mailto:support@carto.com" class="footer-link" v-if="isFreeUser">
+        <a href="mailto:support@carto.com" class="footer-link" v-if="isIndividualUser">
           <h4 class="title-link title is-caption is-txtGrey">
             {{ $t(`Footer.TechSupport.title`) }}<span class="chevron"><img svg-inline src="../assets/icons/common/chevron.svg"/></span>
           </h4>
@@ -68,12 +68,12 @@ export default {
     },
 
     isFreeUser () {
-      const freeUser = ['free', 'free 2020', 'carto for students - anual'];
+      const freeUser = ['free'];
       return freeUser.includes(this.userAccountType);
     },
 
     isIndividualUser () {
-      const noIndividualUsers = ['internal', 'partner', 'ambassador', 'free'];
+      const noIndividualUsers = ['internal', 'partner', 'ambassador', 'free', 'free 2020', 'carto for students - anual'];
       return !(noIndividualUsers.includes(this.userAccountType) || this.user.organization || this.isFreeUser);
     },
 

--- a/lib/assets/javascripts/new-dashboard/components/Footer.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Footer.vue
@@ -51,6 +51,8 @@
 </template>
 
 <script>
+import * as accounts from 'new-dashboard/core/constants/accounts';
+
 export default {
   name: 'Footer',
   props: {
@@ -61,13 +63,24 @@ export default {
       return this.user.account_type.toLowerCase();
     },
 
+    free2020Lowecase () {
+      return accounts.free2020.map(item => item.toLowerCase());
+    },
+
+    freeLowecase () {
+      return accounts.free.map(item => item.toLowerCase());
+    },
+
+    studentLowecase () {
+      return accounts.student.map(item => item.toLowerCase());
+    },
+
     isFreeUser () {
-      const freeUser = ['free'];
-      return freeUser.includes(this.userAccountType);
+      return this.freeLowecase.includes(this.userAccountType);
     },
 
     isIndividualUser () {
-      const noIndividualUsers = ['internal', 'partner', 'ambassador', 'free', 'free 2020', 'carto for students - annual', 'carto for the classroom - annual'];
+      const noIndividualUsers = ['internal', 'partner', 'ambassador', ...this.freeLowecase, ...this.free2020Lowecase, ...this.studentLowecase];
       return !(noIndividualUsers.includes(this.userAccountType) || this.user.organization || this.isFreeUser);
     },
 

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/__snapshots__/Footer.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/__snapshots__/Footer.spec.js.snap
@@ -17,10 +17,6 @@ exports[`Footer.vue should render items for free users 1`] = `
         <h4 class="title-link title is-caption is-txtGrey">
           Footer.GISStackExchange.title<span class="chevron"><img svg-inline="" src="../assets/icons/common/chevron.svg"></span></h4>
         <p class="description-link text is-small is-txtSoftGrey">Footer.GISStackExchange.description</p>
-      </a> <a href="mailto:support@carto.com" class="footer-link">
-        <h4 class="title-link title is-caption is-txtGrey">
-          Footer.TechSupport.title<span class="chevron"><img svg-inline="" src="../assets/icons/common/chevron.svg"></span></h4>
-        <p class="description-link text is-small is-txtSoftGrey">Footer.TechSupport.description</p>
       </a>
       <!---->
       <!---->
@@ -44,7 +40,6 @@ exports[`Footer.vue should render items for organization users (no owner) 1`] = 
         <p class="description-link text is-small is-txtSoftGrey">Footer.DeveloperCenter.description</p>
       </a></div>
     <div class="footer-block">
-      <!---->
       <!---->
       <!----> <a href="mailto:enterprise-support@carto.com" class="footer-link">
         <h4 class="title-link title is-caption is-txtGrey">
@@ -74,7 +69,6 @@ exports[`Footer.vue should render items for organization users (owner) 1`] = `
       </a></div>
     <div class="footer-block">
       <!---->
-      <!---->
       <!----> <a href="mailto:enterprise-support@carto.com" class="footer-link">
         <h4 class="title-link title is-caption is-txtGrey">
           Footer.DedicatedSupport.title<span class="chevron"><img svg-inline="" src="../assets/icons/common/chevron.svg"></span></h4>
@@ -100,7 +94,6 @@ exports[`Footer.vue should render items for pro users 1`] = `
         <p class="description-link text is-small is-txtSoftGrey">Footer.DeveloperCenter.description</p>
       </a></div>
     <div class="footer-block">
-      <!---->
       <!----> <a href="mailto:support@carto.com" class="footer-link">
         <h4 class="title-link title is-caption is-txtGrey">
           Footer.DedicatedSupport.title<span class="chevron"><img svg-inline="" src="../assets/icons/common/chevron.svg"></span></h4>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.160-footer-02",
+  "version": "1.0.0-assets.160",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.160-footer-01",
+  "version": "1.0.0-assets.160-footer-02",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.160-oauth-01",
+  "version": "1.0.0-assets.160-footer-01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove Tech Support link from all account types and remove Dedicated Support from Students accounts. 