### PR TITLE
Split tests load evenly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ sudo make install
 - Sync DO API keys betwenn onpremises & CARTO-managed clouds [#16205](https://github.com/CartoDB/cartodb/pull/16205)
 - Fix master build [#16213](https://github.com/CartoDB/cartodb/pull/16213)
 - Bootstrap new CI & improve stability of old CI [#16220](https://github.com/CartoDB/cartodb/pull/16220)
+- Split tests load evenly in the new CI [#16227](https://github.com/CartoDB/cartodb/pull/16227)
 
 ### Bug fixes / enhancements
 

--- a/script/ci/cloudbuild-rails-tests-pr.yml
+++ b/script/ci/cloudbuild-rails-tests-pr.yml
@@ -156,7 +156,7 @@ steps:
   args:
     - -cx
     - |
-      if [ "${BRANCH_NAME}" = 'feature/ch143305/split-tests-load-more-evenly' ] || [ "${BRANCH_NAME}" = 'master' ] ; then
+      if [ "${BRANCH_NAME}" = 'master' ] ; then
           gsutil cp parallel_test_logs_${BUILD_ID}/parallel_runtime_rspec.log gs://cartodb-ci-tmp-logs/
       fi
 

--- a/script/ci/cloudbuild-rails-tests-pr.yml
+++ b/script/ci/cloudbuild-rails-tests-pr.yml
@@ -1,5 +1,18 @@
 steps:
 
+# Cancel previous job on the same branch
+- name: gcr.io/cloud-builders/gcloud-slim
+  entrypoint: /bin/bash
+  args:
+  - '-c'
+  - 'gcloud builds list --ongoing --filter="buildTriggerId=e6e94e19-02f9-4661-8819-bf8846f5c707 AND substitutions.BRANCH_NAME=${BRANCH_NAME} AND id!=${BUILD_ID}" --format="get(ID)" > jobs_to_cancel'
+
+- name: gcr.io/cloud-builders/gcloud-slim
+  entrypoint: /bin/bash
+  args:
+  - '-c'
+  - 'gcloud builds cancel $(cat jobs_to_cancel | xargs) || true'
+
 # Decrypt github key
 - name: gcr.io/cloud-builders/gcloud-slim
   args:

--- a/script/ci/cloudbuild-rails-tests-pr.yml
+++ b/script/ci/cloudbuild-rails-tests-pr.yml
@@ -118,7 +118,6 @@ steps:
           docker exec -i builder_1 bash -c 'mkdir /cartodb/tmp'
           docker exec -i builder_1 bash -c 'chmod 777 /cartodb/tmp'
           docker cp /workspace/parallel_runtime_rspec.log builder_1:/cartodb/tmp/parallel_runtime_rspec.log
-          # docker exec --user root -i builder_1 bash -c 'chmod 777 /cartodb/tmp/parallel_runtime_rspec.log'
       else
           echo 'Unable to copy previous runtime stats'
       fi

--- a/script/ci/cloudbuild-rails-tests-pr.yml
+++ b/script/ci/cloudbuild-rails-tests-pr.yml
@@ -62,6 +62,7 @@ steps:
       cp config/app_config.yml.sample config/app_config.yml
       cp config/database.yml.sample config/database.yml
       cp lib/assets/javascripts/cdb/secrets.example.json lib/assets/javascripts/cdb/secrets.json
+
 # Build image
 - name: gcr.io/cloud-builders/docker
   entrypoint: /bin/bash
@@ -75,10 +76,39 @@ steps:
           docker tag gcr.io/cartodb-on-gcp-main-artifacts/builder:latest gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}
       fi
       docker build --build-arg COMPILE_ASSETS=false --build-arg BUNDLE_JOBS=16 -t gcr.io/cartodb-on-gcp-main-artifacts/builder:current -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${SHORT_SHA} -t gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG}--${SHORT_SHA} --cache-from gcr.io/cartodb-on-gcp-main-artifacts/builder:${_BRANCH_TAG} .
+
 # Start necessary services (redis, postgres) in background
-- name: 'docker/compose:1.22.0'
+- name: 'docker/compose:1.28.0'
   args: ['-f', 'docker-compose-pg12.yml', 'up', '--build', '-d']
   timeout: 900s
+
+# Download latest runtime stats from GCS
+- name: gcr.io/cloud-builders/gsutil
+  entrypoint: /bin/bash
+  args:
+    - -cx
+    - |
+      if gsutil -q stat gs://cartodb-ci-tmp-logs/parallel_runtime_rspec.log ; then
+          gsutil cp gs://cartodb-ci-tmp-logs/parallel_runtime_rspec.log /workspace/parallel_runtime_rspec.log
+      else
+          echo 'Unable to download previous runtime stats'
+      fi
+
+# Copy latest runtime stats to container
+- name: docker/compose:1.28.0
+  entrypoint: /bin/sh
+  args:
+    - -c
+    - |
+      if [ -f '/workspace/parallel_runtime_rspec.log' ] ; then
+          chmod 777 /workspace/parallel_runtime_rspec.log
+          docker exec -i builder_1 bash -c 'mkdir /cartodb/tmp'
+          docker exec -i builder_1 bash -c 'chmod 777 /cartodb/tmp'
+          docker cp /workspace/parallel_runtime_rspec.log builder_1:/cartodb/tmp/parallel_runtime_rspec.log
+          # docker exec --user root -i builder_1 bash -c 'chmod 777 /cartodb/tmp/parallel_runtime_rspec.log'
+      else
+          echo 'Unable to copy previous runtime stats'
+      fi
 
 # Run tests, first in parallel, then give a second try in serial if some tests fail
 - name: gcr.io/cloud-builders/docker
@@ -90,7 +120,7 @@ steps:
   timeout: 1800s
 
 # Copy tests results and logs from the container
-- name: 'docker/compose:1.22.0'
+- name: 'docker/compose:1.28.0'
   entrypoint: /bin/sh
   args:
     - -c
@@ -101,11 +131,21 @@ steps:
       docker cp builder_1:/cartodb/tmp/parallel_runtime_rspec.log parallel_test_logs_${BUILD_ID}/parallel_runtime_rspec.log
       docker cp builder_1:/cartodb/log/test.log parallel_test_logs_${BUILD_ID}/parallel_test.log
       docker cp builder_1:/cartodb/tmp/tests_exit_code tests_exit_code
-      echo "Logs will be available during 1 day at gs://cartodb-ci-tmp-logs/${BUILD_ID}/"
+      echo "Logs will be available during 14 days at gs://cartodb-ci-tmp-logs/${BUILD_ID}/"
 
 # Upload logs to gcs
 - name: gcr.io/cloud-builders/gsutil
   args: [ '-m', 'cp', '-r', 'parallel_test_logs_${BUILD_ID}', 'gs://cartodb-ci-tmp-logs/' ]
+
+# Upload runtime stats to GCS
+- name: gcr.io/cloud-builders/gsutil
+  entrypoint: /bin/bash
+  args:
+    - -cx
+    - |
+      if [ "${BRANCH_NAME}" = 'feature/ch143305/split-tests-load-more-evenly' ] || [ "${BRANCH_NAME}" = 'master' ] ; then
+          gsutil cp parallel_test_logs_${BUILD_ID}/parallel_runtime_rspec.log gs://cartodb-ci-tmp-logs/
+      fi
 
 # Check tests return value and exit accordingly
 - name: gcr.io/cloud-builders/docker

--- a/script/ci/cloudbuild-tests-pr-pg12.yaml
+++ b/script/ci/cloudbuild-tests-pr-pg12.yaml
@@ -111,7 +111,7 @@ steps:
       docker cp builder_1:/cartodb/parallel_tests_logs test_logs_${BUILD_ID}/parallel_tests_logs
       docker cp builder_1:/cartodb/serial_tests_logs test_logs_${BUILD_ID}/serial_tests_logs || true
       docker cp builder_1:/cartodb/tests_exit_status tests_exit_status
-      echo "Logs will be available during 1 day at gs://cartodb-ci-tmp-logs/${BUILD_ID}/"
+      echo "Logs will be available during 14 days at gs://cartodb-ci-tmp-logs/${BUILD_ID}/"
 
 # Upload logs to gcs
 - name: gcr.io/cloud-builders/gsutil

--- a/script/ci/run_tests.sh
+++ b/script/ci/run_tests.sh
@@ -13,6 +13,8 @@
 
 set -aex
 
+DEBUG=true
+
 if [ -v DEBUG ] && [ $DEBUG = 'true' ]; then
     echo 'Running with the following environment:'
     env

--- a/script/ci/run_tests.sh
+++ b/script/ci/run_tests.sh
@@ -13,8 +13,6 @@
 
 set -aex
 
-DEBUG=true
-
 if [ -v DEBUG ] && [ $DEBUG = 'true' ]; then
     echo 'Running with the following environment:'
     env


### PR DESCRIPTION
Related to: https://app.clubhouse.io/cartoteam/story/143305/split-tests-load-more-evenly

## What does this PR do?

- Uploads Rspec timing stats to GCS after each build on the master branch
- Downloads the latest Rspec from GCS before each build, and uses it to split the tests load evenly between all the available workers
- Cancels previous builds on the same branch

## Acceptance

You can see in [the build logs](https://console.cloud.google.com/cloud-build/builds;region=global/36c7769a-c4dd-4b13-b516-4b372799d42c?project=cartodb-on-gcp-ci-testing):

```
Step #12: Using recorded test runtime
Step #12: 8 processes for 31 specs, ~ 3 specs per process
```

To clarify: this is only printed when `DEBUG=true`, that's why for the logs of the last commit you won't see it.