### PR TITLE
Email settings section in Account page to manage notifications

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Development
 
 ### Features
 * Email notifications toggle API endpoint [#15930](https://github.com/CartoDB/cartodb/pull/15930)
+* New Email settings section in Account page to manage notifications [#15933](https://github.com/CartoDB/cartodb/pull/15933)
 
 ### Bug fixes / enhancements
 * Fix BigQuery connector not importing 0-bytes-processed datasets [#15916](https://github.com/CartoDB/cartodb/pull/15916)

--- a/app/controllers/carto/api/email_notifications_controller.rb
+++ b/app/controllers/carto/api/email_notifications_controller.rb
@@ -27,6 +27,8 @@ module Carto
 
       def decorate_notifications
         payload = {}
+        Carto::UserEmailNotification::VALID_NOTIFICATIONS.map { |n| payload[n] = true }
+
         @notifications.each do |notification|
           payload[notification.notification] = notification.enabled
         end

--- a/assets/stylesheets/common/account_forms.scss
+++ b/assets/stylesheets/common/account_forms.scss
@@ -215,6 +215,12 @@ $sLabel-width: 140px;
   align-items: flex-start;
 }
 
+.FormAccount-rowData--listItemWithAction {
+  justify-content: space-between;
+  background: $cStructure-grayBkg;
+  padding: 8px 14px;
+}
+
 .FormAccount-planTag {
   padding: 5px 10px;
   border-radius: 4px;

--- a/assets/stylesheets/common/account_forms.scss
+++ b/assets/stylesheets/common/account_forms.scss
@@ -79,6 +79,10 @@ $sLabel-width: 140px;
   margin-bottom: 16px;
 }
 
+.FormAccount-row--mediumMarginBottom {
+  margin-bottom: 24px;
+}
+
 .FormAccount-row--wideMarginBottom {
   margin-bottom: 100px;
 }
@@ -218,7 +222,7 @@ $sLabel-width: 140px;
 .FormAccount-rowData--listItemWithAction {
   justify-content: space-between;
   background: $cStructure-grayBkg;
-  padding: 8px 14px;
+  padding: 11px 11px 10px 12px;
 }
 
 .FormAccount-planTag {

--- a/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
+++ b/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
@@ -287,7 +287,6 @@ class AuthenticatedClient extends PublicClient {
       }
     };
   }
-
 }
 
 module.exports = AuthenticatedClient;

--- a/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
+++ b/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
@@ -273,7 +273,6 @@ class AuthenticatedClient extends PublicClient {
    */
   emailNotifications () {
     const notificationsURLParts = ['api/v3/email_notifications'];
-    
     return {
       get: (callback) => {
         return this.get(notificationsURLParts, callback);
@@ -284,11 +283,11 @@ class AuthenticatedClient extends PublicClient {
           data: JSON.stringify({ notifications }),
           dataType: 'json'
         };
-
         return this.put(notificationsURLParts, opts, callback);
       }
-    }
+    };
   }
+
 }
 
 module.exports = AuthenticatedClient;

--- a/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
+++ b/lib/assets/javascripts/carto-node/lib/clients/authenticated.js
@@ -267,6 +267,28 @@ class AuthenticatedClient extends PublicClient {
       }
     };
   }
