### PR TITLE
Speedup query to do ApiKey grants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,7 @@ sudo make install
 * Fix bug reassigning geocodings [#15924](https://github.com/CartoDB/cartodb/pull/15924)
 * Migrate `SharedEntity`, `LayerNodeStyle` and `ExternalSource` to `ActiveRecord` [#15920](https://github.com/CartoDB/cartodb/pull/15920)
 * Fix broken Sequel <> ActiveRecord association [#15928](https://github.com/CartoDB/cartodb/pull/15928)
+* Speedup query to do ApiKey grants [#15927](https://github.com/CartoDB/cartodb/pull/15927)
 
 4.42.0 (2020-09-28)
 -------------------


### PR DESCRIPTION
Related: https://app.clubhouse.io/cartoteam/story/117080/performance-issues-with-datasets-r-scope

**What does this PR do?**

Previously, when generating the `GRANT`s associated to an API key, we were doing a query similar to the following to retrieve the sequences associated with each of the tables the API key had access to:

```sql
SELECT
  n.nspname, c.relname
FROM
  pg_depend d
  JOIN pg_class c ON d.objid = c.oid
  JOIN pg_namespace n ON c.relnamespace = n.oid
WHERE
  d.refobjsubid > 0 AND
  d.classid = 'pg_class'::regclass AND
  c.relkind = 'S'::"char" AND
  d.refobjid IN (
    (QUOTE_IDENT('amiedes') || '.' || QUOTE_IDENT('africa_adm0'))::regclass
  );
```

For an API key with access to 150 tables, this query took ~200ms. This means for the 150 tables it was around 35 seconds.

This PR combines all the queries to retrieve the list of sequences to give the `GRANT`s in a single query, so it is faster:

```sql
SELECT
  n.nspname, c.relname
FROM
  pg_depend d
  JOIN pg_class c ON d.objid = c.oid
  JOIN pg_namespace n ON c.relnamespace = n.oid
WHERE
  d.refobjsubid > 0 AND
  d.classid = 'pg_class'::regclass AND
  c.relkind = 'S'::"char" AND
  d.refobjid IN (
    (QUOTE_IDENT('amiedes') || '.' || QUOTE_IDENT('africa_adm0'))::regclass,
    (QUOTE_IDENT('amiedes') || '.' || QUOTE_IDENT('air_quality_data_2017'))::regclass,
    (QUOTE_IDENT('amiedes') || '.' || QUOTE_IDENT('air_quality_stations_2017'))::regclass,lass
  );
```

Now the same query takes ~2 seconds.