### PR TITLE
Fix workflow when the diff has binary files

### DIFF
--- a/.github/workflows/orm-check.yml
+++ b/.github/workflows/orm-check.yml
@@ -20,19 +20,24 @@ jobs:
           MODIFIED_FILES=()
           while IFS='$\n' read -r c; do
             # Mark files as modified if new lines have been added
-            summary=$(($(echo $c | awk '{print $1}') - $(echo $c | awk '{print $2}')))
-            filename=$(echo $c | awk '{print $3}')
+            added=$(echo $c | awk '{print $1}')
+            removed=$(echo $c | awk '{print $2}')
+            is_numeric='^[0-9]+$'
+            if [[ $added =~ $is_numeric && $removed =~ $is_numeric ]]; then
+              summary=$(( $added - $removed ))
+              filename=$(echo $c | awk '{for(i=3;i<=NF;++i)print $i}')
 
-            if [ $summary -gt 0 ]; then
-              for orm in $ORM_FILES; do
-                if [ $filename = $orm ]; then
-                  MODIFIED_FILES+=($filename)
-                fi
-              done
+              if [ $summary -gt 0 ]; then
+                for orm in $ORM_FILES; do
+                  if [ $filename = $orm ]; then
+                    MODIFIED_FILES+=($filename)
+                  fi
+                done
+              fi
             fi
           done < <(git diff $(git merge-base $(git rev-parse HEAD) origin/master) --numstat)
 
-          if [ ${#MODIFIED_FILES[@]} -gt 0 ]; then
+          if [[ ${#MODIFIED_FILES[@]} -gt 0 ]]; then
             for i in ${MODIFIED_FILES[@]}; do
               echo "::error file=$i::This file has been flagged to be migrated, please do not add new lines."
             done

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,9 @@ Development
 * New management capabilities for API Keys of other users ([#15819](https://github.com/CartoDB/cartodb/pull/15819))
 
 ### Bug fixes / enhancements
-- Return expired subscriptions with status 'expired' ([93673](https://app.clubhouse.io/cartoteam/story/93673/return-expired-subscriptions))
-- Bumps cartodb-common to v0.3.3 to fix error traces ([#15787](https://github.com/CartoDB/cartodb/pull/15787))
+* Fix orm-check workflow when the diff has binary files
+* Return expired subscriptions with status 'expired' ([93673](https://app.clubhouse.io/cartoteam/story/93673/return-expired-subscriptions))
+* Bumps cartodb-common to v0.3.3 to fix error traces ([#15787](https://github.com/CartoDB/cartodb/pull/15787))
 * Fix logs for named maps ([15826](https://github.com/CartoDB/cartodb/pull/15826))
 * Remove automatic geocodings models and table ([#15817](https://github.com/CartoDB/cartodb/pull/15817))
 * Fix column quoting for geometrification ([#15815](https://github.com/CartoDB/cartodb/pull/15815))


### PR DESCRIPTION
This check expects the diff command to output something like:
```
X Y filename
```
but for binary files the output is:
```
- - binary
```
The script has been improved so it checks that `X` and `Y` are numeric before applying basic math operations