### PR TITLE
Update Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -191,7 +191,7 @@ Layout/SpaceInsideParens:
 Layout/SpaceInsideRangeLiteral:
   Enabled: true
 
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
 
 Layout/TrailingWhitespace:


### PR DESCRIPTION
Rubocop linter is failing:
```
Error: The `Layout/Tab` cop has been renamed to `Layout/IndentationStyle`.
(obsolete configuration found in .rubocop.yml, please update it)
```