### PR TITLE
Bump cartodb-common to v0.3.3 and improve error traces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'google-cloud-pubsub', '1.2.0'
 
 # Service components (/services)
 gem 'virtus',                   '1.0.5'
-gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.3.2'
+gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.3.3'
 gem 'email_address',            '~> 0.1.11'
 
 # Markdown
@@ -125,7 +125,7 @@ group :development, :test do
   gem 'rspec-rails',           '2.12.0'
   gem 'rb-readline'
   gem 'byebug'
-  gem 'pry-byebug',            '3.3.0'
+  gem 'pry-byebug',            '3.9.0'
   gem 'rack'
   gem 'zeus'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/cartodb/cartodb-common.git
-  revision: 5fb23da8a3fe048b742e23b02362b25209e02e81
-  tag: v0.3.2
+  revision: 26094bd1cff81b80841e11e0e463d4f98193c2a9
+  tag: v0.3.3
   specs:
     cartodb-common (0.3.0)
       activesupport (~> 4.2.11.3)
@@ -95,7 +95,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     builder (3.2.4)
-    byebug (8.2.2)
+    byebug (11.1.3)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -284,13 +284,13 @@ GEM
     power_assert (0.2.7)
     protected_attributes (1.1.3)
       activemodel (>= 4.0.1, < 5.0)
