### PR TITLE
Safer configuration management

### DIFF
--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -163,7 +163,7 @@ class Admin::VisualizationsController < Admin::AdminController
 
     if @is_data_library
       @name = "Data Library"
-      @user_url = Cartodb.get_config(:data_library, 'path') ? "#{request.protocol}#{CartoDB.account_host}#{Cartodb.config[:data_library]['path']}" : @user_url
+      @user_url = Cartodb.get_config(:data_library, 'path') ? "#{request.protocol}#{CartoDB.account_host}#{Cartodb.get_config(:data_library, 'path')}" : @user_url
     end
 
     @avatar_url             = @visualization.user.avatar
@@ -623,7 +623,7 @@ class Admin::VisualizationsController < Admin::AdminController
   end
 
   def sql_api_url(query, user)
-    "#{ ApplicationHelper.sql_api_template("public").gsub! '{user}', user.username }#{ Cartodb.config[:sql_api]['public']['endpoint'] }?q=#{ URI::encode query }"
+    "#{ ApplicationHelper.sql_api_template("public").gsub! '{user}', user.username }#{Cartodb.get_config(:sql_api, 'public', 'endpoint')}?q=#{ URI::encode query }"
   end
 
   def embed_map_actual

--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -24,7 +24,7 @@ class Api::Json::ImportsController < Api::ApplicationController
     @stats_aggregator.timing('imports.create') do
 
       begin
-        file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
+        file_upload_helper = CartoDB::FileUpload.new(Cartodb.get_config(:importer, 'uploads_path'))
 
         external_source = nil
         concurrent_import_limit =
@@ -51,7 +51,8 @@ class Api::Json::ImportsController < Api::ApplicationController
               filename_param: params[:filename],
               file_param: params[:file],
               request_body: request.body,
-              s3_config: Cartodb.config[:importer]['s3'])
+              s3_config: Cartodb.get_config(:importer, 's3')
+            )
 
             # In Rack < 1.6 / Rails < 4, tempfiles are not inmediately cleaned (https://github.com/rack/rack/pull/671).
             # Instead they stay around until a GC cycle which can take a while in instances with low traffic.

--- a/app/controllers/api/json/uploads_controller.rb
+++ b/app/controllers/api/json/uploads_controller.rb
@@ -22,7 +22,7 @@ class Api::Json::UploadsController < Api::ApplicationController
 
         random_token = Digest::SHA2.hexdigest("#{Time.now.utc}--#{filename.object_id.to_s}").first(20)
 
-        file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
+        file_upload_helper = CartoDB::FileUpload.new(Cartodb.get_config(:importer, 'uploads_path'))
         file_upload_helper.get_uploads_path
 
         @stats_aggregator.timing('save') do

--- a/app/controllers/carto/api/database_groups_controller.rb
+++ b/app/controllers/carto/api/database_groups_controller.rb
@@ -145,7 +145,8 @@ module Carto
         raise "missing org_metadata_api configuration" unless Cartodb.config[:org_metadata_api]
 
         authenticate_or_request_with_http_basic do |username, password|
-          username == Cartodb.config[:org_metadata_api]["username"] && password == Cartodb.config[:org_metadata_api]["password"]
+          username == Cartodb.get_config(:org_metadata_api, 'username') &&
+            password == Cartodb.get_config(:org_metadata_api, 'password')
         end
       end
 

--- a/app/controllers/data_library_controller.rb
+++ b/app/controllers/data_library_controller.rb
@@ -5,7 +5,7 @@ class DataLibraryController < ApplicationController
   before_filter :get_viewed_user
 
   def index
-    render_404 and return if @viewed_user.nil? || (Cartodb.get_config(:data_library, 'username') && (Cartodb.config[:data_library]['username'] != @viewed_user.username))
+    render_404 and return if @viewed_user.nil? || (Cartodb.get_config(:data_library, 'username') && (Cartodb.get_config(:data_library, 'username') != @viewed_user.username))
 
     @dataset_base_url = (Rails.env.production? || Rails.env.staging?) ? "#{request.protocol}#{CartoDB.account_host}/dataset/" : "#{@viewed_user.public_url(nil, request.protocol == "https://" ? "https" : "http")}/tables/"
 

--- a/app/controllers/superadmin/superadmin_controller.rb
+++ b/app/controllers/superadmin/superadmin_controller.rb
@@ -18,7 +18,7 @@ class Superadmin::SuperadminController < ActionController::Base
   def authenticate
     return true if Rails.env.development? || authenticated?(CartoDB.extract_subdomain(request)) && current_user.admin
     authenticate_or_request_with_http_basic do |username, password|
-      username == Cartodb.config[:superadmin]["username"] && password == Cartodb.config[:superadmin]["password"]
+      username == Cartodb.get_config(:superadmin, 'username') && password == Cartodb.get_config(:superadmin, 'password')
     end
   end
 

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -89,13 +89,13 @@ class Superadmin::UsersController < Superadmin::SuperadminController
   end
 
   def dump
