### PR TITLE
Downgrade bundler to 1.17.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,4 +563,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-   2.1.4
+  1.17.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Downgrade bundler to 1.17.3 to avoid problems with Rails version
 
 4.39.0 (2020-07-20)
 -------------------

--- a/gears/carto_gears_api/Gemfile.lock
+++ b/gears/carto_gears_api/Gemfile.lock
@@ -132,4 +132,4 @@ DEPENDENCIES
   rspec-rails (= 2.12.0)
 
 BUNDLED WITH
-   2.1.4
+  1.17.3


### PR DESCRIPTION
To avoid compatibility problems with Rails 4.2.11