### PR TITLE
Connections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ sudo make install
 
 ### Features
 
+- New connections API [15939](https://github.com/CartoDB/cartodb/pull/15939)
 - New endpoints to fetch users' datasets and tilesets from their BigQuery connection [16061](https://github.com/CartoDB/cartodb/pull/16061)
 - New BigQuery connector [16029](https://github.com/CartoDB/cartodb/pull/16029)
 - Add access to DO samples. Refactor samples/subscriptions UI [#15910](https://github.com/CartoDB/cartodb/pull/15910)

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ sudo make install
 - Add preview/visualization of maps in DO catalog [#15973](https://github.com/CartoDB/cartodb/pull/15973)
 - Add new user metrics to Home page [#15950](https://github.com/CartoDB/cartodb/pull/15950)
 - Replace CRUD user operations in Central API client by publishing messages to the Message Broker [#16035](https://github.com/CartoDB/cartodb/pull/16035)
+- Adds JSON-LD with the dataset information in the Data Catalog [#16138](https://github.com/CartoDB/cartodb/pull/16138)
 
 ### Bug fixes / enhancements
 
@@ -60,6 +61,7 @@ sudo make install
 - Upgrade deck.gl version [#16072](https://github.com/CartoDB/cartodb/pull/16072)
 - Configure Dead Lettering & prevent flooding of map views messages [#16059](https://github.com/CartoDB/cartodb/pull/16059)
 - Revamp specs for Message Broker commands and remove old endpoints [#16084](https://github.com/CartoDB/cartodb/pull/16084)
+- Prevent rspec from being executed in any env other than test [#16128](https://github.com/CartoDB/cartodb/pull/16128)
 - Add groups to v4/me endpoint [#16105](https://github.com/CartoDB/cartodb/pull/16105)
 
 4.44.0 (2020-11-20)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -192,6 +192,8 @@ module CartoDB
       end
 
       def drop(table_name)
+        return unless table_name.present?
+
         Carto::OverviewsService.new(database).delete_overviews table_name
         database.execute(%(DROP TABLE #{table_name}))
       rescue StandardError => exception

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -192,7 +192,7 @@ module CartoDB
       end
 
       def drop(table_name)
-        return unless table_name.present?
+        return if table_name.blank?
 
         Carto::OverviewsService.new(database).delete_overviews table_name
         database.execute(%(DROP TABLE #{table_name}))

--- a/app/models/carto/connection.rb
+++ b/app/models/carto/connection.rb
@@ -94,8 +94,8 @@ module Carto
       end
       case connection_type
       when TYPE_OAUTH_SERVICE
-        if !get_service_datasource&.token_valid? # !Carto::ConnectionManager.new(user).oauth_connection_valid?(self)
-          errors.add :token, "Invalid OAuth"
+        if !token.present?
+          errors.add :token, "Missing OAuth"
         elsif parameters.present?
           # OAuth connections that also admit db-connector parameters (BigQuery)
           # can be saved incomplete without the parameters; once the parameters are assigned,

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -46,15 +46,10 @@ class Carto::User < ActiveRecord::Base
   has_many :assets, inverse_of: :user
   has_many :data_imports, inverse_of: :user
   has_many :geocodings, inverse_of: :user
-  has_many :connections, class_name: Carto::Connection, inverse_of: :user, dependent: :destroy
+  has_many :connections, class_name: 'Carto::Connection', inverse_of: :user, dependent: :destroy
 
-  def oauth_connections
-    connections.oauth_connections
-  end
-
-  def db_connections
-    connections.db_connections
-  end
+  delegate :oauth_connections, to: :connections
+  delegate :db_connections, to: :connections
 
   has_many :search_tweets, class_name: Carto::SearchTweet, inverse_of: :user
   has_many :synchronizations, inverse_of: :user
@@ -211,12 +206,10 @@ class Carto::User < ActiveRecord::Base
   end
 
   def oauth_for_service(service)
-    # FIXME: should we use ConnectionsManager here?
-    oauth_connections.where(connector: service, connection_type: Carto::Connection::TYPE_OAUTH_SERVICE).first
+    oauth_connections.find_by(connector: service)
   end
 
   def add_oauth(service, token)
-    # FIXME: use ConnectionsManager here
     connection = Carto::Connection.new(
       user_id: id,
       connection_type: Carto::Connection::TYPE_OAUTH_SERVICE,

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -206,19 +206,11 @@ class Carto::User < ActiveRecord::Base
   end
 
   def oauth_for_service(service)
-    oauth_connections.find_by(connector: service)
+    connection_manager.find_oauth_connection(service)
   end
 
   def add_oauth(service, token)
-    connection = Carto::Connection.new(
-      user_id: id,
-      connection_type: Carto::Connection::TYPE_OAUTH_SERVICE,
-      connector: service,
-      token: token
-    )
-    connection.save
-    connections.append(connection)
-    connection
+    connection_manager.create_oauth_connection(service: service, token: token)
   end
 
   def get_geocoding_calls(options = {})
@@ -337,6 +329,10 @@ class Carto::User < ActiveRecord::Base
   end
 
   private
+
+  def connection_manager
+    Carto::ConnectionManager.new(self)
+  end
 
   def subscriptions_size_in_bytes(project, estimated: false)
     # Note we cannot filter by `project` subscription attribute, we must use the dataset ID.

--- a/app/models/synchronization/synchronization_oauth.rb
+++ b/app/models/synchronization/synchronization_oauth.rb
@@ -1,8 +1,5 @@
 require_relative '../../../services/datasources/lib/datasources'
 
-# TODO: this will be replaced by Carto::Connection; when migration is complete and working
-# this class should be removed
-
 # @see DB table 'synchronization_oauths'
 class SynchronizationOauth < Sequel::Model
 

--- a/app/models/user/oauths.rb
+++ b/app/models/user/oauths.rb
@@ -8,7 +8,7 @@ module CartoDB
     # @param owner_user ::User
     def initialize(owner_user)
       @owner = owner_user
-      @owner = Carto::User.find(@owner.id) unless @owner.kind_of?(Carto::User)
+      @owner = Carto::User.find(@owner.id) unless @owner.is_a?(Carto::User)
     end #initialize
 
     def all
@@ -27,7 +27,6 @@ module CartoDB
     end
 
     def remove(service)
-      # oauth = Carto::Conection.where(connection_type: Connection::TYPE_OAUTH_SERVICE, service: service, user_id: @owner.id).first
       oauth = @owner.oauth_for_service(service)
       oauth.delete unless oauth.nil?
       @owner.reload

--- a/app/services/carto/data_imports_service.rb
+++ b/app/services/carto/data_imports_service.rb
@@ -42,7 +42,7 @@ module Carto
     end
 
     def validate_synchronization_oauth(user, service)
-      oauth =user.oauths.select(service)
+      oauth = user.oauths.select(service)
       return false unless oauth
 
       datasource = oauth.get_service_datasource

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -31,6 +31,7 @@ require_dependency 'carto/export/connector_configuration_exporter'
 
 module Carto
   module UserMetadataExportServiceConfiguration
+
     CURRENT_VERSION = '1.0.18'.freeze
     EXPORTED_USER_ATTRIBUTES = %i(
       email crypted_password database_name username admin enabled invite_token invite_token_date
@@ -155,7 +156,6 @@ module Carto
       if exported_user[:oauth_connections].present?
         exported_user[:oauth_connections].each do |oauth_connection|
           user.oauths.add(oauth_connection[:service], oauth_connection[:token])
-          # FIXME: do we need to restore oauth_connection[:created_at], oauth_connection[:updated_at] ?
         end
       end
 
@@ -346,7 +346,7 @@ module Carto
       user_hash[:notifications] = user.static_notifications.notifications
 
       # TODO: all connections, not only oauth ones, should be exported!
-      user_hash[:oauth_connections] = user.oauths.map { |oc| export_oauth_connection(so) }
+      user_hash[:oauth_connections] = user.oauths.map { |oc| export_oauth_connection(oc) }
 
       user_hash[:connector_configurations] = user.connector_configurations.map do |cc|
         export_connector_configuration(cc)
@@ -441,13 +441,10 @@ module Carto
       }
     end
 
-    def export_synchronization_oauth(connection)
+    def export_oauth_connection(connection)
       {
         service: connection.service,
         token: connection.token
-        # FIXME: do we need:
-        # created_at: ...
-        # updated_at: ...
       }
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -611,7 +611,7 @@ CartoDB::Application.routes.draw do
 
       ## Connections
       get 'connections' => 'connections#index', as: :api_v4_connections_list
-      post 'connections'  => 'connections#create', as: :api_v4_connections_create
+      post 'connections' => 'connections#create', as: :api_v4_connections_create
       get 'connections/:id' => 'connections#show', as: :api_v4_connections_show
       get 'connectors' => 'connections#list_connectors', as: :api_v4_connections_list_connectors
       delete 'connections/:id' => 'connections#destroy', as: :api_v4_connections_destroy

--- a/db/migrate/20201118171809_create_connections.rb
+++ b/db/migrate/20201118171809_create_connections.rb
@@ -1,6 +1,8 @@
 require 'carto/db/migration_helper'
 
+# rubocop:disable Style/MixinUsage
 include Carto::Db::MigrationHelper
+# rubocop:enable Style/MixinUsage
 
 migration(
   proc do

--- a/lib/assets/javascripts/new-dashboard/pages/Data/CatalogDataset.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Data/CatalogDataset.vue
@@ -73,6 +73,8 @@
         </transition>
       </div>
     </section>
+
+    <script v-if="publicWebsite" v-html="jsonld" type="application/ld+json"/>
   </Page>
 </template>
 
@@ -107,6 +109,7 @@ export default {
   computed: {
     ...mapState({
       dataset: state => state.catalog.dataset,
+      keyVariables: state => state.catalog.keyVariables,
       entity_type () {
         return this.$route.params.entity_type;
       }
@@ -127,6 +130,37 @@ export default {
     },
     responsive () {
       return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    },
+    jsonld () {
+      // The JSON-LD is used for SEO purposes and to index the site on Google Dataset Search
+      if (!this.dataset) {
+        return '';
+      }
+      const keyVariables = this.keyVariables && Array.isArray(this.keyVariables) ? this.keyVariables.map(elem => elem.name) : [];
+      const keywords = [...keyVariables];
+      keywords.push('Spatial data');
+      if (this.dataset.category_name) {
+        keywords.push(this.dataset.category_name);
+      }
+      if (this.dataset.data_source_name) {
+        keywords.push(this.dataset.data_source_name);
+      }
+      return {
+        '@context': 'https://schema.org/',
+        '@type': 'Dataset',
+        'name': this.dataset.name,
+        'description': this.dataset.description,
+        'keywords': keywords,
+        'license': this.dataset.licenses_link,
+        'creator': {
+          '@type': 'Organization',
+          'name': this.dataset.provider_name
+        },
+        'spatialCoverage': this.dataset.country_name,
+        'variableMeasured': keyVariables,
+        'version': this.dataset.version,
+        'url': `https://carto.com${this.$router.resolve({ name: 'catalog-dataset-summary', params: {...this.$route.params} }).href}`
+      };
     }
   },
   methods: {

--- a/lib/carto/connector/connection_adapter.rb
+++ b/lib/carto/connector/connection_adapter.rb
@@ -1,6 +1,7 @@
 module Carto
   # ConnectionAdapter is a base class to provide additional connector-specific functionality to Connections
   class ConnectionAdapter
+
     CONFIDENTIAL_PARAMETER_PLACEHOLDER = '********'.freeze
     CONFIDENTIAL_PARAMS = %w(password).freeze
 
@@ -33,6 +34,7 @@ module Carto
     end
 
     def create
+      # does nothing by default
     end
 
     def destroy
@@ -40,6 +42,7 @@ module Carto
     end
 
     def update
+      # does nothing by default
     end
 
     private
@@ -48,7 +51,11 @@ module Carto
       if @connection.connection_type == Carto::Connection::TYPE_OAUTH_SERVICE
         @connection.get_service_datasource.revoke_token
       end
-    rescue CartoDB::Datasources::TokenExpiredOrInvalidError
+    rescue CartoDB::Datasources::TokenExpiredOrInvalidError => e
+      message = "Error revoking token for service #{@connection.service}, user #{@connection.user&.username}"
+      message += ": #{e}"
+      Rails.logger.warn message
     end
+
   end
 end

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -27,7 +27,7 @@ module Carto
 
       def errors
         errors = super
-        if @connector.connection_type == Carto::Connection::TYPE_DB_CONNECTOR
+        if @connection.connection_type == Carto::Connection::TYPE_DB_CONNECTOR
           errors << "Parameter refresh_token not supported for db-connection; use OAuth connection instead" if @connection.parameters['refresh_token'].present?
           errors << "Parameter access_token not supported through connections; use import API" if @connection.parameters['access_token'].present?
         end

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -78,7 +78,7 @@ module Carto
       end
 
       def update_spatial_extension_setup
-        if @connection.changes(:parameters)
+        if @connection.changes[:parameters]
           old_parameters, new_parameters = @connection.changes[:parameters]
           if old_parameters['billing_project'] != new_parameters['billing_project']
           central.update_user(

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -93,7 +93,11 @@ module Carto
 
       def update_redis_metadata
         if @connection.connector == BQ_CONNECTOR && @connection.parameters['service_account'].present?
-          $users_metadata.hset bigquery_redis_key, 'service_account', @connection.parameters['service_account']
+          $users_metadata.hmset(
+            bigquery_redis_key,
+            'service_account', @connection.parameters['service_account'],
+            'billing_project', @connection.parameters['billing_project']
+          )
         end
       end
 

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -36,8 +36,8 @@ module Carto
 
       def create
         super
-        update_redis_metadata(connection)
-        create_spatial_extension_setup(connection)
+        update_redis_metadata(@connection)
+        create_spatial_extension_setup(@connection)
       end
 
       def destroy

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -79,7 +79,16 @@ module Carto
       end
 
       def update_spatial_extension_setup
-        # Nothing to do since all users have inconditionally the spatial extension now
+        if @connection.changes(:parameters)
+          old_parameters, new_parameters = @connection.changes[:parameters]
+          if old_parameters['billing_project'] != new_parameters['billing_project']
+          central.update_user(
+            @connection.user.username,
+            BQ_ADVANCED_CENTRAL_ATTRIBUTE => true,
+            BQ_ADVANCED_PROJECT_CENTRAL_ATTRIBUTE => new_parameters['billing_project']
+          )
+          end
+        end
       end
 
       def update_redis_metadata

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -17,7 +17,7 @@ module Carto
       end
 
       def filtered_connection_parameters
-        @connection.parameters.except(*NON_CONNECTOR_PARAMETERS)
+        @connection.parameters&.except(*NON_CONNECTOR_PARAMETERS)
       end
 
       def singleton?

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -36,8 +36,8 @@ module Carto
 
       def create
         super
-        update_redis_metadata(@connection)
-        create_spatial_extension_setup(@connection)
+        update_redis_metadata
+        create_spatial_extension_setup
       end
 
       def destroy

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -7,8 +7,9 @@ module Carto
     # * Saves credentials in redis
     # * Manages Spatial Extension Setup
     class BigQuery < ConnectionAdapter
-      BQ_CONFIDENTIAL_PARAMS = %w(service_account refresh_token access_token)
-      NON_CONNECTOR_PARAMETERS = []
+
+      BQ_CONFIDENTIAL_PARAMS = %w(service_account refresh_token access_token).freeze
+      NON_CONNECTOR_PARAMETERS = [].freeze
       BQ_ADVANCED_CENTRAL_ATTRIBUTE = :bq_advanced
       BQ_ADVANCED_PROJECT_CENTRAL_ATTRIBUTE = :bq_advanced_project
 
@@ -27,8 +28,12 @@ module Carto
       def errors
         errors = super
         if @connection.connection_type == Carto::Connection::TYPE_DB_CONNECTOR
-          errors << "Parameter refresh_token not supported for db-connection; use OAuth connection instead" if @connection.parameters['refresh_token'].present?
-          errors << "Parameter access_token not supported through connections; use import API" if @connection.parameters['access_token'].present?
+          if @connection.parameters['refresh_token'].present?
+            errors << 'Parameter refresh_token not supported for db-connection; use OAuth connection instead'
+          end
+          if @connection.parameters['access_token'].present?
+            errors << 'Parameter access_token not supported through connections; use import API'
+          end
         end
         errors
       end
@@ -81,11 +86,11 @@ module Carto
         if @connection.changes[:parameters]
           old_parameters, new_parameters = @connection.changes[:parameters]
           if old_parameters['billing_project'] != new_parameters['billing_project']
-          central.update_user(
-            @connection.user.username,
-            BQ_ADVANCED_CENTRAL_ATTRIBUTE => true,
-            BQ_ADVANCED_PROJECT_CENTRAL_ATTRIBUTE => new_parameters['billing_project']
-          )
+            central.update_user(
+              @connection.user.username,
+              BQ_ADVANCED_CENTRAL_ATTRIBUTE => true,
+              BQ_ADVANCED_PROJECT_CENTRAL_ATTRIBUTE => new_parameters['billing_project']
+            )
           end
         end
       end
@@ -107,6 +112,7 @@ module Carto
       def bigquery_redis_key
         "google:bq_settings:#{@connection.user.username}"
       end
+
     end
   end
 end

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -11,7 +11,6 @@ module Carto
       NON_CONNECTOR_PARAMETERS = []
       BQ_ADVANCED_CENTRAL_ATTRIBUTE = :bq_advanced
       BQ_ADVANCED_PROJECT_CENTRAL_ATTRIBUTE = :bq_advanced_project
-      BQ_CONNECTOR = 'bigquery'.freeze
 
       def initialize(connection)
         super(connection, confidential_parameters: BQ_CONFIDENTIAL_PARAMS)
@@ -92,7 +91,7 @@ module Carto
       end
 
       def update_redis_metadata
-        if @connection.connector == BQ_CONNECTOR && @connection.parameters['service_account'].present?
+        if @connection.parameters['service_account'].present?
           $users_metadata.hmset(
             bigquery_redis_key,
             'service_account', @connection.parameters['service_account'],
@@ -102,9 +101,7 @@ module Carto
       end
 
       def remove_redis_metadata
-        if @connection.connector == BQ_CONNECTOR
-          $users_metadata.del bigquery_redis_key
-        end
+        $users_metadata.del bigquery_redis_key
       end
 
       def bigquery_redis_key

--- a/lib/carto/connector/connection_adapter/bigquery.rb
+++ b/lib/carto/connector/connection_adapter/bigquery.rb
@@ -65,7 +65,7 @@ module Carto
         central.update_user(
           @connection.user.username,
           BQ_ADVANCED_CENTRAL_ATTRIBUTE => true,
-          BQ_ADVANCED_PROJECT_CENTRAL_ATTRIBUTE => connection.parameters['billing_project']
+          BQ_ADVANCED_PROJECT_CENTRAL_ATTRIBUTE => @connection.parameters['billing_project']
         )
       end
 

--- a/lib/carto/connector/connection_adapter/factory.rb
+++ b/lib/carto/connector/connection_adapter/factory.rb
@@ -4,6 +4,7 @@ require_relative 'bigquery'
 module Carto
   class ConnectionAdapter
     class Factory
+
       BQ_CONNECTOR = 'bigquery'.freeze
 
       def self.adapter_for_connection(connection)
@@ -14,6 +15,7 @@ module Carto
           Carto::ConnectionAdapter.new(connection)
         end
       end
+
     end
   end
 end

--- a/lib/carto/connector/connection_adapter/factory.rb
+++ b/lib/carto/connector/connection_adapter/factory.rb
@@ -4,9 +4,11 @@ require_relative 'bigquery'
 module Carto
   class ConnectionAdapter
     class Factory
+      BQ_CONNECTOR = 'bigquery'.freeze
+
       def self.adapter_for_connection(connection)
         case connection.connector
-        when 'bigquery'
+        when BQ_CONNECTOR
           Carto::ConnectionAdapter::BigQuery.new(connection)
         else
           Carto::ConnectionAdapter.new(connection)

--- a/lib/carto/connector/connection_manager.rb
+++ b/lib/carto/connector/connection_manager.rb
@@ -26,7 +26,7 @@ module Carto
       oauth_connectors = db_connectors = []
 
       if type.nil? || types.include?(Carto::Connection::TYPE_OAUTH_SERVICE)
-        oauth_connections = list_oauth_connectors(connections: connections)
+        oauth_connectors = list_oauth_connectors(connections: connections)
       end
 
       if type.nil? || types.include?(Carto::Connection::TYPE_DB_CONNECTOR)

--- a/lib/carto/connector/connection_manager.rb
+++ b/lib/carto/connector/connection_manager.rb
@@ -31,7 +31,7 @@ module Carto
           is_enabled = true
           # TODO: use presenter
           connector = {
-            types: [Carto::Connection::TYPE_OAUTH_SERVICE],
+            type: Carto::Connection::TYPE_OAUTH_SERVICE,
             connector: service,
             enabled: is_enabled,
             available: !@user.connections.exists?(connector: service)
@@ -45,7 +45,7 @@ module Carto
         db_connectors = Carto::ConnectionManager.valid_db_connectors.map do |provider|
           is_enabled = Carto::Connector.provider_available?(provider, @user)
           connector = {
-            types: [Carto::Connection::TYPE_DB_CONNECTOR],
+            type: Carto::Connection::TYPE_DB_CONNECTOR,
             connector: provider,
             enabled: is_enabled,
             available: is_enabled
@@ -53,18 +53,6 @@ module Carto
           connector[:connections] = list_connections(connector: provider) if connections
           connector
         end
-      end
-
-      # Unify connectors of dual type
-      oauth_connectors.each do |oauth_connector|
-        db_connector = db_connectors.find { |c| c[:connector] == oauth_connector[:connector] }
-        next if db_connector.blank?
-
-        db_connectors.delete db_connector
-        oauth_connector[:types] += db_connector[:types]
-        # assume enabled is same for both
-        oauth_connector[:available] &&= db_connector[:available]
-        oauth_connector[:connections] += db_connector[:connections] if connections
       end
 
       oauth_connectors + db_connectors

--- a/lib/carto/connector/connection_manager.rb
+++ b/lib/carto/connector/connection_manager.rb
@@ -211,13 +211,13 @@ module Carto
             raise Carto::ParamInvalidError.new("provider: #{provider}", [connection.connector], 422)
           end
         else
-          connector_parameters.merge! provider: connection.connector
+          connector_parameters[:provider] = connection.connector
         end
         connection_parameters = adapter(connection).filtered_connection_parameters
 
-        connector_parameters.merge! connection: connection_parameters
+        connector_parameters[:connection] = connection_parameters
         connector_parameters.delete :connection_id
-        input_parameters.merge! connection_id: connection.id
+        input_parameters[:connection_id] = connection.id
         input_parameters.delete :connection
       end
 

--- a/lib/carto/connector/connection_manager.rb
+++ b/lib/carto/connector/connection_manager.rb
@@ -143,9 +143,20 @@ module Carto
     # get_url_to_create_oauth_connection
     def create_oauth_connection_get_url(service:)
       check_oauth_service!(service)
+
       existing_connection = find_oauth_connection(service)
       delete_connection(existing_connection.id) if existing_connection.present?
       oauth_connection_url(service)
+    end
+
+    def create_oauth_connection(service:, token:)
+      check_oauth_service!(service)
+
+      @user.connections.create!(
+        name: service,
+        connector: service,
+        token: token
+      )
     end
 
     # for dual connection only (BigQuery): after fetching a valid oauth connection,

--- a/lib/carto/connector/connection_manager.rb
+++ b/lib/carto/connector/connection_manager.rb
@@ -366,5 +366,4 @@ module Carto
     end
 
   end
-
 end

--- a/lib/carto/connector/connection_manager.rb
+++ b/lib/carto/connector/connection_manager.rb
@@ -101,7 +101,7 @@ module Carto
     end
 
     def find_oauth_connection(service)
-      @user.oauth_connections.where(connector: service).first
+      @user.oauth_connections.find_by(connector: service)
     end
 
     def create_db_connection(name:, provider:, parameters:)

--- a/lib/carto/connector/connection_manager.rb
+++ b/lib/carto/connector/connection_manager.rb
@@ -6,15 +6,18 @@ require_relative 'connection_adapter/factory'
 
 module Carto
   class ConnectionManager
+
     class ConnectionNotFoundError < CartoError
+
       def initialize(message)
         super(message, 404)
       end
+
     end
 
     def initialize(user)
       @user = user
-      @user = Carto::User.find(@user.id) unless @user.kind_of?(Carto::User)
+      @user = Carto::User.find(@user.id) unless @user.is_a?(Carto::User)
     end
 
     def list_connectors(connections: false, type: nil)
@@ -23,7 +26,7 @@ module Carto
       oauth_connectors = db_connectors = []
 
       if type.nil? || types.include?(Carto::Connection::TYPE_OAUTH_SERVICE)
-        oauth_connectors = Carto::ConnectionManager.valid_oauth_services.map { |service|
+        oauth_connectors = Carto::ConnectionManager.valid_oauth_services.map do |service|
           # TODO: check enabled for @user
           is_enabled = true
           # TODO: use presenter
@@ -35,11 +38,11 @@ module Carto
           }
           connector[:connections] = list_connections(connector: service) if connections
           connector
-        }
+        end
       end
 
       if type.nil? || types.include?(Carto::Connection::TYPE_DB_CONNECTOR)
-        db_connectors = Carto::ConnectionManager.valid_db_connectors.map { |provider|
+        db_connectors = Carto::ConnectionManager.valid_db_connectors.map do |provider|
           is_enabled = Carto::Connector.provider_available?(provider, @user)
           connector = {
             types: [Carto::Connection::TYPE_DB_CONNECTOR],
@@ -49,21 +52,19 @@ module Carto
           }
           connector[:connections] = list_connections(connector: provider) if connections
           connector
-        }
+        end
       end
 
       # Unify connectors of dual type
       oauth_connectors.each do |oauth_connector|
         db_connector = db_connectors.find { |c| c[:connector] == oauth_connector[:connector] }
-        if db_connector.present?
-          db_connectors.delete db_connector
-          oauth_connector[:types] += db_connector[:types]
-          # assume enabled is same for both
-          oauth_connector[:available] &&= db_connector[:available]
-          if connections
-            oauth_connector[:connections] += db_connector[:connections]
-          end
-        end
+        next if db_connector.blank?
+
+        db_connectors.delete db_connector
+        oauth_connector[:types] += db_connector[:types]
+        # assume enabled is same for both
+        oauth_connector[:available] &&= db_connector[:available]
+        oauth_connector[:connections] += db_connector[:connections] if connections
       end
 
       oauth_connectors + db_connectors
@@ -85,7 +86,7 @@ module Carto
         id: connection.id,
         name: connection.name,
         connector: connection.connector,
-        type: connection.connection_type,
+        type: connection.connection_type
       }
       presented_connection[:parameters] = adapter(connection).presented_parameters if connection.parameters.present?
       presented_connection[:token] = adapter(connection).presented_token if connection.token.present?
@@ -94,10 +95,9 @@ module Carto
     end
 
     def find_db_connection(provider, parameters)
-      @user.db_connections.find { |connection|
-        connection.connector == provider &&
-         parameters == connection.parameters
-      }
+      @user.db_connections.find do |connection|
+        connection.connector == provider && parameters == connection.parameters
+      end
     end
 
     def find_oauth_connection(service)
@@ -111,11 +111,11 @@ module Carto
 
     def find_or_create_db_connection(provider, parameters)
       find_db_connection(provider, parameters) ||
-      create_db_connection(
-        name: generate_connection_name(provider),
-        provider: provider,
-        parameters: parameters
-      )
+        create_db_connection(
+          name: generate_connection_name(provider),
+          provider: provider,
+          parameters: parameters
+        )
     end
 
     # create Oauth connection logic
@@ -133,12 +133,15 @@ module Carto
     #      # connection of dual type (bigquery) we must additionally require parameters from the user and assign them:
     #      connection = assign_db_parameters(service, parameters)
     #    end
-    def fetch_valid_oauth_connection(service) # check for valid oauth_connection
+
+    # check for valid oauth_connection
+    def fetch_valid_oauth_connection(service)
       existing_connection = find_oauth_connection(service)
       return existing_connection if oauth_connection_valid?(existing_connection)
     end
 
-    def create_oauth_connection_get_url(service:) # get_url_to_create_oauth_connection
+    # get_url_to_create_oauth_connection
+    def create_oauth_connection_get_url(service:)
       check_oauth_service!(service)
       existing_connection = find_oauth_connection(service)
       delete_connection(existing_connection.id) if existing_connection.present?
@@ -150,7 +153,7 @@ module Carto
     # this may not be needed: API could perform a regular update
     def assign_db_parameters(service:, parameters:)
       connection = find_oauth_connection(service)
-      raise ConnectionNotFoundError.new("Connection not found for service #{service}") unless connection.present?
+      raise ConnectionNotFoundError, "Connection not found for service #{service}" if connection.blank?
 
       connection.update! parameters: parameters
       connection
@@ -214,7 +217,7 @@ module Carto
       connector_parameters = Carto::Connector::Parameters.new(parameters)
       provider = connector_parameters[:provider]
       connection_parameters = connector_parameters[:connection]
-      unless connection.present?
+      if connection.blank?
         connection_id = connector_parameters[:connection_id]
         if connection_id.present?
           connection = fetch_connection(connection_id)
@@ -227,7 +230,9 @@ module Carto
 
       if connection.present?
         if provider.present?
-          raise Carto::ParamInvalidError.new("provider: #{provider}", [connection.connector], 422) if provider != connection.connector
+          if provider != connection.connector
+            raise Carto::ParamInvalidError.new("provider: #{provider}", [connection.connector], 422)
+          end
         else
           connector_parameters.merge! provider: connection.connector
         end
@@ -268,9 +273,11 @@ module Carto
       errors = []
       case connection.connection_type
       when Carto::Connection::TYPE_OAUTH_SERVICE
-        errors << "Not a valid OAuth connector: #{connection.connector}" unless connection.connector.in?(valid_oauth_services)
+        unless connection.connector.in?(valid_oauth_services)
+          errors << "Not a valid OAuth connector: #{connection.connector}"
+        end
       when Carto::Connection::TYPE_DB_CONNECTOR
-        if !connection.connector.in?(valid_db_connectors)
+        unless connection.connector.in?(valid_db_connectors)
           errors << "Not a valid DB connector: #{connection.connector}"
         end
       end
@@ -307,15 +314,16 @@ module Carto
     def generate_connection_name(provider)
       # FIXME: this could produce name collisions
       n = @user.db_connections.where(connector: provider).count
-      n > 0 ? "#{provider}_#{n+1}" : provider
+      n.positive? ? "#{provider}_#{n + 1}" : provider
     end
 
-    def oauth_connection_url(service) # returns auth_url, doesn't actually create connection
+    # returns auth_url, doesn't actually create connection
+    def oauth_connection_url(service)
       DataImportsService.new.get_service_auth_url(@user, service)
     end
 
     def self.valid_oauth_services
-      CartoDB::Datasources::DatasourcesFactory.get_all_oauth_datasources.select { |service|
+      CartoDB::Datasources::DatasourcesFactory.get_all_oauth_datasources.select do |service|
         # FIXME: this includes twitter...
         # begin
         #   config, _ = CartoDB::Datasources::DatasourcesFactory.get_config(service)
@@ -324,7 +332,7 @@ module Carto
         #   false
         # end
         Cartodb.get_config(:oauth, service).present?
-      }
+      end
     end
 
     def self.valid_db_connectors
@@ -334,13 +342,19 @@ module Carto
     def check_oauth_service!(service)
       # TODO: check also that is enabled for @user
       valid_services = Carto::ConnectionManager.valid_oauth_services
-      raise Carto::ParamInvalidError.new("connector: #{service}", valid_services, 422) unless service.in?(valid_services)
+      unless service.in?(valid_services)
+        raise Carto::ParamInvalidError.new("connector: #{service}", valid_services, 422)
+      end
     end
 
     def check_db_provider!(provider)
       # TODO: check also that is enabled for @user
       valid_providers = Carto::ConnectionManager.valid_db_connectors
-      raise Carto::ParamInvalidError.new("connector: #{provider}", valid_providers, 422) unless provider.in?(valid_providers)
+      unless provider.in?(valid_providers)
+        raise Carto::ParamInvalidError.new("connector: #{provider}", valid_providers, 422)
+      end
     end
+
   end
+
 end

--- a/lib/carto/errors.rb
+++ b/lib/carto/errors.rb
@@ -16,10 +16,12 @@ module Carto
   end
 
   class ParamInvalidError < CartoError
+
     def initialize(parameter, valid_values = nil, status = 400)
       extra_message = valid_values ? " Valid values are one of #{valid_values}" : ''
       super("Wrong '#{parameter}' parameter value.#{extra_message}", status)
     end
+
   end
 
   class ParamCombinationInvalidError < CartoError

--- a/lib/tasks/sync_tables.rake
+++ b/lib/tasks/sync_tables.rake
@@ -171,6 +171,7 @@ namespace :cartodb do
       else
         sync = Carto::Synchronization.find_by(id: args.username_or_sync_id)
         raise "User/Sync not found: #{args.username_or_sync_id}" unless sync
+
         user_condition = "AND id = '#{sync.id}'"
       end
     end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.216",
+  "version": "1.0.0-assets.217",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4718,7 +4718,7 @@
           }
         },
         "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.2",
+          "version": "npm:vue-loader-v16@16.1.2",
           "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
           "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
           "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.216",
+  "version": "1.0.0-assets.217",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/script/ci/cloudbuild-new-build-master.yaml
+++ b/script/ci/cloudbuild-new-build-master.yaml
@@ -80,10 +80,11 @@ steps:
         echo '** Push to master **'
         
         echo 'Pulling latest image...'
+        
         docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
-        docker build --build-arg BUNDLE_JOBS=4 --build-arg COMPILE_ASSETS=true -t gcr.io/cartodb-on-gcp-main-artifacts/builder:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:latest .
-        docker build -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}  -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}--${SHORT_SHA}   -f Dockerfile.resque .
-        docker build -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME}--${SHORT_SHA}  -f Dockerfile.subscriber .
+        docker build --label="org.opencontainers.image.created=$$(date --rfc-3339=seconds)" --label=org.opencontainers.image.revision=${COMMIT_SHA} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=4 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:latest .
+        docker build --label="org.opencontainers.image.created=$$(date --rfc-3339=seconds)" --label=org.opencontainers.image.revision=${COMMIT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}  -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}--${SHORT_SHA}   -f Dockerfile.resque .
+        docker build --label="org.opencontainers.image.created=$$(date --rfc-3339=seconds)" --label=org.opencontainers.image.revision=${COMMIT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME}--${SHORT_SHA}  -f Dockerfile.subscriber .
         
         echo 'Pushing builder image...'
         docker push gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}
@@ -102,6 +103,18 @@ steps:
         docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA}
         docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME}--${SHORT_SHA}
         docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:latest
+
+        if [ ! -z "${TAG_NAME}" ]
+        then
+          echo "Tagging image with git tag: $TAG_NAME ..."
+          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder:${TAG_NAME}
+          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${TAG_NAME}
+          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${TAG_NAME}
+          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder:${TAG_NAME}
+          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${TAG_NAME}
+          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${TAG_NAME}
+        fi
+
       else
         echo '** Skipping, this is not a push to master **'
       fi

--- a/script/ci/cloudbuild-new-pr-pg11.yaml
+++ b/script/ci/cloudbuild-new-pr-pg11.yaml
@@ -63,13 +63,12 @@ steps:
     - |
       cp private/script/ci/* .
       cp private/Dockerfile .
-      cp -r private/build_resources/ .
       cp script/ci/* .
       cp config/app_config.yml.sample config/app_config.yml
       cp config/database.yml.sample config/database.yml
       cp lib/assets/javascripts/cdb/secrets.example.json lib/assets/javascripts/cdb/secrets.json
 
-# Build image
+# Build image, we don't compile assets here, since they are not required for tests and the image is not pushed to the registry
 - name: gcr.io/cloud-builders/docker
   entrypoint: /bin/bash
   args:
@@ -81,7 +80,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
         fi
-      docker build --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      docker build --build-arg COMPILE_ASSETS=false --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Run tests
 - name: 'docker/compose:1.22.0'

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -63,7 +63,6 @@ steps:
     - |
       cp private/script/ci/* .
       cp private/Dockerfile .
-      cp -r private/build_resources/ .
       cp script/ci/* .
       cp config/app_config.yml.sample config/app_config.yml
       cp config/database.yml.sample config/database.yml
@@ -80,8 +79,8 @@ steps:
         then
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
-        fi
-      docker build --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      fi
+      docker build --label="org.opencontainers.image.created=$$(date --rfc-3339=seconds)" --label=org.opencontainers.image.revision=${COMMIT_SHA} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker

--- a/services/datasources/lib/datasources/url/box.rb
+++ b/services/datasources/lib/datasources/url/box.rb
@@ -534,8 +534,10 @@ module CartoDB
         def update_user_oauth(refresh_token)
           carto_user = Carto::User.find(@user.id)
           oauth = carto_user.oauth_for_service('box')
-          oauth.token = refresh_token
-          oauth.save
+          if oauth
+            oauth.token = refresh_token
+            oauth.save
+          end
         end
 
         # Formats all data to comply with our desired format

--- a/services/datasources/lib/datasources/url/box.rb
+++ b/services/datasources/lib/datasources/url/box.rb
@@ -111,7 +111,10 @@ module CartoDB
             client_secret = options[:client_secret]
 
             @access_token = access_token
-            raise CartoDB::Datasources::TokenExpiredOrInvalidError.new("Access token cannot be nil", DATASOURCE_NAME) if @access_token.nil?
+            if @access_token.nil?
+              raise CartoDB::Datasources::TokenExpiredOrInvalidError.new('Access token cannot be nil', DATASOURCE_NAME)
+            end
+
             @client_id = client_id
             @client_secret = client_secret
           end

--- a/services/datasources/lib/datasources/url/box.rb
+++ b/services/datasources/lib/datasources/url/box.rb
@@ -111,7 +111,7 @@ module CartoDB
             client_secret = options[:client_secret]
 
             @access_token = access_token
-            raise "Access token cannot be nil" if @access_token.nil?
+            raise CartoDB::Datasources::TokenExpiredOrInvalidError.new("Access token cannot be nil", DATASOURCE_NAME) if @access_token.nil?
             @client_id = client_id
             @client_secret = client_secret
           end

--- a/services/importer/lib/importer/result.rb
+++ b/services/importer/lib/importer/result.rb
@@ -21,11 +21,11 @@ module CartoDB
       end
 
       def qualified_table_name
-        %Q("#{schema}"."#{table_name}")
+        %Q("#{schema}"."#{table_name}") if table_name.present?
       end
 
       def table_name
-        tables.first
+        tables&.first
       end
 
       def update_support_tables(new_list)

--- a/services/importer/lib/importer/result.rb
+++ b/services/importer/lib/importer/result.rb
@@ -21,7 +21,7 @@ module CartoDB
       end
 
       def qualified_table_name
-        %Q("#{schema}"."#{table_name}") if table_name.present?
+        %("#{schema}"."#{table_name}") if table_name.present?
       end
 
       def table_name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,8 @@ require './spec/support/message_broker_stubs'
 require './spec/support/shared_entities_spec_helper'
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-ENV['RAILS_ENV'] ||= 'test'
+raise %(Cannot run tests in an env other than 'test', RAILS_ENV=#{Rails.env}) unless Rails.env.test?
+
 require File.expand_path('../../config/environment', __FILE__)
 
 # Needed because load order changes in Ruby 2.3+, related to https://github.com/rspec/rspec-rails/pull/1372

--- a/spec/spec_helper_min.rb
+++ b/spec/spec_helper_min.rb
@@ -7,7 +7,8 @@ require './spec/support/message_broker_stubs'
 require './spec/support/redis'
 require './spec/support/shared_entities_spec_helper'
 
-ENV['RAILS_ENV'] ||= 'test'
+raise %(Cannot run tests in an env other than 'test', RAILS_ENV=#{Rails.env}) unless Rails.env.test?
+
 # INFO: this is the only slow step of the test boot process
 require File.expand_path('../../config/environment', __FILE__)
 


### PR DESCRIPTION
See https://app.clubhouse.io/cartoteam/story/117351 & https://app.clubhouse.io/cartoteam/story/117356

Experimental implementation of connections.

PENDING: (delayed decisions)

* data_imports, synchronizations: add connection_id foreign key, assign from parameters
* consider: connections are not deleted, but deactivated => old imports can be traced to their connection parameters
* full migration support of connections
* encrypt password, token on exports/imports (migrations), hide in logs
* decide: oauth creation pre-creates connection record
* consider: ConnectionManager identifies connections by name => API does as well (impacts previous  decision)