### PR TITLE
Polish development environment for Message Broker

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ sudo make install
 - Bump cartodb-common to v0.4.8
 - Don't send ActionController::RoutingError to Rollbar [#15968](https://github.com/CartoDB/cartodb/pull/15968)
 - Generate a .pid file to control and manage the subscriber rake process [#15970](https://github.com/CartoDB/cartodb/pull/15970)
+- Make subscriber wait for DB creation in development [#15982](https://github.com/CartoDB/cartodb/pull/15982)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/lib/tasks/central_updates_subscriber.rake
+++ b/lib/tasks/central_updates_subscriber.rake
@@ -4,7 +4,7 @@ namespace :message_broker do
   desc 'Consume messages from subscription "central_cartodb_commands"'
   task cartodb_subscribers: [:environment] do |_task, _args|
     pid_file = ENV['PIDFILE'] || Rails.root.join('tmp/pids/cartodb_subscribers.pid')
-    raise 'pid file exists!' if File.exist?(pid_file)
+    raise "PID file exists: #{pid_file}" if File.exist?(pid_file)
 
     File.open(pid_file, 'w') { |f| f.puts Process.pid }
     begin

--- a/lib/tasks/central_updates_subscriber.rake
+++ b/lib/tasks/central_updates_subscriber.rake
@@ -1,22 +1,5 @@
 require './lib/carto/subscribers/central_user_commands'
 
-def wait_for_db_creation(logger)
-  retries = 0
-  max_retries = 25
-
-  begin
-    ActiveRecord::Base.connection
-  rescue ActiveRecord::NoDatabaseError => e
-    raise e if retries >= max_retries
-
-    retries += 1
-    database_name = Rails.configuration.database_configuration[Rails.env]['database']
-    logger.info("Database '#{database_name}' doesn't exist. Sleeping 5 seconds before retry #{retries}/#{max_retries}")
-    sleep(5)
-    retry
-  end
-end
-
 namespace :message_broker do
   desc 'Consume messages from subscription "central_cartodb_commands"'
   task cartodb_subscribers: [:environment] do |_task, _args|
@@ -27,8 +10,6 @@ namespace :message_broker do
     begin
       $stdout.sync = true
       logger = Carto::Common::Logger.new($stdout)
-
-      wait_for_db_creation(logger) if Rails.env.development? || Rails.env.test?
 
       message_broker = Carto::Common::MessageBroker.new(logger: logger)
       subscription_name = Carto::Common::MessageBroker::Config.instance.central_commands_subscription

--- a/lib/tasks/central_updates_subscriber.rake
+++ b/lib/tasks/central_updates_subscriber.rake
@@ -2,15 +2,16 @@ require './lib/carto/subscribers/central_user_commands'
 
 def wait_for_db_creation
   retries = 0
+  max_retries = 25
 
   begin
     ActiveRecord::Base.connection
   rescue ActiveRecord::NoDatabaseError => e
-    raise e if retries >= 10
+    raise e if retries >= max_retries
 
     retries += 1
     database_name = Rails.configuration.database_configuration[Rails.env]['database']
-    puts "Database '#{database_name}' doesn't exist. Sleeping 5 seconds before retry ##{retries}"
+    puts "Database '#{database_name}' doesn't exist. Sleeping 5 seconds before retry #{retries}/#{max_retries}"
     sleep(5)
     retry
   end


### PR DESCRIPTION
Related: https://app.clubhouse.io/cartoteam/story/119784/wait-for-the-pubsub-emulator-to-be-ready-before-provisioning

This is a part of 3 related PR's:

- https://github.com/CartoDB/cartodb/pull/15982
- https://github.com/CartoDB/cartodb-central/pull/2994
- https://github.com/CartoDB/docker-dev-env/pull/72

It's worth saying that this PR can be merged independently from the other two.