### PR TITLE
Setup Coverband

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ public/images
 public/fonts
 public/flash
 public/static
+public/coverband
 app/assets/stylesheets/tmp/
 app/assets/fonts/icon_font/svgs
 db/schema.rb

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ group :assets do
   gem "compass",               "1.0.3"
 end
 
-# Importer & sync tables
 gem 'roo',                     '1.13.2'
 gem 'state_machines-activerecord', '~> 0.5.0'
 gem 'typhoeus',                '1.3.1'
@@ -63,27 +62,17 @@ gem 'google-api-client',       '0.34.1'
 gem 'dropbox_api',             '0.1.17'
 gem 'gibbon',                  '1.1.4'
 gem 'instagram-continued-continued'
-
-# GCloud
 gem 'google-cloud-pubsub', '1.2.0'
-
-# Service components (/services)
 gem 'virtus',                   '1.0.5'
 gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.3.4'
 gem 'email_address',            '~> 0.1.11'
-
-# Markdown
 gem 'redcarpet', '3.3.3'
-
-# TODO Production gems, put them in :production group
 gem 'rollbar',               '~>2.11.1'
 gem 'resque',                '1.25.2'
 gem 'resque-metrics',        '0.1.1'
-
 gem 'net-telnet'
-
 gem 'rubyzip',               '>= 2.0.0'
-
+gem 'coverband'
 # This is weird. In ruby 2 test-unit is required. We don't know why for sure
 gem 'test-unit'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.1.6)
+    coverband (5.0.0)
+      redis
     crass (1.0.6)
     daemons (1.2.4)
     db-query-matchers (0.4.0)
@@ -503,6 +505,7 @@ DEPENDENCIES
   charlock_holmes (= 0.7.6)
   ci_reporter (= 1.8.4)
   compass (= 1.0.3)
+  coverband
   db-query-matchers (= 0.4.0)
   dbf (= 2.0.6)
   delorean

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Development
 * Adds logging docs [#15813](https://github.com/CartoDB/cartodb/pull/15813)
 * Add wildcard IP for Direct SQL connection [#15818](https://github.com/CartoDB/cartodb/pull/15818)
 * Remove usage of `::User` Sequel model from the `ApplicationController` [#15804](https://github.com/CartoDB/cartodb/pull/15804)
+* Setup Coverband dead code detector [https://github.com/CartoDB/cartodb/pull/15811](https://github.com/CartoDB/cartodb/pull/15811)
 
 4.41.1 (2020-09-03)
 -------------------

--- a/app/models/carto/helpers/user_commons.rb
+++ b/app/models/carto/helpers/user_commons.rb
@@ -280,4 +280,10 @@ module Carto::UserCommons
     end
   end
 
+  def has_access_to_coverband?
+    return true unless Rails.env.production?
+
+    organization&.name == 'team'
+  end
+
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,9 @@ require "active_record/railtie"
 require_relative '../lib/carto/configuration'
 require_relative '../lib/carto/carto_gears_support'
 
+# Forcefully require Coverband config because otherwise it raises an error in the rails console
+require './config/coverband'
+
 if defined?(Bundler)
   Bundler.require(:default, :assets, Rails.env)
 end

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,0 +1,9 @@
+require 'coverband'
+
+Coverband.configure do |config|
+  config.store = Coverband::Adapters::RedisStore.new(Redis.new(url: ENV['COVERBAND_REDIS_URL']))
+  config.logger = Rails.logger
+  config.verbose = Rails.env.development?
+  config.web_enable_clear = Rails.env.development?
+  config.track_views = true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -767,4 +767,12 @@ CartoDB::Application.routes.draw do
   end
 end
 
+Rails.application.routes.draw do
+  mount(
+    Coverband::Reporters::Web.new,
+    at: '/coverband',
+    constraints: lambda { |request| request.env['warden']&.user&.has_access_to_coverband? }
+  )
+end
+
 # rubocop:enable Layout/LineLength, Layout/ExtraSpacing, Layout/SpaceBeforeFirstArg

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -10,4 +10,18 @@ namespace :assets do
       end
     end
   end
+
+  # bundle exec rake assets:copy_coverband_assets
+  desc 'Copy Coverband assets to production path'
+  task :copy_coverband_assets do
+    gem_path = Gem::Specification.find_by_name('coverband').full_gem_path
+    src_path = "#{gem_path}/public/."
+    dst_path = "#{Rails.root}/public/coverband"
+
+    puts "Creating directory: #{dst_path}"
+    FileUtils.mkdir_p(dst_path)
+
+    puts "Copying files from #{src_path} to #{dst_path}"
+    FileUtils.cp_r(src_path, dst_path)
+  end
 end

--- a/spec/models/carto/user_spec.rb
+++ b/spec/models/carto/user_spec.rb
@@ -2,6 +2,8 @@ require_relative '../../spec_helper'
 require_relative '../user_shared_examples'
 
 describe Carto::User do
+  let(:user) { create(:carto_user) }
+
   it_behaves_like 'user models' do
     def get_twitter_imports_count_by_user_id(user_id)
       get_user_by_id(user_id).twitter_imports_count
@@ -12,11 +14,11 @@ describe Carto::User do
     end
 
     def create_user
-      FactoryGirl.create(:carto_user)
+      create(:carto_user)
     end
 
     def build_user
-      FactoryGirl.build(:carto_user)
+      build(:carto_user)
     end
   end
 
@@ -97,6 +99,30 @@ describe Carto::User do
       end
 
       @user.password_reset_sent_at.to_s.should eql now.to_s
+    end
+  end
+
+  describe '#has_access_to_coverband?' do
+    let(:team_organization) { Carto::Organization.find(create(:organization, name: 'team').id) }
+
+    subject { user.has_access_to_coverband? }
+
+    context 'in development' do
+      it { should be_true }
+    end
+
+    context 'in production' do
+      before { Rails.env.stubs(:production?).returns(true) }
+
+      context 'when belongs to team' do
+        before { user.update!(organization: team_organization) }
+
+        it { should be_true }
+      end
+
+      context 'in any other case' do
+        it { should be_false }
+      end
     end
   end
 end


### PR DESCRIPTION
Closes the backend part of: https://app.clubhouse.io/cartoteam/story/97636/add-a-dead-code-detector-that-we-can-use-in-production

**What does this PR do?**

Installs https://github.com/danmayer/coverband. Access is restricted in production to the `team` organization users.

**Related infra work**

There are still a few pending changes in  https://github.com/CartoDB/cartodb-platform/pull/6882, but it should not affect this PR: if Coverband can't connect to redis simply it shows an error but does not affect normal CartoDB behavior.