### PR TITLE
Update pubsub to 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :assets do
   gem "compass",               "1.0.3"
 end
 
-gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.5.1'
+gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', branch: 'chore/ch128685/update-pubsub-ruby-clients-to-2-3-0'
 gem 'roo',                     '1.13.2'
 gem 'state_machines-activerecord', '~> 0.5.0'
 gem 'typhoeus',                '1.3.1'
@@ -62,7 +62,7 @@ gem 'dbf',                     '2.0.6'
 gem 'google-api-client',       '0.34.1'
 gem 'dropbox_api',             '0.1.17'
 gem 'gibbon',                  '1.1.4'
-gem 'google-cloud-pubsub', '~> 1.10'
+gem 'google-cloud-pubsub', '~> 2.3'
 gem 'instagram-continued-continued'
 gem 'virtus',                   '1.0.5'
 gem 'email_address',            '~> 0.1.11'

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ group :assets do
   gem "compass",               "1.0.3"
 end
 
-gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', branch: 'chore/ch128685/update-pubsub-ruby-clients-to-2-3-0'
+gem 'cartodb-common', git: 'https://github.com/cartodb/cartodb-common.git', tag: 'v0.5.3'
 gem 'roo',                     '1.13.2'
 gem 'state_machines-activerecord', '~> 0.5.0'
 gem 'typhoeus',                '1.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/cartodb/cartodb-common.git
-  revision: 2b7a0d13988e1bde309e23ac39489b93b35a9a24
-  branch: chore/ch128685/update-pubsub-ruby-clients-to-2-3-0
+  revision: 626bc3bb7cd2edfdd3f0a7b9236dddbb7fccfee5
+  tag: v0.5.3
   specs:
-    cartodb-common (0.5.2)
+    cartodb-common (0.5.3)
       argon2 (~> 2)
       google-cloud-pubsub (~> 2.3)
       rails (>= 4, < 6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,12 @@ GIT
 
 GIT
   remote: https://github.com/cartodb/cartodb-common.git
-  revision: bc046f0516831af6811f9cfd5748f659d104f1ba
-  tag: v0.5.1
+  revision: 2b7a0d13988e1bde309e23ac39489b93b35a9a24
+  branch: chore/ch128685/update-pubsub-ruby-clients-to-2-3-0
   specs:
-    cartodb-common (0.5.1)
+    cartodb-common (0.5.2)
       argon2 (~> 2)
-      google-cloud-pubsub (~> 1.10)
+      google-cloud-pubsub (~> 2.3)
       rails (>= 4, < 6)
       rollbar
 
@@ -174,8 +174,8 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    gapic-common (0.2.1)
-      google-protobuf (~> 3.2)
+    gapic-common (0.3.4)
+      google-protobuf (~> 3.12, >= 3.12.2)
       googleapis-common-protos (>= 1.3.9, < 2.0)
       googleapis-common-protos-types (>= 1.0.4, < 2.0)
       googleauth (~> 0.9)
@@ -205,19 +205,14 @@ GEM
     google-cloud-env (1.3.0)
       faraday (~> 0.11)
     google-cloud-errors (1.0.1)
-    google-cloud-pubsub (1.10.0)
+    google-cloud-pubsub (2.3.0)
       concurrent-ruby (~> 1.1)
-      google-cloud-core (~> 1.2)
-      google-gax (~> 1.8)
-      googleapis-common-protos (>= 1.3.9, < 2.0)
-      googleapis-common-protos-types (>= 1.0.4, < 2.0)
-      grpc-google-iam-v1 (~> 0.6.9)
-    google-gax (1.8.1)
-      google-protobuf (~> 3.9)
-      googleapis-common-protos (>= 1.3.9, < 2.0)
-      googleauth (~> 0.9)
-      grpc (~> 1.24)
-      rly (~> 0.2.3)
+      google-cloud-core (~> 1.5)
+      google-cloud-pubsub-v1 (~> 0.0)
+    google-cloud-pubsub-v1 (0.2.0)
+      gapic-common (~> 0.3)
+      google-cloud-errors (~> 1.0)
+      grpc-google-iam-v1 (>= 0.6.10, < 2.0)
     google-protobuf (3.14.0)
     googleapis-common-protos (1.3.10)
       google-protobuf (~> 3.11)
@@ -377,7 +372,6 @@ GEM
       resque (~> 1.19)
     retriable (3.1.2)
     rexml (3.2.4)
-    rly (0.2.3)
     rollbar (3.1.1)
     roo (1.13.2)
       nokogiri
@@ -552,7 +546,7 @@ DEPENDENCIES
   gibbon (= 1.1.4)
   google-api-client (= 0.34.1)
   google-cloud-bigquery-storage-v1 (~> 0.2.3)
-  google-cloud-pubsub (~> 1.10)
+  google-cloud-pubsub (~> 2.3)
   hiredis (~> 0.6.1)
   instagram-continued-continued
   json-schema (= 2.1.9)

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ sudo make install
 - Make the MessageBroker subscriber PIDFILE check more resilient [#16022](https://github.com/CartoDB/cartodb/pull/16022)
 - Bump version of lib/sql submodule to 0.37.1
 - Public profile can be disabled via Feature Flag [#15982](https://github.com/CartoDB/cartodb/pull/15995)
+- Update cartodb-common to v0.5.3, which in turns udpates pubsub to 2.3.0 [#16038](https://github.com/CartoDB/cartodb/pull/16038)
 - Migrate Organization CRUD to MessageBroker [#15934](https://github.com/CartoDB/cartodb/pull/15934)
 
 4.44.0 (2020-11-20)


### PR DESCRIPTION
Update pubsub to ~> 2.3 and some other dependencies. In particular I
had to update `gapic` manually in order to solve a conflict, by issuing
the following:

    bundle update gapic-common

A more aggressive update can be performed with `bundle update` (no
extra gem) but did not want to run the risk (it can be done in a
latter PR).

Related to https://github.com/CartoDB/cartodb-common/pull/36 that should be merged and released first (after passing the tests), then make this point to the next tagged version.