### PR TITLE
Disable Ghost Tables trigger for tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,7 @@ RSpec.configure do |config|
       drop_leaked_test_user_databases
     end
 
-    CartoDB::UserModule::DBService.any_instance.stubs(:configure_ghost_table_event_trigger).returns(true)
+    CartoDB::UserModule::DBService.any_instance.stubs(:create_ghost_tables_event_trigger)
   end
 
   config.after(:all) do


### PR DESCRIPTION
This speeds up the execution and hides these annoying messages:
```
INFO:  _CDB_LinkGhostTables() called with username=admin, event_name=ALTER TABLE
WARNING:  Invalidation service configuration not found. Skipping Ghost Tables linking.
```