### PR TITLE
Use pg_restore version matching target DB server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@ Development
 - Avoid order by favorited if no user privided ([#15666](https://github.com/CartoDB/cartodb/issues/15666))
 - Sync last login date ([#2788](https://github.com/CartoDB/cartodb-central/issues/2788))
 - Speed up Ghost Tables Manager checks.
+- Use pg_restore version matching target DB server ([#15676](https://github.com/CartoDB/cartodb/pull/15676))
 
 4.37.0 (2020-04-24)
 -------------------

--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -404,7 +404,7 @@ module CartoDB
 
       def run_file_restore_postgres(file, sections = nil)
         file_path = "#{@path}#{file}"
-        command = "#{pg_restore_bin_path(file_path)} -e --verbose -j4 --disable-triggers -Fc #{file_path} #{conn_string(
+        command = "#{pg_restore_bin_path} -e --verbose -j4 --disable-triggers -Fc #{file_path} #{conn_string(
           @config[:dbuser],
           @target_dbhost,
           @config[:user_dbport],
@@ -456,7 +456,7 @@ module CartoDB
 
       def toc_file(file)
         toc_file = "#{@path}user_#{@target_username}.list"
-        command = "#{pg_restore_bin_path(file)} -l #{file} --file='#{toc_file}'"
+        command = "#{pg_restore_bin_path} -l #{file} --file='#{toc_file}'"
         run_command(command)
         clean_toc_file(toc_file)
         toc_file
@@ -741,8 +741,8 @@ module CartoDB
         importjob_logger.info(@import_log.to_json)
       end
 
-      def pg_restore_bin_path(dump)
-        get_pg_restore_bin_path(superuser_pg_conn, dump)
+      def pg_restore_bin_path
+        get_pg_restore_bin_path(superuser_pg_conn)
       end
 
       def target_dbname

--- a/services/user-mover/utils.rb
+++ b/services/user-mover/utils.rb
@@ -90,7 +90,7 @@ module CartoDB
       end
 
       def get_pg_restore_bin_path(conn, dump_name = nil)
-        bin_version = dump_name ? get_dump_database_version(conn, dump_name) : get_database_version_for_binaries(conn)
+        bin_version = get_database_version_for_binaries(conn)
         Cartodb.get_config(:user_migrator, 'pg_restore_bin_path', bin_version) || 'pg_restore'
       end
 
@@ -103,17 +103,6 @@ module CartoDB
         version = conn.query("SELECT version()").first['version']
         version_match = version.match(/(PostgreSQL (([0-9]+\.?){2,3})).*/)
         version_match[2] if version_match
-      end
-
-      def get_dump_database_version(conn, dump_name)
-        pg_restore_bin_path = get_pg_restore_bin_path(conn)
-
-        stdout, stderr, status = Open3.capture3(pg_restore_bin_path, '-l', dump_name)
-        raise stderr unless status.success?
-        version_match = stdout.match(/(pg_dump version: (([0-9]+\.?){2,3})).*/)
-
-        pg_dump_version = version_match[2] if version_match
-        shorten_version(pg_dump_version)
       end
 
       def shorten_version(version)

--- a/services/user-mover/utils.rb
+++ b/services/user-mover/utils.rb
@@ -89,7 +89,7 @@ module CartoDB
         Cartodb.get_config(:user_migrator, 'pg_dump_bin_path', bin_version) || 'pg_dump'
       end
 
-      def get_pg_restore_bin_path(conn, dump_name = nil)
+      def get_pg_restore_bin_path(conn)
         bin_version = get_database_version_for_binaries(conn)
         Cartodb.get_config(:user_migrator, 'pg_restore_bin_path', bin_version) || 'pg_restore'
       end

--- a/spec/models/carto/user_migration_base_spec.rb
+++ b/spec/models/carto/user_migration_base_spec.rb
@@ -31,18 +31,6 @@ describe 'UserMigration' do
       get_pg_dump_bin_path(@conn_mock).should include 'pg_dump'
       get_pg_restore_bin_path(@conn_mock).should include 'pg_restore'
     end
-
-    it 'raises exception if cannot get dump database version' do
-      expect { get_dump_database_version(@conn_mock, '123') }.to raise_error
-    end
-
-    it 'retrieves dump database version from stubbed dump file name' do
-      @conn_mock.stubs(:query).returns(['version' => 'PostgreSQL 10.1 on x86_64-pc-linux-gnu...'])
-      status_mock = Object.new
-      status_mock.stubs(:success?).returns(true)
-      Open3.stubs(:capture3).returns([';     Dumped by pg_dump version: 9.5.2', '', status_mock])
-      get_dump_database_version(@conn_mock, '/tmp/test.dump').should eq '9.5'
-    end
   end
 
   describe 'export_data being false' do
@@ -248,26 +236,26 @@ describe 'UserMigration' do
 
     it 'exports and imports a user with a data import with two tables' do
       CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
-  
+
       user = create_user_with_visualizations
-  
+
       carto_user = Carto::User.find(user.id)
       user_attributes = carto_user.attributes
-  
+
       source_visualizations = carto_user.visualizations.map(&:name).sort
-  
+
       export = Carto::UserMigrationExport.create(
         user: carto_user,
         export_metadata: true
       )
       export.run_export
-  
+
       puts export.log.entries if export.state != Carto::UserMigrationExport::STATE_COMPLETE
       expect(export.state).to eq(Carto::UserMigrationExport::STATE_COMPLETE)
-  
+
       carto_user.client_applications.each(&:destroy)
       user.destroy
-  
+
       import = Carto::UserMigrationImport.create(
         exported_file: export.exported_file,
         database_host: user_attributes['database_host'],
@@ -279,20 +267,20 @@ describe 'UserMigration' do
       import.stubs(:assert_organization_does_not_exist)
       import.stubs(:assert_user_does_not_exist)
       import.run_import
-  
+
       puts import.log.entries if import.state != Carto::UserMigrationImport::STATE_COMPLETE
       expect(import.state).to eq(Carto::UserMigrationImport::STATE_COMPLETE)
-  
+
       carto_user = Carto::User.find(user_attributes['id'])
-  
+
       attributes_to_test(user_attributes).each do |attribute|
         expect(carto_user.attributes[attribute]).to eq(user_attributes[attribute])
       end
       expect(carto_user.visualizations.map(&:name).sort).to eq(source_visualizations)
-  
+
       user.destroy_cascade
     end
-  
+
     it 'does not export duplicated vizs' do
       user = create_user_with_visualizations
       carto_user = Carto::User.find(user.id)
@@ -305,20 +293,20 @@ describe 'UserMigration' do
       table_visualization.update_column(:updated_at, source_vis.updated_at - 1.minute)
       map.destroy
       visualization.destroy
-  
+
       carto_user.visualizations.count.should eq 4
-  
+
       export = Carto::UserMigrationExport.create(
         user: carto_user,
         export_metadata: true
       )
       export.run_export
-  
+
       puts export.log.entries if export.state != Carto::UserMigrationExport::STATE_COMPLETE
       expect(export.state).to eq(Carto::UserMigrationExport::STATE_COMPLETE)
-  
+
       user.destroy_cascade
-  
+
       import = Carto::UserMigrationImport.create(
         exported_file: export.exported_file,
         database_host: user_attributes['database_host'],
@@ -330,29 +318,29 @@ describe 'UserMigration' do
       import.stubs(:assert_organization_does_not_exist)
       import.stubs(:assert_user_does_not_exist)
       import.run_import
-  
+
       puts import.log.entries if import.state != Carto::UserMigrationImport::STATE_COMPLETE
       expect(export.state).to eq(Carto::UserMigrationImport::STATE_COMPLETE)
       imported_user = Carto::User.find(user_attributes['id'])
       imported_user.visualizations.count.should eq 3
       expect { imported_user.visualizations.find(table_visualization.id) }.to raise_error(ActiveRecord::RecordNotFound)
-  
+
       user.destroy_cascade
     end
-  
+
     it 'exporting and then importing to the same DB host fails but DB is not deleted (#c1945)' do
       CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
-  
+
       user = create_user_with_visualizations
-  
+
       carto_user = Carto::User.find(user.id)
       user_attributes = carto_user.attributes
-  
+
       export = Carto::UserMigrationExport.create(user: carto_user, export_metadata: false)
       export.run_export
-  
+
       expect(export.state).to eq(Carto::UserMigrationExport::STATE_COMPLETE)
-  
+
       import = Carto::UserMigrationImport.create(
         exported_file: export.exported_file,
         database_host: user_attributes['database_host'],
@@ -362,60 +350,60 @@ describe 'UserMigration' do
         dry: false
       )
       import.run_import
-  
+
       expect(import.state).to eq(Carto::UserMigrationImport::STATE_FAILURE)
       expect(import.log.entries).to include('DB already exists at DB host')
-  
+
       # DB exists, otherwise this would fail
       user.in_database.run("select 1;")
-  
+
       user.destroy_cascade
     end
-  
+
     it 'exports users with datasets without a physical table if metadata export is requested (see #13721)' do
       CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
-  
+
       user = FactoryGirl.build(:valid_user).save
       carto_user = Carto::User.find(user.id)
-  
+
       @map, @table, @table_visualization, @visualization = create_full_visualization(carto_user)
-  
+
       carto_user.tables.exists?(name: @table.name).should be
       user.in_database.execute("DROP TABLE #{@table.name}")
       # The table is still registered after the deletion
       carto_user.reload
-  
+
       carto_user.tables.exists?(name: @table.name).should be
-  
+
       export = Carto::UserMigrationExport.create(user: carto_user, export_metadata: true)
       export.run_export
-  
+
       export.log.entries.should_not include("Cannot export if tables aren't synched with db. Please run ghost tables.")
       expect(export.state).to eq(Carto::UserMigrationExport::STATE_COMPLETE)
       export.destroy
-  
+
       user.destroy
     end
-  
+
     it 'does export users with a canonical viz without user table if metadata export is requested (see #12588)' do
       CartoDB::UserModule::DBService.any_instance.stubs(:enable_remote_db_user).returns(true)
-  
+
       user = FactoryGirl.build(:valid_user).save
       carto_user = Carto::User.find(user.id)
-  
+
       @map, @table, @table_visualization, @visualization = create_full_visualization(carto_user)
-  
+
       @table.delete
       user.in_database.execute("DROP TABLE #{@table.name}")
       # The canonical visualization is still registered after the deletion
       @table_visualization.reload
       @table_visualization.should be
-  
+
       export = Carto::UserMigrationExport.create(user: carto_user, export_metadata: true)
       export.run_export
-  
+
       expect(export.state).to eq(Carto::UserMigrationExport::STATE_COMPLETE)
-  
+
       user.destroy
     end
 


### PR DESCRIPTION
Needed for user mover to run migrations from PG11 to PG12 machines. Related to https://app.clubhouse.io/cartoteam/story/72097/pg-12-manually-test-pg-upgrade-and-pg-dump-pg-restore

## What does this PR do?

Modifies `get_pg_restore_bin_path` so it returns the bin version matching the target DB server version. Previously it was using the bin version matching the origin DB server.

## Proposed steps for acceptance

**Migration from PG11 to PG12**

1. Deploy branch to a dedicated staging instance (PG12 installed)
2. Generate a dump

```ruby
user = Carto::User.find_by(username: "amiedes-movetest1")
export = Carto::UserMigrationExport.create(user_id: user.id, organization_id: nil, export_metadata: true, backup: false, export_data: true)
export.enqueue
# wait for job to complete
export.exported_file
export.json_file
```

3. Import the dump from a Rails console launched in the dedicated instance:

```ruby
exported_file = "<fill_with_import_values>"
json_file = "<fill_with_import_values>"
db_host = "127.0.0.1" # PG12 server is installed in the dedicated instance itself
org_id = nil
user_id = nil
org_import = false
import_metadata = true

import = Carto::UserMigrationImport.new(exported_file: exported_file, json_file: json_file, database_host: db_host, org_import: org_import, user_id: user_id, organization_id: org_id, import_metadata: import_metadata, dry: false, import_data: true)
import.save

import.run_import
# puts import.log.entries
```

**Migration from PG11 to PG11**

1. Deploy branch to CartoDB staging
2. Generate a dump as in the previous path (or you can reuse the same one)
3. Import the dump by enqueing a job from a RUI server:

```ruby
exported_file = "<fill_with_import_values>"
json_file = "<fill_with_import_values>"
db_host = "dbd02.stag.cartodb.net" # Any staging DB running PG11
org_id = nil
user_id = nil
org_import = false
import_metadata = false

import = Carto::UserMigrationImport.new(exported_file: exported_file, json_file: json_file, database_host: db_host, org_import: org_import, user_id: user_id, organization_id: org_id, import_metadata: import_metadata, dry: false, import_data: true)
import.save

import.run_import
# puts import.log.entries
```
