### PR TITLE
Install the available odbc_fdw extension version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Development
 -------------------
 
 ### Bug fixes / enhancements
+* Fix error installing odbc_fdw ([#](https://github.com/CartoDB/cartodb/pull/15782))
 * WMTS compatibility: Replace the var `tile_matrix_set` by a supported SRS of the WMTS provided.
 * ArcGIS imports: raise http timeout and max retry attempts for arcgis import service
 * ArcGIS imports: improve log traces to better diagnose json non-conformance errors

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -21,7 +21,6 @@ module CartoDB
       SCHEMA_CDB_DATASERVICES_API = 'cdb_dataservices_client'.freeze
       SCHEMA_AGGREGATION_TABLES = 'aggregation'.freeze
       CDB_DATASERVICES_CLIENT_VERSION = '0.30.0'.freeze
-      ODBC_FDW_VERSION = '0.4.0'.freeze
 
       def initialize(user)
         raise "User nil" unless user
@@ -617,14 +616,12 @@ module CartoDB
 
       def install_odbc_fdw
         @user.in_database(as: :superuser) do |db|
-          db.transaction do
-            db.run('CREATE EXTENSION IF NOT EXISTS odbc_fdw SCHEMA public')
-            db.run("ALTER EXTENSION odbc_fdw UPDATE TO '#{ODBC_FDW_VERSION}'")
-          end
+          db.run('CREATE EXTENSION IF NOT EXISTS odbc_fdw SCHEMA public')
         end
-      rescue Sequel::DatabaseError
+      rescue Sequel::DatabaseError => error
         # For the time being we'll be resilient to the odbc_fdw not being available
         # and just proceed without installing it.
+        CartoDB::Logger.error(exception: error, message: "Could not install odbc_fdw", user: @user)
       end
 
       def setup_organization_owner


### PR DESCRIPTION
So far when we install the odbc_fdw extension, we CREATE it, then ALTER it to set some version fixed in the code.

But we're having problems when that version is not available:
* https://app.clubhouse.io/cartoteam/story/97057
* https://app.clubhouse.io/cartoteam/story/90440

We should just installed whatever is the most recent version that has been provisioned.

A Rollbar trace is also added in the case that installing the extension fails.