### PR TITLE
v1/viz: Stop returning the db_size_in_bytes value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,8 @@ Development
 - Scrub Rollbar data ([#2244](https://github.com/CartoDB/cartodb-central/issues/2244))
 - Avoid order by favorited if no user privided ([#15666](https://github.com/CartoDB/cartodb/issues/15666))
 - Sync last login date ([#2788](https://github.com/CartoDB/cartodb-central/issues/2788))
-- Speed up Ghost Tables Manager checks.
+- Speed up Ghost Tables Manager checks ([#15674](https://github.com/CartoDB/cartodb/pull/15674))
+- v1/viz: Stop returning the db_size_in_bytes value ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
 
 4.37.0 (2020-04-24)
 -------------------

--- a/app/controllers/carto/api/permission_presenter.rb
+++ b/app/controllers/carto/api/permission_presenter.rb
@@ -4,11 +4,12 @@ module Carto
   module Api
     class PermissionPresenter
 
-      def initialize(permission, current_viewer: nil, fetch_user_groups: false)
+      def initialize(permission, current_viewer: nil, fetch_user_groups: false, fetch_db_size: true)
         @permission = permission
         @presenter_cache = Carto::Api::PresenterCache.new
         @current_viewer = current_viewer
         @fetch_user_groups = fetch_user_groups
+        @fetch_db_size = fetch_db_size
       end
 
       def with_presenter_cache(presenter_cache)
@@ -23,7 +24,9 @@ module Carto
           Carto::Api::UserPresenter.new(@permission.owner,
                                         fetch_groups: fetch_user_groups,
                                         current_viewer: current_viewer,
-                                        fetch_profile: false)
+                                        fetch_profile: false,
+                                        fetch_db_size: @fetch_db_size
+                                        )
         end
 
         {
@@ -53,7 +56,7 @@ module Carto
       def to_public_poro
         owner = @presenter_cache.get_poro(@permission.owner) do
           Carto::Api::UserPresenter.new(@permission.owner,
-                                        fetch_groups: fetch_user_groups, current_viewer: current_viewer)
+                                        fetch_groups: fetch_user_groups, current_viewer: current_viewer, fetch_db_size: @fetch_db_size)
         end
 
         {

--- a/app/controllers/carto/api/user_table_presenter.rb
+++ b/app/controllers/carto/api/user_table_presenter.rb
@@ -17,12 +17,13 @@ module Carto
 
       MAX_DERIVED_MAPS_SHOWN = 3
 
-      def initialize(user_table, current_viewer, show_size_and_row_count: true, show_permission: true)
+      def initialize(user_table, current_viewer, show_size_and_row_count: true, show_permission: true, fetch_db_size: true)
         @user_table = user_table
         @current_viewer = current_viewer
         @presenter_cache = Carto::Api::PresenterCache.new
         @show_size_and_row_count = show_size_and_row_count
         @show_permission = show_permission
+        @fetch_db_size = fetch_db_size
       end
 
       def with_presenter_cache(presenter_cache)
@@ -81,7 +82,7 @@ module Carto
         permission = @user_table.permission
         return unless permission
 
-        Carto::Api::PermissionPresenter.new(permission, current_viewer: @current_viewer)
+        Carto::Api::PermissionPresenter.new(permission, current_viewer: @current_viewer, fetch_db_size: @fetch_db_size)
                                        .with_presenter_cache(@presenter_cache)
                                        .to_poro
       end

--- a/app/controllers/carto/api/visualization_presenter.rb
+++ b/app/controllers/carto/api/visualization_presenter.rb
@@ -224,7 +224,8 @@ module Carto
       def user_table_presentation
         Carto::Api::UserTablePresenter.new(@visualization.user_table, @current_viewer,
                                            show_size_and_row_count: show_table_size_and_row_count,
-                                           show_permission: show_permission)
+                                           show_permission: show_permission,
+                                           fetch_db_size: false)
                                       .with_presenter_cache(@presenter_cache).to_poro
       end
 
@@ -234,7 +235,7 @@ module Carto
 
       def permission
         unless @visualization.permission.nil?
-          Carto::Api::PermissionPresenter.new(@visualization.permission, current_viewer: @current_viewer)
+          Carto::Api::PermissionPresenter.new(@visualization.permission, current_viewer: @current_viewer, fetch_db_size: false)
                                          .with_presenter_cache(@presenter_cache).to_poro
         end
       end
@@ -257,7 +258,7 @@ module Carto
                   end
 
         related.map do |table|
-          Carto::Api::UserTablePresenter.new(table, @current_viewer).with_presenter_cache(@presenter_cache).to_poro
+          Carto::Api::UserTablePresenter.new(table, @current_viewer, fetch_db_size: false).with_presenter_cache(@presenter_cache).to_poro
         end
       end
 


### PR DESCRIPTION
Changes v1/viz requests to stop calculating (and returning) the `db_size_in_bytes` value, which requires a really expensive `cartodb.CDB_UserDataSize` call.


I'm not sure if anybody is using this value from this exact call, but that would be a bad dependency that should call the appropriate endpoint, not a random viz list. I think we could remove way more information that is currently output by the API, but I've limited the change to the one that causes performance issues.

Example of old owner output:
```
{"id":"f80dfdef-ea5c-498d-b98a-82362650d944","name":null,"last_name":null,"username":"dev2","email":"rmrodriguez+dev@cartodb.com","avatar_url":"/assets/unversioned/images/avatars/avatar_pacman_yellow.png","website":null,"description":null,"location":null,"twitter_username":null,"disqus_shortname":null,"available_for_hire":false,"base_url":"http://localhost:3000/user/dev2","google_maps_query_string":null,"quota_in_bytes":99999999999999999,"table_count":3396,"viewer":false,"role_display":"builder","org_admin":false,"public_visualization_count":3,"all_visualization_count":11,"org_user":false,"remove_logo":false,"db_size_in_bytes":3194740736}
```

After the change the `db_size_in_bytes` is gone:
```
{"id":"f80dfdef-ea5c-498d-b98a-82362650d944","name":null,"last_name":null,"username":"dev2","email":"rmrodriguez+dev@cartodb.com","avatar_url":"/assets/unversioned/images/avatars/avatar_pacman_yellow.png","website":null,"description":null,"location":null,"twitter_username":null,"disqus_shortname":null,"available_for_hire":false,"base_url":"http://localhost:3000/user/dev2","google_maps_query_string":null,"quota_in_bytes":99999999999999999,"table_count":3396,"viewer":false,"role_display":"builder","org_admin":false,"public_visualization_count":3,"all_visualization_count":11,"org_user":false,"remove_logo":false}
```