### PR TITLE
Make DB Direct certificates server_ca configurable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))
 
 ### Bug fixes / enhancements
+- Make DB Direct server_ca configurable ([15650](https://github.com/CartoDB/cartodb/pull/15650))
 - Fix DB Direct instructions in certificate README ([15647]https://github.com/CartoDB/cartodb/pull/15647)
 - Fix Db Direct IPs Firewall management problem ([15641](https://github.com/CartoDB/cartodb/pull/15641))
 - Fix Db Direct Firewall management credentials problem ([#15640](https://github.com/CartoDB/cartodb/pull/15640))

--- a/app/controllers/carto/api/dbdirect_certificates_controller.rb
+++ b/app/controllers/carto/api/dbdirect_certificates_controller.rb
@@ -93,7 +93,8 @@ module Carto
           certificate_name: certificate_name,
           username: username,
           dbproxy_host: dbproxy_host,
-          dbproxy_port: dbproxy_port
+          dbproxy_port: dbproxy_port,
+          server_ca_present: server_ca.present?
         )
         filename = "#{certificate_name}.zip"
 

--- a/app/views/carto/api/dbdirect_certificates/README.txt.erb
+++ b/app/views/carto/api/dbdirect_certificates/README.txt.erb
@@ -15,10 +15,12 @@ Contents:
 * client.key. Matching private key file in RSA PEM format. On UNIX-like systems (Linux, Mac OS, ...)
  this file should be protected with: `chmod 0600 client.key`.
 * client.key.pk8. Matching private key file in DER PKCS #8 format.
+<% if server_ca_present %>
 * server_ca.pem. This certificate allows you to check the identity of CARTO's database server.
+<% end %>
 
 You'll need to configure your application to use TLS with client.key and client.crt
-(and optionally server_ca.pem) when connecting to your database.
+<% if server_ca_present %>(and optionally server_ca.pem)<% end %> when connecting to your database.
 
 Your database address (host server) is: <%= dbproxy_host %>
 And the TCP port is: <%= dbproxy_port %>
@@ -31,11 +33,19 @@ We advise you to generate specific keys and not to use your master API key.
 We advise against exposing your Master API Key since it allows unrestricted access to your database.
 
 Example: connect using psql:
+<% if server_ca_present %>
  psql "sslmode=verify-full sslrootcert=server_ca.pem \
      sslcert=client.crt sslkey=client.key \
      host=<%= dbproxy_host %> \
      port=<%= dbproxy_port %> \
      user=<%= username %>"
+<% else %>
+ psql "sslmode=require \
+     sslcert=client.crt sslkey=client.key \
+     host=<%= dbproxy_host %> \
+     port=<%= dbproxy_port %> \
+     user=<%= username %>"
+<% end %>
 
 Please note that this feature is a beta version still undergoing testing before an official release.
 

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -779,6 +779,7 @@ defaults: &defaults
       aws_access_key_id: ''
       aws_secret_key: ''
       aws_region: us-east-1
+      server_ca: disabled
     pgproxy:
       host: 'dbconn.carto.com'
       port: 5432

--- a/lib/carto/dbdirect/certificate_manager.rb
+++ b/lib/carto/dbdirect/certificate_manager.rb
@@ -49,7 +49,7 @@ module Carto
       VALIDITY_TYPE_DAYS = "DAYS".freeze
 
       def get_server_ca
-        # If not configured, the CA used to sign client certifivates will be used (handy for development)
+        # If not configured, the CA used to sign client certificates will be used (handy for development)
         return aws_get_ca_certificate_chain unless config['server_ca'].present? || config['server_ca'] == 'client_ca'
 
         # No server_ca file will be generated (it shouldn't be needed) if special value 'disabled' is used


### PR DESCRIPTION
So far, in development, the server_ca certificate has been fetch from the CA used to sign client certificates, but in production we need to control what should be in it or if it should be disabled (e.g. for server certificates signed by CA for which all systems include their root certificates).

So I've added a new configuration parameter `dbdirect.certificates.server_ca` to control this.

* If it's not defined we preserve the current behaviour, which can also be selecte withe the special `client_ca` value (for convenience of chef-controlled configurations)
* The special value `disabled` prevents inclusion of server_ca with client certificates and omits also references to it in the README.
* Otherwise it should contain a URL accessible to download the server_ca file.
