### PR TITLE
Data loss on table rename due to GhostTablesManager

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development
 * Fix BigQuery connector not importing 0-bytes-processed datasets [#15916](https://github.com/CartoDB/cartodb/pull/15916)
 * Error importing geopackage files with multiple layers [#15907](https://github.com/CartoDB/cartodb/pull/15907)
 * Add DO notification in dashboard [#15929](https://github.com/CartoDB/cartodb/pull/15929)
+* Data loss on table rename due to GhostTablesManager
 
 4.43.0 (2020-11-06)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ Development
 * Fix BigQuery connector not importing 0-bytes-processed datasets [#15916](https://github.com/CartoDB/cartodb/pull/15916)
 * Error importing geopackage files with multiple layers [#15907](https://github.com/CartoDB/cartodb/pull/15907)
 * Add DO notification in dashboard [#15929](https://github.com/CartoDB/cartodb/pull/15929)
-* Data loss on table rename due to GhostTablesManager
+* Data loss on table rename due to GhostTablesManager [#15935](https://github.com/CartoDB/cartodb/pull/15935)
 
 4.43.0 (2020-11-06)
 -------------------

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -201,7 +201,12 @@ class UserTable < Sequel::Model
   end
 
   def destroy
-    Carto::UserTable.find_by(id: id)&.destroy
+    carto_user_table = Carto::UserTable.find_by(id: id)
+
+    return if carto_user_table.nil?
+
+    carto_user_table.set_service(service)
+    carto_user_table.destroy
   end
 
   def before_update

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -201,12 +201,12 @@ class UserTable < Sequel::Model
   end
 
   def destroy
-    carto_user_table = Carto::UserTable.find_by(id: id)
+    ar_user_table = Carto::UserTable.find_by(id: id)
 
-    return if carto_user_table.nil?
+    return if ar_user_table.nil?
 
-    carto_user_table.set_service(service)
-    carto_user_table.destroy
+    ar_user_table.set_service(service)
+    ar_user_table.destroy
   end
 
   def before_update


### PR DESCRIPTION
Not really due to `GhostTablesManager` but a ORM destroy callback that was not properly instantiated and was actually dropping user database tables.