### PR TITLE
Now every user manages its own dbdirect IPs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-* Now every user manages its own dbdirect IPs
+* Now every user manages its own dbdirect IPs, regardless of being a organization user [#15805](https://github.com/CartoDB/cartodb/pull/15805)
 * Add a script to measure Sequel model LOC [#15803](https://github.com/CartoDB/cartodb/pull/15803)
 
 4.41.0 (2020-09-01)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-
+* Now every user manages its own dbdirect IPs
 * Add a script to measure Sequel model LOC [#15803](https://github.com/CartoDB/cartodb/pull/15803)
 
 4.41.0 (2020-09-01)

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -307,20 +307,12 @@ class Carto::User < ActiveRecord::Base
 
   def dbdirect_effective_ips=(ips)
     ips ||= []
-    bearer = dbdirect_bearer
-    if bearer.dbdirect_ip
-      bearer.dbdirect_ip.update!(ips: ips)
-    else
-      bearer.create_dbdirect_ip!(ips: ips)
-    end
+    reload
+    dbdirect_ip ? dbdirect_ip.update!(ips: ips) : create_dbdirect_ip!(ips: ips)
   end
 
   def dbdirect_effective_ip
-    dbdirect_bearer.dbdirect_ip
-  end
-
-  def dbdirect_bearer
-    reload
+    reload.dbdirect_ip
   end
 
   private

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -320,11 +320,7 @@ class Carto::User < ActiveRecord::Base
   end
 
   def dbdirect_bearer
-    if organization.present? && organization.owner != self
-      organization.owner.reload
-    else
-      reload
-    end
+    reload
   end
 
   private

--- a/spec/requests/carto/api/dbdirect_ips_controller_spec.rb
+++ b/spec/requests/carto/api/dbdirect_ips_controller_spec.rb
@@ -194,7 +194,7 @@ describe Carto::Api::DbdirectIpsController do
       end
     end
 
-    it 'IP changes affect all the organization members' do
+    it 'IP changes affect only to org user, not org admin' do
       ips = ['100.20.30.40']
       params = {
         ips: ips,
@@ -207,10 +207,9 @@ describe Carto::Api::DbdirectIpsController do
               expect(response.status).to eq(201)
               expect(response.body[:ips]).to eq ips
               expect(@org_user.reload.dbdirect_effective_ips).to eq ips
-              expect(@org_owner.reload.dbdirect_effective_ips).to eq ips
-              expect(@dbdirect_metadata.get(@org_owner.username)).to eq ips
-              expect(@dbdirect_metadata.get(@carto_user1.username)).to be_empty
-              expect(@dbdirect_metadata.get(@org_user.username)).to be_empty
+              expect(@org_owner.reload.dbdirect_effective_ips).to be_empty
+              expect(@dbdirect_metadata.get(@org_owner.username)).to be_empty
+              expect(@dbdirect_metadata.get(@org_user.username)).to eq ips
             end
           end
         end


### PR DESCRIPTION
Sync script to be executed in bch, this will clear redis and dump the dbdirect_ips from org owner to all users that belong to that org:

```ruby
Carto::User.find_each do |user|
  $users_metadata.DEL('dbdirect:' + user.username)
  if user.organization.present?
    if user.organization.owner != user
      user.dbdirect_effective_ips = user.organization.owner.dbdirect_effective_ips
      user.save!
    end
  end
  if user.dbdirect_effective_ips.any?
    $users_metadata.HSETNX('dbdirect:' + user.username, 'ips', user.dbdirect_effective_ips.join(','))
  end
end
```