### PR TITLE
add git tags and docker labels

### DIFF
--- a/script/ci/cloudbuild-new-build-master.yaml
+++ b/script/ci/cloudbuild-new-build-master.yaml
@@ -80,7 +80,7 @@ steps:
         echo '** Push to master **'
         
         echo 'Pulling latest image...'
-        IMAGE_LABELS="--label org.opencontainers.image.created=$(date --rfc-3339=seconds) --label org.opencontainers.image.revision=${COMMIT_SHA}"
+        IMAGE_LABELS="--label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
         
         docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
         docker build ${IMAGE_LABELS} --build-arg BUNDLE_JOBS=4 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:latest .

--- a/script/ci/cloudbuild-new-build-master.yaml
+++ b/script/ci/cloudbuild-new-build-master.yaml
@@ -80,10 +80,12 @@ steps:
         echo '** Push to master **'
         
         echo 'Pulling latest image...'
+        IMAGE_LABELS="--label org.opencontainers.image.created=$(date --rfc-3339=seconds) --label org.opencontainers.image.revision=${COMMIT_SHA}"
+        
         docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
-        docker build --build-arg BUNDLE_JOBS=4 --build-arg COMPILE_ASSETS=true -t gcr.io/cartodb-on-gcp-main-artifacts/builder:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:latest .
-        docker build -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}  -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}--${SHORT_SHA}   -f Dockerfile.resque .
-        docker build -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME}--${SHORT_SHA}  -f Dockerfile.subscriber .
+        docker build ${IMAGE_LABELS} --build-arg BUNDLE_JOBS=4 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:latest .
+        docker build ${IMAGE_LABELS} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}  -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}--${SHORT_SHA}   -f Dockerfile.resque .
+        docker build ${IMAGE_LABELS} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME}--${SHORT_SHA}  -f Dockerfile.subscriber .
         
         echo 'Pushing builder image...'
         docker push gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}
@@ -102,6 +104,18 @@ steps:
         docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA}
         docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME}--${SHORT_SHA}
         docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:latest
+
+        if [ ! -z "${TAG_NAME}" ]
+        then
+          echo "Tagging image with git tag: $TAG_NAME ..."
+          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder:${TAG_NAME}
+          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${TAG_NAME}
+          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${TAG_NAME}
+          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder:${TAG_NAME}
+          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${TAG_NAME}
+          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${TAG_NAME}
+        fi
+
       else
         echo '** Skipping, this is not a push to master **'
       fi

--- a/script/ci/cloudbuild-new-build-master.yaml
+++ b/script/ci/cloudbuild-new-build-master.yaml
@@ -83,7 +83,7 @@ steps:
         IMAGE_LABELS="--label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
         
         docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
-        docker build ${IMAGE_LABELS} --build-arg BUNDLE_JOBS=4 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:latest .
+        docker build ${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=4 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:latest .
         docker build ${IMAGE_LABELS} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}  -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${BRANCH_NAME}--${SHORT_SHA}   -f Dockerfile.resque .
         docker build ${IMAGE_LABELS} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:latest -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${BRANCH_NAME}--${SHORT_SHA}  -f Dockerfile.subscriber .
         

--- a/script/ci/cloudbuild-new-pr-pg11.yaml
+++ b/script/ci/cloudbuild-new-pr-pg11.yaml
@@ -85,7 +85,7 @@ steps:
 
 # Run tests
 - name: 'docker/compose:1.22.0'