-    if Cartodb.config[:users_dumps].nil? || Cartodb.config[:users_dumps]["service"].nil? || Cartodb.config[:users_dumps]["service"]["port"].nil?
-      raise "There is not a dump method configured"
-    end
+    database_port = Cartodb.get_config(:users_dumps, 'service', 'port')
+    raise "There is not a dump method configured" unless database_port
+
     json_data = {database: @user.database_name, username: @user.username}
     http_client = Carto::Http::Client.get(self.class.name, log_requests: true)
     response = http_client.request(
-      "#{@user.database_host}:#{Cartodb.config[:users_dumps]["service"]["port"]}/scripts/db_dump",
+      "#{@user.database_host}:#{database_port}/scripts/db_dump",
       method: :post,
       headers: { "Content-Type" => "application/json" },
       body: json_data.to_json

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,35 +73,35 @@ module ApplicationHelper
     config = {
       maps_api_template:   maps_api_template(api_type),
       user_name:           CartoDB.extract_subdomain(request),
-      cartodb_com_hosted:  Cartodb.config[:cartodb_com_hosted],
+      cartodb_com_hosted:  Cartodb.get_config(:cartodb_com_hosted),
       account_host:        CartoDB.account_host,
-      max_asset_file_size: Cartodb.config[:assets]["max_file_size"],
+      max_asset_file_size: Cartodb.get_config(:assets, 'max_file_size'),
       api_key:             ''
     }
 
     # Assumption: it is safe to expose private SQL API endpoint (or it is the same just using HTTPS)
-    config[:sql_api_template] =  sql_api_template(api_type)
+    config[:sql_api_template] = sql_api_template(api_type)
 
-    if Cartodb.config[:graphite_public].present?
-      config[:statsd_host] = Cartodb.config[:graphite_public]['host']
-      config[:statsd_port] = Cartodb.config[:graphite_public]['port']
+    if Cartodb.get_config(:graphite_public)
+      config[:statsd_host] = Cartodb.get_config(:graphite_public, 'host')
+      config[:statsd_port] = Cartodb.get_config(:graphite_public, 'port')
     end
 
-    if Cartodb.config[:error_track].present?
-      config[:error_track_url] = Cartodb.config[:error_track]["url"]
-      config[:error_track_percent_users] = Cartodb.config[:error_track]["percent_users"]
+    if Cartodb.get_config(:error_track)
+      config[:error_track_url] = Cartodb.get_config(:error_track, 'url')
+      config[:error_track_percent_users] = Cartodb.get_config(:error_track, 'percent_users')
     end
 
-    if Cartodb.config[:cdn_url].present?
-      config[:cdn_url] = Cartodb.config[:cdn_url]
+    if Cartodb.get_config(:cdn_url)
+      config[:cdn_url] = Cartodb.get_config(:cdn_url)
     end
 
-    if Cartodb.config[:explore_api].present?
-      config[:explore_user] = Cartodb.config[:explore_api]['username']
+    if Cartodb.get_config(:explore_api)
+      config[:explore_user] = Cartodb.get_config(:explore_api, 'username')
     end
 
-    if Cartodb.config[:common_data].present?
-      config[:common_data_user] = Cartodb.config[:common_data]['username']
+    if Cartodb.get_config(:common_data)
+      config[:common_data_user] = Cartodb.get_config(:common_data, 'username')
     end
 
     config.to_json

--- a/app/helpers/frontend_config_helper.rb
+++ b/app/helpers/frontend_config_helper.rb
@@ -10,7 +10,7 @@ module FrontendConfigHelper
       maps_api_template:          maps_api_template,
       sql_api_template:           sql_api_template,
       user_name:                  CartoDB.extract_subdomain(request),
-      cartodb_com_hosted:         Cartodb.config[:cartodb_com_hosted].present?,
+      cartodb_com_hosted:         Cartodb.get_config(:cartodb_com_hosted),
       account_host:               CartoDB.account_host,
       trackjs_customer:           Cartodb.get_config(:trackjs, 'customer'),
       trackjs_enabled:            Cartodb.get_config(:trackjs, 'enabled'),
@@ -38,8 +38,8 @@ module FrontendConfigHelper
       sqlserver_enabled:          Cartodb.get_config(:connectors, 'sqlserver', 'enabled'),
       hive_enabled:               Cartodb.get_config(:connectors, 'hive', 'enabled'),
       datasource_search_twitter:  nil,
-      max_asset_file_size:        Cartodb.config[:assets]["max_file_size"],
-      watcher_ttl:                Cartodb.config[:watcher].try("fetch", 'ttl', 60),
+      max_asset_file_size:        Cartodb.get_config(:assets, 'max_file_size'),
+      watcher_ttl:                Cartodb.get_config(:watcher, 'ttl') || 60,
       upgrade_url:                cartodb_com_hosted? ? false : user.try(:upgrade_url, request.protocol).to_s,
       licenses:                   Carto::License.all,
       data_library_enabled:       CartoDB::Visualization::CommonDataService.configured?,
@@ -53,27 +53,27 @@ module FrontendConfigHelper
       config[:hubspot_form_ids] = CartoDB::Hubspot::instance.form_ids
     end
 
-    if Cartodb.config[:datasource_search].present? && Cartodb.config[:datasource_search]['twitter_search'].present? \
-      && Cartodb.config[:datasource_search]['twitter_search']['standard'].present?
-      config[:datasource_search_twitter] = Cartodb.config[:datasource_search]['twitter_search']['standard']['search_url']
+    if Cartodb.get_config(:datasource_search, 'twitter_search', 'standard')
+      search_url = Cartodb.get_config(:datasource_search, 'twitter_search', 'standard', 'search_url')
+      config[:datasource_search_twitter] = search_url
     end
 
-    if Cartodb.config[:graphite_public].present?
-      config[:statsd_host] = Cartodb.config[:graphite_public]['host']
-      config[:statsd_port] = Cartodb.config[:graphite_public]['port']
+    if Cartodb.get_config(:graphite_public)
+      config[:statsd_host] = Cartodb.get_config(:graphite_public, 'host')
+      config[:statsd_port] = Cartodb.get_config(:graphite_public, 'port')
     end
 
-    if Cartodb.config[:error_track].present?
-      config[:error_track_url] = Cartodb.config[:error_track]["url"]
-      config[:error_track_percent_users] = Cartodb.config[:error_track]["percent_users"]
+    if Cartodb.get_config(:error_track)
+      config[:error_track_url] = Cartodb.get_config(:error_track, 'url')
+      config[:error_track_percent_users] = Cartodb.get_config(:error_track, 'percent_users')
     end
 
-    if Cartodb.config[:static_image_upload_endpoint].present?
-      config[:static_image_upload_endpoint] = Cartodb.config[:static_image_upload_endpoint]
+    if Cartodb.get_config(:static_image_upload_endpoint)
+      config[:static_image_upload_endpoint] = Cartodb.get_config(:static_image_upload_endpoint)
     end
 
-    if Cartodb.config[:cdn_url].present?
-      config[:cdn_url] = Cartodb.config[:cdn_url]
+    if Cartodb.get_config(:cdn_url)
+      config[:cdn_url] = Cartodb.get_config(:cdn_url)
     end
 
     if !Cartodb.get_config(:dataservices, 'enabled').nil?

--- a/app/helpers/maps_api_helper.rb
+++ b/app/helpers/maps_api_helper.rb
@@ -4,7 +4,7 @@ module MapsApiHelper
   end
 
   def maps_api_url(username, privacy = "private")
-    maps_api = Cartodb.config[:tiler][privacy]
+    maps_api = Cartodb.get_config(:tiler, privacy)
     if CartoDB.subdomainless_urls?
       maps_api["protocol"] + "://" + maps_api["domain"] + ":" + maps_api["port"].to_s + "/user/#{username}"
     else

--- a/app/helpers/sql_api_helper.rb
+++ b/app/helpers/sql_api_helper.rb
@@ -4,7 +4,7 @@ module SqlApiHelper
   end
 
   def sql_api_url(username, privacy = 'private')
-    sql_api = Cartodb.config[:sql_api][privacy]
+    sql_api = Cartodb.get_config(:sql_api, privacy)
     if CartoDB.subdomainless_urls?
       sql_api["protocol"] + "://" + sql_api["domain"] + ":" + sql_api["port"].to_s + "/user/#{username}"
     else

--- a/app/model_factories/carto/layer_factory.rb
+++ b/app/model_factories/carto/layer_factory.rb
@@ -27,7 +27,7 @@ module Carto
       user = user_table.user
       geometry_type = user_table.geometry_type
 
-      data_layer = Carto::Layer.new(Cartodb.config[:layer_opts]['data'].deep_dup)
+      data_layer = Carto::Layer.new(Cartodb.get_config(:layer_opts, 'data').deep_dup)
       layer_options = data_layer.options
       layer_options['table_name'] = user_table.name
       layer_options['user_name'] = user.username
@@ -67,7 +67,7 @@ module Carto
     private_class_method :builder_tile_style
 
     def self.legacy_tile_style(geometry_type)
-      "#layer #{Cartodb.config[:layer_opts]['default_tile_styles'][geometry_type]}"
+      "#layer #{Cartodb.get_config(:layer_opts, 'default_tile_styles', geometry_type)}"
     end
     private_class_method :legacy_tile_style
   end

--- a/app/model_factories/layer_factory.rb
+++ b/app/model_factories/layer_factory.rb
@@ -23,7 +23,7 @@ module ModelFactories
     end
 
     def self.get_default_data_layer(table_name, user, geometry_type)
-      data_layer = ::Layer.new(Cartodb.config[:layer_opts]['data'].deep_dup)
+      data_layer = ::Layer.new(Cartodb.get_config(:layer_opts, 'data').deep_dup)
       data_layer.options['table_name'] = table_name
       data_layer.options['user_name'] = user.username
       data_layer.options['tile_style'] = tile_style(user, geometry_type)
@@ -68,7 +68,7 @@ module ModelFactories
     end
 
     def self.legacy_tile_style(geometry_type)
-      "#layer #{Cartodb.config[:layer_opts]['default_tile_styles'][geometry_type]}"
+      "#layer #{Cartodb.get_config(:layer_opts, 'default_tile_styles', geometry_type)}"
     end
   end
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -148,10 +148,10 @@ class Asset < Sequel::Model
   end
 
   def s3_bucket
-    s3_config = Cartodb.config[:aws]["s3"].symbolize_keys
+    s3_config = Cartodb.get_config(:aws, 's3').symbolize_keys
     Aws.config = s3_config
     s3 = Aws::S3::Resource.new
-    @s3_bucket ||= s3.bucket(Cartodb.config[:assets]["s3_bucket_name"])
+    @s3_bucket ||= s3.bucket(Cartodb.get_config(:assets, 's3_bucket_name'))
   end
 
   ASSET_SUBFOLDER = 'uploads'.freeze

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -823,7 +823,7 @@ class Carto::Visualization < ActiveRecord::Base
       @user = user
       @visualization = visualization
 
-      default_ttl = Cartodb.config[:watcher].present? ? Cartodb.config[:watcher].try("fetch", 'ttl', 60) : 60
+      default_ttl = Cartodb.get_config(:watcher, 'ttl') || 60
       @notification_ttl = notification_ttl.nil? ? default_ttl : notification_ttl
     end
 

--- a/app/models/carto/visualization_export.rb
+++ b/app/models/carto/visualization_export.rb
@@ -41,7 +41,7 @@ module Carto
 
       file = CartoDB::FileUploadFile.new(filepath)
 
-      s3_config = Cartodb.config[:exporter]['s3'].deep_dup || {}
+      s3_config = Cartodb.get_config(:exporter, 's3').deep_dup || {}
 
       plain_name = header_encode(file.original_filename.force_encoding('iso-8859-1'))
       utf_name = header_encode(file.original_filename)

--- a/app/models/common_data.rb
+++ b/app/models/common_data.rb
@@ -98,12 +98,8 @@ class CommonData
     }).url(query, format, filename)
   end
 
