### PR TITLE
[ch140705] Sanitize column names on overwrite import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,7 @@ sudo make install
 - Prevent a possible `PG::UndefinedFunction` error on DB creation [#16174](https://github.com/CartoDB/cartodb/pull/16174)
 - Add groups to v4/me endpoint [#16105](https://github.com/CartoDB/cartodb/pull/16105)
 - Add deprecation warning for DO analysis in builder and hide option when user creation is later than deprecation notice date [#16118](https://github.com/CartoDB/cartodb/pull/16118)
+- Sanitize column names on overwrite import [#16208](https://github.com/CartoDB/cartodb/pull/16208)
 - Updated robots.txt to allow Google access to our datasets [#16148](https://github.com/CartoDB/cartodb/pull/16148)
 - In the Data Catalog, fixed baseurl as it added an extra `/` on the queries from public pages [#16148](https://github.com/CartoDB/cartodb/pull/16148)
 - Added dynamic meta title and canonical link to improve SEO in public pages for the Spatial Data Catalog [#16157](https://github.com/CartoDB/cartodb/pull/16157)

--- a/lib/carto/importer/table_setup.rb
+++ b/lib/carto/importer/table_setup.rb
@@ -73,6 +73,13 @@ module Carto
         @user.tables.where(name: name).first.update_cdb_tablemetadata
       end
 
+      def sanitize_columns(name)
+        @user.tables.where(name: name).first.service.sanitize_columns(
+          database_schema: @user.database_schema,
+          connection: @user.in_database
+        )
+      end
+
       private
 
       def log_context

--- a/spec/factories/feature_flags.rb
+++ b/spec/factories/feature_flags.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :feature_flag, class: 'Carto::FeatureFlag' do
-    id { |n| (Carto::FeatureFlag.last&.id || 0) + 1 }
+    sequence(:id)
     sequence(:name) { |n| "feature-flag-name-#{n}" }
     restricted { true }
 

--- a/spec/factories/feature_flags.rb
+++ b/spec/factories/feature_flags.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :feature_flag, class: 'Carto::FeatureFlag' do
-    sequence(:id)
+    id { Time.now.utc.to_i }
     sequence(:name) { |n| "feature-flag-name-#{n}" }
     restricted { true }
 

--- a/spec/factories/feature_flags.rb
+++ b/spec/factories/feature_flags.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :feature_flag, class: 'Carto::FeatureFlag' do
-    id { Time.now.utc.to_i }
+    id { |n| (Carto::FeatureFlag.last&.id || 0) + 1 }
     sequence(:name) { |n| "feature-flag-name-#{n}" }
     restricted { true }
 


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/140705/advocacy-institute-incompatibleschemas-error-with-collision-strategy-overwrite-and-column-names-normalization)

### Context

This corner case appears when a table is imported using the `overwrite` collision strategy, and the columns required sanitization. For example, when the column name starts with a number (`1234_column`), an underscore will be added (`_1234_column`). First import is successfully, but the second one compares the schemas. Since the sanitization is executed on table creation (almost as last step), the code is going to compare `1234_column` with `_1234_column` that are indeed different. So an `IncompatibleSchemas` exception will be raised.

The idea is to apply the sanitization to the column names of the original schemas in order to compare the existing table's schema with the real names that the new table would have.

### Changes

- Sanitize column names on comparison when the collision strategy is `overwrite`.
- Add column sanitization to the result table on `overwrite_register`