### PR TITLE
Recognize staging environment in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,3 +162,10 @@ Style/WordArray:
 Rails/CreateTableWithTimestamps:
   Description: Create new tables with created_at and updated_at timestamps
   Enabled: false
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - production
+    - staging
+    - test


### PR DESCRIPTION
Fixes the following warning:

![image](https://user-images.githubusercontent.com/9287468/99803567-fb0d1180-2b39-11eb-9e52-1748c19bbec3.png)
