### PR TITLE
Improve visibility over SAML errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,6 +116,7 @@ sudo make install
 - Show dataset version in subscription list and details [#16235](https://github.com/CartoDB/cartodb/pull/16235)
 - Fix error that avoid to render Spatial Data Catalog properly in Internet Explorer [#16236](https://github.com/CartoDB/cartodb/pull/16236)
 - Free users can't create datasets due to default state was private [16223](https://github.com/CartoDB/cartodb/pull/16223)
+- Improve visibility over SAML errors [#16243](https://github.com/CartoDB/cartodb/pull/16243)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -256,14 +256,14 @@ class SessionsController < ApplicationController
       render 'shared/signup_confirmation'
     else
       errors = account_creator.validation_errors
-      CartoDB.notify_debug('User not valid at signup', { errors: errors } )
+      Rails.logger.warn(message: 'User not valid at signup', errors: errors.inspect)
       @signup_source = created_via.upcase
       @signup_errors = errors
       render 'shared/signup_issue'
     end
   rescue StandardError => e
     new_user = account_creator.nil? ? "account_creator nil" : account_creator.user.inspect
-    CartoDB.report_exception(e, "Creating user", new_user: new_user)
+    Rails.logger.error(exception: e, new_user: new_user.inspect)
     flash.now[:error] = e.message
     render action: 'new'
   end

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -84,7 +84,7 @@ module Carto
     end
 
     def debug_response(message, response)
-      log_info(
+      Rails.logger.warn(
         message: message,
         response: {
           settings: response.settings.to_json,

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -56,12 +56,10 @@ describe SessionsController do
       FakeNetLdap.register_user(username: normal_user_cn, password: normal_user_password)
       FakeNetLdap.register_query(Net::LDAP::Filter.eq('cn', normal_user_username), [ldap_entry_data])
 
-      errors = {
-        errors: {
-          organization: ["Organization owner is not set. Administrator must login first."]
-        }
-      }
-      ::CartoDB.expects(:notify_debug).with('User not valid at signup', errors).returns(nil)
+      Rails.logger.expects(:warn).with(
+        message: 'User not valid at signup',
+        errors: { organization: ['Organization owner is not set. Administrator must login first.'] }.inspect
+      )
 
       post create_session_url(user_domain: user_domain, email: normal_user_username, password: normal_user_password)
 


### PR DESCRIPTION
Related: https://app.clubhouse.io/cartoteam/story/145527/reef-set-up-sso

I need visibility over some of these errors in production, but `notify_debug` does not report at the min error level configured in production (info)