### PR TITLE
[ch127270] Remove temp import table on "IncompatibleSchemas" exception

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@ sudo make install
 - Upgrade deck.gl version [#16072](https://github.com/CartoDB/cartodb/pull/16072)
 - Configure Dead Lettering & prevent flooding of map views messages [#16059](https://github.com/CartoDB/cartodb/pull/16059)
 - Revamp specs for Message Broker commands and remove old endpoints [#16084](https://github.com/CartoDB/cartodb/pull/16084)
+- Remove temp import tables when the IncompatibleSchemas exception is raised [#16181](https://github.com/CartoDB/cartodb/pull/16181)
 - Prevent rspec from being executed in any env other than test [#16128](https://github.com/CartoDB/cartodb/pull/16128)
 - Add groups to v4/me endpoint [#16105](https://github.com/CartoDB/cartodb/pull/16105)
 - Add deprecation warning for DO analysis in builder and hide option when user creation is later than deprecation notice date [#16118](https://github.com/CartoDB/cartodb/pull/16118)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -136,6 +136,9 @@ module CartoDB
         persist_metadata(name, data_import_id, overwrite)
 
         log("Table '#{name}' registered")
+      rescue ::CartoDB::Importer2::IncompatibleSchemas => exception
+        drop("#{ORIGIN_SCHEMA}.#{result.table_name}")
+        raise exception
       rescue StandardError => exception
         if exception.message =~ /canceling statement due to statement timeout/i
           drop("#{ORIGIN_SCHEMA}.#{result.table_name}")


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/137270/xplornet-disk-usage-keeps-growing-and-growing)

### Context

- When you try to import a file using the `overwrite` collision strategy, the exception `::CartoDB::Importer2::IncompatibleSchemas` could be raised if the schemas are incompatible (for example if the type of one column has changed). When this happens, the process is stopped, and it is registered as a `2012` error. But the temporal table `cdb_importer.<table_name>` is never removed.
- This has been generating some storing issues, so the idea is to remove the temporal table when this exception is raised, like when the [timeout exception is raised](https://github.com/CartoDB/cartodb/blob/master/app/connectors/importer.rb#L141).

### Changes

- Rescue the `::CartoDB::Importer2::IncompatibleSchemas` exception and remove the temporal table before continue.