### PR TITLE
Fix inactive public when map quota is unlimited

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Development
 - Fix Kepler maps configuration at Maps section that was causing endless reloads ([#15568](https://github.com/CartoDB/cartodb/pull/15568))
 - Fix issue that caused data request form to don't include the company name for organization users ([#15554](https://github.com/CartoDB/cartodb/pull/15554))
 - Fix "dataset not found" error in geocoding request for non-org users ([#2426](https://github.com/CartoDB/support/issues/2426))
+- Consider unlimited quotas when counting remaining maps ([#2163](https://github.com/CartoDB/support/issues/2163))
 
 4.36.0 (2020-03-09)
 -------------------

--- a/lib/assets/javascripts/builder/data/user-model.js
+++ b/lib/assets/javascripts/builder/data/user-model.js
@@ -133,9 +133,13 @@ var UserModel = Backbone.Model.extend({
 
   hasRemainingPublicMaps: function () {
     if (this.hasPublicMapsLimits()) {
-      return this.get('public_map_quota') > this.getTotalPublicMapsCount();
+      return this.hasUnlimitedPublicMaps() || this.get('public_map_quota') > this.getTotalPublicMapsCount();
     }
     return true;
+  },
+
+  hasUnlimitedPublicMaps: function () {
+    return this.get('public_map_quota') === null;
   },
 
   getTotalPublicMapsCount: function () {
@@ -152,9 +156,13 @@ var UserModel = Backbone.Model.extend({
 
   hasRemainingPrivateMaps: function () {
     if (this.hasPrivateMapsLimits()) {
-      return this.get('private_map_quota') > this.getTotalPrivateMapsCount();
+      return this.hasUnlimitedPrivateMaps() || this.get('private_map_quota') > this.getTotalPrivateMapsCount();
     }
     return true;
+  },
+
+  hasUnlimitedPrivateMaps: function () {
+    return this.get('private_map_quota') === null;
   },
 
   getTotalPrivateMapsCount: function () {

--- a/lib/assets/javascripts/builder/data/user-model.js
+++ b/lib/assets/javascripts/builder/data/user-model.js
@@ -128,12 +128,13 @@ var UserModel = Backbone.Model.extend({
   },
 
   hasPublicMapsLimits: function () {
-    return this.isIndividualUser() || this.isFree2020User();
+    const userWithLimits = this.isIndividualUser() || this.isFree2020User();
+    return userWithLimits && !this.hasUnlimitedPublicMaps();
   },
 
   hasRemainingPublicMaps: function () {
     if (this.hasPublicMapsLimits()) {
-      return this.hasUnlimitedPublicMaps() || this.get('public_map_quota') > this.getTotalPublicMapsCount();
+      return this.get('public_map_quota') > this.getTotalPublicMapsCount();
     }
     return true;
   },
@@ -151,12 +152,13 @@ var UserModel = Backbone.Model.extend({
   },
 
   hasPrivateMapsLimits: function () {
-    return this.isFree2020User();
+    const userWithLimits = this.isFree2020User();
+    return userWithLimits && !this.hasUnlimitedPrivateMaps();
   },
 
   hasRemainingPrivateMaps: function () {
     if (this.hasPrivateMapsLimits()) {
-      return this.hasUnlimitedPrivateMaps() || this.get('private_map_quota') > this.getTotalPrivateMapsCount();
+      return this.get('private_map_quota') > this.getTotalPrivateMapsCount();
     }
     return true;
   },

--- a/lib/assets/javascripts/dashboard/data/user-model.js
+++ b/lib/assets/javascripts/dashboard/data/user-model.js
@@ -157,9 +157,13 @@ const UserModel = Backbone.Model.extend({
 
   hasRemainingPublicMaps: function () {
     if (this.hasPublicMapsLimits()) {
-      return this.get('public_map_quota') > this.getTotalPublicMapsCount();
+      return this.hasUnlimitedPublicMaps() || this.get('public_map_quota') > this.getTotalPublicMapsCount();
     }
     return true;
+  },
+
+  hasUnlimitedPublicMaps: function () {
+    return this.get('public_map_quota') === null;
   },
 
   getTotalPublicMapsCount: function () {
@@ -176,9 +180,13 @@ const UserModel = Backbone.Model.extend({
 
   hasRemainingPrivateMaps: function () {
     if (this.hasPrivateMapsLimits()) {
-      return this.get('private_map_quota') > this.getTotalPrivateMapsCount();
+      return this.hasUnlimitedPrivateMaps() || this.get('private_map_quota') > this.getTotalPrivateMapsCount();
     }
     return true;
+  },
+
+  hasUnlimitedPrivateMaps: function () {
+    return this.get('private_map_quota') === null;
   },
 
   getTotalPrivateMapsCount: function () {

--- a/lib/assets/javascripts/dashboard/data/user-model.js
+++ b/lib/assets/javascripts/dashboard/data/user-model.js
@@ -152,12 +152,13 @@ const UserModel = Backbone.Model.extend({
   },
 
   hasPublicMapsLimits: function () {
-    return this.isIndividualUser() || this.isFree2020User();
+    const userWithLimits = this.isIndividualUser() || this.isFree2020User();
+    return userWithLimits && !this.hasUnlimitedPublicMaps();
   },
 
   hasRemainingPublicMaps: function () {
     if (this.hasPublicMapsLimits()) {
-      return this.hasUnlimitedPublicMaps() || this.get('public_map_quota') > this.getTotalPublicMapsCount();
+      return this.get('public_map_quota') > this.getTotalPublicMapsCount();
     }
     return true;
   },
@@ -175,12 +176,13 @@ const UserModel = Backbone.Model.extend({
   },
 
   hasPrivateMapsLimits: function () {
-    return this.isFree2020User();
+    const userWithLimits = this.isFree2020User();
+    return userWithLimits && !this.hasUnlimitedPrivateMaps();
   },
 
   hasRemainingPrivateMaps: function () {
     if (this.hasPrivateMapsLimits()) {
-      return this.hasUnlimitedPrivateMaps() || this.get('private_map_quota') > this.getTotalPrivateMapsCount();
+      return this.get('private_map_quota') > this.getTotalPrivateMapsCount();
     }
     return true;
   },

--- a/lib/assets/test/spec/builder/data/user-model.spec.js
+++ b/lib/assets/test/spec/builder/data/user-model.spec.js
@@ -141,6 +141,48 @@ describe('data/user-model', function () {
     });
   });
 
+  describe('limits', function () {
+    describe('map', function () {
+      it('should answer if user has unlimited public maps', function () {
+        this.model.set('public_map_quota', null);
+        expect(this.model.hasUnlimitedPublicMaps()).toEqual(true);
+        this.model.set('public_map_quota', 0);
+        expect(this.model.hasUnlimitedPublicMaps()).toEqual(false);
+        this.model.set('public_map_quota', 5);
+        expect(this.model.hasUnlimitedPublicMaps()).toEqual(false);
+      });
+
+      it('should consider unlimited public map quota when counting remaining public maps', function () {
+        this.model.set('account_type', 'Free 2020');
+        this.model.set('public_map_quota', 10);
+        this.model.set('public_privacy_map_count', 10);
+        expect(this.model.hasRemainingPublicMaps()).toEqual(false);
+
+        this.model.set('public_map_quota', null);
+        expect(this.model.hasRemainingPublicMaps()).toEqual(true);
+      });
+
+      it('should answer if user has unlimited private maps', function () {
+        this.model.set('private_map_quota', null);
+        expect(this.model.hasUnlimitedPrivateMaps()).toEqual(true);
+        this.model.set('private_map_quota', 0);
+        expect(this.model.hasUnlimitedPrivateMaps()).toEqual(false);
+        this.model.set('private_map_quota', 5);
+        expect(this.model.hasUnlimitedPrivateMaps()).toEqual(false);
+      });
+
+      it('should consider unlimited private map quota when counting remaining private maps', function () {
+        this.model.set('account_type', 'Free 2020');
+        this.model.set('private_map_quota', 10);
+        this.model.set('private_privacy_map_count', 10);
+        expect(this.model.hasRemainingPrivateMaps()).toEqual(false);
+
+        this.model.set('private_map_quota', null);
+        expect(this.model.hasRemainingPrivateMaps()).toEqual(true);
+      });
+    });
+  });
+
   it('hasFeatureFlagEnabled', function () {
     var flagOK = 'test_flag';
     var feature_flags = [];

--- a/lib/assets/test/spec/dashboard/data/user-model.spec.js
+++ b/lib/assets/test/spec/dashboard/data/user-model.spec.js
@@ -154,6 +154,48 @@ describe('dashboard/data/user-model', function () {
     });
   });
 
+  describe('limits', function () {
+    describe('map', function () {
+      it('should answer if user has unlimited public maps', function () {
+        user.set('public_map_quota', null);
+        expect(user.hasUnlimitedPublicMaps()).toEqual(true);
+        user.set('public_map_quota', 0);
+        expect(user.hasUnlimitedPublicMaps()).toEqual(false);
+        user.set('public_map_quota', 5);
+        expect(user.hasUnlimitedPublicMaps()).toEqual(false);
+      });
+
+      it('should consider unlimited public map quota when counting remaining public maps', function () {
+        user.set('account_type', 'free 2020');
+        user.set('public_map_quota', 10);
+        user.set('public_privacy_map_count', 10);
+        expect(user.hasRemainingPublicMaps()).toEqual(false);
+
+        user.set('public_map_quota', null);
+        expect(user.hasRemainingPublicMaps()).toEqual(true);
+      });
+
+      it('should answer if user has unlimited private maps', function () {
+        user.set('private_map_quota', null);
+        expect(user.hasUnlimitedPrivateMaps()).toEqual(true);
+        user.set('private_map_quota', 0);
+        expect(user.hasUnlimitedPrivateMaps()).toEqual(false);
+        user.set('private_map_quota', 5);
+        expect(user.hasUnlimitedPrivateMaps()).toEqual(false);
+      });
+
+      it('should consider unlimited private map quota when counting remaining private maps', function () {
+        user.set('account_type', 'free 2020');
+        user.set('private_map_quota', 10);
+        user.set('private_privacy_map_count', 10);
+        expect(user.hasRemainingPrivateMaps()).toEqual(false);
+
+        user.set('private_map_quota', null);
+        expect(user.hasRemainingPrivateMaps()).toEqual(true);
+      });
+    });
+  });
+
   it('hasFeatureFlagEnabled', function () {
     var flagOK = 'test_flag';
     var feature_flags = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.170",
+  "version": "1.0.0-assets.171",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.170",
+  "version": "1.0.0-assets.171",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Related to https://github.com/CartoDB/support/issues/2163

This PR takes into account unlimited quotas (quota = null) to avoid disabling certain privacy options in the Dashboard & Builder.

The particular cases added are `public_map_quota` and `private_map_quota`, for those types of accounts that imply map limits (eg. 'Individual' or 'Free 2020')