### PR TITLE
Version cartodb-common with tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'google-cloud-pubsub', '1.2.0'
 
 # Service components (/services)
 gem 'virtus',                   '1.0.5'
-gem 'cartodb-common',           git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.2.0'
+gem 'cartodb-common',           git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.2.1'
 gem 'email_address',            '~> 0.1.11'
 
 # Markdown

--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'google-cloud-pubsub', '1.2.0'
 
 # Service components (/services)
 gem 'virtus',                   '1.0.5'
-gem 'cartodb-common',           git: 'https://github.com/cartodb/cartodb-common.git', branch: 'master'
+gem 'cartodb-common',           git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.2.0'
 gem 'email_address',            '~> 0.1.11'
 
 # Markdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 GIT
   remote: https://github.com/cartodb/cartodb-common.git
   revision: 90e50effa1c49b5eb35aa27279bd7b74e7e0314c
-  tag: v0.2.0
+  tag: v0.2.1
   specs:
     cartodb-common (0.2.1)
       argon2 (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/cartodb/cartodb-common.git
-  revision: e445c66023bfe83fcd62878ec0f3f37909156e01
-  branch: master
+  revision: 90e50effa1c49b5eb35aa27279bd7b74e7e0314c
+  tag: v0.2.0
   specs:
-    cartodb-common (0.1.0)
+    cartodb-common (0.2.1)
       argon2 (~> 2.0)
 
 GIT
@@ -563,4 +563,4 @@ DEPENDENCIES
   zeus
 
 BUNDLED WITH
-  1.17.3
+   1.17.3


### PR DESCRIPTION
**What does this PR do?**

Changes the reference to the `cartodb-common` gem to be a git tag instead of a branch.

**How do I use a newer version of `cartodb-common`?**

1. Merge your code in `cartodb-common` `master` branch
2. Publish a release: https://github.com/CartoDB/cartodb-common/tags by creating and pushing a new tag via git
3. Update the tag in the CartoDB gemfile
4. Run `bundle update cartodb-common` and ensure the `revision` attribute has changed in `Gemfile.lock`

**Other**

The commit hash has changed because we did not run `bundle update cartodb-common` in this repo since some time ago, but the logging behavior is not included in this release yet. cc @rafatower 