### PR TITLE
Update Babelify to version 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4783,9 +4783,9 @@
       }
     },
     "babelify": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/babelify/-/babelify-8.0.0.tgz",
-      "integrity": "sha512-xVr63fKEvMWUrrIbqlHYsMcc5Zdw4FSVesAHgkgajyCE1W8gbm9rbMakqavhxKvikGYMhEcqxTwB/gQmQ6lBtw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+      "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
       "dev": true
     },
     "babylon": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "babel-jest": "^25.2.6",
     "babel-loader": "^8.1.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
-    "babelify": "^8.0.0",
+    "babelify": "^10.0.0",
     "bluebird": "3.5.0",
     "brfs": "^1.4.3",
     "browserify-resolutions": "1.1.0",


### PR DESCRIPTION
Seems like Babelify@8 doesn't work with Babel 7, so here's the update to fix Docker image generation.