### PR TITLE
Bug/ch122116/log traces from subscribers in json format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :assets do
   gem "compass",               "1.0.3"
 end
 
-gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.4.5'
+gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.4.6'
 gem 'roo',                     '1.13.2'
 gem 'state_machines-activerecord', '~> 0.5.0'
 gem 'typhoeus',                '1.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :assets do
   gem "compass",               "1.0.3"
 end
 
-gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.4.6'
+gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.4.7'
 gem 'roo',                     '1.13.2'
 gem 'state_machines-activerecord', '~> 0.5.0'
 gem 'typhoeus',                '1.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,14 @@ GIT
 
 GIT
   remote: https://github.com/cartodb/cartodb-common.git
-  revision: aebf468b520da4065ddb2ec6f9ddfdd0fc320de6
-  tag: v0.4.5
+  revision: 608c1f1ced5e8b56f0dda2b315d0f10ff69d778d
+  tag: v0.4.6
   specs:
     cartodb-common (0.4.5)
-      activesupport (>= 4, < 6)
       argon2 (~> 2)
       google-cloud-pubsub (~> 1.2)
+      rails (>= 4, < 6)
+      rollbar
 
 GIT
   remote: https://github.com/kuldeepaggarwal/fake_net_ldap.git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/cartodb/cartodb-common.git
-  revision: 608c1f1ced5e8b56f0dda2b315d0f10ff69d778d
-  tag: v0.4.6
+  revision: 9b6eed36b18132693f360dc7f88a2f41371f7e13
+  tag: v0.4.7
   specs:
