### PR TITLE
Fix removing API Keys from Redis when user is unlocked

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ sudo make install
 - Generate a .pid file to control and manage the subscriber rake process [#15970](https://github.com/CartoDB/cartodb/pull/15970)
 - Fix buffering of log traces in subscriber [#15980](https://github.com/CartoDB/cartodb/pull/15980)
 - Wrong param name in organization forms [#15975](https://github.com/CartoDB/cartodb/pull/15975)
+- Adding API Keys to Redis when user is unlocked [#15959](https://github.com/CartoDB/cartodb/pull/15959)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -332,7 +332,7 @@ module Carto
       queries
     end
 
-    def set_enabled_for_engine(new_user_attributes)
+    def set_enabled_for_engine(new_user_attributes = nil)
       # We enable/disable API keys for engine usage by adding/removing them from Redis
       valid_user?(new_user_attributes) ? add_to_redis : remove_from_redis
     end
@@ -656,20 +656,11 @@ module Carto
     end
 
     def valid_user?(new_user_attributes = {})
-      engine_enabled = if new_user_attributes.present?(:engine_enabled)
-                         new_user_attributes[:engine_enabled]
-                       else
-                         user.engine_enabled?
-                       end
-
-      locked = if new_user_attributes.present?(:state)
-                 new_user_attributes[:state] == Carto::UserCommons.STATE_LOCKED
-               else
-                 user.locked?
-               end
+      user.engine_enabled = new_user_attributes[:engine_enabled] if new_user_attributes[:engine_enabled].present?
+      user.state = new_user_attributes[:state] if new_user_attributes[:state].present?
 
       # This is not avalidation per-se, since we don't want to remove api keys when a user is disabled
-      !(locked || regular? && engine_enabled)
+      !(user.locked? || regular? && user.engine_enabled?)
     end
   end
 end

--- a/app/models/carto/api_key.rb
+++ b/app/models/carto/api_key.rb
@@ -660,7 +660,7 @@ module Carto
       user.state = new_user_attributes[:state] if new_user_attributes[:state].present?
 
       # This is not avalidation per-se, since we don't want to remove api keys when a user is disabled
-      !(user.locked? || regular? && user.engine_enabled?)
+      !(user.locked? || regular? && !user.engine_enabled?)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1452,8 +1452,8 @@ class User < Sequel::Model
   def sync_enabled_api_keys
     if previous_changes.present?
       new_attributes = {}
-      new_attributes[:state] = previous_changes[:state] if previous_changes[:state].present?
-      new_attributes[:engine_enabled] = previous_changes[:engine_enabled] if previous_changes[:engine_enabled].present?
+      new_attributes[:state] = previous_changes[:state][1] if previous_changes[:state].present?
+      new_attributes[:engine_enabled] = previous_changes[:engine_enabled][1] if previous_changes[:engine_enabled].present?
     end
 
     api_keys.each { |api_key| api_key.set_enabled_for_engine(new_attributes) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1451,10 +1451,9 @@ class User < Sequel::Model
 
   def sync_enabled_api_keys
     if previous_changes.present?
-      new_attributes = {
-        state: previous_changes[:state],
-        engine_enabled: previous_changes[:engine_enabled]
-      }
+      new_attributes = {}
+      new_attributes[:state] = previous_changes[:state] if previous_changes[:state].present?
+      new_attributes[:engine_enabled] = previous_changes[:engine_enabled] if previous_changes[:engine_enabled].present?
     end
 
     api_keys.each { |api_key| api_key.set_enabled_for_engine(new_attributes) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -351,7 +351,7 @@ class User < Sequel::Model
     sync_master_key if changes.include?(:api_key)
     sync_default_public_key if changes.include?(:database_schema)
     $users_metadata.HSET(key, 'map_key', make_token) if locked?
-    db.after_commit { sync_enabled_api_keys } if changes.include?(:engine_enabled) || changes.include?(:state)
+    db.after_commit { sync_enabled_api_keys(changes) } if changes.include?(:engine_enabled) || changes.include?(:state)
 
     if changes.include?(:org_admin) && !organization_owner?
       org_admin ? db_service.grant_admin_permissions : db_service.revoke_admin_permissions
@@ -1449,7 +1449,7 @@ class User < Sequel::Model
     default_key.update_attributes(db_role: database_public_username)
   end
 
-  def sync_enabled_api_keys
-    api_keys.each(&:set_enabled_for_engine)
+  def sync_enabled_api_keys(new_user_attributes)
+    api_keys.each { |api_key| api_key.set_enabled_for_engine(new_user_attributes) }
   end
 end


### PR DESCRIPTION
### Context

When we change the price plan of a locked user then the user is automatically unlocked. The problem is the api_keys are removed from Redis because the method `valid_user?` return `false` when is saved because it checks the persisted user's attributes instead of the new ones.
So the method `set_enabled_for_engine` removes the api_keys from redis:

```ruby
def set_enabled_for_engine
  # We enable/disable API keys for engine usage by adding/removing them from Redis
  valid_user? ? add_to_redis : remove_from_redis
end
```

### Fix
 
This PR includes the needed changes in order to fix this. The `after_save` hook of the user passes the new attributes changed to api_keys in order to check if the user is valid:

```ruby
def sync_enabled_api_keys
  if previous_changes.present?
    new_attributes = {}
    new_attributes[:state] = previous_changes[:state] if previous_changes[:state].present?
    new_attributes[:engine_enabled] = previous_changes[:engine_enabled] if previous_changes[:engine_enabled].present?
  end

  api_keys.each { |api_key| api_key.set_enabled_for_engine(new_attributes) }
end
```

More info: https://app.clubhouse.io/cartoteam/story/120306/reindicator-disappearing-copied-datasets-in-builder