### PR TITLE
Recognize multi-line geojson data on imports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 * Load config files as ERB templates to allow reading ENV values ([15881](https://github.com/CartoDB/cartodb/pull/15881))
 
 ### Bug fixes / enhancements
+* Identify multi-line GeoJSON columns correctly on imports [#15891](https://github.com/CartoDB/cartodb/pull/15891)
 * Add DO geography key variables [#15882](https://github.com/CartoDB/cartodb/pull/15882)
 * Migrate `ClientApplication` model to `ActiveRecord` [#15886](https://github.com/CartoDB/cartodb/pull/15886)
 * Avoid delegating special methods in presenters [#15889](https://github.com/CartoDB/cartodb/pull/15889)

--- a/services/importer/lib/importer/column.rb
+++ b/services/importer/lib/importer/column.rb
@@ -12,7 +12,7 @@ module CartoDB
     class Column
       DEFAULT_SRID    = 4326
       WKB_RE          = /^\d{2}/
-      GEOJSON_RE      = /{.*(type|coordinates).*(type|coordinates).*}/
+      GEOJSON_RE      = /{.*(type|coordinates).*(type|coordinates).*}/m
       WKT_RE          = /POINT|LINESTRING|POLYGON/
       KML_MULTI_RE    = /<Line|<Polygon/
       KML_POINT_RE    = /<Point>/


### PR DESCRIPTION
The georreferencer used in the Import API, that detects geometry columns, couldn't detect GeoJSON columns using multi-line formats. This is relevant for example for data in Snowflake which by default is presented as multile GeoJSON.