-  args: ['-f', 'docker-compose-pg11.yml', 'up', 'q--build', '-d']
+  args: ['-f', 'docker-compose-pg11.yml', 'up', '--build', '-d']
   timeout: 900s
 
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-new-pr-pg11.yaml
+++ b/script/ci/cloudbuild-new-pr-pg11.yaml
@@ -63,7 +63,6 @@ steps:
     - |
       cp private/script/ci/* .
       cp private/Dockerfile .
-      cp -r private/build_resources/ .
       cp script/ci/* .
       cp config/app_config.yml.sample config/app_config.yml
       cp config/database.yml.sample config/database.yml

--- a/script/ci/cloudbuild-new-pr-pg11.yaml
+++ b/script/ci/cloudbuild-new-pr-pg11.yaml
@@ -69,7 +69,7 @@ steps:
       cp config/database.yml.sample config/database.yml
       cp lib/assets/javascripts/cdb/secrets.example.json lib/assets/javascripts/cdb/secrets.json
 
-# Build image
+# Build image, we don't compile assets here, since they are not required for tests and the image is not pushed to the registry
 - name: gcr.io/cloud-builders/docker
   entrypoint: /bin/bash
   args:
@@ -82,7 +82,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}
         fi
-      docker build --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} .
+      docker build --build-arg COMPILE_ASSETS=false --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} .
 
 # Run tests
 - name: 'docker/compose:1.22.0'

--- a/script/ci/cloudbuild-new-pr-pg11.yaml
+++ b/script/ci/cloudbuild-new-pr-pg11.yaml
@@ -69,7 +69,7 @@ steps:
       cp config/database.yml.sample config/database.yml
       cp lib/assets/javascripts/cdb/secrets.example.json lib/assets/javascripts/cdb/secrets.json
 
-# Build image
+# Build image, we don't compile assets here, since they are not required for tests and the image is not pushed to the registry
 - name: gcr.io/cloud-builders/docker
   entrypoint: /bin/bash
   args:
@@ -82,11 +82,11 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}
         fi
-      docker build --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} .
+      docker build --build-arg COMPILE_ASSETS=false --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} .
 
 # Run tests
 - name: 'docker/compose:1.22.0'
-  args: ['-f', 'docker-compose-pg11.yml', 'up', '--build', '-d']
+  args: ['-f', 'docker-compose-pg11.yml', 'up', 'q--build', '-d']
   timeout: 900s
 
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-new-pr-pg11.yaml
+++ b/script/ci/cloudbuild-new-pr-pg11.yaml
@@ -69,7 +69,7 @@ steps:
       cp config/database.yml.sample config/database.yml
       cp lib/assets/javascripts/cdb/secrets.example.json lib/assets/javascripts/cdb/secrets.json
 
-# Build image, we don't compile assets here, since they are not required for tests and the image is not pushed to the registry
+# Build image
 - name: gcr.io/cloud-builders/docker
   entrypoint: /bin/bash
   args:
@@ -82,7 +82,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}
         fi
-      docker build --build-arg COMPILE_ASSETS=false --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} .
+      docker build --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} .
 
 # Run tests
 - name: 'docker/compose:1.22.0'

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -72,6 +72,7 @@ steps:
 # Build image
 - name: gcr.io/cloud-builders/docker
   entrypoint: /bin/bash
+  env
   args:
     - -cx
     - |
@@ -81,8 +82,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
         fi
-      IMAGE_LABELS="--label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
-      docker build ${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      docker build ${_IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker
@@ -108,6 +108,7 @@ steps:
 
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}
+    _IMAGE_LABELS: --label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'
 options:
     machineType: 'N1_HIGHCPU_32'
 timeout: 3600s

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -81,7 +81,8 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
         fi
-      docker build --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      IMAGE_LABELS="--label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
+      docker build ${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -81,8 +81,8 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
-      IMAGE_LABELS="--label org.opencontainers.image.created=\"$$(date --rfc-3339=seconds)\" --label org.opencontainers.image.revision='${COMMIT_SHA}'"
-      docker build $${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      IMAGE_LABELS="--label org.opencontainers.image.created=\"$(date --rfc-3339=seconds)\" --label org.opencontainers.image.revision='${COMMIT_SHA}'"
+      docker build ${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -72,7 +72,6 @@ steps:
 # Build image
 - name: gcr.io/cloud-builders/docker
   entrypoint: /bin/bash
-  env
   args:
     - -cx
     - |

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -81,7 +81,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
-      IMAGE_LABELS=--label="org.opencontainers.image.created=$$(date --rfc-3339=seconds)" --label="org.opencontainers.image.revision=${COMMIT_SHA}"
+      IMAGE_LABELS="--label=\"org.opencontainers.image.created=$$(date --rfc-3339=seconds)\" --label=\"org.opencontainers.image.revision=${COMMIT_SHA}\""
       docker build $${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -81,9 +81,8 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
-      date --rfc-3339=seconds
-      exit 1
-      docker build --label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}' --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      IMAGE_LABELS="--label org.opencontainers.image.created='$$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
+      docker build $${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -107,7 +107,7 @@ steps:
 
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}
-    _IMAGE_LABELS: --label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'
+    _IMAGE_LABELS: "--label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
 options:
     machineType: 'N1_HIGHCPU_32'
 timeout: 3600s

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -81,8 +81,8 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
-      IMAGE_LABELS="--label org.opencontainers.image.created=\"$(date --rfc-3339=seconds)\" --label org.opencontainers.image.revision='${COMMIT_SHA}'"
-      docker build ${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      IMAGE_LABELS=--label="org.opencontainers.image.created=$$(date --rfc-3339=seconds)" --label="org.opencontainers.image.revision=${COMMIT_SHA}"
+      docker build $${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -82,7 +82,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}
         fi
-      docker build --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} .
+      docker build --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${BRANCH_NAME} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -81,7 +81,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
-      IMAGE_LABELS="--label org.opencontainers.image.created='$$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
+      IMAGE_LABELS="--label org.opencontainers.image.created=\"$$(date --rfc-3339=seconds)\" --label org.opencontainers.image.revision='${COMMIT_SHA}'"
       docker build $${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -80,8 +80,9 @@ steps:
         then
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
-        fi
-      docker build ${_IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      fi
+      IMAGE_LABELS="--label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
+      docker build ${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker
@@ -107,7 +108,6 @@ steps:
 
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}
-    _IMAGE_LABELS: "--label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
 options:
     machineType: 'N1_HIGHCPU_32'
 timeout: 3600s

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -81,6 +81,8 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
+      date --rfc-3339=seconds
+      exit 1
       docker build --label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}' --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -81,8 +81,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
-      IMAGE_LABELS="--label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}'"
-      docker build ${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      docker build --label org.opencontainers.image.created='$(date --rfc-3339=seconds)' --label org.opencontainers.image.revision='${COMMIT_SHA}' --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-new-pr-pg12.yaml
+++ b/script/ci/cloudbuild-new-pr-pg12.yaml
@@ -63,7 +63,6 @@ steps:
     - |
       cp private/script/ci/* .
       cp private/Dockerfile .
-      cp -r private/build_resources/ .
       cp script/ci/* .
       cp config/app_config.yml.sample config/app_config.yml
       cp config/database.yml.sample config/database.yml
@@ -81,8 +80,7 @@ steps:
           docker pull gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
-      IMAGE_LABELS="--label=\"org.opencontainers.image.created=$$(date --rfc-3339=seconds)\" --label=\"org.opencontainers.image.revision=${COMMIT_SHA}\""
-      docker build $${IMAGE_LABELS} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+      docker build --label="org.opencontainers.image.created=$$(date --rfc-3339=seconds)" --label=org.opencontainers.image.revision=${COMMIT_SHA} --build-arg COMPILE_ASSETS=true --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
 
 # Push current branch image to registry
 - name: gcr.io/cloud-builders/docker


### PR DESCRIPTION
- Adding docker labels for images (following [opencontainers standard](https://github.com/opencontainers/image-spec/blob/master/annotations.md)):
  - commit_sha
  - creation_date
- Pushing git tags when present
- Specify `--build-arg COMPILE_ASSETS` in all workflows 
- Fix substitutions issue while applying labels (TLDR; you need to use double `$$` when doing var substitution in bash, if `substitutions` is enabled on the build): 
Following this article: https://medium.com/@davidstanke/mastering-google-cloud-build-config-syntax-8c3024607daf and thanks to @ManuelLR too!
```
Step 48/49 : LABEL org.opencontainers.image.created=2021-02-08 11:03:27+00:00
Step #7:  ---> Running in 9f07bb23cc88
Step #7: Removing intermediate container 9f07bb23cc88
Step #7:  ---> e9be851aeb46
Step #7: Step 49/49 : LABEL org.opencontainers.image.revision=2734f7869364cd93a92555672b95a818b848b84f
Step #7:  ---> Running in c3fac785f123
```