-  def config(key, default=nil)
-    if Cartodb.config[:common_data].present?
-      Cartodb.config[:common_data][key].present? ? Cartodb.config[:common_data][key] : default
-    else
-      default
-    end
+  def config(key, default = nil)
+    Cartodb.get_config(:common_data, key) || default
   end
 
   def redis_cache

--- a/app/models/common_data/singleton.rb
+++ b/app/models/common_data/singleton.rb
@@ -16,10 +16,6 @@ class CommonDataSingleton
   end
 
   def cache_ttl
-    ttl = 0
-    if Cartodb.config[:common_data].present?
-      ttl = Cartodb.config[:common_data]['cache_ttl'] || ttl
-    end
-    ttl
+    Cartodb.get_config(:common_data, 'cache_ttl') || 0
   end
 end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -140,16 +140,15 @@ class DataImport < Sequel::Model
   end
 
   def from_common_data?
-    if Cartodb.config[:common_data] &&
-       !Cartodb.config[:common_data]['username'].blank? &&
-       !Cartodb.config[:common_data]['host'].blank?
-      if !self.extra_options.has_key?('common_data') &&
-         self.data_source &&
-         self.data_source.include?("#{Cartodb.config[:common_data]['username']}.#{Cartodb.config[:common_data]['host']}")
-        return true
-      end
+    username = Cartodb.get_config(:common_data, 'username')
+    host = Cartodb.get_config(:common_data, 'host')
+    if username && host &&
+       !extra_options.has_key?('common_data') &&
+       data_source && data_source.include?("#{username}.#{host}")
+      return true
     end
