### PR TITLE
Fix bug affecting sanitization version of sync tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Development
 - None yet
 
 ### Features
+* Fix column sanitization for connector syncs ([15885](https://github.com/CartoDB/cartodb/pull/15885))
 * Load config files as ERB templates to allow reading ENV values ([15881](https://github.com/CartoDB/cartodb/pull/15881))
 
 ### Bug fixes / enhancements

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -268,7 +268,7 @@ module CartoDB
           # but is kept because there may be existing syncs for which this double sanitization
           # (version 1 sanitization which wasn't idemponent) had the effect of altering some
           # satinizated names (e.g. __1 -> _1).
-          table = Carto::UserTable.find(user.tables.find_by(name: 'upcase2').id).service
+          table = Carto::UserTable.find(@user.tables.where(name: @table_name).first.id).service
           table.sanitize_columns(table_name: table_name, database_schema: schema_name, connection: user_database)
 
           # When tables are created using ogr2ogr they are added a ogc_fid or gid primary key

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -268,7 +268,7 @@ module CartoDB
           # but is kept because there may be existing syncs for which this double sanitization
           # (version 1 sanitization which wasn't idemponent) had the effect of altering some
           # satinizated names (e.g. __1 -> _1).
-          table = Carto::UserTable.find(@user.tables.where(name: @table_name).first.id).service
+          table = Carto::UserTable.find(user.tables.find_by(name: 'upcase2').id).service
           table.sanitize_columns(table_name: table_name, database_schema: schema_name, connection: user_database)
 
           # When tables are created using ogr2ogr they are added a ogc_fid or gid primary key

--- a/app/models/synchronization/adapter.rb
+++ b/app/models/synchronization/adapter.rb
@@ -268,8 +268,7 @@ module CartoDB
           # but is kept because there may be existing syncs for which this double sanitization
           # (version 1 sanitization which wasn't idemponent) had the effect of altering some
           # satinizated names (e.g. __1 -> _1).
-          table = ::Table.new(name: @table_name, user_id: @user.id)
-          # we could as well: table = Carto::UserTable.find(@user.tables.where(name: @table_name).first.id).service
+          table = Carto::UserTable.find(@user.tables.where(name: @table_name).first.id).service
           table.sanitize_columns(table_name: table_name, database_schema: schema_name, connection: user_database)
 
           # When tables are created using ogr2ogr they are added a ogc_fid or gid primary key


### PR DESCRIPTION
See https://app.clubhouse.io/cartoteam/story/108990

In connector syncs, when sanitization is (redundantly, see https://github.com/CartoDB/cartodb/issues/15231#issuecomment-564246179) applied, the applied sanitization version was being fetched by a new `Table` object for which a new, unsaved `DataImport` was generated, and that data import was used to obtain the sanitization version. [Until a DataImport is actually created](https://github.com/CartoDB/cartodb/blob/54f424fed2eff08b6793fbe1eb2e86ac13197071/app/models/data_import.rb#L77), the version [defaults to the legacy one](https://github.com/CartoDB/cartodb/blob/54f424fed2eff08b6793fbe1eb2e86ac13197071/app/models/data_import.rb#L343), so that's we were getting