### PR TITLE
[ch113786] Replace 'export_file' by 'http' to download Google Sheet files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Development
 * Fix Dashboard/Data navigation for free users. Update Data preview texts [#15892](https://github.com/CartoDB/cartodb/pull/15892)
 * Force CTE materialization in Ghost Tables query to improve performance [#15895](https://github.com/CartoDB/cartodb/pull/15895)
 * Adapt default Rails mail logs to JSON format [#15894](https://github.com/CartoDB/cartodb/pull/15894)
+* Fix export of Google Sheet files larger than 10MB []()
 
 4.42.0 (2020-09-28)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@ Development
 * Fix Dashboard/Data navigation for free users. Update Data preview texts [#15892](https://github.com/CartoDB/cartodb/pull/15892)
 * Force CTE materialization in Ghost Tables query to improve performance [#15895](https://github.com/CartoDB/cartodb/pull/15895)
 * Adapt default Rails mail logs to JSON format [#15894](https://github.com/CartoDB/cartodb/pull/15894)
-* Fix export of Google Sheet files larger than 10MB []()
+* Fix export of Google Sheet files larger than 10MB [#15903](https://github.com/CartoDB/cartodb/pull/15903)
 
 4.42.0 (2020-09-28)
 -------------------


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/113786/generali-error-1011-while-importing-a-dataset-from-google-drive)

### Context

When a Google Drive file is stored in Google Sheet format, it must be exported in another format. Currently, we are using the [`export_file`](https://github.com/googleapis/google-api-ruby-client/blob/f7fd8441cea0c111e25170a6e4ea5676fdd23164/generated/google/apis/drive_v3/service.rb#L1031) method when the file needs to be exported (the `exported_links` attribute is present when this happens). According to the documentation, this method:

```
Exports a Google Doc to the requested MIME type and returns the exported content. Please note that the exported content is limited to 10MB.
```

That hard-coded 10MB limitation is the reason why the import fails when the file is big and it is stored in Google Sheet format. 

According to [this question](https://stackoverflow.com/questions/55274737/is-there-any-way-download-bigger-than-10mb-documents-using-google-drive-api), an alternative is using the `exported_links` provided.

### Changes

- Use [`http`](https://github.com/googleapis/google-api-ruby-client/blob/f7fd8441cea0c111e25170a6e4ea5676fdd23164/lib/google/apis/core/base_service.rb#L243) method instead [`export_file`](https://github.com/googleapis/google-api-ruby-client/blob/f7fd8441cea0c111e25170a6e4ea5676fdd23164/generated/google/apis/drive_v3/service.rb#L1031) because the first one has no file size limit.
- Minor Rubocop fixes.