-    return false
+
+    false
   end
 
   def extra_options
@@ -311,7 +310,7 @@ class DataImport < Sequel::Model
   def remove_uploaded_resources
     return nil unless uploaded_file
 
-    file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
+    file_upload_helper = CartoDB::FileUpload.new(Cartodb.get_config(:importer, 'uploads_path'))
     path = file_upload_helper.get_uploads_path.join(uploaded_file[1])
     FileUtils.rm_rf(path) if Dir.exists?(path)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -705,13 +705,12 @@ class User < Sequel::Model
   end
 
   def cartodb_avatar
-    if !Cartodb.config[:avatars].nil? &&
-       !Cartodb.config[:avatars]['base_url'].nil? && !Cartodb.config[:avatars]['base_url'].empty? &&
-       !Cartodb.config[:avatars]['kinds'].nil? && !Cartodb.config[:avatars]['kinds'].empty? &&
-       !Cartodb.config[:avatars]['colors'].nil? && !Cartodb.config[:avatars]['colors'].empty?
-      avatar_base_url = Cartodb.config[:avatars]['base_url']
-      avatar_kind = Cartodb.config[:avatars]['kinds'][Random.new.rand(0..Cartodb.config[:avatars]['kinds'].length - 1)]
-      avatar_color = Cartodb.config[:avatars]['colors'][Random.new.rand(0..Cartodb.config[:avatars]['colors'].length - 1)]
+    avatar_base_url = Cartodb.get_config(:avatars, 'base_url')
+    kinds = Cartodb.get_config(:avatars, 'kinds')
+    colors = Cartodb.get_config(:avatars, 'colors')
+    if base_url && kinds && colors
+      avatar_kind = kinds.sample
+      avatar_color = colors.sample
       return "#{avatar_base_url}/avatar_#{avatar_kind}_#{avatar_color}.png"
     else
       CartoDB::Logger.info(message: "Attribute avatars_base_url not found in config. Using default avatar")
@@ -725,7 +724,7 @@ class User < Sequel::Model
 
   def gravatar_enabled?
     # Enabled by default, only disabled if specified in the config
-    value = Cartodb.config[:avatars] && Cartodb.config[:avatars]['gravatar_enabled']
+    value = Cartodb.get_config(:avatars, 'gravatar_enabled')
     value.to_s != 'false'
   end
 
@@ -993,8 +992,8 @@ class User < Sequel::Model
     yesterday = Date.today - 1
     from_date = DateTime.new(yesterday.year, yesterday.month, yesterday.day, 0, 0, 0).strftime("%Q")
     to_date = DateTime.now.strftime("%Q")
-    request_body = Cartodb.config[:api_requests_es_service]['body'].dup
-    request_url = Cartodb.config[:api_requests_es_service]['url'].dup
+    request_body = Cartodb.get_config(:api_requests_es_service, 'body').dup
+    request_url = Cartodb.get_config(:api_requests_es_service, 'url').dup
     request_body.gsub!("$CDB_SUBDOMAIN$", self.username)
     request_body.gsub!("\"$FROM$\"", from_date)
     request_body.gsub!("\"$TO$\"", to_date)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -724,7 +724,7 @@ class User < Sequel::Model
 
   def gravatar_enabled?
     # Enabled by default, only disabled if specified in the config
-    value = Cartodb.get_config(:avatars, 'gravatar_enabled')
+    value = Cartodb.config[:avatars] && Cartodb.config[:avatars]['gravatar_enabled']
     value.to_s != 'false'
   end
 