-    cartodb-common (0.4.5)
+    cartodb-common (0.4.7)
       argon2 (~> 2)
       google-cloud-pubsub (~> 1.2)
       rails (>= 4, < 6)

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Development
 * Data loss on table rename due to GhostTablesManager [#15935](https://github.com/CartoDB/cartodb/pull/15935)
 * Add DO datasets sync size in /me endpoint [#15932](https://github.com/CartoDB/cartodb/pull/15932)
 * Load GoogleMaps library for a map if the owner's query string is available [#15948](https://github.com/CartoDB/cartodb/pull/15948)
+* Log subscribers to STDOUT and fix JSON format [#15957](https://github.com/CartoDB/cartodb/pull/15957)
 
 4.43.0 (2020-11-06)
 -------------------

--- a/lib/tasks/central_updates_subscriber.rake
+++ b/lib/tasks/central_updates_subscriber.rake
@@ -1,3 +1,5 @@
+require './lib/carto/subscribers/central_user_commands'
+
 namespace :message_broker do
   desc 'Consume messages from subscription "central_cartodb_commands"'
   task cartodb_subscribers: [:environment] do |_task, _args|

--- a/lib/tasks/central_updates_subscriber.rake
+++ b/lib/tasks/central_updates_subscriber.rake
@@ -1,31 +1,36 @@
 namespace :message_broker do
   desc 'Consume messages from subscription "central_cartodb_commands"'
   task cartodb_subscribers: [:environment] do |_task, _args|
-    include ::LoggerHelper
+    begin
+      logger = Carto::Common::Logger.new
 
-    message_broker = Carto::Common::MessageBroker.instance
-    subscription_name = Carto::Common::MessageBroker::Config.instance.central_commands_subscription
-    subscription = message_broker.get_subscription(subscription_name)
-    notifications_topic = message_broker.get_topic(:cartodb_central)
-    central_user_commands = Carto::Subscribers::CentralUserCommands.new(notifications_topic)
+      message_broker = Carto::Common::MessageBroker.new(logger: logger)
+      subscription_name = Carto::Common::MessageBroker::Config.instance.central_commands_subscription
+      subscription = message_broker.get_subscription(subscription_name)
+      notifications_topic = message_broker.get_topic(:cartodb_central)
+      central_user_commands = Carto::Subscribers::CentralUserCommands.new(notifications_topic)
 
-    subscription.register_callback(:update_user,
-                                   &central_user_commands.method(:update_user))
+      subscription.register_callback(:update_user,
+                                     &central_user_commands.method(:update_user))
 
-    subscription.register_callback(:create_user,
-                                   &central_user_commands.method(:create_user))
+      subscription.register_callback(:create_user,
+                                     &central_user_commands.method(:create_user))
 
-    subscription.register_callback(:delete_user,
-                                   &central_user_commands.method(:delete_user))
+      subscription.register_callback(:delete_user,
+                                     &central_user_commands.method(:delete_user))
 
-    at_exit do
-      log_debug(message: 'Stopping subscriber...')
-      subscription.stop!
-      log_debug(message: 'Done')
+      at_exit do
+        logger.info(message: 'Stopping subscriber...')
+        subscription.stop!
+        logger.info(message: 'Done')
+      end
+
+      subscription.start
+      logger.info(message: 'Consuming messages from subscription')
+      sleep
+    rescue StandardError => e
+      logger.error(exception: e)
+      exit(1)
     end
-
-    subscription.start
-    log_debug(message: 'Consuming messages from subscription')
-    sleep
   end
 end

--- a/spec/helpers/logger_helper_spec.rb
+++ b/spec/helpers/logger_helper_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
 require './app/helpers/logger_helper'
 
+class MockObject
+
+  include LoggerHelper
+
+end
+
 describe LoggerHelper do
-
-  class MockObject; include LoggerHelper end
-
   before { User.any_instance.stubs(:update_in_central).returns(true) }
 
   let(:mock_object) { MockObject.new }
@@ -23,24 +26,6 @@ describe LoggerHelper do
       Rails.logger.expects(:warn).with('message' => 'Message')
 
       mock_object.log_warning(message: 'Message')
-    end
-
-    it 'reports plain error message to Rollbar' do
-      Rollbar.expects(:error).with('Custom error message')
-
-      mock_object.log_error(message: 'Custom error message')
-    end
-
-    it 'reports exceptions to Rollbar' do
-      Rollbar.expects(:error).with(exception)
-
-      mock_object.log_error(exception: exception)
-    end
-
-    it 'reports exceptions with custom message to Rollbar' do
-      Rollbar.expects(:error).with(exception, 'Message')
-
-      mock_object.log_error(message: 'Message', exception: exception)
     end
   end
 
@@ -79,15 +64,5 @@ describe LoggerHelper do
 
       mock_object.log_info(message: 'Message', organization: carto_organization)
     end
-
-    it 'serializes Exception objects' do
-      Rails.logger.expects(:error).with(
-        'message' => 'Message',
-        'exception' => { 'class' => 'StandardError', 'message' => 'Exception message', 'backtrace_hint' => nil }
-      )
-
-      mock_object.log_error(message: 'Message', exception: exception)
-    end
   end
-
 end

--- a/spec/models/common_data_spec.rb
+++ b/spec/models/common_data_spec.rb
@@ -29,17 +29,10 @@ describe CommonData do
 
   it 'should return empty datasets and notify error for invalid json' do
     stub_api_response(200, INVALID_JSON_RESPONSE)
-    JSON::ParserError.any_instance.stubs(:backtrace).returns(%w(line_1 line_2))
 
     Rails.logger.expects(:error).with(
-      'exception' => {
-        'class' => 'JSON::ParserError',
-        'message' => '784: unexpected token at \'{\'',
-        'backtrace_hint' => ['line_1', 'line_2']
-      },
-      'message' => '784: unexpected token at \'{\''
+      has_entries('exception' => is_a(JSON::ParserError))
     )
-
     Rails.logger.expects(:error).with('message' => 'common-data empty', 'url' => common_data_url)
 
     expect(@common_data.datasets).to be_empty


### PR DESCRIPTION
Related: https://app.clubhouse.io/cartoteam/story/122116/log-traces-from-subscribers-in-json-format

**What does this PR do?**

Bumps the `cartodb-common` version, which:

- Configures the subscribers to output to stdout
- Rescues `StandardError` exceptions in the subscribers rake
- Includes default Exception serialization logic in `Carto::Common::Logger`, so it can be removed from the `LoggerHelper`

**Acceptance in staging** ✅ 

- [x] Subscriber reports to stdout when running (so the log lines appear in the log file where the systemd process is redirecting the output)

```log
[stag] ubuntu@que04:~/www/production.cartodb.com/shared/log$ tail message_broker-cartodb_subscribers.log

Tasks: TOP => message_broker:cartodb_subscribers
(See full trace by running task with --trace)
Searching subscription_name: broker_central_commands_gcp_staging_cloud, project_id: cartodb-on-gcp-staging
Subscription is #<Google::Cloud::PubSub::Subscription:0x000056361cd6d500>
{"subscription_name":"broker_central_commands_gcp_staging_cloud","timestamp":"2020-11-30T16:45:47.238+00:00","levelname":"info","cdb-user":null,"event_message":"Starting message processing in subscriber"}
{"timestamp":"2020-11-30T16:45:47.241+00:00","levelname":"info","cdb-user":null,"event_message":"Consuming messages from subscription"}
{"timestamp":"2020-11-30T16:53:01.856+00:00","levelname":"info","cdb-user":null,"event_message":"Stopping subscriber..."}
{"subscription_name":"broker_central_commands_gcp_staging_cloud","timestamp":"2020-11-30T16:53:01.856+00:00","levelname":"info","cdb-user":null,"event_message":"Stopping message processing in subscriber"}
{"timestamp":"2020-11-30T16:53:01.913+00:00","levelname":"info","cdb-user":null,"event_message":"Done"}
```

![image](https://user-images.githubusercontent.com/9287468/100639063-024fce80-3335-11eb-9de8-b1ced90e302a.png)

- [x] Exception serialization keeps working

![image](https://user-images.githubusercontent.com/9287468/100640462-bb62d880-3336-11eb-9772-fc7cde47594c.png)

- [x] Rollbar reports keep working

```log
# From the Rails console in staging CartoDB queue
irb(main):005:0> Rails.logger.error(exception: StandardError.new('Amiedes test monday'))
{:exception=>#<StandardError: Amiedes test monday>}
[Rollbar] Scheduling item
[Rollbar] Sending item
[Rollbar] Success
[Rollbar] Details: https://rollbar.com/instance/uuid?uuid=95e799d4-aafd-4085-a991-68532d9fc992 (only available if report was successful)
=> {:timestamp=>1606753155, :environment=>"staging", :level=>"error", :language=>"ruby", :framework=>"Rails: 4.2.11.3", :server=>{:host=>"que04.stag.cartodb.net", :root=>"/home/ubuntu/www/production.cartodb.com/releases/20201130124217", :pid=>18922}, :notifier=>{:name=>"rollbar-gem", :version=>"2.11.5"}, :body=>{:trace=>{:frames=>[], :exception=>{:class=>"StandardError", :message=>"Amiedes test monday"}}}, :uuid=>"95e799d4-aafd-4085-a991-68532d9fc992"}
```