### PR TITLE
Raise limit of Box files listed to 2000

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ sudo make install
 - Add new user metrics to Home page [#15950](https://github.com/CartoDB/cartodb/pull/15950)
 - Replace CRUD user operations in Central API client by publishing messages to the Message Broker [#16035](https://github.com/CartoDB/cartodb/pull/16035)
 ### Bug fixes / enhancements
+- Raise limit of Box files [16080](https://github.com/CartoDB/cartodb/pull/16080)
 - Change url Map Loads docs. in quota section [16068](https://github.com/CartoDB/cartodb/pull/16068)
 - Rake task for renaming BQ connector [16030](https://github.com/CartoDB/cartodb/pull/16030)
 - Fix maximum of 50 projects in BQ connector billing project selector [16027](https://github.com/CartoDB/cartodb/pull/16027)

--- a/services/datasources/lib/datasources/url/box.rb
+++ b/services/datasources/lib/datasources/url/box.rb
@@ -382,7 +382,7 @@ module CartoDB
                                  ancestor_folder_ids: nil,
                                  content_types: nil,
                                  type: nil,
-                                 limit: 200,
+                                 limit: 2000,
                                  offset: 0)
 
           result = result.map { |i| format_item_data(i) }.sort { |x, y| y[:updated_at] <=> x[:updated_at] }


### PR DESCRIPTION
See https://app.clubhouse.io/cartoteam/story/132192/justice-nyc-gov-not-able-to-list-200-datasets-in-box-connector
