### PR TITLE
Workaround for problem deleting firewall rules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))
 
 ### Bug fixes / enhancements
+- Fix Db Direct IPs Firewall management problem ([#15638](https://github.com/CartoDB/cartodb/pull/15638))
 - DO user settings are now stored under `do_settings:{@username}` ([#15630](https://github.com/CartoDB/cartodb/pull/15630))
 - Improve performance of dataset view with many maps ([#15627](https://github.com/CartoDB/cartodb/pull/15627))
 - Clarify message at Organization's Auth settings

--- a/lib/carto/dbdirect/firewall_manager.rb
+++ b/lib/carto/dbdirect/firewall_manager.rb
@@ -42,8 +42,7 @@ module Carto
         # but since there could be race conditions anyway we'll just rescue errors
         @service.delete_firewall(config['project_id'], name)
 
-      rescue Google::Apis::ClientError => error
-        raise unless error.message =~ /^notFound:/
+      rescue Google::Apis::ClientError
       end
 
       def create_rule(project_id:, name:, network:, ips:, target_tag:, ports:)


### PR DESCRIPTION
For managing an organization's DB Direct firewall rules, we first try to delete the rule for the organization, then create a new one. If the rule didn't exist previously we get a `NotFound` error that we ignore.
But in production we're getting an unexpected `resourceNotReady` error instead (but the existing rule seems to be deleted anyway)

Since this is not going to be a permanent solution (IP filtering will eventually be performed by pgproxy), let's try a "fire and forget" approach (which we're also already doing when creating a new rule) and ignore any error from the delete request.