@@ -992,8 +992,8 @@ class User < Sequel::Model
     yesterday = Date.today - 1
     from_date = DateTime.new(yesterday.year, yesterday.month, yesterday.day, 0, 0, 0).strftime("%Q")
     to_date = DateTime.now.strftime("%Q")
-    request_body = Cartodb.get_config(:api_requests_es_service, 'body').dup
-    request_url = Cartodb.get_config(:api_requests_es_service, 'url').dup
+    request_body = Cartodb.config[:api_requests_es_service]['body'].dup
+    request_url = Cartodb.config[:api_requests_es_service]['url'].dup
     request_body.gsub!("$CDB_SUBDOMAIN$", self.username)
     request_body.gsub!("\"$FROM$\"", from_date)
     request_body.gsub!("\"$TO$\"", to_date)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -708,7 +708,7 @@ class User < Sequel::Model
     avatar_base_url = Cartodb.get_config(:avatars, 'base_url')
     kinds = Cartodb.get_config(:avatars, 'kinds')
     colors = Cartodb.get_config(:avatars, 'colors')
-    if base_url && kinds && colors
+    if avatar_base_url && kinds && colors
       avatar_kind = kinds.sample
       avatar_color = colors.sample
       return "#{avatar_base_url}/avatar_#{avatar_kind}_#{avatar_color}.png"

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1076,9 +1076,9 @@ module CartoDB
       # depending on CartoDB configuration at time of function definition.
       #
       def create_function_invalidate_varnish
-        if Cartodb.config[:invalidation_service] && Cartodb.config[:invalidation_service].fetch('enabled', false)
+        if Cartodb.get_config(:invalidation_service, 'enabled')
           create_function_invalidate_varnish_invalidation_service
-        elsif Cartodb.config[:varnish_management].fetch('http_port', false)
+        elsif Cartodb.get_config(:varnish_management, 'http_port')
           create_function_invalidate_varnish_http
         else
           create_function_invalidate_varnish_telnet
@@ -1154,15 +1154,12 @@ module CartoDB
 
       def monitor_user_notification
         FileUtils.touch(log_file_path('users_modifications'))
-        if !Cartodb.config[:signups].nil? && !Cartodb.config[:signups]["service"].nil? &&
-           !Cartodb.config[:signups]["service"]["port"].nil?
-          enable_remote_db_user
-        end
+        enable_remote_db_user if Cartodb.get_config(:signups, 'service', 'port')
       end
 
       def enable_remote_db_user
         request = http_client.request(
-          "#{@user.database_host}:#{Cartodb.config[:signups]['service']['port']}/scripts/activate_db_user",
+          "#{@user.database_host}:#{Cartodb.get_config(:signups, 'service', 'port')}/scripts/activate_db_user",
           method: :post,
           headers: { "Content-Type" => "application/json" }
         )
@@ -1449,13 +1446,13 @@ module CartoDB
       def create_function_invalidate_varnish_telnet
         add_python
 
