### PR TITLE
[ch142882] Fix OAuth all datasets scope when there is a temp importing table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ sudo make install
 - Add search in 'new map' screen [16166](https://github.com/CartoDB/cartodb/pull/16166)
 - Migrate FeatureFlag & PricePlan synchronization to the Message Broker [#16098](https://github.com/CartoDB/cartodb/pull/16098)
 - Sync DO Service Account info between central and on-prem and cloud instances [#16189](https://github.com/CartoDB/cartodb/pull/16189)
+- Fix OAuth all datasets scope when there is a temp importing table [#16252](https://github.com/CartoDB/cartodb/pull/16252)
 - Cleanup after [#16189](https://github.com/CartoDB/cartodb/pull/16189). See [#16200](https://github.com/CartoDB/cartodb/pull/16200)
 - Split configuration for Message Broker & Central login redirection [#16150](https://github.com/CartoDB/cartodb/pull/16150)
 - Remove Data Library gallery page (now redirected to Spatial Data Catalog) [#16133](https://github.com/CartoDB/cartodb/pull/16133)

--- a/app/models/carto/user_db_service.rb
+++ b/app/models/carto/user_db_service.rb
@@ -169,7 +169,7 @@ module Carto
         DISTINCT table_schema, table_name, privilege_type
       })).where(Arel.sql(%{
         grantee IN ('#{all_user_roles.join("','")}') AND
-        table_schema NOT IN ('cartodb', 'aggregation') AND
+        table_schema NOT IN ('cartodb', 'aggregation', 'cdb_importer') AND
         grantor != 'postgres' AND
         privilege_type IN ('SELECT', 'UPDATE')
       })).as('uniq_grants')


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/142882/oauth-scope-datasets-r-raising-an-error-when-there-is-a-temporal-import-table)

### Context

- When you are trying to use the `datasets:r:*` wildcard for OAuth application scoping, the process fails if there is a table in the `cdb_importer` schema (temporal tables used in import processes). The reason is that the tables with permission returned by [`user.db_service.tables_granted`](https://github.com/CartoDB/cartodb/blob/master/app/models/carto/user_db_service.rb#L150) are not the same than the ones returned by [`user.db_service.all_tables_granted_hashed`](https://github.com/CartoDB/cartodb/blob/master/app/models/carto/user_db_service.rb#L77). Since the second one is ignoring the tables in the `cdb_importer` schema, and they are temporal tables not related with the OAuth permissions, the idea would be to ignore this schema also in the first method.

### Changes

- Add `cdb_importer` to the list of ignored schemas in `Carto::UserDBService#table_grants`.