### PR TITLE
Fix method privacy

### DIFF
--- a/app/services/carto/do_licensing_service.rb
+++ b/app/services/carto/do_licensing_service.rb
@@ -23,6 +23,16 @@ module Carto
       JSON.parse($users_metadata.hget(@redis_key, PRESELECTED_STORAGE) || '[]').map { |s| present_subscription(s) }
     end
 
+    def add_to_redis(dataset)
+      value = AVAILABLE_STORAGES.map { |storage| [storage, insert_redis_value(dataset, storage)] }.flatten
+      $users_metadata.hmset(@redis_key, value)
+    end
+
+    def remove_from_redis(dataset_id)
+      value = AVAILABLE_STORAGES.map { |storage| [storage, remove_redis_value(dataset_id, storage)] }.flatten
+      $users_metadata.hmset(@redis_key, value)
+    end
+
     private
 
     def present_subscription(subscription)
@@ -41,18 +51,6 @@ module Carto
       }
       subscription.with_indifferent_access
     end
-
-    def add_to_redis(dataset)
-      value = AVAILABLE_STORAGES.map { |storage| [storage, insert_redis_value(dataset, storage)] }.flatten
-      $users_metadata.hmset(@redis_key, value)
-    end
-
-    def remove_from_redis(dataset_id)
-      value = AVAILABLE_STORAGES.map { |storage| [storage, remove_redis_value(dataset_id, storage)] }.flatten
-      $users_metadata.hmset(@redis_key, value)
-    end
-
-    private
 
     def insert_redis_value(dataset, storage)
       redis_value = JSON.parse($users_metadata.hget(@redis_key, storage) || '[]')


### PR DESCRIPTION
I think this is broken in production, since those methods are private the update of subscriptions performed here will fail:
https://github.com/CartoDB/cartodb/blob/a121a0b9961c2556bfabc29d8f0ce4f3b3ca718c/app/models/carto/helpers/user_commons.rb#L279-L293

And this is called from central when subscriptions are created/deleted.

/cc @rafatower sorry to leave this here pending, but I've noticed it's a bug in production just before closing for my holydays (I saw this earlier today but thought it affected only our branches in staging). 
