### PR TITLE
Keep original state on errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ Development
 - v1/viz: Stop returning the db_size_in_bytes value ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
 - Ghost Tables Manager: Unify all table checks into a single query ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
 - Ghost Tables Manager: Don't do any synchronous check if the user has more than MAX_USERTABLES_FOR_SYNC_CHECK tables. ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
+- OAuth: Keep state on errors ([#15684](https://github.com/CartoDB/cartodb/pull/15684))
 
 4.37.0 (2020-04-24)
 -------------------

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -32,14 +32,14 @@ module Carto
     skip_before_action :verify_authenticity_token, only: [:token]
 
     before_action :x_frame_options_allow, only: :consent, if: :silent_flow?
-    before_action :set_redirection_error_handling, only: [:consent, :authorize]
+    before_action :set_redirection_error_handling, :set_state, only: [:consent, :authorize]
     before_action :ensure_required_token_params, only: [:token]
     before_action :load_oauth_app, :verify_redirect_uri
     before_action :login_required_any_user, only: [:consent, :authorize]
     before_action :validate_prompt_request, only: [:consent]
     before_action :reject_client_secret, only: [:consent, :authorize]
     before_action :ensure_required_authorize_params, only: [:consent, :authorize]
-    before_action :validate_response_type, :validate_scopes, :set_state, only: [:consent, :authorize]
+    before_action :validate_response_type, :validate_scopes, only: [:consent, :authorize]
     before_action :load_oauth_app_user, only: [:consent, :authorize]
     before_action :validate_grant_type, :verify_client_secret, only: [:token]
 

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -87,7 +87,6 @@ describe Carto::OauthProviderController do
 
       it 'redirects with an error if requesting unknown scopes' do
         request_endpoint(valid_payload.merge(scope: 'invalid wadus'))
-                
         expect(response.status).to(eq(302))
         expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
         expect(response.location).to(include(valid_payload[:state]))

--- a/spec/requests/carto/oauth_provider_controller_spec.rb
+++ b/spec/requests/carto/oauth_provider_controller_spec.rb
@@ -87,9 +87,10 @@ describe Carto::OauthProviderController do
 
       it 'redirects with an error if requesting unknown scopes' do
         request_endpoint(valid_payload.merge(scope: 'invalid wadus'))
-
+                
         expect(response.status).to(eq(302))
         expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
+        expect(response.location).to(include(valid_payload[:state]))
         qs = parse_uri_parameters(response.location)
         expect(qs['error']).to(eq('invalid_scope'))
       end
@@ -99,6 +100,7 @@ describe Carto::OauthProviderController do
 
         expect(response.status).to(eq(302))
         expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
+        expect(response.location).to(include(valid_payload[:state]))
         qs = parse_uri_parameters(response.location)
         expect(qs['error']).to(eq('invalid_scope'))
       end
@@ -108,6 +110,7 @@ describe Carto::OauthProviderController do
 
         expect(response.status).to(eq(302))
         expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
+        expect(response.location).to(include(valid_payload[:state]))
         qs = parse_uri_parameters(response.location)
         expect(qs['error']).to(eq('invalid_scope'))
       end
@@ -118,6 +121,7 @@ describe Carto::OauthProviderController do
 
         expect(response.status).to(eq(302))
         expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
+        expect(response.location).to(include(valid_payload[:state]))
         qs = parse_uri_parameters(response.location)
         expect(qs['error']).to(eq('invalid_scope'))
       end
@@ -127,6 +131,7 @@ describe Carto::OauthProviderController do
 
         expect(response.status).to(eq(302))
         expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
+        expect(response.location).to(include(valid_payload[:state]))
         qs = parse_uri_parameters(response.location)
         expect(qs['error']).to(eq('invalid_scope'))
       end
@@ -136,6 +141,7 @@ describe Carto::OauthProviderController do
 
         expect(response.status).to(eq(302))
         expect(response.location).to(start_with(@oauth_app.redirect_uris.first))
+        expect(response.location).to(include(valid_payload[:state]))
         qs = parse_uri_parameters(response.location)
         expect(qs['error']).to(eq('invalid_request'))
         expect(qs['error_description']).to(eq('The redirect_uri must match the redirect_uri param used in the authorization request'))


### PR DESCRIPTION
State was set after returning errors so it was lost.