### PR TITLE
[ch101099] Load GoogleMaps library for a map if the owner's query string is available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@ Development
 * Error importing geopackage files with multiple layers [#15907](https://github.com/CartoDB/cartodb/pull/15907)
 * Add DO notification in dashboard [#15929](https://github.com/CartoDB/cartodb/pull/15929)
 * Data loss on table rename due to GhostTablesManager [#15935](https://github.com/CartoDB/cartodb/pull/15935)
+* Load GoogleMaps library for a map if the owner's query string is available [#15948](https://github.com/CartoDB/cartodb/pull/15948)
 
 4.43.0 (2020-11-06)
 -------------------

--- a/app/views/admin/visualizations/show.html.erb
+++ b/app/views/admin/visualizations/show.html.erb
@@ -17,7 +17,7 @@
   </script>
 
   <% content_for(:js) do %>
-    <% if @visualization.map.provider == 'googlemaps' %>
+    <% if @visualization.user.google_maps_query_string.present? %>
       <%= insert_google_maps(@visualization.user.google_maps_query_string) %>
     <% end %>
     <%= editor_javascript_include_tag 'cdb.js','models.js', 'templates.js', 'templates_mustache.js', 'table.js', 'editor.js' %>


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/101099/transportnsw-google-maps-no-longer-supported-warning)

### Context

IMHO, **the main problem is that the Google Maps basemaps are not being showed**, and it seems to be a side effect of https://github.com/CartoDB/cartodb/pull/15536. In that PR, the query string used to load the Google Maps library was changed from the one of the current user to the map's owner one. The reason was to allow sharing maps between organization users when not all of them has Google Maps credentials. But I think the condition to load the library was not totally accurate: until then, the library was only loaded if the current user had Google Maps credentials, but now the library is only loaded if the map has 'googlemaps' as a provider.

It makes sense if it was a read-only view, but it's also used by the owner to edit the map. So, what happens if the current basemap is from 'leaflet' but the user has Google credentials? Is the Google Maps library never loaded again? And that is the problem that this PR is trying to solve. Since the invalid map from 'Nokia' has 'leaflet' as provider, implies that there will be no Google Maps.

About the other issues:

- **Why aren't the other maps shown?**
  - That is not a bug, the code to hide 'leaflet' maps if the user has the `google_maps' feature flag enabled was included long time ago in https://github.com/CartoDB/cartodb/pull/3527. I'm not sure why this fix was implemented, but could be related with the Google Terms of Service, because other basemap options were hidden due to that: https://github.com/CartoDB/cartodb/pull/6334, https://github.com/CartoDB/cartodb/pull/6375 (to solve the issues https://github.com/CartoDB/cartodb-platform/issues/1132 and https://github.com/CartoDB/cartodb-platform/issues/1320).
- **What about the Google deprecation dialog?**
  - In order to show the dialog:
    - The Google Maps library is not loaded.
    - The map is using a basemap from Google Maps.
  - So, with those conditions, I have only found a possibility: there is a map using a Google basemap, but the user credentials were removed or are invalid (so the library can't be loaded). But it wasn't the situation for the current user, its credentials were ok.
  - Probably it can be removed, or the replacement maps could be updated. But, since the map was modified, I can't know the corner case that made the dialog appear, and it is no longer a problem if a Google basemap can be selected; I have decided to keep it as it is and research deeply if it happens again.

### Changes

- Update the condition to load the Google Maps library (and then load the basemap options from Google), to not only load it if the original provider is 'googlemaps', but if the owner user of the map has the query string available. This way, a user using its maps can always select maps from Google Maps if it is enabled, and shared maps from this user with a Google basemap can be visualized using the original basemap (to respect the behavior from https://github.com/CartoDB/cartodb/pull/15536).