### PR TITLE
Fix cleanup on import overquota error.

### DIFF
--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -56,7 +56,7 @@ module CartoDB
         if quota_checker.will_be_over_table_quota?(results.length)
           log('Results would set overquota')
           @aborted = true
-          results.each { |result| drop(result.table_name) }
+          results.each { |result| drop("#{ORIGIN_SCHEMA}.#{result.table_name}") }
         else
           check_map_quotas(runner.visualizations)
           check_dataset_quotas(runner.visualizations)


### PR DESCRIPTION
I found this problem while debugging a new connector: When imports failed due to overquota imported tables where not cleaned up because the schema was missing.