-        varnish_host = Cartodb.config[:varnish_management].try(:[], 'host') || '127.0.0.1'
-        varnish_port = Cartodb.config[:varnish_management].try(:[], 'port') || 6082
-        varnish_timeout = Cartodb.config[:varnish_management].try(:[], 'timeout') || 5
-        varnish_critical = Cartodb.config[:varnish_management].try(:[], 'critical') == true ? 1 : 0
-        varnish_retry = Cartodb.config[:varnish_management].try(:[], 'retry') || 5
-        purge_command = Cartodb::config[:varnish_management]["purge_command"]
-        varnish_trigger_verbose = Cartodb.config[:varnish_management].fetch('trigger_verbose', true) == true ? 1 : 0
+        varnish_host = Cartodb.get_config(:varnish_management, 'host') || '127.0.0.1'
+        varnish_port = Cartodb.get_config(:varnish_management, 'port') || 6082
+        varnish_timeout = Cartodb.get_config(:varnish_management, 'timeout') || 5
+        varnish_critical = Cartodb.get_config(:varnish_management, 'critical') == true ? 1 : 0
+        varnish_retry = Cartodb.get_config(:varnish_management, 'retry') || 5
+        purge_command = Cartodb.get_config(:varnish_management, 'purge_command')
+        varnish_trigger_verbose = Cartodb.get_config(:varnish_management).fetch('trigger_verbose', true) == true ? 1 : 0
 
         @user.in_database(as: :superuser).run(
           <<-TRIGGER
@@ -1509,12 +1506,12 @@ module CartoDB
       def create_function_invalidate_varnish_http
         add_python
 
-        varnish_host = Cartodb.config[:varnish_management].try(:[], 'host') || '127.0.0.1'
-        varnish_port = Cartodb.config[:varnish_management].try(:[], 'http_port') || 6081
-        varnish_timeout = Cartodb.config[:varnish_management].try(:[], 'timeout') || 5
-        varnish_critical = Cartodb.config[:varnish_management].try(:[], 'critical') == true ? 1 : 0
-        varnish_retry = Cartodb.config[:varnish_management].try(:[], 'retry') || 5
-        varnish_trigger_verbose = Cartodb.config[:varnish_management].fetch('trigger_verbose', true) == true ? 1 : 0
+        varnish_host = Cartodb.get_config(:varnish_management, 'host') || '127.0.0.1'
+        varnish_port = Cartodb.get_config(:varnish_management, 'http_port') || 6081
+        varnish_timeout = Cartodb.get_config(:varnish_management, 'timeout') || 5
+        varnish_critical = Cartodb.get_config(:varnish_management, 'critical') == true ? 1 : 0
+        varnish_retry = Cartodb.get_config(:varnish_management, 'retry') || 5
+        varnish_trigger_verbose = Cartodb.get_config(:varnish_management).fetch('trigger_verbose', true) == true ? 1 : 0
 
         # PG12_DEPRECATED remove support for python 2
         @user.in_database(as: :superuser).run(
@@ -1576,13 +1573,13 @@ module CartoDB
       def create_function_invalidate_varnish_invalidation_service
         add_python
 
-        invalidation_host = Cartodb.config[:invalidation_service].try(:[], 'host') || '127.0.0.1'
-        invalidation_port = Cartodb.config[:invalidation_service].try(:[], 'port') || 3142
-        invalidation_timeout = Cartodb.config[:invalidation_service].try(:[], 'timeout') || 5
-        invalidation_critical = Cartodb.config[:invalidation_service].try(:[], 'critical') ? 1 : 0
-        invalidation_retry = Cartodb.config[:invalidation_service].try(:[], 'retry') || 5
-        invalidation_trigger_verbose =
-          Cartodb.config[:invalidation_service].fetch('trigger_verbose', true) == true ? 1 : 0
+        invalidation_host = Cartodb.get_config(:invalidation_service, 'host') || '127.0.0.1'
+        invalidation_port = Cartodb.get_config(:invalidation_service, 'port') || 3142
+        invalidation_timeout = Cartodb.get_config(:invalidation_service, 'timeout') || 5
+        invalidation_critical = Cartodb.get_config(:invalidation_service, 'critical') ? 1 : 0
+        invalidation_retry = Cartodb.get_config(:invalidation_service, 'retry') || 5
+        invalidation_trigger_verbose = 
+          Cartodb.get_config(:invalidation_service).fetch('trigger_verbose', true) == true ? 1 : 0
 
         @user.in_database(as: :superuser).run(
           <<-TRIGGER

--- a/app/views/layouts/application_public_visualization_layout.html.erb
+++ b/app/views/layouts/application_public_visualization_layout.html.erb
@@ -15,11 +15,11 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= request.original_url %>" />
     <meta property="og:image" content="<%= yield :facebook_card %>">
-    <% if Cartodb.config[:facebook].present? && Cartodb.config[:facebook]['app_id'].present? %>
-      <meta property="fb:app_id" content="<%= Cartodb.config[:facebook]['app_id'] %>" />
+    <% if Cartodb.get_config(:facebook, 'app_id') %>
+      <meta property="fb:app_id" content="<%= Cartodb.get_config(:facebook, 'app_id') %>" />
     <% end %>
-    <% if Cartodb.config[:facebook].present? && Cartodb.config[:facebook]['admins'].present? %>
-      <meta property="fb:admins" content="<%= Cartodb.config[:facebook]['admins'] %>" />
+    <% if Cartodb.get_config(:facebook, 'admins') %>
+      <meta property="fb:admins" content="<%= Cartodb.get_config(:facebook, 'admins') %>" />
     <% end %>
     <meta property="article:publisher" content="https://www.facebook.com/cartodb" />
     <meta name="twitter:card" content="summary_large_image">

--- a/app/views/layouts/application_table_public.html.erb
+++ b/app/views/layouts/application_table_public.html.erb
@@ -15,11 +15,11 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= request.original_url %>" />
     <meta property="og:image" content="<%= yield :facebook_card %>">
-    <% if Cartodb.config[:facebook].present? && Cartodb.config[:facebook]['app_id'].present? %>
-      <meta property="fb:app_id" content="<%= Cartodb.config[:facebook]['app_id'] %>" />
+    <% if Cartodb.get_config(:facebook, 'app_id') %>
+      <meta property="fb:app_id" content="<%= Cartodb.get_config(:facebook, 'app_id') %>" />
     <% end %>
-    <% if Cartodb.config[:facebook].present? && Cartodb.config[:facebook]['admins'].present? %>
-      <meta property="fb:admins" content="<%= Cartodb.config[:facebook]['admins'] %>" />
+    <% if Cartodb.get_config(:facebook, 'admins') %>
+      <meta property="fb:admins" content="<%= Cartodb.get_config(:facebook, 'admins') %>" />
     <% end %>
     <meta property="article:publisher" content="https://www.facebook.com/cartodb" />
     <meta name="twitter:card" content="summary_large_image">

--- a/app/views/shared/_olark.html.erb
+++ b/app/views/shared/_olark.html.erb
@@ -1,4 +1,4 @@
-<% if Cartodb.config[:olark].present? && Cartodb.config[:olark]["app_id"].present?  %>
+<% if Cartodb.get_config(:olark, 'app_id')  %>
     <script data-cfasync="false" type='text/javascript'>/*<![CDATA[*/window.olark||(function(c){var f=window,d=document,l=f.location.protocol=="https:"?"https:":"http:",z=c.name,r="load";var nt=function(){
     f[z]=function(){
     (a.s=a.s||[]).push(arguments)};var a=f[z]._={
@@ -16,5 +16,5 @@
     b[k]=o+'d.write("'+p().replace(/"/g,String.fromCharCode(92)+'"')+'");d.close();'}a.P(2)};ld()};nt()})({
     loader: "static.olark.com/jsclient/loader0.js",name:"olark",methods:["configure","extend","declare","identify"]});
     /* custom configuration goes here (www.olark.com/documentation) */
-    olark.identify('<%= Cartodb.config[:olark]["app_id"] %>');/*]]>*/</script><noscript><a href="https://www.olark.com/site/9369-171-10-7255/contact" title="Questions?" target="_blank" rel="noopener noreferrer">Questions? Feedback?</a> powered by <a href="http://www.olark.com?welcome" title="Olark live chat software">Olark live chat software</a></noscript>
+    olark.identify('<%= Cartodb.get_config(:olark, 'app_id') %>');/*]]>*/</script><noscript><a href="https://www.olark.com/site/9369-171-10-7255/contact" title="Questions?" target="_blank" rel="noopener noreferrer">Questions? Feedback?</a> powered by <a href="http://www.olark.com?welcome" title="Olark live chat software">Olark live chat software</a></noscript>
 <% end %>

--- a/config/initializers/01_app_config.rb
+++ b/config/initializers/01_app_config.rb
@@ -44,7 +44,7 @@ module Cartodb
         :user_name            => Cartodb.get_config(:mailer, 'user_name'),
         :password             => Cartodb.get_config(:mailer, 'password'),
         :authentication       => Cartodb.get_config(:mailer, 'authentication'),
-        :enable_starttls_auto => Cartodb.get_config(:mailer, 'enable_starttls_auto')] }
+        :enable_starttls_auto => Cartodb.get_config(:mailer, 'enable_starttls_auto') }
     end
 
     if !@config[:basemaps].present? || @config[:basemaps].count == 0

--- a/config/initializers/01_app_config.rb
+++ b/config/initializers/01_app_config.rb
@@ -39,12 +39,12 @@ module Cartodb
       # AuthSMTP
       CartoDB::Application.config.action_mailer.delivery_method = :smtp
       CartoDB::Application.config.action_mailer.smtp_settings = {
-        :address              => Cartodb.config[:mailer]['address'],
-        :port                 => Cartodb.config[:mailer]['port'],
-        :user_name            => Cartodb.config[:mailer]['user_name'],
-        :password             => Cartodb.config[:mailer]['password'],
-        :authentication       => Cartodb.config[:mailer]['authentication'],
-        :enable_starttls_auto => Cartodb.config[:mailer]['enable_starttls_auto'] }
+        :address              => Cartodb.get_config(:mailer, 'address'),
+        :port                 => Cartodb.get_config(:mailer, 'port'),
+        :user_name            => Cartodb.get_config(:mailer, 'user_name'),
+        :password             => Cartodb.get_config(:mailer, 'password'),
+        :authentication       => Cartodb.get_config(:mailer, 'authentication'),
+        :enable_starttls_auto => Cartodb.get_config(:mailer, 'enable_starttls_auto')] }
     end
 
     if !@config[:basemaps].present? || @config[:basemaps].count == 0
@@ -60,11 +60,8 @@ module Cartodb
 
   def self.asset_path
     return @asset_path if @asset_path
-    if Cartodb.config[:app_assets]
-      @asset_path = Cartodb.config[:app_assets]['asset_host']
-    else
-      @asset_path = nil
-    end
+
+    @asset_path = Cartodb.get_config(:app_assets, 'asset_host')
   end
 
   def self.default_basemap(basemaps = Cartodb.config[:basemaps])

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,8 +1,8 @@
 require 'statsd'
 
 begin
-  Statsd.host = Cartodb.config[:graphite]['host']
-  Statsd.port = Cartodb.config[:graphite]['port']
+  Statsd.host = Cartodb.get_config(:graphite, 'host')
+  Statsd.port = Cartodb.get_config(:graphite, 'port')
 rescue => e
   Rails.logger.info "Ignoring statsd, because there were a error loading the config"
 end

--- a/lib/carto/named_maps/api.rb
+++ b/lib/carto/named_maps/api.rb
@@ -134,21 +134,21 @@ module Carto
       def domain(username)
         return @domain if @domain
 
-        config_domain = Cartodb.config[:tiler]['internal']['domain']
+        config_domain = Cartodb.get_config(:tiler, 'internal', 'domain')
 
         CartoDB.subdomainless_urls? ? config_domain : "#{username}.#{config_domain}"
       end
 
       def port
-        @port ||= Cartodb.config[:tiler]['internal']['port']
+        @port ||= Cartodb.get_config(:tiler, 'internal', 'port')
       end
 
       def protocol
-        @protocol ||= Cartodb.config[:tiler]['internal']['protocol']
+        @protocol ||= Cartodb.get_config(:tiler, 'internal', 'protocol')
       end
 
       def ssl_verifypeer
-        @verifycert ||= Cartodb.config[:tiler]['internal']['verifycert']
+        @verifycert ||= Cartodb.get_config(:tiler, 'internal', 'verifycert')
       end
 
       def ssl_verifyhost
@@ -158,7 +158,7 @@ module Carto
       def host(username)
         return @host if @host
 
-        config_host = Cartodb.config[:tiler]['internal']['host']
+        config_host = Cartodb.get_config(:tiler, 'internal', 'host')
 
         @host ||= config_host.blank? ? domain(username) : config_host
       end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -30,7 +30,7 @@ namespace :cartodb do
                                  .order(:created_at)
                                  .first
 
-    file_upload_helper = CartoDB::FileUpload.new(Cartodb.config[:importer].fetch("uploads_path", nil))
+    file_upload_helper = CartoDB::FileUpload.new(Cartodb.get_config(:importer, 'uploads_path'))
 
     unless data_import_item.nil?
       # be 100% safe in rescue blocks when trying to log the failed id
@@ -50,7 +50,7 @@ namespace :cartodb do
         # Files are temp stored in "/%{uploads_path}/token/basename.ext"
         token = File.basename File.dirname filepath
 
-        file_uri = file_upload_helper.upload_file_to_s3(filepath, filename, token, Cartodb.config[:importer]['s3'])
+        file_uri = file_upload_helper.upload_file_to_s3(filepath, filename, token, Cartodb.get_config(:importer, 's3'))
         begin
           File.delete(filepath)
           folder = filepath.slice(0, filepath.rindex('/')).gsub('..', '')

--- a/lib/tasks/remote_tables_maintenance.rake
+++ b/lib/tasks/remote_tables_maintenance.rake
@@ -138,7 +138,7 @@ namespace :cartodb do
       puts "#{updated_rows} users invalidated"
 
       # Now we try to add the new common-data request to the cache using the common_data user
-      common_data_user = ::User.where(username: Cartodb.get_config(:common_data, 'username').first
+      common_data_user = ::User.where(username: Cartodb.get_config(:common_data, 'username')).first
       if !common_data_user.nil?
         vis_api_url = get_visualizations_api_url
         CartoDB::Visualization::CommonDataService.new.load_common_data_for_user(common_data_user, vis_api_url)

--- a/lib/tasks/remote_tables_maintenance.rake
+++ b/lib/tasks/remote_tables_maintenance.rake
@@ -138,7 +138,7 @@ namespace :cartodb do
       puts "#{updated_rows} users invalidated"
 
       # Now we try to add the new common-data request to the cache using the common_data user
-      common_data_user = ::User.where(username: Cartodb.config[:common_data]["username"]).first
+      common_data_user = ::User.where(username: Cartodb.get_config(:common_data, 'username').first
       if !common_data_user.nil?
         vis_api_url = get_visualizations_api_url
         CartoDB::Visualization::CommonDataService.new.load_common_data_for_user(common_data_user, vis_api_url)

--- a/services/sql-api/sql_api.rb
+++ b/services/sql-api/sql_api.rb
@@ -77,7 +77,7 @@ module CartoDB
     end
 
     def build_base_url(sql_api_config_type)
-      config = ::Cartodb.config[:sql_api][sql_api_config_type.to_s]
+      config = ::Cartodb.get_config(:sql_api, sql_api_config_type.to_s)
       if self.base_url.nil?
         %Q[#{config["protocol"]}://#{username}.#{config["domain"]}#{config["endpoint"]}]
       else

--- a/spec/models/user_part_app_spec.rb
+++ b/spec/models/user_part_app_spec.rb
@@ -53,31 +53,31 @@ describe User do
     end
 
     it "should load a cartodb avatar url if no gravatar associated" do
-      avatar_kind = Cartodb.config[:avatars]['kinds'][0]
-      avatar_color = Cartodb.config[:avatars]['colors'][0]
-      avatar_base_url = Cartodb.config[:avatars]['base_url']
-      Random.any_instance.stubs(:rand).returns(0)
       gravatar_url = %r{gravatar.com}
       Typhoeus.stub(gravatar_url, { method: :get }).and_return(Typhoeus::Response.new(code: 404))
       user1.stubs(:gravatar_enabled?).returns(true)
       user1.avatar_url = nil
       user1.save
       user1.reload_avatar
-      user1.avatar_url.should == "#{avatar_base_url}/avatar_#{avatar_kind}_#{avatar_color}.png"
+      kind_regex = "(#{Cartodb.config[:avatars]['kinds'].join('|')})"
+      color_regex = "(#{Cartodb.config[:avatars]['colors'].join('|')})"
+      expected_url = /#{Cartodb.config[:avatars]['base_url']}\/avatar_#{kind_regex}_#{color_regex}\.png/
+
+      expect(user1.avatar_url).to match(expected_url)
     end
 
     it "should load a cartodb avatar url if gravatar disabled" do
-      avatar_kind = Cartodb.config[:avatars]['kinds'][0]
-      avatar_color = Cartodb.config[:avatars]['colors'][0]
-      avatar_base_url = Cartodb.config[:avatars]['base_url']
-      Random.any_instance.stubs(:rand).returns(0)
       gravatar_url = %r{gravatar.com}
       Typhoeus.stub(gravatar_url, { method: :get }).and_return(Typhoeus::Response.new(code: 200))
       user1.stubs(:gravatar_enabled?).returns(false)
       user1.avatar_url = nil
       user1.save
       user1.reload_avatar
-      user1.avatar_url.should == "#{avatar_base_url}/avatar_#{avatar_kind}_#{avatar_color}.png"
+      kind_regex = "(#{Cartodb.config[:avatars]['kinds'].join('|')})"
+      color_regex = "(#{Cartodb.config[:avatars]['colors'].join('|')})"
+      expected_url = /#{Cartodb.config[:avatars]['base_url']}\/avatar_#{kind_regex}_#{color_regex}\.png/
+
+      expect(user1.avatar_url).to match(expected_url)
     end
 
     it "should load a the user gravatar url" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,13 +87,13 @@ RSpec.configure do |config|
 end
 
 def superadmin_headers
-  http_json_authorization_headers(Cartodb.config[:superadmin]["username"],
-                                  Cartodb.config[:superadmin]["password"])
+  http_json_authorization_headers(Cartodb.get_config(:superadmin, 'username'),
+                                  Cartodb.get_config(:superadmin, 'password'))
 end
 
 def org_metadata_api_headers
-  http_json_authorization_headers(Cartodb.config[:org_metadata_api]["username"],
-                                  Cartodb.config[:org_metadata_api]["password"])
+  http_json_authorization_headers(Cartodb.get_config(:org_metadata_api, 'username'),
+                                  Cartodb.get_config(:org_metadata_api, 'password'))
 end
 
 def http_json_authorization_headers(user, password)


### PR DESCRIPTION
Avoid nested calls navigation on `Cartodb.config` elements and use `Cartodb.get_config` instead, which is safer.

It prevents errors when there is missing configuration and simplifies the code.