### PR TITLE
Force CTE materialization in Ghost Tables query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Development
 * Migrate `ClientApplication` model to `ActiveRecord` [#15886](https://github.com/CartoDB/cartodb/pull/15886)
 * Avoid delegating special methods in presenters [#15889](https://github.com/CartoDB/cartodb/pull/15889)
 * Fix Dashboard/Data navigation for free users. Update Data preview texts [#15892](https://github.com/CartoDB/cartodb/pull/15892)
+* Force CTE materialization in Ghost Tables query to improve performance [#15895](https://github.com/CartoDB/cartodb/pull/15895)
 
 4.42.0 (2020-09-28)
 -------------------

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -11,8 +11,11 @@ module Carto
     MAX_TABLES_FOR_SYNC_RUN = 8
     MAX_USERTABLES_FOR_SYNC_CHECK = 128
 
+    attr_reader :carto_user
+
     def initialize(user_id)
       @user_id = user_id
+      @carto_user = Carto::User.find_by(id: user_id)
     end
 
     def user
@@ -172,7 +175,7 @@ module Carto
                 AND c.relkind = 'r'
                 AND n.nspname = '#{user.database_schema}'
         ),
-        tables_with_columns AS
+        tables_with_columns AS #{force_cte_materialization_keyword}
         (
             SELECT attrelid FROM
             (
@@ -206,6 +209,13 @@ module Carto
       user.in_database(as: :superuser)[sql].all.map do |record|
         Carto::TableFacade.new(record[:reloid], record[:table_name], @user_id)
       end
+    end
+
+    # Forces CTE query to be executed inline to improve performance.
+    # CTEs were materialized by default until PG11, but PG12 changed it.
+    # https://www.depesz.com/2019/02/19/waiting-for-postgresql-12-allow-user-control-of-cte-materialization-and-change-the-default-behavior/
+    def force_cte_materialization_keyword
+      'MATERIALIZED' if carto_user.db_service.pg_server_version > 120_000
     end
   end
 

--- a/lib/carto/ghost_tables_manager.rb
+++ b/lib/carto/ghost_tables_manager.rb
@@ -215,7 +215,9 @@ module Carto
     # CTEs were materialized by default until PG11, but PG12 changed it.
     # https://www.depesz.com/2019/02/19/waiting-for-postgresql-12-allow-user-control-of-cte-materialization-and-change-the-default-behavior/
     def force_cte_materialization_keyword
-      'MATERIALIZED' if carto_user.db_service.pg_server_version > 120_000
+      # rubocop:disable Style/NumericLiterals
+      'MATERIALIZED' if carto_user.db_service.pg_server_version > 12_00_00
+      # rubocop:enable Style/NumericLiterals
     end
   end
 

--- a/spec/models/carto/user_db_service_spec.rb
+++ b/spec/models/carto/user_db_service_spec.rb
@@ -28,7 +28,9 @@ describe Carto::UserDBService do
 
     it 'returns the PostgreSQL server version number' do
       # Support all versions of CI. Don't stub as that would make the spec useless.
-      expect([110_005, 120_001, 120_002]).to include(subject)
+      # rubocop:disable Style/NumericLiterals
+      expect([11_00_05, 12_00_01, 12_00_02]).to include(subject)
+      # rubocop:enable Style/NumericLiterals
     end
   end
 end


### PR DESCRIPTION
Related to https://app.clubhouse.io/cartoteam/story/109356/snieto-carto-can-t-use-account-due-to-500-errors

Forces CTE query to be executed inline to improve performance. CTEs were materialized by default until PG11, but PG12 changed it.

Sources:

- https://www.depesz.com/2019/02/19/waiting-for-postgresql-12-allow-user-control-of-cte-materialization-and-change-the-default-behavior/
- https://paquier.xyz/postgresql-2/postgres-12-with-materialize/