### PR TITLE
Run CI using E2_HIGHCPU_32 instead of N1_HIGHCPU_32

### DIFF
--- a/script/ci/cloudbuild-new-pr-pg11.yaml
+++ b/script/ci/cloudbuild-new-pr-pg11.yaml
@@ -95,5 +95,5 @@ steps:
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}
 options:
-    machineType: 'E2_HIGHCPU_32'
+    machineType: 'E2_HIGHCPU_8'
 timeout: 3600s

--- a/script/ci/cloudbuild-new-pr-pg11.yaml
+++ b/script/ci/cloudbuild-new-pr-pg11.yaml
@@ -95,5 +95,5 @@ steps:
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}
 options:
-    machineType: 'N1_HIGHCPU_32'
+    machineType: 'E2_HIGHCPU_32'
 timeout: 3600s

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -108,5 +108,5 @@ steps:
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}
 options:
-    machineType: 'N1_HIGHCPU_32'
+    machineType: 'E2_HIGHCPU_32'
 timeout: 3600s

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -108,5 +108,5 @@ steps:
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}
 options:
-    machineType: 'E2_HIGHCPU_32'
+    machineType: 'E2_HIGHCPU_8'
 timeout: 3600s


### PR DESCRIPTION
with `E2_HIGHCPU_32`
```
cartodb-backend-PR-testing-pg12 -> 17 min 11 sec 
cartodb-backend-PR-testing-pg11 -> 20 min 3 sec 
```

with `N1_HIGHCPU_32` (latest master build)
```
cartodb-backend-PR-testing-pg12 -> 19 min 9 sec
cartodb-backend-PR-testing-pg11 -> 19 min 55 sec 
```

~Running CI for 10 hours/day the saving would be 80$/month according to [GCP calculator](https://cloud.google.com/products/calculator#id=23563bfd-e957-4738-9828-9dd732c565ff)~ according to GCB docs they offer both instance types at the same price for GCB, so general pricing doesn't apply