### PR TITLE
limit start parameter for dropbox connector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Development
 * Bump cartodb-common to v1.1.2
 
 ### Bug fixes / enhancements
+- Limit start parameter of Dropbox connector [#16264](https://github.com/CartoDB/cartodb/pull/16264)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
 - Fix subscription/sample filter for datasets [#16254](https://github.com/CartoDB/cartodb/pull/16254)
 - Use fully qualified table name while creating a new map from a shared dataset [#16241](https://github.com/CartoDB/cartodb/pull/16241)

--- a/services/datasources/lib/datasources/url/dropbox.rb
+++ b/services/datasources/lib/datasources/url/dropbox.rb
@@ -128,6 +128,7 @@ module CartoDB
               end
               no_more_results = start == START_LIMIT || !response.has_more?
               break if no_more_results
+
               start += SEARCH_BATCH_SIZE
               start = START_LIMIT if start > START_LIMIT
             end

--- a/services/datasources/lib/datasources/url/dropbox.rb
+++ b/services/datasources/lib/datasources/url/dropbox.rb
@@ -30,6 +30,8 @@ module CartoDB
             FORMAT_COMPRESSED =>  %W( .zip )
         }
 
+        START_LIMIT = 9999
+
         # Constructor
         # @param config Array
         # [
@@ -124,8 +126,10 @@ module CartoDB
               response.matches.select { |item| item.resource.is_a?(DropboxApi::Metadata::File) }.each do |item|
                 all_results.push(format_item_data(item.resource))
               end
-              break unless response.has_more?
+              no_more_results = start == START_LIMIT || !response.has_more?
+              break if no_more_results
               start += SEARCH_BATCH_SIZE
+              start = START_LIMIT if start > START_LIMIT
             end
           end
           all_results


### PR DESCRIPTION
Dropbox connector iterates over all the pages using the `start` parameter. In some point, if the user has a lot of files, the start parameter may be not in the range of the Dropbox API, throwing a 400 error with the message `start: 10000 is not within range [0, 9999]`

This PR fixes that error by limit the `start` parameter to `9999`.

More context: https://app.clubhouse.io/cartoteam/story/147166/covidanalytics-error-in-call-to-api-function