### PR TITLE
Fix update notifications when using password-validated operation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ Development
 - None yet
 
 ### Bug fixes / enhancements
-- None yet
+- Fix update notifications when using password-validated operation [#15960](https://github.com/CartoDB/cartodb/pull/15960)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -157,8 +157,10 @@ module.exports = CoreView.extend({
     PasswordValidatedForm.showPasswordModal({
       modalService: this._modals,
       onPasswordTyped: (password) => {
-        this._updateUser(user, password);
-        this._updateNotifications(notifications);
+        const onSuccess = () => {
+          this._updateNotifications(notifications);
+        }
+        this._updateUser(user, password, onSuccess);
       },
       updatePassword: destination.new_password !== '' && destination.confirm_password !== ''
     });
@@ -184,7 +186,7 @@ module.exports = CoreView.extend({
     this._notificationLabel(id).html(newLabel);
   },
 
-  _updateUser: function (user, password) {
+  _updateUser: function (user, password, onSuccess) {
     this._setLoading('Saving changes');
 
     const userParams = { user: { ...user, password_confirmation: password } };
@@ -194,6 +196,7 @@ module.exports = CoreView.extend({
         this.render();
       } else {
         this._getUser();
+        onSuccess && onSuccess();
       }
     });
   },

--- a/lib/assets/javascripts/dashboard/views/account/account-form-view.js
+++ b/lib/assets/javascripts/dashboard/views/account/account-form-view.js
@@ -159,7 +159,7 @@ module.exports = CoreView.extend({
       onPasswordTyped: (password) => {
         const onSuccess = () => {
           this._updateNotifications(notifications);
-        }
+        };
         this._updateUser(user, password, onSuccess);
       },
       updatePassword: destination.new_password !== '' && destination.confirm_password !== ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.208",
+  "version": "1.0.0-assets.209",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.208",
+  "version": "1.0.0-assets.209",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update notifications just after successful (password-validated) user update.
Email notifications api doesn't require password_validation, so ensuring it is not saved until user is (which uses the me endpoint)