### PR TITLE
Disable public sharing options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Development
 ### Bug fixes / enhancements
 - Fix wording for feedback
 - Enable deleting Kepler.gl maps ([#15485](https://github.com/CartoDB/cartodb/issues/15485))
+- Public privacy options for maps & datasets can be disabled in UI with quotas ([#524](https://github.com/CartoDB/product/issues/524))
 
 4.36.0 (2020-03-09)
 -------------------
@@ -27,7 +28,6 @@ Development
 * Fix dataset creation without map quotas ([#15504](https://github.com/CartoDB/cartodb/pull/15504))
 * Fix imports when user quota cannot be calculated ([#15512](https://github.com/CartoDB/cartodb/pull/15512))
 * Update Connectors UI styling ([#15514](https://github.com/CartoDB/cartodb/pull/15514))
-* Public privacy options for maps & datasets can be disabled in UI with quotas ([#524](https://github.com/CartoDB/product/issues/524))
 
 4.35.0 (2020-02-21)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ Development
 * Fix dataset creation without map quotas ([#15504](https://github.com/CartoDB/cartodb/pull/15504))
 * Fix imports when user quota cannot be calculated ([#15512](https://github.com/CartoDB/cartodb/pull/15512))
 * Update Connectors UI styling ([#15514](https://github.com/CartoDB/cartodb/pull/15514))
+* Public privacy options for maps & datasets can be disabled in UI with quotas ([#524](https://github.com/CartoDB/product/issues/524))
 
 4.35.0 (2020-02-21)
 -------------------

--- a/lib/assets/javascripts/builder/components/modals/publish/create-privacy-options.js
+++ b/lib/assets/javascripts/builder/components/modals/publish/create-privacy-options.js
@@ -40,6 +40,7 @@ module.exports = function (visDefinitionModel, userModel) {
   var canSelectPremiumOptions = actions[ isVisualization ? 'private_maps' : 'private_tables' ];
   var currentPrivacy = visDefinitionModel.get('privacy');
   var availableOptions = visDefinitionModel.privacyOptions();
+  let publicSharingIsDisabled = isVisualization ? userModel.hasPublicMapSharingDisabled() : userModel.hasPublicDatasetSharingDisabled();
 
   return _.chain(ALL_OPTIONS)
     .filter(function (option) {
@@ -52,6 +53,10 @@ module.exports = function (visDefinitionModel, userModel) {
         : canChangeToPublic(userModel, currentPrivacy, option));
 
       var enabled = option.alwaysEnabled || (isVisualization ? canSelectPremiumOptions && privacyEnabled : true);
+
+      if (publicSharingIsDisabled && option.privacy !== 'PRIVATE') {
+        enabled = false;
+      }
 
       return _.defaults({
         selected: option.privacy === currentPrivacy,

--- a/lib/assets/javascripts/builder/components/modals/publish/create-privacy-options.js
+++ b/lib/assets/javascripts/builder/components/modals/publish/create-privacy-options.js
@@ -54,7 +54,7 @@ module.exports = function (visDefinitionModel, userModel) {
 
       var enabled = option.alwaysEnabled || (isVisualization ? canSelectPremiumOptions && privacyEnabled : true);
 
-      if (publicSharingIsDisabled && option.privacy !== 'PRIVATE') {
+      if (publicSharingIsDisabled) {
         enabled = false;
       }
 

--- a/lib/assets/javascripts/builder/components/modals/publish/create-privacy-options.js
+++ b/lib/assets/javascripts/builder/components/modals/publish/create-privacy-options.js
@@ -52,11 +52,12 @@ module.exports = function (visDefinitionModel, userModel) {
         ? canChangeToPrivate(userModel, currentPrivacy, option)
         : canChangeToPublic(userModel, currentPrivacy, option));
 
-      var enabled = option.alwaysEnabled || (isVisualization ? canSelectPremiumOptions && privacyEnabled : true);
+      var DEFAULT_ENABLEMENT_FOR_TABLE = true;
+      var premiumEnabled = isVisualization ? (canSelectPremiumOptions && privacyEnabled) : DEFAULT_ENABLEMENT_FOR_TABLE;
 
-      if (publicSharingIsDisabled && option.privacy !== 'PRIVATE') {
-        enabled = false;
-      }
+      var publicMustBeDisabled = (option.privacy !== 'PRIVATE' && publicSharingIsDisabled);
+
+      var enabled = (option.alwaysEnabled || premiumEnabled) && !publicMustBeDisabled;
 
       return _.defaults({
         selected: option.privacy === currentPrivacy,

--- a/lib/assets/javascripts/builder/components/modals/publish/create-privacy-options.js
+++ b/lib/assets/javascripts/builder/components/modals/publish/create-privacy-options.js
@@ -54,7 +54,7 @@ module.exports = function (visDefinitionModel, userModel) {
 
       var enabled = option.alwaysEnabled || (isVisualization ? canSelectPremiumOptions && privacyEnabled : true);
 
-      if (publicSharingIsDisabled) {
+      if (publicSharingIsDisabled && option.privacy !== 'PRIVATE') {
         enabled = false;
       }
 

--- a/lib/assets/javascripts/builder/components/privacy-dropdown/privacy-dialog-view.js
+++ b/lib/assets/javascripts/builder/components/privacy-dropdown/privacy-dialog-view.js
@@ -8,7 +8,8 @@ var REQUIRED_OPTS = [
   'model',
   'collection',
   'userModel',
-  'configModel'
+  'configModel',
+  'visModel'
 ];
 
 module.exports = CoreView.extend({
@@ -41,7 +42,8 @@ module.exports = CoreView.extend({
     this.$el.append(listView.render().el);
     this.addView(listView);
 
-    if (disabledOptions.length > 0 && !customInstall && upgradeURL) {
+    var disabledPublicSharing = this._visModel.isVisualization() ? this._userModel.hasPublicMapSharingDisabled() : this._userModel.hasPublicDatasetSharingDisabled();
+    if (disabledOptions.length > 0 && !customInstall && upgradeURL && !disabledPublicSharing) {
       this.$el.append(
         privacyCTATemplate({
           upgradeURL: upgradeURL,

--- a/lib/assets/javascripts/builder/components/privacy-dropdown/privacy-dropdown-view.js
+++ b/lib/assets/javascripts/builder/components/privacy-dropdown/privacy-dropdown-view.js
@@ -133,7 +133,8 @@ module.exports = CoreView.extend({
       model: this.model,
       collection: this._customCollection,
       userModel: this._userModel,
-      configModel: this._configModel
+      configModel: this._configModel,
+      visModel: this._visDefinitionModel
     });
   },
 

--- a/lib/assets/javascripts/builder/data/user-model.js
+++ b/lib/assets/javascripts/builder/data/user-model.js
@@ -184,6 +184,15 @@ var UserModel = Backbone.Model.extend({
     return !this.isInsideOrg() && this.get('account_type') === 'FREE' && this.get('table_count') > 0;
   },
 
+  // Public sharing
+  hasPublicMapSharingDisabled: function () {
+    return this.get('public_map_quota') === 0;
+  },
+
+  hasPublicDatasetSharingDisabled: function () {
+    return this.get('public_dataset_quota') === 0;
+  },
+
   // Utils
   isActionEnabled: function (action) {
     return this.get('actions') && this.get('actions')[action];

--- a/lib/assets/javascripts/builder/data/user-model.js
+++ b/lib/assets/javascripts/builder/data/user-model.js
@@ -47,6 +47,7 @@ var UserModel = Backbone.Model.extend({
     });
   },
 
+  // Type of user
   isViewer: function () {
     return this.get('viewer') === true;
   },
@@ -55,6 +56,7 @@ var UserModel = Backbone.Model.extend({
     return !this.isViewer();
   },
 
+  // Org-related
   isInsideOrg: function () {
     if (this._organizationModel) {
       return !!this._organizationModel.id || this.isOrgOwner();
@@ -76,6 +78,11 @@ var UserModel = Backbone.Model.extend({
     return false;
   },
 
+  getOrganization: function () {
+    return this._organizationModel;
+  },
+
+  // Plan-related
   isIndividualUser: function () {
     const proUsers = ['Individual', 'Annual Individual'];
     return proUsers.indexOf(this.get('account_type')) > -1;
@@ -86,6 +93,7 @@ var UserModel = Backbone.Model.extend({
     return proUsers.indexOf(this.get('account_type')) > -1;
   },
 
+  // Limits & quotas
   hasRemainingByteQuota: function () {
     return !(!this.get('remaining_byte_quota') || this.get('remaining_byte_quota') <= 0);
   },
@@ -176,6 +184,7 @@ var UserModel = Backbone.Model.extend({
     return !this.isInsideOrg() && this.get('account_type') === 'FREE' && this.get('table_count') > 0;
   },
 
+  // Utils
   isActionEnabled: function (action) {
     return this.get('actions') && this.get('actions')[action];
   },
@@ -242,10 +251,6 @@ var UserModel = Backbone.Model.extend({
     return new UserModel(attrs, {
       configModel: this._configModel
     });
-  },
-
-  getOrganization: function () {
-    return this._organizationModel;
   }
 });
 

--- a/lib/assets/javascripts/dashboard/data/user-model.js
+++ b/lib/assets/javascripts/dashboard/data/user-model.js
@@ -306,6 +306,15 @@ const UserModel = Backbone.Model.extend({
 
   hasAccountType: function (accountType) {
     return this.get('account_type') === accountType;
+  },
+
+  // Public sharing
+  hasPublicMapSharingDisabled: function () {
+    return this.get('public_map_quota') === 0;
+  },
+
+  hasPublicDatasetSharingDisabled: function () {
+    return this.get('public_dataset_quota') === 0;
   }
 });
 

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/change-privacy-view.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/change-privacy-view.js
@@ -73,6 +73,7 @@ const ChangePrivacyView = CoreView.extend({
       el: this.el
     });
     this.addView(this._panes);
+
     this._panes.addTab('start',
       new StartView({
         privacyOptions: this._privacyOptions,
@@ -91,18 +92,23 @@ const ChangePrivacyView = CoreView.extend({
         msg: ''
       }))
     );
+    this._panes.addTab('upgrade',
+      ViewFactory.createByHTML(this._upgradeHtml())
+    );
+
+    this._panes.active('start');
+  },
+
+  _upgradeHtml: function () {
     const upgradeUrl = this._visModel._configModel.get('upgrade_url');
     const userCanUpgrade = upgradeUrl && !this._visModel._configModel.get('cartodb_com_hosted') && (!this._userModel.isInsideOrg() || this._userModel.isOrgOwner());
-    const upgradeHtml = upgradeErrorTemplate({
+    const html = upgradeErrorTemplate({
       errorCode: 8007,
       userCanUpgrade: userCanUpgrade,
       showTrial: this._userModel.canStartTrial(),
       upgradeUrl: upgradeUrl
     });
-    this._panes.addTab('upgrade',
-      ViewFactory.createByHTML(upgradeHtml)
-    );
-    this._panes.active('start');
+    return html;
   },
 
   _initBinds: function () {

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/change-privacy-view.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/change-privacy-view.js
@@ -102,13 +102,12 @@ const ChangePrivacyView = CoreView.extend({
   _upgradeHtml: function () {
     const upgradeUrl = this._visModel._configModel.get('upgrade_url');
     const userCanUpgrade = upgradeUrl && !this._visModel._configModel.get('cartodb_com_hosted') && (!this._userModel.isInsideOrg() || this._userModel.isOrgOwner());
-    const html = upgradeErrorTemplate({
+    return upgradeErrorTemplate({
       errorCode: 8007,
       userCanUpgrade: userCanUpgrade,
       showTrial: this._userModel.canStartTrial(),
       upgradeUrl: upgradeUrl
     });
-    return html;
   },
 
   _initBinds: function () {

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/options-collection.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/options-collection.js
@@ -94,6 +94,7 @@ module.exports = Backbone.Collection.extend({
     const canSelectPremiumOptions = user.get('actions')[ isVisualization ? 'private_maps' : 'private_tables' ];
     const currentPrivacy = vis.get('privacy');
     const availableOptions = vis.privacyOptions();
+    let publicSharingIsDisabled = isVisualization ? user.hasPublicMapSharingDisabled() : user.hasPublicDatasetSharingDisabled();
 
     return new this(
       _.chain(ALL_OPTIONS)
@@ -107,6 +108,10 @@ module.exports = Backbone.Collection.extend({
             : canChangeToPublic(user, currentPrivacy, option));
 
           var enabled = option.alwaysEnabled || (isVisualization ? canSelectPremiumOptions && privacyEnabled : true);
+
+          if (publicSharingIsDisabled && option.privacy !== 'PRIVATE') {
+            enabled = false;
+          }
 
           return _.defaults({
             selected: option.privacy === currentPrivacy,

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/options-collection.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/options-collection.js
@@ -109,7 +109,7 @@ module.exports = Backbone.Collection.extend({
 
           var enabled = option.alwaysEnabled || (isVisualization ? canSelectPremiumOptions && privacyEnabled : true);
 
-          if (publicSharingIsDisabled && option.privacy !== 'PRIVATE') {
+          if (publicSharingIsDisabled) {
             enabled = false;
           }
 

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/options-collection.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/options-collection.js
@@ -107,11 +107,12 @@ module.exports = Backbone.Collection.extend({
             ? canChangeToPrivate(user, currentPrivacy, option)
             : canChangeToPublic(user, currentPrivacy, option));
 
-          var enabled = option.alwaysEnabled || (isVisualization ? canSelectPremiumOptions && privacyEnabled : true);
+          var DEFAULT_ENABLEMENT_FOR_TABLE = true;
+          var premiumEnabled = isVisualization ? (canSelectPremiumOptions && privacyEnabled) : DEFAULT_ENABLEMENT_FOR_TABLE;
 
-          if (publicSharingIsDisabled && option.privacy !== 'PRIVATE') {
-            enabled = false;
-          }
+          var publicMustBeDisabled = (option.privacy !== 'PRIVATE' && publicSharingIsDisabled);
+
+          var enabled = (option.alwaysEnabled || premiumEnabled) && !publicMustBeDisabled;
 
           return _.defaults({
             selected: option.privacy === currentPrivacy,

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/options-collection.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/options-collection.js
@@ -109,7 +109,7 @@ module.exports = Backbone.Collection.extend({
 
           var enabled = option.alwaysEnabled || (isVisualization ? canSelectPremiumOptions && privacyEnabled : true);
 
-          if (publicSharingIsDisabled) {
+          if (publicSharingIsDisabled && option.privacy !== 'PRIVATE') {
             enabled = false;
           }
 

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/start-view.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/start-view.js
@@ -39,11 +39,13 @@ module.exports = CoreView.extend({
     const password = pwdOption ? pwdOption.get('password') : '';
     const selectedOption = this._privacyOptions.selectedOption();
     const sharedEntities = this._visModel.permission.getUsersWithAnyPermission();
+    const publicSharingIsDisabled = this._visModel.isVisualization() ? this._userModel.hasPublicMapSharingDisabled() : this._userModel.hasPublicDatasetSharingDisabled();
 
     this.$el.html(
       template({
         vis: this._visModel,
         privacyOptions: this._privacyOptions,
+        publicSharingIsDisabled,
         password,
         saveBtnClassNames: selectedOption.canSave() ? '' : DISABLED_SAVE_CLASS_NAME,
         upgradeBannerData: this._getUpgradeBannerData(),

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/start-view.js
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/start-view.js
@@ -39,13 +39,11 @@ module.exports = CoreView.extend({
     const password = pwdOption ? pwdOption.get('password') : '';
     const selectedOption = this._privacyOptions.selectedOption();
     const sharedEntities = this._visModel.permission.getUsersWithAnyPermission();
-    const publicSharingIsDisabled = this._visModel.isVisualization() ? this._userModel.hasPublicMapSharingDisabled() : this._userModel.hasPublicDatasetSharingDisabled();
 
     this.$el.html(
       template({
         vis: this._visModel,
         privacyOptions: this._privacyOptions,
-        publicSharingIsDisabled,
         password,
         saveBtnClassNames: selectedOption.canSave() ? '' : DISABLED_SAVE_CLASS_NAME,
         upgradeBannerData: this._getUpgradeBannerData(),
@@ -73,9 +71,11 @@ module.exports = CoreView.extend({
     const publicMapsQuota = this._userModel.get('public_map_quota');
     const privateMapsCount = this._userModel.getTotalPrivateMapsCount();
     const privateMapsQuota = this._userModel.get('private_map_quota');
+    const publicSharingIsDisabled = this._visModel.isVisualization() ? this._userModel.hasPublicMapSharingDisabled() : this._userModel.hasPublicDatasetSharingDisabled();
+    const userHasNoRemainingMaps = !this._userModel.hasRemainingPublicMaps() || !this._userModel.hasRemainingPrivateMaps();
 
     return {
-      show: !this._userModel.hasRemainingPublicMaps() || !this._userModel.hasRemainingPrivateMaps(),
+      show: userHasNoRemainingMaps && !publicSharingIsDisabled,
       upgradeUrl: this._configModel.get('upgrade_url'),
       hasRemainingPublicMaps: this._userModel.hasRemainingPublicMaps(),
       hasRemainingPrivateMaps: this._userModel.hasRemainingPrivateMaps(),

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/start-view.tpl
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/start-view.tpl
@@ -8,7 +8,7 @@
   </p>
 </div>
 <div class="CDB-Text Dialog-body u-inner u-flex  u-flex__direction--column u-flex__align--center">
-  <% if (upgradeBannerData.show) { %>
+  <% if (upgradeBannerData.show && !publicSharingIsDisabled) { %>
     <div class="NotificationBadge NotificationBadge--warning">
       <div class="NotificationBadge__icon"></div>
         <% if (!upgradeBannerData.hasRemainingPublicMaps && upgradeBannerData.hasRemainingPrivateMaps) { %>

--- a/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/start-view.tpl
+++ b/lib/assets/javascripts/dashboard/views/dashboard/dialogs/change-privacy/start-view.tpl
@@ -8,7 +8,7 @@
   </p>
 </div>
 <div class="CDB-Text Dialog-body u-inner u-flex  u-flex__direction--column u-flex__align--center">
-  <% if (upgradeBannerData.show && !publicSharingIsDisabled) { %>
+  <% if (upgradeBannerData.show) { %>
     <div class="NotificationBadge NotificationBadge--warning">
       <div class="NotificationBadge__icon"></div>
         <% if (!upgradeBannerData.hasRemainingPublicMaps && upgradeBannerData.hasRemainingPrivateMaps) { %>

--- a/lib/assets/test/spec/builder/data/user-model.spec.js
+++ b/lib/assets/test/spec/builder/data/user-model.spec.js
@@ -121,6 +121,26 @@ describe('data/user-model', function () {
     expect(this.model.canCreateDatasets()).toEqual(false);
   });
 
+  describe('public sharing', function () {
+    it('should answer if user can share public maps', function () {
+      this.model.set('public_map_quota', null);
+      expect(this.model.hasPublicMapSharingDisabled()).toEqual(false);
+      this.model.set('public_map_quota', 0);
+      expect(this.model.hasPublicMapSharingDisabled()).toEqual(true);
+      this.model.set('public_map_quota', 5);
+      expect(this.model.hasPublicMapSharingDisabled()).toEqual(false);
+    });
+
+    it('should answer if user can share public datasets', function () {
+      this.model.set('public_dataset_quota', null);
+      expect(this.model.hasPublicDatasetSharingDisabled()).toEqual(false);
+      this.model.set('public_dataset_quota', 0);
+      expect(this.model.hasPublicDatasetSharingDisabled()).toEqual(true);
+      this.model.set('public_dataset_quota', 5);
+      expect(this.model.hasPublicDatasetSharingDisabled()).toEqual(false);
+    });
+  });
+
   it('hasFeatureFlagEnabled', function () {
     var flagOK = 'test_flag';
     var feature_flags = [];

--- a/lib/assets/test/spec/dashboard/data/user-model.spec.js
+++ b/lib/assets/test/spec/dashboard/data/user-model.spec.js
@@ -134,6 +134,26 @@ describe('dashboard/data/user-model', function () {
     expect(user.canCreateDatasets()).toEqual(false);
   });
 
+  describe('public sharing', function () {
+    it('should answer if user can share public maps', function () {
+      user.set('public_map_quota', null);
+      expect(user.hasPublicMapSharingDisabled()).toEqual(false);
+      user.set('public_map_quota', 0);
+      expect(user.hasPublicMapSharingDisabled()).toEqual(true);
+      user.set('public_map_quota', 5);
+      expect(user.hasPublicMapSharingDisabled()).toEqual(false);
+    });
+
+    it('should answer if user can share public datasets', function () {
+      user.set('public_dataset_quota', null);
+      expect(user.hasPublicDatasetSharingDisabled()).toEqual(false);
+      user.set('public_dataset_quota', 0);
+      expect(user.hasPublicDatasetSharingDisabled()).toEqual(true);
+      user.set('public_dataset_quota', 5);
+      expect(user.hasPublicDatasetSharingDisabled()).toEqual(false);
+    });
+  });
+
   it('hasFeatureFlagEnabled', function () {
     var flagOK = 'test_flag';
     var feature_flags = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.163",
+  "version": "1.0.0-assets.164",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.163",
+  "version": "1.0.0-assets.164",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Deals with https://github.com/CartoDB/product/issues/524 from the FE side

## Description

There are 4 privacy options available for datasets and maps:

- Public
- Link
- Password
- Private

But there are contexts in which only Private is desired. To avoid, by mistake, setting public sharing options, some backend PRs activated an option to avoid public sharing, using **public_map_quota** and **public_dataset_quota** with value = 0 ([https://github.com/CartoDB/cartodb-central/issues/2699](https://github.com/CartoDB/cartodb-central/issues/2699)) 

This PR complements that, by adapting the UI to those flags. 

From now on, those options will be disabled for Builder & Dashboard if they shouldn't be activated:

## Acceptance

Access to this STAGING users
- [disable-org-1](https://disable-org-1.carto-staging.com/)
- [disable-org-2](https://disable-org-2.carto-staging.com/)

The disable-org has 2 users, to compare the results, having on/off those quotas. They both have 1 dataset and 1 map, set as Private by default:

- **user-1:** public options are not disabled
- **user-2**: both public options, for Map & Dataset, are disabled, with quota = 0

### Tests with user-1

To check everything still works fine without quota

(a) Map in Dashboard 
- Do: /dashboard > Maps tab > Select 1 Map > Change privacy option
- Expect: All privacy options are available
![image](https://user-images.githubusercontent.com/458196/76359088-d90c8f80-631a-11ea-8462-ff00358fefe8.png)
    Note: Private maps option depends on plan

(b) Dataset in Dashboard 
- Do: /dashboard > Maps tab > Select 1 Map > Change privacy option
- Expect: All privacy options are available
![image](https://user-images.githubusercontent.com/458196/76359158-fc373f00-631a-11ea-839a-a62cf42b525c.png)

(c) Map in Builder
- Do: /dashboard > Maps tab > Click on 1 Map, to go to Map view in Builder (eg: /builder/some_guid)
- Expect: All privacy options are available on 'privacy pill-dialog'
![image](https://user-images.githubusercontent.com/458196/76359221-1d982b00-631b-11ea-9095-c301f38c35e3.png)
   Note: Private maps option depends on plan

(d) Dataset in Builder
- Do: /dashboard > Maps tab > Click on 1 Dataset, to go to Dataset table view (eg: /dataset/a_table)
- Expect: All privacy options are available on 'privacy pill-dialog'
![image](https://user-images.githubusercontent.com/458196/76359282-3dc7ea00-631b-11ea-8644-f32fb531ce1b.png)

### Tests with user-2 (disabled)

Same tests as with user-1, BUT with different expectations

- (a) Expect: All privacy options for Map are **disabled**

- (b) Expect: All privacy options for Dataset are **disabled**

- (c) Expect: Options in dialog are **disabled**

- (d) Expect: Options in dialog are **disabled**

