### PR TITLE
Increase limit of certificates for SQL direct from 3 to 5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development
 - UI for managing IPs and Certificates for DB Direct connections ([#15589](https://github.com/CartoDB/cartodb/pull/15589))
 - Add support for Node.js 12
 - Add user mover support for PG12 (first step, only enabled in Central staging) ([#15686](https://github.com/CartoDB/cartodb/pull/15686))
+- Increase limit of certificates for SQL direct from 3 to 5 ([#2536](https://github.com/CartoDB/support/issues/2536))
 
 ### Bug fixes / enhancements
 - Add maxRetries for aws s3 operation to improve reliability ([#15679](https://github.com/CartoDB/cartodb/pull/15679))

--- a/lib/assets/javascripts/new-dashboard/pages/Connections/DBConnection/DBConnection.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Connections/DBConnection/DBConnection.vue
@@ -120,7 +120,7 @@ export default {
   data () {
     return {
       firstStepEnabled: true,
-      certificateLimit: 3,
+      certificateLimit: 5,
       newCertificate: {}
     };
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.181",
+  "version": "1.0.0-assets.182",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.181",
+  "version": "1.0.0-assets.182",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Closes https://github.com/CartoDB/support/issues/2536