### PR TITLE
Fix catalog in staging

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -117,6 +117,7 @@ sudo make install
 - Fix error that avoid to render Spatial Data Catalog properly in Internet Explorer [#16236](https://github.com/CartoDB/cartodb/pull/16236)
 - Free users can't create datasets due to default state was private [16223](https://github.com/CartoDB/cartodb/pull/16223)
 - Improve visibility over SAML errors [#16243](https://github.com/CartoDB/cartodb/pull/16243)
+- Support staging hostname in the catalog
 
 4.44.0 (2020-11-20)
 -------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -117,7 +117,7 @@ sudo make install
 - Fix error that avoid to render Spatial Data Catalog properly in Internet Explorer [#16236](https://github.com/CartoDB/cartodb/pull/16236)
 - Free users can't create datasets due to default state was private [16223](https://github.com/CartoDB/cartodb/pull/16223)
 - Improve visibility over SAML errors [#16243](https://github.com/CartoDB/cartodb/pull/16243)
-- Support staging hostname in the catalog
+- Support staging hostname in the catalog [#16245](https://github.com/CartoDB/cartodb/pull/16245)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/lib/assets/javascripts/new-dashboard/store/actions/catalog.js
+++ b/lib/assets/javascripts/new-dashboard/store/actions/catalog.js
@@ -1,7 +1,7 @@
 import 'whatwg-fetch';
 
 import { setUrlParameters } from 'new-dashboard/utils/catalog/url-parameters';
-import { getBaseURL } from 'new-dashboard/utils/catalog/base-url';
+import { getBaseURL } from 'new-dashboard/utils/base-url';
 
 const entitiesEndpoint = 'data/observatory/metadata/entities';
 const datasetsEndpoint = 'data/observatory/metadata/datasets';

--- a/lib/assets/javascripts/new-dashboard/utils/base-url.js
+++ b/lib/assets/javascripts/new-dashboard/utils/base-url.js
@@ -2,7 +2,7 @@ export function getBaseURL (state, apiVersion = 'v4') {
   if (state.config) {
     return `${state.config.base_url}/api/${apiVersion}`;
   } else if (window.location.hostname === 'carto-staging.com') {
-    return `https://public.carto-staging.com/api/${apiVersion}`
+    return `https://public.carto-staging.com/api/${apiVersion}`;
   } else {
     return `https://public.carto.com/api/${apiVersion}`;
   }

--- a/lib/assets/javascripts/new-dashboard/utils/base-url.js
+++ b/lib/assets/javascripts/new-dashboard/utils/base-url.js
@@ -1,9 +1,8 @@
 export function getBaseURL (state, apiVersion = 'v4') {
   if (state.config) {
-    // const username = state.config.user_name;
-    // const host = state.config.account_host;
-    // return `https://${username}.${host}/api/${apiVersion}`;
     return `${state.config.base_url}/api/${apiVersion}`;
+  } else if (window.location.hostname === 'carto-staging.com') {
+    return `https://public.carto-staging.com/api/${apiVersion}`
   } else {
     return `https://public.carto.com/api/${apiVersion}`;
   }

--- a/lib/assets/javascripts/new-dashboard/utils/catalog/base-url.js
+++ b/lib/assets/javascripts/new-dashboard/utils/catalog/base-url.js
@@ -1,9 +1,0 @@
-export function getBaseURL (state) {
-  if (state.config) {
-    const username = state.config.user_name;
-    const host = state.config.account_host;
-    return `https://${username}.${host}/api/v4`;
-  } else {
-    return 'https://public.carto.com/api/v4';
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.236",
+  "version": "1.0.0-assets.238",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.237",
+  "version": "1.0.0-assets.238",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The public catalog in carto-staging.com was using the production DB (public.carto.com). With this change, the hostname is detected to use the staging DB (public.carto-staging.com) in staging.