### PR TITLE
Generate private key in PEM & PKCS#8 formats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,9 @@ gem 'test-unit'
 gem 'rotp', '~> 3.3', '>= 3.3.1'
 gem 'rqrcode', '~> 0.10.1'
 
+# keys in PKCS#8 format require external command openssl
+gem 'sys_cmd', '>= 1.1.3'
+
 group :test do
   gem 'simplecov', '0.13.0', require: false
   gem 'simplecov-json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,6 +428,8 @@ GEM
       activerecord (>= 4.1, < 5.2)
       state_machines-activemodel (>= 0.5.0)
     statsd-client (0.0.7)
+    sys_cmd (1.1.3)
+      os (>= 0.9.6)
     test-unit (3.1.7)
       power_assert
     thin (1.7.2)
@@ -549,6 +551,7 @@ DEPENDENCIES
   sprockets (= 3.7.2)
   state_machines-activerecord (~> 0.5.0)
   statsd-client (= 0.0.7)
+  sys_cmd (>= 1.1.3)
   test-unit
   thin
   typhoeus (= 1.3.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,7 @@ Development
 - None yet
 
 ### Features
-- New internal API for managing DB-Direct certificates & IPs ([#15567](https://github.com/CartoDB/cartodb/pull/15567))
-  with PKCS#8 keys ([#15622](https://github.com/CartoDB/cartodb/pull/15622))
+- PKCS#8 keys support for DB-Direct certificates ([#15622](https://github.com/CartoDB/cartodb/pull/15622))
 
 ### Bug fixes / enhancements
 - None yet

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ sudo make install
 
 ### Features
 - New internal API for managing DB-Direct certificates & IPs ([#15567](https://github.com/CartoDB/cartodb/pull/15567))
+  with PKCS#8 keys ([#15622](https://github.com/CartoDB/cartodb/pull/15622))
 - Use Dataservices API client 0.30.0
 - Enable deleting Kepler.gl maps ([#15485](https://github.com/CartoDB/cartodb/issues/15485))
 - Add Kepler.gl maps to Recent content section in the Dashboard ([#15486](https://github.com/CartoDB/cartodb/issues/15486))

--- a/app/controllers/carto/api/dbdirect_certificates_controller.rb
+++ b/app/controllers/carto/api/dbdirect_certificates_controller.rb
@@ -36,12 +36,14 @@ module Carto
           name: params[:name],
           passphrase: params[:pass],
           validity_days: validity_days,
-          server_ca: params[:server_ca]
+          server_ca: params[:server_ca],
+          pk8: params[:pk8],
         )
         result = {
           id: cert.id,
           name: cert.name, # must include name since we may have changed or generated it
           client_key: data[:client_key],
+          client_key_pk8: data[:client_key_pk8],
           client_crt: data[:client_crt],
           server_ca: data[:server_ca]
         }
@@ -78,6 +80,7 @@ module Carto
         certificate_id = result[:id]
         certificate_name = result[:name]
         client_key = result[:client_key]
+        client_key_pk8 = result[:client_key_pk8]
         client_crt = result[:client_crt]
         server_ca = result[:server_ca]
 
@@ -93,6 +96,7 @@ module Carto
         zip_data = InMemZipper.zip(
           'README.txt' => readme,
           'client.key' => client_key,
+          'client.key.pk8' => client_key_pk8,
           'client.crt' => client_crt,
           'server_ca.pem' => server_ca
         )

--- a/app/controllers/carto/api/dbdirect_certificates_controller.rb
+++ b/app/controllers/carto/api/dbdirect_certificates_controller.rb
@@ -50,7 +50,11 @@ module Carto
 
         respond_to do |format|
           format.json do
-            render_jsonp(result, 201)
+            if result[:client_key_pk8].present?
+              render_jsonp({error: "binary DER in PKCS8 format not supported in JSON; use zip format"}, 422)
+            else
+              render_jsonp(result, 201)
+            end
           end
           format.zip do
             zip_filename, zip_data = zip_certificates(result)

--- a/app/models/carto/dbdirect_certificate.rb
+++ b/app/models/carto/dbdirect_certificate.rb
@@ -10,7 +10,7 @@ module Carto
 
     before_destroy :revoke
 
-    def self.generate(user:, name:, passphrase: nil, validity_days: nil, server_ca: true)
+    def self.generate(user:, name:, passphrase: nil, validity_days: nil, server_ca: true, pk8: true)
       validity_days ||= config['maximum_validity_days']
       name = valid_name(user, name)
 
@@ -18,7 +18,8 @@ module Carto
         username: user.username,
         passphrase: passphrase,
         validity_days: validity_days,
-        server_ca: server_ca
+        server_ca: server_ca,
+        pk8: pk8
       )
 
       new_record = create(

--- a/app/views/carto/api/dbdirect_certificates/README.txt.erb
+++ b/app/views/carto/api/dbdirect_certificates/README.txt.erb
@@ -1,38 +1,42 @@
-Here's your certificate "<%= certificate_name %>" to use the CARTO Direct SQL BETA service.
+Here's your certificate "<%= certificate_name %>" to use CARTO’s Direct SQL Connection beta version.
 
-You can use it with any application that supports TSL/SSL connections to PostgreSQL
-to directly access and modify your CARTO datasets.
+You can use it with any application that supports SSL connections to PostgreSQL
+with client identity verification to directly access and modify datasets stored in your CARTO account.
+
+Two versions of the private key are provided:
+* RSA PEM format (client.key)
+* DER PKCS #8 format (client.key.pk8)
+Depending on the connection method used by your application you should use one or another.
+For example, connections with the PostgreSQL ODBC driver should use the RSA PEM format and
+connections with the PostgreSQL JDBC driver should use the DER PKCS #8 format.
 
 Contents:
+* client.crt. Client certificate.
+* client.key. Matching private key file in RSA PEM format. On UNIX-like systems (Linux, Mac OS, ...)
+ this file should be protected with: `chmod 0600 client.key`.
+* client.key.pk8. Matching private key file in DER PKCS #8 format.
+* server_ca.pem. This certificate allows you to check the identity of CARTO's database server.
 
-* client.key This file contains your private key that is needed to encrypt the connections.
-  You must keep this file safely, as any one that gets access to this file may impersonate
-  you and access your data. On UNIX-like systems (Linux, Mac OS, ...) this file should be
-  protected with: `chmod 0600 client.key`.
-* client.crt This is the certificate matching private key which will identify you
-  when you connect to your CARTO database. Keep this also safely.
-* server_ca.pem This is optional and allows you to check the identity of CARTO's database server.
-
-You'll need to configure your application to use TSL with client.key and client.crt
+You'll need to configure your application to use TLS with client.key and client.crt
 (and optionally server_ca.pem) when connecting to your database.
 
 Your database address (host server) is: <%= dbproxy_host %>
 And the TCP port is: <%= dbproxy_port %>
 
 You should use your CARTO account user name (<%= username %>) as your database user (role),
-and an API Key as your password. You can generate API Keys from CARTO dashboard. The API Key you use
-will determine which operations can be performed and which tables are accessible. We advise you
-to generate specific keys and not use your master key, since the master key should be exposed as
-little as possible, and it allows unrestricted access to your database.
+and an API Key as your password. You can generate API Keys from your CARTO account dashboard
+(‘API Keys’ section under your user profile on the top right of the screen).
+The API key you use will determine which operations can be performed and which tables are accessible.
+We advise you to generate specific keys and not to use your master API key.
+We advise against exposing your Master API Key since it allows unrestricted access to your database.
 
 Example: connect using psql:
+ psql "sslmode=verify-full sslrootcert=server_ca.pem \
+     sslcert=client.crt sslkey=client.key \
+     hostaddr=<%= dbproxy_host %> \
+     port=<%= dbproxy_port %> \
+     user=<%= username %>"
 
-  psql "sslmode=verify-ca sslrootcert=server_ca.pem \
-      sslcert=client.crt sslkey=client.key \
-      hostaddr=<%= dbproxy_host %> \
-      port=<%= dbproxy_port %> \
-      user=<%= username %>
+Please note that this feature is a beta version still undergoing testing before an official release.
 
-This feature is in BETA. We'll provide more detailed information and guidelines very soon.
-
-Please contact CARTO support for further information.
+Please contact CARTO support (support@carto.com) for further information or any questions you may have.

--- a/lib/carto/dbdirect/certificate_manager.rb
+++ b/lib/carto/dbdirect/certificate_manager.rb
@@ -69,7 +69,7 @@ module Carto
           option '-nocrypt' unless passphrase.present?
         end
         run cmd
-        cmd.output
+        cmd.output.force_encoding(Encoding::ASCII_8BIT)
       end
 
       def openssl_generate_csr(username, key, passphrase)

--- a/lib/carto/dbdirect/certificate_manager.rb
+++ b/lib/carto/dbdirect/certificate_manager.rb
@@ -2,6 +2,7 @@ require 'openssl'
 require 'aws-sdk-acmpca'
 require 'json'
 require 'securerandom'
+require 'sys_cmd'
 
 module Carto
   module Dbdirect
@@ -13,10 +14,11 @@ module Carto
 
       attr_reader :config
 
-      def generate_certificate(username:, passphrase:, validity_days:, server_ca:)
+      def generate_certificate(username:, passphrase:, validity_days:, server_ca:, pk8:)
         certificates = nil
         arn = nil
         key = openssl_generate_key(passphrase)
+        key_pk8 = openssl_converty_key_to_pkcs8(key, passphrase) if pk8
         csr = openssl_generate_csr(username, key, passphrase)
         with_aws_credentials do
           arn = aws_issue_certificate(csr, validity_days)
@@ -26,6 +28,7 @@ module Carto
             client_crt: certificate
           }
           certificates[:server_ca] = aws_get_ca_certificate_chain if server_ca
+          certificates[:client_key_pk8] = key_pk8 if pk8
         end
         [certificates, arn]
       end
@@ -53,6 +56,20 @@ module Carto
         else
           key.to_pem
         end
+      end
+
+      def openssl_converty_key_to_pkcs8(key, passphrase)
+        cmd = SysCmd.command 'openssl pkcs8' do
+          option '-topk8'
+          option '-inform', 'PEM'
+          option '-passin', "pass:#{passphrase}" if passphrase.present?
+          input key
+          option '-outform', 'DER'
+          option '-passout', "pass:#{passphrase}" if passphrase.present?
+          option '-nocrypt' unless passphrase.present?
+        end
+        run cmd
+        cmd.output
       end
 
       def openssl_generate_csr(username, key, passphrase)
@@ -149,6 +166,18 @@ module Carto
           key = key.to_s
           ENV[key] = old[key]
         end
+      end
+
+      def run(cmd, error_message: 'Error')
+        result = cmd.run direct: true, error_output: :separate
+        if cmd.error
+          raise cmd.error
+        elsif cmd.status_value != 0
+          msg = error_message
+          msg += ": " + cmd.error_output if cmd.error_output.present?
+          raise msg
+        end
+        result
       end
     end
   end

--- a/lib/tasks/dbdirect.rake
+++ b/lib/tasks/dbdirect.rake
@@ -12,12 +12,12 @@ namespace :carto do
       puts "  arn: #{arn}"
       files = [
         [:client_key, key_filename],
-        [:client_key_pk8, pk8_filename],
+        [:client_key_pk8, pk8_filename, 'b'],
         [:client_crt, crt_filename],
         [:server_ca, ca_filename]
       ]
-      files.each do |datum, filename|
-        File.open(filename, 'w') do |file|
+      files.each do |datum, filename, binary|
+        File.open(filename, "w#{binary}") do |file|
           file.write data[datum]
         end
         puts "#{datum} written to #{filename}"

--- a/lib/tasks/dbdirect.rake
+++ b/lib/tasks/dbdirect.rake
@@ -6,10 +6,17 @@ namespace :carto do
       key_filename = File.join(output_directory, "#{base_filename}.key")
       crt_filename = File.join(output_directory, "#{base_filename}.crt")
       ca_filename = File.join(output_directory, "server_ca.crt")
+      pk8_filename = File.join(output_directory, "#{base_filename}.key.pk8")
       puts "Certificate #{name} generated for #{username}"
       puts "  id: #{id}"
       puts "  arn: #{arn}"
-      [[:client_key, key_filename], [:client_crt, crt_filename], [:server_ca, ca_filename]].each do |datum, filename|
+      files = [
+        [:client_key, key_filename],
+        [:client_key_pk8, pk8_filename],
+        [:client_crt, crt_filename],
+        [:server_ca, ca_filename]
+      ]
+      files.each do |datum, filename|
         File.open(filename, 'w') do |file|
           file.write data[datum]
         end
@@ -33,7 +40,8 @@ namespace :carto do
         name: args.name,
         passphrase: args.password,
         validity_days: args.validity.blank? ? 365 : args.validity.to_i,
-        server_ca: true
+        server_ca: true,
+        pk8: true
       )
 
       save_certs user.username, cert.name, cert.id, cert.arn, data, '.'

--- a/spec/requests/carto/api/dbdirect_certificates_controller_spec.rb
+++ b/spec/requests/carto/api/dbdirect_certificates_controller_spec.rb
@@ -260,7 +260,7 @@ describe Carto::Api::DbdirectCertificatesController do
       end
     end
 
-    it 'creates certificates with pk8 key and downloads server ca' do
+    it 'does not support pk8 keys in JSON response' do
       params = {
         name: 'cert_name',
         pass: 'the_password',
@@ -272,18 +272,7 @@ describe Carto::Api::DbdirectCertificatesController do
       with_feature_flag @user1, 'dbdirect', true do
         Cartodb.with_config dbdirect: @config do
           post_json(dbdirect_certificates_url, params) do |response|
-            expect(response.status).to eq(201)
-            expect(response.body[:client_crt]).to eq %{crt for user00000001_200_#{@config['certificates']}}
-            expect(response.body[:client_key]).to eq %{key for user00000001_the_password}
-            expect(response.body[:client_key_pk8]).to eq %{keypk8 for user00000001_the_password}
-            expect(response.body[:server_ca]).to eq %{cacrt for #{@config['certificates']}}
-            expect(response.body[:name]).to eq 'cert_name'
-            cert_id = response.body[:id]
-            expect(cert_id).not_to be_empty
-            cert = Carto::DbdirectCertificate.find(cert_id)
-            expect(cert.user.id).to eq @user1.id
-            expect(cert.name).to eq 'cert_name'
-            expect(cert.arn).to eq %{arn for user00000001_200_#{@config['certificates']}}
+            expect(response.status).to eq(422)
           end
         end
       end


### PR DESCRIPTION
We generate the private key with RSA traditional format and PEM (text) encoding, which some applications require, but other applications require DER (binary) PKCS #8 format.

So we should generate the private key in both formats to fulfil all needs.