### PR TITLE
[Rollbar] Change log level for some exception that don't require attention

### DIFF
--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -11,8 +11,12 @@ Rollbar.configure do |config|
   # via the rollbar interface.
   # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
   # 'ignore' will cause the exception to not be reported at all.
+  info_errors = ['error creating usertable']
   config.exception_level_filters.merge!(
-    'ActionController::RoutingError' => 'ignore'
+    'ActionController::RoutingError' => 'ignore',
+    'ActiveRecord::RecordInvalid' => lambda do
+      |error| info_errors.any? { |message| error.to_s.downcase.include?(message) ? 'info' : 'error' }
+    end
   )
 end
 


### PR DESCRIPTION
Let's do a couple of things:

- While reviewing Rollbar exceptions, change from the UI the log level for those that do not require attention.
- Update the initializer to reflect the change in the log level

I'll merge a PR like this every Friday.

@gonzaloriestra @amiedes @oleurud @manmorjim 