### PR TITLE
Skip assets version 239

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.238",
+  "version": "1.0.0-assets.240",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.238",
+  "version": "1.0.0-assets.240",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In https://github.com/CartoDB/cartodb/pull/16256 the assets version was reverted from 239 to 238.

With this PR we are skipping to 240 to avoid anyone reusing 239 which should be cached with the reverted version.

Precedent: https://github.com/CartoDB/cartodb/pull/15675