### PR TITLE
Fix broken Sequel <> ActiveRecord association

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,7 @@ Development
 * Migrate `Organization` model to `ActiveRecord` [#15884](https://github.com/CartoDB/cartodb/pull/15884)
 * Fix bug reassigning geocodings [#15924](https://github.com/CartoDB/cartodb/pull/15924)
 * Migrate `SharedEntity`, `LayerNodeStyle` and `ExternalSource` to `ActiveRecord` [#15920](https://github.com/CartoDB/cartodb/pull/15920)
+* Fix broken Sequel <> ActiveRecord association [#15928](https://github.com/CartoDB/cartodb/pull/15928)
 
 4.42.0 (2020-09-28)
 -------------------

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -35,7 +35,6 @@ class Layer < Sequel::Model
     self.update(:order => order) if self.order.blank?
   end
 
-  one_to_many  :layer_node_styles
   many_to_many :maps,  after_add: proc { |layer, parent| layer.after_added_to_map(parent) }
   many_to_many :users, after_add: proc { |layer, parent| layer.set_default_order(parent) }
   many_to_many :user_tables,
@@ -44,6 +43,10 @@ class Layer < Sequel::Model
                 reciprocal: :layers, class: ::UserTable
 
   plugin  :association_dependencies, :maps => :nullify, :users => :nullify, :user_tables => :nullify
+
+  def layer_node_styles
+    Carto::LayerNodeStyle.where(layer_id: id)
+  end
 
   def public_values
     Hash[ PUBLIC_ATTRIBUTES.map { |attribute| [attribute, send(attribute)] } ]


### PR DESCRIPTION
I did not spot this during the CI or acceptance of https://github.com/CartoDB/cartodb/pull/15920. But when generating a newer version of the Sequel models graph, it breaks because of this.

I've canceled the deploy I had in progress to avoid deploying the code with the broken association.