### PR TITLE
Faster geometry types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ Development
 - Fix kepler.gl link in Maps section ([#15644](https://github.com/CartoDB/cartodb/issues/15644))
 - /api/v3/me endpoint returns less public data ([#5627](https://github.com/CartoDB/cartodb-platform/issues/5627))
 - Retrieve IPs before adding or removing to avoid inconsistencies ([#15643](https://github.com/CartoDB/cartodb/pull/15643))
+- Faster geometry types calculation for big datasets ([#15654](https://github.com/CartoDB/cartodb/pull/15654))
 
 4.37.0 (2020-04-24)
 -------------------

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1288,17 +1288,34 @@ class Table
 
   def query_geometry_types
     # We do not query the DB, if the_geom does not exist we just recover
-    begin
-      owner.in_database[ %Q{
-        SELECT DISTINCT ST_GeometryType(the_geom) FROM (
-          SELECT the_geom
+    query = owner.has_feature_flag?('faster-geometry-types') ? faster_distinct_geometry_sql : old_distinct_geometry_sql
+    owner.in_database[query].all.map { |r| r[:st_geometrytype] }
+  rescue StandardError
+    []
+  end
+
+  def old_distinct_geometry_sql
+    %{
+      SELECT DISTINCT ST_GeometryType(the_geom) FROM (
+        SELECT the_geom
         FROM #{qualified_table_name}
-          WHERE (the_geom is not null) LIMIT 10
-        ) as foo
-      }].all.map {|r| r[:st_geometrytype] }
-    rescue
-      []
-    end
+        WHERE (the_geom is not null) LIMIT 10
+      ) as foo
+    }
+  end
+
+  def faster_distinct_geometry_sql
+    %{
+      SELECT DISTINCT ST_GeometryType(the_geom) FROM (
+        SELECT the_geom
+        FROM (
+          SELECT the_geom
+          FROM #{qualified_table_name}
+          LIMIT 10000
+        )
+        WHERE (the_geom is not null) LIMIT 10
+      ) as foo
+    }
   end
 
   def cache


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/2450

When a table has millions of rows and no geometries, the calculation of the geometry types present in the table throws a timeout (25 s), because we are looking for not null values in all the rows. That makes the /viz endpoint to be really slow when there are datasets like that, because we only cache it for 5 min when there are no geometries.

The solution is to only process the first 10,000 rows.