### PR TITLE
Fix Organization.overquota exception logging

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@ Development
 * Added a script to generate a graph of Sequel models associations [#15865](https://github.com/CartoDB/cartodb/pull/15865)
 * Migrate `::FeatureFlagsUser` to `ActiveRecord` [#15841](https://github.com/CartoDB/cartodb/pull/15841)
 * Migrate `::SearchTweet` to ActiveRecord [#15859](https://github.com/CartoDB/cartodb/pull/15859)
+* Fix Organization.overquota exception logging [#15873](https://github.com/CartoDB/cartodb/pull/15873)
 * Revamp Rubocop config
 
 4.41.1 (2020-09-03)

--- a/app/models/carto/helpers/organization_commons.rb
+++ b/app/models/carto/helpers/organization_commons.rb
@@ -5,7 +5,7 @@ module Carto::OrganizationCommons
 
     def initialize(organization)
       @organization = organization
-      super "Organization #{organization.name} has no owner"
+      super "Organization has no owner"
     end
   end
 end

--- a/app/models/carto/organization.rb
+++ b/app/models/carto/organization.rb
@@ -53,7 +53,7 @@ module Carto
           over_mapzen_routing = o.get_mapzen_routing_calls > limit
           over_geocodings || over_twitter_imports || over_here_isolines || over_obs_snapshot || over_obs_general || over_mapzen_routing
         rescue Carto::Organization::OrganizationWithoutOwner => error
-          log_warning(message: 'Skipping inconsistent organization', organization: self, exception: error)
+          log_warning(message: 'Skipping inconsistent organization', organization: o, exception: error)
           false
         end
       end


### PR DESCRIPTION
Rollbar error: https://rollbar.com/carto/CartoDB/items/43042/ . Thanks @rafatower for reporting the exception.

Taking a look at this piece of code: 
```
rescue Carto::Organization::OrganizationWithoutOwner => error
  log_warning(message: 'Skipping inconsistent organization', organization: self, exception: error)
  false
end
```

The problem is that the `Carto::Organization.overquota` static method was logging `self` as `organization` field in the log entry, but since this method is static, the field was the class itself, not the instance of `Carto::Organization`. The log looked like this:
```
{
  "organization": "Carto::Organization",
  "exception": {
    "class": "Carto::OrganizationCommons::OrganizationWithoutOwner",
    "message": "Organization carto-org has no owner",
    "backtrace_hint": [
      "/cartodb/app/models/carto/organization.rb:168:in `require_organization_owner_presence!'",
      "/cartodb/app/models/carto/organization.rb:63:in `get_geocoding_calls'",
      "/cartodb/app/models/carto/organization.rb:43:in `block in overquota'",
      "/var/lib/gems/2.5.0/gems/activerecord-4.2.11.3/lib/active_record/relation/batches.rb:51:in `block (2 levels) in find_each'",
      "/var/lib/gems/2.5.0/gems/activerecord-4.2.11.3/lib/active_record/relation/batches.rb:51:in `each'"
    ]
  },
  "timestamp": "2020-09-28 07:43:19 +0000",
  "levelname": "warning",
  "cdb-user": null,
  "event_message": "Skipping inconsistent organization"
}
```
I've replaced `organization: self` with `organization: o` and removed the message interpolation:
```
{
  "organization": "carto-org",
  "exception": {
    "class": "Carto::OrganizationCommons::OrganizationWithoutOwner",
    "message": "Organization has no owner",
    "backtrace_hint": [
      "/cartodb/app/models/carto/organization.rb:168:in `require_organization_owner_presence!'",
      "/cartodb/app/models/carto/organization.rb:63:in `get_geocoding_calls'",
      "/cartodb/app/models/carto/organization.rb:43:in `block in overquota'",
      "/var/lib/gems/2.5.0/gems/activerecord-4.2.11.3/lib/active_record/relation/batches.rb:51:in `block (2 levels) in find_each'",
      "/var/lib/gems/2.5.0/gems/activerecord-4.2.11.3/lib/active_record/relation/batches.rb:51:in `each'"
    ]
  },
  "timestamp": "2020-09-28 07:45:07 +0000",
  "levelname": "warning",
  "cdb-user": null,
  "event_message": "Skipping inconsistent organization"
}
```