### PR TITLE
Drop deprecated extensions before updating user metadata

### DIFF
--- a/services/user-mover/import_user.rb
+++ b/services/user-mover/import_user.rb
@@ -225,13 +225,12 @@ module CartoDB
 
         if @options[:data]
           configure_database(@target_dbhost)
+          drop_deprecated_extensions
         end
 
         if @options[:update_metadata]
           update_metadata_user(@target_dbhost)
         end
-
-        drop_deprecated_extensions
 
         log_success
       rescue StandardError => e
@@ -770,8 +769,11 @@ module CartoDB
       def drop_deprecated_extensions
         return if destination_db_major_version != 12
 
-        superuser_user_pg_conn.query("DROP EXTENSION IF EXISTS plpythonu")
-        superuser_user_pg_conn.query("DROP EXTENSION IF EXISTS plpython2u")
+        %w(plpythonu plpython2u).each do |deprecated_extension|
+          sql_command = "DROP EXTENSION IF EXISTS #{deprecated_extension}"
+          logger.info(sql_command)
+          superuser_user_pg_conn.query(sql_command)
+        end
       end
 
       def destination_db_major_version


### PR DESCRIPTION
Fixes https://app.clubhouse.io/cartoteam/story/85069/cloud-database-host-updated-when-migration-fails

**How to test this in staging?**

1. Create a user in staging in PG11
2. Create an update_timestamp function in its user DB using the following:

```sql
CREATE FUNCTION update_timestamp ()
  RETURNS integer
AS $$
  return 123
$$ LANGUAGE plpythonu;
```

3. Run a migration to PG12
4. If https://app.clubhouse.io/cartoteam/story/84359/add-update-timestamp-to-the-legacy-functions-list is already merged, the migration should succeed. If it's not merged, the migration should fail and user.database_host should not be updated.