### PR TITLE
Set the number of BQ projects/datsets/tables per page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ sudo make install
 - Add new user metrics to Home page [#15950](https://github.com/CartoDB/cartodb/pull/15950)
 
 ### Bug fixes / enhancements
+- Fix maximum of 50 projects in BQ connector billing project selector [16027](https://github.com/CartoDB/cartodb/pull/16027)
 - Replace DO metadata SQL with API request [#15983](https://github.com/CartoDB/cartodb/pull/15983)
 - Fix update notifications when using password-validated operation [#15960](https://github.com/CartoDB/cartodb/pull/15960)
 - Improve the syncronization functions by using `CDB_GetTableQueries`.

--- a/services/datasources/lib/datasources/url/bigquery.rb
+++ b/services/datasources/lib/datasources/url/bigquery.rb
@@ -12,6 +12,10 @@ module CartoDB
         # Required for all providers
         DATASOURCE_NAME = 'bigquery'
 
+        MAX_PROJECTS = 500000
+        MAX_DATASETS = 500000
+        MAX_TABLES = 500000
+
         # Constructor (hidden)
         # @param config
         # [
@@ -215,13 +219,13 @@ module CartoDB
         end
 
         def list_projects
-          projects = @bigquery_api.list_projects.projects
+          projects = @bigquery_api.list_projects(max_results: MAX_PROJECTS).projects
           return [] unless projects
           projects.map { |p| { id: p.id, friendly_name: p.friendly_name } }
         end
 
         def list_datasets(project_id)
-          datasets = @bigquery_api.list_datasets(project_id).datasets
+          datasets = @bigquery_api.list_datasets(project_id, max_results: MAX_DATASETS).datasets
           if datasets
             datasets.map { |d|
               qualified_name = d.id.gsub(':', '.') # "#{project_id}.#{d.dataset_reference.dataset_id}"
@@ -233,7 +237,7 @@ module CartoDB
         end
 
         def list_tables(project_id, dataset_id)
-          tables = @bigquery_api.list_tables(project_id, dataset_id).tables
+          tables = @bigquery_api.list_tables(project_id, dataset_id, max_results: MAX_DATASETS).tables
           if tables
             tables.map { |t|
               qualified_name = t.id.gsub(':', '.') # "#{project_id}.#{dataset_id}.#{t.table_reference.table_id}"

--- a/services/datasources/lib/datasources/url/bigquery.rb
+++ b/services/datasources/lib/datasources/url/bigquery.rb
@@ -237,7 +237,7 @@ module CartoDB
         end
 
         def list_tables(project_id, dataset_id)
-          tables = @bigquery_api.list_tables(project_id, dataset_id, max_results: MAX_DATASETS).tables
+          tables = @bigquery_api.list_tables(project_id, dataset_id, max_results: MAX_TABLES).tables
           if tables
             tables.map { |t|
               qualified_name = t.id.gsub(':', '.') # "#{project_id}.#{dataset_id}.#{t.table_reference.table_id}"

--- a/services/datasources/lib/datasources/url/bigquery.rb
+++ b/services/datasources/lib/datasources/url/bigquery.rb
@@ -12,9 +12,9 @@ module CartoDB
         # Required for all providers
         DATASOURCE_NAME = 'bigquery'
 
-        MAX_PROJECTS = 500000
-        MAX_DATASETS = 500000
-        MAX_TABLES = 500000
+        MAX_PROJECTS = 500_000
+        MAX_DATASETS = 500_000
+        MAX_TABLES = 500_000
 
         # Constructor (hidden)
         # @param config


### PR DESCRIPTION
See https://app.clubhouse.io/cartoteam/story/125487

We're returning only the first page of paginated responses for BQ projects, datasets and tables.
We could iterate (using the `next_page_token` in the response) to fetch all items in pages, but it seems simpler to set a high enough page size.