### PR TITLE
Add method to run BigQuery queries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Development
 * Public privacy options for maps & datasets can be disabled in UI with quotas ([#524](https://github.com/CartoDB/product/issues/524))
 * Fix lockout page due to wrong CustomStorage initialization ([#2444](https://github.com/CartoDB/support/issues/2444))
 * Add is_enterprise field to /me ([#15551](https://github.com/CartoDB/cartodb/pull/15551))
+* Add BigQuery execution capability
 
 4.36.0 (2020-03-09)
 -------------------

--- a/services/datasources/lib/datasources/url/bigquery.rb
+++ b/services/datasources/lib/datasources/url/bigquery.rb
@@ -245,17 +245,25 @@ module CartoDB
         end
 
         def dry_run(billing_project_id, sql)
-          query = Google::Apis::BigqueryV2::QueryRequest.new
-          query.query = sql
-          query.dry_run = true
-          query.use_legacy_sql = false
-          begin
-            resp = @bigquery_api.query_job(billing_project_id, query)
+          resp = run(billing_project_id, sql, true)
+          if resp.error
+            resp
+          else
             {
               error: false,
               total_bytes_processed: resp.total_bytes_processed,
               cache_hit: resp.cache_hit
             }
+          end
+        end
+
+        def run(billing_project_id, sql, dry_run=false)
+          query = Google::Apis::BigqueryV2::QueryRequest.new
+          query.query = sql
+          query.dry_run = dry_run
+          query.use_legacy_sql = false
+          begin
+            @bigquery_api.query_job(billing_project_id, query)
           rescue Google::Apis::ClientError => err
             {
               error: true,
@@ -264,6 +272,7 @@ module CartoDB
             }
           end
         end
+
       end
     end
   end

--- a/services/datasources/lib/datasources/url/bigquery.rb
+++ b/services/datasources/lib/datasources/url/bigquery.rb
@@ -246,13 +246,14 @@ module CartoDB
 
         def dry_run(billing_project_id, sql)
           resp = run(billing_project_id, sql, true)
-          if resp.error
+          if resp[:error]
             resp
           else
+            result = resp[:result]
             {
               error: false,
-              total_bytes_processed: resp.total_bytes_processed,
-              cache_hit: resp.cache_hit
+              total_bytes_processed: result.total_bytes_processed,
+              cache_hit: result.cache_hit
             }
           end
         end
@@ -263,7 +264,10 @@ module CartoDB
           query.dry_run = dry_run
           query.use_legacy_sql = false
           begin
-            @bigquery_api.query_job(billing_project_id, query)
+            {
+              error: false,
+              result: @bigquery_api.query_job(billing_project_id, query)
+            }
           rescue Google::Apis::ClientError => err
             {
               error: true,


### PR DESCRIPTION
We had a method to dry-run queries; this add non-dry runs.

This should be eventually refactored and moved out of this repository, but we need it for a quick fix of the BigQuery connector.