### PR TITLE
bug/ch102122/juanra-bugs-when-requesting-premium-subscriptions

### DIFF
--- a/app/controllers/carto/api/public/data_observatory_controller.rb
+++ b/app/controllers/carto/api/public/data_observatory_controller.rb
@@ -231,10 +231,12 @@ module Carto
 
         def license_info(metadata, status)
           doss = Carto::DoSyncServiceFactory.get_for_user(@user)
-          entity_info = doss.entity_info(metadata[:id])
+          entity_info = doss.parsed_entity_id(metadata[:id])
+          # 'requested' datasets may no exists yet in 'bq', but let's assume it will...
+          available_in = (metadata[:available_in].nil? && status == 'requested')? ['bq'] : metadata[:available_in]
           entity_info.merge({
             dataset_id: metadata[:id],
-            available_in: metadata[:available_in],
+            available_in: available_in,
             price: metadata[:subscription_list_price],
             created_at: entity_info[:created_at] || Time.now.round,
             expires_at: entity_info[:expires_at] || Time.now.round + 1.year,

--- a/app/services/carto/do_licensing_service.rb
+++ b/app/services/carto/do_licensing_service.rb
@@ -106,8 +106,10 @@ module Carto
       }))
       if sync_errors then
         return sync_errors[:sync_status], sync_errors[:unsyncable_reason]
-      else
+      elsif dataset[:status] == 'requested' then
         return 'unsynced', nil
+      else
+        return 'syncing', nil
       end
     end
 

--- a/lib/resque/do_sync_jobs.rb
+++ b/lib/resque/do_sync_jobs.rb
@@ -22,7 +22,8 @@ module Resque
       subscription  = licensing_service.subscription(subscription_info['subscription_id'])
       # Check if the subscription has been removed during the synchronization process:
       if subscription.nil?
-        # TODO: Remove table...
+        # Remove just-imported table...
+        Carto::UserTable.find(data_import.table_id).visualization.destroy
         raise StandardError.new("Subscription not found after import! (tablename: #{data_import.table_name})")
       end
 

--- a/lib/resque/do_sync_jobs.rb
+++ b/lib/resque/do_sync_jobs.rb
@@ -34,6 +34,10 @@ module Resque
         status_name, unsyncable_reason = sync_info.values_at(:sync_status, :unsyncable_reason)
       end
 
+      if data_import.state == 'failure' && unsyncable_reason.nil? then
+        unsyncable_reason = data_import.log.entries
+      end
+
       licensing_service.add_to_redis(subscription.merge({
         sync_status: status_name,
         unsyncable_reason: unsyncable_reason,

--- a/spec/models/common_data_spec.rb
+++ b/spec/models/common_data_spec.rb
@@ -34,10 +34,10 @@ describe CommonData do
     Rails.logger.expects(:error).with(
       'exception' => {
         'class' => 'JSON::ParserError',
-        'message' => 'A JSON text must at least contain two octets!',
+        'message' => '784: unexpected token at \'{\'',
         'backtrace_hint' => ['line_1', 'line_2']
       },
-      'message' => 'A JSON text must at least contain two octets!'
+      'message' => '784: unexpected token at \'{\''
     )
 
     Rails.logger.expects(:error).with('message' => 'common-data empty', 'url' => common_data_url)

--- a/spec/requests/carto/api/public/data_observatory_controller_spec.rb
+++ b/spec/requests/carto/api/public/data_observatory_controller_spec.rb
@@ -624,7 +624,7 @@ describe Carto::Api::Public::DataObservatoryController do
 
       mock_sync_service = mock
       Carto::DoSyncServiceFactory.expects(:get_for_user).once.returns(mock_sync_service)
-      mock_sync_service.stubs(:entity_info).returns(expected_params)
+      mock_sync_service.stubs(:parsed_entity_id).returns(expected_params)
 
       mock_service = mock
       mock_service.expects(:subscribe).with(expected_params).once
@@ -667,7 +667,7 @@ describe Carto::Api::Public::DataObservatoryController do
 
       mock_sync_service = mock
       Carto::DoSyncServiceFactory.expects(:get_for_user).once.returns(mock_sync_service)
-      mock_sync_service.stubs(:entity_info).returns(expected_params)
+      mock_sync_service.stubs(:parsed_entity_id).returns(expected_params)
 
       mock_service = mock
       mock_service.expects(:subscribe).with(expected_params).once
@@ -705,7 +705,7 @@ describe Carto::Api::Public::DataObservatoryController do
 
         mock_sync_service = mock
         Carto::DoSyncServiceFactory.expects(:get_for_user).once.returns(mock_sync_service)
-        mock_sync_service.stubs(:entity_info).returns(expected_params)
+        mock_sync_service.stubs(:parsed_entity_id).returns(expected_params)
 
         mock_service = mock
         mock_service.expects(:subscribe).with(expected_params).once
@@ -750,7 +750,7 @@ describe Carto::Api::Public::DataObservatoryController do
 
         mock_sync_service = mock
         Carto::DoSyncServiceFactory.expects(:get_for_user).once.returns(mock_sync_service)
-        mock_sync_service.stubs(:entity_info).returns(expected_params)
+        mock_sync_service.stubs(:parsed_entity_id).returns(expected_params)
 
         mock_service = mock
         mock_service.expects(:subscribe).with(expected_params).once


### PR DESCRIPTION
- Set `sync_status` to `syncing` at the subscription creation time when it's needed.
- Also take into account the status for `requested` subscriptions.
- Delete the imported table when the subscription has been deleted during the importing process.

Related to: https://github.com/CartoDB/cartodb-central/pull/2915 (must be together)