### PR TITLE
test: docker mem limits

### DIFF
--- a/script/ci/cloudbuild-build-master.yaml
+++ b/script/ci/cloudbuild-build-master.yaml
@@ -5,7 +5,7 @@ steps:
   entrypoint: /bin/bash
   args:
   - '-c'
-  - 'gcloud builds list --ongoing --filter="buildTriggerId=70299e98-eed0-4fc6-943b-b8a5e0cf2aca AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
+  - 'gcloud builds list --ongoing --filter="buildTriggerId=6d19ac2c-1e62-4d92-b42e-ed6753d476d8 AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
 
 - name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash

--- a/script/ci/cloudbuild-build-pr-branch.yaml
+++ b/script/ci/cloudbuild-build-pr-branch.yaml
@@ -5,7 +5,7 @@ steps:
   entrypoint: /bin/bash
   args:
   - '-c'
-  - 'gcloud builds list --ongoing --filter="buildTriggerId=70299e98-eed0-4fc6-943b-b8a5e0cf2aca AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
+  - 'gcloud builds list --ongoing --filter="buildTriggerId=e460656e-80d0-4886-b3ec-2098cadbb3a0 AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
 
 - name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash

--- a/script/ci/cloudbuild-build-pr-branch.yaml
+++ b/script/ci/cloudbuild-build-pr-branch.yaml
@@ -66,8 +66,6 @@ steps:
       cp config/database.yml.sample config/database.yml
       cp lib/assets/javascripts/cdb/secrets.example.json lib/assets/javascripts/cdb/secrets.json
 
-
-
 # Build and push image
 - name: gcr.io/cloud-builders/docker
   entrypoint: /bin/bash
@@ -99,24 +97,6 @@ steps:
       docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${_BRANCH_TAG}
       docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA}
       docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${_BRANCH_TAG}--${SHORT_SHA}
-
-      if [ "${_BRANCH_TAG}" == 'master' ]
-      then
-        docker push gcr.io/cartodb-on-gcp-main-artifacts/builder:latest
-        docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:latest
-        docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:latest
-      fi
-
-      if [ ! -z "${TAG_NAME}" ]
-        then
-          echo "Tagging image with git tag: $TAG_NAME ..."
-          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder:${TAG_NAME}
-          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${TAG_NAME}
-          docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${SHORT_SHA} gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${TAG_NAME}
-          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder:${TAG_NAME}
-          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-resque:${TAG_NAME}
-          docker push gcr.io/cartodb-on-gcp-main-artifacts/builder-subscriber:${TAG_NAME}
-      fi
 
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}

--- a/script/ci/cloudbuild-tests-pr-pg12.yaml
+++ b/script/ci/cloudbuild-tests-pr-pg12.yaml
@@ -5,7 +5,7 @@ steps:
   entrypoint: /bin/bash
   args:
   - '-c'
-  - 'gcloud builds list --ongoing --filter="buildTriggerId=e323286e-7003-4480-ae34-677e597ce4dc AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
+  - 'gcloud builds list --ongoing --filter="buildTriggerId=e983e3b9-109f-43a3-82b2-b312e42c878e AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
 
 - name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
@@ -89,10 +89,9 @@ steps:
 
 - name: gcr.io/cloud-builders/docker
   args: ['exec', '-i', 'builder_1', 'bash', '-c', '/cartodb/runParallelTests.sh 24' ]
-  timeout: 3000s
 
 substitutions: 
     _BRANCH_TAG: ${BRANCH_NAME//\//-}
 options:
     machineType: 'N1_HIGHCPU_32'
-timeout: 3600s
+timeout: 2400s


### PR DESCRIPTION
- Related: https://app.clubhouse.io/cartoteam/story/137764/cartodb-backend-tests-failing-after-long-time
- Testing with docker-compose memory limits for services in order to fix parallel tests failing due to (probably) memory issues on the host.
- Testing introducing resource definitions in compose for redis:
```
    deploy:
      resources:
        limits:
          memory: 512M
        reservations:
          memory: 128M
```
- Tests are not failing this way, and are taking ~20 min (current avg time). The bulk fail behaviour does not occur this way.
- Also updating old trigger ids.
- Removing unneeded logic from branch PR build.