### PR TITLE
add subscriptions_premium_estimated_size_in_bytes to /me

### DIFF
--- a/app/controllers/carto/api/user_presenter.rb
+++ b/app/controllers/carto/api/user_presenter.rb
@@ -162,7 +162,9 @@ module Carto
             # DB storage used by public subscriptions:
             subscriptions_public_size_in_bytes: @user.subscriptions_public_size_in_bytes,
             # DB storage used by premium subscriptions:
-            subscriptions_premium_size_in_bytes: @user.subscriptions_premium_size_in_bytes
+            subscriptions_premium_size_in_bytes: @user.subscriptions_premium_size_in_bytes,
+            # Estimated premium datasets size:
+            subscriptions_premium_estimated_size_in_bytes: @user.subscriptions_premium_estimated_size_in_bytes
           },
           map_views: @user.map_views_count,
           map_views_quota: @user.organization_user? ? @user.organization.map_view_quota : @user.map_view_quota,

--- a/app/controllers/carto/api/user_presenter.rb
+++ b/app/controllers/carto/api/user_presenter.rb
@@ -162,9 +162,7 @@ module Carto
             # DB storage used by public subscriptions:
             subscriptions_public_size_in_bytes: @user.subscriptions_public_size_in_bytes,
             # DB storage used by premium subscriptions:
-            subscriptions_premium_size_in_bytes: @user.subscriptions_premium_size_in_bytes,
-            # Estimated premium datasets size:
-            subscriptions_premium_estimated_size_in_bytes: @user.subscriptions_premium_estimated_size_in_bytes
+            subscriptions_premium_size_in_bytes: @user.subscriptions_premium_size_in_bytes
           },
           map_views: @user.map_views_count,
           map_views_quota: @user.organization_user? ? @user.organization.map_view_quota : @user.map_view_quota,

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -328,20 +328,28 @@ class Carto::User < ActiveRecord::Base
     subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT)
   end
 
+  def subscriptions_premium_estimated_size_in_bytes
+    subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT, estimated: true)
+  end
+
   def subscriptions
     Carto::DoLicensingService.new(username).subscriptions || []
   end
 
   private
 
-  def subscriptions_size_in_bytes(project)
+  def subscriptions_size_in_bytes(project, estimated: false)
     # Note we cannot filter by `project` subscription attribute, we must use the dataset ID.
     subs_filtered = subscriptions.select { |d| d['dataset_id'].split('.')[0] == project }
     subs_synced = subs_filtered.select do |d|
       d['sync_status'] == 'synced' && !d['sync_table'].empty? && Carto::UserTable.exists?(d['sync_table_id'])
     end
-    synced_tables = subs_synced.map { |d| Carto::UserTable.find_by(id: d['sync_table_id']) }
-    total = synced_tables.map { |d| d.table_size }.reduce(0) { |a, b| a + b }
+    if estimated == true
+      total = subs_synced.map { |d| d['estimated_size'] }.reduce(0) { |a, b| a + b }
+    else
+      synced_tables = subs_synced.map { |d| Carto::UserTable.find_by(id: d['sync_table_id']) }
+      total = synced_tables.map(&:table_size).reduce(0) { |a, b| a + b }
+    end
     total || 0
   end
 

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -328,28 +328,20 @@ class Carto::User < ActiveRecord::Base
     subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT)
   end
 
-  def subscriptions_premium_estimated_size_in_bytes
-    subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT, true)
-  end
-
   def subscriptions
     Carto::DoLicensingService.new(username).subscriptions || []
   end
 
   private
 
-  def subscriptions_size_in_bytes(project, estimated = false)
+  def subscriptions_size_in_bytes(project)
     # Note we cannot filter by `project` subscription attribute, we must use the dataset ID.
     subs_filtered = subscriptions.select { |d| d['dataset_id'].split('.')[0] == project }
     subs_synced = subs_filtered.select do |d|
       d['sync_status'] == 'synced' && !d['sync_table'].empty? && Carto::UserTable.exists?(d['sync_table_id'])
     end
-    if estimated == true
-      total = subs_synced.map { |d| d['estimated_size'] }.reduce(0) { |a, b| a + b }
-    else
-      synced_tables = subs_synced.map { |d| Carto::UserTable.find_by(id: d['sync_table_id']) }
-      total = synced_tables.map { |d| d.table_size }.reduce(0) { |a, b| a + b }
-    end
+    synced_tables = subs_synced.map { |d| Carto::UserTable.find_by(id: d['sync_table_id']) }
+    total = synced_tables.map { |d| d.table_size }.reduce(0) { |a, b| a + b }
     total || 0
   end
 

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -329,7 +329,7 @@ class Carto::User < ActiveRecord::Base
   end
 
   def subscriptions_premium_estimated_size_in_bytes
