### PR TITLE
returns last updated_at date among map related objects

### DIFF
--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -205,13 +205,15 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def updated_at
-    return user_table.updated_at unless map?
+    return self.updated_at unless table? || derived?
+    return [self.updated_at, user_table&.updated_at].compact.max if table?
+
     # If it's a map, then returns last updated_at from its related objects
-    updated_at_dates = [map.updated_at] \
-                      + analyses.map { |a| a.updated_at } \
-                      + layers.map { |l| l.updated_at} \
-                      + widgets.map { |w| w.updated_at}
-    return updated_at_dates.max
+    updated_at_dates = [self.updated_at, map.updated_at] +
+      analyses.map(&:updated_at) +
+      layers.map(&:updated_at) +
+      widgets.map(&:updated_at)
+    return updated_at_dates.compact.max
   end
 
   # TODO: refactor next methods, all have similar naming but some receive user and some others user_id

--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -204,6 +204,16 @@ class Carto::Visualization < ActiveRecord::Base
     ordered
   end
 
+  def updated_at
+    return user_table.updated_at unless map?
+    # If it's a map, then returns last updated_at from its related objects
+    updated_at_dates = [map.updated_at] \
+                      + analyses.map { |a| a.updated_at } \
+                      + layers.map { |l| l.updated_at} \
+                      + widgets.map { |w| w.updated_at}
+    return updated_at_dates.max
+  end
+
   # TODO: refactor next methods, all have similar naming but some receive user and some others user_id
   def liked_by?(user)
     likes_by_user(user).any?


### PR DESCRIPTION
Map's `update_at` date should take into account:

- Metadata updates (privacy, tags, name, etc).
- Map changes (add a layer, change the basemap, change the style, add a widget, etc).
  the client considers a re-publish as a type of change

https://app.clubhouse.io/cartoteam/story/80322/reef-org-dashboard-last-modified-date-is-incorrect