### PR TITLE
WMTS compatibility: Replace the var `tile_matrix_set`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
+- WMTS compatibility: Replace the var `tile_matrix_set` by a supported SRS of the WMTS provided.
 - ArcGIS imports: raise http timeout and max retry attempts for arcgis import service
 - ArcGIS imports: improve log traces to better diagnose json non-conformance errors
 - Downgrade bundler to 1.17.3 to avoid problems with Rails version

--- a/lib/assets/javascripts/builder/components/modals/add-basemap/wms/wms-layer-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-basemap/wms/wms-layer-model.js
@@ -1,6 +1,7 @@
 var _ = require('underscore');
 var Backbone = require('backbone');
 var CustomBaselayerModel = require('builder/data/custom-baselayer-model');
+const DEFAULT_MATRIX_SET = '3857';
 
 /**
  * Model for an individual WMS/WMTS layer.
@@ -149,8 +150,24 @@ module.exports = Backbone.Model.extend({
 
   _xyzURLTemplate: function () {
     var urlTemplate = this.get('url_template') || '';
-    // Convert the proxy template variables to XYZ format, http://foo.com/bar/%%(z)s/%%(x)s/%%(y)s.png"
-    return urlTemplate.replace(/%%\((\w)\)s/g, '{$1}');
+    const matrixSets = this.get('matrix_sets') || [];
+
+    if (matrixSets.length === 0) {
+      throw new Error('The service does not support any SRS.');
+    }
+
+    let matrixSet = DEFAULT_MATRIX_SET;
+
+    if (!matrixSets.includes(DEFAULT_MATRIX_SET)) {
+      matrixSet = matrixSets[0];
+    }
+
+    // Convert the proxy template variables to XYZ format:
+    // http://foo.com/bar/%(tile_matrix_set)s/%%(z)s/%%(x)s/%%(y)s.png"
+    urlTemplate = urlTemplate.replace(/%%\((\w)\)s/g, '{$1}');
+    urlTemplate = urlTemplate.replace(/%\(tile_matrix_set\)s/g, matrixSet);
+
+    return urlTemplate;
   },
 
   _setCustomBaselayerModel: function (customBaselayerModel) {

--- a/lib/assets/javascripts/builder/components/modals/add-basemap/wms/wms-layer-model.js
+++ b/lib/assets/javascripts/builder/components/modals/add-basemap/wms/wms-layer-model.js
@@ -158,7 +158,7 @@ module.exports = Backbone.Model.extend({
 
     let matrixSet = DEFAULT_MATRIX_SET;
 
-    if (!matrixSets.includes(DEFAULT_MATRIX_SET)) {
+    if (matrixSets.indexOf(DEFAULT_MATRIX_SET) === -1) {
       matrixSet = matrixSets[0];
     }
 

--- a/lib/assets/test/spec/builder/components/modals/add-basemap/wms/wms-layer-model.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-basemap/wms/wms-layer-model.spec.js
@@ -104,6 +104,56 @@ describe('editor/components/modals/add-basemap/wms/wms-layer-model', function ()
         expect(this.model.get('state')).toEqual('saveDone');
       });
     });
+
+    describe('when is a WMTS with the tile_matrix_set variable and two matrix sets one of them is the default 3857', function () {
+      beforeEach(function () {
+        this.model.set({
+          type: 'wmts',
+          url_template: 'http://foo.com/bar/%(tile_matrix_set)s/%%(z)s/%%(x)s/%%(y)s.png',
+          matrix_sets: ['4326', '3857']
+        });
+        spyOn(this.model, '_byCustomURL').and.callThrough();
+        this.model.createProxiedLayerOrCustomBaselayerModel();
+      });
+
+      it('should create the tile layer with a proper XYZ URL', function () {
+        expect(this.model._byCustomURL).toHaveBeenCalled();
+        expect(this.model._byCustomURL.calls.argsFor(0)[0]).toEqual('http://foo.com/bar/3857/{z}/{x}/{y}.png');
+      });
+
+      it('should return a tile layer directly instead', function () {
+        expect(this.model.get('customBaselayerModel') instanceof CustomBaselayerModel).toBeTruthy();
+      });
+
+      it('should set saveDone', function () {
+        expect(this.model.get('state')).toEqual('saveDone');
+      });
+    });
+
+    describe('when is a WMTS with the tile_matrix_set variable and two matrix sets', function () {
+      beforeEach(function () {
+        this.model.set({
+          type: 'wmts',
+          url_template: 'http://foo.com/bar/%(tile_matrix_set)s/%%(z)s/%%(x)s/%%(y)s.png',
+          matrix_sets: ['25830', '4326']
+        });
+        spyOn(this.model, '_byCustomURL').and.callThrough();
+        this.model.createProxiedLayerOrCustomBaselayerModel();
+      });
+
+      it('should create the tile layer with a proper XYZ URL', function () {
+        expect(this.model._byCustomURL).toHaveBeenCalled();
+        expect(this.model._byCustomURL.calls.argsFor(0)[0]).toEqual('http://foo.com/bar/25830/{z}/{x}/{y}.png');
+      });
+
+      it('should return a tile layer directly instead', function () {
+        expect(this.model.get('customBaselayerModel') instanceof CustomBaselayerModel).toBeTruthy();
+      });
+
+      it('should set saveDone', function () {
+        expect(this.model.get('state')).toEqual('saveDone');
+      });
+    });
   });
 
   describe('._newProxiedBaselayerModel', function () {


### PR DESCRIPTION
Replace the var `tile_matrix_set` by a supported SRS of the WMTS provided by the user.

This is, the URL:

`https://wmts-service/%(tile_matrix_set)s/%%(z)s/%%(y)s/%%(x)s` 

is replaced to:

`https://wmts-service/3857/{z}/{y}/{x}` 


The matrix set by default is `3857`. If this matrix set is not supported by the service then the first one supported is used. If no matrix sets are supported by the WMTS provided then an error is thrown.