### PR TITLE
Allow service account credentials on Big Query import UI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ Development
 ### Features
 - Filter support when license DO datasets ([15705](https://github.com/CartoDB/cartodb/pull/15705]))
 - Synchronize REDIS when licensing from superadmin ([15719](https://github.com/CartoDB/cartodb/pull/15719]))
-- Allow service account credentials on Big Query import UI ([15722](https://github.com/CartoDB/cartodb/pull/15722))
+- Allow the use of service account credentials on Big Query import UI ([15722](https://github.com/CartoDB/cartodb/pull/15722))
 
 ### Bug fixes / enhancements
 - Improve OAuth error for expired sessions ([#15707](https://github.com/CartoDB/cartodb/pull/15707))

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ Development
 ### Features
 - Filter support when license DO datasets ([15705](https://github.com/CartoDB/cartodb/pull/15705]))
 - Synchronize REDIS when licensing from superadmin ([15719](https://github.com/CartoDB/cartodb/pull/15719]))
+- Allow service account credentials on Big Query import UI ([15722](https://github.com/CartoDB/cartodb/pull/15722))
 
 ### Bug fixes / enhancements
 - Improve OAuth error for expired sessions ([#15707](https://github.com/CartoDB/cartodb/pull/15707))

--- a/app/helpers/frontend_config_helper.rb
+++ b/app/helpers/frontend_config_helper.rb
@@ -33,6 +33,7 @@ module FrontendConfigHelper
       config[:bigquery_enabled] = Carto::Connector.provider_available?('bigquery', user)
       config[:bigquery_available] = Carto::Connector.provider_public?('bigquery')
       config[:oauth_mechanism_bigquery] = Cartodb.get_config(:oauth, 'bigquery', 'oauth_mechanism')
+      config[:bigquery_uses_service_auth] = Cartodb.get_config(:connectors, 'bigquery', 'credentials_project').present?
       config[:arcgis_enabled] = Cartodb.get_config(:datasources, 'arcgis_enabled')
       config[:salesforce_enabled] = Cartodb.get_config(:datasources, 'salesforce_enabled')
       config[:mysql_enabled] = Cartodb.get_config(:connectors, 'mysql', 'enabled')

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-auth-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-auth-model.js
@@ -1,0 +1,24 @@
+const Backbone = require('backbone');
+const checkAndBuildOpts = require('builder/helpers/required-opts');
+
+const REQUIRED_OPTS = [
+    'configModel'
+];
+
+module.exports = Backbone.Model.extend({
+    initialize: function (opts) {
+        checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+    },
+
+    isUserAuthentication: function () {
+        return !!this._configModel.get('oauth_bigquery');
+    },
+
+    isServiceAuthentication: function () {
+        return this._configModel.get('bigquery_uses_service_auth');
+    },
+
+    hasAnyAuthMethod: function () {
+        return this.isUserAuthentication() || this.isServiceAuthentication();
+    }
+});

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-auth-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-auth-model.js
@@ -2,23 +2,23 @@ const Backbone = require('backbone');
 const checkAndBuildOpts = require('builder/helpers/required-opts');
 
 const REQUIRED_OPTS = [
-    'configModel'
+  'configModel'
 ];
 
 module.exports = Backbone.Model.extend({
-    initialize: function (opts) {
-        checkAndBuildOpts(opts, REQUIRED_OPTS, this);
-    },
+  initialize: function (opts) {
+    checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+  },
 
-    isUserAuthentication: function () {
-        return !!this._configModel.get('oauth_bigquery');
-    },
+  isUserAuthentication: function () {
+    return !!this._configModel.get('oauth_bigquery');
+  },
 
-    isServiceAuthentication: function () {
-        return this._configModel.get('bigquery_uses_service_auth');
-    },
+  isServiceAuthentication: function () {
+    return this._configModel.get('bigquery_uses_service_auth');
+  },
 
-    hasAnyAuthMethod: function () {
-        return this.isUserAuthentication() || this.isServiceAuthentication();
-    }
+  hasAnyAuthMethod: function () {
+    return this.isUserAuthentication() || this.isServiceAuthentication();
+  }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -121,11 +121,12 @@ module.exports = ImportDataFormView.extend({
       importAs: this.$('.js-textInput').val()
     };
 
-    if (this._authModel.isUserAuthentication()) {
+    if (this._authModel.isServiceAuthentication()) {
+      // service mode takes precedence...
+      this._goToConnectStep();
+    } else if (this._authModel.isUserAuthentication()) {
       // Currently dryrun is only supported when working over OAuth, not on service auth
       this._performDryRunBeforeConnectStep();
-    } else if (this._authModel.isServiceAuthentication()) {
-      this._goToConnectStep();
     }
   },
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -9,7 +9,8 @@ const commonForm = require('builder/components/modals/add-layer/content/imports/
 
 const REQUIRED_OPTS = [
   'userModel',
-  'configModel'
+  'configModel',
+  'authModel'
 ];
 
 /**
@@ -34,6 +35,7 @@ module.exports = ImportDataFormView.extend({
 
   initialize: function (opts) {
     checkAndBuildOpts(opts, REQUIRED_OPTS, this);
+
     this.template = template;
 
     this._initBinds();
@@ -101,8 +103,8 @@ module.exports = ImportDataFormView.extend({
 
   _isFormFilled: function () {
     return this.$('.js-select').val() !== '' &&
-           this.codeEditor.getValue() !== '' &&
-           this.$('.js-textInput').val() !== '';
+      this.codeEditor.getValue() !== '' &&
+      this.$('.js-textInput').val() !== '';
   },
 
   _onSubmitForm: function (e) {
@@ -119,6 +121,15 @@ module.exports = ImportDataFormView.extend({
       importAs: this.$('.js-textInput').val()
     };
 
+    if (this._authModel.isUserAuthentication()) {
+      // Currently dryrun is only supported when working over OAuth, not on service auth
+      this._performDryRunBeforeConnectStep();
+    } else if (this._authModel.isServiceAuthentication()) {
+      this._goToConnectStep();
+    }
+  },
+
+  _performDryRunBeforeConnectStep: function () {
     const dbConnectorsClient = new CartoNode.AuthenticatedClient().dbConnectors();
     const params = {
       billing_project: this.formFields.billingProject,
@@ -129,11 +140,15 @@ module.exports = ImportDataFormView.extend({
       if (errors) {
         this._handleErrors(data);
       } else if (data && data.total_bytes_processed) {
-        this._prepareUploadModel(query);
-        this._updateUploadModel();
-        this._goSelectDataset();
+        this._goToConnectStep();
       }
     });
+  },
+
+  _goToConnectStep: function () {
+    this._prepareUploadModel(this.formFields.sqlQuery);
+    this._updateUploadModel();
+    this._goSelectDataset();
   },
 
   _updateUploadModel: function () {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form.tpl
@@ -39,7 +39,7 @@
     <div class="Form-rowLabel ImportOptions__label"></div>
     <div class="Form-row ImportOptions__input--long u-flex__justify--end">
       <button type="submit" class="CDB-Button CDB-Button--primary is-disabled js-submit">
-        <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase"><%- _t('components.modals.add-layer.imports.database.run') %></span>
+        <span class="CDB-Button-Text CDB-Text is-semibold CDB-Size-small u-upperCase"><%- _t('components.modals.add-layer.imports.database.run-bq-go-to-connect') %></span>
       </button>
     </div>
   </div>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
@@ -1,3 +1,4 @@
+const AuthModel = require('./import-bigquery-auth-model');
 const HeaderView = require('./import-bigquery-header-view');
 const ImportDataView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-view');
 const headerTemplate = require('./import-bigquery-header.tpl');
@@ -42,6 +43,7 @@ module.exports = ImportDataView.extend({
     this._userModel = opts.userModel;
     this._configModel = opts.configModel;
     this._DATASOURCE_NAME = this.options.service;
+    this._authModel = new AuthModel({ configModel: this._configModel });
 
     this.model = new UploadModel(
       {
@@ -63,7 +65,7 @@ module.exports = ImportDataView.extend({
     this.model.set('state', 'idle');
     this._initViews();
 
-    if (this._isServiceAuthentication()) {
+    if (this._authModel.isServiceAuthentication()) {
       // if enabled, the oauth flow is omitted
       this._prepareModelToUpload();
     }
@@ -87,7 +89,7 @@ module.exports = ImportDataView.extend({
     this.model.bind('change', this._triggerChange, this);
     this.model.bind('change:state', this._checkState, this);
 
-    if (this._isUserAuthentication()) {
+    if (this._authModel.isUserAuthentication()) {
       this._serviceTokenModel.bind(
         'change:oauth_valid',
         this._onOauthChange,
@@ -102,7 +104,7 @@ module.exports = ImportDataView.extend({
   _initViews: function () {
     this._addDataHeaderView();
 
-    if (this._isUserAuthentication()) {
+    if (this._authModel.isUserAuthentication()) {
       this._addServiceLoaderView();
     }
 
@@ -215,13 +217,5 @@ module.exports = ImportDataView.extend({
         clearInterval(e);
       }
     }, this._WINDOW_INTERVAL);
-  },
-
-  _isUserAuthentication: function () {
-    return !!this._configModel.get('oauth_bigquery');
-  },
-
-  _isServiceAuthentication: function () {
-    return this._configModel.get('bigquery_uses_service_auth');
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
@@ -13,7 +13,7 @@ const ServiceLoaderView = require('../import-service/import-service-loader-view'
 /**
  *  Import BigQuery panel
  *
- *  - It only accepts an query.
+ *  - It only accepts a query.
  *
  */
 
@@ -100,6 +100,17 @@ module.exports = ImportDataView.extend({
   },
 
   _initViews: function () {
+    this._addDataHeaderView();
+
+    if (this._isUserAuthentication()) {
+      this._addServiceLoaderView();
+    }
+
+    this._addSelectedDatasetView();
+    this._addFormView();
+  },
+
+  _addDataHeaderView() {
     // Data header
     const headerView = new HeaderView({
       el: this.$('.ImportPanel-header'),
@@ -112,19 +123,21 @@ module.exports = ImportDataView.extend({
     });
     headerView.render();
     this.addView(headerView);
+  },
 
-    if (this._isUserAuthentication()) {
-      // Loader
-      const loader = new ServiceLoaderView({
-        el: this.$('.ServiceLoader'),
-        model: this.model,
-        serviceTokenModel: this._serviceTokenModel,
-        serviceOauthModel: this._serviceOauthModel
-      });
-      loader.render();
-      this.addView(loader);
-    }
+  _addServiceLoaderView() {
+    // Loader
+    const loader = new ServiceLoaderView({
+      el: this.$('.ServiceLoader'),
+      model: this.model,
+      serviceTokenModel: this._serviceTokenModel,
+      serviceOauthModel: this._serviceOauthModel
+    });
+    loader.render();
+    this.addView(loader);
+  },
 
+  _addSelectedDatasetView() {
     // Dataset selected
     const selected = new SelectedDataset({
       el: this.$('.DatasetSelected'),
@@ -137,6 +150,9 @@ module.exports = ImportDataView.extend({
     selected.render();
     this.addView(selected);
 
+  },
+
+  _addFormView() {
     // Data Form
     const formView = new FormView({
       el: this.$('.ImportPanel-form'),
@@ -145,7 +161,6 @@ module.exports = ImportDataView.extend({
       model: this.model,
       fileEnabled: this.options.fileEnabled,
     });
-
     formView.render();
     this.addView(formView);
   },

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
@@ -48,11 +48,11 @@ module.exports = ImportDataView.extend({
     this.model = new UploadModel(
       {
         type: this.options.type,
-        service_name: this._DATASOURCE_NAME,
+        service_name: this._DATASOURCE_NAME
       },
       {
         userModel: this._userModel,
-        configModel: this._configModel,
+        configModel: this._configModel
       }
     );
 
@@ -112,7 +112,7 @@ module.exports = ImportDataView.extend({
     this._addFormView();
   },
 
-  _addDataHeaderView() {
+  _addDataHeaderView: function () {
     // Data header
     const headerView = new HeaderView({
       el: this.$('.ImportPanel-header'),
@@ -127,7 +127,7 @@ module.exports = ImportDataView.extend({
     this.addView(headerView);
   },
 
-  _addServiceLoaderView() {
+  _addServiceLoaderView: function () {
     // Loader
     const loader = new ServiceLoaderView({
       el: this.$('.ServiceLoader'),
@@ -139,7 +139,7 @@ module.exports = ImportDataView.extend({
     this.addView(loader);
   },
 
-  _addSelectedDatasetView() {
+  _addSelectedDatasetView: function () {
     // Dataset selected
     const selected = new SelectedDataset({
       el: this.$('.DatasetSelected'),
@@ -151,10 +151,9 @@ module.exports = ImportDataView.extend({
     });
     selected.render();
     this.addView(selected);
-
   },
 
-  _addFormView() {
+  _addFormView: function () {
     // Data Form
     const formView = new FormView({
       el: this.$('.ImportPanel-form'),
@@ -162,7 +161,7 @@ module.exports = ImportDataView.extend({
       configModel: this._configModel,
       authModel: this._authModel,
       model: this.model,
-      fileEnabled: this.options.fileEnabled,
+      fileEnabled: this.options.fileEnabled
     });
     formView.render();
     this.addView(formView);

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
@@ -18,7 +18,6 @@ const ServiceLoaderView = require('../import-service/import-service-loader-view'
  */
 
 module.exports = ImportDataView.extend({
-
   _DATASOURCE_NAME: '',
   _WINDOW_INTERVAL: 1000, // miliseconds
 
@@ -36,7 +35,7 @@ module.exports = ImportDataView.extend({
   },
 
   initialize: function (opts) {
-    if (!opts.service) throw new Error('service prodiver is required');
+    if (!opts.service) throw new Error('service provider is required');
     if (!opts.userModel) throw new Error('userModel is required');
     if (!opts.configModel) throw new Error('configModel is required');
 
@@ -44,13 +43,16 @@ module.exports = ImportDataView.extend({
     this._configModel = opts.configModel;
     this._DATASOURCE_NAME = this.options.service;
 
-    this.model = new UploadModel({
-      type: this.options.type,
-      service_name: this._DATASOURCE_NAME
-    }, {
-      userModel: this._userModel,
-      configModel: this._configModel
-    });
+    this.model = new UploadModel(
+      {
+        type: this.options.type,
+        service_name: this._DATASOURCE_NAME,
+      },
+      {
+        userModel: this._userModel,
+        configModel: this._configModel,
+      }
+    );
 
     this._initBinds();
   },
@@ -60,6 +62,11 @@ module.exports = ImportDataView.extend({
     this.$el.html(template(this.options));
     this.model.set('state', 'idle');
     this._initViews();
+
+    if (this._isServiceAuthentication()) {
+      // if enabled, the oauth flow is omitted
+      this._prepareModelToUpload();
+    }
 
     return this;
   },
@@ -79,10 +86,17 @@ module.exports = ImportDataView.extend({
     this._initModels();
     this.model.bind('change', this._triggerChange, this);
     this.model.bind('change:state', this._checkState, this);
-    this._serviceTokenModel.bind('change:oauth_valid', this._onOauthChange, this);
-    this._serviceOauthModel.bind('change:url', this._openWindow, this);
-    this.add_related_model(this._serviceOauthModel);
-    this.add_related_model(this._serviceTokenModel);
+
+    if (this._isUserAuthentication()) {
+      this._serviceTokenModel.bind(
+        'change:oauth_valid',
+        this._onOauthChange,
+        this
+      );
+      this._serviceOauthModel.bind('change:url', this._openWindow, this);
+      this.add_related_model(this._serviceOauthModel);
+      this.add_related_model(this._serviceTokenModel);
+    }
   },
 
   _initViews: function () {
@@ -99,15 +113,17 @@ module.exports = ImportDataView.extend({
     headerView.render();
     this.addView(headerView);
 
-    // Loader
-    const loader = new ServiceLoaderView({
-      el: this.$('.ServiceLoader'),
-      model: this.model,
-      serviceTokenModel: this._serviceTokenModel,
-      serviceOauthModel: this._serviceOauthModel
-    });
-    loader.render();
-    this.addView(loader);
+    if (this._isUserAuthentication()) {
+      // Loader
+      const loader = new ServiceLoaderView({
+        el: this.$('.ServiceLoader'),
+        model: this.model,
+        serviceTokenModel: this._serviceTokenModel,
+        serviceOauthModel: this._serviceOauthModel
+      });
+      loader.render();
+      this.addView(loader);
+    }
 
     // Dataset selected
     const selected = new SelectedDataset({
@@ -127,7 +143,7 @@ module.exports = ImportDataView.extend({
       userModel: this._userModel,
       configModel: this._configModel,
       model: this.model,
-      fileEnabled: this.options.fileEnabled
+      fileEnabled: this.options.fileEnabled,
     });
 
     formView.render();
@@ -170,7 +186,11 @@ module.exports = ImportDataView.extend({
   _openWindow: function () {
     var url = this._serviceOauthModel.get('url');
     var self = this;
-    var i = window.open(url, null, 'menubar=no,toolbar=no,width=600,height=495');
+    var i = window.open(
+      url,
+      null,
+      'menubar=no,toolbar=no,width=600,height=495'
+    );
     var e = window.setInterval(function () {
       if (i && i.closed) {
         self._prepareModelToUpload();
@@ -180,6 +200,13 @@ module.exports = ImportDataView.extend({
         clearInterval(e);
       }
     }, this._WINDOW_INTERVAL);
-  }
+  },
 
+  _isUserAuthentication: function () {
+    return !!this._configModel.get('oauth_bigquery');
+  },
+
+  _isServiceAuthentication: function () {
+    return this._configModel.get('bigquery_uses_service_auth');
+  }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-view.js
@@ -160,6 +160,7 @@ module.exports = ImportDataView.extend({
       el: this.$('.ImportPanel-form'),
       userModel: this._userModel,
       configModel: this._configModel,
+      authModel: this._authModel,
       model: this.model,
       fileEnabled: this.options.fileEnabled,
     });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-options.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-options.js
@@ -2,7 +2,10 @@ var ImportDataView = require('./import-data/import-data-view');
 var ImportServiceView = require('./import-service/import-service-view');
 var ImportArcGISView = require('./import-arcgis/import-arcgis-view');
 var ImportTwitterView = require('./import-twitter/import-twitter-view');
+
 var ImportBigQueryView = require('./import-bigquery/import-bigquery-view');
+var BigQueryAuthModel = require('./import-bigquery/import-bigquery-auth-model');
+
 var ImportDatabaseView = require('./import-database/import-database-view');
 
 /**
@@ -65,9 +68,8 @@ module.exports = {
   BigQuery: {
     view: ImportBigQueryView,
     enabled: function (config, userModel) {
-      const bigQueryWithOauth = !!config.get("oauth_bigquery");
-      const bigQueryWithServiceAuth = config.get("bigquery_uses_service_auth");
-      return bigQueryWithOauth || bigQueryWithServiceAuth;
+      const authModel = new BigQueryAuthModel({ configModel: config });
+      return authModel.hasAnyAuthMethod();
     },
     name: 'bigquery',
     title: 'BigQuery',

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-options.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-options.js
@@ -64,7 +64,11 @@ module.exports = {
   },
   BigQuery: {
     view: ImportBigQueryView,
-    enabled: function (config, userModel) { return !!config.get('oauth_bigquery'); },
+    enabled: function (config, userModel) {
+      const bigQueryWithOauth = !!config.get("oauth_bigquery");
+      const bigQueryWithServiceAuth = config.get("bigquery_uses_service_auth");
+      return bigQueryWithOauth || bigQueryWithServiceAuth;
+    },
     name: 'bigquery',
     title: 'BigQuery',
     type: 'database',

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -1383,6 +1383,7 @@
                         "import-as-field": "CARTO Dataset",
                         "import-as-hint": "Name of the new Dataset that will be created in your CARTO Dashboard with the imported data.",
                         "run": "Run SQL query",
+                        "run-bq-go-to-connect": "Connect to BQ",
                         "placeholder": "SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM table",
                         "sidebar-connect": {
                             "title": "Getting connected",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.184",
+  "version": "1.0.0-assets.185",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.184",
+  "version": "1.0.0-assets.185",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a set of UI adjustments to allow the use of Service Account auth (instead of OAuth), for connecting to BQ for importing datasets. The backend has already been developed on https://github.com/CartoDB/db-connectors/pull/15


## Acceptance

**Given**
- bquser at [https://bquser.carto-staging.com/](https://bquser.carto-staging.com/) (staging ded already configured with a service account auth)

**When**
- Creating a New Dataset

**Then**
- BQ import option is available
- BQ import can be used, with a simple query like
    ```sql
    SELECT *, ST_GeogPoint(lng, lat) as the_geom FROM `cartodb-on-gcp-core-team.f1.circuits`
    ```
- BQ connection is succesful and dataset is properly imported