### PR TITLE
Bump ruby-saml to 1.12.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'protected_attributes'
 gem 'responders', '~> 2.0'
 
 gem 'rails_warden',            '0.5.8' # Auth via the Warden Rack framework
-gem 'ruby-saml',               '1.7.0'
+gem 'ruby-saml',               '1.12.2'
 gem 'oauth',                   '0.4.7'
 gem 'oauth-plugin',            git: 'https://github.com/CartoDB/oauth-plugin.git', :branch => 'cartodb'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,8 +428,9 @@ GEM
     ruby-ole (1.2.12.2)
     ruby-prof (1.4.1)
     ruby-progressbar (1.11.0)
-    ruby-saml (1.7.0)
-      nokogiri (>= 1.5.10)
+    ruby-saml (1.12.2)
+      nokogiri (>= 1.10.5)
+      rexml
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
     sass (3.4.25)
@@ -594,7 +595,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   ruby-prof (= 1.4.1)
-  ruby-saml (= 1.7.0)
+  ruby-saml (= 1.12.2)
   rubyzip (>= 2.0.0)
   selenium-webdriver (>= 2.5.0)
   sequel (~> 4.45.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ Development
 - None yet
 
 ### Features
+* Bump ruby-saml to v1.12.2 [#16273](https://github.com/CartoDB/cartodb/pull/16273)
 * Bump cartodb-common to v1.1.2
 
 ### Bug fixes / enhancements


### PR DESCRIPTION
Upgrade ruby-saml dependency to 1.12.2 in order to fix the issue [`validate_signature`](https://github.com/onelogin/ruby-saml/issues/577)

More context: https://app.clubhouse.io/cartoteam/story/145527/reef-set-up-sso#activity-149854