### PR TITLE
Temporary fix: remove wrong IPs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Development
 - Hooks to override org settings for gear plugin ([#15126](https://github.com/CartoDB/cartodb/pull/15126))
 
 ### Bug fixes / enhancements
+- Fix invalid connector IPs information
 - Fix wording for feedback
 - Use visualization user google api key when present ([#2394](https://github.com/CartoDB/support/issues/2394))
 - Public privacy options for maps & datasets can be disabled in UI with quotas ([#524](https://github.com/CartoDB/product/issues/524))

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1386,11 +1386,11 @@
                         "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM table",
                         "sidebar-connect": {
                             "title": "Getting connected",
-                            "desc": "To ensure CARTO has access to your %{brand} database, please make sure your firewall is configured to allow the connections from these IP addesses:",
-                            "IP1": "54.68.30.98",
-                            "IP2": "54.68.45.3",
-                            "IP3": "54.164.204.122",
-                            "IP4": "54.172.100.146"
+                            "desc": "If you need to configure your firewall To ensure CARTO has access to your %{brand} database, please contact us to obtain a list of IPs",
+                            "IP1": "",
+                            "IP2": "",
+                            "IP3": "",
+                            "IP4": ""
                         }
                     },
                     "notenabled": {

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1386,7 +1386,7 @@
                         "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM table",
                         "sidebar-connect": {
                             "title": "Getting connected",
-                            "desc": "If you need to configure your firewall To ensure CARTO has access to your %{brand} database, please contact us to obtain a list of IPs",
+                            "desc": "If you need to configure your firewall to ensure CARTO has access to your %{brand} database, please contact us to obtain a list of IPs",
                             "IP1": "",
                             "IP2": "",
                             "IP3": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.171",
+  "version": "1.0.0-assets.171stag",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a temporary hotfix to avoid showing incorrect outgoing IPs. The correct IPs must be configured per cloud.