### PR TITLE
Adapt default Rails mails logs to JSON format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :assets do
   gem "compass",               "1.0.3"
 end
 
+gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.3.7'
 gem 'roo',                     '1.13.2'
 gem 'state_machines-activerecord', '~> 0.5.0'
 gem 'typhoeus',                '1.3.1'
@@ -64,7 +65,6 @@ gem 'gibbon',                  '1.1.4'
 gem 'instagram-continued-continued'
 gem 'google-cloud-pubsub', '1.2.0'
 gem 'virtus',                   '1.0.5'
-gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.3.6'
 gem 'email_address',            '~> 0.1.11'
 gem 'redcarpet', '3.3.3'
 gem 'rollbar',               '~>2.11.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/cartodb/cartodb-common.git
-  revision: d6f603d4324587de1ae0b60af14856e2935af75c
-  tag: v0.3.6
+  revision: f098950c5fee57686718fea112d198e6e5e3dfd9
+  tag: v0.3.7
   specs:
     cartodb-common (0.3.6)
       activesupport (~> 4.2.11.3)
@@ -270,7 +270,7 @@ GEM
     mime-types-data (3.2020.0512)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mock_redis (0.25.0)
@@ -293,7 +293,7 @@ GEM
       rack (>= 1.2, < 3)
     os (1.1.1)
     parallel (1.19.2)
-    parser (2.7.1.5)
+    parser (2.7.2.0)
       ast (~> 2.4.1)
     pg (0.20.0)
     poltergeist (1.18.1)
@@ -356,7 +356,7 @@ GEM
     redis (3.3.5)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
-    regexp_parser (1.8.0)
+    regexp_parser (1.8.2)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -396,16 +396,16 @@ GEM
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
       rspec-mocks (~> 2.12.0)
-    rubocop (0.92.0)
+    rubocop (0.93.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
+      regexp_parser (>= 1.8)
       rexml
-      rubocop-ast (>= 0.5.0)
+      rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.5.0)
+    rubocop-ast (1.0.1)
       parser (>= 2.7.1.5)
     rubocop-rails (2.8.1)
       activesupport (>= 4.2.0)

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ WORKING_SPECS_1 = \
 	spec/requests/sessions_controller_spec.rb \
 	spec/services/carto/visualizations_export_service_2_spec.rb \
 	spec/services/carto/visualization_backup_service_spec.rb \
-	spec/requests/carto_logger_spec.rb \
+	spec/lib/carto/common/logger_spec.rb \
 	$(NULL)
 
 WORKING_SPECS_2 = \

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ Development
 * Add DO geography key variables [#15882](https://github.com/CartoDB/cartodb/pull/15882)
 * Migrate `ClientApplication` model to `ActiveRecord` [#15886](https://github.com/CartoDB/cartodb/pull/15886)
 * Avoid delegating special methods in presenters [#15889](https://github.com/CartoDB/cartodb/pull/15889)
+* Adapt default Rails mail logs to JSON format [#15894](https://github.com/CartoDB/cartodb/pull/15894)
 
 4.42.0 (2020-09-28)
 -------------------

--- a/spec/lib/carto/common/logger_spec.rb
+++ b/spec/lib/carto/common/logger_spec.rb
@@ -7,6 +7,7 @@ describe(Carto::Common::Logger, type: :request) do
   include_context 'users helper'
 
   class LogDeviceMock < Logger::LogDevice
+
     attr_accessor :written_text
 
     def write(text)
@@ -17,12 +18,13 @@ describe(Carto::Common::Logger, type: :request) do
 
     def self.capture_output
       original_log_device = Rails.logger.instance_variable_get(:@logdev)
-      mock_log_device = self.new('fake.log')
+      mock_log_device = new('fake.log')
       Rails.logger.instance_variable_set(:@logdev, mock_log_device)
       yield
       Rails.logger.instance_variable_set(:@logdev, original_log_device)
       mock_log_device.written_text
     end
+
   end
 
   let!(:user) do
@@ -91,4 +93,10 @@ describe(Carto::Common::Logger, type: :request) do
     expect(output).to match(/"request_id":"1234".*"filter":":builder_users_only\".*"event_message":"Filter chain halted \(rendered or redirected\)"/)
   end
 
+  it 'logs when an emails was sent' do
+    output = LogDeviceMock.capture_output { user.carto_user.send_password_reset! }
+
+    expect(output).to match(/"event_message":"Mail processed"/)
+    expect(output).to match(/"event_message":"Mail sent"/)
+  end
 end


### PR DESCRIPTION
Story details: https://app.clubhouse.io/cartoteam/story/94485

**What does this PR do?**

Installs the new version of cartodb-commons which includes improvements to the email logs. Now they'll look as follows:

![image](https://user-images.githubusercontent.com/9287468/97029934-60cba500-155e-11eb-91e4-59c18699e930.png)

There are still improvements that can be done but this is the most I could get without altering the default payload of the events emitted by Rails.

**Related Rails documentation**

https://guides.rubyonrails.org/active_support_instrumentation.html#action-mailer