### PR TITLE
[ch123225] Wrong param name in organization forms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ sudo make install
 - Improve the syncronization functions by using `CDB_GetTableQueries`.
 - Bump cartodb-common to v0.4.8
 - Don't send ActionController::RoutingError to Rollbar [#15968](https://github.com/CartoDB/cartodb/pull/15968)
+- Wrong param name in organization forms [#15975](https://github.com/CartoDB/cartodb/pull/15975)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -92,7 +92,7 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def settings_update
     valid_password_confirmation
-    attributes = params[:organization]
+    attributes = params[:carto_organization]
 
     if attributes.include?(:avatar_url) && valid_avatar_file?(attributes[:avatar_url])
       @organization.avatar_url = attributes[:avatar_url]
@@ -152,7 +152,7 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def auth_update
     valid_password_confirmation
-    attributes = params[:organization]
+    attributes = params[:carto_organization]
     @organization.whitelisted_email_domains = attributes[:whitelisted_email_domains].split(",")
     @organization.auth_username_password_enabled = attributes[:auth_username_password_enabled]
     @organization.auth_google_enabled = attributes[:auth_google_enabled]

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -92,7 +92,7 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def settings_update
     valid_password_confirmation
-    attributes = params[:carto_organization]
+    attributes = params[:organization]
 
     if attributes.include?(:avatar_url) && valid_avatar_file?(attributes[:avatar_url])
       @organization.avatar_url = attributes[:avatar_url]
@@ -152,7 +152,7 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def auth_update
     valid_password_confirmation
-    attributes = params[:carto_organization]
+    attributes = params[:organization]
     @organization.whitelisted_email_domains = attributes[:whitelisted_email_domains].split(",")
     @organization.auth_username_password_enabled = attributes[:auth_username_password_enabled]
     @organization.auth_google_enabled = attributes[:auth_google_enabled]

--- a/app/views/admin/organizations/auth.html.erb
+++ b/app/views/admin/organizations/auth.html.erb
@@ -3,7 +3,7 @@
     <% if @ldap_configuration %>
       <%= render :partial => 'admin/organizations/ldap_configuration' %>
     <% else %>
-      <%= form_for @organization, url: CartoDB.url(self, 'organization_auth_update', user: current_user), multipart: true do |f| %>
+      <%= form_for @organization, as: :organization, url: CartoDB.url(self, 'organization_auth_update', user: current_user), multipart: true do |f| %>
         <%= csrf_meta_tags %>
 
         <div class="FormAccount-row">

--- a/app/views/admin/organizations/auth.html.erb
+++ b/app/views/admin/organizations/auth.html.erb
@@ -16,7 +16,7 @@
                 <span class= "CDB-Text CDB-Size-small u-altTextColor FormAccount-tagsList--placeholder js-placeholder">Only valid domains, wildcard (*) accepted (ex. *.carto.com)</span>
               </ul>
             </div>
-            <%= f.hidden_field :whitelisted_email_domains, :value => "#{ @organization[:whitelisted_email_domains].join(',') if !@organization[:whitelisted_email_domains].blank? }", :class => "js-whitelist CDB-InputText CDB-Text", :placeholder => "Only valid domains, wildcard (*) accepted (ex. *.carto.com)" %>
+            <%= f.hidden_field :whitelisted_email_domains, :value => "#{ @organization[:whitelisted_email_domains].join(',') if @organization[:whitelisted_email_domains].present? }", :class => "js-whitelist CDB-InputText CDB-Text", :placeholder => "Only valid domains, wildcard (*) accepted (ex. *.carto.com)" %>
             <div class="u-flex u-lSpace--xl">
               <% if @organization.errors[:whitelisted_email_domains].present? %>
                 <p class="CDB-Text FormAccount-rowInfoText FormAccount-rowInfoText--error u-tSpace"><%= @organization.errors[:whitelisted_email_domains].first%></p>

--- a/app/views/admin/organizations/settings.html.erb
+++ b/app/views/admin/organizations/settings.html.erb
@@ -1,6 +1,6 @@
 <% content_for :settings_body do %>
   <div class="FormAccount-container">
-    <%= form_for @organization, url: CartoDB.url(self, 'organization_settings_update', user: current_user), multipart: true do |f| %>
+    <%= form_for @organization, as: :organization, url: CartoDB.url(self, 'organization_settings_update', user: current_user), multipart: true do |f| %>
       <%= csrf_meta_tags %>
 
       <div class="FormAccount-row js-avatarSelector">


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/123225/datchley-can-t-whitelist-carto-com)
- [Rollbar error](https://rollbar.com/carto/CartoDB/items/43872/occurrences/143901344182/)
- [Related PR](https://github.com/CartoDB/cartodb/pull/15915)

### Context

- The problem is that the attributes of the `Carto::Organization` object are being sent using the `carto_organization` param, but the controller method was expecting them in the `organization` param.
- This would be a side effect of the migration of the `Organization` model. In the template `views/admin/organizations/auth.html.erb`, the helper `form_for @organization` is being used. This Rails helper uses the name of the model (including the modules) as the param name when the form is submitted; and the model was changed in [this PR](https://github.com/CartoDB/cartodb/pull/15915/files#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bR90) from `Organization` to `Carto::Organization`.
- The problem was happening in two actions from the organizations controller: `settings_update` and `auth_update`.

### Changes

- Update the forms to keep using the old `organization` param.