### PR TITLE
Map error message returned by Google Firewall

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))
 
 ### Bug fixes / enhancements
+- More clear DB Direct Firewall error messages ([15652](https://github.com/CartoDB/cartodb/pull/15652))
 - Fix DB Direct instructions in certificate README ([15647]https://github.com/CartoDB/cartodb/pull/15647)
 - Fix Db Direct IPs Firewall management problem ([15641](https://github.com/CartoDB/cartodb/pull/15641))
 - Fix Db Direct Firewall management credentials problem ([#15640](https://github.com/CartoDB/cartodb/pull/15640))

--- a/app/controllers/carto/api/dbdirect_ips_controller.rb
+++ b/app/controllers/carto/api/dbdirect_ips_controller.rb
@@ -10,6 +10,7 @@ module Carto
       before_action :check_permissions
 
       setup_default_rescues
+      rescue_from Carto::FirewallNotReadyError, with: :rescue_from_carto_error
 
       def show
         ips = @user.dbdirect_effective_ips

--- a/app/controllers/carto/controller_helper.rb
+++ b/app/controllers/carto/controller_helper.rb
@@ -19,6 +19,12 @@ module Carto
       status = error.status
       errors_cause = error.errors_cause
 
+      if error.headers.present?
+        error.headers.each do |header, value|
+          response.headers[header] = value
+        end
+      end
+
       respond_to do |format|
         format.html { render text: message, status: status }
         format.json { render json: { errors: message, errors_cause: errors_cause }, status: status }

--- a/lib/carto/dbdirect/firewall_manager.rb
+++ b/lib/carto/dbdirect/firewall_manager.rb
@@ -16,19 +16,27 @@ module Carto
       attr_reader :config
 
       def delete_rule(name)
-        @service.delete_firewall(config['project_id'], name)
+        with_error_mapping do
+          @service.delete_firewall(config['project_id'], name)
+        end
       end
 
       def create_rule(name, ips)
-        @service.insert_firewall(config['project_id'], firewall_rule(name, ips))
+        with_error_mapping do
+          @service.insert_firewall(config['project_id'], firewall_rule(name, ips))
+        end
       end
 
       def update_rule(name, ips)
-        @service.update_firewall(config['project_id'], name, firewall_rule(name, ips))
+        with_error_mapping do
+          @service.update_firewall(config['project_id'], name, firewall_rule(name, ips))
+        end
       end
 
       def get_rule(name)
-        @service.get_firewall(config['project_id'], name).to_h
+        with_error_mapping do
+          @service.get_firewall(config['project_id'], name).to_h
+        end
       end
 
       private
@@ -53,6 +61,13 @@ module Carto
 
       def network_url(project_id, network)
         "#{PROJECTS_URL}/#{project_id}/global/networks/#{network}"
+      end
+
+      def with_error_mapping
+        yield
+      rescue Google::Apis::ClientError => error
+        raise Carto::FirewallNotReadyError.new if error.message =~ /resourceNotReady/
+        raise
       end
     end
   end

--- a/lib/carto/errors.rb
+++ b/lib/carto/errors.rb
@@ -96,4 +96,10 @@ module Carto
       super(message)
     end
   end
+
+  class FirewallNotReadyError < CartoError
+    def initialize(message = "The IP changes couldn't be applied. Please try again.")
+      super(message, 500) # 504?
+    end
+  end
 end

--- a/lib/carto/errors.rb
+++ b/lib/carto/errors.rb
@@ -100,7 +100,7 @@ module Carto
 
   class FirewallNotReadyError < CartoError
     def initialize(message = "The IP changes couldn't be applied. Please try again.")
-      super(message, 500) # 504?
+      super(message, 429, headers: { 'Retry-After' => '5' })
     end
   end
 end

--- a/lib/carto/errors.rb
+++ b/lib/carto/errors.rb
@@ -1,12 +1,13 @@
 module Carto
   class CartoError < StandardError
-    attr_reader :message, :status, :user_message, :errors_cause
+    attr_reader :message, :status, :user_message, :errors_cause, :headers
 
-    def initialize(message, status, user_message: message, errors_cause: nil)
+    def initialize(message, status, user_message: message, errors_cause: nil, headers: nil)
       @message = message
       @status = status
       @user_message = user_message
       @errors_cause = errors_cause
+      @headers = headers
     end
 
     def self.with_full_messages(active_record_exception)


### PR DESCRIPTION
If a change of the firewall rule is tried shortly after another, we get a `Google::Apis::ClientError` with a message like this: "resourceNotReady: The resource '(rule name)' is not ready".

This maps the message for a clearer one for the user.