### PR TITLE
Performance improvements to Ghost tables manager

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@ Development
 - Sync last login date ([#2788](https://github.com/CartoDB/cartodb-central/issues/2788))
 - Speed up Ghost Tables Manager checks ([#15674](https://github.com/CartoDB/cartodb/pull/15674))
 - v1/viz: Stop returning the db_size_in_bytes value ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
+- Ghost Tables Manager: Unify both raster and non raster table checks into a single query and simplify vector comparisons ([#15680]https://github.com/CartoDB/cartodb/pull/15680)
 
 4.37.0 (2020-04-24)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@ Development
 - Sync last login date ([#2788](https://github.com/CartoDB/cartodb-central/issues/2788))
 - Speed up Ghost Tables Manager checks ([#15674](https://github.com/CartoDB/cartodb/pull/15674))
 - v1/viz: Stop returning the db_size_in_bytes value ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
-- Ghost Tables Manager: Unify both raster and non raster table checks into a single query ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
+- Ghost Tables Manager: Unify all table checks into a single query ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
 - Ghost Tables Manager: Don't do any synchronous check if the user has more than MAX_USERTABLES_FOR_SYNC_CHECK tables. ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
 
 4.37.0 (2020-04-24)

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,8 @@ Development
 - Sync last login date ([#2788](https://github.com/CartoDB/cartodb-central/issues/2788))
 - Speed up Ghost Tables Manager checks ([#15674](https://github.com/CartoDB/cartodb/pull/15674))
 - v1/viz: Stop returning the db_size_in_bytes value ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
-- Ghost Tables Manager: Unify both raster and non raster table checks into a single query and simplify vector comparisons ([#15680]https://github.com/CartoDB/cartodb/pull/15680)
+- Ghost Tables Manager: Unify both raster and non raster table checks into a single query ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
+- Ghost Tables Manager: Don't do any synchronous check if the user has more than MAX_USERTABLES_FOR_SYNC_CHECK tables. ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
 
 4.37.0 (2020-04-24)
 -------------------

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -43,7 +43,7 @@ module Carto
       ::Resque.enqueue(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTablesByUsername, user.username)
     end
 
-    # determine linked tables vs cartodbfied tables consistency; i.e.: needs to run
+    # determine linked tables vs cartodbfied tables consistency; that is, check whether it needs to run
     def user_tables_synced_with_db?(*tables)
       tables.all?(&:blank?)
     end

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -38,8 +38,8 @@ module Carto
     end
 
     def link_ghost_tables_asynchronously
-      ::Resque.dequeue(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTablesByUsername, @user.username)
-      ::Resque.enqueue(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTablesByUsername, @user.username)
+      ::Resque.dequeue(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTablesByUsername, user.username)
+      ::Resque.enqueue(::Resque::UserDBJobs::UserDBMaintenance::LinkGhostTablesByUsername, user.username)
     end
 
     # determine linked tables vs cartodbfied tables consistency; i.e.: needs to run

--- a/spec/lib/carto/ghost_tables_manager_spec.rb
+++ b/spec/lib/carto/ghost_tables_manager_spec.rb
@@ -68,15 +68,6 @@ module Carto
       @ghost_tables_manager.send(:should_run_synchronously?).should be_false
     end
 
-    it 'should not run when no tables are changed with tables detected as raster and non-raster' do
-      raster_tables = [Carto::TableFacade.new(123, 'manolito', @user.id)]
-      @ghost_tables_manager.stubs(:fetch_non_raster_cartodbfied_tables).returns(raster_tables)
-      @ghost_tables_manager.stubs(:fetch_raster_tables).returns(raster_tables)
-      @ghost_tables_manager.stubs(:fetch_user_tables).returns(raster_tables)
-
-      @ghost_tables_manager.send(:user_tables_synced_with_db?).should be_true
-    end
-
     it 'should link sql created table, relink sql renamed tables and unlink sql dropped tables' do
       run_in_user_database(%{
         CREATE TABLE manoloescobar ("description" text);

--- a/spec/models/carto/user_migration_base_spec.rb
+++ b/spec/models/carto/user_migration_base_spec.rb
@@ -88,7 +88,7 @@ describe 'UserMigration' do
       end
       expect(carto_user.visualizations.map(&:name).sort).to eq(source_visualizations)
 
-      Carto::GhostTablesManager.new(user.id).user_tables_synced_with_db?.should eq true
+      Carto::GhostTablesManager.new(user.id).fetch_user_tables_synced_with_db?.should eq true
 
       user.destroy_cascade
     end
@@ -199,7 +199,7 @@ describe 'UserMigration' do
         expect(import.state).to eq(Carto::UserMigrationImport::STATE_COMPLETE)
 
         @carto_organization.users.each do |u|
-          Carto::GhostTablesManager.new(u.id).user_tables_synced_with_db?.should eq true
+          Carto::GhostTablesManager.new(u.id).fetch_user_tables_synced_with_db?.should eq true
         end
       end
 

--- a/spec/models/data_import_spec.rb
+++ b/spec/models/data_import_spec.rb
@@ -224,7 +224,7 @@ describe DataImport do
   end
 
   def user_tables_should_be_registered
-    Carto::GhostTablesManager.new(@user.id).user_tables_synced_with_db?.should eq(true), "Tables not properly registered"
+    Carto::GhostTablesManager.new(@user.id).fetch_user_tables_synced_with_db?.should eq(true), "Tables not properly registered"
   end
 
   def create_import(user: @user, overwrite:, truncated:, incomplete_schema: false)


### PR DESCRIPTION
Firstly (bf6a873), make a single query (not one for raster and one for not raster) which allow us to remove the (expensive) `uniq` call since we are already returning unique tables.

Secondly (f93f7ec), optimize the `sync` function to avoid doing multiple array additions and subtractions, which are really expensive operations that scale badly.

Thirdly (dca5f45), don't do any ghost table checks when the user has more than 128 tables. For this users we directly call `link_ghost_tables_asynchronously` to let it decide whether to do anything or not, as calling `should_run_synchronously?` with big arrays has a really bad performance. 
This change has a drawback, as those users won't ever get a synchronous ghost table check but 2 really important wins: it removes really slow checks done in every call, and by being async it will group this checks and do it only once per page load (currently other users do the same work 3 times when loading the dashboard).