### PR TITLE
Improve dataset view performance with many maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,7 @@ SPEC_HELPER_MIN_SPECS = \
 	spec/requests/carto/api/public/federated_tables_controller_spec.rb \
 	spec/services/carto/federated_tables_service_spec.rb \
 	spec/mailers/data_observatory_mailer_spec.rb \
+	spec/requests/carto/api/user_table_presenter_spec.rb \
 	$(NULL)
 
 # This class must be tested isolated as pollutes namespace

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ Development
 - PKCS#8 keys support for DB-Direct certificates ([#15622](https://github.com/CartoDB/cartodb/pull/15622))
 
 ### Bug fixes / enhancements
-- None yet
+- Improve performance of dataset view with many maps
 
 4.37.0 (2020-04-24)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ Development
 - PKCS#8 keys support for DB-Direct certificates ([#15622](https://github.com/CartoDB/cartodb/pull/15622))
 
 ### Bug fixes / enhancements
-- Improve performance of dataset view with many maps
+- Improve performance of dataset view with many maps ([#15627](https://github.com/CartoDB/cartodb/pull/15627))
 
 4.37.0 (2020-04-24)
 -------------------

--- a/app/controllers/carto/api/user_table_presenter.rb
+++ b/app/controllers/carto/api/user_table_presenter.rb
@@ -15,6 +15,8 @@ module Carto
         PRIVACY_LINK => 'link'
       }
 
+      MAX_DERIVED_MAPS_SHOWN = 3
+
       def initialize(user_table, current_viewer, show_size_and_row_count: true, show_permission: true)
         @user_table = user_table
         @current_viewer = current_viewer
@@ -51,6 +53,7 @@ module Carto
 
         if accessible_dependent_derived_maps && context
           poro[:accessible_dependent_derived_maps] = derived_maps_to_presenter(context)
+          poro[:accessible_dependent_derived_maps_count] = @user_table.accessible_dependent_derived_maps.count
         end
 
         if show_permission
@@ -70,7 +73,7 @@ module Carto
       attr_reader :show_size_and_row_count, :show_permission
 
       def derived_maps_to_presenter(context)
-        visualizations = @user_table.accessible_dependent_derived_maps
+        visualizations = @user_table.accessible_dependent_derived_maps.first(MAX_DERIVED_MAPS_SHOWN)
         visualizations.map { |v| Carto::Api::VisualizationPresenter.new(v, @current_viewer, context).to_poro }
       end
 

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -117,7 +117,7 @@ module Carto
     end
 
     def accessible_dependent_derived_maps
-      affected_visualizations.select { |v| (v.has_read_permission?(user) && v.derived?) ? v : nil }
+      affected_visualizations.select { |v| v.has_read_permission?(user) && v.derived? ? v : nil }
     end
 
     def partially_dependent_visualizations

--- a/lib/assets/javascripts/builder/components/modals/remove-dataset/remove-dataset-view.js
+++ b/lib/assets/javascripts/builder/components/modals/remove-dataset/remove-dataset-view.js
@@ -35,6 +35,7 @@ module.exports = ConfirmationView.extend({
 
   render: function () {
     var affectedVisData = this._tableModel.get('accessible_dependent_derived_maps');
+    var affectedVisCount = this._tableModel.get('accessible_dependent_derived_maps_count');
     var affectedEntitiesData = this._prepareVisibleAffectedEntities();
 
     this.clearSubViews();
@@ -43,7 +44,7 @@ module.exports = ConfirmationView.extend({
       template({
         modalModel: this._modalModel,
         tableName: this._tableModel.getUnquotedName(),
-        affectedVisCount: affectedVisData.length,
+        affectedVisCount: affectedVisCount,
         visibleAffectedVis: this._prepareVisibleAffectedVis(affectedVisData.slice(0, AFFECTED_VIS_COUNT)),
         organizationAffected: affectedEntitiesData.organizationAffected,
         affectedEntitiesCount: affectedEntitiesData.count,

--- a/lib/assets/test/spec/builder/components/modals/remove-dataset/remove-dataset-view.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/remove-dataset/remove-dataset-view.spec.js
@@ -26,7 +26,7 @@ describe('modals/remove-dataset-view', function () {
   var tableDataWithNoDependentMaps = {
     name: 'NYC Graffiti sights',
     accessible_dependent_derived_maps: [],
-    accessible_dependent_derived_maps_count: 0,
+    accessible_dependent_derived_maps_count: 0
   };
   var dependentMap = {
     id: '5725afbe-9f51-11e6-af45-080027eb929e',
@@ -99,9 +99,9 @@ describe('modals/remove-dataset-view', function () {
 
     if (numberOfDependentMaps > 0) {
       tableData = _.clone(tableDataWithNoDependentMaps);
+      tableData.accessible_dependent_derived_maps_count = numberOfDependentMaps;
       _.times(numberOfDependentMaps, function () {
         tableData.accessible_dependent_derived_maps.push(dependentMap);
-        tableData.accessible_dependent_derived_maps_count = numberOfDependentMaps;
       });
     } else {
       tableModel = new TableModel(tableDataWithNoDependentMaps, { parse: true, configModel: configModel });

--- a/lib/assets/test/spec/builder/components/modals/remove-dataset/remove-dataset-view.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/remove-dataset/remove-dataset-view.spec.js
@@ -103,6 +103,7 @@ describe('modals/remove-dataset-view', function () {
       _.times(numberOfDependentMaps, function () {
         tableData.accessible_dependent_derived_maps.push(dependentMap);
       });
+      tableModel = new TableModel(tableData, { parse: true, configModel: configModel });
     } else {
       tableModel = new TableModel(tableDataWithNoDependentMaps, { parse: true, configModel: configModel });
     }

--- a/lib/assets/test/spec/builder/components/modals/remove-dataset/remove-dataset-view.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/remove-dataset/remove-dataset-view.spec.js
@@ -25,7 +25,8 @@ describe('modals/remove-dataset-view', function () {
   };
   var tableDataWithNoDependentMaps = {
     name: 'NYC Graffiti sights',
-    accessible_dependent_derived_maps: []
+    accessible_dependent_derived_maps: [],
+    accessible_dependent_derived_maps_count: 0,
   };
   var dependentMap = {
     id: '5725afbe-9f51-11e6-af45-080027eb929e',
@@ -100,6 +101,7 @@ describe('modals/remove-dataset-view', function () {
       tableData = _.clone(tableDataWithNoDependentMaps);
       _.times(numberOfDependentMaps, function () {
         tableData.accessible_dependent_derived_maps.push(dependentMap);
+        tableData.accessible_dependent_derived_maps_count = numberOfDependentMaps;
       });
     } else {
       tableModel = new TableModel(tableDataWithNoDependentMaps, { parse: true, configModel: configModel });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.172",
+  "version": "1.0.0-assets.172b",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/spec/requests/carto/api/user_table_presenter_spec.rb
+++ b/spec/requests/carto/api/user_table_presenter_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper_min'
+
+describe Carto::Api::UserTablePresenter do
+  include_context 'user helper'
+
+  describe '#poro' do
+    context 'when accessible_dependent_derived_maps is enabled' do
+      before(:all) do
+        table = FactoryGirl.create(:carto_user_table, user_id: @user.id)
+        visualization = FactoryGirl.create(:carto_visualization, user_id: @user.id)
+        dependencies = [visualization] * 5
+        table.stubs(:accessible_dependent_derived_maps).returns(dependencies)
+        presenter = Carto::Api::UserTablePresenter.new(table, @user)
+        context = mock
+        context.stubs(request: nil, polymorphic_path: '')
+        @presentation = presenter.to_poro(accessible_dependent_derived_maps: true, context: context)
+      end
+
+      it 'includes only 3 dependencies' do
+        expect(@presentation[:accessible_dependent_derived_maps].count).to eq 3
+      end
+
+      it 'includes the dependencies count' do
+        expect(@presentation[:accessible_dependent_derived_maps_count]).to eq 5
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/2463

When opening a dataset, we are retrieving metadata about all the dependant maps to show this message when trying to delete it:

![image](https://user-images.githubusercontent.com/14979109/80365058-494d8100-8887-11ea-9f85-16c5d0c003ab.png)

This is taking too much time when the number of maps is high, but we really just need the total number of maps and detailed info about 3 of them, so I'm updating the user table presenter to only return that.

In my local environment, having 500 dependencies it took 17 seconds to load, and with this change, it takes 2 s. It could be further improved for sure, but let's go step by step.

For the acceptance, it can be used [this dataset](https://gonzalos.carto-staging.com/u/gonzalor/dataset/tornados), which now takes 25 s to load.