### PR TITLE
[Cloud-native Auth API] Auth code (a.k.a Master key) provisioning

### DIFF
--- a/app/models/carto/auth_code.rb
+++ b/app/models/carto/auth_code.rb
@@ -1,0 +1,33 @@
+module Carto
+  class AuthCode < ActiveRecord::Base
+
+    belongs_to :user
+
+    attr_accessible :user_id, :code
+
+    validates :user, presence: true
+
+    before_save :generate_auth_code_if_nil
+    after_create :add_auth_code_to_redis
+    after_destroy :remove_auth_code_from_redis
+
+    private
+
+    def generate_auth_code_if_nil
+      self.code = Carto::Common::EncryptionService.make_token if self.code.nil?
+    end
+
+    def add_auth_code_to_redis
+      $users_metadata.set(redis_key, self.code)
+    end
+
+    def remove_auth_code_from_redis
+      $users_metadata.del(redis_key)
+    end
+
+    def redis_key
+      "auth_codes:#{user.username}"
+    end
+
+  end
+end

--- a/db/migrate/20210310155105_create_auth_codes.rb
+++ b/db/migrate/20210310155105_create_auth_codes.rb
@@ -1,0 +1,18 @@
+require 'carto/db/migration_helper'
+
+# rubocop:disable Style/MixinUsage
+include Carto::Db::MigrationHelper
+# rubocop:enable Style/MixinUsage
+
+migration(
+  proc do
+    create_table :auth_codes do |t|
+      Uuid :id, primary_key: true, default: Sequel.lit('uuid_generate_v4()')
+      foreign_key :user_id, :users, type: :uuid, null: false, index: true, on_delete: :cascade
+      String :code,                 null: false
+    end
+  end,
+  proc do
+    drop_table :auth_codes
+  end
+)


### PR DESCRIPTION
More info: https://app.clubhouse.io/cartoteam/story/138660/master-key-provisioning

This PR adds the changes to manage authorization codes for each user. 

When an user is created a `auth_code` is generated and stored in the table `auth_codes`. ATM each user will have just one `auth_code` 