-    subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT, true)
+    subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT, estimated: true)
   end
 
   def subscriptions
@@ -338,7 +338,7 @@ class Carto::User < ActiveRecord::Base
 
   private
 
-  def subscriptions_size_in_bytes(project, estimated = false)
+  def subscriptions_size_in_bytes(project, estimated: false)
     # Note we cannot filter by `project` subscription attribute, we must use the dataset ID.
     subs_filtered = subscriptions.select { |d| d['dataset_id'].split('.')[0] == project }
     subs_synced = subs_filtered.select do |d|
@@ -348,7 +348,7 @@ class Carto::User < ActiveRecord::Base
       total = subs_synced.map { |d| d['estimated_size'] }.reduce(0) { |a, b| a + b }
     else
       synced_tables = subs_synced.map { |d| Carto::UserTable.find_by(id: d['sync_table_id']) }
-      total = synced_tables.map { |d| d.table_size }.reduce(0) { |a, b| a + b }
+      total = synced_tables.map(&:table_size).reduce(0) { |a, b| a + b }
     end
     total || 0
   end

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -328,20 +328,28 @@ class Carto::User < ActiveRecord::Base
     subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT)
   end
 
+  def subscriptions_premium_estimated_size_in_bytes
+    subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT, true)
+  end
+
   def subscriptions
     Carto::DoLicensingService.new(username).subscriptions || []
   end
 
   private
 
-  def subscriptions_size_in_bytes(project)
+  def subscriptions_size_in_bytes(project, estimated = false)
     # Note we cannot filter by `project` subscription attribute, we must use the dataset ID.
     subs_filtered = subscriptions.select { |d| d['dataset_id'].split('.')[0] == project }
     subs_synced = subs_filtered.select do |d|
       d['sync_status'] == 'synced' && !d['sync_table'].empty? && Carto::UserTable.exists?(d['sync_table_id'])
     end
-    synced_tables = subs_synced.map { |d| Carto::UserTable.find_by(id: d['sync_table_id']) }
-    total = synced_tables.map { |d| d.table_size }.reduce(0) { |a, b| a + b }
+    if estimated == true
+      total = subs_synced.map { |d| d['estimated_size'] }.reduce(0) { |a, b| a + b }
+    else
+      synced_tables = subs_synced.map { |d| Carto::UserTable.find_by(id: d['sync_table_id']) }
+      total = synced_tables.map { |d| d.table_size }.reduce(0) { |a, b| a + b }
+    end
     total || 0
   end
 

--- a/app/models/carto/user.rb
+++ b/app/models/carto/user.rb
@@ -329,7 +329,7 @@ class Carto::User < ActiveRecord::Base
   end
 
   def subscriptions_premium_estimated_size_in_bytes
-    subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT, estimated: true)
+    subscriptions_size_in_bytes(Carto::DoLicensingService::CARTO_DO_PROJECT, true)
   end
 
   def subscriptions
@@ -338,7 +338,7 @@ class Carto::User < ActiveRecord::Base
 
   private
 
-  def subscriptions_size_in_bytes(project, estimated: false)
+  def subscriptions_size_in_bytes(project, estimated = false)
     # Note we cannot filter by `project` subscription attribute, we must use the dataset ID.
     subs_filtered = subscriptions.select { |d| d['dataset_id'].split('.')[0] == project }
     subs_synced = subs_filtered.select do |d|
@@ -348,7 +348,7 @@ class Carto::User < ActiveRecord::Base
       total = subs_synced.map { |d| d['estimated_size'] }.reduce(0) { |a, b| a + b }
     else
       synced_tables = subs_synced.map { |d| Carto::UserTable.find_by(id: d['sync_table_id']) }
-      total = synced_tables.map(&:table_size).reduce(0) { |a, b| a + b }
+      total = synced_tables.map { |d| d.table_size }.reduce(0) { |a, b| a + b }
     end
     total || 0
   end


### PR DESCRIPTION
https://app.clubhouse.io/cartoteam/story/121627/add-metrics-i-memory

Add the `subscriptions_premium_estimated_size_in_bytes`  field to `storage` info for /me endpoint. i.e:
```
"storage": {
      "quota_in_bytes": 1281620953,
      "db_size_in_bytes": 44130304,
      "subscriptions_public_size_in_bytes": 0,
      "subscriptions_premium_size_in_bytes": 44130304,
      "subscriptions_premium_estimated_size_in_bytes": 20028222
    },
```