### PR TITLE
Fixing logs for named maps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Development
 * New management capabilities for API Keys of other users ([#15819](https://github.com/CartoDB/cartodb/pull/15819))
 
 ### Bug fixes / enhancements
+* Fix logs for named maps ([15826](https://github.com/CartoDB/cartodb/pull/15826))
 * Remove automatic geocodings models and table ([#15817](https://github.com/CartoDB/cartodb/pull/15817))
 * Fix column quoting for geometrification ([#15815](https://github.com/CartoDB/cartodb/pull/15815))
 * Removing unused class ([#15816](https://github.com/CartoDB/cartodb/pull/15816))

--- a/lib/carto/named_maps/api.rb
+++ b/lib/carto/named_maps/api.rb
@@ -180,8 +180,8 @@ module Carto
           visualization_id: visualization.id,
           action: action,
           request_url: response.request.url,
-          response_code: response.code,
-          response: response.body
+          status: response.code,
+          response_body: response.body
         )
       rescue Encoding::UndefinedConversionError => e
         # Hotfix for preventing https://rollbar.com/carto/CartoDB/items/41457 until we find the root cause
@@ -191,7 +191,7 @@ module Carto
       end
 
       def log_context
-        super.merge(request_id: Carto::CurrentRequest.request_id, component: 'cartodb.named-maps')
+        super.merge(request_id: Carto::CurrentRequest.request_id, component: 'cartodb.named-maps-client')
       end
     end
   end

--- a/lib/carto/named_maps/api.rb
+++ b/lib/carto/named_maps/api.rb
@@ -177,16 +177,21 @@ module Carto
         log_error(
           message: 'Error in named maps API',
           current_user: user,
-          visualization: { id: visualization.id },
+          visualization_id: visualization.id,
           action: action,
-          request: { url: response.request.url },
-          response: { status: response.code, body: response.body }
+          request_url: response.request.url,
+          response_code: response.code,
+          response: response.body
         )
       rescue Encoding::UndefinedConversionError => e
         # Hotfix for preventing https://rollbar.com/carto/CartoDB/items/41457 until we find the root cause
         # https://cartoteam.slack.com/archives/CEQLWTW9Z/p1599134417001900
         # https://app.clubhouse.io/cartoteam/story/101908/fix-encoding-error-while-logging-request
         Rollbar.error(e)
+      end
+
+      def log_context
+        super.merge(request_id: Carto::CurrentRequest.request_id, component: 'cartodb.named-maps')
       end
     end
   end


### PR DESCRIPTION
Some logs for named maps like this:

```json
{
  "visualization": {
    "id": "7d116384-b09e-42c4-9c2c-39bd36aadeac"
  },
  "action": "update",
  "request": {
    "url": "https://pellman1.carto.com:443/api/v1/map/named/tpl_7d116384_b09e_42c4_9c2c_39bd36aadeac?api_key=8f95327e43e214536a0bd3e9fe2433e25c9fb61a"
  },
  "response": {
    "status": 429,
    "body": "{\"errors\":[\"You are over platform's limits: too many requests. Please contact us to know more details\"],\"errors_with_context\":[{\"type\":\"limit\",\"message\":\"You are over platform's limits: too many requests. Please contact us to know more details\",\"subtype\":\"rate-limit\"}]}"
  },
  "timestamp": "2020-09-09T00:17:55.268+00:00",
  "levelname": "error",
  "cdb-user": "pellman1",
  "event_message": "Error in named maps API"
}
```

were not being indexed by Elastic due to the field `request` and `response` were storing JSON data whereas Elastic has defined those fields as String type.

In order to fix this I've flattened fields as String.

Also I've added `request_id` and `component` in `log_context`.

More info in CH: https://app.clubhouse.io/cartoteam/story/103253/some-logs-from-rails-are-not-being-ingested-in-kibana