### PR TITLE
Fix table name qualification (WIP)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,12 +11,13 @@ Development
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))
 
 ### Bug fixes / enhancements
+- Fix geocoding analysis for non-org users ([#15659](https://github.com/CartoDB/cartodb/pull/15659))
 - Add metrics for connectors actions ([#155564](https://github.com/CartoDB/cartodb/pull/15564))
-- Make DB Direct server_ca configurable ([15650](https://github.com/CartoDB/cartodb/pull/15650))
-- More clear DB Direct Firewall error messages ([15652](https://github.com/CartoDB/cartodb/pull/15652))
-- Normalize IP ranges applied to Firewall rules ([15649](https://github.com/CartoDB/cartodb/pull/15649))
-- Fix DB Direct instructions in certificate README ([15647]https://github.com/CartoDB/cartodb/pull/15647)
-- Fix Db Direct IPs Firewall management problem ([15641](https://github.com/CartoDB/cartodb/pull/15641))
+- Make DB Direct server_ca configurable ([#15650](https://github.com/CartoDB/cartodb/pull/15650))
+- More clear DB Direct Firewall error messages ([#15652](https://github.com/CartoDB/cartodb/pull/15652))
+- Normalize IP ranges applied to Firewall rules ([#15649](https://github.com/CartoDB/cartodb/pull/15649))
+- Fix DB Direct instructions in certificate README ([#15647]https://github.com/CartoDB/cartodb/pull/15647)
+- Fix Db Direct IPs Firewall management problem ([#15641](https://github.com/CartoDB/cartodb/pull/15641))
 - Fix Db Direct Firewall management credentials problem ([#15640](https://github.com/CartoDB/cartodb/pull/15640))
 - DO user settings are now stored under `do_settings:{@username}` ([#15630](https://github.com/CartoDB/cartodb/pull/15630))
 - Improve performance of dataset view with many maps ([#15627](https://github.com/CartoDB/cartodb/pull/15627))

--- a/app/models/carto/analysis.rb
+++ b/app/models/carto/analysis.rb
@@ -43,12 +43,13 @@ class Carto::Analysis < ActiveRecord::Base
     table_name = layer_options[:table_name]
 
     qualified_table_name = safe_schema_and_table_quoting(layer.user.database_schema, table_name)
+    table_name = qualified_table_name if layer.user.organization_user?
 
     analysis_definition = {
       id: 'abcdefghijklmnopqrstuvwxyz'[index] + '0',
       type: 'source',
       params: { query: layer.default_query(user, layer.user.database_schema) },
-      options: { table_name: qualified_table_name }
+      options: { table_name: table_name }
     }
 
     new(visualization_id: visualization_id, user_id: user_id, analysis_definition: analysis_definition)

--- a/app/models/carto/layer.rb
+++ b/app/models/carto/layer.rb
@@ -227,10 +227,10 @@ module Carto
         table_name = sym_options[:table_name]
         qualify = (user && user.organization_user?) || user_username != user_name
 
-        if table_name.present? && !table_name.include?('.') && user_name.present? && qualify
-          "SELECT * FROM #{safe_table_name_quoting(user_name)}.#{safe_table_name_quoting(table_name)}"
-        elsif database_schema.present?
+        if database_schema.present?
           "SELECT * FROM #{safe_table_name_quoting(database_schema)}.#{safe_table_name_quoting(table_name)}"
+        elsif table_name.present? && !table_name.include?('.') && user_name.present? && qualify
+          "SELECT * FROM #{safe_table_name_quoting(user_name)}.#{safe_table_name_quoting(table_name)}"
         else
           "SELECT * FROM #{qualified_table_name}"
         end

--- a/lib/assets/javascripts/builder/data/layer-definitions-collection.js
+++ b/lib/assets/javascripts/builder/data/layer-definitions-collection.js
@@ -98,10 +98,11 @@ module.exports = Backbone.Collection.extend({
         var userName = o.user_name || TableNameUtils.getUsername(o.table_name);
 
         var qualifyTableName = (userName && self._configModel.get('user_name') !== userName) || self._userModel.isInsideOrg();
-        tableName = TableNameUtils.getQualifiedTableName(o.table_name, userName, qualifyTableName);
+        tableName = TableNameUtils.getQualifiedTableName(o.table_name, userName, qualifyTableName, false);
+        var alwaysQualifiedTableName = TableNameUtils.getQualifiedTableName(o.table_name, userName, qualifyTableName, true);
 
         o.source = o.source || sourceId;
-        o.query = o.query || SQLUtils.getDefaultSQLFromTableName(tableName);
+        o.query = o.query || SQLUtils.getDefaultSQLFromTableName(alwaysQualifiedTableName);
 
         // Add analysis definition unless already existing
         self._analysisDefinitionNodesCollection.createSourceNode({

--- a/lib/assets/javascripts/builder/helpers/sql-utils.js
+++ b/lib/assets/javascripts/builder/helpers/sql-utils.js
@@ -65,7 +65,7 @@ module.exports = {
   },
 
   getDefaultSQL: function (tableName, userName, inOrganization) {
-    return this.getDefaultSQLFromTableName(TableNameUtils.getQualifiedTableName(tableName, userName, inOrganization));
+    return this.getDefaultSQLFromTableName(TableNameUtils.getQualifiedTableName(tableName, userName, inOrganization, true));
   },
 
   getDefaultSQLFromTableName: function (tableName) {

--- a/lib/assets/javascripts/builder/helpers/table-name-utils.js
+++ b/lib/assets/javascripts/builder/helpers/table-name-utils.js
@@ -34,8 +34,11 @@ module.exports = {
     return name;
   },
 
-  getQualifiedTableName: function (tableName, userName, inOrganization) {
+  getQualifiedTableName: function (tableName, userName, inOrganization, forceSchema = false) {
     var schemaPrefix = (inOrganization && userName) ? this._quoteIfNeeded(userName) + '.' : '';
+    if (forceSchema && schemaPrefix === '') {
+      schemaPrefix = 'public.';
+    }
     return schemaPrefix + this._quoteIfNeeded(this.getUnqualifiedName(tableName));
   },
 

--- a/lib/assets/test/spec/builder/data/analysis-definition-node-source-model.spec.js
+++ b/lib/assets/test/spec/builder/data/analysis-definition-node-source-model.spec.js
@@ -23,7 +23,7 @@ describe('builder/data/analysis-definition-node-source-model', function () {
       id: 'a0',
       type: 'source',
       params: {
-        query: 'SELECT * FROM bar'
+        query: 'SELECT * FROM public.bar'
       },
       options: {
         table_name: 'bar',
@@ -40,10 +40,10 @@ describe('builder/data/analysis-definition-node-source-model', function () {
       spyOn(this.model.tableModel, 'getOwnerName');
     });
 
-    it('should provide a default query without qualifing if user does not belong to an organization', function () {
+    it('should provide a default query with qualifing if user does not belong to an organization', function () {
       this.userModel.isInsideOrg.and.returnValue(false);
       this.model.tableModel.getOwnerName.and.returnValue('pericoo');
-      expect(this.model.getDefaultQuery()).toBe('SELECT * FROM bar');
+      expect(this.model.getDefaultQuery()).toBe('SELECT * FROM public.bar');
     });
 
     it('should provide a default query with qualifing if user does belong to an organization', function () {
@@ -94,14 +94,14 @@ describe('builder/data/analysis-definition-node-source-model', function () {
       expect(this.model.get('table_name')).toBe('bar');
       expect(this.model.tableModel.get('name')).toBe('bar');
       expect(this.model.queryRowsCollection._tableName).toBe('bar');
-      expect(this.model.querySchemaModel.get('query')).toBe('SELECT * FROM bar');
+      expect(this.model.querySchemaModel.get('query')).toBe('SELECT * FROM public.bar');
 
       this.model.setTableName('har');
 
       expect(this.model.get('table_name')).toBe('har');
       expect(this.model.tableModel.get('name')).toBe('har');
       expect(this.model.queryRowsCollection._tableName).toBe('har');
-      expect(this.model.querySchemaModel.get('query')).toBe('SELECT * FROM har');
+      expect(this.model.querySchemaModel.get('query')).toBe('SELECT * FROM public.har');
     });
   });
 });

--- a/lib/assets/test/spec/builder/data/analysis-definition-nodes-collection.spec.js
+++ b/lib/assets/test/spec/builder/data/analysis-definition-nodes-collection.spec.js
@@ -38,7 +38,7 @@ describe('data/analysis-definition-nodes-collection', function () {
           id: 'a0',
           type: 'source',
           table_name: 'foo',
-          query: 'SELECT * FROM foo',
+          query: 'SELECT * FROM public.foo',
           status: 'ready'
         });
 
@@ -47,7 +47,7 @@ describe('data/analysis-definition-nodes-collection', function () {
           id: 'b0',
           type: 'source',
           table_name: '000cd294-b124-4f82-b569-0f7fe41d2db8',
-          query: 'SELECT * FROM "000cd294-b124-4f82-b569-0f7fe41d2db8"',
+          query: 'SELECT * FROM public."000cd294-b124-4f82-b569-0f7fe41d2db8"',
           status: 'ready'
         });
 
@@ -56,7 +56,7 @@ describe('data/analysis-definition-nodes-collection', function () {
           id: 'c0',
           type: 'source',
           table_name: 'bar',
-          query: 'SELECT * FROM bar',
+          query: 'SELECT * FROM public.bar',
           status: 'ready'
         });
 
@@ -65,7 +65,7 @@ describe('data/analysis-definition-nodes-collection', function () {
           id: 'd0',
           type: 'source',
           table_name: '000cd294-b124-4f82-b569-0f7fe41d2db8',
-          query: 'SELECT * FROM "000cd294-b124-4f82-b569-0f7fe41d2db8"',
+          query: 'SELECT * FROM public."000cd294-b124-4f82-b569-0f7fe41d2db8"',
           status: 'ready'
         });
       });

--- a/lib/assets/test/spec/builder/data/layer-definitions-collection.spec.js
+++ b/lib/assets/test/spec/builder/data/layer-definitions-collection.spec.js
@@ -188,8 +188,8 @@ describe('data/layer-definitions-collection', function () {
     });
 
     var sourceNode3 = analysisDefinitionNodesCollection.get(layer3.get('source'));
-    expect(layer3.get('sql').toLowerCase()).toBe('select * from table_name');
-    expect(sourceNode3.get('query').toLowerCase()).toBe('select * from table_name');
+    expect(layer3.get('sql').toLowerCase()).toBe('select * from public.table_name');
+    expect(sourceNode3.get('query').toLowerCase()).toBe('select * from public.table_name');
 
     var layer4 = collection.add({
       kind: 'carto',

--- a/lib/assets/test/spec/builder/data/user-actions.spec.js
+++ b/lib/assets/test/spec/builder/data/user-actions.spec.js
@@ -831,7 +831,7 @@ describe('builder/data/user-actions', function () {
         id: 'a0',
         type: 'source',
         table_name: 'foobar',
-        query: 'SELECT * FROM foobar',
+        query: 'SELECT * FROM public.foobar',
         status: 'ready'
       });
     });
@@ -848,7 +848,7 @@ describe('builder/data/user-actions', function () {
         id: 'a0',
         type: 'source',
         table_name: '"000cd294-b124-4f82-b569-0f7fe41d2db8"',
-        query: 'SELECT * FROM "000cd294-b124-4f82-b569-0f7fe41d2db8"',
+        query: 'SELECT * FROM public."000cd294-b124-4f82-b569-0f7fe41d2db8"',
         status: 'ready'
       });
     });

--- a/lib/assets/test/spec/builder/dataset/dataset-header-view.spec.js
+++ b/lib/assets/test/spec/builder/dataset/dataset-header-view.spec.js
@@ -217,7 +217,7 @@ describe('dataset/dataset-header-view', function () {
     it('should set default query when vis name changes', function () {
       HeaderView.prototype._setDocumentTitle.calls.reset();
       this.view._visModel.set('name', 'hello_new_table');
-      expect(this.view._layerDefinitionModel.get('sql')).toBe('SELECT * FROM hello_new_table');
+      expect(this.view._layerDefinitionModel.get('sql')).toBe('SELECT * FROM public.hello_new_table');
     });
 
     it('should open privacy dropdown if user is owner', function () {

--- a/lib/assets/test/spec/builder/editor/layers/analysis-view/source-layers-analysis-view.spec.js
+++ b/lib/assets/test/spec/builder/editor/layers/analysis-view/source-layers-analysis-view.spec.js
@@ -28,7 +28,7 @@ describe('editor/layers/analysis-views/source-layer-analysis-view', function () 
       type: 'source',
       table_name: 'foo_bar',
       params: {
-        query: 'SELECT * FROM foo_bar'
+        query: 'SELECT * FROM public.foo_bar'
       }
     }], {
       configModel: this.configModel,

--- a/lib/assets/test/spec/builder/helpers/sql-utils.spec.js
+++ b/lib/assets/test/spec/builder/helpers/sql-utils.spec.js
@@ -72,20 +72,20 @@ describe('helpers/sql-utils', function () {
   });
 
   it('.getDefaultSQL', function () {
-    expect(SQLUtils.getDefaultSQL('table', 'user', false)).toBe('SELECT * FROM table');
+    expect(SQLUtils.getDefaultSQL('table', 'user', false)).toBe('SELECT * FROM public.table');
     expect(SQLUtils.getDefaultSQL('table', 'user', true)).toBe('SELECT * FROM user.table');
-    expect(SQLUtils.getDefaultSQL('table', undefined, true)).toBe('SELECT * FROM table');
+    expect(SQLUtils.getDefaultSQL('table', undefined, true)).toBe('SELECT * FROM public.table');
 
-    expect(SQLUtils.getDefaultSQL('1table', 'user', false)).toBe('SELECT * FROM "1table"');
+    expect(SQLUtils.getDefaultSQL('1table', 'user', false)).toBe('SELECT * FROM public."1table"');
     expect(SQLUtils.getDefaultSQL('1table', 'user', true)).toBe('SELECT * FROM user."1table"');
-    expect(SQLUtils.getDefaultSQL('1table', undefined, true)).toBe('SELECT * FROM "1table"');
+    expect(SQLUtils.getDefaultSQL('1table', undefined, true)).toBe('SELECT * FROM public."1table"');
 
-    expect(SQLUtils.getDefaultSQL('table', 'user-me', false)).toBe('SELECT * FROM table');
+    expect(SQLUtils.getDefaultSQL('table', 'user-me', false)).toBe('SELECT * FROM public.table');
     expect(SQLUtils.getDefaultSQL('table', 'user-me', true)).toBe('SELECT * FROM "user-me".table');
-    expect(SQLUtils.getDefaultSQL('table', undefined, true)).toBe('SELECT * FROM table');
+    expect(SQLUtils.getDefaultSQL('table', undefined, true)).toBe('SELECT * FROM public.table');
 
-    expect(SQLUtils.getDefaultSQL('tabl-e', '1stuser', false)).toBe('SELECT * FROM "tabl-e"');
+    expect(SQLUtils.getDefaultSQL('tabl-e', '1stuser', false)).toBe('SELECT * FROM public."tabl-e"');
     expect(SQLUtils.getDefaultSQL('tabl-e', '1stuser', true)).toBe('SELECT * FROM "1stuser"."tabl-e"');
-    expect(SQLUtils.getDefaultSQL('tabl-e', undefined, true)).toBe('SELECT * FROM "tabl-e"');
+    expect(SQLUtils.getDefaultSQL('tabl-e', undefined, true)).toBe('SELECT * FROM public."tabl-e"');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.178",
+  "version": "1.0.0-assets.179",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.178",
+  "version": "1.0.0-assets.179",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/spec/models/carto/analysis_spec.rb
+++ b/spec/models/carto/analysis_spec.rb
@@ -197,16 +197,16 @@ describe Carto::Analysis do
         analysis.analysis_node.params[:query].should eq 'SELECT * FROM wadus'
       end
 
-      it 'copies the layer table_name prepending "public"' do
+      it 'copies the layer table_name' do
         @layer.options[:table_name] = 'tt11'
         analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-        analysis.analysis_node.options[:table_name].should eq 'public.tt11'
+        analysis.analysis_node.options[:table_name].should eq 'tt11'
       end
 
-      it 'prepends "public" to table_name' do
+      it 'does not alter table_name' do
         @layer.options.merge!(table_name: 'tt11', user_name: 'juan')
         analysis = Carto::Analysis.source_analysis_for_layer(@layer, 0)
-        analysis.analysis_node.options[:table_name].should eq 'public.tt11'
+        analysis.analysis_node.options[:table_name].should eq 'tt11'
       end
     end
 


### PR DESCRIPTION
This was reverted because some analysis (joins) used `public`-qualified  table names in queries for organization users.