### PR TITLE
Fix bug reassigning geocodings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ Development
 * Fix KML importing error when the layers have slashes in their names [#15897](https://github.com/CartoDB/cartodb/pull/15897)
 * Create OAuth scope for reading/writing all datasets [#15884](https://github.com/CartoDB/cartodb/pull/15884)
 * Migrate `Organization` model to `ActiveRecord` [#15884](https://github.com/CartoDB/cartodb/pull/15884)
+* Fix bug reassigning geocodings [#15924](https://github.com/CartoDB/cartodb/pull/15924)
 
 4.42.0 (2020-09-28)
 -------------------

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1367,14 +1367,18 @@ class User < Sequel::Model
 
   # INFO: assigning to owner is necessary because of payment reasons
   def assign_geocodings_to_organization_owner
-    return if organization.nil? || organization.owner.nil? || organization_owner?
-    geocodings_dataset.all.each do |g|
-      g.user = organization.owner
-      g.data_import_id = nil
-      g.save(raise_on_failure: true)
+    return if organization&.owner.blank? || organization_owner?
+
+    Carto::Geocoding.where(user_id: id).find_each do |geocoding|
+      geocoding.update!(user_id: organization.owner.id, data_import_id: nil)
     end
   rescue StandardError => e
-    log_error(exception: e, message: 'Error assigning geocodings to org owner', target_user: self)
+    log_error(
+      message: 'Error assigning geocodings to org owner',
+      exception: e,
+      target_user: self,
+      organization: organization
+    )
     geocodings.each(&:destroy)
   end
 

--- a/spec/factories/geocodings.rb
+++ b/spec/factories/geocodings.rb
@@ -10,4 +10,10 @@ FactoryGirl.define do
       kind 'high-resolution'
     end
   end
+
+  factory :carto_geocoding, class: 'Carto::Geocoding' do
+    kind { 'namedplace' }
+    formatter { 'foo' }
+    used_credits { 1 }
+  end
 end

--- a/spec/models/user_part_app_spec.rb
+++ b/spec/models/user_part_app_spec.rb
@@ -387,4 +387,28 @@ describe User do
       end
     end
   end
+
+  describe '#assign_geocodings_to_organization_owner' do
+    let(:organization) { create_organization_with_users }
+    let(:organization_owner) { organization.owner }
+    let(:user) { organization.users.where.not(id: organization_owner.id).first }
+
+    before { create(:carto_geocoding, user: user) }
+
+    it 'assigns geocodings to organization owner' do
+      expect(organization_owner.geocodings.count).to eq(0)
+
+      user.sequel_user.send(:assign_geocodings_to_organization_owner)
+
+      expect(organization_owner.geocodings.count).to eq(1)
+    end
+
+    context 'when user does not belong to organization' do
+      let(:user) { create(:valid_user).carto_user }
+
+      it 'does nothing' do
+        user.sequel_user.send(:assign_geocodings_to_organization_owner)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://rollbar.com/carto/CartoDB/items/43590/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification

Fixes an error trying to assign a `ActiveRecord` user to a `Sequel` geocoding. 