### PR TITLE
Improve OAuth error for expired sessions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Improve OAuth error for expired sessions ([#15707](https://github.com/CartoDB/cartodb/pull/15707))
 
 4.38.0 (2020-06-05)
 -------------------

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -80,8 +80,9 @@ module Carto
       render(json: OauthProvider::TokenPresenter.new(access_token, refresh_token: refresh_token).to_hash)
     end
 
-    def not_authorized
+    def not_authorized(exception = nil)
       raise OauthProvider::Errors::LoginRequired.new if silent_flow?
+
       super
     end
 


### PR DESCRIPTION
Fixes https://rollbar.com/carto/CartoDB/items/41436/occurrences/126698739920/

Related to this change: https://github.com/CartoDB/cartodb/commit/94c825b2ce5f03c6ec614d7067a1b63792776772