### PR TITLE
[ch149333] Allow the usage of WMTS URLs with parameters to create custom basemaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Development
 - Guard code for Users and Visualizations [#16265](https://github.com/CartoDB/cartodb/pull/16265)
 - Limit start parameter of Dropbox connector [#16264](https://github.com/CartoDB/cartodb/pull/16264)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
+- Allow the usage of WMTS URLs with parameters to create custom basemaps []()
 - Fix subscription/sample filter for datasets [#16254](https://github.com/CartoDB/cartodb/pull/16254)
 - Use fully qualified table name while creating a new map from a shared dataset [#16241](https://github.com/CartoDB/cartodb/pull/16241)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@ Development
 - Guard code for Users and Visualizations [#16265](https://github.com/CartoDB/cartodb/pull/16265)
 - Limit start parameter of Dropbox connector [#16264](https://github.com/CartoDB/cartodb/pull/16264)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
-- Allow the usage of WMTS URLs with parameters to create custom basemaps []()
+- Allow the usage of WMTS URLs with parameters to create custom basemaps [#16271](https://github.com/CartoDB/cartodb/pull/16271)
 - Fix subscription/sample filter for datasets [#16254](https://github.com/CartoDB/cartodb/pull/16254)
 - Use fully qualified table name while creating a new map from a shared dataset [#16241](https://github.com/CartoDB/cartodb/pull/16241)
 

--- a/lib/assets/javascripts/builder/data/wms-service.js
+++ b/lib/assets/javascripts/builder/data/wms-service.js
@@ -38,7 +38,7 @@ WMSService.prototype.generateURL = function (opts) {
     params.push('service=WMS');
   }
 
-  url += '?' + params.join('&');
+  url = url.split('?')[0] + '?' + params.join('&');
   req += '?url=' + encodeURIComponent(url);
 
   var isWMTS = opts.type === 'wmts';

--- a/lib/assets/test/spec/builder/data/wms-service.spec.js
+++ b/lib/assets/test/spec/builder/data/wms-service.spec.js
@@ -15,13 +15,13 @@ describe('data/wms-service', function () {
     expect(resultURL.indexOf('type=wms')).toBeGreaterThan(0);
   });
 
-  it("shouldn't remove extra params in the URL", function () {
+  it("should keep extra params in the URL", function () {
     var url = 'http://myURL?request=GetCapabilities&service=WMS&type=wms&FORMAT=image/png24';
     this.wmsService.setUrl(url);
     var resultURL = this.wmsService.generateURL({ method: 'create' });
 
-    expect(resultURL.indexOf(encodeURIComponent('FORMAT=image/png24'))).toBeGreaterThan(0);
-    expect(resultURL.indexOf(encodeURIComponent('service=WMS'))).toBeGreaterThan(0);
+    expect(resultURL.indexOf(encodeURIComponent('FORMAT=image/png24'))).toEqual(1);
+    expect(resultURL.indexOf(encodeURIComponent('service=WMS'))).toEqual(1);
   });
 
   it('should set the supported matrix sets to create a WMTS resource', function () {

--- a/lib/assets/test/spec/builder/data/wms-service.spec.js
+++ b/lib/assets/test/spec/builder/data/wms-service.spec.js
@@ -15,7 +15,7 @@ describe('data/wms-service', function () {
     expect(resultURL.indexOf('type=wms')).toBeGreaterThan(0);
   });
 
-  it("should keep extra params in the URL", function () {
+  it('should keep extra params in the URL', function () {
     var url = 'http://myURL?request=GetCapabilities&service=WMS&type=wms&FORMAT=image/png24';
     this.wmsService.setUrl(url);
     var resultURL = this.wmsService.generateURL({ method: 'create' });

--- a/lib/assets/test/spec/builder/data/wms-service.spec.js
+++ b/lib/assets/test/spec/builder/data/wms-service.spec.js
@@ -20,8 +20,8 @@ describe('data/wms-service', function () {
     this.wmsService.setUrl(url);
     var resultURL = this.wmsService.generateURL({ method: 'create' });
 
-    expect(resultURL.indexOf(encodeURIComponent('FORMAT=image/png24'))).toEqual(1);
-    expect(resultURL.indexOf(encodeURIComponent('service=WMS'))).toEqual(1);
+    expect((resultURL.match(encodeURIComponent('FORMAT=image/png24')) || []).length).toEqual(1);
+    expect((resultURL.match(encodeURIComponent('service=WMS')) || []).length).toEqual(1);
   });
 
   it('should set the supported matrix sets to create a WMTS resource', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.243-cgonzalez149333",
+  "version": "1.0.0-assets.243",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.242",
+  "version": "1.0.0-assets.243-cgonzalez149333",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.243-cgonzalez149333",
+  "version": "1.0.0-assets.243",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.242",
+  "version": "1.0.0-assets.243-cgonzalez149333",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/149333/fernando99-error-trying-to-add-a-custom-wmts-basemap-from-a-url-with-parameters)

### Context

If you try to add a custom basemap using a WMTS URL, the URL is modified to add the required parameters (like `request` or `service`). But if the provided URL already has parameters, the request will fail. For example, this happens for the Planet provider, that requires an `api_key`: `https://api.planet.com/basemaps/v1/mosaics/wmts?api_key=XXXXXXXXXXXX`

The problem is the following process:

- An array with the parameters is created.
- We check if that list includes the required parameters, and we add them if needed.
- All the parameters are added to the original URL.

So the result would be a wrong URL like: `https://domain/path?parameter=X?parameter=X&required_parameter=X`.

The idea would be just adding the parameters to the URL without parameters.

### Changes

- Add the parameters to the URL without parameters, instead to the original one.