### PR TITLE
Feature/ch80914/improve error messages while importing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Development
 * Load config files as ERB templates to allow reading ENV values ([15881](https://github.com/CartoDB/cartodb/pull/15881))
 
 ### Bug fixes / enhancements
+* Improve import error messages [#15893](https://github.com/CartoDB/cartodb/pull/15893)
 * Identify multi-line GeoJSON columns correctly on imports [#15891](https://github.com/CartoDB/cartodb/pull/15891)
 * Add DO geography key variables [#15882](https://github.com/CartoDB/cartodb/pull/15882)
 * Migrate `ClientApplication` model to `ActiveRecord` [#15886](https://github.com/CartoDB/cartodb/pull/15886)

--- a/app/controllers/carto/api/connectors_controller.rb
+++ b/app/controllers/carto/api/connectors_controller.rb
@@ -174,7 +174,7 @@ module Carto
           raise Carto::Connector::InvalidParametersError.new(message: "Provider doesn't match")
         end
         parameters[:provider] = provider_id
-        parameters.merge! request_params.except(:provider_id, :format, :controller, :action)
+        parameters.merge! request_params.except(:provider_id, :format, :controller, :action, :api_key)
       end
 
       def check_availability

--- a/app/controllers/carto/api/data_import_presenter.rb
+++ b/app/controllers/carto/api/data_import_presenter.rb
@@ -117,11 +117,7 @@ module Carto
       end
 
       def get_error_text
-        if @data_import.error_code.nil?
-          nil
-        else
-          @data_import.error_code.blank? ? CartoDB::IMPORTER_ERROR_CODES[99999] : CartoDB::IMPORTER_ERROR_CODES[@data_import.error_code]
-        end
+        @data_import.get_error_text
       end
 
       def display_name

--- a/app/models/carto/data_import.rb
+++ b/app/models/carto/data_import.rb
@@ -1,8 +1,10 @@
 require 'active_record'
+require_dependency 'carto/helpers/data_import_commons'
 
 module Carto
   class DataImport < ActiveRecord::Base
     include Carto::DataImportConstants
+    include Carto::DataImportCommons
 
     # INFO: hack to workaround `ActiveRecord::DangerousAttributeError: logger is defined by ActiveRecord`
     class << self

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -4,12 +4,14 @@ require_dependency 'cartodb/import_error_codes'
 module Carto
   module DataImportCommons
 
+    GENERIC_ERROR_CODE = 99999
+
     # Notice that this returns the entire error hash, not just the text
     def get_error_text
       if error_code == CartoDB::NO_ERROR_CODE
         CartoDB::NO_ERROR_CODE
-      elsif error_code.blank? || error_code == 99999
-        connector_error_message || CartoDB::IMPORTER_ERROR_CODES[99999]
+      elsif error_code.blank? || error_code == GENERIC_ERROR_CODE
+        connector_error_message || CartoDB::IMPORTER_ERROR_CODES[GENERIC_ERROR_CODE]
       else
         CartoDB::IMPORTER_ERROR_CODES[error_code]
       end

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -2,7 +2,6 @@ require_dependency 'cartodb/errors'
 require_dependency 'cartodb/import_error_codes'
 
 module Carto::DataImportCommons
-
   # Notice that this returns the entire error hash, not just the text
   def get_error_text
     if self.error_code == CartoDB::NO_ERROR_CODE
@@ -20,7 +19,12 @@ module Carto::DataImportCommons
 
   def connector_error_message
     match = CONNECTOR_ERROR_PATTERN.match(log&.entries)
-    match && match[1]
+    if match.present?
+      {
+        title: 'Connector Error',
+        what_about: match[1],
+        source: ERROR_SOURCE_CARTODB # FIXME, should it typically be ERROR_SOURCE_USER ?
+      }
+    end
   end
-
 end

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -9,7 +9,7 @@ module Carto
       if error_code == CartoDB::NO_ERROR_CODE
         CartoDB::NO_ERROR_CODE
       elsif error_code.blank? || error_code == 99999
-        connector_error_message || CartoDB::IMPORTER_ERROR_CODES[9999]
+        connector_error_message || CartoDB::IMPORTER_ERROR_CODES[99999]
       else
         CartoDB::IMPORTER_ERROR_CODES[error_code]
       end

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -2,7 +2,6 @@ require_dependency 'cartodb/errors'
 require_dependency 'cartodb/import_error_codes'
 
 module Carto
-
   module DataImportCommons
 
     # Notice that this returns the entire error hash, not just the text
@@ -23,6 +22,7 @@ module Carto
     def connector_error_message
       match = CONNECTOR_ERROR_PATTERN.match(log&.entries)
       return unless match.present?
+
       {
         title: 'Connector Error',
         what_about: match[1],
@@ -31,5 +31,4 @@ module Carto
     end
 
   end
-
 end

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -1,30 +1,35 @@
 require_dependency 'cartodb/errors'
 require_dependency 'cartodb/import_error_codes'
 
-module Carto::DataImportCommons
-  # Notice that this returns the entire error hash, not just the text
-  def get_error_text
-    if self.error_code == CartoDB::NO_ERROR_CODE
-      CartoDB::NO_ERROR_CODE
-    elsif self.error_code.blank? || self.error_code == 99999
-      connector_error_message || CartoDB::IMPORTER_ERROR_CODES[9999]
-    else
-      CartoDB::IMPORTER_ERROR_CODES[self.error_code]
+module Carto
+
+  module DataImportCommons
+
+    # Notice that this returns the entire error hash, not just the text
+    def get_error_text
+      if error_code == CartoDB::NO_ERROR_CODE
+        CartoDB::NO_ERROR_CODE
+      elsif error_code.blank? || error_code == 99999
+        connector_error_message || CartoDB::IMPORTER_ERROR_CODES[9999]
+      else
+        CartoDB::IMPORTER_ERROR_CODES[error_code]
+      end
     end
-  end
 
-  private
+    private
 
-  CONNECTOR_ERROR_PATTERN = /Connector Error [^\s]+: ERROR:\s+(.+?)^\d\d\d\d-\d\d-\d\d/mi.freeze
+    CONNECTOR_ERROR_PATTERN = /Connector Error [^\s]+: ERROR:\s+(.+?)^\d\d\d\d-\d\d-\d\d/mi.freeze
 
-  def connector_error_message
-    match = CONNECTOR_ERROR_PATTERN.match(log&.entries)
-    if match.present?
+    def connector_error_message
+      match = CONNECTOR_ERROR_PATTERN.match(log&.entries)
+      return unless match.present?
       {
         title: 'Connector Error',
         what_about: match[1],
         source: CartoDB::ERROR_SOURCE_CARTODB # FIXME, should it typically be ERROR_SOURCE_USER ?
       }
     end
+
   end
+
 end

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -23,7 +23,7 @@ module Carto::DataImportCommons
       {
         title: 'Connector Error',
         what_about: match[1],
-        source: ERROR_SOURCE_CARTODB # FIXME, should it typically be ERROR_SOURCE_USER ?
+        source: CartoDB::ERROR_SOURCE_CARTODB # FIXME, should it typically be ERROR_SOURCE_USER ?
       }
     end
   end

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -18,8 +18,7 @@ module Carto
     end
 
     private
-
-    CONNECTOR_ERROR_PATTERN = /Connector Error [^\s]+: ERROR:\s+(.+?)^\d\d\d\d-\d\d-\d\d/mi.freeze
+    CONNECTOR_ERROR_PATTERN = /Connector(?:Runner)? Error [^\s]+: ERROR:\s+(.+?)^\d\d\d\d-\d\d-\d\d/mi.freeze
 
     def connector_error_message
       match = CONNECTOR_ERROR_PATTERN.match(log&.entries)

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -18,7 +18,7 @@ module Carto
     end
 
     private
-    CONNECTOR_ERROR_PATTERN = /Connector(?:Runner)? Error [^\s]+: ERROR:\s+(.+?)^\d\d\d\d-\d\d-\d\d/mi.freeze
+    CONNECTOR_ERROR_PATTERN = /Connector(?:Runner)? Error(?:[^\s]+: ERROR:)?\s+(.+?)^\d\d\d\d-\d\d-\d\d/mi.freeze
 
     def connector_error_message
       match = CONNECTOR_ERROR_PATTERN.match(log&.entries)

--- a/app/models/carto/helpers/data_import_commons.rb
+++ b/app/models/carto/helpers/data_import_commons.rb
@@ -1,0 +1,26 @@
+require_dependency 'cartodb/errors'
+require_dependency 'cartodb/import_error_codes'
+
+module Carto::DataImportCommons
+
+  # Notice that this returns the entire error hash, not just the text
+  def get_error_text
+    if self.error_code == CartoDB::NO_ERROR_CODE
+      CartoDB::NO_ERROR_CODE
+    elsif self.error_code.blank? || self.error_code == 99999
+      connector_error_message || CartoDB::IMPORTER_ERROR_CODES[9999]
+    else
+      CartoDB::IMPORTER_ERROR_CODES[self.error_code]
+    end
+  end
+
+  private
+
+  CONNECTOR_ERROR_PATTERN = /Connector Error [^\s]+: ERROR:\s+(.+?)^\d\d\d\d-\d\d-\d\d/mi.freeze
+
+  def connector_error_message
+    match = CONNECTOR_ERROR_PATTERN.match(log&.entries)
+    match && match[1]
+  end
+
+end

--- a/app/models/data_import.rb
+++ b/app/models/data_import.rb
@@ -347,14 +347,11 @@ class DataImport < Sequel::Model
 
   private
 
-  CONNECTOR_ERROR_PATTERN = /Connector Error [^\s]+: ERROR:\s+(.+)/.freeze
+  CONNECTOR_ERROR_PATTERN = /Connector Error [^\s]+: ERROR:\s+(.+?)^\d\d\d\d-\d\d-\d\d/mi.freeze
 
   def connector_error_message
-    error_lines = log&.entries.to_s.split("\n").grep(CONNECTOR_ERROR_PATTERN)
-    if error_lines.present?
-      match = CONNECTOR_ERROR_PATTERN.match(error_lines.first)
-      match[1]
-    end
+    match = CONNECTOR_ERROR_PATTERN.match(log&.entries)
+    match && match[1]
   end
 
   def get_provider_name_from_id(service_item_id)

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -188,7 +188,6 @@ module.exports = ImportDataFormView.extend({
   _handleErrors: function (data) {
     let errorMessages = [];
     if (data.responseJSON && data.responseJSON.errors) {
-      errorMessages.push(_t('components.modals.add-layer.imports.database.sql-error'));
       errorMessages.push(this._getPrintableError(data.responseJSON.errors));
     } else {
       errorMessages.push(_t('components.modals.add-layer.imports.database.general-error'));
@@ -202,8 +201,11 @@ module.exports = ImportDataFormView.extend({
   },
 
   _getPrintableError: function (error) {
-    const partialError = error.replace('Error connecting to provider bigquery: ', '');
-    const colonIndex = partialError.indexOf(':');
-    return partialError.substring(colonIndex + 2, partialError.length);
+    let partialError = error.replace('Error connecting to provider bigquery: ', '');
+    const errorMatch = partialError.match(/\bERROR:\s*([\s\S]+)/m);
+    if (errorMatch) {
+      partialError = errorMatch[1];
+    }
+    return partialError;
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-bigquery/import-bigquery-form-view.js
@@ -137,7 +137,7 @@ module.exports = ImportDataFormView.extend({
       sql_query: this.formFields.sqlQuery.replace(/\n/g, ' ')
     };
 
-    dbConnectorsClient.dryRun(params, (errors, _response, data) => {
+    dbConnectorsClient.dryRun('bigquery', params, (errors, _response, data) => {
       if (errors) {
         this._handleErrors(data);
       } else if (data && data.total_bytes_processed) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -90,7 +90,7 @@ module.exports = ImportDataFormView.extend({
     const params = {
       provider: this.options.service,
       connection: this.model.connection,
-      sql_query: query
+      sql_query: query,
       import_as: this.formFields.importAs
     };
     dbConnectorsClient.dryRun(this.options.service, params, (errors, _response, data) => {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -147,5 +147,21 @@ module.exports = ImportDataFormView.extend({
       this.model.set('state', 'selected');
       this.trigger('urlSubmitted', this);
     }
+  },
+
+  _handleErrors: function (data) {
+    let errorMessages = [];
+    if (data.responseJSON && data.responseJSON.errors) {
+      errorMessages.push(_t('components.modals.add-layer.imports.database.sql-error'));
+      errorMessages.push(this._getPrintableError(data.responseJSON.errors));
+    } else {
+      errorMessages.push(_t('components.modals.add-layer.imports.database.general-error'));
+    }
+    this.model.set('state', 'list');
+    this.model.setUpload({
+      value: '',
+      service_item_id: ''
+    });
+    this.model.set('errorMessages', errorMessages);
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -93,7 +93,7 @@ module.exports = ImportDataFormView.extend({
       sql_query: query
       import_as: this.formFields.importAs
     };
-    dbConnectorsClient.dryRun(params, (errors, _response, data) => {
+    dbConnectorsClient.dryRun(this.options.service, params, (errors, _response, data) => {
       if (errors) {
         this._handleErrors(data);
       } else if (data && data.total_bytes_processed) {

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -23,6 +23,7 @@ module.exports = ImportDataFormView.extend({
     );
 
     this._initCodeMirror();
+    this.dbConnectorsClient = new CartoNode.AuthenticatedClient().dbConnectors();
 
     if (this.formFields) {
       this.codeEditor.setValue(this.formFields.sqlQuery);
@@ -86,14 +87,13 @@ module.exports = ImportDataFormView.extend({
   },
 
   _performDryRun: function (query) {
-    const dbConnectorsClient = new CartoNode.AuthenticatedClient().dbConnectors();
     const params = {
       provider: this.options.service,
       connection: this.model.connection,
       sql_query: query,
       import_as: this.formFields.importAs
     };
-    dbConnectorsClient.dryRun(this.options.service, params, (errors, _response, data) => {
+    this.dbConnectorsClient.dryRun(this.options.service, params, (errors, _response, data) => {
       if (errors) {
         this._handleErrors(data);
       } else if (data && data.total_bytes_processed) {
@@ -104,7 +104,7 @@ module.exports = ImportDataFormView.extend({
 
   _goToConnectStep: function (query) {
     this._prepareUploadModel(query);
-    this._updateUploadModel(query);
+    this._updateUploadModel();
     this._goSelectDataset();
   },
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -1,4 +1,5 @@
 const _ = require('underscore');
+const CartoNode = require('carto-node');
 const ImportDataFormView = require('builder/components/modals/add-layer/content/imports/import-data/import-data-form-view');
 const template = require('./import-database-query-form.tpl');
 const CodeMirror = require('codemirror');
@@ -81,8 +82,29 @@ module.exports = ImportDataFormView.extend({
       importAs: this.$('.js-textInput').val()
     };
 
+    this._performDryRun(query);
+  },
+
+  _performDryRun: function (query) {
+    const dbConnectorsClient = new CartoNode.AuthenticatedClient().dbConnectors();
+    const params = {
+      provider: this.options.service,
+      connection: this.model.connection,
+      sql_query: query
+      import_as: this.formFields.importAs
+    };
+    dbConnectorsClient.dryRun(params, (errors, _response, data) => {
+      if (errors) {
+        this._handleErrors(data);
+      } else if (data && data.total_bytes_processed) {
+        this._goToConnectStep(query);
+      }
+    });
+  },
+
+  _goToConnectStep: function (query) {
     this._prepareUploadModel(query);
-    this._updateUploadModel();
+    this._updateUploadModel(query);
     this._goSelectDataset();
   },
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -163,5 +163,11 @@ module.exports = ImportDataFormView.extend({
       service_item_id: ''
     });
     this.model.set('errorMessages', errorMessages);
+  },
+
+  _getPrintableError: function (error) {
+    const partialError = error.replace('Error connecting to provider bigquery: ', '');
+    const colonIndex = partialError.indexOf(':');
+    return partialError.substring(colonIndex + 2, partialError.length);
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -17,7 +17,7 @@ module.exports = ImportDataFormView.extend({
       template({
         title: this.options.title,
         state: this.model.get('state'),
-        errorMessage: this.model.get('errorMessage'),
+        errorMessages: this.model.get('errorMessages'),
         sqlHint: this.options.sql_hint || _t('components.modals.add-layer.imports.database.sql-hint')
       })
     );
@@ -49,7 +49,7 @@ module.exports = ImportDataFormView.extend({
 
   _initBinds: function () {
     this.model.bind('change:state', this._checkVisibility, this);
-    this.model.bind('change:errorMessage', this.render, this);
+    this.model.bind('change:errorMessages', this.render, this);
   },
 
   _checkVisibility: function () {
@@ -96,7 +96,7 @@ module.exports = ImportDataFormView.extend({
     this.dbConnectorsClient.dryRun(this.options.service, params, (errors, _response, data) => {
       if (errors) {
         this._handleErrors(data);
-      } else if (data && data.total_bytes_processed) {
+      } else {
         this._goToConnectStep(query);
       }
     });
@@ -138,7 +138,7 @@ module.exports = ImportDataFormView.extend({
         value: '',
         service_item_id: ''
       });
-      this.model.set('errorMessage', _t('components.modals.add-layer.imports.database.sql-error'));
+      this.model.set('errorMessages', [_t('components.modals.add-layer.imports.database.sql-error')]);
     }
   },
 

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -152,7 +152,6 @@ module.exports = ImportDataFormView.extend({
   _handleErrors: function (data) {
     let errorMessages = [];
     if (data.responseJSON && data.responseJSON.errors) {
-      errorMessages.push(_t('components.modals.add-layer.imports.database.sql-error'));
       errorMessages.push(this._getPrintableError(data.responseJSON.errors));
     } else {
       errorMessages.push(_t('components.modals.add-layer.imports.database.general-error'));
@@ -166,8 +165,11 @@ module.exports = ImportDataFormView.extend({
   },
 
   _getPrintableError: function (error) {
-    const partialError = error.replace(`Error connecting to ${this.options.service}: `, '');
-    const colonIndex = partialError.indexOf(':');
-    return partialError.substring(colonIndex + 2, partialError.length);
+    let partialError = error.replace(`Error connecting to ${this.options.service}: `, '');
+    const errorMatch = partialError.match(/\bERROR:\s*([\s\S]+)/m);
+    if (errorMatch) {
+      partialError = errorMatch[1];
+    }
+    return partialError;
   }
 });

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -166,7 +166,7 @@ module.exports = ImportDataFormView.extend({
   },
 
   _getPrintableError: function (error) {
-    const partialError = error.replace('Error connecting to provider bigquery: ', '');
+    const partialError = error.replace(`Error connecting to ${this.options.service}: `, '');
     const colonIndex = partialError.indexOf(':');
     return partialError.substring(colonIndex + 2, partialError.length);
   }

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.js
@@ -54,7 +54,7 @@ module.exports = ImportDataFormView.extend({
 
   _checkVisibility: function () {
     const state = this.model.get('state');
-    if (state === 'connected') {
+    if (state === 'connected' || state === 'list') {
       this.show();
     } else {
       this.hide();

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form.tpl
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form.tpl
@@ -6,9 +6,11 @@
     <div>
       <div class="ImportOptions__CodeMirror">
         <textarea rows="4" cols="50" class="ImportOptions__input--long Form-input Form-textarea CDB-Text CDB-Size-medium js-textarea"></textarea>
-        <% if (errorMessage) { %>
+        <% if (errorMessages) { %>
           <div class="ImportOptions__input-error CDB-Text">
-            <%- errorMessage %>
+            <% errorMessages.forEach(function (errorMessage) { %>
+              <p><%- errorMessage %></p>
+            <% }); %>
           </div>
         <% } %>
       </div>

--- a/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-options.js
+++ b/lib/assets/javascripts/builder/components/modals/add-layer/content/imports/import-options.js
@@ -228,7 +228,7 @@ const IMPORT_OPTIONS = {
         { key: 'username', type: 'text' },
         { key: 'password', type: 'password' }
       ],
-      placeholder_query: 'SELECT *, ST_GeogPoint(longitude, latitude) AS the_geom FROM table'
+      placeholder_query: 'SELECT ST_GeogPoint(longitude, latitude) AS the_geom, * FROM table'
     }
   },
   MySQL: {
@@ -246,7 +246,7 @@ const IMPORT_OPTIONS = {
         { key: 'username', type: 'text' },
         { key: 'password', type: 'password' }
       ],
-      placeholder_query: 'SELECT *, ST_AsWKT(ST_SRID(Point(lng, lat), 4326)) AS the_geom FROM table'
+      placeholder_query: 'SELECT ST_AsWKT(ST_SRID(Point(lng, lat), 4326)) AS the_geom, * FROM table'
     }
   },
   SQLServer: {
@@ -264,7 +264,7 @@ const IMPORT_OPTIONS = {
         { key: 'username', type: 'text' },
         { key: 'password', type: 'password' }
       ],
-      placeholder_query: 'SELECT *, CONVERT(VARCHAR(1000), geography::Point(lat, lng, 4326).STAsBinary(), 2) AS the_geom FROM table'
+      placeholder_query: 'SELECT CONVERT(VARCHAR(0), geography::Point(lat, lng, 4326).STAsBinary(), 2) AS the_geom, * FROM table'
     }
   },
   Snowflake: {
@@ -283,8 +283,8 @@ const IMPORT_OPTIONS = {
         { key: 'password', type: 'password' },
         { key: 'warehouse', type: 'text', optional: true }
       ],
-      placeholder_query: 'SELECT field1, field2, ST_ASWKT(ST_MAKEPOINT(lng, lat)) AS the_geom FROM table',
-      sql_hint: 'If your query results include columns with a GEOGRAPHY data type, you cannot use the "*" wildcard for retrieving all the fields because the current Snowflake ODBC driver version does not support the GEOGRAPHY data type yet; you must specify the fields you want to retrieve one by one. In addition to this, you need to apply two operations to the GEOGRAPHY column, if you want CARTO to interpret it correctly: you need to transform the column to WKT using the ST_ASWKT function and you must use a "the_geom" alias for this field.'
+      placeholder_query: 'SELECT ST_MAKEPOINT(lng, lat) AS the_geom, * FROM table',
+      sql_hint: 'To import GEOGRAPHY type data as the CARTO geometry you need to give it a `the_geom` alias, unless it already has an accepted name (the_geom, geom, geometry, geojson, wkt or wkb_geometry).'
     }
   },
   Redshift: {
@@ -303,7 +303,7 @@ const IMPORT_OPTIONS = {
         { key: 'username', type: 'text' },
         { key: 'password', type: 'password' }
       ],
-      placeholder_query: 'SELECT *, ST_MakePoint(lng, lat) AS the_geom FROM table'
+      placeholder_query: 'SELECT ST_MakePoint(lng, lat) AS the_geom, * FROM table'
     }
   },
   DataObservatory: {

--- a/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
+++ b/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
@@ -206,8 +206,8 @@ class AuthenticatedClient extends PublicClient {
         return self.get([URIParts, uriParams], callback);
       },
 
-      dryRun: function (data, callback) {
-        const URIParts = ['api/v1/connectors/bigquery/dryrun'];
+      dryRun: function (service, data, callback) {
+        const URIParts = [`api/v1/connectors/${service}/dryrun`];
         const opts = {
           data: JSON.stringify(data),
           dataType: 'json'

--- a/lib/assets/test/spec/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.spec.js
@@ -65,6 +65,7 @@ describe('components/modals/add-layer/content/imports/import-database/import-dat
     beforeEach(function () {
       this.view.codeEditor.setValue('select * from mytable');
       this.view.$('.js-textInput')[0].value = 'dbtable';
+      this.view.dbConnectorsClient.dryRun = function (_s, _p, c) { c(null, null, { total_bytes_processed: 1 }); };
     });
 
     it('should get the entered query in CodeMirror', function () {

--- a/lib/assets/test/spec/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-layer/content/imports/import-database/import-database-query-form-view.spec.js
@@ -65,7 +65,7 @@ describe('components/modals/add-layer/content/imports/import-database/import-dat
     beforeEach(function () {
       this.view.codeEditor.setValue('select * from mytable');
       this.view.$('.js-textInput')[0].value = 'dbtable';
-      this.view.dbConnectorsClient.dryRun = function (_s, _p, c) { c(null, null, { total_bytes_processed: 1 }); };
+      this.view.dbConnectorsClient.dryRun = function (_s, _p, c) { c(); };
     });
 
     it('should get the entered query in CodeMirror', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.202",
+  "version": "1.0.0-assets.203",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.200dry1",
+  "version": "1.0.0-assets.200dry2",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.200dry5",
+  "version": "1.0.0-assets.200dry6",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.200",
+  "version": "1.0.0-assets.200dry1",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.200dry4",
+  "version": "1.0.0-assets.200dry5",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.200dry2",
+  "version": "1.0.0-assets.200dry3",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.200dry3",
+  "version": "1.0.0-assets.200dry4",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.200dry6",
+  "version": "1.0.0-assets.200dry7",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.202dry1",
+  "version": "1.0.0-assets.203",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://app.clubhouse.io/cartoteam/story/80914

This improves import error messages for connectors by extracting information from the logs in the case of generic (9999) errors.
