### PR TITLE
bug/ch106113/datasets-in-catalog-should-be-able-to-be

### DIFF
--- a/app/services/carto/do_licensing_service.rb
+++ b/app/services/carto/do_licensing_service.rb
@@ -63,7 +63,7 @@ module Carto
         # Initial sync status
         sync_status = dataset[:sync_status]
         unsyncable_reason = dataset[:unsyncable_reason]
-        entity_info = get_entity_info(dataset[:dataset_id])
+        entity_info = (dataset[:status] != 'requested') ? get_entity_info(dataset[:dataset_id]) : {}
         if sync_status.nil? then
           sync_status, unsyncable_reason = get_initial_sync_status(dataset, entity_info)
         end
@@ -76,10 +76,10 @@ module Carto
           status: dataset[:status],
           available_in: dataset[:available_in],
           type: dataset[:type],
-          estimated_size: entity_info[:estimated_size].to_i,
-          estimated_row_count: entity_info[:estimated_row_count].to_i,
-          estimated_columns_count: entity_info[:estimated_columns_count].to_i,
-          num_bytes: entity_info[:num_bytes].to_i,
+          estimated_size: entity_info[:estimated_size].to_i || 0,
+          estimated_row_count: entity_info[:estimated_row_count].to_i || 0,
+          estimated_columns_count: entity_info[:estimated_columns_count].to_i || 0,
+          num_bytes: entity_info[:num_bytes].to_i || 0,
           sync_status: sync_status,
           unsyncable_reason: unsyncable_reason,
           unsynced_errors: dataset[:unsynced_errors] || nil,
@@ -101,10 +101,10 @@ module Carto
 
     def get_initial_sync_status(dataset, entity_info)
       sync_info = @doss.check_syncable(dataset) || @doss.check_sync_limits(dataset.merge({
-        estimated_size: entity_info[:estimated_size].to_i,
-        estimated_row_count: entity_info[:estimated_row_count].to_i,
-        estimated_columns_count: entity_info[:estimated_columns_count].to_i,
-        num_bytes: entity_info[:num_bytes].to_i
+        estimated_size: entity_info[:estimated_size].to_i || 0,
+        estimated_row_count: entity_info[:estimated_row_count].to_i || 0,
+        estimated_columns_count: entity_info[:estimated_columns_count].to_i || 0,
+        num_bytes: entity_info[:num_bytes].to_i || 0
       }))
       if sync_info then
         return sync_info[:sync_status], sync_info[:unsyncable_reason]


### PR DESCRIPTION
Do not try to get BQ metadata for 'requested' datasets