### PR TITLE
Remove usages of ::User from ApplicationController

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Development
 * Bump cartodb-common to 0.3.4 [#15808](https://github.com/CartoDB/cartodb/pull/15808)
 * Fixes missing includes of LoggerHelper [#15812](https://github.com/CartoDB/cartodb/pull/15812)
 * Adds logging docs [#15813](https://github.com/CartoDB/cartodb/pull/15813)
+* Remove usage of `::User` Sequel model from the `ApplicationController` [#15804](https://github.com/CartoDB/cartodb/pull/15804)
 
 4.41.1 (2020-09-03)
 -------------------

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -98,7 +98,7 @@ class ApplicationController < ActionController::Base
     if user.present?
       user.invalidate_all_sessions!
     elsif opts[:scope]
-      scope_user = ::User.where(username: opts[:scope]).first
+      scope_user = Carto::User.find_by(username: opts[:scope])
       scope_user&.invalidate_all_sessions!
     end
     auth.cookies.delete(ME_ENDPOINT_COOKIE, domain: Cartodb.config[:session_domain])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,7 +69,7 @@ class ApplicationController < ActionController::Base
         # If current user session was there, do nothing; else, retrieve first available
         if current_user_present.nil?
           unless authenticated_usernames.first.nil?
-            user = ::User.where(username: authenticated_usernames.first).first
+            user = Carto::User.find_by(username: authenticated_usernames.first)
             Carto::AuthenticationManager.validate_session(warden, request, user) unless user.nil?
             @current_viewer = user
           end

--- a/app/models/carto/helpers/active_record_compatibility.rb
+++ b/app/models/carto/helpers/active_record_compatibility.rb
@@ -6,4 +6,8 @@ module Carto::ActiveRecordCompatibility
   def new_record?
     return new?
   end
+
+  def save!
+    return save(raise_on_failure: true)
+  end
 end

--- a/app/models/carto/helpers/active_record_compatibility.rb
+++ b/app/models/carto/helpers/active_record_compatibility.rb
@@ -10,4 +10,8 @@ module Carto::ActiveRecordCompatibility
   def save!
     return save(raise_on_failure: true)
   end
+
+  def attributes
+    values.with_indifferent_access
+  end
 end

--- a/app/models/carto/helpers/sessions.rb
+++ b/app/models/carto/helpers/sessions.rb
@@ -6,9 +6,9 @@ module Carto::Sessions
       # NOTE: this is a hack for making the code AR/Sequel compatible
       save(raise_on_failure: true) || raise(ActiveRecord::RecordNotSaved.new("Failed to save the record", self))
     else
-      CartoDB::Logger.error(message: "Cannot invalidate session")
+      log_error(message: "Could not invalidate session in Central")
     end
   rescue CartoDB::CentralCommunicationFailure, Sequel::ValidationFailed, ActiveRecord::RecordNotSaved => e
-    CartoDB::Logger.error(exception: e, message: "Cannot invalidate session")
+    log_error(exception: e, message: "Could not invalidate session")
   end
 end

--- a/app/models/carto/helpers/sessions.rb
+++ b/app/models/carto/helpers/sessions.rb
@@ -1,0 +1,13 @@
+module Carto::Sessions
+  def invalidate_all_sessions!
+    self.session_salt = SecureRandom.hex
+
+    if update_in_central
+      save(raise_on_failure: true)
+    else
+      CartoDB::Logger.error(message: "Cannot invalidate session")
+    end
+  rescue CartoDB::CentralCommunicationFailure, Sequel::ValidationFailed => e
+    CartoDB::Logger.error(exception: e, message: "Cannot invalidate session")
+  end
+end

--- a/app/models/carto/helpers/sessions.rb
+++ b/app/models/carto/helpers/sessions.rb
@@ -3,11 +3,12 @@ module Carto::Sessions
     self.session_salt = SecureRandom.hex
 
     if update_in_central
-      save(raise_on_failure: true)
+      # NOTE: this is a hack for making the code AR/Sequel compatible
+      save(raise_on_failure: true) || raise(ActiveRecord::RecordNotSaved.new("Failed to save the record", self))
     else
       CartoDB::Logger.error(message: "Cannot invalidate session")
     end
-  rescue CartoDB::CentralCommunicationFailure, Sequel::ValidationFailed => e
+  rescue CartoDB::CentralCommunicationFailure, Sequel::ValidationFailed, ActiveRecord::RecordNotSaved => e
     CartoDB::Logger.error(exception: e, message: "Cannot invalidate session")
   end
 end

--- a/app/models/carto/helpers/sessions.rb
+++ b/app/models/carto/helpers/sessions.rb
@@ -3,8 +3,7 @@ module Carto::Sessions
     self.session_salt = SecureRandom.hex
 
     if update_in_central
-      # NOTE: this is a hack for making the code AR/Sequel compatible
-      save(raise_on_failure: true) || raise(ActiveRecord::RecordNotSaved.new("Failed to save the record", self))
+      save!
     else
       log_error(message: "Could not invalidate session in Central")
     end

--- a/app/models/carto/helpers/sessions_invalidations.rb
+++ b/app/models/carto/helpers/sessions_invalidations.rb
@@ -1,4 +1,4 @@
-module Carto::Sessions
+module Carto::SessionsInvalidations
   def invalidate_all_sessions!
     self.session_salt = SecureRandom.hex
 

--- a/app/models/carto/helpers/user_commons.rb
+++ b/app/models/carto/helpers/user_commons.rb
@@ -9,6 +9,7 @@ require_dependency 'carto/helpers/password'
 require_dependency 'carto/helpers/password_rate_limit'
 require_dependency 'carto/helpers/urls'
 require_dependency 'carto/helpers/varnish_cache_handler'
+require_dependency 'carto/helpers/sessions'
 
 module Carto::UserCommons
   include Carto::BatchQueriesStatementTimeout
@@ -22,6 +23,7 @@ module Carto::UserCommons
   include Carto::PasswordRateLimit
   include Carto::Urls
   include Carto::VarnishCacheHandler
+  include Carto::Sessions
 
   STATE_ACTIVE = 'active'.freeze
   STATE_LOCKED = 'locked'.freeze

--- a/app/models/carto/helpers/user_commons.rb
+++ b/app/models/carto/helpers/user_commons.rb
@@ -9,7 +9,7 @@ require_dependency 'carto/helpers/password'
 require_dependency 'carto/helpers/password_rate_limit'
 require_dependency 'carto/helpers/urls'
 require_dependency 'carto/helpers/varnish_cache_handler'
-require_dependency 'carto/helpers/sessions'
+require_dependency 'carto/helpers/sessions_invalidations'
 
 module Carto::UserCommons
   include Carto::BatchQueriesStatementTimeout
@@ -23,7 +23,7 @@ module Carto::UserCommons
   include Carto::PasswordRateLimit
   include Carto::Urls
   include Carto::VarnishCacheHandler
-  include Carto::Sessions
+  include Carto::SessionsInvalidations
 
   STATE_ACTIVE = 'active'.freeze
   STATE_LOCKED = 'locked'.freeze

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -14,6 +14,7 @@ class Carto::User < ActiveRecord::Base
   include DataServicesMetricsHelper
   include Carto::AuthTokenGenerator
   include Carto::UserCommons
+  include Concerns::CartodbCentralSynchronizable
 
   # INFO: select filter is done for security and performance reasons. Add new columns if needed.
   DEFAULT_SELECT = "users.email, users.username, users.admin, users.organization_id, users.id, users.avatar_url," \

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -99,11 +99,6 @@ class Carto::User < ActiveRecord::Base
   end
   alias_method_chain :static_notifications, :creation
 
-  def invalidate_all_sessions!
-    user = ::User.where(id: self.id).first
-    user&.invalidate_all_sessions!
-  end
-
   def default_avatar
     "cartodb.s3.amazonaws.com/static/public_dashboard_default_avatar.png"
   end

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -133,7 +133,7 @@ module Concerns
           allowed_attributes = %i(seats viewer_seats display_name description website discus_shortname twitter_username
                                   auth_username_password_enabled auth_google_enabled password_expiration_in_d
                                   inherit_owner_ffs)
-          values.slice(*allowed_attributes)
+          attributes.with_indifferent_access.slice(*allowed_attributes)
         end
       elsif is_a_user?
         allowed_attributes = %i(
@@ -151,7 +151,7 @@ module Concerns
           password_reset_sent_at company_employees use_case private_map_quota session_salt public_dataset_quota
           dashboard_viewed_at email_verification_token email_verification_sent_at
         )
-        attrs = values.slice(*allowed_attributes)
+        attrs = attributes.with_indifferent_access.slice(*allowed_attributes)
         attrs[:multifactor_authentication_status] = multifactor_authentication_status()
         case action
         when :create

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -133,7 +133,7 @@ module Concerns
           allowed_attributes = %i(seats viewer_seats display_name description website discus_shortname twitter_username
                                   auth_username_password_enabled auth_google_enabled password_expiration_in_d
                                   inherit_owner_ffs)
-          attributes.with_indifferent_access.slice(*allowed_attributes)
+          attributes.symbolize_keys.slice(*allowed_attributes)
         end
       elsif is_a_user?
         allowed_attributes = %i(
@@ -151,7 +151,7 @@ module Concerns
           password_reset_sent_at company_employees use_case private_map_quota session_salt public_dataset_quota
           dashboard_viewed_at email_verification_token email_verification_sent_at
         )
-        attrs = attributes.with_indifferent_access.slice(*allowed_attributes)
+        attrs = attributes.symbolize_keys.slice(*allowed_attributes)
         attrs[:multifactor_authentication_status] = multifactor_authentication_status()
         case action
         when :create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -561,18 +561,6 @@ class User < Sequel::Model
     @password_confirmation
   end
 
-  def invalidate_all_sessions!
-    self.session_salt = SecureRandom.hex
-
-    if update_in_central
-      save(raise_on_failure: true)
-    else
-      log_error(message: "Cannot invalidate session", current_user: self)
-    end
-  rescue CartoDB::CentralCommunicationFailure, Sequel::ValidationFailed => e
-    log_error(exception: e, current_user: self, message: "Cannot invalidate session")
-  end
-
   # Database configuration setup
 
   def database_username


### PR DESCRIPTION
See https://app.clubhouse.io/cartoteam/story/101632/remove-usages-of-user-from-applicationcontroller

Note: in general warden session black magic internally seems to rely exclusively on username and token, and there's a lot of common stuff already moved to `Carto::UserCommons`.

Note2: this is built on top of the previous PR https://github.com/CartoDB/cartodb/pull/15807