### PR TITLE
Normalize IP ranges for Firewall rules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))
 
 ### Bug fixes / enhancements
+- Normalize IP ranges applied to Firewall rules ([15649](https://github.com/CartoDB/cartodb/pull/15649))
 - Fix Db Direct IPs Firewall management problem ([15641](https://github.com/CartoDB/cartodb/pull/15641))
 - Fix Db Direct Firewall management credentials problem ([#15640](https://github.com/CartoDB/cartodb/pull/15640))
 - DO user settings are now stored under `do_settings:{@username}` ([#15630](https://github.com/CartoDB/cartodb/pull/15630))

--- a/app/models/carto/dbdirect_ip.rb
+++ b/app/models/carto/dbdirect_ip.rb
@@ -80,12 +80,18 @@ module Carto
       )
     end
 
+    def normalize_ip(ip)
+      IpChecker.normalize(ip)
+    end
+
     def update_firewall(old_ips=nil, new_ips=nil)
       return unless self.class.firewall_enabled?
 
       old_ips ||= []
       new_ips ||= []
       return if old_ips.sort == new_ips.sort
+
+      new_ips = new_ips.map { |ip| normalize_ip(ip) }
 
       if new_ips.blank?
         self.class.firewall_manager.delete_rule(firewall_rule_name)

--- a/lib/ip_checker.rb
+++ b/lib/ip_checker.rb
@@ -62,6 +62,15 @@ module IpChecker
   rescue IPAddr::AddressFamilyError, IPAddr::InvalidAddressError => error
     error.message
   end
+
+  # Normalized IP ranges, so that IP bits outside the mask range are 0
+  # (some routers/firewalls may not accept it of not normalied)
+  def normalize(str)
+    ip = IPAddr.new(str)
+    norm_ip = ip.to_s
+    norm_ip += "/#{ip.prefix}" if ip.prefix < IPAddr.new(norm_ip).prefix
+    norm_ip
+  end
 end
 
 # Backport some IPAddr methods from Ruby 2.5

--- a/spec/lib/ip_checker_spec.rb
+++ b/spec/lib/ip_checker_spec.rb
@@ -179,4 +179,27 @@ describe IpChecker do
       IpChecker.validate('0:0:0:0:0:0:0:1', exclude_loopback: false).should be_nil
     end
   end
+
+  describe "#normalize" do
+    it "doesn't change single IPs" do
+      IpChecker.normalize('234.111.7.200').should eq '234.111.7.200'
+      IpChecker.normalize('0.0.0.0').should eq '0.0.0.0'
+      IpChecker.normalize('2001:db8:3333:4444:5555:6666:7777:8888').should eq '2001:db8:3333:4444:5555:6666:7777:8888'
+    end
+
+    it "removes unnecessary mask/prefix" do
+      IpChecker.normalize('234.111.7.200/32').should eq '234.111.7.200'
+      IpChecker.normalize('234.111.7.200/255.255.255.255').should eq '234.111.7.200'
+      IpChecker.normalize('2001:db8:3333:4444:5555:6666:7777:8888/128').should eq '2001:db8:3333:4444:5555:6666:7777:8888'
+    end
+
+    it "zeros out bits outside the range mask" do
+      IpChecker.normalize('234.111.7.200/24').should eq '234.111.7.0/24'
+      IpChecker.normalize('234.111.7.200/255.255.255.0').should eq '234.111.7.0/24'
+      IpChecker.normalize('234.111.7.200/28').should eq '234.111.7.192/28'
+      IpChecker.normalize('234.111.7.200/255.255.255.240').should eq '234.111.7.192/28'
+      IpChecker.normalize('2001:db8:3333:4444:5555:6666:7777:8888/120').should eq '2001:db8:3333:4444:5555:6666:7777:8800/120'
+      IpChecker.normalize('2001:db8:3333:4444:5555:6666:7777:8888/124').should eq '2001:db8:3333:4444:5555:6666:7777:8880/124'
+    end
+  end
 end


### PR DESCRIPTION
IP ranges like `12.12.12.12/24` though technically valid in CIDR notation, are not accepted by GCP firewall because it specifies bits outside of the mask range.

This normalizes ranges when applied to the firewall.