### PR TITLE
Rails 5 / Make carto_gears_api compatible with Rails 5

### DIFF
--- a/gears/carto_gears_api/Gemfile.lock
+++ b/gears/carto_gears_api/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     carto_gears_api (0.0.6)
       pg (= 0.20.0)
-      rails (= 4.2.11.3)
+      rails (>= 4, < 6)
       sprockets (= 3.7.2)
       values (= 1.8.0)
 
@@ -111,7 +111,7 @@ GEM
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -132,4 +132,4 @@ DEPENDENCIES
   rspec-rails (= 2.12.0)
 
 BUNDLED WITH
-  1.17.3
+   1.17.3

--- a/gears/carto_gears_api/carto_gears_api.gemspec
+++ b/gears/carto_gears_api/carto_gears_api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'pg', '0.20.0'
-  s.add_dependency "rails", "4.2.11.3"
+  s.add_dependency 'rails', '>= 4', '< 6'
   s.add_dependency 'sprockets', '3.7.2'
   s.add_dependency 'values', '1.8.0'
 end


### PR DESCRIPTION
Related: https://app.clubhouse.io/cartoteam/story/122793/upgrade-cartodb-to-rails-5