### PR TITLE
Don't override default include list in linter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,14 +2,6 @@
 
 AllCops:
   TargetRubyVersion: 2.5
-  Include:
-  - "**/*.gemspec"
-  - "**/*.podspec"
-  - "**/*.rake"
-  - "**/Gemfile"
-  - "**/Rakefile"
-  - "**/Capfile"
-  - "**/Guardfile"
   Exclude:
   - "vendor/**/*"
   - "db/schema.rb"


### PR DESCRIPTION
This caused all the Ruby files to be ignored, since by overriding the `Include` key we've removed the default Regexp which searches for Ruby files: https://docs.rubocop.org/rubocop/configuration.html#unusual-files-that-would-not-be-included-by-default

I still have pending for my next leapfrog to fix the integration of the linter with the CI, but at least with this change we can have a working version of the linter in local.