### PR TITLE
SAML adjustments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -117,6 +117,7 @@ sudo make install
 - Fix error that avoid to render Spatial Data Catalog properly in Internet Explorer [#16236](https://github.com/CartoDB/cartodb/pull/16236)
 - Free users can't create datasets due to default state was private [16223](https://github.com/CartoDB/cartodb/pull/16223)
 - Improve visibility over SAML errors [#16243](https://github.com/CartoDB/cartodb/pull/16243)
+- SAML adjustments [#16246](https://github.com/CartoDB/cartodb/pull/16246)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -242,6 +242,7 @@ class SessionsController < ApplicationController
     redirect_to login_url + "?error=#{MULTIFACTOR_AUTHENTICATION_INACTIVITY}"
   end
 
+  # rubocop:disable Metrics/AbcSize
   def create_user(params = {}, &config_account_creator_block)
     @organization = Carto::Organization.find(params[:organization_id])
 
@@ -276,6 +277,7 @@ class SessionsController < ApplicationController
     flash.now[:error] = e.message
     render action: 'new'
   end
+  # rubocop:enable Metrics/AbcSize
 
   protected
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -169,10 +169,14 @@ class SessionsController < ApplicationController
 
     username = warden.env['warden.options'][:cartodb_username]
     organization_id = warden.env['warden.options'][:organization_id]
-    email = warden.env['warden.options'][:ldap_email].blank? ? nil : warden.env['warden.options'][:ldap_email]
-    created_via = Carto::UserCreation::CREATED_VIA_LDAP
+    email = warden.env['warden.options'][:ldap_email].presence
 
-    create_user(username, organization_id, email, created_via)
+    create_user(
+      username: username,
+      organization_id: organization_id,
+      email: email,
+      created_via: Carto::UserCreation::CREATED_VIA_LDAP
+    )
   end
 
   def saml_user_not_in_carto
@@ -186,9 +190,14 @@ class SessionsController < ApplicationController
     username = CartoDB::UserAccountCreator.email_to_username(saml_email)
     unique_username = Carto::UsernameProposer.find_unique(username)
     organization_id = warden.env['warden.options'][:organization_id]
-    created_via = Carto::UserCreation::CREATED_VIA_SAML
 
-    create_user(unique_username, organization_id, saml_email, created_via)
+    create_user(
+      username: unique_username,
+      organization_id: organization_id,
+      email: saml_email,
+      created_via: Carto::UserCreation::CREATED_VIA_SAML,
+      viewer: true
+    )
   end
 
   def verify_warden_failure
@@ -233,14 +242,14 @@ class SessionsController < ApplicationController
     redirect_to login_url + "?error=#{MULTIFACTOR_AUTHENTICATION_INACTIVITY}"
   end
 
-  def create_user(username, organization_id, email, created_via, &config_account_creator_block)
-    @organization = Carto::Organization.find(organization_id)
+  def create_user(params = {}, &config_account_creator_block)
+    @organization = Carto::Organization.find(params[:organization_id])
 
-    account_creator = CartoDB::UserAccountCreator.new(created_via)
+    account_creator = CartoDB::UserAccountCreator.new(params[:created_via])
 
-    account_creator.with_organization(@organization)
-                   .with_username(username)
-    account_creator.with_email(email) unless email.nil?
+    account_creator.with_organization(@organization, viewer: params[:viewer] || false)
+                   .with_username(params[:username])
+    account_creator.with_email(params[:email]) if params[:email].present?
 
     # Allows externals gears to override this method and add further configuration to the
     # account creator
@@ -257,7 +266,7 @@ class SessionsController < ApplicationController
     else
       errors = account_creator.validation_errors
       Rails.logger.warn(message: 'User not valid at signup', errors: errors.inspect)
-      @signup_source = created_via.upcase
+      @signup_source = params[:created_via].upcase
       @signup_errors = errors
       render 'shared/signup_issue'
     end

--- a/config/initializers/email_address.rb
+++ b/config/initializers/email_address.rb
@@ -1,4 +1,8 @@
-EmailAddress::Config.configure(local_format: :conventional, host_validation: Cartodb.config[:disable_email_mx_check] ? :syntax : :mx )
+# Previously we validated email domains against DNS records, but since we forced the email verification before
+# provisioning users this is not needed anymore.
+# Also, some user emails coming from SAML IDPs may have domains which don't have a corresponding DNS record
+# https://app.clubhouse.io/cartoteam/story/145527/reef-set-up-sso#activity-146696
+EmailAddress::Config.configure(local_format: :conventional, host_validation: :syntax)
 
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -64,7 +64,7 @@ describe SessionsController do
       post create_session_url(user_domain: user_domain, email: normal_user_username, password: normal_user_password)
 
       response.status.should == 200
-      (response.body =~ /Signup issues/).to_i.should_not eq 0
+      expect(response.body).to include('Signup issues')
     end
 
     it "Allows to login and triggers creation if using the org admin account" do
@@ -87,7 +87,7 @@ describe SessionsController do
       post create_session_url(user_domain: user_domain, email: admin_user_username, password: admin_user_password)
 
       response.status.should == 200
-      (response.body =~ /Your account is being created/).to_i.should_not eq 0
+      expect(response.body).to include('Your account is being created')
     end
 
     it "Allows to login and triggers creation of normal users if admin already present" do
@@ -125,7 +125,7 @@ describe SessionsController do
       post create_session_url(user_domain: user_domain, email: normal_user_username, password: normal_user_password)
 
       response.status.should == 200
-      (response.body =~ /Your account is being created/).to_i.should_not eq 0
+      expect(response.body).to include('Your account is being created')
 
       @admin_user.destroy
     end
@@ -349,7 +349,7 @@ describe SessionsController do
       post create_session_url(user_domain: user_domain, SAMLResponse: 'xx')
 
       response.status.should == 200
-      (response.body =~ /Your account is being created/).to_i.should_not eq 0
+      expect(response.body).to include('Your account is being created')
 
       ::User.where(username: new_user.username).first.try(:destroy)
     end
@@ -366,7 +366,7 @@ describe SessionsController do
       post create_session_url(user_domain: user_domain, SAMLResponse: 'xx')
 
       response.status.should == 200
-      (response.body =~ /Your account is being created/).to_i.should_not eq 0
+      expect(response.body).to include('Your account is being created')
 
       ::User.where(username: new_user.username).first.try(:destroy)
     end
@@ -438,7 +438,7 @@ describe SessionsController do
 
   describe 'SAML authentication' do
     def setup_saml_organization
-      @organization = create(:saml_organization, quota_in_bytes: 1.gigabytes)
+      @organization = create(:saml_organization, quota_in_bytes: 1.gigabytes, viewer_seats: 20)
       @admin_user = create_admin_user(@organization)
       @user = create(:carto_user)
       @user.organization_id = @organization.id


### PR DESCRIPTION
Related: https://app.clubhouse.io/cartoteam/story/145527/reef-set-up-sso#activity-146696

## What does this PR do?

- Disables DNS checks agains user email addresses. This is not needed anymore as we're asking user to verify their emails before provisioning their accounts.
- Users that sign-up via SAML will be created as viewers instead of builders
- Fixes a bug where SAML SP-initiated logout flows closed the session in the IDP but not in CARTO