### PR TITLE
Fix changes on custom API Key after import collision_strategy=overwrite

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 
 ### Bug fixes / enhancements
 - Downgrade bundler to 1.17.3 to avoid problems with Rails version
+- Fix to prevent removing datasets from api_keys when it is replaced using overwrite as collision_strategy ([80981](https://app.clubhouse.io/cartoteam/story/80981/joinzoe-change-on-custom-api-key-after-import-collision-strategy-overwrite))
 
 4.39.0 (2020-07-20)
 -------------------

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -16,18 +16,8 @@ describe "Imports API" do
     @user.destroy
   end
 
-  def auth_user(u)
-    @auth_user = u
-    # host! "#{u.username}.localhost.lan"
-    # login_as(u, scope: u.username)
-  end
-
-  def auth_headers
-      http_json_headers
-    end
-
   def auth_params
-    { user_domain: @auth_user.username, api_key: @auth_user.api_key }
+    { user_domain: @user.username, api_key: @user.api_key }
   end
 
   let(:params) { { :api_key => @user.api_key } }
@@ -258,7 +248,7 @@ describe "Imports API" do
     @user.update max_import_table_row_count: old_max_import_row_count
   end
 
-  it 'keeps api_key for replaced tables' do
+  it 'keeps api_key grants for replaced tables' do
     # imports two files
     post api_v1_imports_create_url,
       params.merge(:filename => upload_file('spec/support/data/csv_with_lat_lon.csv', 'application/octet-stream'))
@@ -302,8 +292,7 @@ describe "Imports API" do
       name: name,
       grants: grants
     }
-    auth_user(@user)
-    post_json api_keys_url, auth_params.merge(payload), auth_headers
+    post_json api_keys_url, auth_params.merge(payload), http_json_headers
 
     # replace the file
     post api_v1_imports_create_url,
@@ -313,9 +302,9 @@ describe "Imports API" do
       )
 
     # gets the api_keys
-    get_json api_key_url(id: 'wadus'), auth_params, auth_headers do |response|
+    get_json api_key_url(id: 'wadus'), auth_params, http_json_headers do |response|
       response.status.should eq 200
-      response.body[:grants][1][:tables][1][:name] = 'csv_with_number_columns'
+      response.body[:grants][1][:tables][1][:name] = @table_from_import
     end
   end
 

--- a/spec/requests/api/imports_spec.rb
+++ b/spec/requests/api/imports_spec.rb
@@ -16,6 +16,20 @@ describe "Imports API" do
     @user.destroy
   end
 
+  def auth_user(u)
+    @auth_user = u
+    # host! "#{u.username}.localhost.lan"
+    # login_as(u, scope: u.username)
+  end
+
+  def auth_headers
+      http_json_headers
+    end
+
+  def auth_params
+    { user_domain: @auth_user.username, api_key: @auth_user.api_key }
+  end
+
   let(:params) { { :api_key => @user.api_key } }
 
   it 'performs asynchronous imports' do
@@ -242,6 +256,67 @@ describe "Imports API" do
     last_import.error_code.should be == 6668
 
     @user.update max_import_table_row_count: old_max_import_row_count
+  end
+
+  it 'keeps api_key for replaced tables' do
+    # imports two files
+    post api_v1_imports_create_url,
+      params.merge(:filename => upload_file('spec/support/data/csv_with_lat_lon.csv', 'application/octet-stream'))
+    post api_v1_imports_create_url,
+      params.merge(:filename => upload_file('spec/support/data/csv_with_number_columns.csv', 'application/octet-stream'))
+
+    # get the last one
+    @table_from_import = UserTable.all.last.service
+
+    # creates an api_key for both files
+    grants = [
+      {
+        type: "apis",
+        apis: ["sql", "maps"]
+      },
+      {
+        type: "database",
+        tables: [
+          {
+            schema: @user.database_schema,
+            name: 'csv_with_lat_lon',
+            permissions: [
+              "insert",
+              "select",
+              "update",
+              "delete"
+            ]
+          },
+          {
+            schema: @user.database_schema,
+            name: 'csv_with_number_columns',
+            permissions: [
+              "select"
+            ]
+          }
+        ]
+      }
+    ]
+    name = 'wadus'
+    payload = {
+      name: name,
+      grants: grants
+    }
+    auth_user(@user)
+    post_json api_keys_url, auth_params.merge(payload), auth_headers
+
+    # replace the file
+    post api_v1_imports_create_url,
+      params.merge(
+        :filename => upload_file('spec/support/data/csv_with_number_columns.csv', 'application/octet-stream'),
+        :collision_strategy => 'overwrite'
+      )
+
+    # gets the api_keys
+    get_json api_key_url(id: 'wadus'), auth_params, auth_headers do |response|
+      response.status.should eq 200
+      response.body[:grants][1][:tables][1][:name] = 'csv_with_number_columns'
+    end
   end
 
 end


### PR DESCRIPTION
For more context: [80981](https://app.clubhouse.io/cartoteam/story/80981/joinzoe-change-on-custom-api-key-after-import-collision-strategy-overwrite).

The problem is related with the collision strategy: To "replace" the dataset, the Import API does a drop table and then rename the imported table like the dropped one. Doing this, the role associated to the dropped table disappears (is removed from `information_schema.table_privileges`). 

To fix that, we execute the method `setup_table_permissions` again on those api_keys which have the replaced table in order to "refresh" the permissions (roles).