### PR TITLE
Avoid duplications in builder usage with faster-dependencies FF

### DIFF
--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -130,13 +130,15 @@ module Carto
 
     def faster_dependent_visualizations(limit: nil)
       query = %{
-        SELECT visualizations.*
-        FROM layers_user_tables, layers_maps, visualizations
-        WHERE layers_user_tables.user_table_id = '#{id}'
-        AND layers_user_tables.layer_id = layers_maps.layer_id
-        AND layers_maps.map_id = visualizations.map_id
-        AND visualizations.type = 'derived'
-        ORDER BY visualizations.updated_at DESC
+        SELECT * FROM (
+          SELECT DISTINCT ON (visualizations.id) *
+          FROM layers_user_tables, layers_maps, visualizations
+          WHERE layers_user_tables.user_table_id = '#{id}'
+          AND layers_user_tables.layer_id = layers_maps.layer_id
+          AND layers_maps.map_id = visualizations.map_id
+          AND visualizations.type = 'derived'
+        ) v
+        ORDER BY v.updated_at DESC
       }
       query = query + " LIMIT(#{limit})" if limit
       Carto::Visualization.find_by_sql(query)
@@ -144,7 +146,7 @@ module Carto
 
     def dependent_visualizations_count
       query = %{
-        SELECT count(visualizations.*)
+        SELECT count(distinct(visualizations.id))
         FROM layers_user_tables, layers_maps, visualizations
         WHERE layers_user_tables.user_table_id = '#{id}'
         AND layers_user_tables.layer_id = layers_maps.layer_id

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -274,6 +274,7 @@ class Carto::VisualizationQueryBuilder
   def with_dependent_visualization_count(query)
     return query unless @order && @order.include?("dependent_visualizations")
 
+    with_prefetch_dependent_visualizations
     Carto::VisualizationQueryIncluder.new(query).include_dependent_visualization_count(@filtering_params)
   end
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/pull/15632

In some cases, the builder usage column can show duplicated maps with the `faster-dependencies` feature flag. Fixed by adding a `DISTINCT` in the SQL query.