### PR TITLE
Untangle rails' ActionController enforcement of HTTPS from the name of the environment in which it is being executed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@ Development
 -----------
 
 ### NOTICES
-- None yet
+- Adds `ssl_required` config parameter to govern ActionController's redirects. Defaults to `false` (no redirects to HTTPS attempted unless explicitly set to `true`). ([15716](https://github.com/CartoDB/cartodb/pull/15716]))
 
 ### Features
 - Filter support when license DO datasets ([15705](https://github.com/CartoDB/cartodb/pull/15705]))

--- a/app/controllers/admin/visualizations_controller.rb
+++ b/app/controllers/admin/visualizations_controller.rb
@@ -122,7 +122,7 @@ class Admin::VisualizationsController < Admin::AdminController
     end
 
     return(redirect_to protocol: 'https://') if @visualization.is_privacy_private? \
-                                                && !(request.ssl? || request.local? || Rails.env.development?)
+                                                && Cartodb.get_config(:ssl_required) == true
 
     # Legacy redirect, now all public pages also with org. name
     if eligible_for_redirect?(@visualization.user)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
   IGNORE_PATHS_FOR_CHECK_USER_STATE = %w(maintenance_mode lockout login logout unauthenticated multifactor_authentication).freeze
 
   def self.ssl_required(*splat)
-    if Rails.env.production? || Rails.env.staging?
+    if Cartodb.config[:ssl_required].nil? || Cartodb.config[:ssl_required]
       if splat.any?
         force_ssl only: splat
       else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,7 @@ class ApplicationController < ActionController::Base
   IGNORE_PATHS_FOR_CHECK_USER_STATE = %w(maintenance_mode lockout login logout unauthenticated multifactor_authentication).freeze
 
   def self.ssl_required(*splat)
-    if Cartodb.config[:ssl_required].nil? || Cartodb.config[:ssl_required]
+    if Cartodb.config[:ssl_required] == true
       if splat.any?
         force_ssl only: splat
       else

--- a/app/controllers/data_library_controller.rb
+++ b/app/controllers/data_library_controller.rb
@@ -7,7 +7,7 @@ class DataLibraryController < ApplicationController
   def index
     render_404 and return if @viewed_user.nil? || (Cartodb.get_config(:data_library, 'username') && (Cartodb.get_config(:data_library, 'username') != @viewed_user.username))
 
-    @dataset_base_url = (Rails.env.production? || Rails.env.staging?) ? "#{request.protocol}#{CartoDB.account_host}/dataset/" : "#{@viewed_user.public_url(nil, request.protocol == "https://" ? "https" : "http")}/tables/"
+    @dataset_base_url = Cartodb.get_config(:ssl_required) == true ? "#{request.protocol}#{CartoDB.account_host}/dataset/" : "#{@viewed_user.public_url(nil, request.protocol == "https://" ? "https" : "http")}/tables/"
 
     respond_to do |format|
       format.html { render 'index' }

--- a/app/controllers/superadmin/superadmin_controller.rb
+++ b/app/controllers/superadmin/superadmin_controller.rb
@@ -6,7 +6,7 @@ class Superadmin::SuperadminController < ActionController::Base
   rescue_from StandardError, with: :rescue_from_superadmin_error
 
   def self.ssl_required(*splat)
-    if Rails.env.production? || Rails.env.staging?
+    if Cartodb.config[:ssl_required].nil? || Cartodb.config[:ssl_required]
       force_ssl only: splat
     end
   end

--- a/app/controllers/superadmin/superadmin_controller.rb
+++ b/app/controllers/superadmin/superadmin_controller.rb
@@ -6,7 +6,7 @@ class Superadmin::SuperadminController < ActionController::Base
   rescue_from StandardError, with: :rescue_from_superadmin_error
 
   def self.ssl_required(*splat)
-    if Cartodb.config[:ssl_required].nil? || Cartodb.config[:ssl_required]
+    if Cartodb.config[:ssl_required] == true
       force_ssl only: splat
     end
   end

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -15,6 +15,8 @@ defaults: &defaults
   subdomainless_urls: false
   http_port:           3000 # nil|integer. HTTP port to use when building urls. Leave empty to use default (80)
   https_port:          # nil|integer. HTTPS port to use when building urls. Leave empty to use default (443)
+  # Setting this to true will enable ActiveController's enforcement of SSL.
+  ssl_required: false
   secret_token:       '71c2b25921b84a1cb21c71503ab8fb23'
   # It's recommended to generate a new secret_key_base for each installation using `bundle exec rake secret`
   secret_key_base:    '65903fa751affcdd71a9eb09308bcb404c50c8df03414db849ea22fbe8d4aae9ff344f6594630eb9c8367b4fd8ed2211d0342a49df473dccc27ae0be120b25ab'

--- a/config/app_config.yml.sample.py2
+++ b/config/app_config.yml.sample.py2
@@ -15,6 +15,8 @@ defaults: &defaults
   subdomainless_urls: false
   http_port:           3000 # nil|integer. HTTP port to use when building urls. Leave empty to use default (80)
   https_port:          # nil|integer. HTTPS port to use when building urls. Leave empty to use default (443)
+  # Setting this to true will enable ActiveController's enforcement of SSL.
+  ssl_required: false
   secret_token:       '71c2b25921b84a1cb21c71503ab8fb23'
   # It's recommended to generate a new secret_key_base for each installation using `bundle exec rake secret`
   secret_key_base:    '65903fa751affcdd71a9eb09308bcb404c50c8df03414db849ea22fbe8d4aae9ff344f6594630eb9c8367b4fd8ed2211d0342a49df473dccc27ae0be120b25ab'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ CartoDB::Application.configure do
   # In production, Apache or nginx will already do this
   config.serve_static_files = true
 
-  # Setting this to false will disable ActiveController's enforcement of SSL.
+  # Setting this to true will enable ActiveController's enforcement of SSL.
   config.ssl_required = false
 
   # Enable serving of images, stylesheets, and javascripts from an asset server

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,9 @@ CartoDB::Application.configure do
   # In production, Apache or nginx will already do this
   config.serve_static_files = true
 
+  # Setting this to false will disable ActiveController's enforcement of SSL.
+  config.ssl_required = false
+
   # Enable serving of images, stylesheets, and javascripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,8 +39,9 @@ CartoDB::Application.configure do
   # Use a different cache store in production
   # config.cache_store = :mem_cache_store
 
-  # Setting this to false will disable ActiveController's enforcement of SSL.
+  # Setting this to true will enable ActiveController's enforcement of SSL.
   config.ssl_required = true
+
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
   config.serve_static_files = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,6 +39,8 @@ CartoDB::Application.configure do
   # Use a different cache store in production
   # config.cache_store = :mem_cache_store
 
+  # Setting this to false will disable ActiveController's enforcement of SSL.
+  config.ssl_required = true
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
   config.serve_static_files = false

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -28,6 +28,8 @@ CartoDB::Application.configure do
 
   config.log_level = :info
 
+  # Setting this to false will disable ActiveController's enforcement of SSL.
+  config.ssl_required = true
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -28,8 +28,9 @@ CartoDB::Application.configure do
 
   config.log_level = :info
 
-  # Setting this to false will disable ActiveController's enforcement of SSL.
+  # Setting this to true will enable ActiveController's enforcement of SSL.
   config.ssl_required = true
+
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,8 +46,9 @@ CartoDB::Application.configure do
   # config.logger = Logger.new(STDOUT)
   # config.logger.level = Logger::WARN
 
-  # Setting this to false will disable ActiveController's enforcement of SSL.
+  # Setting this to true will enable ActiveController's enforcement of SSL.
   config.ssl_required = false
+
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,6 +46,8 @@ CartoDB::Application.configure do
   # config.logger = Logger.new(STDOUT)
   # config.logger.level = Logger::WARN
 
+  # Setting this to false will disable ActiveController's enforcement of SSL.
+  config.ssl_required = false
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"

--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -241,7 +241,7 @@ module CartoDB
   end
 
   def self.use_https?
-    Cartodb.config[:ssl_required].nil? || Cartodb.config[:ssl_required]
+    Cartodb.config[:ssl_required] == true
   end
 
   def self.get_session_domain

--- a/config/initializers/carto_db.rb
+++ b/config/initializers/carto_db.rb
@@ -241,7 +241,7 @@ module CartoDB
   end
 
   def self.use_https?
-    Rails.env.production? || Rails.env.staging?
+    Cartodb.config[:ssl_required].nil? || Cartodb.config[:ssl_required]
   end
 
   def self.get_session_domain

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,2 +1,2 @@
 domain = CartoDB.subdomainless_urls? ? nil : Cartodb.config[:session_domain]
-CartoDB::Application.config.session_store :cookie_store, key: '_cartodb_session', secure_random: true, domain: domain, expire_after: 7.days, httponly: true, secure: !(Rails.env.development? || Rails.env.test?)
+CartoDB::Application.config.session_store :cookie_store, key: '_cartodb_session', secure_random: true, domain: domain, expire_after: 7.days, httponly: true, secure: (Cartodb.config[:ssl_required].nil? || Cartodb.config[:ssl_required])

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,2 +1,2 @@
 domain = CartoDB.subdomainless_urls? ? nil : Cartodb.config[:session_domain]
-CartoDB::Application.config.session_store :cookie_store, key: '_cartodb_session', secure_random: true, domain: domain, expire_after: 7.days, httponly: true, secure: (Cartodb.config[:ssl_required].nil? || Cartodb.config[:ssl_required])
+CartoDB::Application.config.session_store :cookie_store, key: '_cartodb_session', secure_random: true, domain: domain, expire_after: 7.days, httponly: true, secure: Cartodb.config[:ssl_required] == true


### PR DESCRIPTION
The PR untangles rails' ActionController enforcement of HTTPS from the name of the environment in which it is being executed:

It tries to maintain the old behavior by: 
* The default, when the `ssl_required` is not set, is to force SSL (as if it was set to `true`).
* It adds the expected values for `ssl_required` for the four defined config environments.

The reason we are interested in this now is due to https://github.com/CartoDB/onpremises/pull/910

What is your view on this? I fear that [certain app logic](https://github.com/CartoDB/cartodb/blob/master/app/controllers/admin/visualizations_controller.rb#L124) will make it difficult to opt-out of HTTPS entirely (which, as per https://github.com/CartoDB/onpremises/pull/910, is sadly something we need to work around).