### PR TITLE
Guard code for users and visualizations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Development
 * Bump cartodb-common to v1.1.2
 
 ### Bug fixes / enhancements
+- Guard code for Users and Visualizations [#16265](https://github.com/CartoDB/cartodb/pull/16265)
 - Limit start parameter of Dropbox connector [#16264](https://github.com/CartoDB/cartodb/pull/16264)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
 - Fix subscription/sample filter for datasets [#16254](https://github.com/CartoDB/cartodb/pull/16254)

--- a/app/controllers/carto/api/vizjson3_presenter.rb
+++ b/app/controllers/carto/api/vizjson3_presenter.rb
@@ -166,8 +166,9 @@ module Carto
       end
 
       def datasource_vizjson(options, forced_privacy_version)
+        username = @visualization.user.username unless @visualization.user.nil?
         ds = {
-          user_name: @visualization.user.username,
+          user_name: username,
           maps_api_template: ApplicationHelper.maps_api_template(api_templates_type(options)),
           stat_tag: @visualization.id
         }

--- a/app/services/carto/visualization_backup_service.rb
+++ b/app/services/carto/visualization_backup_service.rb
@@ -7,6 +7,8 @@ module Carto
     include ::LoggerHelper
 
     def create_visualization_backup(visualization:, category:, with_mapcaps: true, with_password: true)
+      return unless Carto::Visualization.exists?(id: visualization.id)
+
       export_json = export_visualization_json_hash(
         visualization.id,
         visualization.user,


### PR DESCRIPTION
A lot of Rollbar errors related with vizjson3 have been raising for quite a while generating a lot of noise in `#backend-is-broken` channel and in the rollbar dashboard.

We should check what's wrong with vizjson3 or adding some guard-code in order to prevent those _Nil/not found_ errors in prod.

Some examples of these errors:

Users Nil:
https://rollbar.com/carto/CartoDB/items/48534/#traceback
https://rollbar.com/carto/CartoDB/items/48660/#traceback

Visualizations not found:
https://rollbar.com/carto/CartoDB/items/48661/#traceback
https://rollbar.com/carto/CartoDB/items/48665/#traceback