### PR TITLE
Fix loading of CartoDB::PermissionPresenter dependency

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ sudo make install
 - Adding API Keys to Redis when user is unlocked [#15959](https://github.com/CartoDB/cartodb/pull/15959)
 - Bump version of cartodb-common to v0.4.9 and pubsub to 1.10 [#16007](https://github.com/CartoDB/cartodb/pull/16007)
 - Make subscriber wait for DB creation in development [#15982](https://github.com/CartoDB/cartodb/pull/15982)
+- Fix an issue with autoloading of a model class [#16011](https://github.com/CartoDB/cartodb/pull/16011)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/app/models/visualization/presenter.rb
+++ b/app/models/visualization/presenter.rb
@@ -1,4 +1,5 @@
 require_relative './member'
+require_relative '../permission/presenter'
 
 module CartoDB
   module Visualization


### PR DESCRIPTION
The class CartoDB::PermissionPresenter is not following the
folder/module path conventions and the autoloader may not be able to
load it.

Seen in tests (it may depend on execution order):

```
Failures:

  1) Carto::Api::VisualizationsController index returns valid information for a user with one table
     Failure/Error: table1_visualization_hash = table1_visualization.to_hash(
     NameError:
       uninitialized constant CartoDB::PermissionPresenter
     # ./app/models/visualization/presenter.rb:32:in `to_poro'
     # ./app/models/visualization/member.rb:317:in `to_hash'
     # ./spec/requests/carto/api/visualizations_controller_spec_part_1.rb:317:in `block (3 levels) in <top (required)>'

Finished in 15.05 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/requests/carto/api/visualizations_controller_spec_part_1.rb:314 # Carto::Api::VisualizationsController index returns valid information for a user with one table
```

this makes it robust, but the proper fix is to follow the conventions.