### PR TITLE
api/v4/datasets doesn't return all shared datasets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ Development
 - Fix imports from query that contain `(sql_expression)::cast` ([#15765](https://github.com/CartoDB/cartodb/pull/15765))
 - Fix wrong popup position, via new internal carto.js version 4.2.2-1 ([CARTO.js#2254](https://github.com/CartoDB/carto.js/pull/2254))
 - Modify .gitignore
+- Return all shared datasets
 
 4.39.0 (2020-07-20)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,6 @@ Development
 - Install Carto::Common::Logger with JSON support ([#15762](https://github.com/CartoDB/cartodb/pull/15762))
 - Return all shared datasets ([#15767](https://github.com/CartoDB/cartodb/pull/15767))
 
-
 4.39.0 (2020-07-20)
 -------------------
 


### PR DESCRIPTION
Story details: https://app.clubhouse.io/cartoteam/story/95768

It includes the datasets shared with the org and the datasets shared with any group the user belongs to