### PR TITLE
Update dataservices-api-client to 0.30.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ Development
 - DB Connectors removed from the main repository
 
 ### Features
-- Use Dataservices API client 0.29.0
+- Use Dataservices API client 0.30.0
 - Enable deleting Kepler.gl maps ([#15485](https://github.com/CartoDB/cartodb/issues/15485))
 - Add Kepler.gl maps to Recent content section in the Dashboard ([#15486](https://github.com/CartoDB/cartodb/issues/15486))
 - Add Kepler.gl maps to the Maps section in the Dashboard's Home page ([#15487](https://github.com/CartoDB/cartodb/issues/15487))

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -20,7 +20,7 @@ module CartoDB
       SCHEMA_GEOCODING = 'cdb'.freeze
       SCHEMA_CDB_DATASERVICES_API = 'cdb_dataservices_client'.freeze
       SCHEMA_AGGREGATION_TABLES = 'aggregation'.freeze
-      CDB_DATASERVICES_CLIENT_VERSION = '0.29.0'.freeze
+      CDB_DATASERVICES_CLIENT_VERSION = '0.30.0'.freeze
       ODBC_FDW_VERSION = '0.4.0'.freeze
 
       def initialize(user)
@@ -609,8 +609,7 @@ module CartoDB
       def install_geocoder_api_extension
         @user.in_database(as: :superuser) do |db|
           db.transaction do
-            db.run('CREATE EXTENSION IF NOT EXISTS plproxy SCHEMA public')
-            db.run("CREATE EXTENSION IF NOT EXISTS cdb_dataservices_client VERSION '#{CDB_DATASERVICES_CLIENT_VERSION}'")
+            db.run("CREATE EXTENSION IF NOT EXISTS cdb_dataservices_client VERSION '#{CDB_DATASERVICES_CLIENT_VERSION}' CASCADE")
             db.run("ALTER EXTENSION cdb_dataservices_client UPDATE TO '#{CDB_DATASERVICES_CLIENT_VERSION}'")
           end
         end

--- a/carto-package.json
+++ b/carto-package.json
@@ -11,7 +11,7 @@
             "imagemagick": ">=6.9.0"
         },
         "works_with": {
-            "dataservices-api-client-extension": "0.29.0",
+            "dataservices-api-client-extension": "0.30.0",
             "carto_postgresql_ext": "0.36.0",
             "odbc_fdw": "0.4.0",
             "carto_windshaft": ">=6.2.0",


### PR DESCRIPTION
Update dataservices-api client to 0.30.0 (after it's deployed in the databases). I've removed plproxy and instead install in cascade to avoid a mess managing extensions since dataservices-api will depend on postgis_raster for postgis 3.0+