### PR TITLE
Migrate Organization CRUD actions started by CartoDB

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@ sudo make install
 - Update cartodb-common, which in turns updates the MessageBroker to send a `publisher_validation_token` [#16041](https://github.com/CartoDB/cartodb/pull/16041)
 - Optimize dashboard loading when the number of datasets is very large [#16014](https://github.com/CartoDB/cartodb/pull/16014)
 - 429 error when multiple datasets are requested to be deleted [#15931](https://github.com/CartoDB/cartodb/pull/15931)
+- Migrate Organization CRUD actions started by CartoDB to Message Broker [#16062](https://github.com/CartoDB/cartodb/pull/16062)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/app/models/carto/helpers/user_commons.rb
+++ b/app/models/carto/helpers/user_commons.rb
@@ -440,4 +440,22 @@ module Carto::UserCommons
     end
     payload
   end
+
+  def delete_in_central
+    unless Cartodb::Central.sync_data_with_cartodb_central?
+      log_central_unavailable
+      return true
+    end
+
+    if organization.nil?
+      cartodb_central_client.delete_user(username)
+    else
+      raise "Can't destroy the organization owner" if organization.owner == self
+
+      cartodb_central_client.delete_organization_user(organization.name, username)
+    end
+
+    true
+  end
+
 end

--- a/app/models/carto/organization.rb
+++ b/app/models/carto/organization.rb
@@ -216,13 +216,6 @@ module Carto
     # INFO: replacement for destroy because destroying owner triggers
     # organization destroy
     def destroy_cascade(delete_in_central: false)
-      # This remains commented because we consider that enabling this for users at SaaS is unnecessary and risky.
-      # Nevertheless, code remains, _just in case_. More info at https://github.com/CartoDB/cartodb/issues/12049
-      # Central branch: 1764-Allow_updating_inactive_users
-      # Central asks for usage information before deleting, so organization must be first deleted there
-      # Corollary: you need multithreading for organization to work if you run Central
-      # self.delete_in_central if delete_in_central
-
       groups.each(&:destroy_group_with_extension)
       destroy_non_owner_users
       owner ? owner.sequel_user.destroy_cascade : destroy

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -59,8 +59,14 @@ module CartodbCentralSynchronizable
         cartodb_central_client.update_user(username, allowed_attributes_to_central(:update))
       end
     elsif organization?
-      cartodb_central_client.update_organization(name, allowed_attributes_to_central(:update))
+      Carto::Common::MessageBroker.new(logger: Rails.logger)
+                                  .get_topic(:cartodb_central)
+                                  .publish(
+                                    :update_organization,
+                                    { organization: allowed_attributes_to_central(:update) }
+                                  )
     end
+
     true
   end
 
@@ -128,7 +134,7 @@ module CartodbCentralSynchronizable
         allowed_attributes = %i(seats viewer_seats display_name description website discus_shortname twitter_username
                                 auth_username_password_enabled auth_google_enabled password_expiration_in_d
                                 inherit_owner_ffs)
-        attributes.symbolize_keys.slice(*allowed_attributes)
+        attributes.symbolize_keys.slice(*allowed_attributes).merge(name: name)
       end
     elsif user?
       allowed_attributes = %i(

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -64,30 +64,6 @@ module CartodbCentralSynchronizable
     true
   end
 
-  def delete_in_central
-    unless Cartodb::Central.sync_data_with_cartodb_central?
-      log_central_unavailable
-      return true
-    end
-
-    if user?
-      if organization.nil?
-        cartodb_central_client.delete_user(username)
-      else
-        raise "Can't destroy the organization owner" if organization.owner == self
-
-        cartodb_central_client.delete_organization_user(organization.name, username)
-      end
-    elsif organization?
-      # See Organization#destroy_cascade
-      raise 'Delete organizations is not allowed' if Carto::Configuration.saas?
-
-      cartodb_central_client.delete_organization(name)
-    end
-
-    true
-  end
-
   def allowed_attributes_from_central(action)
     if organization?
       case action

--- a/app/views/admin/organizations/settings.html.erb
+++ b/app/views/admin/organizations/settings.html.erb
@@ -188,22 +188,6 @@
       </div>
     <% end %>
 
-    <% if !saas? && current_user.organization_owner? %>
-        <div class="FormAccount-title">
-          <p class="FormAccount-titleText">Delete organization</p>
-        </div>
-
-        <span class="FormAccount-separator"></span>
-
-        <div class="FormAccount-row FormAccount-row--wideMarginBottom">
-          <div class="FormAccount-rowLabel">
-            <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">Are you sure?</label>
-          </div>
-          <div class="FormAccount-rowData">
-            <span class="FormAccount-button--deleteOrganization CDB-Size-medium js-deleteOrganization">Delete organization, including all users and data</span>
-          </div>
-        </div>
-    <% end %>
   </div>
 <% end %>
 

--- a/lib/carto/configuration.rb
+++ b/lib/carto/configuration.rb
@@ -71,10 +71,6 @@ module Carto
       (config && config['custom_paths'] && config['custom_paths']['views']) || Array.new
     end
 
-    def saas?
-      Cartodb.config[:cartodb_com_hosted] == false
-    end
-
     def geocoder_config
       {
         provider: Cartodb.get_config(:geocoder, 'search_bar_provider'),
@@ -82,11 +78,6 @@ module Carto
         tomtom: Cartodb.get_config(:geocoder, 'tomtom')
       }
     end
-
-    # Make some methods available. Remember that this sets methods as private.
-    # More information: https://idiosyncratic-ruby.com/8-self-improvement.html
-    # This is the chosen approach to avoid including `Configuration` all over the place. Check #12757
-    module_function :saas?
 
     private
 

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -154,13 +154,6 @@ module Cartodb
       cartodb_central_topic.publish(:update_organization, payload)
     end
 
-    def delete_organization(organization_name)
-      payload = {
-        organization_name: organization_name
-      }
-      cartodb_central_topic.publish(:delete_organization, payload)
-    end
-
     ############################################################################
     # Mobile apps
 

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -138,13 +138,6 @@ module Cartodb
       send_request("api/organizations/#{ organization_name }", nil, :get, [200])
     end
 
-    def update_organization(organization_name, organization_attributes)
-      payload = {
-        organization_name: organization_name
-      }.merge(organization_attributes)
-      cartodb_central_topic.publish(:update_organization, payload)
-    end
-
     ############################################################################
     # Mobile apps
 

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -138,15 +138,6 @@ module Cartodb
       send_request("api/organizations/#{ organization_name }", nil, :get, [200])
     end
 
-    # Returns remote organization attributes if response code is 201
-    # otherwise returns nil
-    # luisico asks: Not sure why organization_name is passed to this method. It's not used
-    # rilla answers: That's right, but this methods is just a stub: org creation from the editor is still unsupported
-    def create_organization(organization_name, organization_attributes)
-      body = {organization: organization_attributes}
-      send_request("api/organizations", body, :post, [201])
-    end
-
     def update_organization(organization_name, organization_attributes)
       payload = {
         organization_name: organization_name


### PR DESCRIPTION
Story details: https://app.clubhouse.io/cartoteam/story/128509

Related PR in Central: https://github.com/CartoDB/cartodb-central/pull/3026

## What does this PR do?

- Removes logic associated with Organization creation/deletion launched from Builder. Currently we're always starting these processes from Central, so we've decided to remove this legacy code to make maintenance easier.
- Adapts the payload for the `update_organization` event