### PR TITLE
[ch140037] Error querying datasets using OAuth scopes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,7 @@ sudo make install
 - Bump version of lib/sql submodule to 0.37.1
 - Public profile can be disabled via Feature Flag [#15982](https://github.com/CartoDB/cartodb/pull/15995)
 - Update cartodb-common to v0.5.3, which in turns udpates pubsub to 2.3.0 [#16038](https://github.com/CartoDB/cartodb/pull/16038)
+- Select distinct permissions on OAuth all datasets scope [#16196](https://github.com/CartoDB/cartodb/pull/16196)
 - Migrate Organization CRUD to MessageBroker [#15934](https://github.com/CartoDB/cartodb/pull/15934)
 - Update cartodb-common, which in turns updates the MessageBroker to send a `publisher_validation_token` [#16041](https://github.com/CartoDB/cartodb/pull/16041)
 - Optimize dashboard loading when the number of datasets is very large [#16014](https://github.com/CartoDB/cartodb/pull/16014)


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/140037/site-planning-admin-error-querying-datasets-using-oauth-scopes)

### Context

- The table `information_schema.role_table_grants` has the information about the table grants for each role, but when a user has double permissions for the same table, and you try to log in using the ["all datasets scope" scope](https://github.com/CartoDB/cartodb/pull/15905) via Oauth, the permissions are misinterpreted, and you get the same result as if you don't have permissions.
- That happens, for example, when a user is the owner of a table and at the same time belongs to a group with read permission on that table. When the permissions are aggregated [here](https://github.com/CartoDB/cartodb/blob/master/app/models/carto/user_db_service.rb#L171), if for example two roles are giving read permission, and one of them write permission, the result is the `mode` attribute being `rrw`.
- When this comes to the [`combined_permissions` method](https://github.com/CartoDB/cartodb/blob/master/lib/carto/oauth_provider/scopes/all_datasets_scope.rb#L69), the value `rrw` is not expected (only `r` or `rw`), so the method concludes with an empty array as permissions for the user.

### Alternative approach

- If the `Arel` query is considered too complex, there is another approach, just **replacing the `combined_permissions` method for this one**:
```ruby
        def combined_permissions(table_mode)
          PERMISSIONS[(permission_key.to_s.chars & table_mode.to_s.chars).join.to_sym] || []
        end
```
This way, you are intersecting the permissions from `table_mode` and `permission_key` (and removing duplicates).

### Changes

- Update the query in order to remove duplicates, just selecting one time the same permission type by table and schema names.