### PR TITLE
Read new config for public statics compilation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,7 @@ sudo make install
 - Fix CI build by changing machine spec [#16192](https://github.com/CartoDB/cartodb/pull/16192)
 - Modify superadmin users activity endpoint to allow pagination [#16226](https://github.com/CartoDB/cartodb/pull/16226)
 - Update cartodb-common to v1.1.1, which contains serveral logging fixes [#16182](https://github.com/CartoDB/cartodb/pull/16182)
+- Read config for public statics compilation [#16234](https://github.com/CartoDB/cartodb/pull/16234)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/config/public_statics_config.js
+++ b/config/public_statics_config.js
@@ -1,0 +1,14 @@
+/**
+ * Configuration required for statics pages at frontend assets compilation¡
+ * See its use from /webpack/static-pages/
+ *
+ * Note: don't modify its contents unless it's coordinated to work with deployments in different environments
+ */
+
+const CARTO_BUILDER_ASSET_HOST = process.env.CARTO_BUILDER_ASSET_HOST || '//';
+const CARTO_MAPS_API_V2_EXTERNAL_URL = process.env.CARTO_MAPS_API_V2_EXTERNAL_URL || 'http://localhost.lan:8282';
+
+module.exports = {
+  'CARTO_BUILDER_ASSET_HOST': CARTO_BUILDER_ASSET_HOST,
+  'CARTO_MAPS_API_V2_EXTERNAL_URL': CARTO_MAPS_API_V2_EXTERNAL_URL
+};

--- a/config/public_statics_config.js
+++ b/config/public_statics_config.js
@@ -5,8 +5,8 @@
  * Note: don't modify its contents unless it's coordinated to work with deployments in different environments
  */
 
-const CARTO_BUILDER_ASSET_HOST = process.env.CARTO_BUILDER_ASSET_HOST || '//';
-const CARTO_MAPS_API_V2_EXTERNAL_URL = process.env.CARTO_MAPS_API_V2_EXTERNAL_URL || 'http://localhost.lan:8282';
+const CARTO_BUILDER_ASSET_HOST = JSON.stringify(process.env.CARTO_BUILDER_ASSET_HOST || '/assets');
+const CARTO_MAPS_API_V2_EXTERNAL_URL = JSON.stringify(process.env.CARTO_MAPS_API_V2_EXTERNAL_URL || 'http://localhost.lan:8282');
 
 module.exports = {
   'CARTO_BUILDER_ASSET_HOST': CARTO_BUILDER_ASSET_HOST,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.230",
+  "version": "1.0.0-assets.231-statics-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.231-statics-0",
+  "version": "1.0.0-assets.231",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.231-statics-0",
+  "version": "1.0.0-assets.231",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.230",
+  "version": "1.0.0-assets.231-statics-0",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/webpack/static-pages/webpack.base.config.js
+++ b/webpack/static-pages/webpack.base.config.js
@@ -1,0 +1,35 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const path = require('path');
+const webpack = require('webpack');
+const webpackFiles = require('../../lib/build/files/webpack_files');
+const Package = require('./../../package.json');
+
+const VERSION = Package.version;
+
+module.exports = {
+  entry: Object.assign(
+    { main: './lib/assets/javascripts/dashboard/statics/static.js' },
+    webpackFiles.gearEntryPoints
+  ),
+  output: {
+    filename: `${VERSION}/javascripts/[name].js`,
+    path: path.resolve(__dirname, '../../public/assets'),
+    publicPath: '/assets/'
+  },
+  devtool: 'source-map',
+  plugins: [
+    new webpack.DefinePlugin({
+      __ASSETS_VERSION__: `'${VERSION}'`
+    }),
+
+    ...Object.keys(webpackFiles.htmlFiles).map((entryName) => {
+      return new HtmlWebpackPlugin({
+        inject: false,
+        cache: false,
+        filename: webpackFiles.htmlFiles[entryName].filename || path.resolve(__dirname, `../../public/static/${entryName}/index.html`),
+        template: path.resolve(__dirname, '../../lib/assets/javascripts/dashboard/statics/index.jst.ejs'),
+        config: webpackFiles.htmlFiles[entryName]
+      });
+    })
+  ]
+};

--- a/webpack/static-pages/webpack.base.config.js
+++ b/webpack/static-pages/webpack.base.config.js
@@ -5,6 +5,7 @@ const webpackFiles = require('../../lib/build/files/webpack_files');
 const Package = require('./../../package.json');
 
 const VERSION = Package.version;
+const PUBLIC_STATICS_CONFIG = require('../../config/public_statics_config');
 
 module.exports = {
   entry: Object.assign(
@@ -19,7 +20,9 @@ module.exports = {
   devtool: 'source-map',
   plugins: [
     new webpack.DefinePlugin({
-      __ASSETS_VERSION__: `'${VERSION}'`
+      __ASSETS_VERSION__: `'${VERSION}'`,
+      __CARTO_BUILDER_ASSET_HOST__: PUBLIC_STATICS_CONFIG.CARTO_BUILDER_ASSET_HOST,
+      __CARTO_MAPS_API_V2_EXTERNAL_URL__: PUBLIC_STATICS_CONFIG.CARTO_MAPS_API_V2_EXTERNAL_URL
     }),
 
     ...Object.keys(webpackFiles.htmlFiles).map((entryName) => {

--- a/webpack/static-pages/webpack.dev.config.js
+++ b/webpack/static-pages/webpack.dev.config.js
@@ -1,32 +1,6 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const path = require('path');
-const webpack = require('webpack');
-const webpackFiles = require('../../lib/build/files/webpack_files');
-const Package = require('./../../package.json');
+const merge = require('webpack-merge');
+const baseConfig = require('./webpack.base.config.js');
 
-const VERSION = Package.version;
-
-module.exports = {
-  entry: './lib/assets/javascripts/dashboard/statics/static.js',
-  output: {
-    filename: `${VERSION}/javascripts/[name].js`,
-    path: path.resolve(__dirname, '../../public/assets'),
-    publicPath: '/assets/'
-  },
-  devtool: 'source-map',
-  plugins: [
-    new webpack.DefinePlugin({
-      __ASSETS_VERSION__: `'${VERSION}'`
-    }),
-
-    ...Object.keys(webpackFiles.htmlFiles).map((entryName) => {
-      return new HtmlWebpackPlugin({
-        inject: false,
-        cache: false,
-        filename: webpackFiles.htmlFiles[entryName].filename || path.resolve(__dirname, `../../public/static/${entryName}/index.html`),
-        template: path.resolve(__dirname, '../../lib/assets/javascripts/dashboard/statics/index.jst.ejs'),
-        config: webpackFiles.htmlFiles[entryName]
-      });
-    })
-  ]
-};
+module.exports = merge(baseConfig, {
+  mode: 'development'
+});

--- a/webpack/static-pages/webpack.prod.config.js
+++ b/webpack/static-pages/webpack.prod.config.js
@@ -1,35 +1,6 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const path = require('path');
-const webpack = require('webpack');
-const webpackFiles = require('../../lib/build/files/webpack_files');
-const Package = require('./../../package.json');
+const merge = require('webpack-merge');
+const baseConfig = require('./webpack.base.config.js');
 
-const VERSION = Package.version;
-
-module.exports = {
-  entry: Object.assign(
-    { main: './lib/assets/javascripts/dashboard/statics/static.js' },
-    webpackFiles.gearEntryPoints
-  ),
-  output: {
-    filename: `${VERSION}/javascripts/[name].js`,
-    path: path.resolve(__dirname, '../../public/assets'),
-    publicPath: '/assets/'
-  },
-  devtool: 'source-map',
-  plugins: [
-    new webpack.DefinePlugin({
-      __ASSETS_VERSION__: `'${VERSION}'`
-    }),
-
-    ...Object.keys(webpackFiles.htmlFiles).map((entryName) => {
-      return new HtmlWebpackPlugin({
-        inject: false,
-        cache: false,
-        filename: webpackFiles.htmlFiles[entryName].filename || path.resolve(__dirname, `../../public/static/${entryName}/index.html`),
-        template: path.resolve(__dirname, '../../lib/assets/javascripts/dashboard/statics/index.jst.ejs'),
-        config: webpackFiles.htmlFiles[entryName]
-      });
-    })
-  ]
-};
+module.exports = merge(baseConfig, {
+  mode: 'production'
+});


### PR DESCRIPTION
A new configuration file that allows to read certain variables, required by frontend when compiling (public) static assets 

## Cloud deploy instructions (edited by jvillar)

1. Merge https://github.com/CartoDB/cartodb-platform/pull/7120
2.  Run chef in `bch + rui + que`
3.  Merge https://github.com/CartoDB/cartodb/pull/16234/files
4. Perform a deploy