### PR TITLE
Fixes bug in CartoDB Central communication: ruby's JSON parser parser…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ Development
 - Hooks to override org settings for gear plugin ([#15126](https://github.com/CartoDB/cartodb/pull/15126))
 
 ### Bug fixes / enhancements
+- Fixes bug in CartoDB Central communication ([#15606](https://github.com/CartoDB/cartodb/pull/15606))
 - Fix invalid connector IPs information
 - Fix wording for feedback
 - Use visualization user google api key when present ([#2394](https://github.com/CartoDB/support/issues/2394))

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -36,7 +36,7 @@ module Cartodb
       http_client.request(
         "#{@host}/#{path}",
         method: method,
-        body: body.to_json,
+        body: body.nil? ? nil: body.to_json,
         userpwd: "#{@auth[:username]}:#{@auth[:password]}",
         headers: { "Content-Type" => "application/json" },
         ssl_verifypeer: Rails.env.production?,


### PR DESCRIPTION
Fixes bug in CartoDB Central communication: ruby's JSON parser parser nil into a simple "null" string, which is invalid (incomplete) JSON

```
irb(main):001:0> require 'json'
=> true
irb(main):002:0> body = nil
=> nil
irb(main):003:0> body.to_json
=> "null"
```