### PR TITLE
Make PIDFILE check more resilient

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@ sudo make install
 - Fix an issue with autoloading of a model class [#16011](https://github.com/CartoDB/cartodb/pull/16011)
 - Propagate request_id in MessageBroker logs [#16006](https://github.com/CartoDB/cartodb/pull/16006)
 - Don't report Coverband errors to Rollbar [#16021](https://github.com/CartoDB/cartodb/pull/16021)
+- Make the MessageBroker subscriber PIDFILE check more resilient [#16022](https://github.com/CartoDB/cartodb/pull/16022)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/lib/tasks/central_updates_subscriber.rake
+++ b/lib/tasks/central_updates_subscriber.rake
@@ -1,16 +1,32 @@
 require './lib/carto/subscribers/central_user_commands'
 
+def process_exists?(pid)
+  Process.getpgid(pid)
+  true
+rescue Errno::ESRCH
+  false
+end
+
 namespace :message_broker do
   desc 'Consume messages from subscription "central_cartodb_commands"'
   task cartodb_subscribers: [:environment] do |_task, _args|
+    $stdout.sync = true
+    logger = Carto::Common::Logger.new($stdout)
     pid_file = ENV['PIDFILE'] || Rails.root.join('tmp/pids/cartodb_subscribers.pid')
-    raise "PID file exists: #{pid_file}" if File.exist?(pid_file)
+
+    if File.exist?(pid_file)
+      pid = File.read(pid_file).to_i
+
+      raise "PID file exists: #{pid_file}" if process_exists?(pid)
+
+      # A warning should be better, but let's keep it like so until the MessageBroker is stable enough
+      logger.error(message: 'PID file exists, but process is not running. Removing PID file.')
+      File.delete(pid_file)
+    end
 
     File.open(pid_file, 'w') { |f| f.puts Process.pid }
-    begin
-      $stdout.sync = true
-      logger = Carto::Common::Logger.new($stdout)
 
+    begin
       message_broker = Carto::Common::MessageBroker.new(logger: logger)
       subscription_name = Carto::Common::MessageBroker::Config.instance.central_subscription_name
       subscription = message_broker.get_subscription(subscription_name)


### PR DESCRIPTION
Related https://app.clubhouse.io/cartoteam/story/124557/acceptance-testing-in-staging#activity-126435

## Acceptance in staging

**Case 1**

1. Process was running normally
2. Killed it with `kill -9 4942`
3. Monit detected it. PID file was remaining but process was able to recover:

```json
{"timestamp":"2020-12-17T16:30:10.652+00:00","levelname":"error","cdb-user":null,"event_message":"PID file exists, but process is not running. Removing PID file."}
{"subscription_name":"broker_central_gcp_staging_cloud","timestamp":"2020-12-17T16:30:11.788+00:00","levelname":"info","cdb-user":null,"event_message":"Starting message processing in subscriber"}
{"timestamp":"2020-12-17T16:30:11.793+00:00","levelname":"info","cdb-user":null,"event_message":"Consuming messages from subscription"}
```

**Case 2**

1. Process was running normally
2. Attempted to boot a second subscriber manually:

```bash
[stag] ubuntu@que04:~/www/production.cartodb.com/current$ RAILS_ENV=staging MESSAGE_BROKER_PUBSUB_PROJECT_ID=cartodb-on-gcp-staging MESSAGE_BROKER_CENTRAL_SUBSCRIPTION_NAME=central_gcp_staging_cloud COVERBAND_DISABLE_AUTO_START=true PIDFILE=/home/ubuntu/www/production.cartodb.com/shared/pids/message_broker-cartodb_subscribers.pid bundle exec rake message_broker:cartodb_subscribers
```

3. Process failed to start, as the subscriber is already running:

```
rake aborted!
PID file exists: /home/ubuntu/www/production.cartodb.com/shared/pids/message_broker-cartodb_subscribers.pid

Tasks: TOP => message_broker:cartodb_subscribers
(See full trace by running task with --trace)
```