-    pry (0.11.0)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-    pry-byebug (3.3.0)
-      byebug (~> 8.0)
-      pry (~> 0.10)
     public_suffix (3.0.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rack (1.6.13)
     rack-protection (1.5.5)
       rack
@@ -519,7 +519,7 @@ DEPENDENCIES
   pg (= 0.20.0)
   poltergeist (= 1.18.1)
   protected_attributes
-  pry-byebug (= 3.3.0)
+  pry-byebug (= 3.9.0)
   rack
   rack-test (= 0.6.3)
   rails (= 4.2.11.3)

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ WORKING_SPECS_1 = \
 	spec/lib/carto/authentication_manager_spec.rb \
 	spec/helpers/uuidhelper_spec.rb \
 	spec/helpers/url_validator_spec.rb \
+	spec/helpers/logger_helper_spec.rb \
 	spec/models/carto/data_import_spec.rb \
 	spec/models/carto/visualization_spec.rb \
 	spec/models/carto/visualization/watcher_spec.rb \
@@ -92,6 +93,7 @@ WORKING_SPECS_1 = \
 	spec/requests/sessions_controller_spec.rb \
 	spec/services/carto/visualizations_export_service_2_spec.rb \
 	spec/services/carto/visualization_backup_service_spec.rb \
+	spec/requests/carto_logger_spec.rb \
 	$(NULL)
 
 WORKING_SPECS_2 = \

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,8 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+
+* Bumps cartodb-common to v0.3.3 to fix error traces ([#15787](https://github.com/CartoDB/cartodb/pull/15787))
 
 4.40.0 (2020-07-31)
 -------------------

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ require_dependency 'carto/http_header_authentication'
 class ApplicationController < ActionController::Base
   include UrlHelper
   include Carto::ControllerHelper
+  include ::LoggerControllerHelper
 
   protect_from_forgery
 

--- a/app/controllers/carto/api/groups_controller.rb
+++ b/app/controllers/carto/api/groups_controller.rb
@@ -170,6 +170,8 @@ module Carto
       end
 
       def rescue_from_password_confirmation_error(error)
+        log_rescue_from(__method__, error)
+
         render_jsonp({ message: "Error modifying groups", errors: [error.message] }, 403)
       end
     end

--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -111,6 +111,8 @@ module Carto
         end
 
         def rescue_from_central_error(exception)
+          log_rescue_from(__method__, exception)
+
           render_jsonp({ errors: exception.errors }, 500)
         end
 

--- a/app/controllers/carto/api/public/datasets_controller.rb
+++ b/app/controllers/carto/api/public/datasets_controller.rb
@@ -19,7 +19,7 @@ module Carto
         rescue_from Carto::OauthProvider::Errors::ServerError, with: :rescue_oauth_errors
 
         VALID_ORDER_PARAMS = %i(name).freeze
- 
+
         def index
           tables = @user.in_database[select_tables_query].all
           result = enrich_tables(tables)
@@ -63,7 +63,7 @@ module Carto
             privacy: nil,
             updated_at: nil
           }
-        end        
+        end
 
         def table_visualizations(names)
           visualizations = Carto::VisualizationQueryBuilder.new
@@ -100,12 +100,12 @@ module Carto
         def query
           roles_in = @user.db_service.all_user_roles.join("','")
           %{
-            SELECT table_schema, table_name as name,   
-              string_agg(CASE privilege_type WHEN 'SELECT' THEN 'r' ELSE 'w' END, 
+            SELECT table_schema, table_name as name,
+              string_agg(CASE privilege_type WHEN 'SELECT' THEN 'r' ELSE 'w' END,
                         '' order by privilege_type) as mode
             FROM information_schema.role_table_grants
             WHERE grantee IN ('#{roles_in}')
-              AND table_schema not in ('cartodb', 'aggregation')  
+              AND table_schema not in ('cartodb', 'aggregation')
               AND grantor!='postgres'
               AND privilege_type in ('SELECT', 'UPDATE')
             GROUP BY table_schema,  table_name
@@ -125,6 +125,8 @@ module Carto
         end
 
         def rescue_oauth_errors(exception)
+          log_rescue_from(__method__, exception)
+
           render json: { errors: exception.parameters[:error_description] }, status: 500
         end
       end

--- a/app/controllers/carto/api/public/federated_tables_controller.rb
+++ b/app/controllers/carto/api/public/federated_tables_controller.rb
@@ -245,6 +245,8 @@ module Carto
         end
 
         def rescue_from_service_error(exception)
+          log_rescue_from(__method__, exception)
+
           message = get_error_message(exception)
           case message
           when /(.*) does not exist/

--- a/app/controllers/carto/controller_helper.rb
+++ b/app/controllers/carto/controller_helper.rb
@@ -15,6 +15,8 @@ module Carto
     end
 
     def rescue_from_carto_error(error)
+      log_rescue_from(__method__, error)
+
       message = error.message
       status = error.status
       errors_cause = error.errors_cause
@@ -32,6 +34,8 @@ module Carto
     end
 
     def rescue_from_protected_visualization_load_error(error)
+      log_rescue_from(__method__, error)
+
       message = error.message
       status = error.status
 
@@ -54,6 +58,8 @@ module Carto
     end
 
     def rescue_from_standard_error(error)
+      log_rescue_from(__method__, error)
+
       CartoDB::Logger.error(exception: error)
       message = error.message
       respond_to do |format|
@@ -64,6 +70,8 @@ module Carto
     end
 
     def rescue_from_validation_error(exception)
+      log_rescue_from(__method__, exception)
+
       render_jsonp({ errors: exception.record.errors.messages }, 422)
     end
 
@@ -72,6 +80,7 @@ module Carto
     end
 
     def rescue_from_central_error(error)
+      log_rescue_from(__method__, error)
       CartoDB::Logger.error(exception: error,
                             message: 'Error while updating data in Central',
                             user: @user)

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -104,6 +104,7 @@ module Carto
     end
 
     def rescue_oauth_errors(exception)
+      log_rescue_from(__method__, exception)
       CartoDB::Logger.debug(message: 'Oauth provider error',
                             exception: exception,
                             redirect_on_error: @redirect_on_error,
@@ -120,14 +121,19 @@ module Carto
     end
 
     def rescue_generic_errors(exception)
+      log_rescue_from(__method__, exception)
       CartoDB::Logger.error(exception: exception)
+
       if exception.is_a?(Carto::RelationDoesNotExistError)
         return rescue_oauth_errors(OauthProvider::Errors::InvalidScope.new(nil, message: exception.user_message))
       end
+
       rescue_oauth_errors(OauthProvider::Errors::ServerError.new)
     end
 
     def rescue_missing_params_error(exception)
+      log_rescue_from(__method__, exception)
+
       rescue_oauth_errors(OauthProvider::Errors::InvalidRequest.new(exception.message))
     end
 

--- a/app/controllers/superadmin/superadmin_controller.rb
+++ b/app/controllers/superadmin/superadmin_controller.rb
@@ -1,5 +1,6 @@
 class Superadmin::SuperadminController < ActionController::Base
   include Carto::ControllerHelper
+  include ::LoggerControllerHelper
 
   before_filter :authenticate
 
@@ -31,6 +32,8 @@ class Superadmin::SuperadminController < ActionController::Base
   private
 
   def rescue_from_superadmin_error(error)
+    log_rescue_from(__method__, error)
+
     CartoDB::Logger.error(exception: error)
     render(json: { errors: { message: error.inspect, backtrace: error.backtrace.inspect } }, status: 500)
   end

--- a/app/helpers/logger_controller_helper.rb
+++ b/app/helpers/logger_controller_helper.rb
@@ -1,0 +1,24 @@
+module LoggerControllerHelper
+
+  extend ActiveSupport::Concern
+  include ::LoggerHelper
+
+  def log_rescue_from(hook_id, exception)
+    log_info(message: 'Captured exception in rescue_from hook', exception: exception, hook_id: hook_id)
+  end
+
+  private
+
+  def log_context
+    {
+      current_user: current_user&.username,
+      request_id: request.uuid,
+      controller: controller_id
+    }.with_indifferent_access
+  end
+
+  def controller_id
+    "#{self.class.name}##{action_name}"
+  end
+
+end

--- a/app/helpers/logger_helper.rb
+++ b/app/helpers/logger_helper.rb
@@ -1,0 +1,67 @@
+require 'active_support/concern'
+
+module LoggerHelper
+
+  extend ActiveSupport::Concern
+
+  def log_debug(params = {})
+    rails_log(:debug, params)
+  end
+
+  def log_info(params = {})
+    rails_log(:info, params)
+  end
+
+  def log_warning(params = {})
+    rails_log(:warn, params)
+  end
+
+  def log_error(params = {})
+    rails_log(:error, params)
+    send_exception_to_rollbar(params)
+  end
+
+  def log_fatal(params = {})
+    rails_log(:fatal, params)
+    send_exception_to_rollbar(params)
+  end
+
+  private
+
+  def rails_log(level, params)
+    parsed_params = {}.with_indifferent_access
+
+    params.each do |key, value|
+      if value.is_a?(Exception)
+        parsed_params[:exception] = { class: value.class.name, message: value.message, backtrace_hint: value.backtrace&.take(5) }
+        parsed_params[:message] = value.message if params[:message].blank?
+      elsif value.is_a?(User) || value.is_a?(Carto::User)
+        parsed_params[key] = value.username
+      elsif value.is_a?(Organization) || value.is_a?(Carto::Organization)
+        parsed_params[key] = value.name
+      else
+        parsed_params[key] = value
+      end
+    end
+
+    Rails.logger.send(level, log_context.merge(parsed_params))
+  end
+
+  def send_exception_to_rollbar(params)
+    exception = params[:exception]
+    message = params[:message]
+
+    if message && exception && exception.is_a?(Exception)
+      Rollbar.error(exception, message)
+    else
+      Rollbar.error(exception || message)
+    end
+  end
+
+  # Can be overriden in more specific contexts to add additional information.
+  # Example: current_user and request_id in a controller
+  def log_context
+    {}.with_indifferent_access
+  end
+
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,8 @@
 CartoDB::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
+  ActiveSupport::Dependencies.autoload_paths << File::join(Rails.root, 'lib')
+
   # The test environment is used exclusively to run your application's
   # test suite.  You never need to work with it otherwise.  Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/config/initializers/04_install_carto_logger.rb
+++ b/config/initializers/04_install_carto_logger.rb
@@ -1,1 +1,5 @@
 Carto::Common::Logger.install
+
+# Log more easily from all models
+ActiveRecord::Base.class_eval { include ::LoggerHelper }
+Sequel::Model.class_eval { include ::LoggerHelper }

--- a/spec/helpers/logger_helper_spec.rb
+++ b/spec/helpers/logger_helper_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+require './app/helpers/logger_helper'
+
+describe LoggerHelper do
+
+  class MockObject; include LoggerHelper end
+
+  before { User.any_instance.stubs(:update_in_central).returns(true) }
+
+  let(:mock_object) { MockObject.new }
+  let(:exception) { StandardError.new('Exception message') }
+
+  describe 'log levels' do
+    it 'logs a message with the appropiate level' do
+      Rails.logger.expects(:info).with('message' => 'Message')
+      mock_object.log_info(message: 'Message')
+
+      Rails.logger.expects(:error).with('message' => 'Message')
+      mock_object.log_error(message: 'Message')
+    end
+
+    it 'parses the warning log level to Rails nomenclature' do
+      Rails.logger.expects(:warn).with('message' => 'Message')
+
+      mock_object.log_warning(message: 'Message')
+    end
+
+    it 'reports plain error message to Rollbar' do
+      Rollbar.expects(:error).with('Custom error message')
+
+      mock_object.log_error(message: 'Custom error message')
+    end
+
+    it 'reports exceptions to Rollbar' do
+      Rollbar.expects(:error).with(exception)
+
+      mock_object.log_error(exception: exception)
+    end
+
+    it 'reports exceptions with custom message to Rollbar' do
+      Rollbar.expects(:error).with(exception, 'Message')
+
+      mock_object.log_error(message: 'Message', exception: exception)
+    end
+  end
+
+  describe 'serialization' do
+    let!(:user) { create(:user) }
+    let(:carto_user) { Carto::User.find(user.id) }
+    let(:organization) { create(:organization) }
+    let(:carto_organization) { Carto::Organization.find(organization.id) }
+
+    it 'accepts usernames as current_user' do
+      Rails.logger.expects(:info).with('message' => 'Message', 'current_user' => user.username)
+
+      mock_object.log_info(message: 'Message', current_user: user.username)
+    end
+
+    it 'serializes User instances to usernames' do
+      Rails.logger.expects(:info).with('message' => 'Message', 'current_user' => user.username)
+
+      mock_object.log_info(message: 'Message', current_user: user)
+    end
+
+    it 'serializes Carto::User instances to usernames' do
+      Rails.logger.expects(:info).with('message' => 'Message', 'current_user' => carto_user.username)
+
+      mock_object.log_info(message: 'Message', current_user: carto_user)
+    end
+
+    it 'accepts organization names as organization' do
+      Rails.logger.expects(:info).with('message' => 'Message', 'organization' => organization.name)
+
+      mock_object.log_info(message: 'Message', organization: organization.name)
+    end
+
+    it 'serializes Carto::Organization instances to names' do
+      Rails.logger.expects(:info).with('message' => 'Message', 'organization' => carto_organization.name)
+
+      mock_object.log_info(message: 'Message', organization: carto_organization)
+    end
+
+    it 'serializes Exception objects' do
+      Rails.logger.expects(:error).with(
+        'message' => 'Message',
+        'exception' => { 'class' => 'StandardError', 'message' => 'Exception message', 'backtrace_hint' => nil }
+      )
+
+      mock_object.log_error(message: 'Message', exception: exception)
+    end
+  end
+
+end

--- a/spec/requests/carto_logger_spec.rb
+++ b/spec/requests/carto_logger_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'support/helpers'
+require 'factories/users_helper'
+
+describe(Carto::Common::Logger, type: :request) do
+  include Warden::Test::Helpers
+  include_context 'users helper'
+
+  class LogDeviceMock < Logger::LogDevice
+    attr_accessor :written_text
+
+    def write(text)
+      super(text)
+      self.written_text = '' unless written_text
+      self.written_text += text
+    end
+
+    def self.capture_output
+      original_log_device = Rails.logger.instance_variable_get(:@logdev)
+      mock_log_device = self.new('fake.log')
+      Rails.logger.instance_variable_set(:@logdev, mock_log_device)
+      yield
+      Rails.logger.instance_variable_set(:@logdev, original_log_device)
+      mock_log_device.written_text
+    end
+  end
+
+  let!(:user) do
+    @user1.builder_enabled = true
+    @user1.save
+    @user1
+  end
+  let(:map) { create(:map, user_id: user.id) }
+  let(:visualization) { create(:carto_visualization, user_id: user.id, map_id: map.id) }
+  let(:visualization_url) { builder_visualization_url(id: visualization.id) }
+  let(:output) { LogDeviceMock.capture_output { get(visualization_url) } }
+
+  before { ActionDispatch::Request.any_instance.stubs(:uuid).returns('1234') }
+
+  it 'logs request arrival' do
+    login(user)
+
+    expect(output).to match(/"request_id":"1234".*"request_method":"GET".*"request_path":"\/builder\/#{visualization.id}".*"event_message":"Received request"/)
+  end
+
+  it 'obfuscates sensitive parameters' do
+    output = LogDeviceMock.capture_output do
+      get(root_path, password: 'password', nested: { token: 'token', auth_stuff: 'auth_stuff' })
+    end
+
+    expect(output).to match(/"password":"********".*"token":"*****".*"auth_stuff":"**********"/)
+  end
+
+  it 'logs request processing' do
+    login(user)
+
+    expect(output).to match(%r{"request_id":"1234".*"controller":"Carto::Builder::VisualizationsController#show".*"cdb-user":"#{user.username}".*"event_message":"Processing request"})
+  end
+
+  it 'logs request completion' do
+    login(user)
+
+    expect(output).to match(/"request_id":"1234".*"status":200.*"cdb-user":"#{user.username}".*"event_message":"Request completed"/)
+  end
+
+  it 'logs request completion when failed' do
+    login(user)
+    Carto::Builder::VisualizationsController.any_instance.stubs(:show).raises(StandardError, 'Unexpected error')
+
+    output = LogDeviceMock.capture_output do
+      begin
+        get(visualization_url)
+      rescue StandardError
+      end
+    end
+
+    expect(output).to match(/"request_id":"1234".*"status":500.*"cdb-user":"#{user.username}".*"event_message":"Request completed"/)
+  end
+
+  it 'logs when a controller hook halted execution' do
+    output = LogDeviceMock.capture_output { get(visualization_url) }
+
+    expect(output).to match(/"request_id":"1234".*"filter":":builder_users_only\".*"event_message":"Filter chain halted \(rendered or redirected\)"/)
+  end
+
+end


### PR DESCRIPTION
Related to:

- https://app.clubhouse.io/cartoteam/story/95491/fix-bug-serializing-request-parameters
- https://app.clubhouse.io/cartoteam/story/95488/exception-trace-lost-and-logged-as-info

**What does this PR do?**

Bumps cartodb-common in order to fix a couple of bugs. Also, creates the `LoggerHelper` and `LoggerControllerHelper` which act as a wrapper around the new logger.
