### PR TITLE
Remove temporary info logs about PubSub metrics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,6 @@ Development
 - Fix dataset creation without map quotas ([#15504](https://github.com/CartoDB/cartodb/pull/15504))
 - Fix imports when user quota cannot be calculated ([#15512](https://github.com/CartoDB/cartodb/pull/15512))
 - Update Connectors UI styling ([#15514](https://github.com/CartoDB/cartodb/pull/15514))
-- Remove temporary info logs in rollbar for PubSub metrics ([#15521](https://github.com/CartoDB/cartodb/pull/15521)
 
 4.35.0 (2020-02-21)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ Development
 - Fix dataset creation without map quotas ([#15504](https://github.com/CartoDB/cartodb/pull/15504))
 - Fix imports when user quota cannot be calculated ([#15512](https://github.com/CartoDB/cartodb/pull/15512))
 - Update Connectors UI styling ([#15514](https://github.com/CartoDB/cartodb/pull/15514))
+- Remove temporary info logs in rollbar for PubSub metrics ([#15521](https://github.com/CartoDB/cartodb/pull/15521)
 
 4.35.0 (2020-02-21)
 -------------------

--- a/lib/carto/tracking/services/pubsub_tracker.rb
+++ b/lib/carto/tracking/services/pubsub_tracker.rb
@@ -43,9 +43,7 @@ class PubSubTracker
 
     result = topic.publish(event, attributes)
 
-    if result
-      CartoDB::Logger.info(message: "PubSubTracker: event #{event} published to #{topic.name}")
-    else
+    unless result
       CartoDB::Logger.error(message: "PubSubTracker: error publishing to topic #{topic.name} for event #{event}")
     end
 


### PR DESCRIPTION
After some time working in production we can remove the temporary info logs we added to assert events were being sent to PubSub.