### PR TITLE
[support#2394] Fix Google Maps Load

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,14 +2,15 @@ Development
 -----------
 
 ### NOTICES
-- None yet
+* None yet
 
 ### Features
-- Use Dataservices API client 0.29.0
+* Use Dataservices API client 0.29.0
 
 ### Bug fixes / enhancements
-- Fix wording for feedback
-- Enable deleting Kepler.gl maps ([#15485](https://github.com/CartoDB/cartodb/issues/15485))
+* Fix wording for feedback
+* Enable deleting Kepler.gl maps ([#15485](https://github.com/CartoDB/cartodb/issues/15485))
+* Use visualization user google api key when present ([#2394](https://github.com/CartoDB/support/issues/2394)
 
 4.36.0 (2020-03-09)
 -------------------

--- a/app/controllers/carto/builder/datasets_controller.rb
+++ b/app/controllers/carto/builder/datasets_controller.rb
@@ -31,7 +31,7 @@ module Carto
           Carto::Api::LayerPresenter.new(l, with_style_properties: true).to_poro(migrate_builder_infowindows: true)
         end
 
-        @google_maps_qs = @canonical_visualization.user.google_maps_query_string
+        @google_maps_query_string = @canonical_visualization.user.google_maps_query_string
 
         carto_viewer = current_viewer && Carto::User.where(id: current_viewer.id).first
         @dashboard_notifications = carto_viewer ? carto_viewer.notifications_for_category(:dashboard) : {}

--- a/app/controllers/carto/builder/public/embeds_controller.rb
+++ b/app/controllers/carto/builder/public/embeds_controller.rb
@@ -18,7 +18,7 @@ module Carto
         before_filter :ensure_viewable, only: [:show]
         before_filter :ensure_protected_viewable,
                       :load_auth_tokens,
-                      :load_google_maps_qs, only: [:show, :show_protected]
+                      :load_google_maps_query_string, only: [:show, :show_protected]
 
         skip_before_filter :builder_users_only # This is supposed to be public even in beta
         skip_before_filter :verify_authenticity_token, only: [:show_protected]
@@ -66,8 +66,8 @@ module Carto
                          end
         end
 
-        def load_google_maps_qs
-          @google_maps_qs = @visualization.user.google_maps_query_string
+        def load_google_maps_query_string
+          @google_maps_query_string = @visualization.user.google_maps_query_string
         end
 
         def load_vizjson

--- a/app/controllers/carto/builder/visualizations_controller.rb
+++ b/app/controllers/carto/builder/visualizations_controller.rb
@@ -43,7 +43,7 @@ module Carto
         end
         latest_mapcap = @visualization.latest_mapcap
         @mapcaps_data = latest_mapcap ? [Carto::Api::MapcapPresenter.new(latest_mapcap).to_poro] : []
-        @google_maps_qs = @visualization.user.google_maps_query_string
+        @google_maps_query_string = @visualization.user.google_maps_query_string
 
         @builder_notifications = notifications(:builder)
         @dashboard_notifications = notifications(:dashboard)

--- a/app/views/admin/visualizations/public_dataset.html.erb
+++ b/app/views/admin/visualizations/public_dataset.html.erb
@@ -13,7 +13,7 @@
 
 <% content_for(:js) do %>
   <% if @table.map.provider == 'googlemaps' %>
-    <%= insert_google_maps(@user.google_maps_query_string) %>
+    <%= insert_google_maps(@visualization.user.google_maps_query_string) %>
   <% end %>
 
   <%= javascript_include_tag 'common', 'common_vendor', 'public_table_new' %>

--- a/app/views/admin/visualizations/public_map.html.erb
+++ b/app/views/admin/visualizations/public_map.html.erb
@@ -302,7 +302,7 @@
   <%= insert_trackjs('embeds', Cartodb.get_config(:trackjs, 'frequency')) %>
 
   <% if @visualization.map.provider == 'googlemaps' %>
-    <%= insert_google_maps(@google_maps_query_string) %>
+    <%= insert_google_maps(@visualization.user.google_maps_query_string) %>
   <% end %>
 
   <script>

--- a/app/views/admin/visualizations/show.html.erb
+++ b/app/views/admin/visualizations/show.html.erb
@@ -17,8 +17,8 @@
   </script>
 
   <% content_for(:js) do %>
-    <% if !@google_maps_query_string.blank? %>
-      <%= insert_google_maps(@google_maps_query_string) %>
+    <% if @visualization.map.provider == 'googlemaps' %>
+      <%= insert_google_maps(@visualization.user.google_maps_query_string) %>
     <% end %>
     <%= editor_javascript_include_tag 'cdb.js','models.js', 'templates.js', 'templates_mustache.js', 'table.js', 'editor.js' %>
   <% end %>

--- a/app/views/carto/builder/datasets/show.html.erb
+++ b/app/views/carto/builder/datasets/show.html.erb
@@ -12,8 +12,8 @@
   var geocoderConfiguration = <%= safe_js_object geocoder_config.to_json %>;
 </script>
 
-<% if @canonical_visualization.map.provider == 'googlemaps' && @google_maps_query_string.present? %>
-  <%= insert_google_maps(@google_maps_query_string) %>
+<% if @canonical_visualization.map.provider == 'googlemaps' %>
+  <%= insert_google_maps(@canonical_visualization.user.google_maps_query_string) %>
 <% end %>
 
 <%= javascript_include_tag 'common', 'common_vendor', 'dataset' %>

--- a/app/views/carto/builder/datasets/show.html.erb
+++ b/app/views/carto/builder/datasets/show.html.erb
@@ -12,8 +12,8 @@
   var geocoderConfiguration = <%= safe_js_object geocoder_config.to_json %>;
 </script>
 
-<% if @canonical_visualization.map.provider == 'googlemaps' && @google_maps_qs.present? %>
-  <%= insert_google_maps(@google_maps_qs) %>
+<% if @canonical_visualization.map.provider == 'googlemaps' && @google_maps_query_string.present? %>
+  <%= insert_google_maps(@google_maps_query_string) %>
 <% end %>
 
 <%= javascript_include_tag 'common', 'common_vendor', 'dataset' %>

--- a/app/views/carto/builder/public/embeds/show.html.erb
+++ b/app/views/carto/builder/public/embeds/show.html.erb
@@ -27,8 +27,8 @@
 <%= content_for(:js) do %>
   <%= insert_trackjs('builder-embeds', Cartodb.get_config(:trackjs, 'frequency')) %>
 
-  <% if @vizjson[:map_provider] == 'googlemaps' && @google_maps_qs.present? %>
-    <%= insert_google_maps(@google_maps_qs) %>
+  <% if @vizjson[:map_provider] == 'googlemaps' && @google_maps_query_string.present? %>
+    <%= insert_google_maps(@google_maps_query_string) %>
   <% end %>
 
   <script>

--- a/app/views/carto/builder/visualizations/show.html.erb
+++ b/app/views/carto/builder/visualizations/show.html.erb
@@ -21,8 +21,8 @@
   var geocoderConfiguration = <%= safe_js_object geocoder_config.to_json %>;
 </script>
 
-<% if @google_maps_qs.present? %>
-  <%= insert_google_maps(@google_maps_qs) %>
+<% if @google_maps_query_string.present? %>
+  <%= insert_google_maps(@google_maps_query_string) %>
 <% end %>
 
 <%= javascript_include_tag 'common.js' %>

--- a/app/views/carto/builder/visualizations/show.html.erb
+++ b/app/views/carto/builder/visualizations/show.html.erb
@@ -21,8 +21,8 @@
   var geocoderConfiguration = <%= safe_js_object geocoder_config.to_json %>;
 </script>
 
-<% if @google_maps_query_string.present? %>
-  <%= insert_google_maps(@google_maps_query_string) %>
+<% if @visualization.map.provider == 'googlemaps' %>
+  <%= insert_google_maps(@visualization.user.google_maps_query_string) %>
 <% end %>
 
 <%= javascript_include_tag 'common.js' %>

--- a/spec/requests/carto/builder/visualizations_controller_spec.rb
+++ b/spec/requests/carto/builder/visualizations_controller_spec.rb
@@ -13,8 +13,8 @@ describe Carto::Builder::VisualizationsController do
 
   describe '#show' do
     before(:each) do
-      map = FactoryGirl.create(:map, user_id: @user1.id)
-      @visualization = FactoryGirl.create(:carto_visualization, user_id: @user1.id, map_id: map.id)
+      @map = FactoryGirl.create(:map, user_id: @user1.id)
+      @visualization = FactoryGirl.create(:carto_visualization, user_id: @user1.id, map_id: @map.id)
       login(@user1)
     end
 
@@ -207,8 +207,10 @@ describe Carto::Builder::VisualizationsController do
     end
 
     it 'includes the google maps client id if configured' do
+      @map.provider = 'googlemaps'
       @user1.google_maps_key = 'client=wadus_cid'
       @user1.save
+      @visualization
       get builder_visualization_url(id: @visualization.id)
 
       response.status.should == 200

--- a/spec/requests/carto/builder/visualizations_controller_spec.rb
+++ b/spec/requests/carto/builder/visualizations_controller_spec.rb
@@ -208,6 +208,7 @@ describe Carto::Builder::VisualizationsController do
 
     it 'includes the google maps client id if configured' do
       @map.provider = 'googlemaps'
+      @map.save
       @user1.google_maps_key = 'client=wadus_cid'
       @user1.save
       @visualization


### PR DESCRIPTION
Related issue https://github.com/CartoDB/support/issues/2394

Context
--------

- A user can config two different providers: `leaflet` or `googlemaps`
- We've two users in an organization
- One of them has google maps enabled [google-user] (`google_maps` flag and the google maps api key).
- This user loads a dataset and shares it with the other user [non-google-user]
- The [non-google-user] opens the shared dataset and clicks on preview
- Since the [google-user] provider is `googlemaps`, it should do the preview using google maps with the [google-user] api key

Notes
-----

- I *think* that when sharing a dataset from a [google-user] to a [non-google-user], the map visualization should not use `googlemaps` as a provider, but leaflet.
- In addition, I noticed that if the organization has a google maps api key, automatically all the users (even the ones without `google_maps` flag enabled) all the visualizations have `googlemaps` provider. I don't know if this is the expected behaviour, but it sounds a bit weird to me.

Acceptance
------------

- Staging: `ded-dynamic-aefbz8m.stag.cartodb.net`
- Staging non-google-user: `elena-test-google-maps`
- Staging google-user: `elena-test-google-maps-dev`
- Organization: `bytesandhumans`

