### PR TITLE
lastlogin hubspot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@ Development
 - Fix signup with multiple active invitations ([#15629](https://github.com/CartoDB/cartodb/pull/15629))
 - Restore twitter connector for those having their own credentials ([#15656](https://github.com/CartoDB/cartodb/pull/15656))
 - Avoid order by favorited if no user privided ([#15666](https://github.com/CartoDB/cartodb/issues/15666))
+- Sync last login date ([#2788](https://github.com/CartoDB/cartodb-central/issues/2788))
 
 4.37.0 (2020-04-24)
 -------------------

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -111,7 +111,7 @@ module Concerns
            mapzen_routing_quota mapzen_routing_block_price soft_mapzen_routing_limit no_map_logo
            user_render_timeout database_render_timeout state industry company phone job_role
            password_reset_token password_reset_sent_at maintenance_mode company_employees use_case private_map_quota
-           session_salt public_dataset_quota)
+           session_salt public_dataset_quota dashboard_viewed_at)
       end
     end
 
@@ -140,6 +140,7 @@ module Concerns
           geocoder_provider isolines_provider routing_provider builder_enabled engine_enabled mapzen_routing_quota
           mapzen_routing_block_price soft_mapzen_routing_limit industry company phone job_role password_reset_token
           password_reset_sent_at company_employees use_case private_map_quota session_salt public_dataset_quota
+          dashboard_viewed_at
         )
         attrs = values.slice(*allowed_attributes)
         attrs[:multifactor_authentication_status] = multifactor_authentication_status

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -42,6 +42,11 @@ module CartoStrategy
     # after login (see #11946), so marking that event on authentication is more accurate with the
     # meaning (although not with the name).
     user.view_dashboard
+    begin
+      user.update_in_central
+    rescue StandardError => e
+      CartoDB::Logger.warning(message: "Error updating lastlogin_date in central", exception: e)
+    end
   end
 end
 


### PR DESCRIPTION
cartodb part.

This PR just take into account sync when an org user logins. We update the `dashboard_viewed_at` everytime the dashboard page is visited, but in that case I'm not syncing it.

That means it's fine `dashboard_viewed_at` to be unsynced eventually between cartodb and central.

https://github.com/CartoDB/cartodb-central/issues/2788