### PR TITLE
Deprecate UUIDTools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ gem 'google-cloud-pubsub', '1.2.0'
 
 # Service components (/services)
 gem 'virtus',                   '1.0.5'
-gem 'uuidtools',                '2.1.5'
 gem 'cartodb-common',           git: 'https://github.com/cartodb/cartodb-common.git', branch: 'master'
 gem 'email_address',            '~> 0.1.11'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,7 +447,6 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
-    uuidtools (2.1.5)
     values (1.8.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -547,7 +546,6 @@ DEPENDENCIES
   typhoeus (= 1.3.1)
   unicorn (= 4.8.2)
   unicorn-worker-killer
-  uuidtools (= 2.1.5)
   values (= 1.8.0)
   virtus (= 1.0.5)
   webrick (= 1.3.1)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -1,4 +1,3 @@
-require 'uuidtools'
 require 'carto/importer/table_setup'
 
 require_relative '../models/visualization/support_tables'

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -271,7 +271,7 @@ module CartoDB
       def rename_the_geom_index_if_exists(current_name, new_name, schema)
         database.execute(%Q{
           ALTER INDEX IF EXISTS "#{schema}"."#{current_name}_geom_idx"
-          RENAME TO "the_geom_#{UUIDTools::UUID.timestamp_create.to_s.gsub('-', '_')}"
+          RENAME TO "the_geom_#{SecureRandom.uuid.gsub('-', '_')}"
         })
       rescue => exception
         log("Silently failed rename_the_geom_index_if_exists from " +

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -270,7 +270,7 @@ module CartoDB
       def rename_the_geom_index_if_exists(current_name, new_name, schema)
         database.execute(%Q{
           ALTER INDEX IF EXISTS "#{schema}"."#{current_name}_geom_idx"
-          RENAME TO "the_geom_#{SecureRandom.uuid.gsub('-', '_')}"
+          RENAME TO "the_geom_#{Carto::UUIDHelper.random_uuid.gsub('-', '_')}"
         })
       rescue => exception
         log("Silently failed rename_the_geom_index_if_exists from " +

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -10,10 +10,12 @@ require_dependency 'resque/user_jobs'
 require_dependency 'static_maps_url_helper'
 require_dependency 'carto/helpers/frame_options_helper'
 require_dependency 'carto/visualization'
+require_dependency 'carto/uuidhelper'
 
 class Admin::VisualizationsController < Admin::AdminController
   include CartoDB, VisualizationsControllerHelper
   include Carto::FrameOptionsHelper
+  include Carto::UUIDHelper
 
   MAX_MORE_VISUALIZATIONS = 3
   DEFAULT_PLACEHOLDER_CHARS = 4
@@ -616,11 +618,6 @@ class Admin::VisualizationsController < Admin::AdminController
     return nil, nil if user_table.nil?
     visualization = user_table.visualization
     return Carto::Admin::VisualizationPublicMapAdapter.new(visualization, current_user, self), visualization.table_service
-  end
-
-  # TODO: remove this method and use  app/helpers/carto/uuidhelper.rb. Not used yet because this changed was pushed before
-  def is_uuid?(text)
-    !(Regexp.new(%r{\A#{UUIDTools::UUID_REGEXP}\Z}) =~ text).nil?
   end
 
   def sql_api_url(query, user)

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -613,7 +613,7 @@ class Admin::VisualizationsController < Admin::AdminController
   end
 
   def get_visualization_and_table_from_table_id(table_id)
-    return nil, nil if !is_uuid?(table_id)
+    return nil, nil if !uuid?(table_id)
     user_table = Carto::UserTable.where({ id: table_id }).first
     return nil, nil if user_table.nil?
     visualization = user_table.visualization

--- a/app/controllers/carto/api/analyses_controller.rb
+++ b/app/controllers/carto/api/analyses_controller.rb
@@ -141,7 +141,7 @@ module Carto
         end
 
         unless params[:id].nil?
-          @analysis = Carto::Analysis.where(id: params[:id]).first if is_uuid?(params[:id])
+          @analysis = Carto::Analysis.where(id: params[:id]).first if uuid?(params[:id])
 
           if @analysis.nil?
             @analysis = Carto::Analysis.find_by_natural_id(@visualization.id, params[:id])

--- a/app/controllers/carto/api/oembed_controller.rb
+++ b/app/controllers/carto/api/oembed_controller.rb
@@ -151,8 +151,7 @@ module Carto
       end
 
       def extract_uuid_from_string(str)
-        # TODO: move this method to  app/helpers/carto/uuidhelper.rb. Not used yet because this changed was pushed before
-        # UUIDTools::UUID_REGEXP cannot be reused because of /^ $/
+        # Carto::UUIDHelper::UUID_REGEXP cannot be reused because of /^ $/
         matches = /([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})/.match(str)
         if matches
           matches[0]

--- a/app/controllers/carto/controller_helper.rb
+++ b/app/controllers/carto/controller_helper.rb
@@ -7,7 +7,7 @@ module Carto
 
     def uuid_parameter(parameter)
       param = params[parameter]
-      if is_uuid?(param)
+      if uuid?(param)
         param
       else
         raise Carto::UUIDParameterFormatError.new(parameter: parameter, value: param)

--- a/app/controllers/superadmin/users_controller.rb
+++ b/app/controllers/superadmin/users_controller.rb
@@ -204,7 +204,7 @@ class Superadmin::UsersController < Superadmin::SuperadminController
   def get_user
     id = params[:id]
 
-    @user = if is_uuid?(id)
+    @user = if uuid?(id)
               ::User[params[:id]]
             else
               ::User.where(username: id).first

--- a/app/controllers/visualizations_controller_helper.rb
+++ b/app/controllers/visualizations_controller_helper.rb
@@ -14,7 +14,7 @@ module VisualizationsControllerHelper
     def initialize(visualization_locator_string, force_name: false)
       table_id_or_name, @schema = visualization_locator_string.split('.').reverse
 
-      if !force_name && is_uuid?(table_id_or_name)
+      if !force_name && uuid?(table_id_or_name)
         @id = table_id_or_name
       else
         @name = table_id_or_name

--- a/app/helpers/organization_users_helper.rb
+++ b/app/helpers/organization_users_helper.rb
@@ -6,7 +6,7 @@ module OrganizationUsersHelper
   def load_organization
     id_or_name = params[:id_or_name]
 
-    @organization = ::Organization.where(is_uuid?(id_or_name) ? { id: id_or_name } : { name: id_or_name }).first
+    @organization = ::Organization.where(uuid?(id_or_name) ? { id: id_or_name } : { name: id_or_name }).first
 
     unless @organization
       render_jsonp({}, 401) # Not giving clues to guessers via 404

--- a/app/models/carto/oauth_access_token.rb
+++ b/app/models/carto/oauth_access_token.rb
@@ -43,7 +43,7 @@ module Carto
       end
 
       self.api_key = oauth_app_user.user.api_keys.create_oauth_key!(
-        name: "oauth_authorization #{SecureRandom.uuid}",
+        name: "oauth_authorization #{Carto::UUIDHelper.random_uuid}",
         grants: grants,
         ownership_role_name: ownership_role_name
       )

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -1,6 +1,5 @@
 require 'sequel'
 require 'fileutils'
-require 'uuidtools'
 require_relative './user'
 require_relative './table'
 require_relative './log'

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -30,12 +30,14 @@ require_dependency 'carto/tracking/events'
 require_dependency 'carto/valid_table_name_proposer'
 require_dependency 'carto/configuration'
 require_dependency 'carto/db/user_schema'
+require_dependency 'carto/uuidhelper'
 
 include CartoDB::Datasources
 
 class DataImport < Sequel::Model
   include Carto::DataImportConstants
   include Carto::Configuration
+  include Carto::UUIDHelper
 
   MERGE_WITH_UNMATCHING_COLUMN_TYPES_RE = /No .*matches.*argument type.*/
   DIRECT_STATEMENT_TIMEOUT = 1.hour * 1000
@@ -449,14 +451,6 @@ class DataImport < Sequel::Model
     "https://#{current_user.username}.carto.com/#{uploaded_file[0]}"
   end
 
-  def valid_uuid?(text)
-    !!UUIDTools::UUID.parse(text)
-  rescue TypeError
-    false
-  rescue ArgumentError
-    false
-  end
-
   def before_destroy
     self.remove_uploaded_resources
   end
@@ -464,7 +458,7 @@ class DataImport < Sequel::Model
   def instantiate_log
     uuid = logger
 
-    if valid_uuid?(uuid)
+    if is_uuid?(uuid)
       self.log = CartoDB::Log.where(id: uuid.to_s).first
     else
       self.log = CartoDB::Log.new(

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -457,7 +457,7 @@ class DataImport < Sequel::Model
   def instantiate_log
     uuid = logger
 
-    if is_uuid?(uuid)
+    if uuid?(uuid)
       self.log = CartoDB::Log.where(id: uuid.to_s).first
     else
       self.log = CartoDB::Log.new(

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -536,14 +536,6 @@ module CartoDB
         @log = CartoDB::Log.where(log_attributes).first
       end
 
-      def valid_uuid?(text)
-        !!UUIDTools::UUID.parse(text)
-      rescue TypeError
-        false
-      rescue ArgumentError
-        false
-      end
-
       def get_datasource(datasource_name)
         begin
           datasource = DatasourcesFactory.get_datasource(datasource_name, user, {

--- a/app/models/visualization/locator.rb
+++ b/app/models/visualization/locator.rb
@@ -2,11 +2,13 @@ require_relative '../visualization'
 require_relative './member'
 require_relative '../user'
 require_relative '../table'
-require 'uuidtools'
+
+require_dependency 'carto/uuidhelper'
 
 module CartoDB
   module Visualization
     class Locator
+      include Carto::UUIDHelper
 
       def initialize(user_model=nil)
         @user_model   = user_model  || ::User
@@ -46,13 +48,9 @@ module CartoDB
       rescue
         false
       end
-        
+
       def get_by_id(uuid, filters)
-        begin
-          ::UUIDTools::UUID.parse(uuid)
-        rescue ArgumentError
-          return nil
-        end
+        return nil unless is_uuid?(uuid)
 
         params = {
           id: uuid

--- a/app/models/visualization/locator.rb
+++ b/app/models/visualization/locator.rb
@@ -50,7 +50,7 @@ module CartoDB
       end
 
       def get_by_id(uuid, filters)
-        return nil unless is_uuid?(uuid)
+        return nil unless uuid?(uuid)
 
         params = {
           id: uuid

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -59,7 +59,7 @@ class Carto::VisualizationQueryBuilder
   def with_id_or_name(id_or_name)
     raise 'VisualizationQueryBuilder: id or name supplied is nil' if id_or_name.nil?
 
-    if is_uuid?(id_or_name)
+    if uuid?(id_or_name)
       with_id(id_or_name)
     else
       with_name(id_or_name)

--- a/app/services/carto/data_imports_service.rb
+++ b/app/services/carto/data_imports_service.rb
@@ -27,7 +27,7 @@ module Carto
     end
 
     def process_by_id(id)
-      return nil if !is_uuid?(id)
+      return nil if !uuid?(id)
 
       import = Carto::DataImport.where(id: id).first
 

--- a/app/services/carto/visualizations_export_persistence_service.rb
+++ b/app/services/carto/visualizations_export_persistence_service.rb
@@ -1,4 +1,3 @@
-require 'uuidtools'
 require_dependency 'carto/uuidhelper'
 require_dependency 'carto/query_rewriter'
 

--- a/lib/carto/http_header_authentication.rb
+++ b/lib/carto/http_header_authentication.rb
@@ -65,7 +65,7 @@ module Carto
 
       if value.include?('@')
         'email'
-      elsif is_uuid?(value)
+      elsif uuid?(value)
         'id'
       else
         'username'

--- a/lib/carto/uuidhelper.rb
+++ b/lib/carto/uuidhelper.rb
@@ -4,7 +4,7 @@ module Carto
 
     UUID_REGEXP = Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})$")
 
-    def is_uuid?(text)
+    def uuid?(text)
       !(Regexp.new(%r{\A#{UUID_REGEXP}\Z}) =~ text).nil?
     end
 

--- a/lib/carto/uuidhelper.rb
+++ b/lib/carto/uuidhelper.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module Carto
   module UUIDHelper
     module_function

--- a/lib/carto/uuidhelper.rb
+++ b/lib/carto/uuidhelper.rb
@@ -1,15 +1,13 @@
-require 'uuidtools'
-
 module Carto
   module UUIDHelper
+    UUID_REGEXP = Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})$")
 
     def is_uuid?(text)
-      !(Regexp.new(%r{\A#{UUIDTools::UUID_REGEXP}\Z}) =~ text).nil?
+      !(Regexp.new(%r{\A#{UUID_REGEXP}\Z}) =~ text).nil?
     end
 
     def random_uuid
-      UUIDTools::UUID.random_create.to_s
+      SecureRandom.uuid
     end
-
   end
 end

--- a/lib/carto/uuidhelper.rb
+++ b/lib/carto/uuidhelper.rb
@@ -1,5 +1,7 @@
 module Carto
   module UUIDHelper
+    module_function
+
     UUID_REGEXP = Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})$")
 
     def is_uuid?(text)

--- a/lib/cartodb/trending_maps.rb
+++ b/lib/cartodb/trending_maps.rb
@@ -1,7 +1,8 @@
-require 'uuidtools'
+require_dependency 'carto/uuidhelper'
 
 module CartoDB
   class TrendingMaps
+    include Carto::UUIDHelper
 
     # The ratio for this sequence is 2
     GEOMETRIC_SEQUENCE_BASE = 500
@@ -17,7 +18,7 @@ module CartoDB
         key_parts = key.split(':')
         username = key_parts[1]
         visualization_id = key_parts[4]
-        next unless valid_uuid?(visualization_id)
+        next unless is_uuid?(visualization_id)
         yesterday_mapviews = stats_manager.get_api_calls_from_redis(
           username,
           from: date,
@@ -31,13 +32,6 @@ module CartoDB
         end
       end
       trending_maps
-    end
-
-    def valid_uuid?(visualization_id)
-      UUIDTools::UUID.parse(visualization_id)
-      true
-    rescue ArgumentError
-      false
     end
 
     def build_trending_map(visualization_id, username, total_mapviews)

--- a/lib/cartodb/trending_maps.rb
+++ b/lib/cartodb/trending_maps.rb
@@ -18,7 +18,7 @@ module CartoDB
         key_parts = key.split(':')
         username = key_parts[1]
         visualization_id = key_parts[4]
-        next unless is_uuid?(visualization_id)
+        next unless uuid?(visualization_id)
         yesterday_mapviews = stats_manager.get_api_calls_from_redis(
           username,
           from: date,

--- a/lib/tasks/acceptance/ghost_tables.rake
+++ b/lib/tasks/acceptance/ghost_tables.rake
@@ -1,5 +1,3 @@
-require 'uuidtools'
-
 namespace :cartodb do
   namespace :acceptance do
 

--- a/lib/tasks/connectors_api.rake
+++ b/lib/tasks/connectors_api.rake
@@ -17,7 +17,7 @@ namespace :cartodb do
 
     def find_by_uuid_or_name(id_or_name, klass, name_attribute = :name)
       include Carto::UUIDHelper
-      if is_uuid?(id_or_name)
+      if uuid?(id_or_name)
         klass.find(id_or_name)
       else
         klass.where(name_attribute => id_or_name).first

--- a/services/data-repository/backend/sequel.rb
+++ b/services/data-repository/backend/sequel.rb
@@ -37,7 +37,7 @@ module DataRepository
       end
 
       def next_id
-        UUIDTools::UUID.timestamp_create
+        SecureRandom.uuid
       end
 
       def apply_filters(dataset, filters={}, available_filters=[])

--- a/services/data-repository/backend/sequel.rb
+++ b/services/data-repository/backend/sequel.rb
@@ -1,5 +1,4 @@
 require 'sequel'
-require 'uuidtools'
 
 module DataRepository
   module Backend

--- a/services/data-repository/backend/sequel.rb
+++ b/services/data-repository/backend/sequel.rb
@@ -36,7 +36,7 @@ module DataRepository
       end
 
       def next_id
-        SecureRandom.uuid
+        Carto::UUIDHelper.random_uuid
       end
 
       def apply_filters(dataset, filters={}, available_filters=[])

--- a/services/data-repository/repository.rb
+++ b/services/data-repository/repository.rb
@@ -38,7 +38,7 @@ module DataRepository
     end
 
     def next_id
-      UUIDTools::UUID.timestamp_create     
+      SecureRandom.uuid     
     end
 
     private

--- a/services/data-repository/repository.rb
+++ b/services/data-repository/repository.rb
@@ -1,4 +1,3 @@
-require 'uuidtools'
 require_relative 'backend/detector'
 require_relative 'backend/memory'
 
@@ -38,7 +37,7 @@ module DataRepository
     end
 
     def next_id
-      SecureRandom.uuid     
+      SecureRandom.uuid
     end
 
     private

--- a/services/data-repository/repository.rb
+++ b/services/data-repository/repository.rb
@@ -37,7 +37,7 @@ module DataRepository
     end
 
     def next_id
-      SecureRandom.uuid
+      Carto::UUIDHelper.random_uuid
     end
 
     private

--- a/services/importer/lib/importer/job.rb
+++ b/services/importer/lib/importer/job.rb
@@ -1,6 +1,5 @@
 require 'pg'
 require 'sequel'
-require 'uuidtools'
 
 module CartoDB
   module Importer2

--- a/services/importer/lib/importer/job.rb
+++ b/services/importer/lib/importer/job.rb
@@ -9,7 +9,7 @@ module CartoDB
       DEFAULT_IMPORT_SCHEMA = 'cdb_importer'
 
       def initialize(attributes={})
-        @id         = attributes.fetch(:id, UUIDTools::UUID.timestamp_create.to_s)
+        @id         = attributes.fetch(:id, SecureRandom.uuid)
         @logger     = attributes.fetch(:logger, nil)
         # Avoid calling new_logger (and thus, requiring CartoDB::Log) if param comes
         @logger     = new_logger if @logger.nil?

--- a/services/importer/lib/importer/job.rb
+++ b/services/importer/lib/importer/job.rb
@@ -8,7 +8,7 @@ module CartoDB
       DEFAULT_IMPORT_SCHEMA = 'cdb_importer'
 
       def initialize(attributes={})
-        @id         = attributes.fetch(:id, SecureRandom.uuid)
+        @id         = attributes.fetch(:id, Carto::UUIDHelper.random_uuid)
         @logger     = attributes.fetch(:logger, nil)
         # Avoid calling new_logger (and thus, requiring CartoDB::Log) if param comes
         @logger     = new_logger if @logger.nil?

--- a/services/platform-limits/spec/unit/input_file_size_spec.rb
+++ b/services/platform-limits/spec/unit/input_file_size_spec.rb
@@ -1,7 +1,5 @@
 require_relative '../../platform_limits'
-
 require_relative '../doubles/user'
-require 'uuidtools'
 
 include CartoDB::PlatformLimits
 

--- a/services/table-geocoder/lib/table_geocoder.rb
+++ b/services/table-geocoder/lib/table_geocoder.rb
@@ -188,7 +188,7 @@ module CartoDB
     end
 
     def temp_table_name
-      @temp_table_name ||= "#{@schema}.geo_#{SecureRandom.uuid.gsub('-', '')}"
+      @temp_table_name ||= "#{@schema}.geo_#{Carto::UUIDHelper.random_uuid.gsub('-', '')}"
     end
 
     def deflated_results_path

--- a/services/table-geocoder/lib/table_geocoder.rb
+++ b/services/table-geocoder/lib/table_geocoder.rb
@@ -1,4 +1,3 @@
-require 'uuidtools'
 require_relative '../../geocoder/lib/hires_geocoder_factory'
 require_relative '../../geocoder/lib/geocoder_config'
 require_relative 'geocoder_cache'

--- a/services/table-geocoder/lib/table_geocoder.rb
+++ b/services/table-geocoder/lib/table_geocoder.rb
@@ -189,7 +189,7 @@ module CartoDB
     end
 
     def temp_table_name
-      @temp_table_name ||= "#{@schema}.geo_#{UUIDTools::UUID.timestamp_create.to_s.gsub('-', '')}"
+      @temp_table_name ||= "#{@schema}.geo_#{SecureRandom.uuid.gsub('-', '')}"
     end
 
     def deflated_results_path

--- a/services/user-mover/export_user.rb
+++ b/services/user-mover/export_user.rb
@@ -510,7 +510,7 @@ module CartoDB
         @logger = options[:logger] || default_logger
         @@exportjob_logger = options[:export_job_logger]
 
-        job_uuid = @options[:job_uuid] || SecureRandom.uuid
+        job_uuid = @options[:job_uuid] || Carto::UUIDHelper.random_uuid
         export_log = { job_uuid:     job_uuid,
                        id:           @options[:id] || @options[:organization_name] || nil,
                        type:         'export',

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -37,7 +37,7 @@ module CartoDB
 
         @path = File.expand_path(File.dirname(@options[:file])) + "/"
 
-        job_uuid = @options[:job_uuid] || SecureRandom.uuid
+        job_uuid = @options[:job_uuid] || Carto::UUIDHelper.random_uuid
         @import_log = { job_uuid:     job_uuid,
                         id:           nil,
                         type:         'import',

--- a/spec/connectors/importer_spec.rb
+++ b/spec/connectors/importer_spec.rb
@@ -39,7 +39,7 @@ describe CartoDB::Connector::Importer do
     runner.stubs(:log).returns(log)
     log.expects(:append).at_least(0)
     quota_checker = mock
-    id = SecureRandom.uuid
+    id = Carto::UUIDHelper.random_uuid
     destination_schema = 'public'
 
     database = mock
@@ -54,7 +54,7 @@ describe CartoDB::Connector::Importer do
     table_registrar = mock
     table_registrar.stubs(:user).returns(@user)
 
-    importer_table_name = "table_#{SecureRandom.uuid}"
+    importer_table_name = "table_#{Carto::UUIDHelper.random_uuid}"
     desired_table_name = 'european_countries'
 
     result_mock = CartoDB::Doubles::Importer2::Result.new({table_name: importer_table_name, name: desired_table_name})

--- a/spec/connectors/importer_spec.rb
+++ b/spec/connectors/importer_spec.rb
@@ -39,7 +39,7 @@ describe CartoDB::Connector::Importer do
     runner.stubs(:log).returns(log)
     log.expects(:append).at_least(0)
     quota_checker = mock
-    id = UUIDTools::UUID.timestamp_create.to_s
+    id = SecureRandom.uuid
     destination_schema = 'public'
 
     database = mock
@@ -54,7 +54,7 @@ describe CartoDB::Connector::Importer do
     table_registrar = mock
     table_registrar.stubs(:user).returns(@user)
 
-    importer_table_name = "table_#{UUIDTools::UUID.timestamp_create.to_s}"
+    importer_table_name = "table_#{SecureRandom.uuid}"
     desired_table_name = 'european_countries'
 
     result_mock = CartoDB::Doubles::Importer2::Result.new({table_name: importer_table_name, name: desired_table_name})

--- a/spec/factories/mobile_apps.rb
+++ b/spec/factories/mobile_apps.rb
@@ -7,7 +7,7 @@ include UniqueNamesHelper
 FactoryGirl.define do
 
   factory :mobile_app, class: Carto::MobileApp do
-    id UUIDTools::UUID.timestamp_create.to_s
+    id SecureRandom.uuid
     name 'MyApp'
     description 'My app description'
     icon_url 'example.com/icon_url'

--- a/spec/factories/mobile_apps.rb
+++ b/spec/factories/mobile_apps.rb
@@ -7,7 +7,7 @@ include UniqueNamesHelper
 FactoryGirl.define do
 
   factory :mobile_app, class: Carto::MobileApp do
-    id SecureRandom.uuid
+    id Carto::UUIDHelper.random_uuid
     name 'MyApp'
     description 'My app description'
     icon_url 'example.com/icon_url'

--- a/spec/factories/synchronizations.rb
+++ b/spec/factories/synchronizations.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :carto_synchronization, class: Carto::Synchronization do
-    id { UUIDTools::UUID.random_uuid }
+    id { SecureRandom.uuid }
     name 'histcounties_1979_present'
     interval 2592000
     url 'https://common-data.cartodb.com/api/v2/sql?q=select+*+from+%22histcounties_1979_present%22&format=shp&filename=histcounties_1979_present'

--- a/spec/factories/synchronizations.rb
+++ b/spec/factories/synchronizations.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :carto_synchronization, class: Carto::Synchronization do
-    id { SecureRandom.uuid }
+    id { Carto::UUIDHelper.random_uuid }
     name 'histcounties_1979_present'
     interval 2592000
     url 'https://common-data.cartodb.com/api/v2/sql?q=select+*+from+%22histcounties_1979_present%22&format=shp&filename=histcounties_1979_present'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
     password_confirmation  { email.split('@').first }
     table_quota            5
     quota_in_bytes         5000000
-    id                     { SecureRandom.uuid }
+    id                     { Carto::UUIDHelper.random_uuid }
     builder_enabled        nil # Most tests still assume editor
 
     trait :admin_privileges do
@@ -84,7 +84,7 @@ FactoryGirl.define do
     api_key '21ee521b8a107ea55d61fd7b485dd93d54c0b9d2'
     table_quota nil
     quota_in_bytes 5000000
-    id { SecureRandom.uuid }
+    id { Carto::UUIDHelper.random_uuid }
     builder_enabled nil # Most tests still assume editor
 
     before(:build) do |carto_user|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
     password_confirmation  { email.split('@').first }
     table_quota            5
     quota_in_bytes         5000000
-    id                     { UUIDTools::UUID.timestamp_create.to_s }
+    id                     { SecureRandom.uuid }
     builder_enabled        nil # Most tests still assume editor
 
     trait :admin_privileges do
@@ -84,7 +84,7 @@ FactoryGirl.define do
     api_key '21ee521b8a107ea55d61fd7b485dd93d54c0b9d2'
     table_quota nil
     quota_in_bytes 5000000
-    id { UUIDTools::UUID.timestamp_create.to_s }
+    id { SecureRandom.uuid }
     builder_enabled nil # Most tests still assume editor
 
     before(:build) do |carto_user|

--- a/spec/factories/visualization_exports.rb
+++ b/spec/factories/visualization_exports.rb
@@ -2,7 +2,7 @@ require_relative '../../app/models/carto/visualization_export'
 
 FactoryGirl.define do
   factory :visualization_export, class: Carto::VisualizationExport do
-    id { UUIDTools::UUID.timestamp_create.to_s }
+    id { SecureRandom.uuid }
     state Carto::VisualizationExport::STATE_PENDING
     file { "#{Cartodb.get_config(:exporter, "uploads_path")}/abcd/Untitled Map (on 2016-05-26 at 06.08.15).carto" }
     url { "/api/v3/visualization_exports/#{id}/download" }

--- a/spec/factories/visualization_exports.rb
+++ b/spec/factories/visualization_exports.rb
@@ -2,7 +2,7 @@ require_relative '../../app/models/carto/visualization_export'
 
 FactoryGirl.define do
   factory :visualization_export, class: Carto::VisualizationExport do
-    id { SecureRandom.uuid }
+    id { Carto::UUIDHelper.random_uuid }
     state Carto::VisualizationExport::STATE_PENDING
     file { "#{Cartodb.get_config(:exporter, "uploads_path")}/abcd/Untitled Map (on 2016-05-26 at 06.08.15).carto" }
     url { "/api/v3/visualization_exports/#{id}/download" }

--- a/spec/factories/visualizations.rb
+++ b/spec/factories/visualizations.rb
@@ -1,4 +1,3 @@
-require 'uuidtools'
 require_dependency 'carto/uuidhelper'
 
 include Carto::UUIDHelper

--- a/spec/helpers/uuidhelper_spec.rb
+++ b/spec/helpers/uuidhelper_spec.rb
@@ -13,27 +13,27 @@ describe 'UUIDHelper' do
   end
 
   it 'validates a valid UUID' do
-    @uuid_helper.is_uuid?('5b632a9e-ae07-11e4-ac8d-080027880ca6').should be(true)
+    @uuid_helper.uuid?('5b632a9e-ae07-11e4-ac8d-080027880ca6').should be(true)
   end
 
   it 'validates a random UUID' do
-    @uuid_helper.is_uuid?(Carto::UUIDHelper.random_uuid).should be(true)
+    @uuid_helper.uuid?(Carto::UUIDHelper.random_uuid).should be(true)
   end
 
   it 'fails if content prepended' do
-    @uuid_helper.is_uuid?("hi" + Carto::UUIDHelper.random_uuid).should be(false)
+    @uuid_helper.uuid?("hi" + Carto::UUIDHelper.random_uuid).should be(false)
   end
 
   it 'fails if content appended' do
-    @uuid_helper.is_uuid?(Carto::UUIDHelper.random_uuid + "hola").should be(false)
+    @uuid_helper.uuid?(Carto::UUIDHelper.random_uuid + "hola").should be(false)
   end
 
   it 'fails if content prepended with newlines' do
-    @uuid_helper.is_uuid?("hi\n" + Carto::UUIDHelper.random_uuid).should be(false)
+    @uuid_helper.uuid?("hi\n" + Carto::UUIDHelper.random_uuid).should be(false)
   end
 
   it 'fails if content appended with newlines' do
-    @uuid_helper.is_uuid?(Carto::UUIDHelper.random_uuid + "\nhola").should be(false)
+    @uuid_helper.uuid?(Carto::UUIDHelper.random_uuid + "\nhola").should be(false)
   end
 
 end

--- a/spec/helpers/uuidhelper_spec.rb
+++ b/spec/helpers/uuidhelper_spec.rb
@@ -17,23 +17,23 @@ describe 'UUIDHelper' do
   end
 
   it 'validates a random UUID' do
-    @uuid_helper.is_uuid?(SecureRandom.uuid).should be(true)
+    @uuid_helper.is_uuid?(Carto::UUIDHelper.random_uuid).should be(true)
   end
 
   it 'fails if content prepended' do
-    @uuid_helper.is_uuid?("hi" + SecureRandom.uuid).should be(false)
+    @uuid_helper.is_uuid?("hi" + Carto::UUIDHelper.random_uuid).should be(false)
   end
 
   it 'fails if content appended' do
-    @uuid_helper.is_uuid?(SecureRandom.uuid + "hola").should be(false)
+    @uuid_helper.is_uuid?(Carto::UUIDHelper.random_uuid + "hola").should be(false)
   end
 
   it 'fails if content prepended with newlines' do
-    @uuid_helper.is_uuid?("hi\n" + SecureRandom.uuid).should be(false)
+    @uuid_helper.is_uuid?("hi\n" + Carto::UUIDHelper.random_uuid).should be(false)
   end
 
   it 'fails if content appended with newlines' do
-    @uuid_helper.is_uuid?(SecureRandom.uuid + "\nhola").should be(false)
+    @uuid_helper.is_uuid?(Carto::UUIDHelper.random_uuid + "\nhola").should be(false)
   end
 
 end

--- a/spec/helpers/uuidhelper_spec.rb
+++ b/spec/helpers/uuidhelper_spec.rb
@@ -2,38 +2,28 @@ require_relative '../simplecov_helper'
 require_relative '../rspec_configuration.rb'
 require_relative '../../lib/carto/uuidhelper'
 
-class Carto::UUIDHelperInstance
-  include Carto::UUIDHelper
-end
-
 describe 'UUIDHelper' do
-
-  before(:each) do
-    @uuid_helper = Carto::UUIDHelperInstance.new
-  end
-
   it 'validates a valid UUID' do
-    @uuid_helper.uuid?('5b632a9e-ae07-11e4-ac8d-080027880ca6').should be(true)
+    Carto::UUIDHelper.uuid?('5b632a9e-ae07-11e4-ac8d-080027880ca6').should be(true)
   end
 
   it 'validates a random UUID' do
-    @uuid_helper.uuid?(Carto::UUIDHelper.random_uuid).should be(true)
+    Carto::UUIDHelper.uuid?(Carto::UUIDHelper.random_uuid).should be(true)
   end
 
   it 'fails if content prepended' do
-    @uuid_helper.uuid?("hi" + Carto::UUIDHelper.random_uuid).should be(false)
+    Carto::UUIDHelper.uuid?("hi" + Carto::UUIDHelper.random_uuid).should be(false)
   end
 
   it 'fails if content appended' do
-    @uuid_helper.uuid?(Carto::UUIDHelper.random_uuid + "hola").should be(false)
+    Carto::UUIDHelper.uuid?(Carto::UUIDHelper.random_uuid + "hola").should be(false)
   end
 
   it 'fails if content prepended with newlines' do
-    @uuid_helper.uuid?("hi\n" + Carto::UUIDHelper.random_uuid).should be(false)
+    Carto::UUIDHelper.uuid?("hi\n" + Carto::UUIDHelper.random_uuid).should be(false)
   end
 
   it 'fails if content appended with newlines' do
-    @uuid_helper.uuid?(Carto::UUIDHelper.random_uuid + "\nhola").should be(false)
+    Carto::UUIDHelper.uuid?(Carto::UUIDHelper.random_uuid + "\nhola").should be(false)
   end
-
 end

--- a/spec/lib/carto/http_header_authentication_spec.rb
+++ b/spec/lib/carto/http_header_authentication_spec.rb
@@ -8,7 +8,7 @@ describe Carto::HttpHeaderAuthentication do
 
   EMAIL = "user@carto.com"
   USERNAME = "user"
-  ID = SecureRandom.uuid
+  ID = Carto::UUIDHelper.random_uuid
 
   let(:mock_unauthenticated_request) do
     OpenStruct.new(headers: {})

--- a/spec/lib/carto/http_header_authentication_spec.rb
+++ b/spec/lib/carto/http_header_authentication_spec.rb
@@ -1,5 +1,4 @@
 require 'ostruct'
-require 'uuidtools'
 require_relative '../../spec_helper'
 require_relative '../../../lib/carto/http_header_authentication'
 require_relative '../../requests/http_authentication_helper'

--- a/spec/lib/carto/http_header_authentication_spec.rb
+++ b/spec/lib/carto/http_header_authentication_spec.rb
@@ -9,7 +9,7 @@ describe Carto::HttpHeaderAuthentication do
 
   EMAIL = "user@carto.com"
   USERNAME = "user"
-  ID = UUIDTools::UUID.timestamp_create.to_s
+  ID = SecureRandom.uuid
 
   let(:mock_unauthenticated_request) do
     OpenStruct.new(headers: {})

--- a/spec/models/carto/visualization/watcher_spec.rb
+++ b/spec/models/carto/visualization/watcher_spec.rb
@@ -13,7 +13,7 @@ describe Carto::Visualization::Watcher do
     it 'tests notify and list methods' do
       watcher_ttl = 2
 
-      org_id = SecureRandom.uuid
+      org_id = Carto::UUIDHelper.random_uuid
       organization_mock = mock
       organization_mock.stubs(:id).returns(org_id)
 
@@ -29,7 +29,7 @@ describe Carto::Visualization::Watcher do
       user2_mock.stubs(:username).returns(user2_name)
       user2_mock.stubs(:organization).returns(organization_mock)
 
-      vis_id = SecureRandom.uuid
+      vis_id = Carto::UUIDHelper.random_uuid
       visualization_mock = mock
       visualization_mock.stubs(:id).returns(vis_id)
 

--- a/spec/models/carto/visualization/watcher_spec.rb
+++ b/spec/models/carto/visualization/watcher_spec.rb
@@ -13,7 +13,7 @@ describe Carto::Visualization::Watcher do
     it 'tests notify and list methods' do
       watcher_ttl = 2
 
-      org_id = UUIDTools::UUID.timestamp_create.to_s
+      org_id = SecureRandom.uuid
       organization_mock = mock
       organization_mock.stubs(:id).returns(org_id)
 
@@ -29,7 +29,7 @@ describe Carto::Visualization::Watcher do
       user2_mock.stubs(:username).returns(user2_name)
       user2_mock.stubs(:organization).returns(organization_mock)
 
-      vis_id = UUIDTools::UUID.timestamp_create.to_s
+      vis_id = SecureRandom.uuid
       visualization_mock = mock
       visualization_mock.stubs(:id).returns(vis_id)
 

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -498,7 +498,7 @@ describe Carto::Visualization do
       end
 
       it 'fail if a user try to favorite a visualization without permissions' do
-        user_id = SecureRandom.uuid
+        user_id = Carto::UUIDHelper.random_uuid
         user_mock = mock
         user_mock.stubs(:id).returns(user_id)
         expect(@visualization.likes.count).to eq(0)
@@ -509,7 +509,7 @@ describe Carto::Visualization do
       end
 
       it 'raises an error if same user tries to like again the same content' do
-        user_id  = SecureRandom.uuid
+        user_id  = Carto::UUIDHelper.random_uuid
         user_mock = mock
         user_mock.stubs(:id).returns(user_id)
 
@@ -563,7 +563,7 @@ describe Carto::Visualization do
       end
 
       it 'raises an error if you try to remove a favorite in a visualization you dont have permission' do
-        user_id = SecureRandom.uuid
+        user_id = Carto::UUIDHelper.random_uuid
         user_mock = mock
         user_mock.stubs(:id).returns(user_id)
 
@@ -612,7 +612,7 @@ describe Carto::Visualization do
       end
 
       it 'returns false when checking a user without likes on the visualization' do
-        user_id = SecureRandom.uuid
+        user_id = Carto::UUIDHelper.random_uuid
         user_mock = mock
         user_mock.stubs(:id).returns(user_id)
 

--- a/spec/models/carto/visualization_spec.rb
+++ b/spec/models/carto/visualization_spec.rb
@@ -498,7 +498,7 @@ describe Carto::Visualization do
       end
 
       it 'fail if a user try to favorite a visualization without permissions' do
-        user_id = UUIDTools::UUID.timestamp_create.to_s
+        user_id = SecureRandom.uuid
         user_mock = mock
         user_mock.stubs(:id).returns(user_id)
         expect(@visualization.likes.count).to eq(0)
@@ -509,7 +509,7 @@ describe Carto::Visualization do
       end
 
       it 'raises an error if same user tries to like again the same content' do
-        user_id  = UUIDTools::UUID.timestamp_create.to_s
+        user_id  = SecureRandom.uuid
         user_mock = mock
         user_mock.stubs(:id).returns(user_id)
 
@@ -563,7 +563,7 @@ describe Carto::Visualization do
       end
 
       it 'raises an error if you try to remove a favorite in a visualization you dont have permission' do
-        user_id = UUIDTools::UUID.timestamp_create.to_s
+        user_id = SecureRandom.uuid
         user_mock = mock
         user_mock.stubs(:id).returns(user_id)
 
@@ -612,7 +612,7 @@ describe Carto::Visualization do
       end
 
       it 'returns false when checking a user without likes on the visualization' do
-        user_id = UUIDTools::UUID.timestamp_create.to_s
+        user_id = SecureRandom.uuid
         user_mock = mock
         user_mock.stubs(:id).returns(user_id)
 

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -6,7 +6,7 @@ describe CartoDB::Log do
 
   describe '#basic' do
     it 'checks basic operations' do
-      user_id = SecureRandom.uuid
+      user_id = Carto::UUIDHelper.random_uuid
       type = Log::TYPE_DATA_IMPORT
       text1 = 'test'
       text2 = 'anothertest'

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -6,7 +6,7 @@ describe CartoDB::Log do
 
   describe '#basic' do
     it 'checks basic operations' do
-      user_id = UUIDTools::UUID.timestamp_create.to_s
+      user_id = SecureRandom.uuid
       type = Log::TYPE_DATA_IMPORT
       text1 = 'test'
       text2 = 'anothertest'

--- a/spec/models/map/copier_spec.rb
+++ b/spec/models/map/copier_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../../app/models/layer'
 
 describe CartoDB::Map::Copier do
   before do
-    @user_id  = SecureRandom.uuid
+    @user_id  = Carto::UUIDHelper.random_uuid
     @map      = Map.new(user_id: @user_id)
     @map.stubs(:layers).returns((1..5).map { Layer.new(kind: 'carto') })
     @copier = CartoDB::Map::Copier.new

--- a/spec/models/map/copier_spec.rb
+++ b/spec/models/map/copier_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../../app/models/layer'
 
 describe CartoDB::Map::Copier do
   before do
-    @user_id  = UUIDTools::UUID.timestamp_create.to_s
+    @user_id  = SecureRandom.uuid
     @map      = Map.new(user_id: @user_id)
     @map.stubs(:layers).returns((1..5).map { Layer.new(kind: 'carto') })
     @copier = CartoDB::Map::Copier.new

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -679,7 +679,7 @@ describe Organization do
       privacy:      attributes.fetch(:privacy, Visualization::Member::PRIVACY_PUBLIC),
       tags:         attributes.fetch(:tags, ['tag 1']),
       type:         attributes.fetch(:type, Visualization::Member::TYPE_DERIVED),
-      user_id:      attributes.fetch(:user_id, UUIDTools::UUID.timestamp_create.to_s)
+      user_id:      attributes.fetch(:user_id, SecureRandom.uuid)
     }
   end # random_attributes
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -679,7 +679,7 @@ describe Organization do
       privacy:      attributes.fetch(:privacy, Visualization::Member::PRIVACY_PUBLIC),
       tags:         attributes.fetch(:tags, ['tag 1']),
       type:         attributes.fetch(:type, Visualization::Member::TYPE_DERIVED),
-      user_id:      attributes.fetch(:user_id, SecureRandom.uuid)
+      user_id:      attributes.fetch(:user_id, Carto::UUIDHelper.random_uuid)
     }
   end # random_attributes
 

--- a/spec/models/shared_entity_shared_examples.rb
+++ b/spec/models/shared_entity_shared_examples.rb
@@ -13,8 +13,8 @@ shared_examples_for 'shared entity models' do
 
   describe '#create' do
     it 'tests basic creation and validation' do
-      recipient_id   = SecureRandom.uuid
-      entity_id      = SecureRandom.uuid
+      recipient_id   = Carto::UUIDHelper.random_uuid
+      entity_id      = Carto::UUIDHelper.random_uuid
 
       shared_entity_class.where(entity_id: entity_id).count.should eq 0
 

--- a/spec/models/shared_entity_shared_examples.rb
+++ b/spec/models/shared_entity_shared_examples.rb
@@ -13,8 +13,8 @@ shared_examples_for 'shared entity models' do
 
   describe '#create' do
     it 'tests basic creation and validation' do
-      recipient_id   = UUIDTools::UUID.timestamp_create.to_s
-      entity_id      = UUIDTools::UUID.timestamp_create.to_s
+      recipient_id   = SecureRandom.uuid
+      entity_id      = SecureRandom.uuid
 
       shared_entity_class.where(entity_id: entity_id).count.should eq 0
 

--- a/spec/models/synchronization/synchronization_oauth_spec.rb
+++ b/spec/models/synchronization/synchronization_oauth_spec.rb
@@ -57,7 +57,7 @@ describe SynchronizationOauth do
       oauth_entry.service = service_name
 
       expect {
-        oauth_entry.user_id = UUIDTools::UUID.timestamp_create
+        oauth_entry.user_id = SecureRandom.uuid
         oauth_entry.save
       }.to raise_exception Sequel::ValidationFailed
 
@@ -65,7 +65,7 @@ describe SynchronizationOauth do
         SynchronizationOauth.create(
             user_id: @user.id,
             service: service_name,
-            token: UUIDTools::UUID.timestamp_create
+            token: SecureRandom.uuid
         )
       }.to raise_exception Sequel::ValidationFailed
 
@@ -89,7 +89,7 @@ describe SynchronizationOauth do
 
   context '#deletion' do
     it 'tests deletion of items' do
-      another_uuid = UUIDTools::UUID.timestamp_create.to_s
+      another_uuid = SecureRandom.uuid
       service_name = 'testtest'
       service_name_2 = '123456'
       token_value = 'qv2345q235erfaweerfdsdfsds'

--- a/spec/models/synchronization/synchronization_oauth_spec.rb
+++ b/spec/models/synchronization/synchronization_oauth_spec.rb
@@ -57,7 +57,7 @@ describe SynchronizationOauth do
       oauth_entry.service = service_name
 
       expect {
-        oauth_entry.user_id = SecureRandom.uuid
+        oauth_entry.user_id = Carto::UUIDHelper.random_uuid
         oauth_entry.save
       }.to raise_exception Sequel::ValidationFailed
 
@@ -65,7 +65,7 @@ describe SynchronizationOauth do
         SynchronizationOauth.create(
             user_id: @user.id,
             service: service_name,
-            token: SecureRandom.uuid
+            token: Carto::UUIDHelper.random_uuid
         )
       }.to raise_exception Sequel::ValidationFailed
 
@@ -89,7 +89,7 @@ describe SynchronizationOauth do
 
   context '#deletion' do
     it 'tests deletion of items' do
-      another_uuid = SecureRandom.uuid
+      another_uuid = Carto::UUIDHelper.random_uuid
       service_name = 'testtest'
       service_name_2 = '123456'
       token_value = 'qv2345q235erfaweerfdsdfsds'

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1862,7 +1862,7 @@ describe Table do
 
     describe '#validation_for_link_privacy' do
       it 'checks that only users with private tables enabled can set LINK privacy' do
-        table_id = UUIDTools::UUID.timestamp_create.to_s
+        table_id = SecureRandom.uuid
 
         user_mock = mock
         user_mock.stubs(:private_tables_enabled).returns(true)
@@ -1887,7 +1887,7 @@ describe Table do
         user_table.stubs(:user).returns(user_mock)
         user_table.send(:default_privacy_value).should eq ::UserTable::PRIVACY_PRIVATE
 
-        user_table.user_id = UUIDTools::UUID.timestamp_create.to_s
+        user_table.user_id = SecureRandom.uuid
         user_table.privacy = UserTable::PRIVACY_PUBLIC
         user_table.name = 'test'
         user_table.validate

--- a/spec/models/table_spec.rb
+++ b/spec/models/table_spec.rb
@@ -1862,7 +1862,7 @@ describe Table do
 
     describe '#validation_for_link_privacy' do
       it 'checks that only users with private tables enabled can set LINK privacy' do
-        table_id = SecureRandom.uuid
+        table_id = Carto::UUIDHelper.random_uuid
 
         user_mock = mock
         user_mock.stubs(:private_tables_enabled).returns(true)
@@ -1887,7 +1887,7 @@ describe Table do
         user_table.stubs(:user).returns(user_mock)
         user_table.send(:default_privacy_value).should eq ::UserTable::PRIVACY_PRIVATE
 
-        user_table.user_id = SecureRandom.uuid
+        user_table.user_id = Carto::UUIDHelper.random_uuid
         user_table.privacy = UserTable::PRIVACY_PUBLIC
         user_table.name = 'test'
         user_table.validate

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -465,7 +465,7 @@ describe Visualization::Collection do
       privacy:        attributes.fetch(:privacy, 'public'),
       tags:           attributes.fetch(:tags, ['tag 1']),
       type:           attributes.fetch(:type, CartoDB::Visualization::Member::TYPE_CANONICAL),
-      user_id:        attributes.fetch(:user_id, SecureRandom.uuid),
+      user_id:        attributes.fetch(:user_id, Carto::UUIDHelper.random_uuid),
       locked:         attributes.fetch(:locked, false),
       title:          attributes.fetch(:title, ''),
       source:         attributes.fetch(:source, ''),

--- a/spec/models/visualization/collection_spec.rb
+++ b/spec/models/visualization/collection_spec.rb
@@ -465,7 +465,7 @@ describe Visualization::Collection do
       privacy:        attributes.fetch(:privacy, 'public'),
       tags:           attributes.fetch(:tags, ['tag 1']),
       type:           attributes.fetch(:type, CartoDB::Visualization::Member::TYPE_CANONICAL),
-      user_id:        attributes.fetch(:user_id, UUIDTools::UUID.timestamp_create.to_s),
+      user_id:        attributes.fetch(:user_id, SecureRandom.uuid),
       locked:         attributes.fetch(:locked, false),
       title:          attributes.fetch(:title, ''),
       source:         attributes.fetch(:source, ''),

--- a/spec/models/visualization/locator_spec.rb
+++ b/spec/models/visualization/locator_spec.rb
@@ -28,9 +28,9 @@ describe Visualization::Locator do
 
     Visualization.repository  = DataRepository::Backend::Sequel.new(@db, :visualizations)
 
-    @user_id = UUIDTools::UUID.timestamp_create.to_s
+    @user_id = SecureRandom.uuid
 
-    @map_id = UUIDTools::UUID.timestamp_create.to_s
+    @map_id = SecureRandom.uuid
 
     # For relator->permission
     @user_mock = create_mocked_user

--- a/spec/models/visualization/locator_spec.rb
+++ b/spec/models/visualization/locator_spec.rb
@@ -28,9 +28,9 @@ describe Visualization::Locator do
 
     Visualization.repository  = DataRepository::Backend::Sequel.new(@db, :visualizations)
 
-    @user_id = SecureRandom.uuid
+    @user_id = Carto::UUIDHelper.random_uuid
 
-    @map_id = SecureRandom.uuid
+    @map_id = Carto::UUIDHelper.random_uuid
 
     # For relator->permission
     @user_mock = create_mocked_user

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -27,7 +27,7 @@ describe Visualization::Member do
     bypass_named_maps
 
     # For relator->permission
-    user_id = SecureRandom.uuid
+    user_id = Carto::UUIDHelper.random_uuid
     user_name = 'whatever'
     user_apikey = '123'
     @user_mock = mock
@@ -350,19 +350,19 @@ describe Visualization::Member do
 
   describe '#permissions' do
     it 'checks is_owner? permissions' do
-      user_id  = SecureRandom.uuid
+      user_id  = Carto::UUIDHelper.random_uuid
       member  = Visualization::Member.new(name: 'foo', user_id: user_id)
 
       user    = OpenStruct.new(id: user_id)
       member.is_owner?(user).should == true
 
-      user    = OpenStruct.new(id: SecureRandom.uuid)
+      user    = OpenStruct.new(id: Carto::UUIDHelper.random_uuid)
       member.is_owner?(user).should == false
     end
 
     def mock_user(username, viewer: false)
       user_mock = mock
-      user_mock.stubs(:id).returns(SecureRandom.uuid)
+      user_mock.stubs(:id).returns(Carto::UUIDHelper.random_uuid)
       user_mock.stubs(:username).returns(username)
       user_mock.stubs(:organization).returns(nil)
       user_mock.stubs(:viewer).returns(viewer)
@@ -538,7 +538,7 @@ describe Visualization::Member do
 
   describe '#privacy_and_exceptions' do
     it 'checks different privacy options to make sure exceptions are raised when they should' do
-      user_id = SecureRandom.uuid
+      user_id = Carto::UUIDHelper.random_uuid
 
       visualization = Visualization::Member.new(type: Visualization::Member::TYPE_DERIVED)
       visualization.name = 'test'
@@ -586,7 +586,7 @@ describe Visualization::Member do
 
   describe '#validation_for_link_privacy' do
     it 'checks that only users with private tables enabled can set LINK privacy' do
-      user_id = SecureRandom.uuid
+      user_id = Carto::UUIDHelper.random_uuid
       Visualization::Member.any_instance.stubs(:named_maps)
 
       visualization = Visualization::Member.new(
@@ -641,7 +641,7 @@ describe Visualization::Member do
 
   describe '#default_privacy_values' do
     it 'Checks deault privacies for visualizations' do
-      user_id = SecureRandom.uuid
+      user_id = Carto::UUIDHelper.random_uuid
       user_mock = mock
       user_mock.stubs(:id).returns(user_id)
 
@@ -668,7 +668,7 @@ describe Visualization::Member do
     member.store
     member = Visualization::Member.new(id: member.id).fetch
     member.permission.should_not be nil
-    member.permission_id = SecureRandom.uuid
+    member.permission_id = Carto::UUIDHelper.random_uuid
     member.valid?.should eq false
     delete_user_data(@user)
   end
@@ -730,7 +730,7 @@ describe Visualization::Member do
       random_attributes_for_vis_member({
                                           user_id: @user_mock.id,
                                           type:       Visualization::Member::TYPE_SLIDE,
-                                          parent_id:  SecureRandom.uuid
+                                          parent_id:  Carto::UUIDHelper.random_uuid
                                         }))
     expect {
       child_member.store

--- a/spec/models/visualization/member_spec.rb
+++ b/spec/models/visualization/member_spec.rb
@@ -27,7 +27,7 @@ describe Visualization::Member do
     bypass_named_maps
 
     # For relator->permission
-    user_id = UUIDTools::UUID.timestamp_create.to_s
+    user_id = SecureRandom.uuid
     user_name = 'whatever'
     user_apikey = '123'
     @user_mock = mock
@@ -350,19 +350,19 @@ describe Visualization::Member do
 
   describe '#permissions' do
     it 'checks is_owner? permissions' do
-      user_id  = UUIDTools::UUID.timestamp_create.to_s
+      user_id  = SecureRandom.uuid
       member  = Visualization::Member.new(name: 'foo', user_id: user_id)
 
       user    = OpenStruct.new(id: user_id)
       member.is_owner?(user).should == true
 
-      user    = OpenStruct.new(id: UUIDTools::UUID.timestamp_create.to_s)
+      user    = OpenStruct.new(id: SecureRandom.uuid)
       member.is_owner?(user).should == false
     end
 
     def mock_user(username, viewer: false)
       user_mock = mock
-      user_mock.stubs(:id).returns(UUIDTools::UUID.timestamp_create.to_s)
+      user_mock.stubs(:id).returns(SecureRandom.uuid)
       user_mock.stubs(:username).returns(username)
       user_mock.stubs(:organization).returns(nil)
       user_mock.stubs(:viewer).returns(viewer)
@@ -538,7 +538,7 @@ describe Visualization::Member do
 
   describe '#privacy_and_exceptions' do
     it 'checks different privacy options to make sure exceptions are raised when they should' do
-      user_id = UUIDTools::UUID.timestamp_create.to_s
+      user_id = SecureRandom.uuid
 
       visualization = Visualization::Member.new(type: Visualization::Member::TYPE_DERIVED)
       visualization.name = 'test'
@@ -586,7 +586,7 @@ describe Visualization::Member do
 
   describe '#validation_for_link_privacy' do
     it 'checks that only users with private tables enabled can set LINK privacy' do
-      user_id = UUIDTools::UUID.timestamp_create.to_s
+      user_id = SecureRandom.uuid
       Visualization::Member.any_instance.stubs(:named_maps)
 
       visualization = Visualization::Member.new(
@@ -641,7 +641,7 @@ describe Visualization::Member do
 
   describe '#default_privacy_values' do
     it 'Checks deault privacies for visualizations' do
-      user_id = UUIDTools::UUID.timestamp_create.to_s
+      user_id = SecureRandom.uuid
       user_mock = mock
       user_mock.stubs(:id).returns(user_id)
 
@@ -668,7 +668,7 @@ describe Visualization::Member do
     member.store
     member = Visualization::Member.new(id: member.id).fetch
     member.permission.should_not be nil
-    member.permission_id = UUIDTools::UUID.timestamp_create.to_s
+    member.permission_id = SecureRandom.uuid
     member.valid?.should eq false
     delete_user_data(@user)
   end
@@ -730,7 +730,7 @@ describe Visualization::Member do
       random_attributes_for_vis_member({
                                           user_id: @user_mock.id,
                                           type:       Visualization::Member::TYPE_SLIDE,
-                                          parent_id:  UUIDTools::UUID.timestamp_create.to_s
+                                          parent_id:  SecureRandom.uuid
                                         }))
     expect {
       child_member.store

--- a/spec/models/visualization/organization_visualization_spec.rb
+++ b/spec/models/visualization/organization_visualization_spec.rb
@@ -108,7 +108,7 @@ describe Visualization::Member do
   def create_table(user)
     table = Table.new
     table.user_id = user.id
-    table.name = 'wadus_table_' + UUIDTools::UUID.timestamp_create.to_s
+    table.name = 'wadus_table_' + SecureRandom.uuid
     table.save
     table.reload
 

--- a/spec/models/visualization/organization_visualization_spec.rb
+++ b/spec/models/visualization/organization_visualization_spec.rb
@@ -108,7 +108,7 @@ describe Visualization::Member do
   def create_table(user)
     table = Table.new
     table.user_id = user.id
-    table.name = 'wadus_table_' + SecureRandom.uuid
+    table.name = 'wadus_table_' + Carto::UUIDHelper.random_uuid
     table.save
     table.reload
 

--- a/spec/models/visualization/presenter_spec.rb
+++ b/spec/models/visualization/presenter_spec.rb
@@ -56,10 +56,10 @@ describe Visualization::Member do
       perm_mock = FactoryGirl.build(:carto_permission)
 
       vis_mock = mock
-      vis_mock.stubs(:id).returns(SecureRandom.uuid)
+      vis_mock.stubs(:id).returns(Carto::UUIDHelper.random_uuid)
       vis_mock.stubs(:name).returns('vis1')
       vis_mock.stubs(:display_name).returns('vis1')
-      vis_mock.stubs(:map_id).returns(SecureRandom.uuid)
+      vis_mock.stubs(:map_id).returns(Carto::UUIDHelper.random_uuid)
       vis_mock.stubs(:active_layer_id).returns(1)
       vis_mock.stubs(:type).returns(Visualization::Member::TYPE_CANONICAL)
       vis_mock.stubs(:tags).returns(['tag1'])

--- a/spec/models/visualization/presenter_spec.rb
+++ b/spec/models/visualization/presenter_spec.rb
@@ -56,10 +56,10 @@ describe Visualization::Member do
       perm_mock = FactoryGirl.build(:carto_permission)
 
       vis_mock = mock
-      vis_mock.stubs(:id).returns(UUIDTools::UUID.timestamp_create.to_s)
+      vis_mock.stubs(:id).returns(SecureRandom.uuid)
       vis_mock.stubs(:name).returns('vis1')
       vis_mock.stubs(:display_name).returns('vis1')
-      vis_mock.stubs(:map_id).returns(UUIDTools::UUID.timestamp_create.to_s)
+      vis_mock.stubs(:map_id).returns(SecureRandom.uuid)
       vis_mock.stubs(:active_layer_id).returns(1)
       vis_mock.stubs(:type).returns(Visualization::Member::TYPE_CANONICAL)
       vis_mock.stubs(:tags).returns(['tag1'])

--- a/spec/models/visualization/tags_spec.rb
+++ b/spec/models/visualization/tags_spec.rb
@@ -19,7 +19,7 @@ describe Visualization::Tags do
     bypass_named_maps
 
     # For relator->permission
-    user_id = SecureRandom.uuid
+    user_id = Carto::UUIDHelper.random_uuid
     user_name = 'whatever'
     user_apikey = '123'
     @user_mock = create_mocked_user(user_id: user_id, user_name: user_name, user_apikey: user_apikey)
@@ -90,7 +90,7 @@ describe Visualization::Tags do
       privacy:      attributes.fetch(:privacy, 'public'),
       tags:         attributes.fetch(:tags, ['tag 1']),
       type:         attributes.fetch(:type, CartoDB::Visualization::Member::TYPE_CANONICAL),
-      user_id:      attributes.fetch(:user_id, SecureRandom.uuid),
+      user_id:      attributes.fetch(:user_id, Carto::UUIDHelper.random_uuid),
       locked:       attributes.fetch(:locked, false)
     }
   end

--- a/spec/models/visualization/tags_spec.rb
+++ b/spec/models/visualization/tags_spec.rb
@@ -19,7 +19,7 @@ describe Visualization::Tags do
     bypass_named_maps
 
     # For relator->permission
-    user_id = UUIDTools::UUID.timestamp_create.to_s
+    user_id = SecureRandom.uuid
     user_name = 'whatever'
     user_apikey = '123'
     @user_mock = create_mocked_user(user_id: user_id, user_name: user_name, user_apikey: user_apikey)
@@ -90,7 +90,7 @@ describe Visualization::Tags do
       privacy:      attributes.fetch(:privacy, 'public'),
       tags:         attributes.fetch(:tags, ['tag 1']),
       type:         attributes.fetch(:type, CartoDB::Visualization::Member::TYPE_CANONICAL),
-      user_id:      attributes.fetch(:user_id, UUIDTools::UUID.timestamp_create.to_s),
+      user_id:      attributes.fetch(:user_id, SecureRandom.uuid),
       locked:       attributes.fetch(:locked, false)
     }
   end

--- a/spec/requests/account_tokens_controller_spec.rb
+++ b/spec/requests/account_tokens_controller_spec.rb
@@ -5,7 +5,7 @@ describe AccountTokensController do
   describe 'token validation' do
 
     it 'returns 404 for nonexisting tokens' do
-      get enable_account_token_show_url(id: SecureRandom.uuid)
+      get enable_account_token_show_url(id: Carto::UUIDHelper.random_uuid)
       response.status.should == 404
     end
 
@@ -36,7 +36,7 @@ describe AccountTokensController do
     describe 'resend validation mail' do
 
       it 'returns 404 for nonexisting users' do
-        get resend_validation_mail_url(user_id: SecureRandom.uuid)
+        get resend_validation_mail_url(user_id: Carto::UUIDHelper.random_uuid)
         response.status.should == 404
       end
 

--- a/spec/requests/account_tokens_controller_spec.rb
+++ b/spec/requests/account_tokens_controller_spec.rb
@@ -5,7 +5,7 @@ describe AccountTokensController do
   describe 'token validation' do
 
     it 'returns 404 for nonexisting tokens' do
-      get enable_account_token_show_url(id: UUIDTools::UUID.timestamp_create.to_s)
+      get enable_account_token_show_url(id: SecureRandom.uuid)
       response.status.should == 404
     end
 
@@ -36,7 +36,7 @@ describe AccountTokensController do
     describe 'resend validation mail' do
 
       it 'returns 404 for nonexisting users' do
-        get resend_validation_mail_url(user_id: UUIDTools::UUID.timestamp_create.to_s)
+        get resend_validation_mail_url(user_id: SecureRandom.uuid)
         response.status.should == 404
       end
 

--- a/spec/requests/api/geocodings_spec.rb
+++ b/spec/requests/api/geocodings_spec.rb
@@ -149,7 +149,7 @@ describe "Geocodings API" do
 
   describe 'PUT /api/v1/geocodings/:id' do
     it 'fails gracefully on job cancel failure' do
-      geocoding = FactoryGirl.create(:geocoding, table_id: UUIDTools::UUID.timestamp_create.to_s, formatter: 'b', user: @user)
+      geocoding = FactoryGirl.create(:geocoding, table_id: SecureRandom.uuid, formatter: 'b', user: @user)
       Geocoding.any_instance.stubs(:cancel).raises('wadus')
 
       put_json api_v1_geocodings_update_url(params.merge(id: geocoding.id)), { state: 'cancelled' } do |response|

--- a/spec/requests/api/geocodings_spec.rb
+++ b/spec/requests/api/geocodings_spec.rb
@@ -149,7 +149,7 @@ describe "Geocodings API" do
 
   describe 'PUT /api/v1/geocodings/:id' do
     it 'fails gracefully on job cancel failure' do
-      geocoding = FactoryGirl.create(:geocoding, table_id: SecureRandom.uuid, formatter: 'b', user: @user)
+      geocoding = FactoryGirl.create(:geocoding, table_id: Carto::UUIDHelper.random_uuid, formatter: 'b', user: @user)
       Geocoding.any_instance.stubs(:cancel).raises('wadus')
 
       put_json api_v1_geocodings_update_url(params.merge(id: geocoding.id)), { state: 'cancelled' } do |response|

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -104,7 +104,7 @@ describe ApplicationController do
       end
 
       it 'does not load the dashboard for an unknown user id' do
-        get dashboard_url, {}, authentication_headers(UUIDTools::UUID.timestamp_create.to_s)
+        get dashboard_url, {}, authentication_headers(SecureRandom.uuid)
         response.status.should == 302
       end
 
@@ -147,7 +147,7 @@ describe ApplicationController do
       end
 
       it 'does not load the dashboard for an unknown user id' do
-        get dashboard_url, {}, authentication_headers(UUIDTools::UUID.timestamp_create.to_s)
+        get dashboard_url, {}, authentication_headers(SecureRandom.uuid)
         response.status.should == 302
       end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -104,7 +104,7 @@ describe ApplicationController do
       end
 
       it 'does not load the dashboard for an unknown user id' do
-        get dashboard_url, {}, authentication_headers(SecureRandom.uuid)
+        get dashboard_url, {}, authentication_headers(Carto::UUIDHelper.random_uuid)
         response.status.should == 302
       end
 
@@ -147,7 +147,7 @@ describe ApplicationController do
       end
 
       it 'does not load the dashboard for an unknown user id' do
-        get dashboard_url, {}, authentication_headers(SecureRandom.uuid)
+        get dashboard_url, {}, authentication_headers(Carto::UUIDHelper.random_uuid)
         response.status.should == 302
       end
 

--- a/spec/requests/carto/api/analyses_controller_spec.rb
+++ b/spec/requests/carto/api/analyses_controller_spec.rb
@@ -84,7 +84,7 @@ describe Carto::Api::AnalysesController do
         :source_analysis,
         visualization_id: @visualization.id,
         user_id: @user.id,
-        analysis_definition: { id: UUIDTools::UUID.random_create.to_s }
+        analysis_definition: { id: SecureRandom.uuid }
       )
 
       get_json viz_analysis_url(@user, @visualization, analysis2.natural_id) do |response|

--- a/spec/requests/carto/api/analyses_controller_spec.rb
+++ b/spec/requests/carto/api/analyses_controller_spec.rb
@@ -84,7 +84,7 @@ describe Carto::Api::AnalysesController do
         :source_analysis,
         visualization_id: @visualization.id,
         user_id: @user.id,
-        analysis_definition: { id: SecureRandom.uuid }
+        analysis_definition: { id: Carto::UUIDHelper.random_uuid }
       )
 
       get_json viz_analysis_url(@user, @visualization, analysis2.natural_id) do |response|

--- a/spec/requests/carto/api/data_import_presenter_spec.rb
+++ b/spec/requests/carto/api/data_import_presenter_spec.rb
@@ -19,7 +19,7 @@ describe Carto::Api::DataImportPresenter do
       success: true,
       created_at: Time.now,
       updated_at: Time.now,
-      id: UUIDTools::UUID.timestamp_create.to_s,
+      id: SecureRandom.uuid,
       stats: '{}',
       type_guessing: false,
       quoted_fields_guessing: false,

--- a/spec/requests/carto/api/data_import_presenter_spec.rb
+++ b/spec/requests/carto/api/data_import_presenter_spec.rb
@@ -18,7 +18,7 @@ describe Carto::Api::DataImportPresenter do
       success: true,
       created_at: Time.now,
       updated_at: Time.now,
-      id: SecureRandom.uuid,
+      id: Carto::UUIDHelper.random_uuid,
       stats: '{}',
       type_guessing: false,
       quoted_fields_guessing: false,

--- a/spec/requests/carto/api/data_import_presenter_spec.rb
+++ b/spec/requests/carto/api/data_import_presenter_spec.rb
@@ -1,6 +1,5 @@
 require_relative '../../../rspec_configuration'
 require 'ostruct'
-require 'uuidtools'
 require_relative '../../../../app/controllers/carto/api/data_import_presenter'
 require_relative '../../../spec_helper'
 

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -30,7 +30,7 @@ describe 'legacy behaviour tests' do
 
       it 'returns every geocoding belonging to current_user' do
         FactoryGirl.create(:geocoding, table_name: 'a', formatter: 'b', user: @user, state: 'wadus')
-        FactoryGirl.create(:geocoding, table_name: 'a', formatter: 'b', user_id: UUIDTools::UUID.timestamp_create.to_s)
+        FactoryGirl.create(:geocoding, table_name: 'a', formatter: 'b', user_id: SecureRandom.uuid)
         get_json api_v1_geocodings_index_url(params) do |response|
           response.status.should be_success
           response.body[:geocodings].size.should == 1
@@ -47,7 +47,7 @@ describe 'legacy behaviour tests' do
         user_geocoder_metrics = CartoDB::GeocoderUsageMetrics.new(@user.username, _orgname = nil, _redis = redis_mock)
         CartoDB::GeocoderUsageMetrics.stubs(:new).returns(user_geocoder_metrics)
         user_geocoder_metrics.incr(:geocoder_here, :success_responses, 100)
-        geocoding = FactoryGirl.create(:geocoding, table_id: UUIDTools::UUID.timestamp_create.to_s, formatter: 'b', user: @user, used_credits: 100, processed_rows: 100, kind: 'high-resolution')
+        geocoding = FactoryGirl.create(:geocoding, table_id: SecureRandom.uuid, formatter: 'b', user: @user, used_credits: 100, processed_rows: 100, kind: 'high-resolution')
 
         get_json api_v1_geocodings_show_url(params.merge(id: geocoding.id)) do |response|
           response.status.should be_success
@@ -59,7 +59,7 @@ describe 'legacy behaviour tests' do
       end
 
       it 'does not return a geocoding owned by another user' do
-        geocoding = FactoryGirl.create(:geocoding, table_id: UUIDTools::UUID.timestamp_create.to_s, formatter: 'b', user_id: UUIDTools::UUID.timestamp_create.to_s)
+        geocoding = FactoryGirl.create(:geocoding, table_id: SecureRandom.uuid, formatter: 'b', user_id: SecureRandom.uuid)
 
         get_json api_v1_geocodings_show_url(params.merge(id: geocoding.id)) do |response|
           response.status.should eq 404

--- a/spec/requests/carto/api/geocodings_controller_spec.rb
+++ b/spec/requests/carto/api/geocodings_controller_spec.rb
@@ -30,7 +30,7 @@ describe 'legacy behaviour tests' do
 
       it 'returns every geocoding belonging to current_user' do
         FactoryGirl.create(:geocoding, table_name: 'a', formatter: 'b', user: @user, state: 'wadus')
-        FactoryGirl.create(:geocoding, table_name: 'a', formatter: 'b', user_id: SecureRandom.uuid)
+        FactoryGirl.create(:geocoding, table_name: 'a', formatter: 'b', user_id: Carto::UUIDHelper.random_uuid)
         get_json api_v1_geocodings_index_url(params) do |response|
           response.status.should be_success
           response.body[:geocodings].size.should == 1
@@ -47,7 +47,7 @@ describe 'legacy behaviour tests' do
         user_geocoder_metrics = CartoDB::GeocoderUsageMetrics.new(@user.username, _orgname = nil, _redis = redis_mock)
         CartoDB::GeocoderUsageMetrics.stubs(:new).returns(user_geocoder_metrics)
         user_geocoder_metrics.incr(:geocoder_here, :success_responses, 100)
-        geocoding = FactoryGirl.create(:geocoding, table_id: SecureRandom.uuid, formatter: 'b', user: @user, used_credits: 100, processed_rows: 100, kind: 'high-resolution')
+        geocoding = FactoryGirl.create(:geocoding, table_id: Carto::UUIDHelper.random_uuid, formatter: 'b', user: @user, used_credits: 100, processed_rows: 100, kind: 'high-resolution')
 
         get_json api_v1_geocodings_show_url(params.merge(id: geocoding.id)) do |response|
           response.status.should be_success
@@ -59,7 +59,7 @@ describe 'legacy behaviour tests' do
       end
 
       it 'does not return a geocoding owned by another user' do
-        geocoding = FactoryGirl.create(:geocoding, table_id: SecureRandom.uuid, formatter: 'b', user_id: SecureRandom.uuid)
+        geocoding = FactoryGirl.create(:geocoding, table_id: Carto::UUIDHelper.random_uuid, formatter: 'b', user_id: Carto::UUIDHelper.random_uuid)
 
         get_json api_v1_geocodings_show_url(params.merge(id: geocoding.id)) do |response|
           response.status.should eq 404

--- a/spec/requests/carto/api/mapcaps_controller_spec.rb
+++ b/spec/requests/carto/api/mapcaps_controller_spec.rb
@@ -9,7 +9,7 @@ describe Carto::Api::MapcapsController do
 
   let(:dummy_mapcap) do
     dummy = mock
-    dummy.stubs(:id).returns(UUIDTools::UUID.random_create.to_s)
+    dummy.stubs(:id).returns(SecureRandom.uuid)
     dummy
   end
 

--- a/spec/requests/carto/api/mapcaps_controller_spec.rb
+++ b/spec/requests/carto/api/mapcaps_controller_spec.rb
@@ -9,7 +9,7 @@ describe Carto::Api::MapcapsController do
 
   let(:dummy_mapcap) do
     dummy = mock
-    dummy.stubs(:id).returns(SecureRandom.uuid)
+    dummy.stubs(:id).returns(Carto::UUIDHelper.random_uuid)
     dummy
   end
 

--- a/spec/requests/carto/api/organization_notifications_controller_spec.rb
+++ b/spec/requests/carto/api/organization_notifications_controller_spec.rb
@@ -104,7 +104,7 @@ module Carto
       end
 
       it 'returns 404 if notification is not found' do
-        destroy_notification_request(@organization.id, @owner, SecureRandom.uuid) do |response|
+        destroy_notification_request(@organization.id, @owner, Carto::UUIDHelper.random_uuid) do |response|
           expect(response.status).to eq 404
           expect(Notification.exists?(@notification.id)).to be_true
         end

--- a/spec/requests/carto/api/organization_notifications_controller_spec.rb
+++ b/spec/requests/carto/api/organization_notifications_controller_spec.rb
@@ -104,7 +104,7 @@ module Carto
       end
 
       it 'returns 404 if notification is not found' do
-        destroy_notification_request(@organization.id, @owner, UUIDTools::UUID.random_create) do |response|
+        destroy_notification_request(@organization.id, @owner, SecureRandom.uuid) do |response|
           expect(response.status).to eq 404
           expect(Notification.exists?(@notification.id)).to be_true
         end

--- a/spec/requests/carto/api/overlays_controller_spec.rb
+++ b/spec/requests/carto/api/overlays_controller_spec.rb
@@ -29,7 +29,7 @@ describe Carto::Api::OverlaysController do
 
   let(:params) { { api_key: @user.api_key, visualization_id: @table.table_visualization.id } }
 
-  FAKE_UUID = UUIDTools::UUID.random_create
+  FAKE_UUID = SecureRandom.uuid
 
   describe '#index' do
     it 'lists all overlays' do

--- a/spec/requests/carto/api/overlays_controller_spec.rb
+++ b/spec/requests/carto/api/overlays_controller_spec.rb
@@ -29,7 +29,7 @@ describe Carto::Api::OverlaysController do
 
   let(:params) { { api_key: @user.api_key, visualization_id: @table.table_visualization.id } }
 
-  FAKE_UUID = SecureRandom.uuid
+  FAKE_UUID = Carto::UUIDHelper.random_uuid
 
   describe '#index' do
     it 'lists all overlays' do

--- a/spec/requests/carto/api/received_notifications_controller_spec.rb
+++ b/spec/requests/carto/api/received_notifications_controller_spec.rb
@@ -51,14 +51,14 @@ module Carto
       end
 
       it 'returns 404 if notification not found' do
-        invalid_options = url_options.merge(id: SecureRandom.uuid)
+        invalid_options = url_options.merge(id: Carto::UUIDHelper.random_uuid)
         put_json(user_notification_url(invalid_options), notification: { read_at: 'wadus ' }) do |response|
           expect(response.status).to eq 404
         end
       end
 
       it 'returns 403 if not not logged in as user' do
-        invalid_options = url_options.merge(user_id: SecureRandom.uuid)
+        invalid_options = url_options.merge(user_id: Carto::UUIDHelper.random_uuid)
         put_json(user_notification_url(invalid_options), notification: { read_at: 'wadus ' }) do |response|
           expect(response.status).to eq 403
         end

--- a/spec/requests/carto/api/received_notifications_controller_spec.rb
+++ b/spec/requests/carto/api/received_notifications_controller_spec.rb
@@ -51,14 +51,14 @@ module Carto
       end
 
       it 'returns 404 if notification not found' do
-        invalid_options = url_options.merge(id: UUIDTools::UUID.random_create)
+        invalid_options = url_options.merge(id: SecureRandom.uuid)
         put_json(user_notification_url(invalid_options), notification: { read_at: 'wadus ' }) do |response|
           expect(response.status).to eq 404
         end
       end
 
       it 'returns 403 if not not logged in as user' do
-        invalid_options = url_options.merge(user_id: UUIDTools::UUID.random_create)
+        invalid_options = url_options.merge(user_id: SecureRandom.uuid)
         put_json(user_notification_url(invalid_options), notification: { read_at: 'wadus ' }) do |response|
           expect(response.status).to eq 403
         end

--- a/spec/requests/carto/api/user_creations_controller_spec.rb
+++ b/spec/requests/carto/api/user_creations_controller_spec.rb
@@ -1,4 +1,3 @@
-require 'uuidtools'
 require_relative '../../../spec_helper'
 require_relative '../../../../app/controllers/carto/api/user_creations_controller'
 require 'helpers/account_types_helper'

--- a/spec/requests/carto/api/user_creations_controller_spec.rb
+++ b/spec/requests/carto/api/user_creations_controller_spec.rb
@@ -19,7 +19,7 @@ describe Carto::Api::UserCreationsController do
     end
 
     it 'returns 404 for unknown user creations' do
-      get_json api_v1_user_creations_show_url(id: SecureRandom.uuid), @headers do |response|
+      get_json api_v1_user_creations_show_url(id: Carto::UUIDHelper.random_uuid), @headers do |response|
         response.status.should == 404
       end
     end

--- a/spec/requests/carto/api/user_creations_controller_spec.rb
+++ b/spec/requests/carto/api/user_creations_controller_spec.rb
@@ -20,7 +20,7 @@ describe Carto::Api::UserCreationsController do
     end
 
     it 'returns 404 for unknown user creations' do
-      get_json api_v1_user_creations_show_url(id: UUIDTools::UUID.timestamp_create.to_s), @headers do |response|
+      get_json api_v1_user_creations_show_url(id: SecureRandom.uuid), @headers do |response|
         response.status.should == 404
       end
     end

--- a/spec/requests/carto/api/visualization_exports_controller_spec.rb
+++ b/spec/requests/carto/api/visualization_exports_controller_spec.rb
@@ -93,7 +93,8 @@ describe Carto::Api::VisualizationExportsController, type: :controller do
       it 'enqueues a job and returns the id' do
         job_params = has_entries(
           download_path: regexp_matches(/download$/),
-          job_id: regexp_matches(UUIDTools::UUID_REGEXP))
+          job_id: regexp_matches(Carto::UUIDHelper::UUID_REGEXP)
+        )
         Resque.expects(:enqueue).with(Resque::ExporterJobs, job_params).once
         post_json create_visualization_export_url(@user), visualization_id: @visualization.id do |response|
           response.status.should eq 201

--- a/spec/requests/carto/api/widgets_controller_spec.rb
+++ b/spec/requests/carto/api/widgets_controller_spec.rb
@@ -89,9 +89,9 @@ end
 describe Carto::Api::WidgetsController do
   include_context 'layer hierarchy'
 
-  let(:random_map_id) { UUIDTools::UUID.timestamp_create.to_s }
-  let(:random_layer_id) { UUIDTools::UUID.timestamp_create.to_s }
-  let(:random_widget_id) { UUIDTools::UUID.timestamp_create.to_s }
+  let(:random_map_id) { SecureRandom.uuid }
+  let(:random_layer_id) { SecureRandom.uuid }
+  let(:random_widget_id) { SecureRandom.uuid }
 
   describe '#show' do
     it 'returns 401 for non-authenticated requests' do

--- a/spec/requests/carto/api/widgets_controller_spec.rb
+++ b/spec/requests/carto/api/widgets_controller_spec.rb
@@ -89,9 +89,9 @@ end
 describe Carto::Api::WidgetsController do
   include_context 'layer hierarchy'
 
-  let(:random_map_id) { SecureRandom.uuid }
-  let(:random_layer_id) { SecureRandom.uuid }
-  let(:random_widget_id) { SecureRandom.uuid }
+  let(:random_map_id) { Carto::UUIDHelper.random_uuid }
+  let(:random_layer_id) { Carto::UUIDHelper.random_uuid }
+  let(:random_widget_id) { Carto::UUIDHelper.random_uuid }
 
   describe '#show' do
     it 'returns 401 for non-authenticated requests' do

--- a/spec/requests/carto/builder/datasets_controller_spec.rb
+++ b/spec/requests/carto/builder/datasets_controller_spec.rb
@@ -36,7 +36,7 @@ describe Carto::Builder::DatasetsController do
     end
 
     it 'returns 404 for non-existent visualizations' do
-      get builder_dataset_url(id: SecureRandom.uuid)
+      get builder_dataset_url(id: Carto::UUIDHelper.random_uuid)
 
       response.status.should == 404
     end

--- a/spec/requests/carto/builder/datasets_controller_spec.rb
+++ b/spec/requests/carto/builder/datasets_controller_spec.rb
@@ -36,7 +36,7 @@ describe Carto::Builder::DatasetsController do
     end
 
     it 'returns 404 for non-existent visualizations' do
-      get builder_dataset_url(id: UUIDTools::UUID.timestamp_create.to_s)
+      get builder_dataset_url(id: SecureRandom.uuid)
 
       response.status.should == 404
     end

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -220,7 +220,7 @@ describe Carto::Builder::Public::EmbedsController do
     end
 
     it 'returns 404 for inexistent visualizations' do
-      get builder_visualization_public_embed_url(visualization_id: UUIDTools::UUID.timestamp_create.to_s)
+      get builder_visualization_public_embed_url(visualization_id: SecureRandom.uuid)
 
       response.status.should == 404
     end

--- a/spec/requests/carto/builder/public/embeds_controller_spec.rb
+++ b/spec/requests/carto/builder/public/embeds_controller_spec.rb
@@ -220,7 +220,7 @@ describe Carto::Builder::Public::EmbedsController do
     end
 
     it 'returns 404 for inexistent visualizations' do
-      get builder_visualization_public_embed_url(visualization_id: SecureRandom.uuid)
+      get builder_visualization_public_embed_url(visualization_id: Carto::UUIDHelper.random_uuid)
 
       response.status.should == 404
     end

--- a/spec/requests/carto/builder/visualizations_controller_spec.rb
+++ b/spec/requests/carto/builder/visualizations_controller_spec.rb
@@ -114,7 +114,7 @@ describe Carto::Builder::VisualizationsController do
     end
 
     it 'returns 404 for non-existent visualizations' do
-      get builder_visualization_url(id: SecureRandom.uuid)
+      get builder_visualization_url(id: Carto::UUIDHelper.random_uuid)
 
       response.status.should == 404
     end
@@ -122,7 +122,7 @@ describe Carto::Builder::VisualizationsController do
     it 'returns 404 for non-derived visualizations' do
       @visualization.type = Carto::Visualization::TYPE_CANONICAL
       @visualization.save
-      get builder_visualization_url(id: SecureRandom.uuid)
+      get builder_visualization_url(id: Carto::UUIDHelper.random_uuid)
 
       response.status.should == 404
     end

--- a/spec/requests/carto/builder/visualizations_controller_spec.rb
+++ b/spec/requests/carto/builder/visualizations_controller_spec.rb
@@ -114,7 +114,7 @@ describe Carto::Builder::VisualizationsController do
     end
 
     it 'returns 404 for non-existent visualizations' do
-      get builder_visualization_url(id: UUIDTools::UUID.timestamp_create.to_s)
+      get builder_visualization_url(id: SecureRandom.uuid)
 
       response.status.should == 404
     end
@@ -122,7 +122,7 @@ describe Carto::Builder::VisualizationsController do
     it 'returns 404 for non-derived visualizations' do
       @visualization.type = Carto::Visualization::TYPE_CANONICAL
       @visualization.save
-      get builder_visualization_url(id: UUIDTools::UUID.timestamp_create.to_s)
+      get builder_visualization_url(id: SecureRandom.uuid)
 
       response.status.should == 404
     end

--- a/spec/requests/carto/superadmin/organizations_controller_spec.rb
+++ b/spec/requests/carto/superadmin/organizations_controller_spec.rb
@@ -290,7 +290,7 @@ describe Carto::Superadmin::OrganizationsController do
     end
 
     it 'returns an error for unknown organization' do
-      get_json(usage_superadmin_user_url(UUIDTools::UUID.random_create.to_s), {}, superadmin_headers) do |response|
+      get_json(usage_superadmin_user_url(SecureRandom.uuid), {}, superadmin_headers) do |response|
         response.status.should eq 404
       end
     end

--- a/spec/requests/carto/superadmin/organizations_controller_spec.rb
+++ b/spec/requests/carto/superadmin/organizations_controller_spec.rb
@@ -290,7 +290,7 @@ describe Carto::Superadmin::OrganizationsController do
     end
 
     it 'returns an error for unknown organization' do
-      get_json(usage_superadmin_user_url(SecureRandom.uuid), {}, superadmin_headers) do |response|
+      get_json(usage_superadmin_user_url(Carto::UUIDHelper.random_uuid), {}, superadmin_headers) do |response|
         response.status.should eq 404
       end
     end

--- a/spec/requests/carto/superadmin/users_controller_spec.rb
+++ b/spec/requests/carto/superadmin/users_controller_spec.rb
@@ -286,7 +286,7 @@ describe Carto::Superadmin::UsersController do
     end
 
     it 'returns an error for unknown user' do
-      get_json(usage_superadmin_user_url(SecureRandom.uuid), {}, superadmin_headers) do |response|
+      get_json(usage_superadmin_user_url(Carto::UUIDHelper.random_uuid), {}, superadmin_headers) do |response|
         response.status.should eq 404
       end
     end

--- a/spec/requests/carto/superadmin/users_controller_spec.rb
+++ b/spec/requests/carto/superadmin/users_controller_spec.rb
@@ -286,7 +286,7 @@ describe Carto::Superadmin::UsersController do
     end
 
     it 'returns an error for unknown user' do
-      get_json(usage_superadmin_user_url(UUIDTools::UUID.random_create.to_s), {}, superadmin_headers) do |response|
+      get_json(usage_superadmin_user_url(SecureRandom.uuid), {}, superadmin_headers) do |response|
         response.status.should eq 404
       end
     end

--- a/spec/support/factories/maps.rb
+++ b/spec/support/factories/maps.rb
@@ -4,7 +4,7 @@ module CartoDB
       attributes = attributes.dup
       map = ::Map.new(attributes)
       map.user_id = if attributes[:user_id].nil?
-        UUIDTools::UUID.timestamp_create.to_s
+        SecureRandom.uuid
         #create_user.id
       else
         attributes.delete(:user_id)

--- a/spec/support/factories/maps.rb
+++ b/spec/support/factories/maps.rb
@@ -4,7 +4,7 @@ module CartoDB
       attributes = attributes.dup
       map = ::Map.new(attributes)
       map.user_id = if attributes[:user_id].nil?
-        SecureRandom.uuid
+        Carto::UUIDHelper.random_uuid
         #create_user.id
       else
         attributes.delete(:user_id)

--- a/spec/support/factories/tables.rb
+++ b/spec/support/factories/tables.rb
@@ -8,7 +8,7 @@ module CartoDB
       attributes = attributes.dup
       table = ::Table.new(attributes)
       table.user_id = if attributes[:user_id].nil?
-        UUIDTools::UUID.timestamp_create.to_s
+        SecureRandom.uuid
       else
         attributes.delete(:user_id)
       end

--- a/spec/support/factories/tables.rb
+++ b/spec/support/factories/tables.rb
@@ -8,7 +8,7 @@ module CartoDB
       attributes = attributes.dup
       table = ::Table.new(attributes)
       table.user_id = if attributes[:user_id].nil?
-        SecureRandom.uuid
+        Carto::UUIDHelper.random_uuid
       else
         attributes.delete(:user_id)
       end

--- a/spec/support/factories/tags.rb
+++ b/spec/support/factories/tags.rb
@@ -7,7 +7,7 @@ module CartoDB
       attributes = attributes.dup
       attributes[:name] ||= unique_name('tag')
       user_id = if attributes[:user_id].nil?
-        UUIDTools::UUID.timestamp_create.to_s
+        SecureRandom.uuid
         #user = create_user
         #user.id
       else

--- a/spec/support/factories/tags.rb
+++ b/spec/support/factories/tags.rb
@@ -7,7 +7,7 @@ module CartoDB
       attributes = attributes.dup
       attributes[:name] ||= unique_name('tag')
       user_id = if attributes[:user_id].nil?
-        SecureRandom.uuid
+        Carto::UUIDHelper.random_uuid
         #user = create_user
         #user.id
       else

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -149,7 +149,7 @@ module CartoDB
       user
     end
 
-    def create_mocked_user(user_id: SecureRandom.uuid,
+    def create_mocked_user(user_id: Carto::UUIDHelper.random_uuid,
                            user_name: 'whatever',
                            user_apikey: '123',
                            groups: [],

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -149,7 +149,7 @@ module CartoDB
       user
     end
 
-    def create_mocked_user(user_id: UUIDTools::UUID.timestamp_create.to_s,
+    def create_mocked_user(user_id: SecureRandom.uuid,
                            user_name: 'whatever',
                            user_apikey: '123',
                            groups: [],

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -97,7 +97,7 @@ module HelperMethods
   end
 
   def random_attributes_for_vis_member(attributes={})
-    random = UUIDTools::UUID.timestamp_create.to_s
+    random = SecureRandom.uuid
     {
       name:               attributes.fetch(:name, "name #{random}"),
       display_name:       attributes.fetch(:display_name, "display name #{random}"),

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -97,7 +97,7 @@ module HelperMethods
   end
 
   def random_attributes_for_vis_member(attributes={})
-    random = SecureRandom.uuid
+    random = Carto::UUIDHelper.random_uuid
     {
       name:               attributes.fetch(:name, "name #{random}"),
       display_name:       attributes.fetch(:display_name, "display name #{random}"),


### PR DESCRIPTION
[UUIDTools](https://github.com/sporkmonger/uuidtools) fails to generate a random UUID in Ubuntu 18 without [net-tools](https://launchpad.net/ubuntu/bionic/+package/net-tools) and it hasn't been updated since 2015, so we can remove it and use [SecureRandom](https://docs.ruby-lang.org/en/2.4.0/SecureRandom.html) instead.