### PR TITLE
Query builder improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Development
 - Set right referrer header for password reset page ([#15699](https://github.com/CartoDB/cartodb/pull/15699))
 - Fix navigation bar tests
 - Ignore update_timestamp function on migrations ([#15710](https://github.com/CartoDB/cartodb/pull/15710))
+- Improve query builder performance ([#15725](https://github.com/CartoDB/cartodb/pull/15725))
 
 4.38.0 (2020-06-05)
 -------------------

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -371,7 +371,7 @@ class Admin::PagesController < Admin::AdminController
     @user               = optional.fetch(:user, nil)
     @is_org             = model.is_a? Organization
     @tables_num = (@is_org ? org_datasets_public_builder(model) : user_datasets_public_builder(model)).count
-    @maps_count = (@is_org ? org_maps_public_builder(model) : user_maps_public_builder(model)).build
+    @maps_count = (@is_org ? org_maps_public_builder(model) : user_maps_public_builder(model)).count
 
     @needs_gmaps_lib = @most_viewed_vis_map.try(:map).try(:provider) == 'googlemaps'
     @needs_gmaps_lib ||= @default_fallback_basemap['className'] == 'googlemaps'

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -133,8 +133,8 @@ class Admin::PagesController < Admin::AdminController
 
       @name                = @viewed_user.name_or_username
       @avatar_url          = @viewed_user.avatar
-      @tables_num          = dataset_builder.build.count
-      @maps_count          = maps_builder.build.count
+      @tables_num          = dataset_builder.count
+      @maps_count          = maps_builder.count
       @website             = website_url(@viewed_user.website)
       @website_clean       = @website ? @website.gsub(/https?:\/\//, "") : ""
 
@@ -208,7 +208,7 @@ class Admin::PagesController < Admin::AdminController
 
   def render_datasets(vis_query_builder, user = nil)
     home = CartoDB.url(self, 'public_datasets_home', params: { page: PAGE_NUMBER_PLACEHOLDER }, user: user)
-    set_pagination_vars(total_count: vis_query_builder.build.count,
+    set_pagination_vars(total_count: vis_query_builder.count,
                         per_page: DATASETS_PER_PAGE,
                         first_page_url: CartoDB.url(self, 'public_datasets_home', user: user),
                         numbered_page_url: home)
@@ -245,7 +245,7 @@ class Admin::PagesController < Admin::AdminController
 
   def render_maps(vis_query_builder, user=nil)
     set_pagination_vars(
-      total_count: vis_query_builder.build.count,
+      total_count: vis_query_builder.count,
       per_page:    MAPS_PER_PAGE,
       first_page_url: CartoDB.url(self, 'public_maps_home', user: user),
       numbered_page_url: CartoDB.url(self, 'public_maps_home', params: { page: PAGE_NUMBER_PLACEHOLDER }, user: user)
@@ -370,8 +370,8 @@ class Admin::PagesController < Admin::AdminController
     @available_for_hire = optional.fetch(:available_for_hire, false)
     @user               = optional.fetch(:user, nil)
     @is_org             = model.is_a? Organization
-    @tables_num = (@is_org ? org_datasets_public_builder(model) : user_datasets_public_builder(model)).build.count
-    @maps_count = (@is_org ? org_maps_public_builder(model) : user_maps_public_builder(model)).build.count
+    @tables_num = (@is_org ? org_datasets_public_builder(model) : user_datasets_public_builder(model)).count
+    @maps_count = (@is_org ? org_maps_public_builder(model) : user_maps_public_builder(model)).build
 
     @needs_gmaps_lib = @most_viewed_vis_map.try(:map).try(:provider) == 'googlemaps'
     @needs_gmaps_lib ||= @default_fallback_basemap['className'] == 'googlemaps'

--- a/app/controllers/carto/admin/user_public_map_adapter.rb
+++ b/app/controllers/carto/admin/user_public_map_adapter.rb
@@ -16,15 +16,15 @@ module Carto
       end
 
       def public_table_count
-        @public_table_count ||= Carto::VisualizationQueryBuilder.user_public_tables(@user).build.count
+        @public_table_count ||= Carto::VisualizationQueryBuilder.user_public_tables(@user).count
       end
 
       def public_visualization_count
-        @public_visualization_count ||= Carto::VisualizationQueryBuilder.user_public_visualizations(@user).build.count
+        @public_visualization_count ||= Carto::VisualizationQueryBuilder.user_public_visualizations(@user).count
       end
 
       def all_visualization_count
-        @all_visualization_count ||= Carto::VisualizationQueryBuilder.user_all_visualizations(@user).build.count
+        @all_visualization_count ||= Carto::VisualizationQueryBuilder.user_all_visualizations(@user).count
       end
 
     end

--- a/app/controllers/carto/api/public/apps_controller.rb
+++ b/app/controllers/carto/api/public/apps_controller.rb
@@ -34,7 +34,7 @@ class Carto::Api::Public::AppsController < Carto::Api::Public::ApplicationContro
     end
     response = {
       apps: apps,
-      total_entries: vqb.build.size
+      total_entries: vqb.count
     }
     render_jsonp(response)
   rescue Carto::ParamInvalidError => e

--- a/app/controllers/carto/api/public/custom_visualizations_controller.rb
+++ b/app/controllers/carto/api/public/custom_visualizations_controller.rb
@@ -45,7 +45,7 @@ class Carto::Api::Public::CustomVisualizationsController < Carto::Api::Public::A
     end
     response = {
       visualizations: visualizations,
-      total_entries: vqb.build.size
+      total_entries: vqb.count
     }
     render_jsonp(response)
   rescue Carto::ParamInvalidError, Carto::ParamCombinationInvalidError => e

--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -98,7 +98,7 @@ module Carto
         end
         response = {
           visualizations: visualizations,
-          total_entries: vqb.build.size
+          total_entries: vqb.count
         }
         if current_user && (params[:load_totals].to_s != 'false')
           response.merge!(calculate_totals(types))
@@ -482,24 +482,23 @@ module Carto
           total_user_entries: VisualizationQueryBuilder.new
                                                        .with_types(total_types)
                                                        .with_user_id(current_user.id)
-                                                       .build.size,
+                                                       .count,
           total_locked: VisualizationQueryBuilder.new
                                                  .with_types(total_types)
                                                  .with_user_id(current_user.id)
                                                  .with_locked(true)
-                                                 .build.size,
+                                                 .count,
           total_likes: VisualizationQueryBuilder.new
                                                 .with_types(total_types)
                                                 .with_liked_by_user_id(current_user.id)
                                                 .with_locked(false)
-                                                .build.size,
+                                                .count,
           total_shared: VisualizationQueryBuilder.new
                                                  .with_types(total_types)
                                                  .with_shared_with_user_id(current_user.id)
                                                  .with_user_id_not(current_user.id)
                                                  .with_locked(false)
-                                                 .with_prefetch_table
-                                                 .build.size
+                                                 .count
         }
       end
     end

--- a/app/models/carto/template.rb
+++ b/app/models/carto/template.rb
@@ -61,7 +61,6 @@ module Carto
             Carto::VisualizationQueryBuilder.new
                                             .with_name(table_name)
                                             .with_user_id(user.id)
-                                            .build
                                             .count == 0
           rescue
             true

--- a/app/models/carto/user_service.rb
+++ b/app/models/carto/user_service.rb
@@ -18,7 +18,6 @@ module Carto
       Carto::VisualizationQueryBuilder.new
                                       .with_user_id(@user.id)
                                       .with_type(Carto::Visualization::TYPE_CANONICAL)
-                                      .build
                                       .count
     end
 
@@ -28,7 +27,6 @@ module Carto
       Carto::VisualizationQueryBuilder.new
                                       .with_user_id(@user.id)
                                       .with_type(Carto::Visualization::TYPE_DERIVED)
-                                      .build
                                       .count
     end
 
@@ -37,7 +35,6 @@ module Carto
 
       Carto::VisualizationQueryBuilder.new
                                       .with_owned_by_or_shared_with_user_id(@user.id)
-                                      .build
                                       .count
     end
 
@@ -45,7 +42,6 @@ module Carto
       return 0 unless @user.id
 
       Carto::VisualizationQueryBuilder.user_public_visualizations(@user)
-                                      .build
                                       .count
     end
 
@@ -53,7 +49,6 @@ module Carto
       return 0 unless @user.id
 
       Carto::VisualizationQueryBuilder.user_public_privacy_visualizations(@user)
-                                      .build
                                       .count
     end
 
@@ -61,7 +56,6 @@ module Carto
       return 0 unless @user.id
 
       Carto::VisualizationQueryBuilder.user_public_privacy_visualizations(@user)
-                                      .build
                                       .count
     end
 
@@ -69,7 +63,6 @@ module Carto
       return 0 unless @user.id
 
       Carto::VisualizationQueryBuilder.user_link_privacy_visualizations(@user)
-                                      .build
                                       .count
     end
 
@@ -77,7 +70,6 @@ module Carto
       return 0 unless @user.id
 
       Carto::VisualizationQueryBuilder.user_password_privacy_visualizations(@user)
-                                      .build
                                       .count
     end
 
@@ -85,7 +77,6 @@ module Carto
       return 0 unless @user.id
 
       Carto::VisualizationQueryBuilder.user_private_privacy_visualizations(@user)
-                                      .build
                                       .count
     end
 
@@ -93,7 +84,6 @@ module Carto
       return 0 unless @user.id
 
       Carto::VisualizationQueryBuilder.user_all_visualizations(@user)
-                                      .build
                                       .count
     end
 

--- a/app/models/organization/organization_decorator.rb
+++ b/app/models/organization/organization_decorator.rb
@@ -61,10 +61,10 @@ module CartoDB
       }
 
       if options[:extended]
-        dataset_count = visualizations_builder.with_type(Carto::Visualization::TYPE_CANONICAL).build.count
+        dataset_count = visualizations_builder.with_type(Carto::Visualization::TYPE_CANONICAL).count
         org_presentation[:table_count] = dataset_count
 
-        map_count = visualizations_builder.with_type(Carto::Visualization::TYPE_DERIVED).build.count
+        map_count = visualizations_builder.with_type(Carto::Visualization::TYPE_DERIVED).count
         org_presentation[:map_count] = map_count
       end
 

--- a/app/models/quota_checker.rb
+++ b/app/models/quota_checker.rb
@@ -51,7 +51,7 @@ module CartoDB
     end
 
     def private_map_count
-      Carto::VisualizationQueryBuilder.user_private_privacy_visualizations(@user).build.count
+      Carto::VisualizationQueryBuilder.user_private_privacy_visualizations(@user).count
     end
 
     def regular_api_key_count
@@ -63,7 +63,7 @@ module CartoDB
                       with_user_id(@user.id).
                       with_types(types).
                       with_privacy(not_private)
-      query_builder.build.count
+      query_builder.count
     end
 
     def not_private
@@ -73,7 +73,6 @@ module CartoDB
         Carto::Visualization::PRIVACY_PROTECTED
       ]
     end
-      
 
     attr_reader :user
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1252,7 +1252,7 @@ class User < Sequel::Model
       vqb.with_owned_by_or_shared_with_user_id(id)
     end
     vqb.without_raster if filters[:exclude_raster] == true
-    vqb.build.count
+    vqb.count
   end
 
   def last_visualization_created_at

--- a/app/queries/carto/dashboard_preview_searcher.rb
+++ b/app/queries/carto/dashboard_preview_searcher.rb
@@ -28,7 +28,7 @@ class Carto::DashboardPreviewSearcher
     if @visualization_types.any?
       visualization_query_builder = initialize_builder(Carto::VisualizationQueryBuilder)
       result.visualizations = visualization_query_builder.build_paged(1, @limit).to_a
-      result.total_count += visualization_query_builder.build.count
+      result.total_count += visualization_query_builder.count
     end
 
     result

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -219,17 +219,47 @@ class Carto::VisualizationQueryBuilder
   end
 
   def build
+    offdatabase_order? ? build_regular : build_subquery
+  end
+
+  def count
+    filtered_query.count
+  end
+
+  def build_paged(page = 1, per_page = 20)
+    if offdatabase_order?
+      build_regular.offset((page.to_i - 1) * per_page.to_i).limit(per_page.to_i)
+    else
+      paged_subquery = subquery.offset((page.to_i - 1) * per_page.to_i).limit(per_page.to_i)
+      query = Carto::Visualization.from(paged_subquery, 'visualizations')
+      with_associations(query)
+    end
+  end
+
+  private
+
+  def build_regular
     query = Carto::Visualization.all
     query = Carto::VisualizationQueryFilterer.new(query).filter(@filtering_params)
     query = with_associations(query)
     order_query(query)
   end
 
-  def build_paged(page = 1, per_page = 20)
-    build.offset((page.to_i - 1) * per_page.to_i).limit(per_page.to_i)
+  def build_subquery
+    # Fetching related tables after filtering the results for better performance
+    query = Carto::Visualization.from(subquery, 'visualizations')
+    with_associations(query)
   end
 
-  private
+  def subquery
+    subquery = with_ordering_associations(filtered_query)
+    order_query(subquery)
+  end
+
+  def filtered_query
+    query = Carto::Visualization.all
+    Carto::VisualizationQueryFilterer.new(query).filter(@filtering_params)
+  end
 
   def order_query(query)
     # Search has its own ordering criteria
@@ -252,6 +282,16 @@ class Carto::VisualizationQueryBuilder
   def with_associations(query)
     query = query.includes(@include_associations) unless @include_associations.empty?
     query = query.eager_load(@eager_load_associations) unless @eager_load_associations.empty?
+    query
+  end
+
+  def with_ordering_associations(query)
+    query = with_favorited(query) unless @filtering_params[:liked_by_user_id]
+    query = with_dependent_visualization_count(query)
+    query
+  end
+
+  def with_favorited(query)
     # We have to include favorites if we're not filtering by them
     # Why? Both of them include a join with the likes table: favorited uses
     # a left-join one and the filter will use an inner-join.
@@ -260,21 +300,22 @@ class Carto::VisualizationQueryBuilder
     # And what is the difference?
     #  - Filtering leaves only the favorited/liked visualizations by the user
     #  - With favorited we add the like/favorite data to the visualization information
-    query = with_favorited(query) unless @filtering_params[:liked_by_user_id]
-    with_dependent_visualization_count(query)
-  end
-
-  def with_favorited(query)
-    return query unless @order&.include?("favorited") && @current_user_id
+    return query unless @order&.include?('favorited') && @current_user_id
 
     Carto::VisualizationQueryIncluder.new(query).include_favorited(@current_user_id)
   end
 
   def with_dependent_visualization_count(query)
-    return query unless @order && @order.include?("dependent_visualizations")
+    return query unless @order&.include?('dependent_visualizations')
 
     with_prefetch_dependent_visualizations
     Carto::VisualizationQueryIncluder.new(query).include_dependent_visualization_count(@filtering_params)
+  end
+
+  def offdatabase_order?
+    Carto::VisualizationQueryOrderer.SUPPORTED_OFFDATABASE_ORDERS.any do |offdatabase_order|
+      @order.include?(offdatabase_order)
+    end
   end
 
 end

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -307,8 +307,8 @@ class Carto::VisualizationQueryBuilder
   end
 
   def offdatabase_order?
-    Carto::VisualizationQueryOrderer.SUPPORTED_OFFDATABASE_ORDERS.any do |offdatabase_order|
-      @order.include?(offdatabase_order)
+    Carto::VisualizationQueryOrderer::SUPPORTED_OFFDATABASE_ORDERS.any? do |offdatabase_order|
+      @order&.include?(offdatabase_order)
     end
   end
 


### PR DESCRIPTION
Related to [ch79934](https://app.clubhouse.io/cartoteam/story/79934/zapp360-admin-dashboard-won-t-load)

Performance improvements for query builder (mostly for `/viz`) when having a big number of visualizations.

Basically 2 things:
1. Fetch the related tables only after applying filters and limit, by using a subquery (only available when ordering by SQL)
2. Do not fetch related tables for the count operations

For example, `/dashboard/datasets` generated a SQL like this (simplified):
```
SELECT * FROM "visualizations" 
LEFT OUTER JOIN "maps" ON "maps"."id" = "visualizations"."map_id" 
LEFT OUTER JOIN "user_tables" ON "user_tables"."map_id" = "maps"."id" 
LEFT OUTER JOIN "layers_user_tables" ON "layers_user_tables"."user_table_id" = "user_tables"."id" 
LEFT OUTER JOIN "layers" ON "layers"."id" = "layers_user_tables"."layer_id" 
LEFT OUTER JOIN "layers_maps" ON "layers_maps"."layer_id" = "layers"."id" 
LEFT OUTER JOIN "maps" "maps_layers" ON "maps_layers"."id" = "layers_maps"."map_id" 
LEFT OUTER JOIN "visualizations" "visualizations_maps" ON "visualizations_maps"."map_id" = "maps_layers"."id" 
LEFT OUTER JOIN "maps" "maps_visualizations" ON "maps_visualizations"."id" = "visualizations_maps"."map_id" 
LEFT OUTER JOIN "layers_maps" "layers_maps_maps_join" ON "layers_maps_maps_join"."map_id" = "maps_visualizations"."id" 
LEFT OUTER JOIN "layers" "layers_maps_2" ON "layers_maps_2"."id" = "layers_maps_maps_join"."layer_id" 
LEFT OUTER JOIN "layers_user_tables" "layers_user_tables_layers" ON "layers_user_tables_layers"."layer_id" = "layers_maps_2"."id" 
LEFT OUTER JOIN "permissions" ON "permissions"."id" = "visualizations_maps"."permission_id" 
LEFT OUTER JOIN "users" ON "users"."id" = "permissions"."owner_id" 
LEFT OUTER JOIN "permissions" "permissions_visualizations" ON "permissions_visualizations"."id" = "visualizations"."permission_id" 
LEFT OUTER JOIN "users" "owners_permissions" ON "owners_permissions"."id" = "permissions_visualizations"."owner_id" 
LEFT OUTER JOIN "synchronizations" ON "synchronizations"."visualization_id" = "visualizations"."id" 
LEFT OUTER JOIN "external_sources" ON "external_sources"."visualization_id" = "visualizations"."id" 
LEFT OUTER JOIN "users" "users_visualizations" ON "users_visualizations"."id" = "visualizations"."user_id" 
LEFT JOIN likes ON "likes"."subject" = "visualizations"."id" AND "likes"."actor" = 'd19b9f5a-0e72-4f95-8ca2-a97ae222df6a' 
WHERE "visualizations"."user_id" = 'd19b9f5a-0e72-4f95-8ca2-a97ae222df6a' 
AND "visualizations"."locked" = 'f' 
AND "visualizations"."type" = 'table'  
ORDER BY (likes.actor IS NOT NULL) desc,visualizations.updated_at desc 
LIMIT 12 OFFSET 0;
```

And now, it will generate something like:
```
SELECT * FROM (
  SELECT "visualizations".* FROM "visualizations" 
  LEFT JOIN likes ON "likes"."subject" = "visualizations"."id" AND "likes"."actor" = 'd19b9f5a-0e72-4f95-8ca2-a97ae222df6a'
  WHERE "visualizations"."user_id" = 'd19b9f5a-0e72-4f95-8ca2-a97ae222df6a'
  AND "visualizations"."locked" = 'f'
  AND "visualizations"."type" = 'table'
  ORDER BY (likes.actor IS NOT NULL) desc,visualizations.updated_at desc
  LIMIT 12 OFFSET 0
) visualizations 
LEFT OUTER JOIN "maps" ON "maps"."id" = "visualizations"."map_id" 
LEFT OUTER JOIN "user_tables" ON "user_tables"."map_id" = "maps"."id" 
LEFT OUTER JOIN "layers_user_tables" ON "layers_user_tables"."user_table_id" = "user_tables"."id" 
LEFT OUTER JOIN "layers" ON "layers"."id" = "layers_user_tables"."layer_id" 
LEFT OUTER JOIN "layers_maps" ON "layers_maps"."layer_id" = "layers"."id" 
LEFT OUTER JOIN "maps" "maps_layers" ON "maps_layers"."id" = "layers_maps"."map_id" 
LEFT OUTER JOIN "visualizations" "visualizations_maps" ON "visualizations_maps"."map_id" = "maps_layers"."id" 
LEFT OUTER JOIN "maps" "maps_visualizations" ON "maps_visualizations"."id" = "visualizations_maps"."map_id" 
LEFT OUTER JOIN "layers_maps" "layers_maps_maps_join" ON "layers_maps_maps_join"."map_id" = "maps_visualizations"."id" 
LEFT OUTER JOIN "layers" "layers_maps_2" ON "layers_maps_2"."id" = "layers_maps_maps_join"."layer_id" 
LEFT OUTER JOIN "layers_user_tables" "layers_user_tables_layers" ON "layers_user_tables_layers"."layer_id" = "layers_maps_2"."id" 
LEFT OUTER JOIN "permissions" ON "permissions"."id" = "visualizations_maps"."permission_id" 
LEFT OUTER JOIN "users" ON "users"."id" = "permissions"."owner_id" 
LEFT OUTER JOIN "permissions" "permissions_visualizations" ON "permissions_visualizations"."id" = "visualizations"."permission_id" 
LEFT OUTER JOIN "users" "owners_permissions" ON "owners_permissions"."id" = "permissions_visualizations"."owner_id" 
LEFT OUTER JOIN "synchronizations" ON "synchronizations"."visualization_id" = "visualizations"."id" 
LEFT OUTER JOIN "external_sources" ON "external_sources"."visualization_id" = "visualizations"."id" 
LEFT OUTER JOIN "users" "users_visualizations" ON "users_visualizations"."id" = "visualizations"."user_id";
```

This query takes around 400ms for a case with 20k tables with related stuff, while the old one takes around 40 seconds.

Already tested in staging.