### PR TITLE
Fix a loop between our logger and rollbar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@ sudo make install
 - Propagate request_id in MessageBroker logs [#16006](https://github.com/CartoDB/cartodb/pull/16006)
 - Don't report Coverband errors to Rollbar [#16021](https://github.com/CartoDB/cartodb/pull/16021)
 - Maps API client now honors 429 Too Many Requests error [#16025](https://github.com/CartoDB/cartodb/pull/16025)
+- Fix a loop between our logger and rollbar [#16026](https://github.com/CartoDB/cartodb/pull/16026)
 - Make the MessageBroker subscriber PIDFILE check more resilient [#16022](https://github.com/CartoDB/cartodb/pull/16022)
 
 4.44.0 (2020-11-20)

--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -7,7 +7,7 @@ Rollbar.configure do |config|
 
   # Avoid a loop between our logger (who sends errors through rollbar)
   # and rollbar itself when it cannot send an error to rollbar service
-  config.defaul_logger = Logger.new(STDERR)
+  config.logger = Logger.new(STDERR)
 
   # Add exception class names to the exception_level_filters hash to
   # change the level that exception is reported at. Note that if an exception

--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -7,7 +7,7 @@ Rollbar.configure do |config|
 
   # Avoid a loop between our logger (who sends errors through rollbar)
   # and rollbar itself when it cannot send an error to rollbar service
-  config.logger = Logger.new(STDERR)
+  config.logger = Logger.new($stderr)
 
   # Add exception class names to the exception_level_filters hash to
   # change the level that exception is reported at. Note that if an exception

--- a/config/initializers/error_notifier.rb
+++ b/config/initializers/error_notifier.rb
@@ -5,6 +5,10 @@ Rollbar.configure do |config|
   config.enabled = (Rails.env.production? || Rails.env.staging?) && config.access_token.present?
   config.net_retries = 1 # This is actually 6 requests (18s), as Rollbar retries two times (failsafes) and CartoDB once
 
+  # Avoid a loop between our logger (who sends errors through rollbar)
+  # and rollbar itself when it cannot send an error to rollbar service
+  config.defaul_logger = Logger.new(STDERR)
+
   # Add exception class names to the exception_level_filters hash to
   # change the level that exception is reported at. Note that if an exception
   # has already been reported and logged the level will need to be changed


### PR DESCRIPTION
See https://app.clubhouse.io/cartoteam/story/126685/infinite-loop-when-rollbar-error-processing

See https://docs.rollbar.com/docs/gem-configuration-reference

> `default_logger`
> What logger to use for printing debugging and informational messages during operation.
> Default: Logger.new(STDERR) or ::Rails.logger when using Rails

> `logger`
> The logger to use instead of the default logger. Especially useful when you wish to send log messages elsewhere.

thanks @amiedes for pointing out