### PR TITLE
Return certificate files in a zip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem 'resque-metrics',        '0.1.1'
 
 gem 'net-telnet'
 
+gem 'rubyzip',               '>= 2.0.0'
 
 # This is weird. In ruby 2 test-unit is required. We don't know why for sure
 gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -539,6 +539,7 @@ DEPENDENCIES
   rspec-rails (= 2.12.0)
   ruby-prof (= 0.15.1)
   ruby-saml (= 1.4.1)
+  rubyzip (>= 2.0.0)
   selenium-webdriver (>= 2.5.0)
   sequel (~> 4.45.0)
   sequel-rails (~> 1.0.1)

--- a/app/controllers/carto/api/dbdirect_certificates_controller.rb
+++ b/app/controllers/carto/api/dbdirect_certificates_controller.rb
@@ -49,7 +49,13 @@ module Carto
             render_jsonp(result, 201)
           end
           format.zip do
-            send_data(*zip_certificates(result, 201))
+            zip_filename, zip_data = zip_certificates(result)
+            send_data(
+              zip_data,
+              type: "application/zip; charset=binary; header=present",
+              disposition: "attachment; filename=#{zip_filename}",
+              status: 201
+            )
           end
         end
       end
@@ -63,7 +69,7 @@ module Carto
 
       private
 
-      def zip_certificates(result, status)
+      def zip_certificates(result)
         username = @user.username
         dbproxy_host = Cartodb.get_config(:dbdirect, 'pgproxy', 'host')
         dbproxy_port = Cartodb.get_config(:dbdirect, 'pgproxy', 'port')
@@ -88,13 +94,7 @@ module Carto
           'client.crt' => client_crt,
           'server_pa.pem' => server_ca
         )
-
-        [
-          zip_data,
-          type: "application/zip; charset=binary; header=present",
-          disposition: "attachment; filename=#{filename}",
-          status: status
-        ]
+        [ filename, zip_data ]
       end
 
       def generate_readme(readme_params)

--- a/app/controllers/carto/controller_helper.rb
+++ b/app/controllers/carto/controller_helper.rb
@@ -53,6 +53,7 @@ module Carto
       respond_to do |format|
         format.html { render text: message, status: 500 }
         format.json { render json: { errors: message }, status: 500 }
+        format.zip { render text: message, status: 500 }
       end
     end
 

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -779,6 +779,9 @@ defaults: &defaults
       aws_access_key_id: XXXXXXXXXXXX
       aws_secret_key: YYYYYYYYYYY
       aws_region: us-east-1
+    pgproxy:
+      host: 'dbconn.carto.com'
+      port: 5432
 
 development:
   <<: *defaults

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -8,3 +8,4 @@ Mime::Type.register "application/vnd.google-earth.kml+xml", :kmz
 Mime::Type.register "application/octet-stream", :shp #sent as zip
 Mime::Type.register "application/octet-stream", :sql #sent as zip
 Mime::Type.register "image/svg+xml", :svg
+Mime::Type.register "application/zip", :zip

--- a/lib/carto/dbdirect/certificate_manager.rb
+++ b/lib/carto/dbdirect/certificate_manager.rb
@@ -13,7 +13,7 @@ module Carto
 
       attr_reader :config
 
-      def generate_certificateusername(passphrase:, validity_days:, server_ca:)
+      def generate_certificate(username:, passphrase:, validity_days:, server_ca:)
         certificates = nil
         arn = nil
         key = openssl_generate_key(passphrase)

--- a/lib/in_mem_zipper.rb
+++ b/lib/in_mem_zipper.rb
@@ -1,0 +1,28 @@
+require 'zip'
+
+module InMemZipper
+  module_function
+
+  def zip(entries)
+    zipstream = Zip::OutputStream.write_buffer do |zio|
+      entries.each do |name, contents|
+        if contents.present?
+          zio.put_next_entry name
+          zio.write contents
+        end
+      end
+    end
+    zip_data = zipstream.string
+  end
+
+  def unzip(zip_data)
+    fin = StringIO.new(zip_data.force_encoding(Encoding::ASCII_8BIT))
+    entries = {}
+    Zip::InputStream.open(fin) do |fzip|
+      while entry = fzip.get_next_entry
+        entries[entry.name] = fzip.read
+      end
+    end
+    entries
+  end
+end

--- a/spec/requests/carto/api/dbdirect_certificates_controller_spec.rb
+++ b/spec/requests/carto/api/dbdirect_certificates_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper_min'
 require 'support/helpers'
 require 'helpers/feature_flag_helper'
