### PR TITLE
Bring profiler to 2020

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@ Development
 - v1/viz: Stop returning the db_size_in_bytes value ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
 - Ghost Tables Manager: Unify all table checks into a single query ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
 - Ghost Tables Manager: Don't do any synchronous check if the user has more than MAX_USERTABLES_FOR_SYNC_CHECK tables. ([#15678](https://github.com/CartoDB/cartodb/pull/15678))
+- Modernize profiler code a little ([#15691](https://github.com/CartoDB/cartodb/pull/15691))
 - OAuth: Keep state on errors ([#15684](https://github.com/CartoDB/cartodb/pull/15684))
 
 4.37.0 (2020-04-24)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -143,7 +143,7 @@ class ApplicationController < ActionController::Base
 
   def wrap_in_profiler
     if params[:profile_request].present? && current_user.present? && current_user.has_feature_flag?('profiler')
-      CartoDB::Profiler.new().call(request) { yield }
+      CartoDB::Profiler.new().call(request, response) { yield }
     else
       yield
     end

--- a/lib/cartodb/profiler.rb
+++ b/lib/cartodb/profiler.rb
@@ -13,7 +13,7 @@ module CartoDB
       @exclusions = options[:exclude]
 
       @path = options[:path]
-      @path ||= log_dir_path + 'tmp/performance' if defined?(Rails)
+      @path ||= log_dir_path + '/tmp/performance' if defined?(Rails)
       @path ||= ::File.join((ENV["TMPDIR"] || "/tmp"), 'performance')
       @path = Pathname(@path)
     end

--- a/lib/cartodb/profiler.rb
+++ b/lib/cartodb/profiler.rb
@@ -8,11 +8,11 @@ module CartoDB
   class Profiler
     include Carto::Configuration
 
-    def initialize(options = {})
-      @printer = options[:printer] || ::RubyProf::CallTreePrinter
-      @exclusions = options[:exclude]
+    def initialize(printer: nil, exclude: nil, path: nil)
+      @printer = printer || ::RubyProf::CallTreePrinter
+      @exclusions = exclude
 
-      @path = options[:path]
+      @path = path
       @path ||= log_dir_path + '/tmp/performance' if defined?(Rails)
       @path ||= ::File.join((ENV["TMPDIR"] || "/tmp"), 'performance')
       @path = Pathname(@path)

--- a/lib/cartodb/profiler.rb
+++ b/lib/cartodb/profiler.rb
@@ -9,14 +9,9 @@ module CartoDB
   class Profiler
     include Carto::Configuration
 
-    def initialize(printer: nil, exclude: nil, path: nil)
+    def initialize(printer: nil, exclude: nil)
       @printer = printer || ::RubyProf::CallTreePrinter
       @exclusions = exclude
-
-      @path = path
-      @path ||= log_dir_path + '/tmp/performance' if defined?(Rails)
-      @path ||= ::File.join((ENV["TMPDIR"] || "/tmp"), 'performance')
-      @path = Pathname(@path)
     end
 
     def call(request, response)
@@ -76,7 +71,6 @@ module CartoDB
     def write_result(result, request, response)
       result.eliminate_methods!(@exclusions) if @exclusions
       printer = @printer.new(result)
-      Dir.mkdir(@path) unless ::File.exists?(@path)
       url = request.fullpath.gsub(/[?\/]/, '-')
       filename = "#{prefix(printer)}#{Time.now.strftime('%Y-%m-%d-%H-%M-%S')}-#{url.slice(0, 50)}.#{format(printer)}"
 


### PR DESCRIPTION
A couple of light touches to the best tool under my belt to profile slow ruby code.

Amazed it almost worked out of the box 5 years later.

The biggest change is returning the profile trace as the request payload, instead of making you look it up in rui servers in production.

See this wiki page (I know, update pending): https://github.com/CartoDB/cartodb-management/wiki/Profiling-rails

cc/ @CartoDB/backend-team FWIW

have a nice :frog: time!