### PR TITLE
Db Direct firewall operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,13 +6,12 @@ Development
 
 ### Features
 - GCP Firewall managemente for DB Direct IPs ([#15610](https://github.com/CartoDB/cartodb/pull/15610))
-  ([15641](https://github.com/CartoDB/cartodb/pull/15641))
 - Rake tasks to list DB Direct certificates ([#15625](https://github.com/CartoDB/cartodb/pull/15625))
 - PKCS#8 keys support for DB-Direct certificates ([#15622](https://github.com/CartoDB/cartodb/pull/15622))
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))
 
 ### Bug fixes / enhancements
-- Fix Db Direct IPs Firewall management problem ([#15638](https://github.com/CartoDB/cartodb/pull/15638))
+- Fix Db Direct IPs Firewall management problem ([15641](https://github.com/CartoDB/cartodb/pull/15641))
 - Fix Db Direct Firewall management credentials problem ([#15640](https://github.com/CartoDB/cartodb/pull/15640))
 - DO user settings are now stored under `do_settings:{@username}` ([#15630](https://github.com/CartoDB/cartodb/pull/15630))
 - Improve performance of dataset view with many maps ([#15627](https://github.com/CartoDB/cartodb/pull/15627))

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Development
 
 ### Features
 - GCP Firewall managemente for DB Direct IPs ([#15610](https://github.com/CartoDB/cartodb/pull/15610))
+  ([15641](https://github.com/CartoDB/cartodb/pull/15641))
 - Rake tasks to list DB Direct certificates ([#15625](https://github.com/CartoDB/cartodb/pull/15625))
 - PKCS#8 keys support for DB-Direct certificates ([#15622](https://github.com/CartoDB/cartodb/pull/15622))
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))

--- a/app/models/carto/dbdirect_ip.rb
+++ b/app/models/carto/dbdirect_ip.rb
@@ -80,14 +80,20 @@ module Carto
       )
     end
 
-    def update_firewall(old_ips, new_ips)
+    def update_firewall(old_ips=nil, new_ips=nil)
       return unless self.class.firewall_enabled?
 
       old_ips ||= []
       new_ips ||= []
       return if old_ips.sort == new_ips.sort
 
-      self.class.firewall_manager.replace_rule(firewall_rule_name, new_ips)
+      if new_ips.blank?
+        self.class.firewall_manager.delete_rule(firewall_rule_name)
+      elsif old_ips.blank?
+        self.class.firewall_manager.create_rule(firewall_rule_name, new_ips)
+      else
+        self.class.firewall_manager.update_rule(firewall_rule_name, new_ips)
+      end
     end
   end
 end

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -314,9 +314,13 @@ class Carto::User < ActiveRecord::Base
   end
 
   def dbdirect_effective_ips=(ips)
+    ips ||= []
     bearer = dbdirect_bearer
-    bearer.dbdirect_ip&.destroy
-    bearer.create_dbdirect_ip!(ips: ips) if ips.present?
+    if bearer.dbdirect_ip
+      bearer.dbdirect_ip.update!(ips: ips)
+    else
+      bearer.create_dbdirect_ip!(ips: ips)
+    end
   end
 
   def dbdirect_effective_ip
@@ -325,9 +329,9 @@ class Carto::User < ActiveRecord::Base
 
   def dbdirect_bearer
     if organization.present? && organization.owner != self
-      organization.owner
+      organization.owner.reload
     else
-      self
+      reload
     end
   end
 

--- a/lib/carto/dbdirect/firewall_manager.rb
+++ b/lib/carto/dbdirect/firewall_manager.rb
@@ -60,7 +60,7 @@ module Carto
         rule.souce_ranges = ips
         rule.target_tags = config['target_tag']
 
-        @service.update_firewall(project, name, rule)
+        @service.update_firewall(config['project_id'], name, rule)
       end
 
       private

--- a/lib/carto/dbdirect/firewall_manager.rb
+++ b/lib/carto/dbdirect/firewall_manager.rb
@@ -60,7 +60,7 @@ module Carto
         rule.souce_ranges = ips
         rule.target_tags = config['target_tag']
 
-        service.update_firewall(project, name, rule)
+        @service.update_firewall(project, name, rule)
       end
 
       private

--- a/lib/carto/dbdirect/firewall_manager.rb
+++ b/lib/carto/dbdirect/firewall_manager.rb
@@ -20,11 +20,11 @@ module Carto
       end
 
       def create_rule(name, ips)
-        @service.insert_firewall(config['project_id'], firewall_rule(name))
+        @service.insert_firewall(config['project_id'], firewall_rule(name, ips))
       end
 
       def update_rule(name, ips)
-        @service.update_firewall(config['project_id'], name, firewall_rule(name))
+        @service.update_firewall(config['project_id'], name, firewall_rule(name, ips))
       end
 
       def get_rule(name)
@@ -41,7 +41,7 @@ module Carto
         )
       end
 
-      def firewall_rule(name)
+      def firewall_rule(name, ips)
         Google::Apis::ComputeV1::Firewall.new(
           name: name,
           allowed: [firewall_allowed],

--- a/lib/carto/dbdirect/firewall_manager.rb
+++ b/lib/carto/dbdirect/firewall_manager.rb
@@ -19,15 +19,15 @@ module Carto
         @service.delete_firewall(config['project_id'], name)
       end
 
-      def create_rule(name:, ips:)
+      def create_rule(name, ips)
         @service.insert_firewall(config['project_id'], firewall_rule(name))
       end
 
-      def update_rule(name:, ips:)
+      def update_rule(name, ips)
         @service.update_firewall(config['project_id'], name, firewall_rule(name))
       end
 
-      def get_rule(name:)
+      def get_rule(name)
         @service.get_firewall(config['project_id'], name).to_h
       end
 


### PR DESCRIPTION
Firewall rule management was performed by deleting/creating new rules for every change. The logic for it was to eventually restore inconsistencies between the rules and the metadata, but combining two operations (destroy & create) while using a "fire and forget" approach to avoid blocking the process proved to be problematic (the create could end up being executed before the destroy was effective).

This changes firewall management to perform always single operations