### PR TITLE
Make remote_data_updated mechanism usable for connectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@ Development
 - Allow the use of service account credentials on Big Query import UI ([15722](https://github.com/CartoDB/cartodb/pull/15722))
 
 ### Bug fixes / enhancements
-- Fix last modified check for db connecctors ([#15711](https://github.com/CartoDB/cartodb/pull/15711))
+- Fix last modified check for db connectors ([#15711](https://github.com/CartoDB/cartodb/pull/15711))
 - Improve OAuth error for expired sessions ([#15707](https://github.com/CartoDB/cartodb/pull/15707))
 - Verify user email. ([#15683](https://github.com/CartoDB/cartodb/pull/15683))
 - Set right referrer header for password reset page ([#15699](https://github.com/CartoDB/cartodb/pull/15699))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Development
 - Allow the use of service account credentials on Big Query import UI ([15722](https://github.com/CartoDB/cartodb/pull/15722))
 
 ### Bug fixes / enhancements
+- Fix last modified check for db connecctors ([#15711](https://github.com/CartoDB/cartodb/pull/15711))
 - Improve OAuth error for expired sessions ([#15707](https://github.com/CartoDB/cartodb/pull/15707))
 - Verify user email. ([#15683](https://github.com/CartoDB/cartodb/pull/15683))
 - Set right referrer header for password reset page ([#15699](https://github.com/CartoDB/cartodb/pull/15699))

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -288,12 +288,15 @@ module CartoDB
       end
 
       def get_connector
+        # get_runner passes then syncrhonization modified_at to the downloader to the runner,
+        # but here we must pass it directly to the connector runner
         CartoDB::Importer2::ConnectorRunner.check_availability!(user)
         CartoDB::Importer2::ConnectorRunner.new(
           service_item_id,
           user: user,
           pg: pg_options,
-          log: log
+          log: log,
+          modified_at: modified_at
         )
       end
 

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -288,15 +288,17 @@ module CartoDB
       end
 
       def get_connector
-        # get_runner passes then syncrhonization modified_at to the downloader to the runner,
-        # but here we must pass it directly to the connector runner
+        # get_runner passes the synchronization `modified_at` time (which corresponds to the
+        # last-modified time of the external data at the last synchronization) through the
+        # downloader provided to the runner.
+        # For connectors we need to pass it directly to the connector runner.
         CartoDB::Importer2::ConnectorRunner.check_availability!(user)
         CartoDB::Importer2::ConnectorRunner.new(
           service_item_id,
           user: user,
           pg: pg_options,
           log: log,
-          modified_at: modified_at
+          previous_last_modified: modified_at
         )
       end
 

--- a/lib/carto/connector.rb
+++ b/lib/carto/connector.rb
@@ -65,6 +65,10 @@ module Carto
       @provider.remote_data_updated?
     end
 
+    def last_modified
+      @provider.last_modified
+    end
+
     def table_name
       @provider.table_name
     end

--- a/lib/carto/connector/provider.rb
+++ b/lib/carto/connector/provider.rb
@@ -34,12 +34,12 @@ module Carto
         true
       end
 
-      def initialize(parameters: {}, user: nil, logger: nil, modified_at: nil)
+      def initialize(parameters: {}, user: nil, logger: nil, previous_last_modified: nil)
         @params = Parameters.new(parameters, required: required_parameters + [:provider], optional: optional_parameters)
         @user = user
         @logger = logger
-        # modified_at is the time at which previous synchronization data was modified
-        @modified_at = modified_at
+        # previous_last_modified is the time at which external data had been modified at the previous synchronization
+        @previous_last_modified = previous_last_modified
       end
 
       def errors(only_for: nil)

--- a/lib/carto/connector/provider.rb
+++ b/lib/carto/connector/provider.rb
@@ -34,10 +34,12 @@ module Carto
         true
       end
 
-      def initialize(parameters: {}, user: nil, logger: nil)
+      def initialize(parameters: {}, user: nil, logger: nil, modified_at: nil)
         @params = Parameters.new(parameters, required: required_parameters + [:provider], optional: optional_parameters)
         @user = user
         @logger = logger
+        # modified_at is the time at which previous synchronization data was modified
+        @modified_at = modified_at
       end
 
       def errors(only_for: nil)
@@ -82,7 +84,13 @@ module Carto
       end
 
       def remote_data_updated?
-        must_be_defined_in_derived_class
+        # By default connectors don't check for updated data
+        true
+      end
+
+      def last_modified
+        # By default connectors don't support last modified time
+        nil
       end
 
       # Name of the table to be imported

--- a/services/importer/lib/importer/connector_runner.rb
+++ b/services/importer/lib/importer/connector_runner.rb
@@ -106,8 +106,7 @@ module CartoDB
       end
 
       def last_modified
-        # This method is needed to make the interface of ConnectorRunner compatible with Runner,
-        # but we have no meaningful data to return here.
+        # see https://github.com/CartoDB/cartodb/pull/15711#issuecomment-651245994
         @connector.last_modified
       end
 

--- a/services/importer/lib/importer/connector_runner.rb
+++ b/services/importer/lib/importer/connector_runner.rb
@@ -26,7 +26,7 @@ module CartoDB
         @log        = options[:log] || new_logger
         @job        = options[:job] || new_job(@log, @pg_options)
         @user       = options[:user]
-        modified_at = options[:modified_at]
+        previous_last_modified = options[:previous_last_modified]
         @collision_strategy = options[:collision_strategy]
         @georeferencer      = options[:georeferencer] || new_georeferencer(@job)
 
@@ -34,7 +34,7 @@ module CartoDB
         @unique_suffix = @id.delete('-')
         @json_params = JSON.parse(connector_source)
         extract_params
-        @connector = Carto::Connector.new(parameters: @params, user: @user, logger: @log, modified_at: modified_at)
+        @connector = Carto::Connector.new(parameters: @params, user: @user, logger: @log, previous_last_modified: previous_last_modified)
         @results = []
         @tracker = nil
         @stats = {}

--- a/services/importer/lib/importer/connector_runner.rb
+++ b/services/importer/lib/importer/connector_runner.rb
@@ -26,6 +26,7 @@ module CartoDB
         @log        = options[:log] || new_logger
         @job        = options[:job] || new_job(@log, @pg_options)
         @user       = options[:user]
+        @previous_modified_at = options[:modified_at]
         @collision_strategy = options[:collision_strategy]
         @georeferencer      = options[:georeferencer] || new_georeferencer(@job)
 
@@ -33,7 +34,7 @@ module CartoDB
         @unique_suffix = @id.delete('-')
         @json_params = JSON.parse(connector_source)
         extract_params
-        @connector = Carto::Connector.new(parameters: @params, user: @user, logger: @log)
+        @connector = Carto::Connector.new(parameters: @params, user: @user, logger: @log, modified_at: modified_at)
         @results = []
         @tracker = nil
         @stats = {}
@@ -103,6 +104,7 @@ module CartoDB
       def last_modified
         # This method is needed to make the interface of ConnectorRunner compatible with Runner,
         # but we have no meaningful data to return here.
+        @connector.last_modified
       end
 
       def provider_name

--- a/services/importer/lib/importer/connector_runner.rb
+++ b/services/importer/lib/importer/connector_runner.rb
@@ -26,7 +26,7 @@ module CartoDB
         @log        = options[:log] || new_logger
         @job        = options[:job] || new_job(@log, @pg_options)
         @user       = options[:user]
-        @previous_modified_at = options[:modified_at]
+        modified_at = options[:modified_at]
         @collision_strategy = options[:collision_strategy]
         @georeferencer      = options[:georeferencer] || new_georeferencer(@job)
 

--- a/services/importer/lib/importer/connector_runner.rb
+++ b/services/importer/lib/importer/connector_runner.rb
@@ -59,8 +59,6 @@ module CartoDB
           @job.log 'Georeference geometry column'
           georeference
           @warnings.merge! warnings if warnings.present?
-        else
-          @job.log "Table #{table_name} won't be imported"
         end
       rescue => error
         @job.log "ConnectorRunner Error #{error}"

--- a/services/importer/spec/doubles/connector.rb
+++ b/services/importer/spec/doubles/connector.rb
@@ -86,6 +86,18 @@ class DummyConnectorProvider < Carto::Connector::Provider
   end
 end
 
+class DummyConnectorProviderWithModifiedDate < DummyConnectorProvider
+  metadata id: 'dummy_with_modified_date', name: 'DummyWithModifiedDate'
+  LAST_MODIFIED = Time.new(2020, 6, 16)
+  def remote_data_updated?
+    @modified_at.blank? || last_modified > @modified_at
+  end
+
+  def last_modified
+    LAST_MODIFIED
+  end
+end
+
 def dummy_connector_provider_with_id(id, name=nil, features=DummyConnectorProvider::DEFAULT_FEATURES)
   Class.new(DummyConnectorProvider) do
     metadata id: id, name: name || id

--- a/services/importer/spec/doubles/connector.rb
+++ b/services/importer/spec/doubles/connector.rb
@@ -88,6 +88,7 @@ end
 
 class DummyConnectorProviderWithModifiedDate < DummyConnectorProvider
   metadata id: 'dummy_with_modified_date', name: 'DummyWithModifiedDate'
+  @copies = []
   LAST_MODIFIED = Time.new(2020, 6, 16)
   def remote_data_updated?
     @modified_at.blank? || last_modified > @modified_at

--- a/services/importer/spec/doubles/connector.rb
+++ b/services/importer/spec/doubles/connector.rb
@@ -91,7 +91,7 @@ class DummyConnectorProviderWithModifiedDate < DummyConnectorProvider
   @copies = []
   LAST_MODIFIED = Time.new(2020, 6, 16)
   def remote_data_updated?
-    @modified_at.blank? || last_modified > @modified_at
+    @previous_last_modified.blank? || last_modified > @previous_last_modified
   end
 
   def last_modified

--- a/services/importer/spec/unit/connector_runner_spec.rb
+++ b/services/importer/spec/unit/connector_runner_spec.rb
@@ -304,7 +304,7 @@ describe CartoDB::Importer2::ConnectorRunner do
         pg:   @pg_options,
         log:  @fake_log,
         user: @user,
-        modified_at: date_the_data_was_last_copied
+        previous_last_modified: date_the_data_was_last_copied
       }
       config = { provider => { 'enabled' => true } }
       Cartodb.with_config connectors: config do
@@ -333,7 +333,7 @@ describe CartoDB::Importer2::ConnectorRunner do
       provider = DummyConnectorProviderWithModifiedDate.provider_id
       date_the_data_was_modified = DummyConnectorProviderWithModifiedDate::LAST_MODIFIED
       date_the_data_was_last_copied = date_the_data_was_modified - 1
-      config = { provider => { 'enabled' => true }, modified_at: date_the_data_was_last_copied }
+      config = { provider => { 'enabled' => true }, previous_last_modified: date_the_data_was_last_copied }
       Cartodb.with_config connectors: config do
         connector = CartoDB::Importer2::ConnectorRunner.new(parameters.merge(provider: provider).to_json, options)
         connector.run

--- a/services/importer/spec/unit/connector_runner_spec.rb
+++ b/services/importer/spec/unit/connector_runner_spec.rb
@@ -21,6 +21,7 @@ describe CartoDB::Importer2::ConnectorRunner do
     @providers = %w(dummy)
     @fake_log.clear
     Carto::Connector::PROVIDERS << DummyConnectorProvider
+    Carto::Connector::PROVIDERS << DummyConnectorProviderWithModifiedDate
     Carto::Connector.providers(all: true).keys.each do |provider_name|
       Carto::ConnectorProvider.create! name: provider_name
     end
@@ -42,6 +43,7 @@ describe CartoDB::Importer2::ConnectorRunner do
 
   after(:each) do
     DummyConnectorProvider.copies.clear
+    DummyConnectorProviderWithModifiedDate.copies.clear
   end
 
   include FeatureFlagHelper
@@ -286,5 +288,61 @@ describe CartoDB::Importer2::ConnectorRunner do
       DummyConnectorProvider.copies.map(&:last).uniq.should eq [{enabled: true, max_rows: 10}]
     end
   end
-  # TODO: check Runner compatibility
+
+  it "Avoids copying data that hasn't changed" do
+    with_feature_flag @user, 'carto-connectors', true do
+      parameters = {
+        table:    'thetable',
+        req1: 'a',
+        req2: 'b',
+        opt1: 'c'
+      }
+      provider = DummyConnectorProviderWithModifiedDate.provider_id
+      date_the_data_was_modified = DummyConnectorProviderWithModifiedDate::LAST_MODIFIED
+      date_the_data_was_last_copied = date_the_data_was_modified
+      options = {
+        pg:   @pg_options,
+        log:  @fake_log,
+        user: @user,
+        modified_at: date_the_data_was_last_copied
+      }
+      config = { provider => { 'enabled' => true } }
+      Cartodb.with_config connectors: config do
+        connector = CartoDB::Importer2::ConnectorRunner.new(parameters.merge(provider: provider).to_json, options)
+        connector.run
+        connector.success?.should be true
+        connector.provider_name.should eq provider
+      end
+      DummyConnectorProviderWithModifiedDate.copies.size.should eq 0
+    end
+  end
+
+  it "Copies data that has changed" do
+    with_feature_flag @user, 'carto-connectors', true do
+      parameters = {
+        table:    'thetable',
+        req1: 'a',
+        req2: 'b',
+        opt1: 'c'
+      }
+      options = {
+        pg:   @pg_options,
+        log:  @fake_log,
+        user: @user
+      }
+      provider = DummyConnectorProviderWithModifiedDate.provider_id
+      date_the_data_was_modified = DummyConnectorProviderWithModifiedDate::LAST_MODIFIED
+      date_the_data_was_last_copied = date_the_data_was_modified - 1
+      config = { provider => { 'enabled' => true }, modified_at: date_the_data_was_last_copied }
+      Cartodb.with_config connectors: config do
+        connector = CartoDB::Importer2::ConnectorRunner.new(parameters.merge(provider: provider).to_json, options)
+        connector.run
+        connector.success?.should be true
+        connector.provider_name.should eq provider
+      end
+      DummyConnectorProviderWithModifiedDate.copies.size.should eq 1
+      DummyConnectorProviderWithModifiedDate.copies[0][0].should eq 'cdb_importer'
+      DummyConnectorProviderWithModifiedDate.copies[0][1].should match /\Aimporter_/
+    end
+  end
 end

--- a/services/importer/spec/unit/connector_spec.rb
+++ b/services/importer/spec/unit/connector_spec.rb
@@ -15,6 +15,7 @@ describe Carto::Connector do
     Carto::Connector::PROVIDERS << DummyConnectorProvider
     Carto::Connector::PROVIDERS << dummy_connector_provider_with_id('another_dummy')
     Carto::Connector::PROVIDERS << dummy_connector_provider_with_id('third_dummy')
+    Carto::Connector::PROVIDERS << DummyConnectorProviderWithModifiedDate
     Carto::Connector.providers.keys.each do |provider_name|
       Carto::ConnectorProvider.create! name: provider_name
     end
@@ -41,6 +42,7 @@ describe Carto::Connector do
       Carto::Connector.providers(user: @user).should == {
         "dummy"         => { name: "Dummy",         enabled: true,  description: nil },
         "another_dummy" => { name: "another_dummy", enabled: false, description: nil },
+        "dummy_with_modified_date" => { name: "DummyWithModifiedDate", enabled: false, description: nil },
         "third_dummy"   => { name: "third_dummy",   enabled: false, description: nil }
       }
     end
@@ -58,6 +60,7 @@ describe Carto::Connector do
       Carto::Connector.providers(user: @user).should == {
         "dummy"         => { name: "Dummy",         enabled: true,  description: nil },
         "another_dummy" => { name: "another_dummy", enabled: false, description: nil },
+        "dummy_with_modified_date" => { name: "DummyWithModifiedDate", enabled: false, description: nil },
         "third_dummy" => { name: "third_dummy",     enabled: false, description: nil }
       }
     end
@@ -114,5 +117,44 @@ describe Carto::Connector do
     expect {
       Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log)
     }.to raise_error(Carto::Connector::InvalidParametersError)
+  end
+
+  it 'By default providers consider data modified' do
+    parameters = {
+      provider: 'dummy',
+      table:    'thetable',
+      req1: 'a',
+      req2: 'b',
+      opt1: 'c'
+    }
+    future = Time.now + 1
+    past = Time.new(0)
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log)
+    connector.remote_data_updated?.should eq true
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: future)
+    connector.remote_data_updated?.should eq true
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: past)
+    connector.remote_data_updated?.should eq true
+  end
+
+  it 'Providers can detect data modifications' do
+    parameters = {
+      provider: DummyConnectorProviderWithModifiedDate.provider_id,
+      table:    'thetable',
+      req1: 'a',
+      req2: 'b',
+      opt1: 'c'
+    }
+    same_date = DummyConnectorProviderWithModifiedDate::LAST_MODIFIED
+    prior_date = same_date - 1
+    posterior_date = same_date + 1
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log)
+    connector.remote_data_updated?.should eq true
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: prior_date)
+    connector.remote_data_updated?.should eq true
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: posterior_date)
+    connector.remote_data_updated?.should eq false
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: same_date)
+    connector.remote_data_updated?.should eq false
   end
 end

--- a/services/importer/spec/unit/connector_spec.rb
+++ b/services/importer/spec/unit/connector_spec.rb
@@ -131,9 +131,9 @@ describe Carto::Connector do
     past = Time.new(0)
     connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log)
     connector.remote_data_updated?.should eq true
-    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: future)
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, previous_last_modified: future)
     connector.remote_data_updated?.should eq true
-    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: past)
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, previous_last_modified: past)
     connector.remote_data_updated?.should eq true
   end
 
@@ -150,11 +150,11 @@ describe Carto::Connector do
     posterior_date = same_date + 1
     connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log)
     connector.remote_data_updated?.should eq true
-    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: prior_date)
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, previous_last_modified: prior_date)
     connector.remote_data_updated?.should eq true
-    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: posterior_date)
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, previous_last_modified: posterior_date)
     connector.remote_data_updated?.should eq false
-    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, modified_at: same_date)
+    connector = Carto::Connector.new(parameters: parameters, user: @user, logger: @fake_log, previous_last_modified: same_date)
     connector.remote_data_updated?.should eq false
   end
 end


### PR DESCRIPTION
Connectors were missing access to the modified_at field of synchronizations.

For non-connector runner it worked because the modified_at date was passed through the downloader.