+require 'in_mem_zipper'
 
 class TestCertificateManager
   @crl = []
@@ -265,7 +266,7 @@ describe Carto::Api::DbdirectCertificatesController do
         Cartodb.with_config dbdirect: @config do
           post_json_with_zip_response(dbdirect_certificates_url(format: 'zip'), params) do |response|
             expect(response.status).to eq(201)
-            data = unzip_data(response.body)
+            data = InMemZipper.unzip(response.body)
             expect(data['README.txt']).to eq(%{This is cert_name})
             expect(data['client.key']).to eq(%{key for user00000001_})
             expect(data['client.crt']).to eq(%{crt for user00000001_300_#{@config['certificates']}})

--- a/spec/requests/carto/api/dbdirect_certificates_controller_spec.rb
+++ b/spec/requests/carto/api/dbdirect_certificates_controller_spec.rb
@@ -49,6 +49,10 @@ describe Carto::Api::DbdirectCertificatesController do
         aws_access_key_id: 'the_aws_key',
         aws_secret_key: 'the_aws_secret',
         aws_region: 'the_aws_region'
+      },
+      pgproxy: {
+        host: 'the-pgproxy-host',
+        port: 9876
       }
     }.with_indifferent_access
   end
@@ -244,6 +248,23 @@ describe Carto::Api::DbdirectCertificatesController do
             expect(cert.user.id).to eq @user1.id
             expect(cert.name).to eq 'cert_name'
             expect(cert.arn).to eq %{arn for user00000001_200_#{@config['certificates']}}
+          end
+        end
+      end
+    end
+
+    it 'downloads zipped certificates' do
+      params = {
+        name: 'cert_name',
+        api_key: @user1.api_key
+      }
+      with_feature_flag @user1, 'dbdirect', true do
+        Cartodb.with_config dbdirect: @config do
+          post_json_with_zip_response api_v1_dbdirect_certificates_create_url(params.merge(format: 'zip')) do |response|
+            expect(response.status).to eq(201)
+            # TODO:
+            # response.body contains expected zip payload
+            # response.headers["Content-Disposition"] matches: "attachment; filename=#{EXPECTED_FILENAME}"
           end
         end
       end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -65,6 +65,17 @@ module HelperMethods
     ) if block_given?
   end
 
+  def post_json_with_zip_response(path, params = {}, headers = http_json_headers)
+    headers = headers.merge("CONTENT_TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/zip')
+    post path, JSON.dump(params), headers
+    the_response = response || get_last_response
+    yield OpenStruct.new(
+      body: the_response.body,
+      status: the_response.status,
+      headers: the_response.headers
+    ) if block_given?
+  end
+
   def delete_json(path, params = {}, headers = http_json_headers)
     headers = headers.merge("CONTENT_TYPE" => "application/json", 'HTTP_ACCEPT' => 'application/json')
     delete path, JSON.dump(params), headers

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -131,15 +131,4 @@ module HelperMethods
       locked:             attributes.fetch(:locked, false)
     }
   end
-
-  def unzip_data(data)
-    fin = StringIO.new(data.force_encoding(Encoding::ASCII_8BIT))
-    entries = {}
-    Zip::InputStream.open(fin) do |fzip|
-      while entry = fzip.get_next_entry
-        entries[entry.name] = fzip.read
-      end
-    end
-    entries
-  end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -131,4 +131,15 @@ module HelperMethods
       locked:             attributes.fetch(:locked, false)
     }
   end
+
+  def unzip_data(data)
+    fin = StringIO.new(data.force_encoding(Encoding::ASCII_8BIT))
+    entries = {}
+    Zip::InputStream.open(fin) do |fzip|
+      while entry = fzip.get_next_entry
+        entries[entry.name] = fzip.read
+      end
+    end
+    entries
+  end
 end


### PR DESCRIPTION
And include also: a README with usage instructions, including the pgproxy address to connect to.

I'm implementing this as another format of the certificate generation endpoint.
When the format is zip it returns the artifacts in a zipped file. The filename (as per the `Content-Disposition` header may include the certificate name and id, which could also appear in the README).

Another alternative, could be to add a zipped parameter and include the zipped contents (base64?) in the JSON response.

- [x] Tests
- [x] Controller support for the new format
- [x] Zip contents on-the-fly (use rubyzip gem?)
- [x] README template (should it be just another view template?)
- [ ] Use zipped format in rake task to generate certificates