### PR TITLE
Bump to 4.41.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
+- None yet
+
+4.41.1 (2020-09-03)
+-------------------
+
+### Bug fixes / enhancements
 * Now every user manages its own dbdirect IPs, regardless of being a organization user [#15805](https://github.com/CartoDB/cartodb/pull/15805)
 * Add a script to measure Sequel model LOC [#15803](https://github.com/CartoDB/cartodb/pull/15803)
 


### PR DESCRIPTION
4.41.1 (2020-09-03)
-------------------

### Bug fixes / enhancements
* Now every user manages its own dbdirect IPs, regardless of being a organization user [#15805](https://github.com/CartoDB/cartodb/pull/15805)
* Add a script to measure Sequel model LOC [#15803](https://github.com/CartoDB/cartodb/pull/15803)