### PR TITLE
Send public.table_name as the analysis source

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@ Development
 - Fix ie11 bug due to non babelified toolkit packages ([#2456](https://github.com/CartoDB/support/issues/2456))
 - Fix wrong link in footer for location-data-streams
 - Fix Kepler maps configuration at Maps section that was causing endless reloads ([#15568](https://github.com/CartoDB/cartodb/pull/15568))
+- Fix dataset not found in geocoding request for non-org users ([#2426](https://github.com/CartoDB/support/issues/2426))
 
 4.36.0 (2020-03-09)
 -------------------

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -45,7 +45,11 @@ class Carto::Analysis < ActiveRecord::Base
     qualified_table_name = if layer.user.organization_user?
                              safe_schema_and_table_quoting(username, table_name)
                            else
-                             safe_schema_and_table_quoting('public', table_name)
+                             if table_name.present?
+                               safe_schema_and_table_quoting('public', table_name)
+                             else
+                               table_name
+                             end
                            end
 
     analysis_definition = {

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -42,11 +42,7 @@ class Carto::Analysis < ActiveRecord::Base
     username = layer_options[:user_name] || layer.user.username
     table_name = layer_options[:table_name]
 
-    qualified_table_name = if layer.user.organization_user?
-                             safe_schema_and_table_quoting(username, table_name)
-                           else
-                             safe_schema_and_table_quoting(layer.user.database_schema, table_name)
-                           end
+    qualified_table_name = safe_schema_and_table_quoting(layer.user.database_schema, table_name)
 
     analysis_definition = {
       id: 'abcdefghijklmnopqrstuvwxyz'[index] + '0',

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -42,7 +42,11 @@ class Carto::Analysis < ActiveRecord::Base
     username = layer_options[:user_name] || layer.user.username
     table_name = layer_options[:table_name]
 
-    qualified_table_name = safe_schema_and_table_quoting(layer.user.database_schema, table_name)
+    qualified_table_name = if layer.user.organization_user?
+                             safe_schema_and_table_quoting(username, table_name)
+                           else
+                             safe_schema_and_table_quoting(layer.user.database_schema, table_name)
+                           end
 
     analysis_definition = {
       id: 'abcdefghijklmnopqrstuvwxyz'[index] + '0',

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -42,15 +42,7 @@ class Carto::Analysis < ActiveRecord::Base
     username = layer_options[:user_name] || layer.user.username
     table_name = layer_options[:table_name]
 
-    qualified_table_name = if layer.user.organization_user?
-                             safe_schema_and_table_quoting(username, table_name)
-                           else
-                             if table_name.present?
-                               safe_schema_and_table_quoting('public', table_name)
-                             else
-                               table_name
-                             end
-                           end
+    qualified_table_name = safe_schema_and_table_quoting(layer.user.database_schema, table_name)
 
     analysis_definition = {
       id: 'abcdefghijklmnopqrstuvwxyz'[index] + '0',

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -45,7 +45,7 @@ class Carto::Analysis < ActiveRecord::Base
     qualified_table_name = if layer.user.organization_user?
                              safe_schema_and_table_quoting(username, table_name)
                            else
-                             table_name
+                             safe_schema_and_table_quoting('public', table_name)
                            end
 
     analysis_definition = {

--- a/lib/carto/table_utils.rb
+++ b/lib/carto/table_utils.rb
@@ -11,6 +11,8 @@ module Carto
     end
 
     def safe_schema_and_table_quoting(schema_name, table_name)
+      return nil if table_name.nil?
+
       safe_schema = safe_schema_name_quoting(schema_name)
       safe_table_name = safe_table_name_quoting(table_name)
       "#{safe_schema}.#{safe_table_name}"

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -204,13 +204,13 @@ describe Carto::Analysis do
     it 'copies the layer table_name' do
       @layer.options[:table_name] = 'tt11'
       analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.options[:table_name].should eq 'tt11'
+      analysis.analysis_node.options[:table_name].should eq 'public.tt11'
     end
 
     it 'copies only the table_name for non-org users' do
       @layer.options.merge!(table_name: 'tt11', user_name: 'juan')
       analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.options[:table_name].should eq 'tt11'
+      analysis.analysis_node.options[:table_name].should eq 'public.tt11'
     end
 
     it 'always qualifies table_name in organizations' do

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -201,13 +201,13 @@ describe Carto::Analysis do
       analysis.analysis_node.params[:query].should eq 'SELECT * FROM wadus'
     end
 
-    it 'copies the layer table_name' do
+    it 'copies the layer table_name prepending "public"' do
       @layer.options[:table_name] = 'tt11'
       analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
       analysis.analysis_node.options[:table_name].should eq 'public.tt11'
     end
 
-    it 'copies only the table_name for non-org users' do
+    it 'prepends "public" to table_name for non-org users' do
       @layer.options.merge!(table_name: 'tt11', user_name: 'juan')
       analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
       analysis.analysis_node.options[:table_name].should eq 'public.tt11'

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -183,78 +183,58 @@ describe Carto::Analysis do
   describe '#source_analysis_for_layer non-org user' do
     include Carto::Factories::Visualizations
 
-    before(:all) do
-      @user = FactoryGirl.create(:carto_user)
-      @map, @table, @table_visualization, @visualization = create_full_visualization(@user)
-      @layer = @visualization.data_layers.first
+    context 'with regular user' do
+      include_context 'user helper'
+
+      before(:all) do
+        @map, @table, @table_visualization, @visualization = create_full_visualization(@user1)
+        @layer = @visualization.data_layers.first
+      end
+
+      it 'copies the layer query' do
+        @layer.options[:query] = 'SELECT * FROM wadus'
+        analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
+        analysis.analysis_node.params[:query].should eq 'SELECT * FROM wadus'
+      end
+
+      it 'copies the layer table_name prepending "public"' do
+        @layer.options[:table_name] = 'tt11'
+        analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
+        analysis.analysis_node.options[:table_name].should eq 'public.tt11'
+      end
+
+      it 'prepends "public" to table_name' do
+        @layer.options.merge!(table_name: 'tt11', user_name: 'juan')
+        analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
+        analysis.analysis_node.options[:table_name].should eq 'public.tt11'
+      end
     end
 
-    after(:all) do
-      destroy_full_visualization(@map, @table, @table_visualization, @visualization)
-      # This avoids connection leaking.
-      ::User[@user.id].destroy
-    end
+    context 'with organization user' do
+      include_context 'organization with users helper'
 
-    it 'copies the layer query' do
-      @layer.options[:query] = 'SELECT * FROM wadus'
-      analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.params[:query].should eq 'SELECT * FROM wadus'
-    end
+      before(:all) do
+        @map, @table, @table_visualization, @visualization = create_full_visualization(@carto_org_user_1)
+        @layer = @visualization.data_layers.first
+      end
 
-    it 'copies the layer table_name prepending "public"' do
-      @layer.options[:table_name] = 'tt11'
-      analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.options[:table_name].should eq 'public.tt11'
-    end
+      it 'copies the layer query' do
+        @layer.options[:query] = 'SELECT * FROM wadus'
+        analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
+        analysis.analysis_node.params[:query].should eq 'SELECT * FROM wadus'
+      end
 
-    it 'prepends "public" to table_name' do
-      @layer.options.merge!(table_name: 'tt11', user_name: 'juan')
-      analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.options[:table_name].should eq 'public.tt11'
-    end
+      it 'always qualifies table_name in organizations' do
+        @layer.options.merge!(table_name: 'tt33', user_name: @carto_org_user_1.username)
+        analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
+        analysis.analysis_node.options[:table_name].should eq "#{@carto_org_user_1.username}.tt33"
+      end
 
-    it 'uses default SQL query if missing' do
-      @layer.options.merge!(table_name: 'tt33', user_name: @user.username, query: '')
-      Carto::User.any_instance.stubs(:organization_user?).returns(true)
-      analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.params[:query].should eq "SELECT * FROM #{@user.username}.tt33"
-    end
-  end
-
-  describe '#source_analysis_for_layer org user' do
-  include Carto::Factories::Visualizations
-
-    before(:all) do
-      @user = FactoryGirl.create(:carto_user)
-      @map, @table, @table_visualization, @visualization = create_full_visualization(@user)
-      @layer = @visualization.data_layers.first
-      @layer.user.stubs(:organization_user?).returns(true)
-      @layer.user.database_schema = @user.username
-    end
-
-    after(:all) do
-      destroy_full_visualization(@map, @table, @table_visualization, @visualization)
-      # This avoids connection leaking.
-      ::User[@user.id].destroy
-    end
-
-    it 'copies the layer query' do
-      @layer.options[:query] = 'SELECT * FROM wadus'
-      analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.params[:query].should eq 'SELECT * FROM wadus'
-    end
-
-    it 'always qualifies table_name in organizations' do
-      @layer.options.merge!(table_name: 'tt33', user_name: @user.username)
-      analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.options[:table_name].should eq "#{@user.username}.tt33"
-    end
-
-    it 'uses default SQL query if missing' do
-      @layer.options.merge!(table_name: 'tt33', user_name: @user.username, query: '')
-      Carto::User.any_instance.stubs(:organization_user?).returns(true)
-      analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-      analysis.analysis_node.params[:query].should eq "SELECT * FROM #{@user.username}.tt33"
+      it 'uses default SQL query if missing' do
+        @layer.options.merge!(table_name: 'tt33', user_name: @carto_org_user_1.username, query: '')
+        analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
+        analysis.analysis_node.params[:query].should eq "SELECT * FROM #{@carto_org_user_1.username}.tt33"
+      end
     end
   end
 end

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -180,13 +180,13 @@ describe Carto::Analysis do
     end
   end
 
-  describe '#source_analysis_for_layer non-org user' do
+  describe '#source_analysis_for_layer' do
     include Carto::Factories::Visualizations
 
     context 'with regular user' do
-      include_context 'user helper'
+      include_context 'users helper'
 
-      before(:all) do
+      before(:each) do
         @map, @table, @table_visualization, @visualization = create_full_visualization(@user1)
         @layer = @visualization.data_layers.first
       end
@@ -213,7 +213,7 @@ describe Carto::Analysis do
     context 'with organization user' do
       include_context 'organization with users helper'
 
-      before(:all) do
+      before(:each) do
         @map, @table, @table_visualization, @visualization = create_full_visualization(@carto_org_user_1)
         @layer = @visualization.data_layers.first
       end

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -187,7 +187,6 @@ describe Carto::Analysis do
       @user = FactoryGirl.create(:carto_user)
       @map, @table, @table_visualization, @visualization = create_full_visualization(@user)
       @layer = @visualization.data_layers.first
-      @layer.user.database_schema = @user.username
     end
 
     after(:all) do
@@ -230,6 +229,7 @@ describe Carto::Analysis do
       @map, @table, @table_visualization, @visualization = create_full_visualization(@user)
       @layer = @visualization.data_layers.first
       @layer.user.stubs(:organization_user?).returns(true)
+      @layer.user.database_schema = @user.username
     end
 
     after(:all) do

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -214,6 +214,7 @@ describe Carto::Analysis do
     end
 
     it 'always qualifies table_name in organizations' do
+      @layer.user.database_schema = @user.username
       @layer.options.merge!(table_name: 'tt33', user_name: @user.username)
       @layer.user.stubs(:organization_user?).returns(true)
       analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)


### PR DESCRIPTION
Send `public.table_name` as the analysis source

Related to CartoDB/support#2426

More context on the decision that led to this PR: https://github.com/CartoDB/support/issues/2426#issuecomment-603882352