### PR TITLE
Filter support when license DO datasets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ Development
 - None yet
 
 ### Features
-- None yet
+- Filter support when license DO datasets ([15705](https://github.com/CartoDB/cartodb/pull/15705]))
 
 ### Bug fixes / enhancements
 - None yet

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -11,9 +11,9 @@ namespace :cartodb do
       raise usage unless username.present? && datasets_csv.present?
 
       datasets = []
-      CSV.foreach(args[:datasets_csv], { headers: true }) do |row|
+      CSV.foreach(args[:datasets_csv], headers: true) do |row|
         available_in = row['available_in'].split(';')
-        dataset = {
+        dataset = { 
           dataset_id: row['dataset_id'],
           available_in: available_in,
           price: row['price'].to_f,

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -11,9 +11,9 @@ namespace :cartodb do
       raise usage unless username.present? && datasets_csv.present?
 
       datasets = []
-      CSV.foreach(args[:datasets_csv], :headers => true) do |row|
+      CSV.foreach(args[:datasets_csv], { headers: true }) do |row|
         available_in = row['available_in'].split(';')
-        dataset = { 
+        dataset = {
           dataset_id: row['dataset_id'],
           available_in: available_in,
           price: row['price'].to_f,

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -11,9 +11,15 @@ namespace :cartodb do
       raise usage unless username.present? && datasets_csv.present?
 
       datasets = []
-      CSV.foreach(args[:datasets_csv]) do |row|
-        available_in = row[1].split(';')
-        dataset = { dataset_id: row[0], available_in: available_in, price: row[2].to_f, expires_at: Time.parse(row[3]) }
+      CSV.foreach(args[:datasets_csv], :headers => true) do |row|
+        available_in = row['available_in'].split(';')
+        dataset = { 
+          dataset_id: row['dataset_id'], 
+          available_in: available_in, 
+          price: row['price'].to_f, 
+          expires_at: Time.parse(row['expires_at']),
+          view_def: row['view_def']
+        }
         datasets << dataset
       end
 

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -14,9 +14,9 @@ namespace :cartodb do
       CSV.foreach(args[:datasets_csv], :headers => true) do |row|
         available_in = row['available_in'].split(';')
         dataset = { 
-          dataset_id: row['dataset_id'], 
-          available_in: available_in, 
-          price: row['price'].to_f, 
+          dataset_id: row['dataset_id'],
+          available_in: available_in,
+          price: row['price'].to_f,
           expires_at: Time.parse(row['expires_at']),
           view_def: row['view_def']
         }

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -1,4 +1,5 @@
 # Datasets CSV example:
+# dataset_id,available_in,price,expires_at,view_def
 # carto-do-public-data.open_data.geography_usa_state_2015,bq;bigtable,999,2020-09-27T08:00:00
 # carto-do-public-data.open_data.demographics_acs_usa_cbsaclipped_2015_yearly_2015,bq,2000,2020-09-27T08:00:00
 namespace :cartodb do

--- a/lib/tasks/data_observatory.rake
+++ b/lib/tasks/data_observatory.rake
@@ -13,7 +13,7 @@ namespace :cartodb do
       datasets = []
       CSV.foreach(args[:datasets_csv], headers: true) do |row|
         available_in = row['available_in'].split(';')
-        dataset = { 
+        dataset = {
           dataset_id: row['dataset_id'],
           available_in: available_in,
           price: row['price'].to_f,

--- a/spec/lib/tasks/data_observatory_rake_spec.rb
+++ b/spec/lib/tasks/data_observatory_rake_spec.rb
@@ -38,9 +38,9 @@ describe 'data_observatory.rake' do
       File.stubs(:open).returns(csv_example)
       expected_datasets = [
         { dataset_id: 'dataset1', available_in: ['bq', 'bigtable'], price: 100.0,
-          expires_at: Time.new(2020, 9, 27, 8, 0, 0) },
+          expires_at: Time.new(2020, 9, 27, 8, 0, 0), view_def: "where do_date='1986-11-12'" },
         { dataset_id: 'dataset2', available_in: ['bigtable'], price: 200.0,
-          expires_at: Time.new(2020, 12, 31, 12, 0, 0) }
+          expires_at: Time.new(2020, 12, 31, 12, 0, 0), view_def: nil }
       ]
       service_mock = mock
       service_mock.expects(:subscribe).once.with(expected_datasets)
@@ -78,8 +78,9 @@ describe 'data_observatory.rake' do
 
   def csv_example
     CSV.generate do |csv|
-      csv << ["dataset1", "bq;bigtable", "100", "2020-09-27T08:00:00"]
-      csv << ["dataset2", "bigtable", "200", "2020-12-31T12:00:00"]
+      csv << ["dataset_id", "available_in", "price", "expires_at", "view_def"]
+      csv << ["dataset1", "bq;bigtable", "100", "2020-09-27T08:00:00", "where do_date='1986-11-12'"]
+      csv << ["dataset2", "bigtable", "200", "2020-12-31T12:00:00", nil]
     end
   end
 


### PR DESCRIPTION
Add filter support when license DO datasets: https://github.com/CartoDB/cartodb-central/pull/2845

It adds a header to license rake and a new column (named `view_def`) to define either a query or a where condition on the view to license. 

Example CSV with `view_def` column:

```
dataset_id,available_in,price,expires_at,view_def
carto-do.here.pointsofinterest_pointsofinterest_usa_latlon_v1_quarterly_v1,bq,0,2021-05-21T00:00:00,"select * from `carto-do-staging.here.pointsofinterest_pointsofinterest_usa_latlon_v1_quarterly_v1` where do_date = '2020-04-01'"
carto-do.here.pointsofinterest_pointsofinterest_bel_latlon_v1_quarterly_v1,bq,0,2021-05-21T00:00:00,"where do_date = '2020-04-01'"
```

Example CSV without `view_def` column:
```
dataset_id,available_in,price,expires_at
carto-do.here.pointsofinterest_pointsofinterest_usa_latlon_v1_quarterly_v1,bq,0,2021-05-21T00:00:00
```