+
+  /**
+   * API to enable/disable email notifications, such as DO notifications
+   */
+  emailNotifications () {
+    const notificationsURLParts = ['api/v3/email_notifications'];
+    
+    return {
+      get: (callback) => {
+        return this.get(notificationsURLParts, callback);
+      },
+
+      set: (notifications, callback) => {
+        const opts = {
+          data: JSON.stringify({ notifications }),
+          dataType: 'json'
+        };
+
+        return this.put(notificationsURLParts, opts, callback);
+      }
+    }
+  }
 }
 
 module.exports = AuthenticatedClient;

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -176,9 +176,9 @@ module.exports = CoreView.extend({
     this.killEvent(event);
 
     const id = event.target.id;
-    const newLabel = (this._notificationStatus(id) ?
-      _t('account.views.form.email_section.notifications.enabled') :
-      _t('account.views.form.email_section.notifications.disabled')
+    const newLabel = (this._notificationStatus(id)
+      ? _t('account.views.form.email_section.notifications.enabled')
+      : _t('account.views.form.email_section.notifications.disabled')
     );
 
     this._notificationLabel(id).html(newLabel);
@@ -216,7 +216,7 @@ module.exports = CoreView.extend({
     };
   },
 
-  _getNotifications: function () {  
+  _getNotifications: function () {
     this._client.emailNotifications().get((errors, response, data) => {
       if (errors) {
         this.options.onError(data, response, errors);

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -231,8 +231,7 @@ module.exports = CoreView.extend({
   _updateNotifications: function (notifications) {
     this._setLoading('Saving email notifications');
 
-    const notificationsParams = { notifications: notifications };
-    this._client.emailNotifications().set(notificationsParams, (errors, response, data) => {
+    this._client.emailNotifications().set(notifications, (errors, response, data) => {
       if (errors) {
         this.options.onError(data, errors);
         this.render();

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -27,7 +27,8 @@ module.exports = CoreView.extend({
   events: {
     'click .js-save': '_onClickSave',
     'submit form': '_onClickSave',
-    'change .js-toggle-mfa': '_onToggleMfa'
+    'change .js-toggle-mfa': '_onToggleMfa',
+    'change .js-toggle-notification' : '_onToggleNotification'
   },
 
   initialize: function (options) {
@@ -163,6 +164,18 @@ module.exports = CoreView.extend({
     this._mfaLabel().html(newLabel);
   },
 
+  _onToggleNotification: function (event) {
+    this.killEvent(event);
+
+    const id = event.target.id;
+    const newLabel = (this._notificationStatus(id) ? 
+      _t('account.views.form.email_section.notifications.enabled') : 
+      _t('account.views.form.email_section.notifications.disabled')
+    );
+
+    this._notificationLabel(id).html(newLabel);
+  },
+
   _updateUser: function (user, password) {
     this._setLoading('Saving changes');
 
@@ -262,6 +275,18 @@ module.exports = CoreView.extend({
 
   _mfaLabel: function () {
     return this.$('.js-mfa-label');
+  },
+
+  _notificationStatus: function (id) {
+    const selector = `.js-toggle-notification-${id}`;
+    if (this.$(selector).length === 0) {
+      return false;
+    }
+    return this.$(selector)[0].checked;
+  },
+
+  _notificationLabel: function (id) {
+    return this.$(`.js-notification-label-${id}`);
   },
 
   _formatLicenseExpiration: function () {

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -38,8 +38,9 @@ module.exports = CoreView.extend({
   },
 
   _initModels: function () {
-    this._errors = this.options.errors || {};
+    this._errors = this.options.errors || {};    
     this.add_related_model(this._renderModel);
+    this._getNotifications();
   },
 
   _initBinds: function () {
@@ -75,6 +76,7 @@ module.exports = CoreView.extend({
         services: this._getField('services') || [],
         mfaEnabled: this._getField('mfa_configured'),
         licenseExpiration: this._formatLicenseExpiration(),
+        notifications: this._notifications || {},
         view: this
       };
 
@@ -191,6 +193,43 @@ module.exports = CoreView.extend({
     return {
       username: this._getField('username')
     };
+  },
+
+  _getNotifications: function () {
+    this._notifications = {
+      "do_subscriptions": false,
+      "real_do_subscriptions": true
+    };
+
+    // note: the api requires an object with key
+
+    // real API request
+    // this._client.emailNotifications().get((errors, response, data) => {
+    //   if (errors) {
+    //     this.options.onError(data, response, errors);
+    //   } else {
+    //     this.options.onSuccess(data); // ?
+    //     this._notifications = data;
+    //   }
+
+    //   this.render();
+    // });
+
+
+  },
+
+  _updateNotifications: function (notifications) {
+    this._setLoading('Saving email notifications config');
+
+    const notificationsParams = { notifications: notifications };
+    this._client.emailNotifications().set(notificationsParams, (errors, response, data) => {
+      if (errors) {
+        this.options.onError(data, errors);
+        this.render();
+      } else {
+        this._getNotifications();
+      }
+    });
   },
 
   _getDestinationValues: function () {

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -216,43 +216,30 @@ module.exports = CoreView.extend({
     };
   },
 
-  _getNotifications: function () {
-    this._notifications = {
-      "do_subscriptions": false,
-      "fake_subscriptions": true
-    };
+  _getNotifications: function () {  
+    this._client.emailNotifications().get((errors, response, data) => {
+      if (errors) {
+        this.options.onError(data, response, errors);
+      } else {
+        this._notifications = data.notifications;
+      }
 
-    // note: the api requires an object with key
-
-    // real API request
-    // this._client.emailNotifications().get((errors, response, data) => {
-    //   if (errors) {
-    //     this.options.onError(data, response, errors);
-    //   } else {
-    //     this.options.onSuccess(data); // ?
-    //     this._notifications = data;
-    //   }
-
-    //   this.render();
-    // });
-
-
+      this.render();
+    });
   },
 
   _updateNotifications: function (notifications) {
-    this._setLoading('Saving email notifications config');
+    this._setLoading('Saving email notifications');
 
     const notificationsParams = { notifications: notifications };
-    console.log(notificationsParams);
-    // real API request
-    // this._client.emailNotifications().set(notificationsParams, (errors, response, data) => {
-    //   if (errors) {
-    //     this.options.onError(data, errors);
-    //     this.render();
-    //   } else {
-    //     this._getNotifications();
-    //   }
-    // });
+    this._client.emailNotifications().set(notificationsParams, (errors, response, data) => {
+      if (errors) {
+        this.options.onError(data, errors);
+        this.render();
+      } else {
+        this._getNotifications();
+      }
+    });
   },
 
   _getDestinationValues: function () {

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -215,7 +215,7 @@ module.exports = CoreView.extend({
       username: this._getField('username')
     };
   },
-∫
+
   _getNotifications: function () {
     this._notifications = {
       "do_subscriptions": false,

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -136,22 +136,30 @@ module.exports = CoreView.extend({
   _onClickSave: function (event) {
     this.killEvent(event);
 
+    // updated user info
     const origin = this._getUserFields();
     const destination = this._getDestinationValues();
     const destinationKeys = _.keys(destination);
     const differenceKeys = _.filter(destinationKeys, key =>
       origin[key] !== destination[key]
     );
-
     const user = _.pick(destination, differenceKeys);
 
+    // updated notifications info
+    const notifications = this._getNotificationValuesFromUI();
+
     if (!this._userModel.get('needs_password_confirmation')) {
-      return this._updateUser(user);
+      this._updateUser(user);
+      this._updateNotifications(notifications);
+      return;
     }
 
     PasswordValidatedForm.showPasswordModal({
       modalService: this._modals,
-      onPasswordTyped: (password) => this._updateUser(user, password),
+      onPasswordTyped: (password) => {
+        this._updateUser(user, password);
+        this._updateNotifications(notifications);
+      },
       updatePassword: destination.new_password !== '' && destination.confirm_password !== ''
     });
   },
@@ -235,14 +243,16 @@ module.exports = CoreView.extend({
     this._setLoading('Saving email notifications config');
 
     const notificationsParams = { notifications: notifications };
-    this._client.emailNotifications().set(notificationsParams, (errors, response, data) => {
-      if (errors) {
-        this.options.onError(data, errors);
-        this.render();
-      } else {
-        this._getNotifications();
-      }
-    });
+    console.log(notificationsParams);
+    // real API request
+    // this._client.emailNotifications().set(notificationsParams, (errors, response, data) => {
+    //   if (errors) {
+    //     this.options.onError(data, errors);
+    //     this.render();
+    //   } else {
+    //     this._getNotifications();
+    //   }
+    // });
   },
 
   _getDestinationValues: function () {
@@ -252,6 +262,13 @@ module.exports = CoreView.extend({
       confirm_password: this._confirmPassword(),
       mfa: this._mfaStatus()
     };
+  },
+
+  _getNotificationValuesFromUI: function () {
+    return _.reduce(this._notifications, function (params, value, key) {
+      params[key] = this._notificationStatus(key);      
+      return params;
+    }, {}, this);
   },
 
   _username: function () {

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -28,7 +28,7 @@ module.exports = CoreView.extend({
     'click .js-save': '_onClickSave',
     'submit form': '_onClickSave',
     'change .js-toggle-mfa': '_onToggleMfa',
-    'change .js-toggle-notification' : '_onToggleNotification'
+    'change .js-toggle-notification': '_onToggleNotification'
   },
 
   initialize: function (options) {
@@ -39,7 +39,7 @@ module.exports = CoreView.extend({
   },
 
   _initModels: function () {
-    this._errors = this.options.errors || {};    
+    this._errors = this.options.errors || {};
     this.add_related_model(this._renderModel);
     this._getNotifications();
   },
@@ -176,8 +176,8 @@ module.exports = CoreView.extend({
     this.killEvent(event);
 
     const id = event.target.id;
-    const newLabel = (this._notificationStatus(id) ? 
-      _t('account.views.form.email_section.notifications.enabled') : 
+    const newLabel = (this._notificationStatus(id) ?
+      _t('account.views.form.email_section.notifications.enabled') :
       _t('account.views.form.email_section.notifications.disabled')
     );
 
@@ -215,11 +215,11 @@ module.exports = CoreView.extend({
       username: this._getField('username')
     };
   },
-
+∫
   _getNotifications: function () {
     this._notifications = {
       "do_subscriptions": false,
-      "real_do_subscriptions": true
+      "fake_subscriptions": true
     };
 
     // note: the api requires an object with key
@@ -266,7 +266,7 @@ module.exports = CoreView.extend({
 
   _getNotificationValuesFromUI: function () {
     return _.reduce(this._notifications, function (params, value, key) {
-      params[key] = this._notificationStatus(key);      
+      params[key] = this._notificationStatus(key);
       return params;
     }, {}, this);
   },

--- a/lib/assets/javascripts/dashboard/views/account/account-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/account/account-form.tpl
@@ -139,12 +139,12 @@
       <div class="FormAccount-rowData">
         <div class="Toggler">
           <input name="<%='notifications[' + notificationKey + ']'%>" type="hidden" value="0">
-          <input class="js-toggle-notification" id="<%=notificationKey%>" name="<%='notifications[' + notificationKey + ']'%>" type="checkbox" value="1" <% if (notifications[notificationKey]) { %>checked="checked"<% } %>>
+          <input class="js-toggle-notification <%='js-toggle-notification-' + notificationKey%>" id="<%=notificationKey%>" name="<%='notifications[' + notificationKey + ']'%>" type="checkbox" value="1" <% if (notifications[notificationKey]) { %>checked="checked"<% } %>>
           <label for="<%=notificationKey%>"></label>
         </div>
       
         <div class="FormAccount-rowInfo u-lSpace--xl">
-          <p class="CDB-Text CDB-Size-medium js-mfa-label">
+          <p class="CDB-Text CDB-Size-medium <%='js-notification-label-' + notificationKey%>">
             <%= notifications[notificationKey] ? _t('account.views.form.email_section.notifications.enabled') : _t('account.views.form.email_section.notifications.disabled') %>
           </p>
         </div>
@@ -152,8 +152,7 @@
     </div>
     <% }); %>
 
-  </div>
- 
+  </div> 
 
   <!-- External datasources -->
   <% if (services.length > 0) { %>

--- a/lib/assets/javascripts/dashboard/views/account/account-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/account/account-form.tpl
@@ -125,34 +125,35 @@
   <div class="FormAccount-row FormAccount-row--smallMarginBottom">
     <p class="CDB-Text CDB-Size-medium"><%= _t('account.views.form.email_section.description') %></p>
   </div>
-
-  <!-- One row per notification (eg: do_subscriptions) -->
+  
   <div class="FormAccount-row">
-    
-    <div class="FormAccount-rowData FormAccount-rowData--listItemWithAction u-tspace-xs">
+
+    <!-- One row per notification (eg: do_subscriptions) -->
+    <% Object.keys(notifications).forEach(function (notificationKey) { %>
+    <div class="FormAccount-rowData FormAccount-rowData--listItemWithAction">
       <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">
         <!-- extract to a 'description' property -->
-        <%= _t('account.views.form.email_section.notifications.do_subscriptions') %>
+        <%= _t('account.views.form.email_section.notifications.' + notificationKey) %>
       </label>
       
       <div class="FormAccount-rowData">
         <div class="Toggler">
-          <input name="user[mfa]" type="hidden" value="0">
-          <input class="js-toggle-mfa" id="mfa" name="user[mfa]" type="checkbox" value="1" <% if (mfaEnabled) { %>checked="checked"<% } %>>
-          <label for="mfa"></label>
+          <input name="<%='notifications[' + notificationKey + ']'%>" type="hidden" value="0">
+          <input class="js-toggle-notification" id="<%=notificationKey%>" name="<%='notifications[' + notificationKey + ']'%>" type="checkbox" value="1" <% if (notifications[notificationKey]) { %>checked="checked"<% } %>>
+          <label for="<%=notificationKey%>"></label>
         </div>
       
         <div class="FormAccount-rowInfo u-lSpace--xl">
           <p class="CDB-Text CDB-Size-medium js-mfa-label">
-            <%= mfaEnabled ? _t('account.views.form.email_section.notifications.enabled') : _t('account.views.form.email_section.notifications.disabled') %>
+            <%= notifications[notificationKey] ? _t('account.views.form.email_section.notifications.enabled') : _t('account.views.form.email_section.notifications.disabled') %>
           </p>
         </div>
-
       </div>
     </div>
+    <% }); %>
 
   </div>
-
+ 
 
   <!-- External datasources -->
   <% if (services.length > 0) { %>

--- a/lib/assets/javascripts/dashboard/views/account/account-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/account/account-form.tpl
@@ -116,43 +116,43 @@
   <% } %>
 
   <!-- Email settings -->
-  <div class="FormAccount-title">
-    <p class="FormAccount-titleText"><%= _t('account.views.form.email_section.title') %></p>
-  </div>
+  <% if (Object.keys(notifications).length > 0) { %>
+    <div class="FormAccount-title">
+      <p class="FormAccount-titleText"><%= _t('account.views.form.email_section.title') %></p>
+    </div>
 
-  <span class="FormAccount-separator"></span>
+    <span class="FormAccount-separator"></span>
 
-  <div class="FormAccount-row FormAccount-row--smallMarginBottom">
-    <p class="CDB-Text CDB-Size-medium"><%= _t('account.views.form.email_section.description') %></p>
-  </div>
-  
-  <div class="FormAccount-row">
-
-    <!-- One row per notification (eg: do_subscriptions) -->
-    <% Object.keys(notifications).forEach(function (notificationKey) { %>
-    <div class="FormAccount-rowData FormAccount-rowData--listItemWithAction">
-      <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">
-        <!-- extract to a 'description' property -->
-        <%= _t('account.views.form.email_section.notifications.' + notificationKey) %>
-      </label>
-      
-      <div class="FormAccount-rowData">
-        <div class="Toggler">
-          <input name="<%='notifications[' + notificationKey + ']'%>" type="hidden" value="0">
-          <input class="js-toggle-notification <%='js-toggle-notification-' + notificationKey%>" id="<%=notificationKey%>" name="<%='notifications[' + notificationKey + ']'%>" type="checkbox" value="1" <% if (notifications[notificationKey]) { %>checked="checked"<% } %>>
-          <label for="<%=notificationKey%>"></label>
-        </div>
-      
-        <div class="FormAccount-rowInfo u-lSpace--xl">
-          <p class="CDB-Text CDB-Size-medium <%='js-notification-label-' + notificationKey%>">
-            <%= notifications[notificationKey] ? _t('account.views.form.email_section.notifications.enabled') : _t('account.views.form.email_section.notifications.disabled') %>
-          </p>
+    <div class="FormAccount-row FormAccount-row--smallMarginBottom">
+      <p class="CDB-Text CDB-Size-medium"><%= _t('account.views.form.email_section.description') %></p>
+    </div>
+    
+    <div class="FormAccount-row">
+      <!-- One row per notification (eg: do_subscriptions) -->
+      <% Object.keys(notifications).forEach(function (notificationKey) { %>
+      <div class="FormAccount-rowData FormAccount-rowData--listItemWithAction">
+        <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">
+          <!-- extract to a 'description' property -->
+          <%= _t('account.views.form.email_section.notifications.' + notificationKey) %>
+        </label>
+        
+        <div class="FormAccount-rowData">
+          <div class="Toggler">
+            <input name="<%='notifications[' + notificationKey + ']'%>" type="hidden" value="0">
+            <input class="js-toggle-notification <%='js-toggle-notification-' + notificationKey%>" id="<%=notificationKey%>" name="<%='notifications[' + notificationKey + ']'%>" type="checkbox" value="1" <% if (notifications[notificationKey]) { %>checked="checked"<% } %>>
+            <label for="<%=notificationKey%>"></label>
+          </div>
+        
+          <div class="FormAccount-rowInfo u-lSpace--xl">
+            <p class="CDB-Text CDB-Size-medium <%='js-notification-label-' + notificationKey%>">
+              <%= notifications[notificationKey] ? _t('account.views.form.email_section.notifications.enabled') : _t('account.views.form.email_section.notifications.disabled') %>
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-    <% }); %>
-
-  </div> 
+      <% }); %>
+    </div> 
+  <% } %>
 
   <!-- External datasources -->
   <% if (services.length > 0) { %>

--- a/lib/assets/javascripts/dashboard/views/account/account-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/account/account-form.tpl
@@ -1,4 +1,6 @@
 <form accept-charset="UTF-8">
+
+  <!-- Username -->
   <div class="FormAccount-row">
     <div class="FormAccount-rowLabel">
       <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor"><%= _t('account.views.form.username') %></label>
@@ -12,6 +14,7 @@
     </div>
   </div>
 
+  <!-- Change password -->
   <% if (!hidePasswordFields) { %>
     <div class="VerticalAligned--FormRow">
       <div class="FormAccount-row">
@@ -41,6 +44,7 @@
 
   <%= accountFormExtension %>
 
+  <!-- Multifactor authentication -->
   <div class="FormAccount-row">
     <div class="FormAccount-rowLabel">
       <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">
@@ -59,7 +63,7 @@
         </p>
       </div>
     </div>
-    <div class="FormAccount-rowData u-tspace-xs">
+    <div class="FormAccount-rowData u-tspace-xs u-vspace-s">
       <p class="CDB-Text CDB-Size-small u-altTextColor"><%= _t('account.views.form.mfa_description') %></p>
     </div>
   </div>
@@ -111,6 +115,46 @@
     <% } %>
   <% } %>
 
+  <!-- Email settings -->
+  <div class="FormAccount-title">
+    <p class="FormAccount-titleText"><%= _t('account.views.form.email_section.title') %></p>
+  </div>
+
+  <span class="FormAccount-separator"></span>
+
+  <div class="FormAccount-row FormAccount-row--smallMarginBottom">
+    <p class="CDB-Text CDB-Size-medium"><%= _t('account.views.form.email_section.description') %></p>
+  </div>
+
+  <!-- One row per notification (eg: do_subscriptions) -->
+  <div class="FormAccount-row">
+    
+    <div class="FormAccount-rowData FormAccount-rowData--listItemWithAction u-tspace-xs">
+      <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">
+        <!-- extract to a 'description' property -->
+        <%= _t('account.views.form.email_section.notifications.do_subscriptions') %>
+      </label>
+      
+      <div class="FormAccount-rowData">
+        <div class="Toggler">
+          <input name="user[mfa]" type="hidden" value="0">
+          <input class="js-toggle-mfa" id="mfa" name="user[mfa]" type="checkbox" value="1" <% if (mfaEnabled) { %>checked="checked"<% } %>>
+          <label for="mfa"></label>
+        </div>
+      
+        <div class="FormAccount-rowInfo u-lSpace--xl">
+          <p class="CDB-Text CDB-Size-medium js-mfa-label">
+            <%= mfaEnabled ? _t('account.views.form.email_section.notifications.enabled') : _t('account.views.form.email_section.notifications.disabled') %>
+          </p>
+        </div>
+
+      </div>
+    </div>
+
+  </div>
+
+
+  <!-- External datasources -->
   <% if (services.length > 0) { %>
     <div class="FormAccount-title">
       <p class="FormAccount-titleText"><%= _t('account.views.form.connect_external_datasources') %></p>
@@ -121,6 +165,7 @@
     <div class="js-datasourcesContent"></div>
   <% } %>
 
+  <!-- Delete account -->
   <div class="FormAccount-footer <% if (cantBeDeletedReason) { %>FormAccount-footer--noMarginBottom<% } %>">
     <% if (cantBeDeletedReason) { %>
       <p class="FormAccount-footerText">

--- a/lib/assets/javascripts/dashboard/views/account/account-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/account/account-form.tpl
@@ -123,7 +123,7 @@
 
     <span class="FormAccount-separator"></span>
 
-    <div class="FormAccount-row FormAccount-row--smallMarginBottom">
+    <div class="FormAccount-row FormAccount-row--mediumMarginBottom">
       <p class="CDB-Text CDB-Size-medium"><%= _t('account.views.form.email_section.description') %></p>
     </div>
     

--- a/lib/assets/javascripts/dashboard/views/account/account-form.tpl
+++ b/lib/assets/javascripts/dashboard/views/account/account-form.tpl
@@ -68,6 +68,7 @@
     </div>
   </div>
 
+  <!-- Account type -->
   <% if (isCartoDBHosted) { %>
     <% if ((isOrgAdmin || isOrgOwner) && licenseExpiration) { %>
       <div class="FormAccount-title">

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -92,7 +92,8 @@
                     "notifications": {
                         "enabled": "On",
                         "disabled": "Off",
-                        "do_subscriptions":"Emails from Data Observatory"
+                        "do_subscriptions":"Emails from Data Observatory NEW",
+                        "real_do_subscriptions":"REAL Emails from Data Observatory NEW"
                     }
                 }
             }

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -85,6 +85,15 @@
                 "email_google": "Your account is linked to your Google account.",
                 "errors": {
                     "change_email": "You can change the email if you set a password."
+                },
+                "email_section": {
+                    "title": "Email settings",
+                    "description": "Choose what type of emails you'd like to receive.",
+                    "notifications": {
+                        "enabled": "On",
+                        "disabled": "Off",
+                        "do_subscriptions":"Emails from Data Observatory"
+                    }
                 }
             }
         }

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -92,8 +92,8 @@
                     "notifications": {
                         "enabled": "On",
                         "disabled": "Off",
-                        "do_subscriptions":"Emails from Data Observatory NEW",
-                        "real_do_subscriptions":"REAL Emails from Data Observatory NEW"
+                        "do_subscriptions":"Emails from Data Observatory",
+                        "fake_subscriptions":"Emails from Data Observatory (II)"
                     }
                 }
             }

--- a/lib/assets/javascripts/locale/en.json
+++ b/lib/assets/javascripts/locale/en.json
@@ -92,8 +92,7 @@
                     "notifications": {
                         "enabled": "On",
                         "disabled": "Off",
-                        "do_subscriptions":"Emails from Data Observatory",
-                        "fake_subscriptions":"Emails from Data Observatory (II)"
+                        "do_subscriptions":"Emails from Data Observatory"
                     }
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.207",
+  "version": "1.0.0-assets.208",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.207",
+  "version": "1.0.0-assets.207-01",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.207",
+  "version": "1.0.0-assets.208",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.207-01",
+  "version": "1.0.0-assets.207",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/spec/requests/carto/api/email_notifications_controller_spec.rb
+++ b/spec/requests/carto/api/email_notifications_controller_spec.rb
@@ -22,7 +22,7 @@ describe Carto::Api::EmailNotificationsController do
 
     it 'list the current notifications' do
       @carto_user.email_notifications = {
-          do_subscriptions: false
+        do_subscriptions: false
       }
       get_json(api_v3_email_notifications_show_url(auth_params)) do |response|
         response.status.should eq 200

--- a/spec/requests/carto/api/email_notifications_controller_spec.rb
+++ b/spec/requests/carto/api/email_notifications_controller_spec.rb
@@ -6,9 +6,6 @@ describe Carto::Api::EmailNotificationsController do
 
   before(:all) do
     @carto_user = FactoryGirl.create(:carto_user)
-    @carto_user.email_notifications = {
-      do_subscriptions: true
-    }
   end
 
   let(:auth_params) do
@@ -16,10 +13,20 @@ describe Carto::Api::EmailNotificationsController do
   end
 
   describe '#show' do
-    it 'list the current notifications' do
+    it 'always list available notifications with default value if missing in database' do
       get_json(api_v3_email_notifications_show_url(auth_params)) do |response|
         response.status.should eq 200
         response.body.should eq({ notifications: { do_subscriptions: true } })
+      end
+    end
+
+    it 'list the current notifications' do
+      @carto_user.email_notifications = {
+          do_subscriptions: false
+      }
+      get_json(api_v3_email_notifications_show_url(auth_params)) do |response|
+        response.status.should eq 200
+        response.body.should eq({ notifications: { do_subscriptions: false } })
       end
     end
 


### PR DESCRIPTION
To manage if the user wants email enabled for certain notifications (currently just `do_subscriptions`) from the /account page.

It adds the frontend to this previous API PR: https://github.com/CartoDB/cartodb/pull/15930