### PR TITLE
Fix instructions for using DB direct with psql

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))
 
 ### Bug fixes / enhancements
+- Fix DB Direct instructions in certificate README ([15647]https://github.com/CartoDB/cartodb/pull/15647)
 - Fix Db Direct IPs Firewall management problem ([15641](https://github.com/CartoDB/cartodb/pull/15641))
 - Fix Db Direct Firewall management credentials problem ([#15640](https://github.com/CartoDB/cartodb/pull/15640))
 - DO user settings are now stored under `do_settings:{@username}` ([#15630](https://github.com/CartoDB/cartodb/pull/15630))

--- a/app/views/carto/api/dbdirect_certificates/README.txt.erb
+++ b/app/views/carto/api/dbdirect_certificates/README.txt.erb
@@ -33,7 +33,7 @@ We advise against exposing your Master API Key since it allows unrestricted acce
 Example: connect using psql:
  psql "sslmode=verify-full sslrootcert=server_ca.pem \
      sslcert=client.crt sslkey=client.key \
-     hostaddr=<%= dbproxy_host %> \
+     host=<%= dbproxy_host %> \
      port=<%= dbproxy_port %> \
      user=<%= username %>"
 


### PR DESCRIPTION
The example psql connection string is wrong; hostaddr is used for IPs, and we're using DNS names.