### PR TITLE
Retrieve user email for SAML logout before closing CARTO session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -118,6 +118,7 @@ sudo make install
 - Free users can't create datasets due to default state was private [16223](https://github.com/CartoDB/cartodb/pull/16223)
 - Improve visibility over SAML errors [#16243](https://github.com/CartoDB/cartodb/pull/16243)
 - SAML adjustments [#16246](https://github.com/CartoDB/cartodb/pull/16246)
+- Retrieve user email for SAML logout before closing CARTO session [#16248](https://github.com/CartoDB/cartodb/pull/16248)
 
 4.44.0 (2020-11-20)
 -------------------

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -418,8 +418,9 @@ class SessionsController < ApplicationController
       redirect_to default_logout_url
     # SP-initiated logout
     else
+      user_email = current_user.email # Save email for afterwards (current_user is cleared by cdb_logout)
       cdb_logout # Close session in CARTO first, in case somthing goes wrong in the IDP
-      redirect_to saml_service.sp_logout_request(current_user)
+      redirect_to saml_service.sp_logout_request(user_email)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -418,9 +418,10 @@ class SessionsController < ApplicationController
       redirect_to default_logout_url
     # SP-initiated logout
     else
-      user_email = current_user.email # Save email for afterwards (current_user is cleared by cdb_logout)
+      user_email = current_user&.email # Save email for afterwards (current_user is cleared by cdb_logout)
       cdb_logout # Close session in CARTO first, in case somthing goes wrong in the IDP
-      redirect_to saml_service.sp_logout_request(user_email)
+      redirect_url = user_email ? saml_service.sp_logout_request(user_email) : default_logout_url
+      redirect_to(redirect_url)
     end
   end
 

--- a/lib/carto/saml_service.rb
+++ b/lib/carto/saml_service.rb
@@ -32,11 +32,11 @@ module Carto
 
     # SLO (Single Log Out) request initiated from CARTO
     # Returns the SAML logout request that to be redirected to
-    def sp_logout_request(user)
+    def sp_logout_request(user_email)
       settings = saml_settings
 
       if logout_url_configured?
-        settings.name_identifier_value = user.email
+        settings.name_identifier_value = user_email
         OneLogin::RubySaml::Logoutrequest.new.create(settings)
       else
         raise "SLO IdP Endpoint not found in settings for #{@organization}"

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -34,6 +34,20 @@ FactoryBot.define do
       end
     end
 
+    trait :saml_enabled do
+      auth_saml_configuration do
+        {
+          issuer: 'localhost.lan',
+          idp_sso_target_url: 'https://example.com/saml/signon/',
+          idp_slo_target_url: 'https://example.com/saml/signon/',
+          idp_cert_fingerprint: '',
+          assertion_consumer_service_url: 'https://localhost.lan/saml/finalize',
+          name_identifier_format: '',
+          email_attribute: 'username'
+        }.stringify_keys
+      end
+    end
+
     factory :organization_whitelist_carto, class: 'Carto::Organization' do
       whitelisted_email_domains { ['carto.com'] }
       auth_username_password_enabled { true }

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -4,6 +4,7 @@ require_relative '../helpers/subdomainless_helper'
 require 'fake_net_ldap'
 require_relative '../lib/fake_net_ldap_bind_as'
 
+# rubocop:disable RSpec/InstanceVariable
 describe SessionsController do
 
   def create_ldap_user(admin_user_username, admin_user_password)
@@ -382,7 +383,7 @@ describe SessionsController do
 
     describe 'SAML logout' do
       it 'calls SamlService#sp_logout_request from user-initiated logout' do
-        SessionsController.any_instance.stubs(:current_user).returns(@user)
+        described_class.any_instance.stubs(:current_user).returns(@user)
         stub_saml_service(@user)
 
         host! "#{@user.username}.localhost.lan"
@@ -1078,3 +1079,4 @@ describe SessionsController do
     Carto::NamedMaps::Api.any_instance.stubs(show: nil, create: true, update: true, destroy: true)
   end
 end
+# rubocop:enable RSpec/InstanceVariable

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -382,6 +382,7 @@ describe SessionsController do
 
     describe 'SAML logout' do
       it 'calls SamlService#sp_logout_request from user-initiated logout' do
+        SessionsController.any_instance.stubs(:current_user).returns(@user)
         stub_saml_service(@user)
 
         host! "#{@user.username}.localhost.lan"


### PR DESCRIPTION
Hotfix for https://app.clubhouse.io/cartoteam/story/145527/reef-set-up-sso