### PR TITLE
Ignore deprecated function on migration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Ignore update_timestamp function on migrations ([#15710](https://github.com/CartoDB/cartodb/pull/15710))
 
 4.38.0 (2020-06-05)
 -------------------

--- a/services/user-mover/legacy_functions.rb
+++ b/services/user-mover/legacy_functions.rb
@@ -3179,7 +3179,7 @@ module CartoDB
         'TYPE valid_detail',
         'TYPE valuecount',
         'TYPE wktgeomval',
-        'FUNCTION update_timestamp()',
+        'FUNCTION update_timestamp()'
       ].freeze
 
       def remove_line?(line)

--- a/services/user-mover/legacy_functions.rb
+++ b/services/user-mover/legacy_functions.rb
@@ -3178,7 +3178,8 @@ module CartoDB
         'TYPE validatetopology_returntype',
         'TYPE valid_detail',
         'TYPE valuecount',
-        'TYPE wktgeomval'
+        'TYPE wktgeomval',
+        'FUNCTION update_timestamp()',
       ].freeze
 
       def remove_line?(line)

--- a/spec/models/carto/user_migration_api_key_spec.rb
+++ b/spec/models/carto/user_migration_api_key_spec.rb
@@ -60,7 +60,7 @@ describe 'UserMigration' do
     end
 
     it 'loads legacy functions' do
-      CartoDB::DataMover::LegacyFunctions::LEGACY_FUNCTIONS.count.should eq 2510
+      CartoDB::DataMover::LegacyFunctions::LEGACY_FUNCTIONS.count.should eq 2511
     end
 
     it 'matches functions with attributes qualified with namespace' do


### PR DESCRIPTION
Related to [ch84359](https://app.clubhouse.io/cartoteam/story/84359/add-update-timestamp-to-the-legacy-functions-list).

Already tested in staging.