### PR TITLE
Fix Coverband - Resque integration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ Development
 * Bump version of cartodb-common module to v0.3.6 [#15820](https://github.com/CartoDB/cartodb/pull/15820)
 * Setup Coverband dead code detector [https://github.com/CartoDB/cartodb/pull/15811](https://github.com/CartoDB/cartodb/pull/15811)
 * Include LoggerHelper as class methods in models [https://github.com/CartoDB/cartodb/pull/15824](https://github.com/CartoDB/cartodb/pull/15824)
+* Fix Coverband - Resque integration [#15827](https://github.com/CartoDB/cartodb/pull/15827)
 
 4.41.1 (2020-09-03)
 -------------------

--- a/config/coverband.rb
+++ b/config/coverband.rb
@@ -1,3 +1,6 @@
+# Load the ::Resque constant manually so Coverband installs the corresponding hooks
+# https://github.com/danmayer/coverband/blob/v5.0.1/lib/coverband.rb#L114
+require 'resque'
 require 'coverband'
 
 Coverband.configure do |config|


### PR DESCRIPTION
Loads the ::Resque constant manually before loading coverband because otherwise the Resque reporting hooks defined by Coverband are not installed